### PR TITLE
Run scan queue consumers up to 10 in parallel

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -50,6 +50,7 @@
 				"queue": "staged-publish-review-scans",
 				"max_batch_size": 1,
 				"max_batch_timeout": 5,
+				"max_concurrency": 10,
 				"max_retries": 3,
 				"dead_letter_queue": "staged-publish-review-scans-dlq"
 			}


### PR DESCRIPTION
## Summary
- Sets `max_concurrency: 10` on the `staged-publish-review-scans` queue consumer in `wrangler.jsonc` so independent scan jobs run in parallel instead of one-at-a-time.
- No code changes — each scan message is already atomic, so Cloudflare can fan out consumer invocations safely.

## Test plan
- [ ] After deploy, enqueue several scans and confirm they run concurrently (overlapping start/end times in logs).
- [ ] Watch for Workers AI throttling and npm registry 429s; lower the value if downstream pressure becomes an issue.
- [ ] Confirm the DLQ (`staged-publish-review-scans-dlq`) is not seeing new entries from the increased parallelism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)