### PR TITLE
Disable automatic staged-publish discovery on dashboard load

### DIFF
--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -30,7 +30,6 @@ export default function DashboardPage() {
   const request = useModel(ScanRequestModel);
   const stagedPublishes = useModel(StagedPublishesModel);
   const sessionChecked = useSignal(false);
-  const stagedPublishesConnectionId = useSignal<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -50,19 +49,10 @@ export default function DashboardPage() {
   }, []);
 
   useSignalEffect(() => {
-    const checked = sessionChecked.value;
-    const connectionId = npm.connection.value?.id ?? null;
-    const refreshing = stagedPublishes.refreshing.value;
-    const loadedConnectionId = stagedPublishesConnectionId.value;
-    if (!checked) return;
-    if (!connectionId) {
-      stagedPublishesConnectionId.value = null;
+    if (!sessionChecked.value) return;
+    if (!npm.connection.value?.id) {
       stagedPublishes.reset();
-      return;
     }
-    if (refreshing || loadedConnectionId === connectionId) return;
-    stagedPublishesConnectionId.value = connectionId;
-    void discoverStagedPublishes(stagedPublishes, scans);
   });
 
   useSignalEffect(() => {


### PR DESCRIPTION
## Summary
- Removes the dashboard's auto-discover effect; staged-publish discovery now runs only when the user clicks "Check npm" or submits a stage ID.
- Replaces the gated useSignalEffect with a minimal reset-on-disconnect and drops the now-unused per-connection tracking signal.

## Test plan
- [ ] Open dashboard with a connected npm token — no scan should be triggered automatically.
- [ ] Click "Check npm" — discovery runs and any new stages are queued.
- [ ] Disconnect the npm token — previously shown discovery results clear from the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)