### PR TITLE
Add open staged publishes panel to dashboard

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -207,6 +207,7 @@ Current API:
 
 - `POST /api/v1/scans` — create queued/background scan;
 - `POST /api/v1/scan` — synchronous compatibility scan;
+- `POST /api/v1/staged-publishes/scan` — discover open staged publishes and create scans for newly found stage IDs;
 - `GET /api/v1/scans` — list organization scans;
 - `GET /api/v1/scans/:id` — scan status/report detail;
 - `GET /api/v1/npm-connection` — read connection metadata;

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -72,6 +72,7 @@ Use cards for interactive containment and lists that need table-like edges. Pref
 - Empty findings do not get full bordered panels; represent them as compact badges or `EmptyLine`s inside an existing section.
 - Dashboard order follows user intent: request a review first, recent reviews second, workspace setup last.
 - Open staged publishes refresh automatically once an npm connection becomes available and clear when npm is disconnected, so first-time setup does not leave a stale loading state.
+- The recent reviews list returns only the newest scan per stage ID; repeated reviews of the same staged publish should not create duplicate dashboard rows.
 - Connected workspace setup is collapsed by default, but the closed row must look clickable and include an explicit “Open settings” affordance.
 - Connection metadata is displayed as compact label/value rows, while the editable credential form remains inside a card.
 - Marketing hero copy is unboxed; feature claims use cards below the headline.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -72,6 +72,7 @@ Use cards for interactive containment and lists that need table-like edges. Pref
 - Empty findings do not get full bordered panels; represent them as compact badges or `EmptyLine`s inside an existing section.
 - Dashboard order follows user intent: request a review first, recent reviews second, workspace setup last.
 - Open staged publishes refresh automatically once an npm connection becomes available and clear when npm is disconnected, so first-time setup does not leave a stale loading state.
+- Scan actions in the open staged publishes table start a fresh review in place; pasted stage ID submissions open the saved report when the scan record is created.
 - The recent reviews list returns only the newest scan per stage ID; repeated reviews of the same staged publish should not create duplicate dashboard rows.
 - Connected workspace setup is collapsed by default, but the closed row must look clickable and include an explicit “Open settings” affordance.
 - Connection metadata is displayed as compact label/value rows, while the editable credential form remains inside a card.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -71,8 +71,7 @@ Use cards for interactive containment and lists that need table-like edges. Pref
 - Saved scan reports and immediate review results use badge rows + mono metadata instead of grids of `SummaryCard`s.
 - Empty findings do not get full bordered panels; represent them as compact badges or `EmptyLine`s inside an existing section.
 - Dashboard order follows user intent: request a review first, recent reviews second, workspace setup last.
-- Open staged publishes refresh automatically once an npm connection becomes available and clear when npm is disconnected, so first-time setup does not leave a stale loading state.
-- Scan actions in the open staged publishes table start a fresh review in place; pasted stage ID submissions open the saved report when the scan record is created.
+- Open staged publishes are not displayed directly. Discovery starts scan records for newly found stage IDs, and those records appear in Recent reviews.
 - The recent reviews list returns only the newest scan per stage ID; repeated reviews of the same staged publish should not create duplicate dashboard rows.
 - Connected workspace setup is collapsed by default, but the closed row must look clickable and include an explicit “Open settings” affordance.
 - Connection metadata is displayed as compact label/value rows, while the editable credential form remains inside a card.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -71,6 +71,7 @@ Use cards for interactive containment and lists that need table-like edges. Pref
 - Saved scan reports and immediate review results use badge rows + mono metadata instead of grids of `SummaryCard`s.
 - Empty findings do not get full bordered panels; represent them as compact badges or `EmptyLine`s inside an existing section.
 - Dashboard order follows user intent: request a review first, recent reviews second, workspace setup last.
+- Open staged publishes refresh automatically once an npm connection becomes available and clear when npm is disconnected, so first-time setup does not leave a stale loading state.
 - Connected workspace setup is collapsed by default, but the closed row must look clickable and include an explicit “Open settings” affordance.
 - Connection metadata is displayed as compact label/value rows, while the editable credential form remains inside a card.
 - Marketing hero copy is unboxed; feature claims use cards below the headline.

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -321,7 +321,7 @@ export async function persistScan(db: AppDb, input: PersistedScanInput) {
 }
 
 export async function listScans(db: AppDb, organizationId: string) {
-  return db
+  const rows = await db
     .select({
       id: scans.id,
       stageId: scans.stageId,
@@ -342,7 +342,17 @@ export async function listScans(db: AppDb, organizationId: string) {
     .from(scans)
     .where(eq(scans.organizationId, organizationId))
     .orderBy(desc(scans.createdAt))
-    .limit(50);
+    .limit(100);
+
+  const unique: typeof rows = [];
+  const seenStageIds = new Set<string>();
+  for (const row of rows) {
+    if (seenStageIds.has(row.stageId)) continue;
+    seenStageIds.add(row.stageId);
+    unique.push(row);
+    if (unique.length === 50) break;
+  }
+  return unique;
 }
 
 export async function getScan(db: AppDb, id: string, organizationId: string) {

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -179,6 +179,19 @@ export async function createScanJob(db: AppDb, input: CreateScanJobInput) {
   return getScan(db, input.id, input.organizationId);
 }
 
+export async function listExistingScanStageIds(
+  db: AppDb,
+  organizationId: string,
+  stageIds: string[],
+) {
+  if (!stageIds.length) return new Set<string>();
+  const rows = await db
+    .select({ stageId: scans.stageId })
+    .from(scans)
+    .where(and(eq(scans.organizationId, organizationId), inArray(scans.stageId, stageIds)));
+  return new Set(rows.map((row) => row.stageId));
+}
+
 const NON_TERMINAL_STATUSES = ["pending", "running"] as const;
 
 export async function claimScanForRun(db: AppDb, scanId: string, organizationId: string) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -11,6 +11,7 @@ import {
 import { npmConnectionRoutes } from "./routes/npm-connection";
 import { scanRoutes } from "./routes/scan";
 import { scansRoutes } from "./routes/scans";
+import { stagedPublishesRoutes } from "./routes/staged-publishes";
 import type { Bindings, Variables } from "./types";
 
 export { NpmStageGateway } from "./lib/sandbox";
@@ -166,6 +167,7 @@ app.get("/api", (c) =>
       compatibilityScan: "POST /api/v1/scan { stageId }",
       scans: "GET /api/v1/scans",
       scanDetail: "GET /api/v1/scans/:id",
+      stagedPublishes: "GET /api/v1/staged-publishes",
       npmConnection: "GET/POST/DELETE /api/v1/npm-connection; POST /api/v1/npm-connection/validate",
       health: "GET /api/health",
     },
@@ -177,6 +179,7 @@ app.get("/api", (c) =>
 app.route("/api/v1/npm-connection", npmConnectionRoutes);
 app.route("/api/v1/scan", scanRoutes);
 app.route("/api/v1/scans", scansRoutes);
+app.route("/api/v1/staged-publishes", stagedPublishesRoutes);
 
 app.notFound((c) => c.json({ error: "not found" }, 404));
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -167,7 +167,7 @@ app.get("/api", (c) =>
       compatibilityScan: "POST /api/v1/scan { stageId }",
       scans: "GET /api/v1/scans",
       scanDetail: "GET /api/v1/scans/:id",
-      stagedPublishes: "GET /api/v1/staged-publishes",
+      stagedPublishes: "POST /api/v1/staged-publishes/scan",
       npmConnection: "GET/POST/DELETE /api/v1/npm-connection; POST /api/v1/npm-connection/validate",
       health: "GET /api/health",
     },

--- a/server/lib/staged-publishes.ts
+++ b/server/lib/staged-publishes.ts
@@ -17,6 +17,19 @@ export interface StagedPublishesPage {
   page: number | null;
 }
 
+export interface StartedStagedPublishScan {
+  id: string;
+  stageId: string;
+}
+
+export interface StagedPublishesScanResponse {
+  found: number;
+  created: number;
+  skipped: number;
+  queued: boolean;
+  scans: StartedStagedPublishScan[];
+}
+
 const MAX_PER_PAGE = 100;
 const STAGE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{5,160}$/;
 

--- a/server/lib/staged-publishes.ts
+++ b/server/lib/staged-publishes.ts
@@ -1,0 +1,98 @@
+import { normalizeRegistryUrl } from "./npm-connection";
+
+export interface StagedPublishItem {
+  id: string;
+  packageName: string | null;
+  version: string | null;
+  tag: string | null;
+  access: string | null;
+  actor: string | null;
+  createdAt: string | null;
+}
+
+export interface StagedPublishesPage {
+  items: StagedPublishItem[];
+  total: number | null;
+  perPage: number | null;
+  page: number | null;
+}
+
+const MAX_PER_PAGE = 100;
+const STAGE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{5,160}$/;
+
+export interface ListStagedPublishesOptions {
+  perPage?: number;
+  packageName?: string;
+}
+
+export async function listStagedPublishes(
+  registryUrl: string,
+  token: string,
+  options: ListStagedPublishesOptions = {},
+): Promise<StagedPublishesPage> {
+  const registry = normalizeRegistryUrl(registryUrl);
+  const perPage = Math.min(Math.max(options.perPage ?? 25, 1), MAX_PER_PAGE);
+  const params = new URLSearchParams({ perPage: String(perPage) });
+  if (options.packageName) params.set("package", options.packageName);
+  const response = await fetch(`${registry}/-/stage?${params.toString()}`, {
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${token}`,
+      "user-agent": "staged-publish-review/staged-list",
+    },
+  });
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new StagedPublishesFetchError(response.status, detail.slice(0, 200));
+  }
+  const data = (await response.json().catch(() => null)) as unknown;
+  return parseStagedPublishesResponse(data);
+}
+
+export class StagedPublishesFetchError extends Error {
+  constructor(
+    readonly status: number,
+    readonly detail: string,
+  ) {
+    super(`staged publishes fetch failed: ${status}`);
+    this.name = "StagedPublishesFetchError";
+  }
+}
+
+export function parseStagedPublishesResponse(data: unknown): StagedPublishesPage {
+  const root = isRecord(data) ? data : {};
+  const rawItems = Array.isArray(root.items) ? root.items : [];
+  const items: StagedPublishItem[] = [];
+  for (const entry of rawItems) {
+    if (!isRecord(entry)) continue;
+    const id = readString(entry.id);
+    if (!id || !STAGE_ID_RE.test(id)) continue;
+    items.push({
+      id,
+      packageName: readString(entry.packageName) ?? readString(entry.name),
+      version: readString(entry.version),
+      tag: readString(entry.tag),
+      access: readString(entry.access),
+      actor: readString(entry.actor),
+      createdAt: readString(entry.createdAt) ?? readString(entry.created_at),
+    });
+  }
+  return {
+    items,
+    total: readNumber(root.total),
+    perPage: readNumber(root.perPage),
+    page: readNumber(root.page),
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function readNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}

--- a/server/routes/staged-publishes.ts
+++ b/server/routes/staged-publishes.ts
@@ -2,31 +2,37 @@ import { Hono } from "hono";
 import {
   RateLimitError,
   createDb,
+  createScanJob,
   enforceRateLimit,
   ensurePersonalOrganization,
+  listExistingScanStageIds,
   recordScanEvent,
 } from "../db";
 import { getOrganizationNpmToken } from "../lib/npm-connection";
 import { StagedPublishesFetchError, listStagedPublishes } from "../lib/staged-publishes";
+import { executeScanJob, type ScanQueueMessage } from "../lib/scan-job";
 import type { Bindings, Variables } from "../types";
 
 export const stagedPublishesRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
-stagedPublishesRoutes.get("/", async (c) => {
+stagedPublishesRoutes.post("/scan", async (c) => {
   const db = createDb(c.env.DB);
   const session = c.get("authSession");
   const organizationId = await ensurePersonalOrganization(db, session);
 
   try {
     await enforceRateLimit(db, {
-      key: `staged-publishes:list:${organizationId}`,
-      limit: 60,
-      windowMs: 60 * 1000,
+      key: `staged-publishes:scan:${organizationId}`,
+      limit: 12,
+      windowMs: 10 * 60 * 1000,
     });
   } catch (err) {
     if (err instanceof RateLimitError) {
       return c.json(
-        { error: "staged publishes rate limit exceeded", retryAfterSeconds: err.retryAfterSeconds },
+        {
+          error: "staged publish discovery rate limit exceeded",
+          retryAfterSeconds: err.retryAfterSeconds,
+        },
         429,
         { "retry-after": String(err.retryAfterSeconds) },
       );
@@ -37,7 +43,7 @@ stagedPublishesRoutes.get("/", async (c) => {
   const connection = await getOrganizationNpmToken(db, c.env, organizationId);
   if (!connection) {
     return c.json(
-      { error: "Connect an organization npm token before listing staged publishes." },
+      { error: "Connect an organization npm token before discovering staged publishes." },
       400,
     );
   }
@@ -46,13 +52,66 @@ stagedPublishesRoutes.get("/", async (c) => {
     const page = await listStagedPublishes(connection.registryUrl, connection.token, {
       perPage: 50,
     });
+    const stageIds = [...new Set(page.items.map((item) => item.id))];
+    const existingStageIds = await listExistingScanStageIds(db, organizationId, stageIds);
+    const scans: Array<{ id: string; stageId: string }> = [];
+
+    for (const stageId of stageIds) {
+      if (existingStageIds.has(stageId)) continue;
+      const scanId = crypto.randomUUID();
+      const detail = await createScanJob(db, {
+        id: scanId,
+        stageId,
+        organizationId,
+        ownerUserId: session.userId,
+      });
+      if (!detail) continue;
+      existingStageIds.add(stageId);
+      scans.push({ id: scanId, stageId });
+
+      const message: ScanQueueMessage = {
+        stageId,
+        scanId,
+        organizationId,
+        actorUserId: session.userId,
+      };
+      await recordScanEvent(db, {
+        organizationId,
+        actorUserId: session.userId,
+        scanId,
+        type: c.env.SCAN_QUEUE ? "scan.queued" : "scan.backgrounded",
+        metadata: { stageId, source: "staged_publishes.discovery" },
+      });
+      if (c.env.SCAN_QUEUE) {
+        await c.env.SCAN_QUEUE.send(message);
+      } else {
+        c.executionCtx.waitUntil(
+          executeScanJob(c.env, c.executionCtx, message, db, { finalAttempt: true }),
+        );
+      }
+    }
+
     await recordScanEvent(db, {
       organizationId,
       actorUserId: session.userId,
-      type: "staged_publishes.listed",
-      metadata: { count: page.items.length, total: page.total },
+      type: "staged_publishes.scans_started",
+      metadata: {
+        found: stageIds.length,
+        created: scans.length,
+        skipped: stageIds.length - scans.length,
+      },
     });
-    return c.json(page);
+
+    return c.json(
+      {
+        found: stageIds.length,
+        created: scans.length,
+        skipped: stageIds.length - scans.length,
+        queued: Boolean(c.env.SCAN_QUEUE),
+        scans,
+      },
+      202,
+    );
   } catch (err) {
     if (err instanceof StagedPublishesFetchError) {
       return c.json(

--- a/server/routes/staged-publishes.ts
+++ b/server/routes/staged-publishes.ts
@@ -1,0 +1,69 @@
+import { Hono } from "hono";
+import {
+  RateLimitError,
+  createDb,
+  enforceRateLimit,
+  ensurePersonalOrganization,
+  recordScanEvent,
+} from "../db";
+import { getOrganizationNpmToken } from "../lib/npm-connection";
+import { StagedPublishesFetchError, listStagedPublishes } from "../lib/staged-publishes";
+import type { Bindings, Variables } from "../types";
+
+export const stagedPublishesRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+stagedPublishesRoutes.get("/", async (c) => {
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const organizationId = await ensurePersonalOrganization(db, session);
+
+  try {
+    await enforceRateLimit(db, {
+      key: `staged-publishes:list:${organizationId}`,
+      limit: 60,
+      windowMs: 60 * 1000,
+    });
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      return c.json(
+        { error: "staged publishes rate limit exceeded", retryAfterSeconds: err.retryAfterSeconds },
+        429,
+        { "retry-after": String(err.retryAfterSeconds) },
+      );
+    }
+    throw err;
+  }
+
+  const connection = await getOrganizationNpmToken(db, c.env, organizationId);
+  if (!connection) {
+    return c.json(
+      { error: "Connect an organization npm token before listing staged publishes." },
+      400,
+    );
+  }
+
+  try {
+    const page = await listStagedPublishes(connection.registryUrl, connection.token, {
+      perPage: 50,
+    });
+    await recordScanEvent(db, {
+      organizationId,
+      actorUserId: session.userId,
+      type: "staged_publishes.listed",
+      metadata: { count: page.items.length, total: page.total },
+    });
+    return c.json(page);
+  } catch (err) {
+    if (err instanceof StagedPublishesFetchError) {
+      return c.json(
+        {
+          error: "npm registry rejected the staged publishes request",
+          status: err.status,
+          detail: err.detail,
+        },
+        502,
+      );
+    }
+    throw err;
+  }
+});

--- a/src/models/staged-publishes.ts
+++ b/src/models/staged-publishes.ts
@@ -1,0 +1,37 @@
+import { createModel, signal } from "@preact/signals";
+import type { StagedPublishItem, StagedPublishesPage } from "../../server/lib/staged-publishes";
+import { apiFetch } from "./api";
+
+export type { StagedPublishItem, StagedPublishesPage };
+
+export function listStagedPublishes(): Promise<StagedPublishesPage> {
+  return apiFetch<StagedPublishesPage>("/api/v1/staged-publishes");
+}
+
+export const StagedPublishesModel = createModel(() => {
+  const items = signal<StagedPublishItem[]>([]);
+  const loaded = signal(false);
+  const refreshing = signal(false);
+  const error = signal<string | null>(null);
+
+  return {
+    items,
+    loaded,
+    refreshing,
+    error,
+
+    async refresh(): Promise<void> {
+      this.refreshing.value = true;
+      try {
+        const page = await listStagedPublishes();
+        this.items.value = page.items;
+        this.error.value = null;
+      } catch (err) {
+        this.error.value = err instanceof Error ? err.message : String(err);
+      } finally {
+        this.loaded.value = true;
+        this.refreshing.value = false;
+      }
+    },
+  };
+});

--- a/src/models/staged-publishes.ts
+++ b/src/models/staged-publishes.ts
@@ -1,33 +1,43 @@
 import { createModel, signal } from "@preact/signals";
-import type { StagedPublishItem, StagedPublishesPage } from "../../server/lib/staged-publishes";
+import type { StagedPublishesScanResponse } from "../../server/lib/staged-publishes";
 import { apiFetch } from "./api";
 
-export type { StagedPublishItem, StagedPublishesPage };
+export type { StagedPublishesScanResponse };
 
-export function listStagedPublishes(): Promise<StagedPublishesPage> {
-  return apiFetch<StagedPublishesPage>("/api/v1/staged-publishes");
+export function startStagedPublishScans(): Promise<StagedPublishesScanResponse> {
+  return apiFetch<StagedPublishesScanResponse>("/api/v1/staged-publishes/scan", {
+    method: "POST",
+  });
 }
 
 export const StagedPublishesModel = createModel(() => {
-  const items = signal<StagedPublishItem[]>([]);
+  const lastResult = signal<StagedPublishesScanResponse | null>(null);
   const loaded = signal(false);
   const refreshing = signal(false);
   const error = signal<string | null>(null);
 
   return {
-    items,
+    lastResult,
     loaded,
     refreshing,
     error,
 
-    async refresh(): Promise<void> {
+    reset(): void {
+      this.lastResult.value = null;
+      this.loaded.value = false;
+      this.error.value = null;
+    },
+
+    async discover(): Promise<StagedPublishesScanResponse | null> {
       this.refreshing.value = true;
       try {
-        const page = await listStagedPublishes();
-        this.items.value = page.items;
+        const result = await startStagedPublishScans();
+        this.lastResult.value = result;
         this.error.value = null;
+        return result;
       } catch (err) {
         this.error.value = err instanceof Error ? err.message : String(err);
+        return null;
       } finally {
         this.loaded.value = true;
         this.refreshing.value = false;

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -5,7 +5,7 @@ import { useLocation } from "preact-iso";
 import { sessionModel } from "../../models/auth";
 import { NpmConnectionModel } from "../../models/npm-connection";
 import { ScanListModel, ScanRequestModel, type ScanListItem } from "../../models/scan";
-import { StagedPublishesModel, type StagedPublishItem } from "../../models/staged-publishes";
+import { StagedPublishesModel } from "../../models/staged-publishes";
 import {
   Alert,
   Badge,
@@ -28,10 +28,9 @@ export default function DashboardPage() {
   const scans = useModel(ScanListModel);
   const npm = useModel(NpmConnectionModel);
   const request = useModel(ScanRequestModel);
-  const openStages = useModel(StagedPublishesModel);
+  const stagedPublishes = useModel(StagedPublishesModel);
   const sessionChecked = useSignal(false);
   const stagedPublishesConnectionId = useSignal<string | null>(null);
-  const openReportAfterSubmit = useSignal(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -53,36 +52,29 @@ export default function DashboardPage() {
   useSignalEffect(() => {
     const checked = sessionChecked.value;
     const connectionId = npm.connection.value?.id ?? null;
-    const refreshing = openStages.refreshing.value;
+    const refreshing = stagedPublishes.refreshing.value;
     const loadedConnectionId = stagedPublishesConnectionId.value;
     if (!checked) return;
     if (!connectionId) {
       stagedPublishesConnectionId.value = null;
-      openStages.items.value = [];
-      openStages.loaded.value = false;
-      openStages.error.value = null;
+      stagedPublishes.reset();
       return;
     }
     if (refreshing || loadedConnectionId === connectionId) return;
     stagedPublishesConnectionId.value = connectionId;
-    void openStages.refresh();
+    void discoverStagedPublishes(stagedPublishes, scans);
   });
 
   useSignalEffect(() => {
-    const status = request.status.value;
+    if (request.status.value !== "done") return;
     const id = request.lastResult.value?.scan.id;
-    const shouldOpenReport = openReportAfterSubmit.value;
-    if (status !== "done") return;
     if (!id) return;
     void scans.refresh();
-    if (shouldOpenReport) {
-      location.route(`/dashboard/scans/${encodeURIComponent(id)}`);
-    }
+    location.route(`/dashboard/scans/${encodeURIComponent(id)}`);
   });
 
   const onSubmit = async (event: Event) => {
     event.preventDefault();
-    openReportAfterSubmit.value = true;
     await request.submit();
   };
 
@@ -124,21 +116,21 @@ export default function DashboardPage() {
         </div>
       </header>
 
-      <OpenStagedPublishesSection
-        npm={npm}
-        openStages={openStages}
-        scans={scans}
-        request={request}
-        openReportAfterSubmit={openReportAfterSubmit}
-      />
-
       <ReviewRequestCard npm={npm} request={request} onSubmit={onSubmit} />
 
-      <RecentReviewsSection scans={scans} />
+      <RecentReviewsSection scans={scans} stagedPublishes={stagedPublishes} npm={npm} />
 
       <WorkspaceSetupPanel npm={npm} />
     </PageShell>
   );
+}
+
+async function discoverStagedPublishes(
+  stagedPublishes: ReturnType<typeof useModel<typeof StagedPublishesModel.prototype>>,
+  scans: ReturnType<typeof useModel<typeof ScanListModel.prototype>>,
+) {
+  await stagedPublishes.discover();
+  await scans.refresh();
 }
 
 function ReviewRequestCard({
@@ -201,147 +193,36 @@ function ReviewRequestCard({
   );
 }
 
-function OpenStagedPublishesSection({
-  npm,
-  openStages,
+function RecentReviewsSection({
   scans,
-  request,
-  openReportAfterSubmit,
+  stagedPublishes,
+  npm,
 }: {
-  npm: ReturnType<typeof useModel<typeof NpmConnectionModel.prototype>>;
-  openStages: ReturnType<typeof useModel<typeof StagedPublishesModel.prototype>>;
   scans: ReturnType<typeof useModel<typeof ScanListModel.prototype>>;
-  request: ReturnType<typeof useModel<typeof ScanRequestModel.prototype>>;
-  openReportAfterSubmit: { value: boolean };
+  stagedPublishes: ReturnType<typeof useModel<typeof StagedPublishesModel.prototype>>;
+  npm: ReturnType<typeof useModel<typeof NpmConnectionModel.prototype>>;
 }) {
   const connected = npm.isConnected.value;
-  const refreshing = openStages.refreshing.value;
-  const loaded = openStages.loaded.value;
-  const items = openStages.items.value;
-  const fetchError = openStages.error.value;
-  const requestStatus = request.status.value;
-  const pendingStageId = requestStatus === "scanning" ? request.stageId.value : null;
-  const scansByStageId = new Map<string, ScanListItem>(
-    scans.scans.value.map((scan: ScanListItem) => [scan.stageId, scan]),
-  );
-
-  const onScan = async (stageId: string) => {
-    openReportAfterSubmit.value = false;
-    request.stageId.value = stageId;
-    await request.submit();
+  const discovery = stagedPublishes.lastResult.value;
+  const discoveryError = stagedPublishes.error.value;
+  const discoveryRefreshing = stagedPublishes.refreshing.value;
+  const onDiscover = async () => {
+    await discoverStagedPublishes(stagedPublishes, scans);
   };
 
   return (
     <section class="flex flex-col gap-3">
       <div class="flex items-center gap-3">
-        <SectionLabel class="flex-1 min-w-0">Open staged publishes</SectionLabel>
+        <SectionLabel class="flex-1 min-w-0">Recent reviews</SectionLabel>
         <Button
           variant="secondary"
           size="sm"
-          onClick={() => void openStages.refresh()}
+          onClick={() => void onDiscover()}
           class="shrink-0"
-          disabled={refreshing || !connected}
+          disabled={discoveryRefreshing || !connected}
         >
-          {refreshing ? "Refreshing…" : "Refresh"}
+          {discoveryRefreshing ? "Checking…" : "Check npm"}
         </Button>
-      </div>
-      <Card class="p-0 overflow-hidden">
-        {!connected ? (
-          <div class="p-5">
-            <EmptyLine>
-              Connect npm access in workspace setup to list staged publishes for this org.
-            </EmptyLine>
-          </div>
-        ) : !loaded ? (
-          <div class="p-5">
-            <LoadingLine>Loading staged publishes…</LoadingLine>
-          </div>
-        ) : fetchError ? (
-          <div class="p-5">
-            <Alert tone="critical">{fetchError}</Alert>
-          </div>
-        ) : items.length ? (
-          <StagedPublishesTable
-            items={items}
-            scansByStageId={scansByStageId}
-            pendingStageId={pendingStageId}
-            onScan={onScan}
-          />
-        ) : (
-          <div class="p-5">
-            <EmptyLine>
-              No open staged publishes. New stages will appear here once the registry returns them.
-            </EmptyLine>
-          </div>
-        )}
-      </Card>
-    </section>
-  );
-}
-
-function StagedPublishesTable({
-  items,
-  scansByStageId,
-  pendingStageId,
-  onScan,
-}: {
-  items: StagedPublishItem[];
-  scansByStageId: Map<string, ScanListItem>;
-  pendingStageId: string | null;
-  onScan: (stageId: string) => Promise<void> | void;
-}) {
-  return (
-    <div class="overflow-x-auto">
-      <table class="w-full border-collapse text-[13px]">
-        <thead>
-          <tr class="border-b border-border bg-surface-2">
-            <Th>Package</Th>
-            <Th>Version</Th>
-            <Th>Tag</Th>
-            <Th>Staged by</Th>
-            <Th>Staged</Th>
-            <Th>Action</Th>
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((item) => {
-            const existingScan = scansByStageId.get(item.id);
-            const isPending = pendingStageId === item.id;
-            return (
-              <tr key={item.id} class="border-b border-border last:border-b-0 hover:bg-surface-2">
-                <Td>{item.packageName || item.id}</Td>
-                <Td class="font-mono text-xs text-ink-muted">{item.version || "—"}</Td>
-                <Td class="font-mono text-xs text-ink-muted">{item.tag || "—"}</Td>
-                <Td class="font-mono text-xs text-ink-muted">{item.actor || "—"}</Td>
-                <Td class="font-mono text-xs text-ink-muted">{formatDate(item.createdAt)}</Td>
-                <Td>
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    onClick={() => void onScan(item.id)}
-                    disabled={isPending || pendingStageId !== null}
-                  >
-                    {isPending ? "Scanning…" : existingScan ? "Scan again" : "Scan"}
-                  </Button>
-                </Td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </div>
-  );
-}
-
-function RecentReviewsSection({
-  scans,
-}: {
-  scans: ReturnType<typeof useModel<typeof ScanListModel.prototype>>;
-}) {
-  return (
-    <section class="flex flex-col gap-3">
-      <div class="flex items-center gap-3">
-        <SectionLabel class="flex-1 min-w-0">Recent reviews</SectionLabel>
         <Button
           variant="secondary"
           size="sm"
@@ -352,6 +233,16 @@ function RecentReviewsSection({
           {scans.refreshing.value ? "Refreshing…" : "Refresh"}
         </Button>
       </div>
+      {discoveryError ? <Alert tone="critical">{discoveryError}</Alert> : null}
+      {discovery && !discoveryError ? (
+        <Muted class="text-[13px] m-0">
+          {discovery.created
+            ? `Started ${discovery.created} new review${discovery.created === 1 ? "" : "s"} from npm.`
+            : discovery.found
+              ? "No new staged publishes need review."
+              : "No open staged publishes found."}
+        </Muted>
+      ) : null}
       <Card class="p-0 overflow-hidden">
         {scans.scans.value.length ? (
           <ScanTable scans={scans.scans.value} />

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -31,6 +31,7 @@ export default function DashboardPage() {
   const openStages = useModel(StagedPublishesModel);
   const sessionChecked = useSignal(false);
   const stagedPublishesConnectionId = useSignal<string | null>(null);
+  const openReportAfterSubmit = useSignal(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -68,15 +69,20 @@ export default function DashboardPage() {
   });
 
   useSignalEffect(() => {
-    if (request.status.value !== "done") return;
+    const status = request.status.value;
     const id = request.lastResult.value?.scan.id;
+    const shouldOpenReport = openReportAfterSubmit.value;
+    if (status !== "done") return;
     if (!id) return;
     void scans.refresh();
-    location.route(`/dashboard/scans/${encodeURIComponent(id)}`);
+    if (shouldOpenReport) {
+      location.route(`/dashboard/scans/${encodeURIComponent(id)}`);
+    }
   });
 
   const onSubmit = async (event: Event) => {
     event.preventDefault();
+    openReportAfterSubmit.value = true;
     await request.submit();
   };
 
@@ -123,6 +129,7 @@ export default function DashboardPage() {
         openStages={openStages}
         scans={scans}
         request={request}
+        openReportAfterSubmit={openReportAfterSubmit}
       />
 
       <ReviewRequestCard npm={npm} request={request} onSubmit={onSubmit} />
@@ -199,11 +206,13 @@ function OpenStagedPublishesSection({
   openStages,
   scans,
   request,
+  openReportAfterSubmit,
 }: {
   npm: ReturnType<typeof useModel<typeof NpmConnectionModel.prototype>>;
   openStages: ReturnType<typeof useModel<typeof StagedPublishesModel.prototype>>;
   scans: ReturnType<typeof useModel<typeof ScanListModel.prototype>>;
   request: ReturnType<typeof useModel<typeof ScanRequestModel.prototype>>;
+  openReportAfterSubmit: { value: boolean };
 }) {
   const connected = npm.isConnected.value;
   const refreshing = openStages.refreshing.value;
@@ -217,6 +226,7 @@ function OpenStagedPublishesSection({
   );
 
   const onScan = async (stageId: string) => {
+    openReportAfterSubmit.value = false;
     request.stageId.value = stageId;
     await request.submit();
   };
@@ -305,23 +315,14 @@ function StagedPublishesTable({
                 <Td class="font-mono text-xs text-ink-muted">{item.actor || "—"}</Td>
                 <Td class="font-mono text-xs text-ink-muted">{formatDate(item.createdAt)}</Td>
                 <Td>
-                  {existingScan ? (
-                    <a
-                      href={`/dashboard/scans/${encodeURIComponent(existingScan.id)}`}
-                      class="font-mono text-xs"
-                    >
-                      View review
-                    </a>
-                  ) : (
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => void onScan(item.id)}
-                      disabled={isPending || pendingStageId !== null}
-                    >
-                      {isPending ? "Scanning…" : "Scan"}
-                    </Button>
-                  )}
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => void onScan(item.id)}
+                    disabled={isPending || pendingStageId !== null}
+                  >
+                    {isPending ? "Scanning…" : existingScan ? "Scan again" : "Scan"}
+                  </Button>
                 </Td>
               </tr>
             );

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -5,6 +5,7 @@ import { useLocation } from "preact-iso";
 import { sessionModel } from "../../models/auth";
 import { NpmConnectionModel } from "../../models/npm-connection";
 import { ScanListModel, ScanRequestModel, type ScanListItem } from "../../models/scan";
+import { StagedPublishesModel, type StagedPublishItem } from "../../models/staged-publishes";
 import {
   Alert,
   Badge,
@@ -27,6 +28,7 @@ export default function DashboardPage() {
   const scans = useModel(ScanListModel);
   const npm = useModel(NpmConnectionModel);
   const request = useModel(ScanRequestModel);
+  const openStages = useModel(StagedPublishesModel);
   const sessionChecked = useSignal(false);
 
   useEffect(() => {
@@ -40,6 +42,8 @@ export default function DashboardPage() {
       }
       sessionChecked.value = true;
       await Promise.all([scans.refresh(), npm.load()]);
+      if (cancelled) return;
+      if (npm.isConnected.value) await openStages.refresh();
     })();
     return () => {
       cancelled = true;
@@ -96,6 +100,13 @@ export default function DashboardPage() {
           </Button>
         </div>
       </header>
+
+      <OpenStagedPublishesSection
+        npm={npm}
+        openStages={openStages}
+        scans={scans}
+        request={request}
+      />
 
       <ReviewRequestCard npm={npm} request={request} onSubmit={onSubmit} />
 
@@ -163,6 +174,144 @@ function ReviewRequestCard({
       </form>
       {request.error.value ? <Alert tone="critical">{request.error.value}</Alert> : null}
     </Card>
+  );
+}
+
+function OpenStagedPublishesSection({
+  npm,
+  openStages,
+  scans,
+  request,
+}: {
+  npm: ReturnType<typeof useModel<typeof NpmConnectionModel.prototype>>;
+  openStages: ReturnType<typeof useModel<typeof StagedPublishesModel.prototype>>;
+  scans: ReturnType<typeof useModel<typeof ScanListModel.prototype>>;
+  request: ReturnType<typeof useModel<typeof ScanRequestModel.prototype>>;
+}) {
+  const connected = npm.isConnected.value;
+  const refreshing = openStages.refreshing.value;
+  const loaded = openStages.loaded.value;
+  const items = openStages.items.value;
+  const fetchError = openStages.error.value;
+  const requestStatus = request.status.value;
+  const pendingStageId = requestStatus === "scanning" ? request.stageId.value : null;
+  const scansByStageId = new Map<string, ScanListItem>(
+    scans.scans.value.map((scan: ScanListItem) => [scan.stageId, scan]),
+  );
+
+  const onScan = async (stageId: string) => {
+    request.stageId.value = stageId;
+    await request.submit();
+  };
+
+  return (
+    <section class="flex flex-col gap-3">
+      <div class="flex items-center gap-3">
+        <SectionLabel class="flex-1 min-w-0">Open staged publishes</SectionLabel>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => void openStages.refresh()}
+          class="shrink-0"
+          disabled={refreshing || !connected}
+        >
+          {refreshing ? "Refreshing…" : "Refresh"}
+        </Button>
+      </div>
+      <Card class="p-0 overflow-hidden">
+        {!connected ? (
+          <div class="p-5">
+            <EmptyLine>
+              Connect npm access in workspace setup to list staged publishes for this org.
+            </EmptyLine>
+          </div>
+        ) : !loaded ? (
+          <div class="p-5">
+            <LoadingLine>Loading staged publishes…</LoadingLine>
+          </div>
+        ) : fetchError ? (
+          <div class="p-5">
+            <Alert tone="critical">{fetchError}</Alert>
+          </div>
+        ) : items.length ? (
+          <StagedPublishesTable
+            items={items}
+            scansByStageId={scansByStageId}
+            pendingStageId={pendingStageId}
+            onScan={onScan}
+          />
+        ) : (
+          <div class="p-5">
+            <EmptyLine>
+              No open staged publishes. New stages will appear here once the registry returns them.
+            </EmptyLine>
+          </div>
+        )}
+      </Card>
+    </section>
+  );
+}
+
+function StagedPublishesTable({
+  items,
+  scansByStageId,
+  pendingStageId,
+  onScan,
+}: {
+  items: StagedPublishItem[];
+  scansByStageId: Map<string, ScanListItem>;
+  pendingStageId: string | null;
+  onScan: (stageId: string) => Promise<void> | void;
+}) {
+  return (
+    <div class="overflow-x-auto">
+      <table class="w-full border-collapse text-[13px]">
+        <thead>
+          <tr class="border-b border-border bg-surface-2">
+            <Th>Package</Th>
+            <Th>Version</Th>
+            <Th>Tag</Th>
+            <Th>Staged by</Th>
+            <Th>Staged</Th>
+            <Th>Action</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => {
+            const existingScan = scansByStageId.get(item.id);
+            const isPending = pendingStageId === item.id;
+            return (
+              <tr key={item.id} class="border-b border-border last:border-b-0 hover:bg-surface-2">
+                <Td>{item.packageName || item.id}</Td>
+                <Td class="font-mono text-xs text-ink-muted">{item.version || "—"}</Td>
+                <Td class="font-mono text-xs text-ink-muted">{item.tag || "—"}</Td>
+                <Td class="font-mono text-xs text-ink-muted">{item.actor || "—"}</Td>
+                <Td class="font-mono text-xs text-ink-muted">{formatDate(item.createdAt)}</Td>
+                <Td>
+                  {existingScan ? (
+                    <a
+                      href={`/dashboard/scans/${encodeURIComponent(existingScan.id)}`}
+                      class="font-mono text-xs"
+                    >
+                      View review
+                    </a>
+                  ) : (
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => void onScan(item.id)}
+                      disabled={isPending || pendingStageId !== null}
+                    >
+                      {isPending ? "Scanning…" : "Scan"}
+                    </Button>
+                  )}
+                </Td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
   );
 }
 
@@ -444,7 +593,8 @@ function Td({ children, class: className }: { children: ComponentChildren; class
   return <td class={`px-4 py-2.5 align-middle ${className || ""}`}>{children}</td>;
 }
 
-function formatDate(value: ScanListItem["createdAt"]) {
+function formatDate(value: string | number | Date | null | undefined) {
+  if (value === null || value === undefined) return "—";
   const date = new Date(value);
   return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString();
 }

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -30,6 +30,7 @@ export default function DashboardPage() {
   const request = useModel(ScanRequestModel);
   const openStages = useModel(StagedPublishesModel);
   const sessionChecked = useSignal(false);
+  const stagedPublishesConnectionId = useSignal<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -42,13 +43,29 @@ export default function DashboardPage() {
       }
       sessionChecked.value = true;
       await Promise.all([scans.refresh(), npm.load()]);
-      if (cancelled) return;
-      if (npm.isConnected.value) await openStages.refresh();
     })();
     return () => {
       cancelled = true;
     };
   }, []);
+
+  useSignalEffect(() => {
+    const checked = sessionChecked.value;
+    const connectionId = npm.connection.value?.id ?? null;
+    const refreshing = openStages.refreshing.value;
+    const loadedConnectionId = stagedPublishesConnectionId.value;
+    if (!checked) return;
+    if (!connectionId) {
+      stagedPublishesConnectionId.value = null;
+      openStages.items.value = [];
+      openStages.loaded.value = false;
+      openStages.error.value = null;
+      return;
+    }
+    if (refreshing || loadedConnectionId === connectionId) return;
+    stagedPublishesConnectionId.value = connectionId;
+    void openStages.refresh();
+  });
 
   useSignalEffect(() => {
     if (request.status.value !== "done") return;

--- a/test/workers/cross-org-routes.test.ts
+++ b/test/workers/cross-org-routes.test.ts
@@ -1,4 +1,5 @@
 import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { describe, expect, test } from "vitest";
 import { createDb, createScanJob, ensurePersonalOrganization, persistScan } from "../../server/db";
@@ -28,17 +29,26 @@ async function seedUser(): Promise<SeededUser> {
 }
 
 async function seedCompletedScan(owner: SeededUser, packageName: string) {
+  return seedCompletedScanWithStage(owner, packageName, undefined);
+}
+
+async function seedCompletedScanWithStage(
+  owner: SeededUser,
+  packageName: string,
+  stageIdOverride?: string,
+) {
   const db = createDb(env.DB);
   const scanId = `scan_${crypto.randomUUID()}`;
+  const stageId = stageIdOverride ?? `stage-${scanId.slice(-12)}`;
   await createScanJob(db, {
     id: scanId,
-    stageId: `stage-${scanId.slice(-12)}`,
+    stageId,
     organizationId: owner.organizationId,
     ownerUserId: owner.userId,
   });
   await persistScan(db, {
     id: scanId,
-    stageId: `stage-${scanId.slice(-12)}`,
+    stageId,
     organizationId: owner.organizationId,
     ownerUserId: owner.userId,
     packageJson: { name: packageName, version: "1.2.3" },
@@ -89,6 +99,31 @@ describe("scans routes enforce organization boundaries", () => {
     expect(intruderRes.status).toBe(200);
     const intruderBody = (await intruderRes.json()) as { scans: Array<{ id: string }> };
     expect(intruderBody.scans.map((s) => s.id)).not.toContain(scanId);
+  });
+
+  test("GET /scans returns only the newest scan for each stage id", async () => {
+    const owner = await seedUser();
+    const db = createDb(env.DB);
+    const stageId = `stage-${crypto.randomUUID().slice(0, 12)}`;
+    const olderId = await seedCompletedScanWithStage(owner, "@org/retry-package", stageId);
+    const newerId = await seedCompletedScanWithStage(owner, "@org/retry-package", stageId);
+
+    await Promise.all([
+      db
+        .update(schema.scans)
+        .set({ createdAt: new Date(1), updatedAt: new Date(1) })
+        .where(eq(schema.scans.id, olderId)),
+      db
+        .update(schema.scans)
+        .set({ createdAt: new Date(2), updatedAt: new Date(2) })
+        .where(eq(schema.scans.id, newerId)),
+    ]);
+
+    const res = await fetchWithSession(buildTestApp(owner), "/api/v1/scans");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { scans: Array<{ id: string; stageId: string }> };
+    const matching = body.scans.filter((scan) => scan.stageId === stageId);
+    expect(matching.map((scan) => scan.id)).toEqual([newerId]);
   });
 
   test("GET /scans/:id returns 404 for scans owned by another organization", async () => {

--- a/test/workers/staged-publishes-routes.test.ts
+++ b/test/workers/staged-publishes-routes.test.ts
@@ -1,0 +1,110 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  createDb,
+  createScanJob,
+  ensurePersonalOrganization,
+  listScans,
+  upsertNpmConnection,
+} from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { encryptNpmToken } from "../../server/lib/npm-connection";
+import { stagedPublishesRoutes } from "../../server/routes/staged-publishes";
+import type { Bindings, Variables } from "../../server/types";
+
+interface SeededUser {
+  userId: string;
+  organizationId: string;
+}
+
+async function seedUser(): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+function buildTestApp(session: { userId: string }) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.use("*", async (c, next) => {
+    c.set("authSession", { userId: session.userId });
+    await next();
+  });
+  app.route("/api/v1/staged-publishes", stagedPublishesRoutes);
+  return app;
+}
+
+describe("staged publishes route", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("POST /scan creates scans only for newly discovered stage ids", async () => {
+    const owner = await seedUser();
+    const db = createDb(env.DB);
+    const encrypted = await encryptNpmToken(env, "npm_test_token_0123456789");
+    await upsertNpmConnection(db, {
+      organizationId: owner.organizationId,
+      registryUrl: "https://registry.npmjs.org",
+      label: "npm registry",
+      createdByUserId: owner.userId,
+      ...encrypted,
+    });
+    await createScanJob(db, {
+      id: `scan_${crypto.randomUUID()}`,
+      stageId: "stage-existing-123",
+      organizationId: owner.organizationId,
+      ownerUserId: owner.userId,
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL | Request) => {
+        expect(String(url)).toBe("https://registry.npmjs.org/-/stage?perPage=50");
+        return Response.json({
+          items: [{ id: "stage-existing-123" }, { id: "stage-new-123" }],
+          total: 2,
+          perPage: 50,
+          page: 1,
+        });
+      }),
+    );
+    const queue = { send: vi.fn(async () => undefined) };
+    const app = buildTestApp(owner);
+    const ctx = createExecutionContext();
+    const res = await app.fetch(
+      new Request("http://test.local/api/v1/staged-publishes/scan", { method: "POST" }),
+      { ...env, SCAN_QUEUE: queue } as unknown as Bindings,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as {
+      found: number;
+      created: number;
+      skipped: number;
+      scans: Array<{ id: string; stageId: string }>;
+    };
+    expect(body).toMatchObject({
+      found: 2,
+      created: 1,
+      skipped: 1,
+      scans: [{ stageId: "stage-new-123" }],
+    });
+    expect(queue.send).toHaveBeenCalledTimes(1);
+    expect(queue.send.mock.calls[0]?.[0]).toMatchObject({ stageId: "stage-new-123" });
+    const scans = await listScans(db, owner.organizationId);
+    expect(scans.map((scan) => scan.stageId)).toContain("stage-new-123");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/staged-publishes`, which calls the registry's `GET /-/stage` endpoint with the org's stored npm token and returns a sanitized `{ items, total, perPage, page }`.
- New dashboard panel "Open staged publishes" lists those stages with package / version / tag / staged-by / staged-at columns and a per-row action: links to the existing review if a scan already exists for that `stageId`, otherwise kicks off a scan through the existing `ScanRequestModel` pipeline.
- Adds `StagedPublishesModel` on the client and a defensive `parseStagedPublishesResponse` server-side (validates `id` against the same `STAGE_ID_RE` the scan pipeline accepts).

## Test plan
- [ ] `pnpm run verify` passes locally (lint + format + typecheck + 52 tests).
- [ ] With an npm connection configured, the panel populates from `/-/stage` and the per-row Scan / View review action behaves correctly.
- [ ] With no npm connection, the panel shows the connect-npm empty line and the refresh button is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)