### PR TITLE
Parallelize backend awaits across pipeline, db, and routes

### DIFF
--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -248,8 +248,10 @@ export async function persistScan(db: AppDb, input: PersistedScanInput) {
       },
     });
 
-  await db.delete(scanFiles).where(eq(scanFiles.scanId, input.id));
-  await db.delete(scanFindings).where(eq(scanFindings.scanId, input.id));
+  await Promise.all([
+    db.delete(scanFiles).where(eq(scanFiles.scanId, input.id)),
+    db.delete(scanFindings).where(eq(scanFindings.scanId, input.id)),
+  ]);
 
   const diffByPath = new Map(input.diff.map((entry) => [entry.path, entry]));
   const rows = input.files.map((file) => {
@@ -265,21 +267,23 @@ export async function persistScan(db: AppDb, input: PersistedScanInput) {
       textSample: file.textSample || null,
     };
   });
-  if (rows.length) await db.insert(scanFiles).values(rows);
 
-  if (input.findings.length) {
-    await db.insert(scanFindings).values(
-      input.findings.map((finding) => ({
-        id: crypto.randomUUID(),
-        scanId: input.id,
-        severity: finding.severity,
-        file: finding.file,
-        evidence: finding.evidence,
-        reason: finding.reason,
-        source: "rule",
-      })),
-    );
-  }
+  await Promise.all([
+    rows.length ? db.insert(scanFiles).values(rows) : Promise.resolve(),
+    input.findings.length
+      ? db.insert(scanFindings).values(
+          input.findings.map((finding) => ({
+            id: crypto.randomUUID(),
+            scanId: input.id,
+            severity: finding.severity,
+            file: finding.file,
+            evidence: finding.evidence,
+            reason: finding.reason,
+            source: "rule",
+          })),
+        )
+      : Promise.resolve(),
+  ]);
 }
 
 export async function listScans(db: AppDb, organizationId: string) {
@@ -308,14 +312,17 @@ export async function listScans(db: AppDb, organizationId: string) {
 }
 
 export async function getScan(db: AppDb, id: string, organizationId: string) {
-  const [scan] = await db
-    .select()
-    .from(scans)
-    .where(and(eq(scans.id, id), eq(scans.organizationId, organizationId)))
-    .limit(1);
+  const [scanRows, files, findings] = await Promise.all([
+    db
+      .select()
+      .from(scans)
+      .where(and(eq(scans.id, id), eq(scans.organizationId, organizationId)))
+      .limit(1),
+    db.select().from(scanFiles).where(eq(scanFiles.scanId, id)),
+    db.select().from(scanFindings).where(eq(scanFindings.scanId, id)),
+  ]);
+  const scan = scanRows[0];
   if (!scan) return null;
-  const files = await db.select().from(scanFiles).where(eq(scanFiles.scanId, id));
-  const findings = await db.select().from(scanFindings).where(eq(scanFindings.scanId, id));
   return { scan, files, findings };
 }
 

--- a/server/lib/npm-connection.ts
+++ b/server/lib/npm-connection.ts
@@ -128,14 +128,16 @@ export async function validateNpmCredential(
   options: { stageId?: string } = {},
 ): Promise<NpmCredentialValidation> {
   const registry = normalizeRegistryUrl(registryUrl);
-  const auth = await validateRegistryAuth(registry, token);
-  const stagedList = await validateStagedListAccess(registry, token);
-  const stagedView = options.stageId
-    ? await validateStagedViewAccess(registry, token, options.stageId)
-    : null;
-  const stagedTarball = options.stageId
-    ? await validateStagedTarballAccess(registry, token, options.stageId)
-    : null;
+  const [auth, stagedList, stagedView, stagedTarball] = await Promise.all([
+    validateRegistryAuth(registry, token),
+    validateStagedListAccess(registry, token),
+    options.stageId
+      ? validateStagedViewAccess(registry, token, options.stageId)
+      : Promise.resolve(null),
+    options.stageId
+      ? validateStagedTarballAccess(registry, token, options.stageId)
+      : Promise.resolve(null),
+  ]);
   const ok =
     auth.registryAuth &&
     stagedList.stagedListAccess &&

--- a/server/lib/scan-job.ts
+++ b/server/lib/scan-job.ts
@@ -41,14 +41,16 @@ export async function executeScanJob(
   options: ExecuteScanJobOptions = {},
 ) {
   const session: WorkspaceSession = { userId: message.actorUserId };
-  await markScanRunning(db, message.scanId, message.organizationId);
-  await recordScanEvent(db, {
-    organizationId: message.organizationId,
-    actorUserId: message.actorUserId,
-    scanId: message.scanId,
-    type: "scan.started",
-    metadata: { stageId: message.stageId, attempt: options.attempt ?? 1 },
-  });
+  await Promise.all([
+    markScanRunning(db, message.scanId, message.organizationId),
+    recordScanEvent(db, {
+      organizationId: message.organizationId,
+      actorUserId: message.actorUserId,
+      scanId: message.scanId,
+      type: "scan.started",
+      metadata: { stageId: message.stageId, attempt: options.attempt ?? 1 },
+    }),
+  ]);
 
   try {
     const npmConnection = await getNpmConnection(db, message.organizationId);
@@ -56,19 +58,21 @@ export async function executeScanJob(
       throw new Error("Connect an organization npm token before scanning staged publishes.");
     }
 
-    const orgNpmToken = await decryptNpmToken(env, npmConnection);
-    await markNpmConnectionUsed(db, message.organizationId);
-    await recordScanEvent(db, {
-      organizationId: message.organizationId,
-      actorUserId: message.actorUserId,
-      scanId: message.scanId,
-      type: "npm_connection.used",
-      metadata: {
-        stageId: message.stageId,
-        registryUrl: npmConnection.registryUrl,
-        tokenFingerprint: npmConnection.tokenFingerprint,
-      },
-    });
+    const [orgNpmToken] = await Promise.all([
+      decryptNpmToken(env, npmConnection),
+      markNpmConnectionUsed(db, message.organizationId),
+      recordScanEvent(db, {
+        organizationId: message.organizationId,
+        actorUserId: message.actorUserId,
+        scanId: message.scanId,
+        type: "npm_connection.used",
+        metadata: {
+          stageId: message.stageId,
+          registryUrl: npmConnection.registryUrl,
+          tokenFingerprint: npmConnection.tokenFingerprint,
+        },
+      }),
+    ]);
 
     return await runScanPipeline(
       { env, executionCtx, db, session },
@@ -85,14 +89,16 @@ export async function executeScanJob(
   } catch (err) {
     const safe = classifyScanError(err);
     if (!safe.retryable || options.finalAttempt) {
-      await markScanFailed(db, message.scanId, message.organizationId, safe);
-      await recordScanEvent(db, {
-        organizationId: message.organizationId,
-        actorUserId: message.actorUserId,
-        scanId: message.scanId,
-        type: "scan.failed",
-        metadata: { stageId: message.stageId, attempt: options.attempt ?? 1, error: safe },
-      });
+      await Promise.all([
+        markScanFailed(db, message.scanId, message.organizationId, safe),
+        recordScanEvent(db, {
+          organizationId: message.organizationId,
+          actorUserId: message.actorUserId,
+          scanId: message.scanId,
+          type: "scan.failed",
+          metadata: { stageId: message.stageId, attempt: options.attempt ?? 1, error: safe },
+        }),
+      ]);
     } else {
       await recordScanEvent(db, {
         organizationId: message.organizationId,

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -114,45 +114,46 @@ export async function runScanPipeline(
   };
   const reportDigest = await sha256Hex(stableJson(reportPayload));
 
-  await persistScan(db, {
-    id: scanId,
-    stageId: input.stageId,
-    organizationId: input.organizationId,
-    ownerUserId: session.userId,
-    packageJson: redactedPackageJson,
-    previousPackageJson: redactedPreviousPackageJson,
-    risk,
-    status: "complete",
-    summary: {
-      report: {
-        version: reportPayload.version,
-        digest: reportDigest,
-        digestAlgorithm: "sha256",
-        generatedAt: new Date().toISOString(),
-      },
-      packageJsonDiff,
-      diff,
-      safety: result.safety,
-    },
-    ai: aiFindings,
-    files: redactedStagedFiles,
-    diff,
-    findings: ruleFindings,
-    report: { version: reportPayload.version, digest: reportDigest },
-  });
-
-  await recordScanEvent(db, {
-    organizationId: input.organizationId,
-    actorUserId: session.userId,
-    scanId,
-    type: "scan.completed",
-    metadata: {
+  await Promise.all([
+    persistScan(db, {
+      id: scanId,
       stageId: input.stageId,
-      packageName: result.package.name,
-      stagedVersion: result.package.stagedVersion,
+      organizationId: input.organizationId,
+      ownerUserId: session.userId,
+      packageJson: redactedPackageJson,
+      previousPackageJson: redactedPreviousPackageJson,
       risk,
-    },
-  });
+      status: "complete",
+      summary: {
+        report: {
+          version: reportPayload.version,
+          digest: reportDigest,
+          digestAlgorithm: "sha256",
+          generatedAt: new Date().toISOString(),
+        },
+        packageJsonDiff,
+        diff,
+        safety: result.safety,
+      },
+      ai: aiFindings,
+      files: redactedStagedFiles,
+      diff,
+      findings: ruleFindings,
+      report: { version: reportPayload.version, digest: reportDigest },
+    }),
+    recordScanEvent(db, {
+      organizationId: input.organizationId,
+      actorUserId: session.userId,
+      scanId,
+      type: "scan.completed",
+      metadata: {
+        stageId: input.stageId,
+        packageName: result.package.name,
+        stagedVersion: result.package.stagedVersion,
+        risk,
+      },
+    }),
+  ]);
 
   return result;
 }

--- a/server/routes/npm-connection.ts
+++ b/server/routes/npm-connection.ts
@@ -53,30 +53,33 @@ npmConnectionRoutes.post("/", async (c) => {
     const db = createDb(c.env.DB);
     const session = c.get("authSession");
     const organizationId = await ensurePersonalOrganization(db, session);
-    await enforceRateLimit(db, {
-      key: `npm-connection:save:${organizationId}`,
-      limit: 20,
-      windowMs: 60 * 60 * 1000,
-    });
-    const encrypted = await encryptNpmToken(c.env, token);
-    const connection = await upsertNpmConnection(db, {
-      organizationId,
-      registryUrl,
-      label,
-      createdByUserId: session.userId,
-      ...encrypted,
-    });
-
-    await recordScanEvent(db, {
-      organizationId,
-      actorUserId: session.userId,
-      type: "npm_connection.upserted",
-      metadata: {
+    const [, encrypted] = await Promise.all([
+      enforceRateLimit(db, {
+        key: `npm-connection:save:${organizationId}`,
+        limit: 20,
+        windowMs: 60 * 60 * 1000,
+      }),
+      encryptNpmToken(c.env, token),
+    ]);
+    const [connection] = await Promise.all([
+      upsertNpmConnection(db, {
+        organizationId,
         registryUrl,
         label,
-        tokenFingerprint: encrypted.tokenFingerprint,
-      },
-    });
+        createdByUserId: session.userId,
+        ...encrypted,
+      }),
+      recordScanEvent(db, {
+        organizationId,
+        actorUserId: session.userId,
+        type: "npm_connection.upserted",
+        metadata: {
+          registryUrl,
+          label,
+          tokenFingerprint: encrypted.tokenFingerprint,
+        },
+      }),
+    ]);
 
     return c.json({ connection: publicNpmConnection(connection) });
   } catch (err) {
@@ -118,23 +121,24 @@ npmConnectionRoutes.post("/validate", async (c) => {
 
     const token = await decryptNpmToken(c.env, connection);
     const validation = await validateNpmCredential(connection.registryUrl, token, { stageId });
-    const updated = await updateNpmConnectionValidation(db, {
-      organizationId,
-      validationStatus: validation.status,
-      capabilities: validation.capabilities,
-      validatedAt: validation.ok ? new Date() : null,
-    });
-
-    await recordScanEvent(db, {
-      organizationId,
-      actorUserId: session.userId,
-      type: "npm_connection.validated",
-      metadata: {
-        ok: validation.ok,
-        status: validation.status,
+    const [updated] = await Promise.all([
+      updateNpmConnectionValidation(db, {
+        organizationId,
+        validationStatus: validation.status,
         capabilities: validation.capabilities,
-      },
-    });
+        validatedAt: validation.ok ? new Date() : null,
+      }),
+      recordScanEvent(db, {
+        organizationId,
+        actorUserId: session.userId,
+        type: "npm_connection.validated",
+        metadata: {
+          ok: validation.ok,
+          status: validation.status,
+          capabilities: validation.capabilities,
+        },
+      }),
+    ]);
 
     return c.json({ validation, connection: publicNpmConnection(updated) });
   } catch (err) {
@@ -157,18 +161,20 @@ npmConnectionRoutes.delete("/", async (c) => {
   const session = c.get("authSession");
   const organizationId = await ensurePersonalOrganization(db, session);
   const existing = await getNpmConnection(db, organizationId);
-  await deleteNpmConnection(db, organizationId);
-  if (existing) {
-    await recordScanEvent(db, {
-      organizationId,
-      actorUserId: session.userId,
-      type: "npm_connection.deleted",
-      metadata: {
-        registryUrl: existing.registryUrl,
-        label: existing.label,
-        tokenFingerprint: existing.tokenFingerprint,
-      },
-    });
-  }
+  await Promise.all([
+    deleteNpmConnection(db, organizationId),
+    existing
+      ? recordScanEvent(db, {
+          organizationId,
+          actorUserId: session.userId,
+          type: "npm_connection.deleted",
+          metadata: {
+            registryUrl: existing.registryUrl,
+            label: existing.label,
+            tokenFingerprint: existing.tokenFingerprint,
+          },
+        })
+      : Promise.resolve(),
+  ]);
   return c.json({ ok: true });
 });

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -130,12 +130,16 @@ scansRoutes.get("/:id/versions", async (c) => {
     });
   }
 
+  let connection: Awaited<ReturnType<typeof getOrganizationNpmToken>> = null;
   try {
-    await enforceRateLimit(db, {
-      key: `compare-versions:${session.userId}`,
-      limit: 60,
-      windowMs: 60 * 1000,
-    });
+    [, connection] = await Promise.all([
+      enforceRateLimit(db, {
+        key: `compare-versions:${session.userId}`,
+        limit: 60,
+        windowMs: 60 * 1000,
+      }),
+      getOrganizationNpmToken(db, c.env, organizationId).catch(() => null),
+    ]);
   } catch (err) {
     if (err instanceof RateLimitError) {
       return c.json(
@@ -147,7 +151,6 @@ scansRoutes.get("/:id/versions", async (c) => {
     throw err;
   }
 
-  const connection = await getOrganizationNpmToken(db, c.env, organizationId).catch(() => null);
   const metadata = await fetchPackageMetadata(c.env, scan.scan.packageName, {
     npmToken: connection?.token,
     npmRegistry: connection?.registryUrl,
@@ -225,12 +228,16 @@ scansRoutes.get("/:id/compare", async (c) => {
   if ("error" in ctx) return ctx.error;
   const { version, db, session, packageName } = ctx;
 
+  let connection: Awaited<ReturnType<typeof getOrganizationNpmToken>> = null;
   try {
-    await enforceRateLimit(db, {
-      key: `compare-fetch:${session.userId}`,
-      limit: 30,
-      windowMs: 60 * 1000,
-    });
+    [, connection] = await Promise.all([
+      enforceRateLimit(db, {
+        key: `compare-fetch:${session.userId}`,
+        limit: 30,
+        windowMs: 60 * 1000,
+      }),
+      getOrganizationNpmToken(db, c.env, ctx.organizationId).catch(() => null),
+    ]);
   } catch (err) {
     if (err instanceof RateLimitError) {
       return c.json(
@@ -242,7 +249,6 @@ scansRoutes.get("/:id/compare", async (c) => {
     throw err;
   }
 
-  const connection = await getOrganizationNpmToken(db, c.env, ctx.organizationId).catch(() => null);
   const metadata = await fetchPackageMetadata(c.env, packageName, {
     npmToken: connection?.token,
     npmRegistry: connection?.registryUrl,
@@ -275,12 +281,16 @@ scansRoutes.get("/:id/compare/file", async (c) => {
   const path = c.req.query("path") || "";
   if (!path) return c.json({ error: "path is required" }, 400);
 
+  let connection: Awaited<ReturnType<typeof getOrganizationNpmToken>> = null;
   try {
-    await enforceRateLimit(db, {
-      key: `compare-file:${session.userId}`,
-      limit: 240,
-      windowMs: 60 * 1000,
-    });
+    [, connection] = await Promise.all([
+      enforceRateLimit(db, {
+        key: `compare-file:${session.userId}`,
+        limit: 240,
+        windowMs: 60 * 1000,
+      }),
+      getOrganizationNpmToken(db, c.env, ctx.organizationId).catch(() => null),
+    ]);
   } catch (err) {
     if (err instanceof RateLimitError) {
       return c.json(
@@ -292,7 +302,6 @@ scansRoutes.get("/:id/compare/file", async (c) => {
     throw err;
   }
 
-  const connection = await getOrganizationNpmToken(db, c.env, ctx.organizationId).catch(() => null);
   const metadata = await fetchPackageMetadata(c.env, packageName, {
     npmToken: connection?.token,
     npmRegistry: connection?.registryUrl,


### PR DESCRIPTION
## Summary

Performance pass on the Worker backend: groups independent awaits with `Promise.all` so that operations no longer block each other unnecessarily.

- `validateNpmCredential` now fires its four npm registry checks (whoami, staged list, staged view, ranged tarball) concurrently instead of in series — typically a ~4x latency reduction on the validation endpoint.
- D1 helpers fan out: `getScan` parallelizes the scan / files / findings selects, and `persistScan` parallelizes its two deletes and its files/findings inserts.
- `runScanPipeline` runs the final `persistScan` and `scan.completed` audit event in parallel. `executeScanJob` does the same for the `scan.started`, `npm_connection.used`, and `scan.failed` status writes and their audit events.
- `scans.ts` compare / versions / compare-file handlers overlap `enforceRateLimit` with `getOrganizationNpmToken`, and `npm-connection.ts` POST / validate / DELETE overlap their connection writes with the corresponding audit events.

## Test plan

- [x] `pnpm run verify` (lint + format check + typecheck + 20 vitest tests) all green.