### PR TITLE
Share tar parser between sandbox and tests; add archive + npm-connection regression suites

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -59,6 +59,8 @@ The Dynamic Worker handles untrusted package bytes. It:
 
 The sandbox must stay small and boring. Do not add package execution, dependency installation, build steps, import resolution, or rendering.
 
+The dynamic Worker's tar parser is defined in `server/lib/tar-parser.js` and concatenated into the sandbox module by `server/lib/sandbox.ts` via `Function.prototype.toString()`. This keeps the parser code path the one exercised by the unit tests in `test/tar-parser.test.mjs` instead of a sibling string copy that could drift.
+
 ### NpmStageGateway
 
 `NpmStageGateway` is the only component allowed to attach npm authorization. It follows Cloudflare's [outbound Worker pattern for sandbox auth](https://blog.cloudflare.com/sandbox-auth/): the sandbox makes a normal fetch, while a trusted WorkerEntrypoint receives props from the parent Worker and conditionally injects credentials without exposing them to the sandbox.

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -18,11 +18,12 @@ The prototype-to-product foundation is in place: authenticated organization-scop
 
 Private beta blockers:
 
-- Tenant-boundary, sandbox-gateway, and archive-parser regression tests.
 - Operator-visible failure metrics for scan duration, queue retries, and AI/npm failures.
 - Signup/credential abuse controls for an invite-only beta.
 - Report deletion plus a documented retention policy for persisted redacted evidence.
 - Production deploy checklist covering D1 migrations, Queues, KV, secrets, and incident response.
+
+Closed: tenant-boundary, sandbox-gateway, and archive-parser regression tests now have route- and unit-level coverage (`test/workers/cross-org-routes.test.ts`, `test/workers/cross-org-npm-connection.test.ts`, `test/workers/sandbox-gateway-runtime.test.ts`, `test/tar-parser.test.mjs`).
 
 Not private-beta blockers unless customer evidence demands them:
 
@@ -112,9 +113,9 @@ Reliability and operations:
 
 Security boundaries:
 
-- Add cross-organization tests for npm connection isolation. (Scan detail/list/compare route-level coverage landed via `test/workers/cross-org-routes.test.ts`; DB-layer assertion landed earlier via `test/workers/scan-idempotency.test.ts`. Still need route-level cross-org coverage for npm-connection endpoints.)
-- Sandbox gateway runtime credential-injection coverage landed via `test/workers/sandbox-gateway-runtime.test.ts`. (Pure-function policy coverage in `test/sandbox-gateway.test.mjs` remains as a fast unit test.)
-- Add tar parser regression tests for traversal paths, absolute paths, PAX paths, GNU long names, links, truncation, huge file counts, and archive-size caps.
+- Cross-organization tests for npm connection isolation now cover scan detail/list/compare (`test/workers/cross-org-routes.test.ts`), DB-layer ownership (`test/workers/scan-idempotency.test.ts`), and the npm-connection routes themselves (`test/workers/cross-org-npm-connection.test.ts`).
+- Sandbox gateway runtime credential-injection coverage landed via `test/workers/sandbox-gateway-runtime.test.ts`. Pure-function policy coverage in `test/sandbox-gateway.test.mjs` remains as a fast unit test.
+- Tar parser regression coverage landed via `test/tar-parser.test.mjs` (traversal paths, absolute-path normalization, PAX paths, GNU long names, link skipping, truncation, file-count caps, archive-bomb caps). The pure parser lives in `server/lib/tar-parser.js`; `server/lib/sandbox.ts` concatenates the same function source into the dynamic Worker so the unit-tested code path is the one that runs in the isolated sandbox.
 - Investigate build output to ensure local `.dev.vars` secrets are never included in deployable or public artifacts.
 
 Abuse and data lifecycle:
@@ -282,9 +283,9 @@ Exit criteria:
 
 ## Suggested next implementation slice
 
-With route-level cross-org coverage, sandbox gateway runtime tests, and deterministic rule IDs landed, the next two slices are:
+With cross-org coverage extended to the npm-connection routes and the tar parser now unit-tested via a shared module, the security-test baseline for private beta is in place. The next two slices are:
 
 1. **Private beta operations:** configure production Queues/KV/D1/secrets, add metrics/logging for scan duration and failure classes, add invite-only signup protection, and document deployment + incident response.
-2. **Remaining boundary tests:** add archive parser regression fixtures (traversal, PAX, GNU long names, links, truncation, archive-bomb caps) and route-level cross-org coverage for npm-connection endpoints.
+2. **Data lifecycle:** ship scan/report deletion plus a documented retention policy for persisted redacted text samples.
 
 After those land, improve maintainer UX by grouping findings (now that rule IDs exist) and adding the lifecycle timeline before broadening beta access.

--- a/server/lib/sandbox.ts
+++ b/server/lib/sandbox.ts
@@ -1,9 +1,30 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
 import type { FileRecord, PackageJsonSummary } from "./review";
+import * as tarParser from "./tar-parser.js";
 
 const MAX_FILES = 250;
 const MAX_BYTES_PER_FILE = 64 * 1024;
 const MAX_TAR_BYTES = 25 * 1024 * 1024;
+
+// Functions whose source text is concatenated into the sandbox worker module.
+// They must remain referenced only by lexical name (no closures) so the order
+// of concatenation and the names below stay stable after bundling.
+const SANDBOX_TAR_PARSER_EXPORTS = [
+  tarParser.readString,
+  tarParser.decodeText,
+  tarParser.isSafePaxPath,
+  tarParser.normalizeTarPath,
+  tarParser.parsePax,
+  tarParser.sha256Hex,
+  tarParser.summarizeFile,
+  tarParser.readTar,
+  tarParser.parsePackageJson,
+  tarParser.gunzipBounded,
+];
+
+function renderTarParserSource() {
+  return SANDBOX_TAR_PARSER_EXPORTS.map((fn) => fn.toString()).join("\n\n");
+}
 
 interface NpmStageGatewayProps {
   npmToken?: string;
@@ -142,7 +163,8 @@ export async function downloadInSandbox(
 }
 
 function sandboxSource() {
-  return String.raw`
+  return `${renderTarParserSource()}
+
 const STAGE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{5,160}$/;
 
 export default {
@@ -151,7 +173,7 @@ export default {
     if (!tarballUrl && !STAGE_ID_RE.test(stageId)) return json({ error: "invalid stageId" }, 400);
 
     const registry = env.NPM_REGISTRY || "https://registry.npmjs.org";
-    const url = tarballUrl || registry.replace(/\/$/, "") + "/-/stage/" + encodeURIComponent(stageId) + "/tarball";
+    const url = tarballUrl || registry.replace(/\\/$/, "") + "/-/stage/" + encodeURIComponent(stageId) + "/tarball";
     const res = await fetch(url, { headers: { accept: "application/octet-stream" } });
     if (!res.ok) return json({ error: "download failed", status: res.status }, 502);
 
@@ -175,146 +197,6 @@ export default {
   },
 };
 
-async function gunzipBounded(body, maxBytes) {
-  if (!body) throw new Error("tarball decompression failed");
-  const ds = new DecompressionStream("gzip");
-  const reader = body.pipeThrough(ds).getReader();
-  const chunks = [];
-  let total = 0;
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    total += value.byteLength;
-    if (total > maxBytes) {
-      reader.cancel().catch(() => undefined);
-      throw new Error("archive expands beyond safety limit");
-    }
-    chunks.push(value);
-  }
-  const out = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) {
-    out.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return out.buffer;
-}
-
-async function readTar(buffer, maxFiles, maxBytesPerFile, maxTarBytes) {
-  const bytes = new Uint8Array(buffer);
-  const files = [];
-  let nextLongName = null;
-  let pax = null;
-
-  for (let offset = 0; offset + 512 <= bytes.length && files.length < maxFiles;) {
-    const header = bytes.subarray(offset, offset + 512);
-    if (header.every((b) => b === 0)) break;
-
-    const rawName = readString(header, 0, 100);
-    const prefix = readString(header, 345, 155);
-    const sizeText = readString(header, 124, 12).trim() || "0";
-    if (!/^[0-7]+$/.test(sizeText)) throw new Error("invalid tar entry size");
-    const size = parseInt(sizeText, 8);
-    if (!Number.isFinite(size) || size < 0 || size > maxTarBytes) throw new Error("invalid tar entry size");
-    const type = String.fromCharCode(header[156] || 48);
-    offset += 512;
-    if (offset + size > bytes.length) throw new Error("truncated tar entry");
-    const body = bytes.subarray(offset, offset + size);
-
-    if (type === "x") {
-      pax = parsePax(body);
-      if (pax && typeof pax.path === "string" && !isSafePaxPath(pax.path)) {
-        throw new Error("invalid pax path");
-      }
-    } else if (type === "L") {
-      const candidate = readString(body, 0, body.length).replace(/\0+$/, "");
-      if (!isSafePaxPath(candidate)) throw new Error("invalid long-name path");
-      nextLongName = candidate;
-    } else if (type === "0" || type === "\0") {
-      const path = normalizeTarPath(pax?.path || nextLongName || (prefix ? prefix + "/" : "") + rawName);
-      if (path) files.push(await summarizeFile(path, body, maxBytesPerFile));
-      nextLongName = null;
-      pax = null;
-    } else if (type === "1" || type === "2") {
-      // Hardlinks and symlinks are not extracted. They are skipped so link targets cannot escape the package tree.
-      nextLongName = null;
-      pax = null;
-    } else if (type !== "L") {
-      nextLongName = null;
-      pax = null;
-    }
-
-    offset += Math.ceil(size / 512) * 512;
-  }
-  return files;
-}
-
-function isSafePaxPath(value) {
-  return typeof value === "string" && !value.includes("\0") && !value.includes("\\");
-}
-
-async function summarizeFile(path, body, maxBytesPerFile) {
-  const flags = [];
-  if (body.length > maxBytesPerFile) flags.push("truncated");
-  const sample = body.subarray(0, Math.min(body.length, maxBytesPerFile));
-  const text = decodeText(sample);
-  if (!text) flags.push("binary");
-  return { path, size: body.length, sha256: await sha256(body), flags, ...(text ? { textSample: text } : {}) };
-}
-
-function normalizeTarPath(rawPath) {
-  if (!rawPath || rawPath.includes("\0") || rawPath.includes("\\")) return null;
-  let path = rawPath.replace(/^\/+/, "").replace(/^package\//, "");
-  if (!path || path.startsWith("../") || path.includes("/../") || /^[A-Za-z]:/.test(path)) return null;
-  const parts = path.split("/").filter(Boolean);
-  if (!parts.length || parts.some((part) => part === "." || part === "..")) return null;
-  path = parts.join("/");
-  if (path.length > 512) return null;
-  return path;
-}
-
-function parsePax(body) {
-  const text = decodeText(body.subarray(0, Math.min(body.length, 8192)));
-  const out = {};
-  let index = 0;
-  while (index < text.length) {
-    const space = text.indexOf(" ", index);
-    if (space === -1) break;
-    const length = Number(text.slice(index, space));
-    if (!Number.isFinite(length) || length <= 0) break;
-    const record = text.slice(space + 1, index + length).replace(/\n$/, "");
-    const equals = record.indexOf("=");
-    if (equals > 0) out[record.slice(0, equals)] = record.slice(equals + 1);
-    index += length;
-  }
-  return out;
-}
-
-function parsePackageJson(files) {
-  const pkg = files.find((f) => f.path === "package.json" && f.textSample);
-  if (!pkg) return null;
-  try {
-    const parsed = JSON.parse(pkg.textSample);
-    return {
-      name: parsed.name,
-      version: parsed.version,
-      scripts: parsed.scripts || {},
-      dependencies: parsed.dependencies || {},
-      devDependencies: parsed.devDependencies || {},
-      peerDependencies: parsed.peerDependencies || {},
-      optionalDependencies: parsed.optionalDependencies || {},
-      bin: parsed.bin,
-      main: parsed.main,
-      module: parsed.module,
-      types: parsed.types,
-      exports: parsed.exports,
-    };
-  } catch { return null; }
-}
-
-function readString(bytes, start, len) { let out = ""; for (let i = start; i < start + len && bytes[i]; i++) out += String.fromCharCode(bytes[i]); return out; }
-function decodeText(bytes) { if (bytes.some((b) => b === 0)) return ""; const text = new TextDecoder("utf-8", { fatal: false }).decode(bytes); const control = [...text].filter((ch) => ch < " " && !"\n\r\t".includes(ch)).length; if (control > Math.max(5, text.length * 0.02)) return ""; return text; }
-async function sha256(bytes) { const digest = await crypto.subtle.digest("SHA-256", bytes); return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join(""); }
 function json(value, status = 200) { return new Response(JSON.stringify(value, null, 2), { status, headers: { "content-type": "application/json; charset=utf-8" } }); }
 `;
 }

--- a/server/lib/tar-parser.d.ts
+++ b/server/lib/tar-parser.d.ts
@@ -1,0 +1,45 @@
+export interface ParsedFile {
+  path: string;
+  size: number;
+  sha256: string;
+  flags: string[];
+  textSample?: string;
+}
+
+export interface ParsedPackageJson {
+  name?: string;
+  version?: string;
+  scripts?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  bin?: unknown;
+  main?: string;
+  module?: string;
+  types?: string;
+  exports?: unknown;
+}
+
+export function readString(bytes: Uint8Array, start: number, len: number): string;
+export function decodeText(bytes: Uint8Array): string;
+export function isSafePaxPath(value: unknown): boolean;
+export function normalizeTarPath(rawPath: string | null | undefined): string | null;
+export function parsePax(body: Uint8Array): Record<string, string>;
+export function sha256Hex(bytes: Uint8Array): Promise<string>;
+export function summarizeFile(
+  path: string,
+  body: Uint8Array,
+  maxBytesPerFile: number,
+): Promise<ParsedFile>;
+export function readTar(
+  buffer: ArrayBuffer | Uint8Array,
+  maxFiles: number,
+  maxBytesPerFile: number,
+  maxTarBytes: number,
+): Promise<ParsedFile[]>;
+export function parsePackageJson(files: ParsedFile[]): ParsedPackageJson | null;
+export function gunzipBounded(
+  body: ReadableStream<Uint8Array> | null,
+  maxBytes: number,
+): Promise<ArrayBuffer>;

--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -15,9 +15,6 @@
 
 /** @typedef {{ path: string, size: number, sha256: string, flags: string[], textSample?: string }} ParsedFile */
 
-// String.fromCharCode(0) avoids embedding a literal NUL byte in this source
-// file, which would not survive every round-trip through tooling.
-const NUL = String.fromCharCode(0);
 export function readString(bytes, start, len) {
   let out = "";
   for (let i = start; i < start + len && bytes[i]; i++) out += String.fromCharCode(bytes[i]);
@@ -33,11 +30,13 @@ export function decodeText(bytes) {
 }
 
 export function isSafePaxPath(value) {
-  return typeof value === "string" && !value.includes(NUL) && !value.includes("\\");
+  const nul = String.fromCharCode(0);
+  return typeof value === "string" && !value.includes(nul) && !value.includes("\\");
 }
 
 export function normalizeTarPath(rawPath) {
-  if (!rawPath || rawPath.includes(NUL) || rawPath.includes("\\")) return null;
+  const nul = String.fromCharCode(0);
+  if (!rawPath || rawPath.includes(nul) || rawPath.includes("\\")) return null;
   let path = rawPath.replace(/^\/+/, "").replace(/^package\//, "");
   if (!path || path.startsWith("../") || path.includes("/../") || /^[A-Za-z]:/.test(path))
     return null;
@@ -86,6 +85,7 @@ export async function summarizeFile(path, body, maxBytesPerFile) {
 }
 
 export async function readTar(buffer, maxFiles, maxBytesPerFile, maxTarBytes) {
+  const nul = String.fromCharCode(0);
   const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
   const files = [];
   let nextLongName = null;
@@ -118,7 +118,7 @@ export async function readTar(buffer, maxFiles, maxBytesPerFile, maxTarBytes) {
       const candidate = readString(body, 0, body.length);
       if (!isSafePaxPath(candidate)) throw new Error("invalid long-name path");
       nextLongName = candidate;
-    } else if (type === "0" || type === NUL) {
+    } else if (type === "0" || type === nul) {
       const path = normalizeTarPath(
         (pax && pax.path) || nextLongName || (prefix ? prefix + "/" : "") + rawName,
       );

--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -1,0 +1,189 @@
+// Pure tar parsing helpers used by the sandbox download worker.
+//
+// This module is loaded two ways:
+//   1. As an ESM module by the regression tests in `test/tar-parser.test.mjs`.
+//   2. Through `Function.prototype.toString()` from `server/lib/sandbox.ts`,
+//      which concatenates the source of each exported function into the
+//      dynamic Worker that runs in the isolated sandbox.
+//
+// Constraints:
+//   - Only built-in globals available in both Node and Cloudflare Workers
+//     (crypto.subtle, TextDecoder, DecompressionStream) may be referenced.
+//   - No external imports; everything must be self-contained.
+//   - Identifier names matter: when the rendered source runs in the sandbox,
+//     cross-function calls resolve by the lexical names below.
+
+/** @typedef {{ path: string, size: number, sha256: string, flags: string[], textSample?: string }} ParsedFile */
+
+// String.fromCharCode(0) avoids embedding a literal NUL byte in this source
+// file, which would not survive every round-trip through tooling.
+const NUL = String.fromCharCode(0);
+export function readString(bytes, start, len) {
+  let out = "";
+  for (let i = start; i < start + len && bytes[i]; i++) out += String.fromCharCode(bytes[i]);
+  return out;
+}
+
+export function decodeText(bytes) {
+  if (bytes.some((b) => b === 0)) return "";
+  const text = new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+  const control = [...text].filter((ch) => ch < " " && !"\n\r\t".includes(ch)).length;
+  if (control > Math.max(5, text.length * 0.02)) return "";
+  return text;
+}
+
+export function isSafePaxPath(value) {
+  return typeof value === "string" && !value.includes(NUL) && !value.includes("\\");
+}
+
+export function normalizeTarPath(rawPath) {
+  if (!rawPath || rawPath.includes(NUL) || rawPath.includes("\\")) return null;
+  let path = rawPath.replace(/^\/+/, "").replace(/^package\//, "");
+  if (!path || path.startsWith("../") || path.includes("/../") || /^[A-Za-z]:/.test(path))
+    return null;
+  const parts = path.split("/").filter(Boolean);
+  if (!parts.length || parts.some((part) => part === "." || part === "..")) return null;
+  path = parts.join("/");
+  if (path.length > 512) return null;
+  return path;
+}
+
+export function parsePax(body) {
+  const text = decodeText(body.subarray(0, Math.min(body.length, 8192)));
+  const out = {};
+  let index = 0;
+  while (index < text.length) {
+    const space = text.indexOf(" ", index);
+    if (space === -1) break;
+    const length = Number(text.slice(index, space));
+    if (!Number.isFinite(length) || length <= 0) break;
+    const record = text.slice(space + 1, index + length).replace(/\n$/, "");
+    const equals = record.indexOf("=");
+    if (equals > 0) out[record.slice(0, equals)] = record.slice(equals + 1);
+    index += length;
+  }
+  return out;
+}
+
+export async function sha256Hex(bytes) {
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export async function summarizeFile(path, body, maxBytesPerFile) {
+  const flags = [];
+  if (body.length > maxBytesPerFile) flags.push("truncated");
+  const sample = body.subarray(0, Math.min(body.length, maxBytesPerFile));
+  const text = decodeText(sample);
+  if (!text) flags.push("binary");
+  return {
+    path,
+    size: body.length,
+    sha256: await sha256Hex(body),
+    flags,
+    ...(text ? { textSample: text } : {}),
+  };
+}
+
+export async function readTar(buffer, maxFiles, maxBytesPerFile, maxTarBytes) {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  const files = [];
+  let nextLongName = null;
+  let pax = null;
+
+  for (let offset = 0; offset + 512 <= bytes.length && files.length < maxFiles; ) {
+    const header = bytes.subarray(offset, offset + 512);
+    if (header.every((b) => b === 0)) break;
+
+    const rawName = readString(header, 0, 100);
+    const prefix = readString(header, 345, 155);
+    const sizeText = readString(header, 124, 12).trim() || "0";
+    if (!/^[0-7]+$/.test(sizeText)) throw new Error("invalid tar entry size");
+    const size = parseInt(sizeText, 8);
+    if (!Number.isFinite(size) || size < 0 || size > maxTarBytes)
+      throw new Error("invalid tar entry size");
+    const type = String.fromCharCode(header[156] || 48);
+    offset += 512;
+    if (offset + size > bytes.length) throw new Error("truncated tar entry");
+    const body = bytes.subarray(offset, offset + size);
+
+    if (type === "x") {
+      pax = parsePax(body);
+      if (pax && typeof pax.path === "string" && !isSafePaxPath(pax.path)) {
+        throw new Error("invalid pax path");
+      }
+    } else if (type === "L") {
+      // readString already stops at the first NUL terminator, so the long-name
+      // payload is implicitly trimmed at the NUL boundary.
+      const candidate = readString(body, 0, body.length);
+      if (!isSafePaxPath(candidate)) throw new Error("invalid long-name path");
+      nextLongName = candidate;
+    } else if (type === "0" || type === NUL) {
+      const path = normalizeTarPath(
+        (pax && pax.path) || nextLongName || (prefix ? prefix + "/" : "") + rawName,
+      );
+      if (path) files.push(await summarizeFile(path, body, maxBytesPerFile));
+      nextLongName = null;
+      pax = null;
+    } else if (type === "1" || type === "2") {
+      // Hardlinks and symlinks are skipped so link targets cannot escape the package tree.
+      nextLongName = null;
+      pax = null;
+    } else if (type !== "L") {
+      nextLongName = null;
+      pax = null;
+    }
+
+    offset += Math.ceil(size / 512) * 512;
+  }
+  return files;
+}
+
+export function parsePackageJson(files) {
+  const pkg = files.find((f) => f.path === "package.json" && f.textSample);
+  if (!pkg || !pkg.textSample) return null;
+  try {
+    const parsed = JSON.parse(pkg.textSample);
+    return {
+      name: parsed.name,
+      version: parsed.version,
+      scripts: parsed.scripts || {},
+      dependencies: parsed.dependencies || {},
+      devDependencies: parsed.devDependencies || {},
+      peerDependencies: parsed.peerDependencies || {},
+      optionalDependencies: parsed.optionalDependencies || {},
+      bin: parsed.bin,
+      main: parsed.main,
+      module: parsed.module,
+      types: parsed.types,
+      exports: parsed.exports,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function gunzipBounded(body, maxBytes) {
+  if (!body) throw new Error("tarball decompression failed");
+  const ds = new DecompressionStream("gzip");
+  const reader = body.pipeThrough(ds).getReader();
+  const chunks = [];
+  let total = 0;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      reader.cancel().catch(() => undefined);
+      throw new Error("archive expands beyond safety limit");
+    }
+    chunks.push(value);
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out.buffer;
+}

--- a/test/tar-parser.test.mjs
+++ b/test/tar-parser.test.mjs
@@ -1,0 +1,404 @@
+// @ts-nocheck
+import { describe, expect, test } from "vitest";
+import * as tarParser from "../server/lib/tar-parser.js";
+
+const {
+  decodeText,
+  gunzipBounded,
+  isSafePaxPath,
+  normalizeTarPath,
+  parsePackageJson,
+  parsePax,
+  readTar,
+} = tarParser;
+
+// Minimal POSIX/ustar tar writer for fixture archives.
+//
+// Each header is exactly 512 bytes; entry bodies are zero-padded to a
+// multiple of 512. The archive is terminated with two zero blocks.
+const BLOCK = 512;
+const encoder = new TextEncoder();
+
+function pad(bytes, length) {
+  if (bytes.length > length) throw new Error("field overflow: " + bytes.length + " > " + length);
+  const out = new Uint8Array(length);
+  out.set(bytes, 0);
+  return out;
+}
+
+function octal(value, length) {
+  const text = value.toString(8).padStart(length - 1, "0");
+  return pad(encoder.encode(text + "\0"), length);
+}
+
+function header({ name = "", size = 0, type = "0", prefix = "" }) {
+  const buf = new Uint8Array(BLOCK);
+  buf.set(pad(encoder.encode(name), 100), 0);
+  buf.set(pad(encoder.encode("0000644"), 8), 100); // mode
+  buf.set(pad(encoder.encode("0000000"), 8), 108); // uid
+  buf.set(pad(encoder.encode("0000000"), 8), 116); // gid
+  buf.set(octal(size, 12), 124);
+  buf.set(pad(encoder.encode("00000000000"), 12), 136); // mtime
+  // checksum placeholder (8 spaces) — readTar doesn't validate it
+  buf.set(pad(encoder.encode("        "), 8), 148);
+  buf[156] = type.charCodeAt(0);
+  buf.set(pad(encoder.encode(""), 100), 157); // linkname
+  buf.set(pad(encoder.encode("ustar"), 6), 257);
+  buf.set(pad(encoder.encode("00"), 2), 263);
+  buf.set(pad(encoder.encode(prefix), 155), 345);
+  return buf;
+}
+
+function body(content) {
+  const bytes = content instanceof Uint8Array ? content : encoder.encode(content);
+  const padded = Math.ceil(bytes.length / BLOCK) * BLOCK;
+  const out = new Uint8Array(padded);
+  out.set(bytes, 0);
+  return out;
+}
+
+function buildTar(entries) {
+  const parts = [];
+  for (const entry of entries) {
+    const data = entry.body ?? "";
+    const bytes = data instanceof Uint8Array ? data : encoder.encode(data);
+    parts.push(header({ ...entry, size: bytes.length }));
+    parts.push(body(bytes));
+  }
+  parts.push(new Uint8Array(BLOCK * 2)); // end-of-archive
+  let total = 0;
+  for (const p of parts) total += p.length;
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const p of parts) {
+    out.set(p, offset);
+    offset += p.length;
+  }
+  return out;
+}
+
+const PARSE_LIMITS = { maxFiles: 250, maxBytesPerFile: 64 * 1024, maxTarBytes: 25 * 1024 * 1024 };
+
+function parse(tar, limits = PARSE_LIMITS) {
+  return readTar(tar.buffer, limits.maxFiles, limits.maxBytesPerFile, limits.maxTarBytes);
+}
+
+describe("normalizeTarPath", () => {
+  test("strips leading slashes and `package/` prefix", () => {
+    expect(normalizeTarPath("package/index.js")).toBe("index.js");
+    expect(normalizeTarPath("/package/lib/foo.js")).toBe("lib/foo.js");
+    expect(normalizeTarPath("//etc/passwd")).toBe("etc/passwd");
+  });
+
+  test("rejects path traversal sequences", () => {
+    expect(normalizeTarPath("package/../../../etc/passwd")).toBeNull();
+    expect(normalizeTarPath("../escape")).toBeNull();
+    expect(normalizeTarPath("a/../b")).toBeNull();
+    expect(normalizeTarPath("./hidden")).toBeNull();
+  });
+
+  test("rejects null bytes and backslashes", () => {
+    expect(normalizeTarPath("foo\0bar")).toBeNull();
+    expect(normalizeTarPath("foo\\bar")).toBeNull();
+  });
+
+  test("rejects Windows drive letters", () => {
+    expect(normalizeTarPath("C:foo")).toBeNull();
+    expect(normalizeTarPath("Z:bar/baz")).toBeNull();
+  });
+
+  test("rejects paths longer than 512 chars", () => {
+    expect(normalizeTarPath("a/".repeat(300) + "x")).toBeNull();
+  });
+
+  test("rejects empty or whitespace-only paths", () => {
+    expect(normalizeTarPath("")).toBeNull();
+    expect(normalizeTarPath("package/")).toBeNull();
+    expect(normalizeTarPath("/")).toBeNull();
+  });
+});
+
+describe("isSafePaxPath", () => {
+  test("rejects null bytes, backslashes, and non-strings", () => {
+    expect(isSafePaxPath("clean/path.js")).toBe(true);
+    expect(isSafePaxPath("nope\\path")).toBe(false);
+    expect(isSafePaxPath("nope\0path")).toBe(false);
+    expect(isSafePaxPath(undefined)).toBe(false);
+    expect(isSafePaxPath(123)).toBe(false);
+  });
+});
+
+describe("parsePax", () => {
+  test("parses length-prefixed key=value records", () => {
+    const record = "15 path=foo/bar\n";
+    const parsed = parsePax(encoder.encode(record));
+    expect(parsed.path).toBe("foo/bar");
+  });
+
+  test("returns empty object when the body is malformed", () => {
+    expect(parsePax(encoder.encode("nope"))).toEqual({});
+    expect(parsePax(encoder.encode(""))).toEqual({});
+  });
+});
+
+describe("decodeText", () => {
+  test("returns text when content is mostly printable utf-8", () => {
+    expect(decodeText(encoder.encode("hello world\n"))).toBe("hello world\n");
+  });
+
+  test("returns empty for binary-looking content (null bytes or control chars)", () => {
+    expect(decodeText(new Uint8Array([0, 1, 2, 3]))).toBe("");
+    expect(decodeText(new Uint8Array([1, 1, 1, 1, 1, 1, 1, 1]))).toBe("");
+  });
+});
+
+describe("readTar regular files", () => {
+  test("decodes a regular file with text body", async () => {
+    const tar = buildTar([{ name: "package/index.js", body: "export const x = 1;\n" }]);
+    const files = await parse(tar);
+    expect(files).toHaveLength(1);
+    expect(files[0].path).toBe("index.js");
+    expect(files[0].textSample).toBe("export const x = 1;\n");
+    expect(files[0].flags).toEqual([]);
+    expect(files[0].size).toBeGreaterThan(0);
+    expect(files[0].sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("combines prefix + name when both are set", async () => {
+    const tar = buildTar([{ name: "deep/file.js", prefix: "package/scope", body: "// deep\n" }]);
+    const files = await parse(tar);
+    expect(files.map((f) => f.path)).toEqual(["scope/deep/file.js"]);
+  });
+
+  test("flags binary content and omits textSample", async () => {
+    const binary = new Uint8Array([0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]);
+    const tar = buildTar([{ name: "package/bin/native.node", body: binary }]);
+    const files = await parse(tar);
+    expect(files[0].flags).toEqual(["binary"]);
+    expect(files[0].textSample).toBeUndefined();
+  });
+
+  test("flags `truncated` when a file body exceeds maxBytesPerFile", async () => {
+    const big = new Uint8Array(2048).fill(0x41); // 'A' x 2048
+    const tar = buildTar([{ name: "package/large.txt", body: big }]);
+    const files = await parse(tar, { ...PARSE_LIMITS, maxBytesPerFile: 1024 });
+    expect(files[0].flags).toContain("truncated");
+    expect(files[0].size).toBe(2048);
+    expect(files[0].textSample?.length).toBe(1024);
+  });
+});
+
+describe("readTar path safety", () => {
+  test("drops entries with traversal paths but keeps siblings", async () => {
+    const tar = buildTar([
+      { name: "package/../../../etc/passwd", body: "evil\n" },
+      { name: "package/good.js", body: "ok\n" },
+    ]);
+    const files = await parse(tar);
+    expect(files.map((f) => f.path)).toEqual(["good.js"]);
+  });
+
+  test("normalizes absolute paths to relative without traversal", async () => {
+    const tar = buildTar([
+      { name: "/etc/passwd", body: "evil\n" },
+      { name: "package/ok.js", body: "ok\n" },
+    ]);
+    const files = await parse(tar);
+    // Leading slashes are stripped so the entry can never resolve outside the
+    // package tree downstream; the path itself is preserved for evidence.
+    expect(files.map((f) => f.path)).toEqual(["etc/passwd", "ok.js"]);
+    for (const f of files) {
+      expect(f.path.startsWith("/")).toBe(false);
+      expect(f.path.includes("..")).toBe(false);
+    }
+  });
+
+  test("skips hardlink and symlink entries entirely", async () => {
+    const tar = buildTar([
+      { name: "package/symlink", type: "2", body: "" },
+      { name: "package/hardlink", type: "1", body: "" },
+      { name: "package/real.js", body: "real\n" },
+    ]);
+    const files = await parse(tar);
+    expect(files.map((f) => f.path)).toEqual(["real.js"]);
+  });
+});
+
+describe("readTar PAX and GNU long-name handling", () => {
+  test("applies a safe PAX path override to the next regular entry", async () => {
+    const paxRecord = "30 path=package/long/clean.js\n";
+    const tar = buildTar([
+      { name: "PaxHeader", type: "x", body: paxRecord },
+      { name: "ignored", body: "x = 1\n" },
+    ]);
+    const files = await parse(tar);
+    expect(files.map((f) => f.path)).toEqual(["long/clean.js"]);
+  });
+
+  test("rejects PAX paths containing null bytes or backslashes", async () => {
+    const paxRecord = "21 path=evil\\path.js\n";
+    const tar = buildTar([
+      { name: "PaxHeader", type: "x", body: paxRecord },
+      { name: "ignored", body: "x = 1\n" },
+    ]);
+    await expect(parse(tar)).rejects.toThrow(/invalid pax path/);
+  });
+
+  test("applies a safe GNU long-name override to the next regular entry", async () => {
+    const longName = "package/" + "really-long-segment/".repeat(8) + "leaf.js";
+    const tar = buildTar([
+      { name: "././@LongLink", type: "L", body: longName + "\0" },
+      { name: "ignored", body: "leaf\n" },
+    ]);
+    const files = await parse(tar);
+    expect(files.map((f) => f.path)).toEqual([longName.replace(/^package\//, "")]);
+  });
+
+  test("rejects GNU long-name entries containing a backslash", async () => {
+    const evilLongName = "package/leaf\\escape";
+    const tar = buildTar([{ name: "././@LongLink", type: "L", body: evilLongName }]);
+    await expect(parse(tar)).rejects.toThrow(/invalid long-name path/);
+  });
+});
+
+describe("readTar limits and malformed archives", () => {
+  test("throws on a truncated tar entry whose declared size overflows the buffer", async () => {
+    const tar = buildTar([{ name: "package/x.js", body: "abc" }]);
+    // Corrupt the size field to claim the entry is 4 KB even though only ~512B
+    // of payload follows; the parser should detect the overflow.
+    const sizeField = encoder.encode("00000010000\0");
+    tar.set(sizeField, 124);
+    await expect(parse(tar)).rejects.toThrow(/truncated tar entry/);
+  });
+
+  test("throws when the size field is not valid octal", async () => {
+    const tar = buildTar([{ name: "package/x.js", body: "abc" }]);
+    tar.set(encoder.encode("XYZZZZZZZZZ\0"), 124);
+    await expect(parse(tar)).rejects.toThrow(/invalid tar entry size/);
+  });
+
+  test("stops reading once the file-count cap is reached", async () => {
+    const tar = buildTar(
+      Array.from({ length: 12 }, (_, i) => ({ name: `package/f${i}.js`, body: `// ${i}\n` })),
+    );
+    const files = await parse(tar, { ...PARSE_LIMITS, maxFiles: 5 });
+    expect(files).toHaveLength(5);
+    expect(files.map((f) => f.path)).toEqual(["f0.js", "f1.js", "f2.js", "f3.js", "f4.js"]);
+  });
+
+  test("stops at the end-of-archive marker even with trailing garbage", async () => {
+    const tar = buildTar([{ name: "package/a.js", body: "// a\n" }]);
+    // Append garbage after the zero blocks; readTar should not see it.
+    const extended = new Uint8Array(tar.length + 1024);
+    extended.set(tar, 0);
+    extended.fill(0x66, tar.length); // 'f'
+    const files = await parse(extended);
+    expect(files.map((f) => f.path)).toEqual(["a.js"]);
+  });
+});
+
+describe("parsePackageJson", () => {
+  test("normalizes scripts and dependency maps", () => {
+    const files = [
+      {
+        path: "package.json",
+        size: 0,
+        sha256: "",
+        flags: [],
+        textSample: JSON.stringify({
+          name: "@scope/pkg",
+          version: "1.2.3",
+          scripts: { preinstall: "node bad.js" },
+          dependencies: { foo: "1.0.0" },
+        }),
+      },
+    ];
+    const parsed = parsePackageJson(files);
+    expect(parsed?.name).toBe("@scope/pkg");
+    expect(parsed?.version).toBe("1.2.3");
+    expect(parsed?.scripts?.preinstall).toBe("node bad.js");
+    expect(parsed?.dependencies?.foo).toBe("1.0.0");
+    expect(parsed?.devDependencies).toEqual({});
+  });
+
+  test("returns null on malformed JSON or missing package.json", () => {
+    expect(parsePackageJson([])).toBeNull();
+    expect(
+      parsePackageJson([
+        { path: "package.json", size: 0, sha256: "", flags: [], textSample: "{not-json" },
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe("rendered sandbox parser source", () => {
+  // The dynamic sandbox worker is built by concatenating
+  // `Function.toString()` of these parser exports (see
+  // `renderTarParserSource` in server/lib/sandbox.ts). If a bundler ever
+  // strips or renames any of them, the sandbox module fails to load.
+  const SANDBOX_EXPORT_NAMES = [
+    "readString",
+    "decodeText",
+    "isSafePaxPath",
+    "normalizeTarPath",
+    "parsePax",
+    "sha256Hex",
+    "summarizeFile",
+    "readTar",
+    "parsePackageJson",
+    "gunzipBounded",
+  ];
+
+  test("every required parser export keeps its function name", () => {
+    for (const name of SANDBOX_EXPORT_NAMES) {
+      const fn = tarParser[name];
+      expect(typeof fn, `${name} must be exported`).toBe("function");
+      expect(fn.name, `${name} must keep its declared name`).toBe(name);
+    }
+  });
+
+  test("concatenated source parses as valid JS containing all dependencies", () => {
+    const source = SANDBOX_EXPORT_NAMES.map((name) => tarParser[name].toString()).join("\n\n");
+    for (const name of SANDBOX_EXPORT_NAMES) {
+      expect(source).toContain(`function ${name}`);
+    }
+    expect(() => new Function(source)).not.toThrow();
+  });
+});
+
+describe("gunzipBounded", () => {
+  function streamFrom(bytes) {
+    return new ReadableStream({
+      start(controller) {
+        controller.enqueue(bytes);
+        controller.close();
+      },
+    });
+  }
+
+  async function gzip(input) {
+    const cs = new CompressionStream("gzip");
+    const writer = cs.writable.getWriter();
+    writer.write(input);
+    writer.close();
+    return new Uint8Array(await new Response(cs.readable).arrayBuffer());
+  }
+
+  test("decompresses a small gzip stream", async () => {
+    const compressed = await gzip(encoder.encode("hello hello hello"));
+    const buf = await gunzipBounded(streamFrom(compressed), 1024);
+    expect(new TextDecoder().decode(buf)).toBe("hello hello hello");
+  });
+
+  test("throws when decompressed bytes exceed the cap", async () => {
+    // 64 KB of repeated text compresses well — small input expands past the cap.
+    const compressed = await gzip(encoder.encode("a".repeat(64 * 1024)));
+    await expect(gunzipBounded(streamFrom(compressed), 1024)).rejects.toThrow(
+      /archive expands beyond safety limit/,
+    );
+  });
+
+  test("throws on a missing body", async () => {
+    await expect(gunzipBounded(null, 1024)).rejects.toThrow(/tarball decompression failed/);
+  });
+});

--- a/test/tar-parser.test.mjs
+++ b/test/tar-parser.test.mjs
@@ -357,12 +357,22 @@ describe("rendered sandbox parser source", () => {
     }
   });
 
-  test("concatenated source parses as valid JS containing all dependencies", () => {
+  test("concatenated source parses and runs without module-level dependencies", () => {
     const source = SANDBOX_EXPORT_NAMES.map((name) => tarParser[name].toString()).join("\n\n");
     for (const name of SANDBOX_EXPORT_NAMES) {
       expect(source).toContain(`function ${name}`);
     }
     expect(() => new Function(source)).not.toThrow();
+    const run = new Function(
+      source +
+        `
+return {
+  safe: isSafePaxPath("clean/path.js"),
+  unsafe: isSafePaxPath("nope" + String.fromCharCode(0) + "path"),
+  normalized: normalizeTarPath("package/index.js")
+};`,
+    );
+    expect(run()).toEqual({ safe: true, unsafe: false, normalized: "index.js" });
   });
 });
 

--- a/test/workers/cross-org-npm-connection.test.ts
+++ b/test/workers/cross-org-npm-connection.test.ts
@@ -1,0 +1,160 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { describe, expect, test, vi } from "vitest";
+import { createDb, ensurePersonalOrganization, getNpmConnection } from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { npmConnectionRoutes } from "../../server/routes/npm-connection";
+import type { Bindings, Variables } from "../../server/types";
+
+interface SeededUser {
+  userId: string;
+  organizationId: string;
+}
+
+async function seedUser(): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+function buildTestApp(session: { userId: string }) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.use("*", async (c, next) => {
+    c.set("authSession", { userId: session.userId });
+    await next();
+  });
+  app.route("/api/v1/npm-connection", npmConnectionRoutes);
+  return app;
+}
+
+async function call(
+  app: Hono<{ Bindings: Bindings; Variables: Variables }>,
+  method: string,
+  path: string,
+  body?: unknown,
+) {
+  const ctx = createExecutionContext();
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+    init.headers = { "content-type": "application/json" };
+  }
+  const res = await app.fetch(new Request(`http://test.local${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+const OWNER_TOKEN = "npm_owner_secret_token_AAAAAAA";
+const INTRUDER_TOKEN = "npm_intruder_secret_token_ZZZZZZZ";
+
+describe("npm-connection routes enforce organization boundaries", () => {
+  test("GET /npm-connection only returns the caller's connection", async () => {
+    const owner = await seedUser();
+    const intruder = await seedUser();
+
+    const upsert = await call(buildTestApp(owner), "POST", "/api/v1/npm-connection", {
+      token: OWNER_TOKEN,
+      label: "owner registry",
+    });
+    expect(upsert.status).toBe(200);
+
+    const intruderRes = await call(buildTestApp(intruder), "GET", "/api/v1/npm-connection");
+    expect(intruderRes.status).toBe(200);
+    const intruderBody = (await intruderRes.json()) as { connection: unknown };
+    expect(intruderBody.connection).toBeNull();
+
+    const ownerRes = await call(buildTestApp(owner), "GET", "/api/v1/npm-connection");
+    expect(ownerRes.status).toBe(200);
+    const ownerBody = (await ownerRes.json()) as {
+      connection: { organizationId: string; tokenLast4: string | null; label: string } | null;
+    };
+    expect(ownerBody.connection?.organizationId).toBe(owner.organizationId);
+    expect(ownerBody.connection?.label).toBe("owner registry");
+    expect(ownerBody.connection?.tokenLast4).toBe(OWNER_TOKEN.slice(-4));
+  });
+
+  test("POST /npm-connection from a foreign session writes to that session's org, not the target's", async () => {
+    const owner = await seedUser();
+    const intruder = await seedUser();
+    const db = createDb(env.DB);
+
+    await call(buildTestApp(owner), "POST", "/api/v1/npm-connection", {
+      token: OWNER_TOKEN,
+      label: "owner registry",
+    });
+
+    const upsert = await call(buildTestApp(intruder), "POST", "/api/v1/npm-connection", {
+      token: INTRUDER_TOKEN,
+      label: "intruder registry",
+    });
+    expect(upsert.status).toBe(200);
+
+    const ownerConnection = await getNpmConnection(db, owner.organizationId);
+    const intruderConnection = await getNpmConnection(db, intruder.organizationId);
+    expect(ownerConnection?.label).toBe("owner registry");
+    expect(ownerConnection?.tokenLast4).toBe(OWNER_TOKEN.slice(-4));
+    expect(intruderConnection?.label).toBe("intruder registry");
+    expect(intruderConnection?.tokenLast4).toBe(INTRUDER_TOKEN.slice(-4));
+    expect(ownerConnection?.tokenCiphertext).not.toBe(intruderConnection?.tokenCiphertext);
+  });
+
+  test("DELETE /npm-connection only removes the caller's connection", async () => {
+    const owner = await seedUser();
+    const intruder = await seedUser();
+    const db = createDb(env.DB);
+
+    await call(buildTestApp(owner), "POST", "/api/v1/npm-connection", {
+      token: OWNER_TOKEN,
+      label: "owner registry",
+    });
+
+    const deleteRes = await call(buildTestApp(intruder), "DELETE", "/api/v1/npm-connection");
+    expect(deleteRes.status).toBe(200);
+
+    const ownerConnection = await getNpmConnection(db, owner.organizationId);
+    expect(ownerConnection).not.toBeNull();
+    expect(ownerConnection?.tokenLast4).toBe(OWNER_TOKEN.slice(-4));
+  });
+
+  test("POST /npm-connection/validate without a connection returns 404 and never touches the network", async () => {
+    const intruder = await seedUser();
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    try {
+      const res = await call(buildTestApp(intruder), "POST", "/api/v1/npm-connection/validate", {});
+      expect(res.status).toBe(404);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  test("POST /npm-connection/validate against another org's connection still returns 404 for the foreign caller", async () => {
+    const owner = await seedUser();
+    const intruder = await seedUser();
+
+    await call(buildTestApp(owner), "POST", "/api/v1/npm-connection", {
+      token: OWNER_TOKEN,
+      label: "owner registry",
+    });
+
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    try {
+      const res = await call(buildTestApp(intruder), "POST", "/api/v1/npm-connection/validate", {});
+      expect(res.status).toBe(404);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Extracted the tar parsing helpers out of the inline dynamic-Worker source in `server/lib/sandbox.ts` into a shared `server/lib/tar-parser.js` (with `.d.ts`); `sandbox.ts` now concatenates each helper's `Function.toString()` into the sandbox module so the unit-tested code is the same code that runs in the isolated sandbox.
- Added `test/tar-parser.test.mjs` (33 cases) covering path traversal, absolute-path normalization, PAX overrides, GNU long names, link skipping, malformed/truncated archives, per-file and file-count caps, and `gunzipBounded` archive-bomb protection, plus a smoke test that pins the lexical names the rendered sandbox source depends on.
- Added `test/workers/cross-org-npm-connection.test.ts` (5 cases) covering tenant isolation across the `/npm-connection` GET/POST/DELETE and `/validate` routes, including the no-fetch-before-404 guarantee.
- Updated `docs/architecture.md` and `docs/production-roadmap.md` to reflect the shared parser layout and to close the archive-parser and npm-connection cross-org line items; the next suggested slice is now private-beta ops + data lifecycle.

## Test plan
- [x] \`pnpm run verify\` (lint + format check + typecheck + tests) is green; node 67/67, workers 23/23.
- [ ] Sanity-check a real scan after merge to confirm the rendered sandbox source still loads in the dynamic Worker (the unit suite + name-stability smoke test cover the parser, but the LOADER round-trip is not exercised in tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)