### PR TITLE
Hold full layout while dashboard and report screens load

### DIFF
--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,0 +1,39 @@
+import { Card } from "./Card";
+import { cn } from "./cn";
+import { LoadingLine } from "./Typography";
+
+export function IndeterminateBar({ class: className }: { class?: string }) {
+  return (
+    <div
+      class={cn("relative h-1 w-full overflow-hidden rounded-sm bg-surface-2", className)}
+      role="progressbar"
+      aria-busy="true"
+      aria-label="Loading"
+    >
+      <span
+        class="absolute inset-y-0 left-0 w-1/3 rounded-sm bg-accent motion-safe:animate-progress-sweep"
+        aria-hidden
+      />
+    </div>
+  );
+}
+
+export function LoadingState({
+  title,
+  detail,
+  class: className,
+}: {
+  title: string;
+  detail?: string;
+  class?: string;
+}) {
+  return (
+    <Card class={cn("flex flex-col gap-4 p-5 md:p-6", className)}>
+      <LoadingLine>{title}</LoadingLine>
+      <IndeterminateBar />
+      {detail ? (
+        <p class="font-mono text-[11px] tracking-[0.02em] text-ink-subtle m-0">{detail}</p>
+      ) : null}
+    </Card>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -20,6 +20,7 @@ export {
   LoadingLine,
   EmptyLine,
 } from "./Typography";
+export { IndeterminateBar, LoadingState } from "./Loading";
 export { FileTree } from "./FileTree";
 export { DiffView } from "./DiffView";
 export type { DiffViewProps } from "./DiffView";

--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -17,6 +17,7 @@ import {
   FindingCard,
   FindingRow,
   LoadingLine,
+  LoadingState,
   MonoDetail,
   PageShell,
   SectionLabel,
@@ -147,7 +148,8 @@ export default function ScanDetailPage() {
   if (!sessionChecked.value) {
     return (
       <PageShell>
-        <LoadingLine>Opening review</LoadingLine>
+        <ScanDetailHeader />
+        <LoadingState title="Opening review" detail="confirming session · fetching report" />
       </PageShell>
     );
   }
@@ -167,29 +169,7 @@ export default function ScanDetailPage() {
 
   return (
     <PageShell>
-      <header class="flex flex-col gap-2">
-        <a href="/dashboard" class="text-[13px] text-ink-muted hover:text-ink no-underline">
-          ← Reviews
-        </a>
-        <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">
-          {detail?.scan.packageName || "Release review"}
-        </h1>
-        {detail ? (
-          <MonoDetail
-            parts={[
-              <span key="version">
-                {detail.scan.previousVersion || "—"} → {detail.scan.stagedVersion || "—"}
-              </span>,
-              <Badge key="risk" tone={severityTone(detail.scan.risk)}>
-                {detail.scan.risk}
-              </Badge>,
-              <span key="scan-id">scan {detail.scan.id.slice(0, 12)}</span>,
-            ]}
-          />
-        ) : (
-          <LoadingLine>Loading saved review</LoadingLine>
-        )}
-      </header>
+      <ScanDetailHeader detail={detail} />
 
       {error ? <Alert tone="critical">{error}</Alert> : null}
       {detail?.scan.status === "pending" || detail?.scan.status === "running" ? (
@@ -200,6 +180,10 @@ export default function ScanDetailPage() {
       ) : null}
       {detail?.scan.status === "failed" ? (
         <ScanFailureAlert errorJson={detail.scan.errorJson} />
+      ) : null}
+
+      {!detail && !error ? (
+        <LoadingState title="Loading saved review" detail="fetching report · normalizing diff" />
       ) : null}
 
       {detail ? (
@@ -298,6 +282,34 @@ export default function ScanDetailPage() {
         </>
       ) : null}
     </PageShell>
+  );
+}
+
+function ScanDetailHeader({ detail }: { detail?: PersistedScanDetail | null } = {}) {
+  return (
+    <header class="flex flex-col gap-2">
+      <a href="/dashboard" class="text-[13px] text-ink-muted hover:text-ink no-underline">
+        ← Reviews
+      </a>
+      <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">
+        {detail?.scan.packageName || "Release review"}
+      </h1>
+      {detail ? (
+        <MonoDetail
+          parts={[
+            <span key="version">
+              {detail.scan.previousVersion || "—"} → {detail.scan.stagedVersion || "—"}
+            </span>,
+            <Badge key="risk" tone={severityTone(detail.scan.risk)}>
+              {detail.scan.risk}
+            </Badge>,
+            <span key="scan-id">scan {detail.scan.id.slice(0, 12)}</span>,
+          ]}
+        />
+      ) : (
+        <LoadingLine size="inline">Loading saved review</LoadingLine>
+      )}
+    </header>
   );
 }
 

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -15,7 +15,7 @@ import {
   Eyebrow,
   Field,
   Input,
-  LoadingLine,
+  LoadingState,
   MonoDetail,
   Muted,
   PageShell,
@@ -85,15 +85,20 @@ export default function DashboardPage() {
 
   if (!sessionChecked.value) {
     return (
-      <PageShell width="narrow">
-        <Card>
-          <LoadingLine>Opening workspace</LoadingLine>
-        </Card>
+      <PageShell>
+        <DashboardHeader />
+        <LoadingState
+          title="Opening workspace"
+          detail="confirming session · fetching recent reviews"
+        />
       </PageShell>
     );
   }
 
   const user = sessionModel.user.value;
+  const scansLoaded = scans.loaded.value;
+  const npmLoaded = npm.loaded.value;
+  const workspaceLoaded = scansLoaded && npmLoaded;
 
   return (
     <PageShell
@@ -108,21 +113,40 @@ export default function DashboardPage() {
         </div>
       }
     >
-      <header class="flex flex-col gap-2 max-w-[640px]">
-        <Eyebrow>Review workspace</Eyebrow>
-        <h1 class="text-3xl font-semibold tracking-[-0.02em] m-0">Ready for the next release</h1>
-        <Muted class="text-[14px] leading-[1.55] m-0">
-          Bring a staged npm publish into drydock, compare it with the live version, and leave with
-          a focused safety brief before maintainers approve.
-        </Muted>
-      </header>
+      <DashboardHeader />
 
-      <ReviewRequestCard npm={npm} request={request} onSubmit={onSubmit} />
-
-      <RecentReviewsSection scans={scans} stagedPublishes={stagedPublishes} npm={npm} />
-
-      <WorkspaceSetupPanel npm={npm} />
+      {workspaceLoaded ? (
+        <>
+          <ReviewRequestCard npm={npm} request={request} onSubmit={onSubmit} />
+          <RecentReviewsSection scans={scans} stagedPublishes={stagedPublishes} npm={npm} />
+          <WorkspaceSetupPanel npm={npm} />
+        </>
+      ) : (
+        <LoadingState
+          title="Loading workspace"
+          detail={
+            npmLoaded
+              ? "fetching recent reviews"
+              : scansLoaded
+                ? "checking npm connection"
+                : "fetching recent reviews · checking npm connection"
+          }
+        />
+      )}
     </PageShell>
+  );
+}
+
+function DashboardHeader() {
+  return (
+    <header class="flex flex-col gap-2 max-w-[640px]">
+      <Eyebrow>Review workspace</Eyebrow>
+      <h1 class="text-3xl font-semibold tracking-[-0.02em] m-0">Ready for the next release</h1>
+      <Muted class="text-[14px] leading-[1.55] m-0">
+        Bring a staged npm publish into drydock, compare it with the live version, and leave with a
+        focused safety brief before maintainers approve.
+      </Muted>
+    </header>
   );
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -31,6 +31,17 @@
 
   --shadow-sm: 0 1px 2px rgba(24, 24, 27, 0.04);
   --shadow-md: 0 4px 12px rgba(24, 24, 27, 0.06);
+
+  --animate-progress-sweep: progress-sweep 1.6s ease-in-out infinite;
+
+  @keyframes progress-sweep {
+    0% {
+      transform: translateX(-110%);
+    }
+    100% {
+      transform: translateX(360%);
+    }
+  }
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary
- Replaces the narrow loading card on the dashboard and scan-detail pages with a wide `PageShell` that keeps the brand mark, static header, and content width fixed while data loads — so the page no longer jumps from a condensed shell to the expanded view.
- Adds a `LoadingState` component (Card composing `LoadingLine` + a new `IndeterminateBar` + a mono status-detail line) plus a `progress-sweep` keyframe in `src/style.css`; both stay inside DESIGN.md (no spinners, no skeletons — indeterminate bars are the sanctioned progress treatment).
- The dashboard's detail copy adapts to which model is still loading ("checking npm connection" / "fetching recent reviews"), and scan-detail now shows a `LoadingState` for the detail-fetch phase instead of an empty body under the header.

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm exec oxlint` + `pnpm exec oxfmt --check`
- [x] `pnpm run build`
- [x] `pnpm run test` (106 tests pass)
- [x] Visually verified dashboard and scan-detail loading screens via headless browser screenshots — layout width matches the loaded state, accent indeterminate bar animates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)