### PR TITLE
Rebrand front-end to Drydock

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="dark light" />
-    <title>Staged Publish Review</title>
+    <title>Drydock — review staged npm publishes before they ship</title>
     <meta
       name="description"
-      content="Authenticated review of npm staged publishes before manual approval."
+      content="Drydock holds staged npm publishes for inspection — diff against the live release, surface risk, and approve safely."
     />
   </head>
   <body>

--- a/src/components/BrandMark.tsx
+++ b/src/components/BrandMark.tsx
@@ -1,0 +1,38 @@
+import { cn } from "./cn";
+
+type Size = "sm" | "md" | "lg";
+
+const SIZE_CLASS: Record<Size, string> = {
+  sm: "text-[15px] tracking-[-0.025em]",
+  md: "text-[20px] tracking-[-0.03em]",
+  lg: "text-[28px] tracking-[-0.04em] leading-none",
+};
+
+export function BrandMark({
+  href,
+  size = "sm",
+  class: className,
+}: {
+  href?: string;
+  size?: Size;
+  class?: string;
+}) {
+  const classes = cn(
+    "inline-block font-semibold text-accent select-none",
+    SIZE_CLASS[size],
+    href ? "no-underline transition-colors hover:text-accent-hover" : "",
+    className,
+  );
+  if (href) {
+    return (
+      <a href={href} class={classes} aria-label="Drydock home">
+        drydock
+      </a>
+    );
+  }
+  return (
+    <span class={classes} aria-label="Drydock">
+      drydock
+    </span>
+  );
+}

--- a/src/components/PageShell.tsx
+++ b/src/components/PageShell.tsx
@@ -1,23 +1,34 @@
 import type { ComponentChildren } from "preact";
 import { cn } from "./cn";
+import { BrandMark } from "./BrandMark";
 
 export function PageShell({
   class: className,
   children,
   width = "wide",
+  brand = true,
+  headerActions,
 }: {
   class?: string;
   children: ComponentChildren;
   width?: "narrow" | "wide";
+  brand?: boolean;
+  headerActions?: ComponentChildren;
 }) {
   return (
     <main
       class={cn(
-        "mx-auto w-full px-6 py-12 pb-24 flex flex-col gap-6",
+        "mx-auto w-full px-6 pt-6 pb-24 flex flex-col gap-6",
         width === "narrow" ? "max-w-[640px]" : "max-w-[1160px]",
         className,
       )}
     >
+      {brand ? (
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <BrandMark href="/" size="sm" />
+          {headerActions ? <div class="flex items-center gap-2">{headerActions}</div> : null}
+        </div>
+      ) : null}
       {children}
     </main>
   );

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -10,6 +10,7 @@ export type { AlertTone } from "./Alert";
 export { Card, SummaryCard } from "./Card";
 export type { SummaryCardTone, SummaryCardValue } from "./Card";
 export { PageShell } from "./PageShell";
+export { BrandMark } from "./BrandMark";
 export {
   Eyebrow,
   SectionLabel,

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -77,16 +77,8 @@ export default function DashboardPage() {
   const user = sessionModel.user.value;
 
   return (
-    <PageShell>
-      <header class="flex flex-wrap gap-4 items-start justify-between">
-        <div class="flex flex-col gap-2 max-w-[640px]">
-          <Eyebrow>Review workspace</Eyebrow>
-          <h1 class="text-3xl font-semibold tracking-[-0.02em] m-0">Ready for the next release</h1>
-          <Muted class="text-[14px] leading-[1.55] m-0">
-            Bring in a staged npm publish, compare it with the live version, and get a focused
-            safety brief before maintainers approve.
-          </Muted>
-        </div>
+    <PageShell
+      headerActions={
         <div class="flex items-center gap-2.5 bg-surface border border-border rounded-lg pl-3.5 pr-1.5 py-1.5">
           <span class="font-mono text-xs text-ink-muted">
             {user?.email || user?.name || "signed in"}
@@ -95,6 +87,15 @@ export default function DashboardPage() {
             Sign out
           </Button>
         </div>
+      }
+    >
+      <header class="flex flex-col gap-2 max-w-[640px]">
+        <Eyebrow>Review workspace</Eyebrow>
+        <h1 class="text-3xl font-semibold tracking-[-0.02em] m-0">Ready for the next release</h1>
+        <Muted class="text-[14px] leading-[1.55] m-0">
+          Bring a staged npm publish into drydock, compare it with the live version, and leave with
+          a focused safety brief before maintainers approve.
+        </Muted>
       </header>
 
       <ReviewRequestCard npm={npm} request={request} onSubmit={onSubmit} />


### PR DESCRIPTION
## Summary
- Names the product **Drydock** and introduces a typography-only `BrandMark` wordmark (accent orange, per DESIGN.md).
- Surfaces the wordmark on every page via `PageShell`, with an optional `headerActions` slot, and updates the document title + meta description.
- Threads the brand into the dashboard chrome (moves the user/sign-out pill into the new brand row, lightly works the metaphor into copy).

## Test plan
- [ ] Visit `/`, `/login`, `/register`, `/dashboard`, and a scan detail page — confirm the wordmark renders at the top and links home.
- [ ] Confirm the dashboard user pill sits beside the wordmark and Sign out still works.
- [ ] Verify the page title and tab favicon-line read "Drydock".

🤖 Generated with [Claude Code](https://claude.com/claude-code)