### PR TITLE
Add deterministic rule IDs and tenant-boundary tests

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -188,8 +188,9 @@ Reports should become canonical data objects even before public signing launches
 Implemented foundation:
 
 - newly completed scans store report metadata inside `summary_json.report`;
-- `digest` is SHA-256 over stable canonical report JSON built from redacted scan evidence;
-- persisted scan detail renders report version, digest, package diff, AI review, and safety posture.
+- `digest` is SHA-256 over stable canonical report JSON built from redacted scan evidence, including the deterministic rules version so digests change when the ruleset changes;
+- each deterministic finding carries `ruleId` and `ruleVersion` (see `DETERMINISTIC_RULES_VERSION` in `server/lib/review.ts`), persisted on `scan_findings.rule_id` / `rule_version`;
+- persisted scan detail renders report version, digest, rules version, package diff, AI review, and safety posture.
 
 Prepare next for:
 

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -87,10 +87,8 @@ Exit criteria:
 ## Phase 7 — Production hardening (remaining)
 
 - Add structured error classes and user-safe messages across all scan failures.
-- Add cross-organization access tests.
 - Add archive parser fuzz/regression tests and deeper archive-bomb protections.
 - Add line numbers to deterministic findings where possible.
-- Add deterministic rule IDs and versions.
 - Add metrics/logging for scan durations, queue retries/exhaustion, failures, AI failures, and npm failures.
 - Add D1/R2 retention controls for persisted redacted text samples and derived artifacts.
 - Add deployment checklist and incident-response notes.
@@ -114,8 +112,8 @@ Reliability and operations:
 
 Security boundaries:
 
-- Add cross-organization tests for scan detail/list/compare access and npm connection isolation. (DB-layer cross-org assertion landed via `test/workers/scan-idempotency.test.ts`; still need route-level coverage.)
-- Add sandbox gateway tests that prove credentials are only attached to allowed npm registry requests. (Pure-function policy coverage exists; add an end-to-end test that exercises the gateway through the Worker runtime — the `@cloudflare/vitest-pool-workers` harness is now in place.)
+- Add cross-organization tests for npm connection isolation. (Scan detail/list/compare route-level coverage landed via `test/workers/cross-org-routes.test.ts`; DB-layer assertion landed earlier via `test/workers/scan-idempotency.test.ts`. Still need route-level cross-org coverage for npm-connection endpoints.)
+- Sandbox gateway runtime credential-injection coverage landed via `test/workers/sandbox-gateway-runtime.test.ts`. (Pure-function policy coverage in `test/sandbox-gateway.test.mjs` remains as a fast unit test.)
 - Add tar parser regression tests for traversal paths, absolute paths, PAX paths, GNU long names, links, truncation, huge file counts, and archive-size caps.
 - Investigate build output to ensure local `.dev.vars` secrets are never included in deployable or public artifacts.
 
@@ -154,7 +152,6 @@ Tasks:
 - Add report digest tests for stable canonical ordering and evidence changes.
 - Store scanner version, deterministic rules version, prompt version, model/provider metadata, and report schema version.
 - Add a report provenance section: package name, staged version, previous version, selected comparison version, stage ID, generated timestamp, artifact digests, and review limitations.
-- Add deterministic finding rule IDs and versions.
 - Add AI failure states that preserve deterministic findings when AI is unavailable.
 - Store AI latency and provider/model metadata where available, including whether the default model or escalation model reviewed the scan.
 - Keep signed/public report URLs deferred, but design exports so signing can wrap the same canonical artifact later.
@@ -285,9 +282,9 @@ Exit criteria:
 
 ## Suggested next implementation slice
 
-With queue idempotency landed, the next two slices for Phase 8 are:
+With route-level cross-org coverage, sandbox gateway runtime tests, and deterministic rule IDs landed, the next two slices are:
 
-1. **Boundary tests:** add cross-organization tests for list/detail/compare routes, sandbox gateway credential-injection tests at the runtime layer, and archive parser regression fixtures.
-2. **Private beta operations:** configure production Queues/KV/D1/secrets, add metrics/logging for scan duration and failure classes, add invite-only signup protection, and document deployment + incident response.
+1. **Private beta operations:** configure production Queues/KV/D1/secrets, add metrics/logging for scan duration and failure classes, add invite-only signup protection, and document deployment + incident response.
+2. **Remaining boundary tests:** add archive parser regression fixtures (traversal, PAX, GNU long names, links, truncation, archive-bomb caps) and route-level cross-org coverage for npm-connection endpoints.
 
-After those land, improve maintainer UX by grouping findings and adding the lifecycle timeline before broadening beta access.
+After those land, improve maintainer UX by grouping findings (now that rule IDs exist) and adding the lifecycle timeline before broadening beta access.

--- a/drizzle/0005_even_true_believers.sql
+++ b/drizzle/0005_even_true_believers.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `scan_findings` ADD `rule_id` text;--> statement-breakpoint
+ALTER TABLE `scan_findings` ADD `rule_version` text;

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1195 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "12b086ab-0422-4136-baf3-34cb31d6665b",
+  "prevId": "14fdc182-3fef-432f-b6d8-1201d0022ac6",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_unique_idx": {
+          "name": "npm_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1779354372693,
       "tag": "0004_warm_zombie",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1779401548052,
+      "tag": "0005_even_true_believers",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -310,6 +310,8 @@ export async function persistScan(db: AppDb, input: PersistedScanInput) {
             evidence: finding.evidence,
             reason: finding.reason,
             source: "rule",
+            ruleId: finding.ruleId ?? null,
+            ruleVersion: finding.ruleVersion ?? null,
           })),
         )
       : Promise.resolve(),

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -110,6 +110,8 @@ export const scanFindings = sqliteTable("scan_findings", {
   evidence: text("evidence").notNull(),
   reason: text("reason").notNull(),
   source: text("source").notNull().default("rule"),
+  ruleId: text("rule_id"),
+  ruleVersion: text("rule_version"),
 });
 
 export const scanEvents = sqliteTable(

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -14,7 +14,29 @@ export interface Finding {
   evidence: string;
   reason: string;
   line?: number;
+  ruleId?: string;
+  ruleVersion?: string;
 }
+
+// Bump when deterministic rule semantics, severities, or coverage change in a
+// way that should invalidate cached scan reports. Stored alongside each
+// finding so historical reports can be traced back to the ruleset that
+// produced them.
+export const DETERMINISTIC_RULES_VERSION = "1.0.0";
+
+export const DETERMINISTIC_RULE_IDS = {
+  installScriptPreinstall: "install-script.preinstall",
+  installScript: "install-script.lifecycle",
+  codeProcessExecution: "code.process-execution",
+  codeNetworkAccess: "code.network-access",
+  codeDynamicEvaluation: "code.dynamic-evaluation",
+  codeCredentialAccess: "code.credential-access",
+  fileSecretContent: "file.secret-content",
+  fileLargeBinary: "file.large-binary",
+  fileNativeArtifact: "file.native-artifact",
+  diffCredentialFileAdded: "diff.credential-file-added",
+  diffLargeNewFile: "diff.large-new-file",
+} as const;
 
 export interface PackageJsonSummary {
   name?: string;
@@ -72,6 +94,14 @@ const SECRET_PATTERNS: Array<[RegExp, string]> = [
 export function deterministicFindings(files: FileRecord[], diff: DiffEntry[] = []): Finding[] {
   const findings: Finding[] = [];
   const diffByPath = new Map(diff.map((entry) => [entry.path, entry]));
+  const tag = (
+    rule: keyof typeof DETERMINISTIC_RULE_IDS,
+    finding: Omit<Finding, "ruleId" | "ruleVersion">,
+  ): Finding => ({
+    ...finding,
+    ruleId: DETERMINISTIC_RULE_IDS[rule],
+    ruleVersion: DETERMINISTIC_RULES_VERSION,
+  });
 
   for (const file of files) {
     const p = file.path.toLowerCase();
@@ -87,12 +117,14 @@ export function deterministicFindings(files: FileRecord[], diff: DiffEntry[] = [
       const scripts = pkg?.scripts || {};
       for (const script of LIFECYCLE_SCRIPTS) {
         if (scripts[script]) {
-          findings.push({
-            severity: script === "preinstall" ? "critical" : "high",
-            file: file.path,
-            evidence: `${script}: ${scripts[script]}`,
-            reason: "install lifecycle hooks execute on consumer machines",
-          });
+          findings.push(
+            tag(script === "preinstall" ? "installScriptPreinstall" : "installScript", {
+              severity: script === "preinstall" ? "critical" : "high",
+              file: file.path,
+              evidence: `${script}: ${scripts[script]}`,
+              reason: "install lifecycle hooks execute on consumer machines",
+            }),
+          );
         }
       }
     }
@@ -101,25 +133,29 @@ export function deterministicFindings(files: FileRecord[], diff: DiffEntry[] = [
         sample,
       )
     ) {
-      findings.push({
-        severity: "high",
-        file: file.path,
-        evidence: `${changedPrefix}process or shell execution`,
-        reason: "package may execute arbitrary commands",
-      });
+      findings.push(
+        tag("codeProcessExecution", {
+          severity: "high",
+          file: file.path,
+          evidence: `${changedPrefix}process or shell execution`,
+          reason: "package may execute arbitrary commands",
+        }),
+      );
     }
     if (
       /\b(require\(["'](?:node:)?(?:http|https|net|dns)["']\)|from\s+["'](?:node:)?(?:http|https|net|dns)["']|fetch\s*\(|XMLHttpRequest|axios\s*\.)/.test(
         sample,
       )
     ) {
-      findings.push({
-        severity: changed === "added" ? "high" : "medium",
-        file: file.path,
-        evidence: `${changedPrefix}network-capable code path`,
-        reason:
-          "unexpected network access in package code can be used for exfiltration or staged payload retrieval",
-      });
+      findings.push(
+        tag("codeNetworkAccess", {
+          severity: changed === "added" ? "high" : "medium",
+          file: file.path,
+          evidence: `${changedPrefix}network-capable code path`,
+          reason:
+            "unexpected network access in package code can be used for exfiltration or staged payload retrieval",
+        }),
+      );
     }
     if (
       /\beval\s*\(/.test(sample) ||
@@ -128,66 +164,80 @@ export function deterministicFindings(files: FileRecord[], diff: DiffEntry[] = [
       /\batob\s*\(/.test(sample) ||
       /\bBuffer\.from\s*\([^,]+,\s*["']base64["']\s*\)/.test(sample)
     ) {
-      findings.push({
-        severity: changed === "added" ? "high" : "medium",
-        file: file.path,
-        evidence: `${changedPrefix}dynamic code or obfuscation primitive`,
-        reason: "common malware and obfuscation technique",
-      });
+      findings.push(
+        tag("codeDynamicEvaluation", {
+          severity: changed === "added" ? "high" : "medium",
+          file: file.path,
+          evidence: `${changedPrefix}dynamic code or obfuscation primitive`,
+          reason: "common malware and obfuscation technique",
+        }),
+      );
     }
     if (
       /\b(process\.env|npm_config_|NPM_TOKEN|GITHUB_TOKEN|AWS_SECRET|PRIVATE_KEY)\b/.test(sample)
     ) {
-      findings.push({
-        severity: changed === "added" ? "high" : "medium",
-        file: file.path,
-        evidence: `${changedPrefix}secret/environment access`,
-        reason: "package may read credentials from the install environment",
-      });
+      findings.push(
+        tag("codeCredentialAccess", {
+          severity: changed === "added" ? "high" : "medium",
+          file: file.path,
+          evidence: `${changedPrefix}secret/environment access`,
+          reason: "package may read credentials from the install environment",
+        }),
+      );
     }
     if (/\.npmrc|\.env|id_rsa|id_ed25519/i.test(file.path) || containsSecretLikeText(sample)) {
-      findings.push({
-        severity: changed === "added" ? "critical" : "high",
-        file: file.path,
-        evidence: `${changedPrefix}secret-looking file or content`,
-        reason: "published artifacts should not include credentials or private material",
-      });
+      findings.push(
+        tag("fileSecretContent", {
+          severity: changed === "added" ? "critical" : "high",
+          file: file.path,
+          evidence: `${changedPrefix}secret-looking file or content`,
+          reason: "published artifacts should not include credentials or private material",
+        }),
+      );
     }
     if (file.flags.includes("binary") && file.size > 1024 * 1024) {
-      findings.push({
-        severity: changed === "added" ? "high" : "info",
-        file: file.path,
-        evidence: `${file.size} byte binary`,
-        reason: "large binary should be reviewed manually",
-      });
+      findings.push(
+        tag("fileLargeBinary", {
+          severity: changed === "added" ? "high" : "info",
+          file: file.path,
+          evidence: `${file.size} byte binary`,
+          reason: "large binary should be reviewed manually",
+        }),
+      );
     }
     if (/\.(node|dll|so|dylib|exe|wasm)$/i.test(file.path)) {
-      findings.push({
-        severity: "high",
-        file: file.path,
-        evidence: "native, wasm, or executable artifact",
-        reason:
-          "native binaries are hard to audit and can execute outside JavaScript policy checks",
-      });
+      findings.push(
+        tag("fileNativeArtifact", {
+          severity: "high",
+          file: file.path,
+          evidence: "native, wasm, or executable artifact",
+          reason:
+            "native binaries are hard to audit and can execute outside JavaScript policy checks",
+        }),
+      );
     }
   }
 
   for (const entry of diff) {
     if (entry.status === "added" && /(^|\/)(\.npmrc|\.env|id_rsa|id_ed25519)$/i.test(entry.path)) {
-      findings.push({
-        severity: "critical",
-        file: entry.path,
-        evidence: "credential-looking file added",
-        reason: "package artifact includes a file name commonly associated with secrets",
-      });
+      findings.push(
+        tag("diffCredentialFileAdded", {
+          severity: "critical",
+          file: entry.path,
+          evidence: "credential-looking file added",
+          reason: "package artifact includes a file name commonly associated with secrets",
+        }),
+      );
     }
     if (entry.status === "added" && entry.stagedSize && entry.stagedSize > 2 * 1024 * 1024) {
-      findings.push({
-        severity: "medium",
-        file: entry.path,
-        evidence: `${entry.stagedSize} byte new file`,
-        reason: "large new package artifact should be reviewed",
-      });
+      findings.push(
+        tag("diffLargeNewFile", {
+          severity: "medium",
+          file: entry.path,
+          evidence: `${entry.stagedSize} byte new file`,
+          reason: "large new package artifact should be reviewed",
+        }),
+      );
     }
   }
 

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -4,6 +4,7 @@ import { fetchPackageMetadata, pickPreviousVersion } from "./registry";
 import {
   createPackageDiff,
   deterministicFindings,
+  DETERMINISTIC_RULES_VERSION,
   redactFileRecords,
   redactFindings,
   redactJson,
@@ -100,6 +101,7 @@ export async function runScanPipeline(
 
   const reportPayload = {
     version: 1,
+    rulesVersion: DETERMINISTIC_RULES_VERSION,
     stageId: input.stageId,
     package: result.package,
     fileCount: result.fileCount,
@@ -129,6 +131,7 @@ export async function runScanPipeline(
         digest: reportDigest,
         digestAlgorithm: "sha256",
         generatedAt: new Date().toISOString(),
+        rulesVersion: reportPayload.rulesVersion,
       },
       packageJsonDiff,
       diff,

--- a/src/components/FindingCard.tsx
+++ b/src/components/FindingCard.tsx
@@ -5,11 +5,13 @@ import { cn } from "./cn";
 export function FindingCard({
   severity,
   file,
+  ruleId,
   children,
   class: className,
 }: {
   severity: string;
   file: string;
+  ruleId?: string | null;
   children: ComponentChildren;
   class?: string;
 }) {
@@ -25,6 +27,14 @@ export function FindingCard({
           {severity}
         </Badge>
         <code class="text-[13px] text-ink-muted truncate">{file}</code>
+        {ruleId ? (
+          <code
+            class="ml-auto text-[11px] text-ink-subtle font-mono uppercase tracking-[0.05em] flex-shrink-0"
+            title={`Rule ${ruleId}`}
+          >
+            {ruleId}
+          </code>
+        ) : null}
       </div>
       <div class="text-[13px] leading-[1.55] flex flex-col gap-0.5">{children}</div>
     </li>

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -68,6 +68,8 @@ export interface PersistedScanDetail {
     evidence: string;
     reason: string;
     source: string;
+    ruleId?: string | null;
+    ruleVersion?: string | null;
   }>;
 }
 

--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -33,6 +33,7 @@ interface PersistedSummary {
     digest?: string;
     digestAlgorithm?: string;
     generatedAt?: string;
+    rulesVersion?: string;
   };
   packageJsonDiff?: PackageJsonDiff;
   diff?: DiffEntry[];
@@ -278,7 +279,12 @@ export default function ScanDetailPage() {
                 <SectionLabel>Risk signals</SectionLabel>
                 <ul class="list-none p-0 m-0 flex flex-col gap-2">
                   {detail.findings.map((finding) => (
-                    <FindingCard key={finding.id} severity={finding.severity} file={finding.file}>
+                    <FindingCard
+                      key={finding.id}
+                      severity={finding.severity}
+                      file={finding.file}
+                      ruleId={finding.ruleId}
+                    >
                       <FindingRow label="evidence" value={finding.evidence} />
                       <FindingRow label="reason" value={finding.reason} />
                     </FindingCard>
@@ -470,6 +476,7 @@ function PersistedReportSections({
                 summary.report.generatedAt ? formatDate(summary.report.generatedAt) : "unknown"
               }
             />
+            <MetadataRow label="rules" value={`v${summary.report.rulesVersion ?? "unknown"}`} />
           </div>
         ) : (
           <EmptyLine>This older review does not include a report fingerprint.</EmptyLine>

--- a/test/workers/cross-org-routes.test.ts
+++ b/test/workers/cross-org-routes.test.ts
@@ -1,0 +1,197 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { describe, expect, test } from "vitest";
+import { createDb, createScanJob, ensurePersonalOrganization, persistScan } from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { scansRoutes } from "../../server/routes/scans";
+import type { Bindings, Variables } from "../../server/types";
+
+interface SeededUser {
+  userId: string;
+  organizationId: string;
+}
+
+async function seedUser(): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+async function seedCompletedScan(owner: SeededUser, packageName: string) {
+  const db = createDb(env.DB);
+  const scanId = `scan_${crypto.randomUUID()}`;
+  await createScanJob(db, {
+    id: scanId,
+    stageId: `stage-${scanId.slice(-12)}`,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+  });
+  await persistScan(db, {
+    id: scanId,
+    stageId: `stage-${scanId.slice(-12)}`,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+    packageJson: { name: packageName, version: "1.2.3" },
+    risk: "low",
+    status: "complete",
+    summary: { ok: true },
+    ai: null,
+    files: [],
+    diff: [],
+    findings: [],
+    report: { version: 1, digest: "digest" },
+  });
+  return scanId;
+}
+
+function buildTestApp(session: { userId: string }) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.use("*", async (c, next) => {
+    c.set("authSession", { userId: session.userId });
+    await next();
+  });
+  app.route("/api/v1/scans", scansRoutes);
+  return app;
+}
+
+async function fetchWithSession(
+  app: Hono<{ Bindings: Bindings; Variables: Variables }>,
+  path: string,
+) {
+  const ctx = createExecutionContext();
+  const res = await app.fetch(new Request(`http://test.local${path}`, { method: "GET" }), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+describe("scans routes enforce organization boundaries", () => {
+  test("GET /scans only lists scans owned by the caller's organization", async () => {
+    const owner = await seedUser();
+    const intruder = await seedUser();
+    const scanId = await seedCompletedScan(owner, "@org/owned-package");
+
+    const ownerRes = await fetchWithSession(buildTestApp(owner), "/api/v1/scans");
+    expect(ownerRes.status).toBe(200);
+    const ownerBody = (await ownerRes.json()) as { scans: Array<{ id: string }> };
+    expect(ownerBody.scans.map((s) => s.id)).toContain(scanId);
+
+    const intruderRes = await fetchWithSession(buildTestApp(intruder), "/api/v1/scans");
+    expect(intruderRes.status).toBe(200);
+    const intruderBody = (await intruderRes.json()) as { scans: Array<{ id: string }> };
+    expect(intruderBody.scans.map((s) => s.id)).not.toContain(scanId);
+  });
+
+  test("GET /scans/:id returns 404 for scans owned by another organization", async () => {
+    const owner = await seedUser();
+    const intruder = await seedUser();
+    const scanId = await seedCompletedScan(owner, "@org/private-package");
+
+    const ownerRes = await fetchWithSession(buildTestApp(owner), `/api/v1/scans/${scanId}`);
+    expect(ownerRes.status).toBe(200);
+
+    const intruderRes = await fetchWithSession(buildTestApp(intruder), `/api/v1/scans/${scanId}`);
+    expect(intruderRes.status).toBe(404);
+  });
+
+  test("GET /scans/:id/versions returns 404 for foreign scan ids", async () => {
+    const owner = await seedUser();
+    const intruder = await seedUser();
+    const scanId = await seedCompletedScan(owner, "@org/private-package");
+
+    const intruderRes = await fetchWithSession(
+      buildTestApp(intruder),
+      `/api/v1/scans/${scanId}/versions`,
+    );
+    expect(intruderRes.status).toBe(404);
+  });
+
+  test("GET /scans/:id/compare returns 404 before touching the registry for foreign scans", async () => {
+    const owner = await seedUser();
+    const intruder = await seedUser();
+    const scanId = await seedCompletedScan(owner, "@org/private-package");
+
+    const compareRes = await fetchWithSession(
+      buildTestApp(intruder),
+      `/api/v1/scans/${scanId}/compare?version=1.0.0`,
+    );
+    expect(compareRes.status).toBe(404);
+  });
+
+  test("GET /scans/:id/compare/file returns 404 for foreign scans even with path query", async () => {
+    const owner = await seedUser();
+    const intruder = await seedUser();
+    const scanId = await seedCompletedScan(owner, "@org/private-package");
+
+    const fileRes = await fetchWithSession(
+      buildTestApp(intruder),
+      `/api/v1/scans/${scanId}/compare/file?version=1.0.0&path=package.json`,
+    );
+    expect(fileRes.status).toBe(404);
+  });
+
+  test("scan_files and scan_findings are isolated by organization", async () => {
+    const owner = await seedUser();
+    const intruder = await seedUser();
+    const db = createDb(env.DB);
+
+    const scanId = `scan_${crypto.randomUUID()}`;
+    await createScanJob(db, {
+      id: scanId,
+      stageId: `stage-${scanId.slice(-12)}`,
+      organizationId: owner.organizationId,
+      ownerUserId: owner.userId,
+    });
+    await persistScan(db, {
+      id: scanId,
+      stageId: `stage-${scanId.slice(-12)}`,
+      organizationId: owner.organizationId,
+      ownerUserId: owner.userId,
+      packageJson: { name: "@org/with-files", version: "0.1.0" },
+      risk: "high",
+      status: "complete",
+      summary: { ok: true },
+      ai: null,
+      files: [
+        {
+          path: "package.json",
+          size: 12,
+          sha256: "abc",
+          flags: [],
+          textSample: '{"name":"@org/with-files"}',
+        },
+      ],
+      diff: [{ path: "package.json", status: "added" }],
+      findings: [
+        {
+          severity: "high",
+          file: "package.json",
+          evidence: "install script added",
+          reason: "lifecycle script touches network",
+        },
+      ],
+      report: { version: 1, digest: "digest" },
+    });
+
+    const ownerRes = await fetchWithSession(buildTestApp(owner), `/api/v1/scans/${scanId}`);
+    expect(ownerRes.status).toBe(200);
+    const ownerBody = (await ownerRes.json()) as {
+      files: Array<{ path: string }>;
+      findings: Array<{ severity: string }>;
+    };
+    expect(ownerBody.files.map((f) => f.path)).toEqual(["package.json"]);
+    expect(ownerBody.findings.map((f) => f.severity)).toEqual(["high"]);
+
+    const intruderRes = await fetchWithSession(buildTestApp(intruder), `/api/v1/scans/${scanId}`);
+    expect(intruderRes.status).toBe(404);
+  });
+});

--- a/test/workers/sandbox-gateway-runtime.test.ts
+++ b/test/workers/sandbox-gateway-runtime.test.ts
@@ -1,0 +1,128 @@
+import { createExecutionContext, env } from "cloudflare:test";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { NpmStageGateway } from "../../server/lib/sandbox";
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  authorization: string | null;
+  userAgent: string | null;
+}
+
+function setupGateway(props: { npmToken?: string; npmRegistry?: string }) {
+  const captured: CapturedRequest[] = [];
+  const fetchSpy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    captured.push({
+      url: request.url,
+      method: request.method,
+      authorization: request.headers.get("authorization"),
+      userAgent: request.headers.get("user-agent"),
+    });
+    return new Response("upstream-ok", { status: 200 });
+  });
+  vi.stubGlobal("fetch", fetchSpy);
+
+  const ctx = createExecutionContext() as ExecutionContext & {
+    props: { npmToken?: string; npmRegistry?: string };
+  };
+  ctx.props = props;
+  const gateway = new (NpmStageGateway as unknown as new (
+    ctx: ExecutionContext,
+    env: Cloudflare.Env,
+  ) => { fetch(request: Request): Promise<Response> })(ctx, env);
+  return { gateway, captured };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("NpmStageGateway runtime credential injection", () => {
+  test("attaches Authorization on staged-tarball requests", async () => {
+    const { gateway, captured } = setupGateway({ npmToken: "npm_secret_token_123" });
+    const res = await gateway.fetch(
+      new Request("https://registry.npmjs.org/-/stage/stage-abc123/tarball"),
+    );
+    expect(res.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].authorization).toBe("Bearer npm_secret_token_123");
+    expect(captured[0].userAgent).toBe("staged-publish-review/0.3");
+  });
+
+  test("attaches Authorization on published-tarball requests", async () => {
+    const { gateway, captured } = setupGateway({ npmToken: "npm_secret_token_xyz" });
+    const res = await gateway.fetch(new Request("https://registry.npmjs.org/pkg/-/pkg-1.2.3.tgz"));
+    expect(res.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].authorization).toBe("Bearer npm_secret_token_xyz");
+  });
+
+  test("attaches Authorization on package-metadata requests", async () => {
+    const { gateway, captured } = setupGateway({ npmToken: "npm_secret_meta" });
+    const res = await gateway.fetch(new Request("https://registry.npmjs.org/@scope%2fpkg"));
+    expect(res.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].authorization).toBe("Bearer npm_secret_meta");
+  });
+
+  test("blocks foreign origins without forwarding or sending the token", async () => {
+    const { gateway, captured } = setupGateway({ npmToken: "npm_should_not_leak" });
+    const res = await gateway.fetch(
+      new Request("https://example.com/-/stage/stage-abc123/tarball"),
+    );
+    expect(res.status).toBe(403);
+    expect(captured).toHaveLength(0);
+  });
+
+  test("blocks state-changing methods even on allowed paths", async () => {
+    const { gateway, captured } = setupGateway({ npmToken: "npm_should_not_leak" });
+    const res = await gateway.fetch(
+      new Request("https://registry.npmjs.org/-/stage/stage-abc123/tarball", { method: "POST" }),
+    );
+    expect(res.status).toBe(403);
+    expect(captured).toHaveLength(0);
+  });
+
+  test("blocks /-/whoami and other unrelated registry paths", async () => {
+    const { gateway, captured } = setupGateway({ npmToken: "npm_should_not_leak" });
+
+    const whoami = await gateway.fetch(new Request("https://registry.npmjs.org/-/whoami"));
+    expect(whoami.status).toBe(403);
+
+    const readme = await gateway.fetch(new Request("https://registry.npmjs.org/pkg/readme"));
+    expect(readme.status).toBe(403);
+
+    expect(captured).toHaveLength(0);
+  });
+
+  test("omits Authorization when no npm token is configured", async () => {
+    const { gateway, captured } = setupGateway({});
+    const res = await gateway.fetch(
+      new Request("https://registry.npmjs.org/-/stage/stage-no-token/tarball"),
+    );
+    expect(res.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].authorization).toBeNull();
+    expect(captured[0].userAgent).toBe("staged-publish-review/0.3");
+  });
+
+  test("respects custom registry origins supplied via props", async () => {
+    const { gateway, captured } = setupGateway({
+      npmToken: "npm_custom_registry_token",
+      npmRegistry: "https://registry.example.com",
+    });
+
+    const allowed = await gateway.fetch(
+      new Request("https://registry.example.com/-/stage/stage-custom/tarball"),
+    );
+    expect(allowed.status).toBe(200);
+    expect(captured[0].authorization).toBe("Bearer npm_custom_registry_token");
+
+    const blocked = await gateway.fetch(
+      new Request("https://registry.npmjs.org/-/stage/stage-custom/tarball"),
+    );
+    expect(blocked.status).toBe(403);
+    expect(captured).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Tag every deterministic finding with stable `ruleId` + `ruleVersion` driven by `DETERMINISTIC_RULES_VERSION`, persist them on `scan_findings` (migration 0005), include `rulesVersion` in the report payload so digests change when the ruleset changes, and surface rule IDs + rules version in the scan detail UI.
- Add `@cloudflare/vitest-pool-workers` coverage for tenant boundaries: route-level cross-org isolation for `/scans` list/detail/versions/compare endpoints, and runtime credential-injection tests for `NpmStageGateway` proving the npm token is only attached on allowed registry endpoints.
- Refresh `docs/architecture.md` and `docs/production-roadmap.md` to reflect what landed and the next suggested slices.

## Test plan
- [x] \`pnpm run verify\` (lint, format, typecheck, 34 logic + 18 worker-pool tests)
- [ ] Manually load a completed scan in the dashboard and confirm rule IDs render on finding cards and the rules version appears on the report fingerprint card