### PR TITLE
Promote risk signals to their own full-width section

### DIFF
--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -162,9 +162,7 @@ export default function ScanDetailPage() {
   const selectedVersion = model.selectedVersion.value;
   const compare = model.compare.value;
   const hasRuleFindings = Boolean(detail?.findings.length);
-  const workbenchGridClass = hasRuleFindings
-    ? "grid grid-cols-1 lg:grid-cols-[300px_minmax(0,1fr)_320px] gap-4"
-    : "grid grid-cols-1 lg:grid-cols-[300px_minmax(0,1fr)] gap-4";
+  const workbenchGridClass = "grid grid-cols-1 lg:grid-cols-[300px_minmax(0,1fr)] gap-4";
 
   return (
     <PageShell>
@@ -239,26 +237,26 @@ export default function ScanDetailPage() {
                 stagedVersion={detail.scan.stagedVersion}
               />
             </Card>
-
-            {hasRuleFindings ? (
-              <Card as="aside" class="p-5 flex flex-col gap-3">
-                <SectionLabel>Risk signals</SectionLabel>
-                <ul class="list-none p-0 m-0 flex flex-col gap-2">
-                  {detail.findings.map((finding) => (
-                    <FindingCard
-                      key={finding.id}
-                      severity={finding.severity}
-                      file={finding.file}
-                      ruleId={finding.ruleId}
-                    >
-                      <FindingRow label="evidence" value={finding.evidence} />
-                      <FindingRow label="reason" value={finding.reason} />
-                    </FindingCard>
-                  ))}
-                </ul>
-              </Card>
-            ) : null}
           </section>
+
+          {hasRuleFindings ? (
+            <section class="flex flex-col gap-3">
+              <SectionLabel>Risk signals</SectionLabel>
+              <ul class="list-none p-0 m-0 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+                {detail.findings.map((finding) => (
+                  <FindingCard
+                    key={finding.id}
+                    severity={finding.severity}
+                    file={finding.file}
+                    ruleId={finding.ruleId}
+                  >
+                    <FindingRow label="evidence" value={finding.evidence} />
+                    <FindingRow label="reason" value={finding.reason} />
+                  </FindingCard>
+                ))}
+              </ul>
+            </section>
+          ) : null}
 
           <PersistedReportSections summary={summary.value} ai={ai.value} />
         </>


### PR DESCRIPTION
## Summary
- Pulled the risk signals panel out of the cramped 320px workbench sidebar on the scan detail page.
- Workbench is now a clean tree + diff two-column layout; findings render below as a responsive 1/2/3-column card grid so each card has room to breathe.

## Test plan
- [ ] Open a scan with rule findings and confirm risk signals render as a full-width grid below the diff workbench.
- [ ] Open a scan without findings and confirm the section is hidden and the workbench still fills the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)