### PR TITLE
Route signed-in visitors to dashboard

### DIFF
--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -1,6 +1,6 @@
-import { useState } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 import { useLocation } from "preact-iso";
-import { signIn } from "../../models/auth";
+import { getSession, signIn } from "../../models/auth";
 import {
   Alert,
   Button,
@@ -18,6 +18,17 @@ export default function LoginPage() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getSession().then((session) => {
+      if (cancelled) return;
+      if (session?.user) location.route("/dashboard", true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const onSubmit = async (event: Event) => {
     event.preventDefault();

--- a/src/pages/Auth/Register.tsx
+++ b/src/pages/Auth/Register.tsx
@@ -1,6 +1,6 @@
-import { useState } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 import { useLocation } from "preact-iso";
-import { signIn, signUp } from "../../models/auth";
+import { getSession, signIn, signUp } from "../../models/auth";
 import {
   Alert,
   Button,
@@ -19,6 +19,17 @@ export default function RegisterPage() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getSession().then((session) => {
+      if (cancelled) return;
+      if (session?.user) location.route("/dashboard", true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const onSubmit = async (event: Event) => {
     event.preventDefault();

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -1,3 +1,6 @@
+import { useEffect } from "preact/hooks";
+import { useSignal } from "@preact/signals";
+import { getSession } from "../../models/auth";
 import {
   Card,
   Eyebrow,
@@ -9,6 +12,19 @@ import {
 } from "../../components";
 
 export default function LandingPage() {
+  const authed = useSignal(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    getSession().then((session) => {
+      if (cancelled) return;
+      authed.value = Boolean(session?.user);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <PageShell class="gap-10">
       <section class="py-8 md:py-12 border-y border-border flex flex-col gap-5">
@@ -21,10 +37,16 @@ export default function LandingPage() {
           without executing package code or exposing credentials to untrusted package contents.
         </p>
         <div class="flex gap-3 mt-2">
-          <LinkButton href="/register">Create account</LinkButton>
-          <LinkButton href="/login" variant="secondary">
-            Sign in
-          </LinkButton>
+          {authed.value ? (
+            <LinkButton href="/dashboard">Open dashboard</LinkButton>
+          ) : (
+            <>
+              <LinkButton href="/register">Create account</LinkButton>
+              <LinkButton href="/login" variant="secondary">
+                Sign in
+              </LinkButton>
+            </>
+          )}
         </div>
       </section>
 

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "preact/hooks";
 import { useSignal } from "@preact/signals";
+import { Show } from "@preact/signals/utils";
 import { getSession } from "../../models/auth";
 import {
   Card,
@@ -37,16 +38,19 @@ export default function LandingPage() {
           without executing package code or exposing credentials to untrusted package contents.
         </p>
         <div class="flex gap-3 mt-2">
-          {authed.value ? (
+          <Show
+            when={authed}
+            fallback={
+              <>
+                <LinkButton href="/register">Create account</LinkButton>
+                <LinkButton href="/login" variant="secondary">
+                  Sign in
+                </LinkButton>
+              </>
+            }
+          >
             <LinkButton href="/dashboard">Open dashboard</LinkButton>
-          ) : (
-            <>
-              <LinkButton href="/register">Create account</LinkButton>
-              <LinkButton href="/login" variant="secondary">
-                Sign in
-              </LinkButton>
-            </>
-          )}
+          </Show>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- Landing page swaps the register/sign-in CTAs for an "Open dashboard" link when a session exists (signal-backed check)
- `/login` and `/register` redirect to `/dashboard` if the visitor already has a session

## Test plan
- [ ] Visit `/`, `/login`, `/register` while signed in — should land on `/dashboard`
- [ ] Visit the same routes while signed out — register/sign-in flows still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)