### PR TITLE
Tighten security posture across auth, sandbox, and storage

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { createDb, enforceRateLimit, RateLimitError } from "./db";
 import { createAuth, getAuthSession } from "./lib/auth";
 import {
   classifyScanError,
@@ -57,21 +58,89 @@ app.use("/api/*", async (c, next) => {
   try {
     c.set("auth", createAuth(c.env));
   } catch (err) {
-    return c.json(
-      {
-        error: "auth is not configured",
-        detail: err instanceof Error ? err.message : String(err),
-      },
-      503,
-    );
+    console.error("auth initialization failed", err);
+    return c.json({ error: "auth is not configured" }, 503);
   }
   await next();
+});
+
+const STATE_CHANGING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+app.use("/api/*", async (c, next) => {
+  if (!STATE_CHANGING_METHODS.has(c.req.method)) return next();
+  const expected = c.env.BETTER_AUTH_URL;
+  if (!expected) return next();
+  const expectedOrigin = (() => {
+    try {
+      return new URL(expected).origin;
+    } catch {
+      return null;
+    }
+  })();
+  if (!expectedOrigin) return next();
+  const origin = c.req.header("origin");
+  const referer = c.req.header("referer");
+  const sourceOrigin =
+    origin ||
+    (referer
+      ? (() => {
+          try {
+            return new URL(referer).origin;
+          } catch {
+            return null;
+          }
+        })()
+      : null);
+  if (!sourceOrigin || sourceOrigin !== expectedOrigin) {
+    return c.json({ error: "request origin not allowed" }, 403);
+  }
+  return next();
+});
+
+app.use("/api/auth/*", async (c, next) => {
+  if (c.req.method !== "POST") return next();
+  const path = c.req.path;
+  const limit = authIpLimit(path);
+  if (!limit) return next();
+  const ip =
+    c.req.header("cf-connecting-ip") || c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
+  if (!ip) return next();
+  try {
+    await enforceRateLimit(createDb(c.env.DB), {
+      key: `auth:${limit.bucket}:${ip}`,
+      limit: limit.max,
+      windowMs: limit.windowMs,
+    });
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      return c.json(
+        { error: "too many authentication attempts", retryAfterSeconds: err.retryAfterSeconds },
+        429,
+        { "retry-after": String(err.retryAfterSeconds) },
+      );
+    }
+    throw err;
+  }
+  return next();
 });
 
 app.all("/api/auth/*", (c) => {
   const auth = c.get("auth");
   return (auth as { handler(request: Request): Promise<Response> }).handler(c.req.raw);
 });
+
+function authIpLimit(path: string): { bucket: string; max: number; windowMs: number } | null {
+  if (path.startsWith("/api/auth/sign-in")) {
+    return { bucket: "sign-in", max: 10, windowMs: 15 * 60 * 1000 };
+  }
+  if (path.startsWith("/api/auth/sign-up")) {
+    return { bucket: "sign-up", max: 5, windowMs: 60 * 60 * 1000 };
+  }
+  if (path.startsWith("/api/auth/forget-password") || path.startsWith("/api/auth/reset-password")) {
+    return { bucket: "password-reset", max: 5, windowMs: 60 * 60 * 1000 };
+  }
+  return null;
+}
 
 app.use("/api/*", async (c, next) => {
   const session = await getAuthSession(c.get("auth"), c.req.raw);

--- a/server/lib/auth.ts
+++ b/server/lib/auth.ts
@@ -14,10 +14,12 @@ export function createAuth(env: Cloudflare.Env) {
   if (!env.BETTER_AUTH_SECRET) throw new Error("BETTER_AUTH_SECRET is required");
 
   const db = createDb(env.DB);
+  const trustedOrigins = env.BETTER_AUTH_URL ? [env.BETTER_AUTH_URL] : [];
   return betterAuth({
     secret: env.BETTER_AUTH_SECRET,
     baseURL: env.BETTER_AUTH_URL,
     basePath: "/api/auth",
+    trustedOrigins,
     database: drizzleAdapter(db, {
       provider: "sqlite",
       schema,
@@ -25,6 +27,17 @@ export function createAuth(env: Cloudflare.Env) {
     }) as never,
     emailAndPassword: {
       enabled: true,
+      minPasswordLength: 12,
+      maxPasswordLength: 256,
+    },
+    advanced: {
+      cookiePrefix: "spr",
+      defaultCookieAttributes: {
+        httpOnly: true,
+        secure: true,
+        sameSite: "lax",
+        path: "/",
+      },
     },
   });
 }

--- a/server/lib/compare-cache.ts
+++ b/server/lib/compare-cache.ts
@@ -8,21 +8,26 @@ export interface CachedCompare {
   cachedAt: string;
 }
 
-const CACHE_PREFIX = "compare:v1:";
+const CACHE_PREFIX = "compare:v2:";
 const CACHE_TTL_SECONDS = 60 * 60 * 24 * 30;
 
-function cacheKey(packageName: string, version: string): string {
-  return `${CACHE_PREFIX}${packageName}@${version}`;
+export async function computeCompareCacheKey(
+  registryUrl: string,
+  tarballUrl: string,
+): Promise<string> {
+  const data = new TextEncoder().encode(`${registryUrl}|${tarballUrl}`);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  const hex = [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+  return `${CACHE_PREFIX}${hex}`;
 }
 
 export async function readCompareCache(
   env: Cloudflare.Env,
-  packageName: string,
-  version: string,
+  key: string,
 ): Promise<CachedCompare | null> {
   if (!env.COMPARE_CACHE) return null;
   try {
-    return await env.COMPARE_CACHE.get<CachedCompare>(cacheKey(packageName, version), "json");
+    return await env.COMPARE_CACHE.get<CachedCompare>(key, "json");
   } catch {
     return null;
   }
@@ -31,34 +36,30 @@ export async function readCompareCache(
 async function writeCompareCache(
   env: Cloudflare.Env,
   ctx: ExecutionContext,
-  packageName: string,
+  key: string,
   payload: CachedCompare,
 ) {
   if (!env.COMPARE_CACHE) return;
-  const write = env.COMPARE_CACHE.put(
-    cacheKey(packageName, payload.version),
-    JSON.stringify(payload),
-    {
-      expirationTtl: CACHE_TTL_SECONDS,
-    },
-  ).catch(() => undefined);
+  const write = env.COMPARE_CACHE.put(key, JSON.stringify(payload), {
+    expirationTtl: CACHE_TTL_SECONDS,
+  }).catch(() => undefined);
   ctx.waitUntil(write);
 }
 
 export async function loadCompare(
   env: Cloudflare.Env,
   ctx: ExecutionContext,
-  packageName: string,
   version: string,
-  options: { tarballUrl: string; npmToken?: string; npmRegistry?: string },
+  options: { tarballUrl: string; registryUrl: string; npmToken?: string },
 ): Promise<CachedCompare> {
-  const cached = await readCompareCache(env, packageName, version);
+  const key = await computeCompareCacheKey(options.registryUrl, options.tarballUrl);
+  const cached = await readCompareCache(env, key);
   if (cached) return cached;
 
   const downloaded = await downloadInSandbox(env, ctx, {
     tarballUrl: options.tarballUrl,
     npmToken: options.npmToken,
-    npmRegistry: options.npmRegistry,
+    npmRegistry: options.registryUrl,
   });
 
   const payload: CachedCompare = {
@@ -67,7 +68,7 @@ export async function loadCompare(
     packageJson: redactJson(downloaded.packageJson ?? null),
     cachedAt: new Date().toISOString(),
   };
-  await writeCompareCache(env, ctx, packageName, payload);
+  await writeCompareCache(env, ctx, key, payload);
   return payload;
 }
 

--- a/server/lib/npm-connection.ts
+++ b/server/lib/npm-connection.ts
@@ -79,10 +79,12 @@ export function publicNpmConnection(
   };
 }
 
+const CIPHERTEXT_VERSION_V1 = "v1:";
+
 export async function encryptNpmToken(env: Cloudflare.Env, token: string): Promise<EncryptedToken> {
   const trimmed = token.trim();
   if (trimmed.length < 16) throw new Error("npm token is too short");
-  const key = await encryptionKey(env);
+  const key = await encryptionKey(env, "v1");
   const nonce = crypto.getRandomValues(new Uint8Array(12));
   const ciphertext = await crypto.subtle.encrypt(
     { name: "AES-GCM", iv: nonce },
@@ -90,7 +92,7 @@ export async function encryptNpmToken(env: Cloudflare.Env, token: string): Promi
     new TextEncoder().encode(trimmed),
   );
   return {
-    tokenCiphertext: base64UrlEncode(new Uint8Array(ciphertext)),
+    tokenCiphertext: CIPHERTEXT_VERSION_V1 + base64UrlEncode(new Uint8Array(ciphertext)),
     tokenNonce: base64UrlEncode(nonce),
     tokenFingerprint: await tokenFingerprint(trimmed),
     tokenLast4: trimmed.slice(-4),
@@ -101,13 +103,21 @@ export async function decryptNpmToken(
   env: Cloudflare.Env,
   encrypted: { tokenCiphertext: string; tokenNonce: string },
 ): Promise<string> {
-  const key = await encryptionKey(env);
+  const { version, payload } = splitCiphertext(encrypted.tokenCiphertext);
+  const key = await encryptionKey(env, version);
   const plaintext = await crypto.subtle.decrypt(
     { name: "AES-GCM", iv: base64UrlDecode(encrypted.tokenNonce) },
     key,
-    base64UrlDecode(encrypted.tokenCiphertext),
+    base64UrlDecode(payload),
   );
   return new TextDecoder().decode(plaintext);
+}
+
+function splitCiphertext(value: string): { version: "v0" | "v1"; payload: string } {
+  if (value.startsWith(CIPHERTEXT_VERSION_V1)) {
+    return { version: "v1", payload: value.slice(CIPHERTEXT_VERSION_V1.length) };
+  }
+  return { version: "v0", payload: value };
 }
 
 export async function getOrganizationNpmToken(
@@ -260,11 +270,33 @@ function npmAuthHeaders(token: string, accept: string) {
   };
 }
 
-async function encryptionKey(env: Cloudflare.Env) {
+async function encryptionKey(env: Cloudflare.Env, version: "v0" | "v1") {
   const secret = env.NPM_CONNECTIONS_ENCRYPTION_KEY;
   if (!secret) throw new Error("NPM_CONNECTIONS_ENCRYPTION_KEY is required");
-  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(secret));
-  return crypto.subtle.importKey("raw", digest, { name: "AES-GCM" }, false, ["encrypt", "decrypt"]);
+  if (secret.length < 32) {
+    throw new Error("NPM_CONNECTIONS_ENCRYPTION_KEY must be at least 32 characters of entropy");
+  }
+  const ikm = new TextEncoder().encode(secret);
+  if (version === "v0") {
+    const digest = await crypto.subtle.digest("SHA-256", ikm);
+    return crypto.subtle.importKey("raw", digest, { name: "AES-GCM" }, false, [
+      "encrypt",
+      "decrypt",
+    ]);
+  }
+  const keyMaterial = await crypto.subtle.importKey("raw", ikm, "HKDF", false, ["deriveKey"]);
+  return crypto.subtle.deriveKey(
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      salt: new TextEncoder().encode("staged-publish-review:npm-connection:salt:v1"),
+      info: new TextEncoder().encode("aes-gcm-256"),
+    },
+    keyMaterial,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"],
+  );
 }
 
 async function tokenFingerprint(token: string) {

--- a/server/lib/registry.ts
+++ b/server/lib/registry.ts
@@ -4,11 +4,22 @@ export interface RegistryMetadata {
   time?: Record<string, string>;
 }
 
+const NPM_PACKAGE_NAME_RE = /^(?:@[a-z0-9][a-z0-9._~-]*\/)?[a-z0-9][a-z0-9._~-]*$/;
+
+export function isValidNpmPackageName(name: string): boolean {
+  if (typeof name !== "string") return false;
+  if (name.length === 0 || name.length > 214) return false;
+  return NPM_PACKAGE_NAME_RE.test(name);
+}
+
 export async function fetchPackageMetadata(
   env: Cloudflare.Env,
   name: string,
   options: { npmToken?: string; npmRegistry?: string } = {},
 ): Promise<RegistryMetadata> {
+  if (!isValidNpmPackageName(name)) {
+    throw new Error("invalid package name");
+  }
   const registry = (
     options.npmRegistry ||
     env.NPM_REGISTRY ||

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -47,13 +47,24 @@ const RISK_RANK: Record<RiskLevel, number> = { low: 0, medium: 1, high: 2, criti
 const SECRET_PATTERNS: Array<[RegExp, string]> = [
   [/npm_[A-Za-z0-9]{20,}/g, "[REDACTED_NPM_TOKEN]"],
   [/gh[pousr]_[A-Za-z0-9_]{20,}/g, "[REDACTED_GITHUB_TOKEN]"],
+  [/github_pat_[A-Za-z0-9_]{20,}/g, "[REDACTED_GITHUB_TOKEN]"],
   [/AKIA[0-9A-Z]{16}/g, "[REDACTED_AWS_ACCESS_KEY]"],
+  [/ASIA[0-9A-Z]{16}/g, "[REDACTED_AWS_SESSION_KEY]"],
+  [/AIza[0-9A-Za-z\-_]{35}/g, "[REDACTED_GOOGLE_API_KEY]"],
+  [/ya29\.[0-9A-Za-z\-_]{20,}/g, "[REDACTED_GOOGLE_OAUTH_TOKEN]"],
+  [/sk_(?:live|test)_[0-9a-zA-Z]{16,}/g, "[REDACTED_STRIPE_KEY]"],
+  [/rk_(?:live|test)_[0-9a-zA-Z]{16,}/g, "[REDACTED_STRIPE_KEY]"],
+  [/xox[abprs]-[A-Za-z0-9-]{10,}/g, "[REDACTED_SLACK_TOKEN]"],
+  [/https:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9/]+/g, "[REDACTED_SLACK_WEBHOOK]"],
+  [/eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g, "[REDACTED_JWT]"],
+  [/\b(?:[A-Za-z]+:\/\/)[^\s/@:]+:[^\s/@]+@[^\s'"\\]+/g, "[REDACTED_URL_WITH_CREDENTIALS]"],
   [
-    /-----BEGIN (?:RSA |OPENSSH |EC |DSA )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |OPENSSH |EC |DSA )?PRIVATE KEY-----/g,
+    /-----BEGIN (?:RSA |OPENSSH |EC |DSA |PGP |ENCRYPTED )?PRIVATE KEY(?: BLOCK)?-----[\s\S]*?-----END (?:RSA |OPENSSH |EC |DSA |PGP |ENCRYPTED )?PRIVATE KEY(?: BLOCK)?-----/g,
     "[REDACTED_PRIVATE_KEY]",
   ],
+  [/(authorization\s*[:=]\s*)['"]?Bearer\s+[A-Za-z0-9._\-+/=]{16,}/gi, "$1[REDACTED_BEARER]"],
   [
-    /((?:secret|token|password|passwd|pwd|api[_-]?key)\s*=\s*)['"]?[^'"\s]{12,}/gi,
+    /((?:secret|token|password|passwd|pwd|api[_-]?key|access[_-]?key|client[_-]?secret)\s*[:=]\s*)['"]?[^'"\s]{12,}/gi,
     "$1[REDACTED_SECRET]",
   ],
 ];

--- a/server/lib/sandbox.ts
+++ b/server/lib/sandbox.ts
@@ -89,6 +89,21 @@ export async function downloadInSandbox(
   ctx: ExecutionContext,
   options: DownloadOptions,
 ): Promise<DownloadResult> {
+  const registry = options.npmRegistry || env.NPM_REGISTRY || "https://registry.npmjs.org";
+  if (options.tarballUrl) {
+    try {
+      const tarball = new URL(options.tarballUrl);
+      const registryOrigin = new URL(registry).origin;
+      if (tarball.origin !== registryOrigin || tarball.protocol !== "https:") {
+        throw new SandboxError(
+          JSON.stringify({ error: "tarball URL is not allowed by the gateway", status: 400 }),
+        );
+      }
+    } catch (err) {
+      if (err instanceof SandboxError) throw err;
+      throw new SandboxError(JSON.stringify({ error: "invalid tarball URL", status: 400 }));
+    }
+  }
   const sandbox = env.LOADER.load({
     compatibilityDate: "2026-05-20",
     mainModule: "sandbox.js",
@@ -140,24 +155,52 @@ export default {
     const res = await fetch(url, { headers: { accept: "application/octet-stream" } });
     if (!res.ok) return json({ error: "download failed", status: res.status }, 502);
 
+    const maxTarBytes = env.MAX_TAR_BYTES || 26214400;
     const contentLength = Number(res.headers.get("content-length") || "0");
-    if (contentLength > (env.MAX_TAR_BYTES || 26214400)) return json({ error: "tarball too large", status: 413 }, 413);
-    const gzip = await res.arrayBuffer();
-    const tar = await gunzip(gzip);
-    if (tar.byteLength > (env.MAX_TAR_BYTES || 26214400)) return json({ error: "archive expands beyond safety limit", status: 413 }, 413);
-    const files = await readTar(tar, env.MAX_FILES || 250, env.MAX_BYTES_PER_FILE || 65536);
+    if (contentLength > maxTarBytes) return json({ error: "tarball too large", status: 413 }, 413);
+    let tar;
+    try {
+      tar = await gunzipBounded(res.body, maxTarBytes);
+    } catch (err) {
+      const reason = err && err.message === "archive expands beyond safety limit"
+        ? "archive expands beyond safety limit"
+        : "tarball decompression failed";
+      const status = reason === "archive expands beyond safety limit" ? 413 : 400;
+      return json({ error: reason, status }, status);
+    }
+    if (tar.byteLength > maxTarBytes) return json({ error: "archive expands beyond safety limit", status: 413 }, 413);
+    const files = await readTar(tar, env.MAX_FILES || 250, env.MAX_BYTES_PER_FILE || 65536, maxTarBytes);
     const packageJson = parsePackageJson(files);
     return json({ files, packageJson });
   },
 };
 
-async function gunzip(buffer) {
+async function gunzipBounded(body, maxBytes) {
+  if (!body) throw new Error("tarball decompression failed");
   const ds = new DecompressionStream("gzip");
-  const stream = new Response(buffer).body.pipeThrough(ds);
-  return await new Response(stream).arrayBuffer();
+  const reader = body.pipeThrough(ds).getReader();
+  const chunks = [];
+  let total = 0;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      reader.cancel().catch(() => undefined);
+      throw new Error("archive expands beyond safety limit");
+    }
+    chunks.push(value);
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out.buffer;
 }
 
-async function readTar(buffer, maxFiles, maxBytesPerFile) {
+async function readTar(buffer, maxFiles, maxBytesPerFile, maxTarBytes) {
   const bytes = new Uint8Array(buffer);
   const files = [];
   let nextLongName = null;
@@ -172,6 +215,7 @@ async function readTar(buffer, maxFiles, maxBytesPerFile) {
     const sizeText = readString(header, 124, 12).trim() || "0";
     if (!/^[0-7]+$/.test(sizeText)) throw new Error("invalid tar entry size");
     const size = parseInt(sizeText, 8);
+    if (!Number.isFinite(size) || size < 0 || size > maxTarBytes) throw new Error("invalid tar entry size");
     const type = String.fromCharCode(header[156] || 48);
     offset += 512;
     if (offset + size > bytes.length) throw new Error("truncated tar entry");
@@ -179,8 +223,13 @@ async function readTar(buffer, maxFiles, maxBytesPerFile) {
 
     if (type === "x") {
       pax = parsePax(body);
+      if (pax && typeof pax.path === "string" && !isSafePaxPath(pax.path)) {
+        throw new Error("invalid pax path");
+      }
     } else if (type === "L") {
-      nextLongName = readString(body, 0, body.length).replace(/\0+$/, "");
+      const candidate = readString(body, 0, body.length).replace(/\0+$/, "");
+      if (!isSafePaxPath(candidate)) throw new Error("invalid long-name path");
+      nextLongName = candidate;
     } else if (type === "0" || type === "\0") {
       const path = normalizeTarPath(pax?.path || nextLongName || (prefix ? prefix + "/" : "") + rawName);
       if (path) files.push(await summarizeFile(path, body, maxBytesPerFile));
@@ -198,6 +247,10 @@ async function readTar(buffer, maxFiles, maxBytesPerFile) {
     offset += Math.ceil(size / 512) * 512;
   }
   return files;
+}
+
+function isSafePaxPath(value) {
+  return typeof value === "string" && !value.includes("\0") && !value.includes("\\");
 }
 
 async function summarizeFile(path, body, maxBytesPerFile) {

--- a/server/lib/scan-job.ts
+++ b/server/lib/scan-job.ts
@@ -24,7 +24,6 @@ export const MAX_SCAN_JOB_ATTEMPTS = 3;
 export interface SafeScanError {
   code: string;
   message: string;
-  detail?: string;
   retryable: boolean;
 }
 
@@ -118,7 +117,6 @@ export function classifyScanError(err: unknown): SafeScanError {
     return {
       code: sandbox.code,
       message: sandbox.message,
-      detail: err.detail,
       retryable: sandbox.retryable,
     };
   }
@@ -130,10 +128,10 @@ export function classifyScanError(err: unknown): SafeScanError {
       retryable: false,
     };
   }
+  console.error("scan job failed", err);
   return {
     code: "scan_failed",
     message: "The scan failed before a report could be generated.",
-    detail: message,
     retryable: true,
   };
 }

--- a/server/routes/npm-connection.ts
+++ b/server/routes/npm-connection.ts
@@ -93,10 +93,8 @@ npmConnectionRoutes.post("/", async (c) => {
         { "retry-after": String(err.retryAfterSeconds) },
       );
     }
-    return c.json(
-      { error: err instanceof Error ? err.message : "failed to store npm connection" },
-      400,
-    );
+    console.error("npm connection upsert failed", err);
+    return c.json({ error: "failed to store npm connection" }, 400);
   }
 });
 
@@ -149,10 +147,8 @@ npmConnectionRoutes.post("/validate", async (c) => {
         { "retry-after": String(err.retryAfterSeconds) },
       );
     }
-    return c.json(
-      { error: err instanceof Error ? err.message : "failed to validate npm connection" },
-      400,
-    );
+    console.error("npm connection validation failed", err);
+    return c.json({ error: "failed to validate npm connection" }, 400);
   }
 });
 

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -194,6 +194,21 @@ scansRoutes.get("/:id/versions", async (c) => {
 
 const VERSION_RE = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$/;
 
+function isTarballUrlAllowed(tarballUrl: string, registryUrl: string): boolean {
+  try {
+    const tarball = new URL(tarballUrl);
+    const registry = new URL(registryUrl);
+    return (
+      tarball.origin === registry.origin &&
+      tarball.protocol === "https:" &&
+      tarball.pathname.endsWith(".tgz") &&
+      tarball.pathname.includes("/-/")
+    );
+  } catch {
+    return false;
+  }
+}
+
 async function resolveCompareContext(
   c: import("hono").Context<{ Bindings: Bindings; Variables: Variables }>,
 ) {
@@ -256,10 +271,15 @@ scansRoutes.get("/:id/compare", async (c) => {
   const tarballUrl = metadata?.versions?.[version]?.dist?.tarball;
   if (!tarballUrl) return c.json({ error: "unknown version" }, 404);
 
-  const cached = await loadCompare(c.env, c.executionCtx, packageName, version, {
+  const registryUrl = connection?.registryUrl || c.env.NPM_REGISTRY || "https://registry.npmjs.org";
+  if (!isTarballUrlAllowed(tarballUrl, registryUrl)) {
+    return c.json({ error: "registry returned an unexpected tarball URL" }, 502);
+  }
+
+  const cached = await loadCompare(c.env, c.executionCtx, version, {
     tarballUrl,
+    registryUrl,
     npmToken: connection?.token,
-    npmRegistry: connection?.registryUrl,
   });
 
   return c.json(
@@ -309,10 +329,15 @@ scansRoutes.get("/:id/compare/file", async (c) => {
   const tarballUrl = metadata?.versions?.[version]?.dist?.tarball;
   if (!tarballUrl) return c.json({ error: "unknown version" }, 404);
 
-  const cached = await loadCompare(c.env, c.executionCtx, packageName, version, {
+  const registryUrl = connection?.registryUrl || c.env.NPM_REGISTRY || "https://registry.npmjs.org";
+  if (!isTarballUrlAllowed(tarballUrl, registryUrl)) {
+    return c.json({ error: "registry returned an unexpected tarball URL" }, 502);
+  }
+
+  const cached = await loadCompare(c.env, c.executionCtx, version, {
     tarballUrl,
+    registryUrl,
     npmToken: connection?.token,
-    npmRegistry: connection?.registryUrl,
   });
 
   const file = cached.files.find((entry) => entry.path === path);

--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -326,15 +326,12 @@ function toDiffSide(file: FileRecord) {
 function ScanFailureAlert({ errorJson }: { errorJson: unknown }) {
   const error =
     errorJson && typeof errorJson === "object"
-      ? (errorJson as { message?: unknown; detail?: unknown; code?: unknown })
+      ? (errorJson as { message?: unknown; code?: unknown })
       : null;
   return (
     <Alert tone="critical">
       <div class="flex flex-col gap-1">
         <strong>{typeof error?.message === "string" ? error.message : "Review failed."}</strong>
-        {typeof error?.detail === "string" ? (
-          <span class="font-mono text-xs break-all">{error.detail}</span>
-        ) : null}
         {typeof error?.code === "string" ? (
           <span class="font-mono text-xs">code: {error.code}</span>
         ) : null}

--- a/test/compare-cache.test.mjs
+++ b/test/compare-cache.test.mjs
@@ -1,0 +1,41 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("cloudflare:workers", () => ({
+  WorkerEntrypoint: class {},
+}));
+
+const { computeCompareCacheKey } = await import("../server/lib/compare-cache.ts");
+
+describe("compare cache key", () => {
+  test("differs between registries even for the same package@version", async () => {
+    const a = await computeCompareCacheKey(
+      "https://registry.npmjs.org",
+      "https://registry.npmjs.org/acme/-/acme-1.0.0.tgz",
+    );
+    const b = await computeCompareCacheKey(
+      "https://npm.internal.example.com",
+      "https://npm.internal.example.com/acme/-/acme-1.0.0.tgz",
+    );
+    expect(a).not.toBe(b);
+  });
+
+  test("differs between tarball URLs on the same registry", async () => {
+    const a = await computeCompareCacheKey(
+      "https://registry.npmjs.org",
+      "https://registry.npmjs.org/acme/-/acme-1.0.0.tgz",
+    );
+    const b = await computeCompareCacheKey(
+      "https://registry.npmjs.org",
+      "https://registry.npmjs.org/acme/-/acme-1.0.1.tgz",
+    );
+    expect(a).not.toBe(b);
+  });
+
+  test("uses a v2 prefix so old v1 entries cannot be hit", async () => {
+    const key = await computeCompareCacheKey(
+      "https://registry.npmjs.org",
+      "https://registry.npmjs.org/acme/-/acme-1.0.0.tgz",
+    );
+    expect(key.startsWith("compare:v2:")).toBe(true);
+  });
+});

--- a/test/redaction.test.mjs
+++ b/test/redaction.test.mjs
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest";
+import { redactText } from "../server/lib/review.ts";
+
+describe("secret redaction", () => {
+  test("redacts npm and github tokens", () => {
+    const out = redactText(
+      "use npm_aaaaaaaaaaaaaaaaaaaaaaaa and ghp_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    );
+    expect(out).toContain("[REDACTED_NPM_TOKEN]");
+    expect(out).toContain("[REDACTED_GITHUB_TOKEN]");
+    expect(out).not.toMatch(/npm_a{10,}/);
+    expect(out).not.toMatch(/ghp_b{10,}/);
+  });
+
+  test("redacts aws, google, stripe, and slack tokens", () => {
+    const out = redactText(
+      [
+        "AKIAABCDEFGHIJKLMNOP",
+        "AIza1234567890abcdefghijklmnopqrstuvwxy",
+        "sk_live_aaaaaaaaaaaaaaaaaaaaaaaa",
+        "xoxb-12345-abcdefghij",
+        "https://hooks.slack.com/services/T0/B0/abcdef",
+      ].join("\n"),
+    );
+    expect(out).toContain("[REDACTED_AWS_ACCESS_KEY]");
+    expect(out).toContain("[REDACTED_GOOGLE_API_KEY]");
+    expect(out).toContain("[REDACTED_STRIPE_KEY]");
+    expect(out).toContain("[REDACTED_SLACK_TOKEN]");
+    expect(out).toContain("[REDACTED_SLACK_WEBHOOK]");
+  });
+
+  test("redacts standalone JWT tokens and URLs with embedded credentials", () => {
+    const bareJwt = redactText("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.signaturepart12345");
+    expect(bareJwt).toBe("[REDACTED_JWT]");
+    const urlOut = redactText("connect via https://user:pass@example.com/path?ok=1");
+    expect(urlOut).toContain("[REDACTED_URL_WITH_CREDENTIALS]");
+  });
+
+  test("redacts authorization bearer headers", () => {
+    const out = redactText('Authorization: "Bearer abcdef0123456789abcdef0123456789"');
+    expect(out).toContain("[REDACTED_BEARER]");
+  });
+});

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "vitest";
+import { isValidNpmPackageName } from "../server/lib/registry.ts";
+
+describe("npm package name validation", () => {
+  test("accepts well-formed unscoped and scoped names", () => {
+    expect(isValidNpmPackageName("acme")).toBe(true);
+    expect(isValidNpmPackageName("acme-tool")).toBe(true);
+    expect(isValidNpmPackageName("@acme/tool")).toBe(true);
+    expect(isValidNpmPackageName("@acme-co/some_pkg.name")).toBe(true);
+  });
+
+  test("rejects names with traversal, slashes, or shell metacharacters", () => {
+    expect(isValidNpmPackageName("..")).toBe(false);
+    expect(isValidNpmPackageName("../foo")).toBe(false);
+    expect(isValidNpmPackageName("foo/bar")).toBe(false);
+    expect(isValidNpmPackageName("foo bar")).toBe(false);
+    expect(isValidNpmPackageName("foo?bar")).toBe(false);
+    expect(isValidNpmPackageName("FOO")).toBe(false);
+    expect(isValidNpmPackageName("")).toBe(false);
+    expect(isValidNpmPackageName("a".repeat(215))).toBe(false);
+  });
+});

--- a/test/scan-job.test.mjs
+++ b/test/scan-job.test.mjs
@@ -8,7 +8,7 @@ const { classifyScanError, retryDelaySeconds } = await import("../server/lib/sca
 const { SandboxError } = await import("../server/lib/sandbox.ts");
 
 describe("scan job retry classification", () => {
-  test("retries transient sandbox download failures", () => {
+  test("retries transient sandbox download failures and does not leak raw detail", () => {
     const safe = classifyScanError(
       new SandboxError(JSON.stringify({ error: "download failed", status: 503 })),
     );
@@ -17,6 +17,17 @@ describe("scan job retry classification", () => {
       code: "sandbox_download_transient",
       retryable: true,
     });
+    expect(safe).not.toHaveProperty("detail");
+  });
+
+  test("does not include raw error messages on generic failures", () => {
+    const safe = classifyScanError(new Error("D1_ERROR: column not found"));
+    expect(safe).toEqual({
+      code: "scan_failed",
+      message: "The scan failed before a report could be generated.",
+      retryable: true,
+    });
+    expect(JSON.stringify(safe)).not.toContain("D1_ERROR");
   });
 
   test("does not retry credential and missing-stage sandbox failures", () => {


### PR DESCRIPTION
## Summary
- Cache key for the cross-package compare endpoint now hashes `registry|tarballUrl`, closing a cross-org leak where an attacker-controlled `package.json` `name` could steer cache lookups into another org's data.
- Better Auth gets explicit `trustedOrigins`, hardened cookie attributes, and a 12-char password floor; a new Origin/Referer middleware blocks cross-site state-changing requests, and `/api/auth/sign-{in,up}` now carry IP-keyed rate limits.
- The npm token KDF moves from raw `SHA-256(secret)` to HKDF-SHA-256 with a `v1:` ciphertext prefix (legacy ciphertexts still decrypt), and the secret minimum-entropy is enforced.
- Sandbox tar handling now stream-gunzips with an incremental size cap, rejects PAX/long-name paths containing NUL/backslash, bounds entry sizes before pointer math, and validates `tarballUrl` origin before invoking the loader; the npm package-name shape is checked before any registry call.
- Scan/connection error paths no longer surface raw `err.message`/sandbox detail to API responses or persisted scans, and the redactor adds Slack/Stripe/Google/JWT/Bearer/URL-cred patterns.

## Test plan
- [x] `pnpm run verify` (lint + format + typecheck + 30 tests across 10 files)
- [ ] Manual: sign-in/sign-up succeeds from the dashboard origin
- [ ] Manual: cross-site POST to `/api/v1/scans` is rejected with 403
- [ ] Manual: rotate npm token, scan + compare a staged publish, confirm new ciphertext decrypts on next request

🤖 Generated with [Claude Code](https://claude.com/claude-code)