### PR TITLE
Lead persisted report with manifest changes and tidy finding rows

### DIFF
--- a/src/components/FindingCard.tsx
+++ b/src/components/FindingCard.tsx
@@ -36,18 +36,16 @@ export function FindingCard({
           </code>
         ) : null}
       </div>
-      <div class="text-[13px] leading-[1.55] flex flex-col gap-0.5">{children}</div>
+      <div class="text-[13px] leading-[1.55] flex flex-col gap-1.5">{children}</div>
     </li>
   );
 }
 
 export function FindingRow({ label, value }: { label: string; value: ComponentChildren }) {
   return (
-    <div>
-      <span class="text-ink-subtle font-mono text-[11px] uppercase tracking-[0.08em] mr-1.5">
-        {label}:
-      </span>
-      <span>{value}</span>
+    <div class="grid grid-cols-[88px_minmax(0,1fr)] gap-2.5 items-baseline">
+      <span class="text-ink-subtle font-mono text-[10px] uppercase tracking-[0.1em]">{label}</span>
+      <span class="min-w-0">{value}</span>
     </div>
   );
 }

--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -503,6 +503,14 @@ function PersistedReportSections({
 }) {
   return (
     <section class="grid grid-cols-1 lg:grid-cols-2 gap-x-8 gap-y-6">
+      <ReportSection title="Manifest changes" class="lg:col-span-2">
+        {summary.packageJsonDiff ? (
+          <PackageJsonDiffView diff={summary.packageJsonDiff} />
+        ) : (
+          <EmptyLine>No manifest changes were saved for this review.</EmptyLine>
+        )}
+      </ReportSection>
+
       {/* eslint-disable-next-line no-constant-binary-expression -- AI review intentionally disabled; JSX preserved for paid-tier re-introduction. */}
       {false && (
         <ReportSection title="Reviewer notes">
@@ -573,14 +581,6 @@ function PersistedReportSections({
           </details>
         ) : null}
       </ReportSection>
-
-      <ReportSection title="Manifest changes" class="lg:col-span-2">
-        {summary.packageJsonDiff ? (
-          <PackageJsonDiffView diff={summary.packageJsonDiff} />
-        ) : (
-          <EmptyLine>No manifest changes were saved for this review.</EmptyLine>
-        )}
-      </ReportSection>
     </section>
   );
 }
@@ -605,7 +605,7 @@ function ReportSection({
 function AiFindingList({ findings }: { findings: AiFinding[] }) {
   return (
     <ul class="list-none p-0 m-0 flex flex-col gap-2">
-      {findings.map((finding, index) => (
+      {sortFindingsBySeverity(findings).map((finding, index) => (
         <FindingCard
           key={`${finding.file}-${index}`}
           severity={finding.severity}


### PR DESCRIPTION
## Summary
- Manifest changes now sits at the top of the persisted-report block as a full-width row, so the package/version/scripts/deps summary lands before the secondary panels.
- `FindingRow` switches to a two-column grid so the label gets its own gutter and long evidence/reason/recommendation text wraps cleanly without flowing under the label; inter-row gap inside `FindingCard` is bumped for readability.
- `AiFindingList` reuses the shared `sortFindingsBySeverity` helper so assistant findings sort highest-first, matching the recent change for rule findings.

## Test plan
- [ ] Open a persisted scan and confirm Manifest changes is the first section under the workbench.
- [ ] Verify finding cards (risk signals + reviewer notes when AI is re-enabled) render with aligned labels and clean wrapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)