### PR TITLE
[codex] Clarify first-run npm setup path

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -74,7 +74,7 @@ Use cards for interactive containment and lists that need table-like edges. Pref
 - Open staged publishes are not displayed directly. Discovery starts scan records for newly found stage IDs, and those records appear in Recent reviews.
 - The recent reviews list paginates with `GET /api/v1/scans?cursor=…&filter=…`. The default filter is `undecided`; filter chips (Undecided / Approved / Blocked / All) sit above the table and re-fetch on change. Retries appear as separate rows — the old "newest-per-stage" dedup is gone now that decisions and pagination both depend on a one-row-per-scan model.
 - The scan detail page renders a publish decision panel above the diff workbench whenever the scan is `complete`. Approve / Block buttons record a decision via `POST /api/v1/scans/:id/decision`; a recorded decision is displayed with timestamp, optional reason, and a "Change decision" affordance that re-opens the form. The dashboard exposes the same decision as a badge column.
-- Connected workspace setup is collapsed by default, but the closed row must look clickable and include an explicit “Open settings” affordance.
+- When npm access is missing, the blocked request-review card links directly to workspace setup. Connected workspace setup is collapsed by default, but the closed row must look clickable and include an explicit “Open settings” affordance.
 - Connection metadata is displayed as compact label/value rows, while the editable credential form remains inside a card.
 - Marketing hero copy is unboxed; feature claims use cards below the headline.
 

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -21,6 +21,7 @@ import {
   Eyebrow,
   Field,
   Input,
+  LinkButton,
   LoadingState,
   MonoDetail,
   Muted,
@@ -209,7 +210,12 @@ function ReviewRequestCard({
       </div>
       {!hasConnection ? (
         <Alert tone="info">
-          Connect npm access in workspace setup before reviewing staged packages.
+          <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <span>Connect npm access in workspace setup before reviewing staged packages.</span>
+            <LinkButton href="#workspace-setup" variant="secondary" size="sm" class="shrink-0">
+              Open settings
+            </LinkButton>
+          </div>
         </Alert>
       ) : !hasValidatedConnection ? (
         <Alert tone="info">
@@ -390,39 +396,41 @@ function WorkspaceSetupPanel({
 }) {
   const connection = npm.connection.value;
   return (
-    <Card as="section" class="p-0 overflow-hidden">
-      <details open={!connection} class="group">
-        <summary class="list-none cursor-pointer px-5 py-4 transition-colors duration-150 ease-out hover:bg-surface-2 group-open:border-b group-open:border-border">
-          <div class="flex flex-wrap items-center justify-between gap-3">
-            <div class="flex flex-col gap-1.5 min-w-0">
-              <SectionLabel>Workspace setup</SectionLabel>
-              <Muted class="text-[13px] m-0">
-                Manage npm access, credential checks, and workspace safety defaults.
-              </Muted>
-              <MonoDetail
-                parts={[
-                  <span key="connection">npm {connection ? "connected" : "not connected"}</span>,
-                  <span key="evidence">redacted evidence</span>,
-                  <span key="approval">human approval</span>,
-                ]}
-              />
+    <section id="workspace-setup" class="scroll-mt-6">
+      <Card as="div" class="p-0 overflow-hidden">
+        <details open={!connection} class="group">
+          <summary class="list-none cursor-pointer px-5 py-4 transition-colors duration-150 ease-out hover:bg-surface-2 group-open:border-b group-open:border-border">
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <div class="flex flex-col gap-1.5 min-w-0">
+                <SectionLabel>Workspace setup</SectionLabel>
+                <Muted class="text-[13px] m-0">
+                  Manage npm access, credential checks, and workspace safety defaults.
+                </Muted>
+                <MonoDetail
+                  parts={[
+                    <span key="connection">npm {connection ? "connected" : "not connected"}</span>,
+                    <span key="evidence">redacted evidence</span>,
+                    <span key="approval">human approval</span>,
+                  ]}
+                />
+              </div>
+              <div class="flex flex-wrap items-center justify-end gap-2">
+                <Badge tone={connection ? "ok" : "info"}>
+                  {connection ? connection.validationStatus : "connect npm"}
+                </Badge>
+                <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
+                  <span class="group-open:hidden">open settings</span>
+                  <span class="hidden group-open:inline">close settings</span>
+                </span>
+              </div>
             </div>
-            <div class="flex flex-wrap items-center justify-end gap-2">
-              <Badge tone={connection ? "ok" : "info"}>
-                {connection ? connection.validationStatus : "connect npm"}
-              </Badge>
-              <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
-                <span class="group-open:hidden">show</span>
-                <span class="hidden group-open:inline">hide</span>
-              </span>
-            </div>
+          </summary>
+          <div class="p-5">
+            <NpmConnectionCard npm={npm} />
           </div>
-        </summary>
-        <div class="p-5">
-          <NpmConnectionCard npm={npm} />
-        </div>
-      </details>
-    </Card>
+        </details>
+      </Card>
+    </section>
   );
 }
 


### PR DESCRIPTION
## Summary
- adds an explicit setup link when the primary review action is blocked by missing npm access
- gives workspace setup a stable anchor and clearer open/close affordance text
- updates UI guidance for the first-run setup path

## Validation
- pnpm run verify