### PR TITLE
Move org creation into a dialog and hide per-org npm token state

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,0 +1,70 @@
+import type { ComponentChildren } from "preact";
+import { useEffect, useRef } from "preact/hooks";
+import { cn } from "./cn";
+
+interface DialogProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  description?: string;
+  children: ComponentChildren;
+  footer?: ComponentChildren;
+  class?: string;
+}
+
+export function Dialog({
+  open,
+  onClose,
+  title,
+  description,
+  children,
+  footer,
+  class: className,
+}: DialogProps) {
+  const ref = useRef<HTMLDialogElement | null>(null);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    if (open && !node.open) {
+      node.showModal();
+    } else if (!open && node.open) {
+      node.close();
+    }
+  }, [open]);
+
+  const onCancel = (event: Event) => {
+    event.preventDefault();
+    onClose();
+  };
+
+  const onBackdropClick = (event: MouseEvent) => {
+    if (event.target === ref.current) onClose();
+  };
+
+  return (
+    <dialog
+      ref={ref}
+      onClose={onClose}
+      onCancel={onCancel}
+      onClick={onBackdropClick}
+      class={cn(
+        "p-0 m-auto bg-surface text-ink border border-border rounded-lg shadow-md",
+        "w-[min(92vw,440px)] max-w-[440px]",
+        "backdrop:bg-black/40",
+        className,
+      )}
+    >
+      <div class="flex flex-col gap-4 p-5">
+        <header class="flex flex-col gap-1">
+          <h2 class="text-[18px] font-medium tracking-[-0.01em] leading-[1.35] m-0">{title}</h2>
+          {description ? (
+            <p class="text-[13px] leading-[1.55] text-ink-muted m-0">{description}</p>
+          ) : null}
+        </header>
+        <div class="flex flex-col gap-3">{children}</div>
+        {footer ? <footer class="flex flex-wrap justify-end gap-2 pt-1">{footer}</footer> : null}
+      </div>
+    </dialog>
+  );
+}

--- a/src/components/OrgSwitcher.tsx
+++ b/src/components/OrgSwitcher.tsx
@@ -3,6 +3,8 @@ import { useSignal } from "@preact/signals";
 import type { Organization } from "../models/organization";
 import { Alert } from "./Alert";
 import { Button } from "./Button";
+import { Dialog } from "./Dialog";
+import { Field } from "./Field";
 import { Input } from "./Input";
 import { cn } from "./cn";
 
@@ -31,13 +33,22 @@ export function OrgSwitcher({
     if (value && value !== activeOrganizationId) void onActivate(value);
   };
 
+  const openCreate = () => {
+    draftName.value = "";
+    creating.value = true;
+  };
+
+  const closeCreate = () => {
+    creating.value = false;
+    draftName.value = "";
+  };
+
   const submitCreate = async (event: Event) => {
     event.preventDefault();
     const name = draftName.value.trim();
     if (!name) return;
     await onCreate(name);
-    draftName.value = "";
-    creating.value = false;
+    closeCreate();
   };
 
   return (
@@ -62,40 +73,53 @@ export function OrgSwitcher({
             <option key={org.id} value={org.id}>
               {org.name}
               {org.isPersonal ? " (personal)" : ""}
-              {org.npmConnectionConfigured ? "" : " — no npm token"}
             </option>
           ))}
         </select>
-        <Button
-          variant="secondary"
-          size="sm"
-          onClick={() => (creating.value = !creating.value)}
-          disabled={busy}
-          class="shrink-0"
-        >
-          {creating.value ? "Cancel" : "New organization"}
+        <Button variant="secondary" size="sm" onClick={openCreate} disabled={busy} class="shrink-0">
+          New organization
         </Button>
       </div>
 
-      {creating.value ? (
-        <form class="flex flex-wrap items-center gap-2" onSubmit={submitCreate}>
-          <Input
-            type="text"
-            value={draftName.value}
-            placeholder="acme-frontend"
-            onInput={(e) => (draftName.value = (e.target as HTMLInputElement).value)}
-            disabled={busy}
-            autoComplete="off"
-            spellcheck={false}
-            class="min-w-[220px]"
-          />
-          <Button type="submit" size="sm" disabled={busy || !draftName.value.trim()}>
-            {busy ? "Creating…" : "Create"}
-          </Button>
-        </form>
-      ) : null}
-
       {error ? <Alert tone="critical">{error}</Alert> : null}
+
+      <Dialog
+        open={creating.value}
+        onClose={closeCreate}
+        title="New organization"
+        description="Create a workspace for a team or product. You can add an npm token afterwards."
+        footer={
+          <>
+            <Button variant="secondary" size="sm" onClick={closeCreate} disabled={busy}>
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              size="sm"
+              form="org-create-form"
+              disabled={busy || !draftName.value.trim()}
+            >
+              {busy ? "Creating…" : "Create"}
+            </Button>
+          </>
+        }
+      >
+        <form id="org-create-form" onSubmit={submitCreate} class="flex flex-col gap-3">
+          <Field label="Name" for="orgName">
+            <Input
+              id="orgName"
+              type="text"
+              value={draftName.value}
+              placeholder="acme-frontend"
+              onInput={(e) => (draftName.value = (e.target as HTMLInputElement).value)}
+              disabled={busy}
+              autoComplete="off"
+              spellcheck={false}
+              autofocus
+            />
+          </Field>
+        </form>
+      </Dialog>
     </div>
   );
 }

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -7,6 +7,7 @@ export { Badge, severityTone, statusTone } from "./Badge";
 export type { Severity, Status, BadgeTone } from "./Badge";
 export { Alert } from "./Alert";
 export type { AlertTone } from "./Alert";
+export { Dialog } from "./Dialog";
 export { Card, SummaryCard } from "./Card";
 export type { SummaryCardTone, SummaryCardValue } from "./Card";
 export { PageShell } from "./PageShell";


### PR DESCRIPTION
## Summary
- Replace the inline expanding "New organization" form (which shifted the dashboard header layout) with a modal `Dialog` component built on the native `<dialog>` element.
- Remove the `— no npm token` annotation from the organization `<select>` options so credential state no longer leaks through the picker.
- Add a reusable `Dialog` primitive to `src/components/` (backdrop dismiss, Esc to close, design-system styling) and export it from the components index.

## Test plan
- [ ] Open the dashboard, click **New organization**, confirm the dialog opens with the name input focused and the header doesn't shift.
- [ ] Submit a name → org is created, dialog closes, switcher updates.
- [ ] Press Esc / click the backdrop / Cancel → dialog closes without creating.
- [ ] Verify org `<select>` options no longer show the "no npm token" suffix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)