### PR TITLE
Log AI review escalations with their trigger reasons

### DIFF
--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -59,6 +59,7 @@ export async function runScanPipeline(
   const redactedStagedFiles = redactFileRecords(staged.files);
   const redactedPackageJson = redactJson(staged.packageJson ?? null);
   const redactedPreviousPackageJson = redactJson(previous?.packageJson ?? null);
+  const scanId = input.scanId || crypto.randomUUID();
   const aiFindings = await runSelectiveAiReview(env, {
     files: redactedStagedFiles,
     diff,
@@ -66,8 +67,18 @@ export async function runScanPipeline(
     ruleFindings,
     previousVersionAvailable: previous !== null,
   });
+  if (aiFindings.escalated) {
+    console.log("ai review escalated to stronger model", {
+      scanId,
+      stageId: input.stageId,
+      organizationId: input.organizationId,
+      packageName: staged.packageJson?.name ?? null,
+      stagedVersion: staged.packageJson?.version ?? null,
+      model: aiFindings.model,
+      reasons: aiFindings.escalationReasons,
+    });
+  }
   const risk = computeScanRisk(ruleFindings, aiFindings);
-  const scanId = input.scanId || crypto.randomUUID();
 
   const safety: ScanResult["safety"] = {
     tokenExposedToSandbox: false,


### PR DESCRIPTION
## Summary
- When `runSelectiveAiReview` escalates to the stronger model, the scan pipeline now logs a structured `console.log` with the scan/package context, the chosen model, and the `escalationReasons` so we can tell from logs exactly what triggered the upgrade (deterministic finding, lifecycle script, dependency change, context-budget overflow, default-model suspicion, etc.).

## Test plan
- [x] `pnpm run verify`