### PR TITLE
Fix assistant review normalization

### DIFF
--- a/server/lib/ai-review.ts
+++ b/server/lib/ai-review.ts
@@ -82,11 +82,13 @@ const FINDING_SCHEMA = {
           recommendation: { type: "string" },
         },
         required: ["severity", "file", "evidence", "reason", "recommendation"],
+        additionalProperties: false,
       },
     },
     requiresManualReview: { type: "boolean" },
   },
   required: ["risk", "releaseAssessment", "summary", "findings", "requiresManualReview"],
+  additionalProperties: false,
 };
 
 export async function analyzeWithAi(
@@ -129,7 +131,10 @@ export async function analyzeWithAi(
             }),
           },
         ],
-        response_format: { type: "json_schema", json_schema: FINDING_SCHEMA },
+        response_format: {
+          type: "json_schema",
+          json_schema: { name: "release_review", strict: true, schema: FINDING_SCHEMA },
+        },
       },
       {
         extraHeaders: {
@@ -143,34 +148,50 @@ export async function analyzeWithAi(
   } catch (err) {
     return fallbackReview(
       "unavailable",
-      `AI review unavailable; deterministic scanner result is authoritative. ${err instanceof Error ? err.message : String(err)}`,
+      `Assistant review didn't run: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 }
 
 function normalizeAiResponse(result: unknown): AiReview {
-  const response =
-    typeof result === "object" && result && "response" in result
-      ? (result as { response: unknown }).response
-      : result;
-  if (typeof response === "string") {
+  const content = extractContent(result);
+  if (typeof content === "string") {
     try {
-      return normalizeParsedReview(JSON.parse(response));
+      return normalizeParsedReview(JSON.parse(content));
     } catch {
       return fallbackReview(
         "invalid",
-        "AI returned non-JSON output; deterministic scanner result is authoritative.",
+        "Assistant returned non-JSON output; review didn't complete.",
       );
     }
   }
-  return normalizeParsedReview(response);
+  return normalizeParsedReview(content);
+}
+
+function extractContent(result: unknown): unknown {
+  if (typeof result === "string") return result;
+  if (!result || typeof result !== "object") return result;
+  const obj = result as Record<string, unknown>;
+  const choices = obj.choices;
+  if (Array.isArray(choices) && choices.length > 0) {
+    const first = choices[0];
+    if (first && typeof first === "object") {
+      const message = (first as Record<string, unknown>).message;
+      if (message && typeof message === "object") {
+        const content = (message as Record<string, unknown>).content;
+        if (content !== undefined && content !== null) return content;
+      }
+    }
+  }
+  if ("response" in obj) return obj.response;
+  return obj;
 }
 
 function normalizeParsedReview(value: unknown): AiReview {
   if (!value || typeof value !== "object") {
     return fallbackReview(
       "invalid",
-      "AI returned an empty or invalid review; deterministic scanner result is authoritative.",
+      "Assistant returned an empty or invalid review; review didn't complete.",
     );
   }
   const review = value as Partial<AiReview>;
@@ -198,7 +219,7 @@ function normalizeParsedReview(value: unknown): AiReview {
   ) {
     return fallbackReview(
       "invalid",
-      `AI review was incomplete (${missing.join(", ")}); deterministic scanner result is authoritative.`,
+      `Assistant review was incomplete: missing ${missing.join(", ")}.`,
     );
   }
 

--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -367,23 +367,25 @@ function ReportOverview({
     detail.files.filter((file) => file.status !== "unchanged").length;
   const severityCounts = countSeverities([...findings, ...aiFindings]);
   const findingTotal = Object.values(severityCounts).reduce((sum, count) => sum + (count ?? 0), 0);
-  const assistantTake = ai?.releaseAssessment?.replaceAll("_", " ") || "assessment missing";
+  const aiComplete = ai?.status === "complete";
 
   return (
     <section class="flex flex-col gap-3 border-y border-border py-4">
       <div class="flex flex-wrap items-center gap-2">
         <Badge tone={severityTone(detail.scan.risk)}>{detail.scan.risk}</Badge>
-        {ai ? (
-          <Badge tone={ai.requiresManualReview ? "medium" : "ok"}>
-            {ai.requiresManualReview ? "manual review" : "no extra review"}
-          </Badge>
+        {aiComplete ? (
+          <>
+            <Badge tone={ai.requiresManualReview ? "medium" : "ok"}>
+              {ai.requiresManualReview ? "manual review" : "no extra review"}
+            </Badge>
+            <Badge tone="neutral">{ai.releaseAssessment.replaceAll("_", " ")}</Badge>
+          </>
         ) : (
           <Badge tone="neutral">assistant unavailable</Badge>
         )}
         <Badge tone={findingTotal ? "medium" : "ok"}>
           {findingTotal ? `${findingTotal} ${pluralize("finding", findingTotal)}` : "no findings"}
         </Badge>
-        <Badge tone="neutral">{assistantTake}</Badge>
       </div>
       <MonoDetail
         parts={[
@@ -438,25 +440,36 @@ function PersistedReportSections({
     <section class="grid grid-cols-1 lg:grid-cols-2 gap-x-8 gap-y-6">
       <ReportSection title="Reviewer notes">
         {ai ? (
-          <>
-            <div class="flex flex-wrap gap-2">
-              <Badge tone={severityTone(ai.risk)}>{ai.risk}</Badge>
-              <Badge tone={ai.requiresManualReview ? "medium" : "ok"}>
-                {ai.requiresManualReview ? "manual review" : "no extra review"}
-              </Badge>
-              <Badge tone="neutral">
-                {ai.releaseAssessment?.replaceAll("_", " ") || "assessment stored"}
-              </Badge>
-            </div>
-            {ai.summary ? (
-              <p class="m-0 text-[13px] leading-[1.6] text-ink-muted">{ai.summary}</p>
-            ) : null}
-            {ai.findings?.length ? (
-              <AiFindingList findings={ai.findings} />
-            ) : (
-              <EmptyLine>No assistant findings.</EmptyLine>
-            )}
-          </>
+          ai.status === "complete" ? (
+            <>
+              <div class="flex flex-wrap gap-2">
+                <Badge tone={severityTone(ai.risk)}>{ai.risk}</Badge>
+                <Badge tone={ai.requiresManualReview ? "medium" : "ok"}>
+                  {ai.requiresManualReview ? "manual review" : "no extra review"}
+                </Badge>
+                <Badge tone="neutral">
+                  {ai.releaseAssessment?.replaceAll("_", " ") || "assessment stored"}
+                </Badge>
+              </div>
+              {ai.summary ? (
+                <p class="m-0 text-[13px] leading-[1.6] text-ink-muted">{ai.summary}</p>
+              ) : null}
+              {ai.findings?.length ? (
+                <AiFindingList findings={ai.findings} />
+              ) : (
+                <EmptyLine>No assistant findings.</EmptyLine>
+              )}
+            </>
+          ) : (
+            <>
+              <div class="flex flex-wrap gap-2">
+                <Badge tone="neutral">assistant unavailable</Badge>
+              </div>
+              {ai.summary ? (
+                <p class="m-0 text-[13px] leading-[1.6] text-ink-muted">{ai.summary}</p>
+              ) : null}
+            </>
+          )
         ) : (
           <EmptyLine>No reviewer notes were saved for this review.</EmptyLine>
         )}

--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -51,6 +51,10 @@ describe("ai review normalization", () => {
     expect(userPayload.untrustedChangedPackageFiles[0].textSample).toContain(
       "Ignore previous instructions",
     );
+    const schema = capturedInput?.response_format?.json_schema?.schema;
+    expect(capturedInput?.response_format?.json_schema?.strict).toBe(true);
+    expect(schema.additionalProperties).toBe(false);
+    expect(schema.properties.findings.items.additionalProperties).toBe(false);
   });
 
   test("incomplete AI output is not treated as medium package risk", async () => {
@@ -96,6 +100,79 @@ describe("ai review normalization", () => {
 
     expect(ai.status).toBe("complete");
     expect(computeScanRisk([], ai)).toBe("low");
+  });
+
+  test("OpenAI-style choices[0].message.content shape parses as complete", async () => {
+    const aiPayload = {
+      risk: "low",
+      releaseAssessment: "nothing_unusual",
+      summary: "Routine docs change.",
+      findings: [],
+      requiresManualReview: false,
+    };
+    const ai = await analyzeWithAi(
+      {
+        AI_MODEL: "test-model",
+        AI: {
+          run: async () => ({
+            id: "chatcmpl-1",
+            object: "chat.completion",
+            created: 0,
+            model: "test-model",
+            choices: [
+              {
+                index: 0,
+                message: { role: "assistant", content: JSON.stringify(aiPayload), refusal: null },
+                finish_reason: "stop",
+                logprobs: null,
+              },
+            ],
+          }),
+        },
+      },
+      [],
+      [],
+      {},
+      [],
+    );
+
+    expect(ai.status).toBe("complete");
+    expect(ai.risk).toBe("low");
+    expect(ai.releaseAssessment).toBe("nothing_unusual");
+    expect(ai.summary).toBe("Routine docs change.");
+  });
+
+  test("OpenAI-style content with already-parsed object also parses as complete", async () => {
+    const aiPayload = {
+      risk: "medium",
+      releaseAssessment: "review_recommended",
+      summary: "Needs eyes.",
+      findings: [],
+      requiresManualReview: true,
+    };
+    const ai = await analyzeWithAi(
+      {
+        AI_MODEL: "test-model",
+        AI: {
+          run: async () => ({
+            choices: [
+              {
+                index: 0,
+                message: { role: "assistant", content: aiPayload, refusal: null },
+                finish_reason: "stop",
+              },
+            ],
+          }),
+        },
+      },
+      [],
+      [],
+      {},
+      [],
+    );
+
+    expect(ai.status).toBe("complete");
+    expect(ai.requiresManualReview).toBe(true);
   });
 
   test("complete AI output can still raise package risk with evidence", async () => {


### PR DESCRIPTION
## Summary
- Wrap Workers AI JSON schema in an OpenAI-compatible strict response format and disallow extra properties at each object level.
- Normalize both Workers AI response payloads and OpenAI-style `choices[0].message.content` responses while keeping invalid or unavailable assistant reviews from raising risk.
- Update scan detail copy so incomplete assistant reviews show as unavailable, with regression coverage for the schema and response shapes.

## Validation
- `pnpm run verify`