### PR TITLE
Record publish decisions on completed scans and paginate the list

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -211,8 +211,9 @@ Current API:
 - `POST /api/v1/scans` — create queued/background scan;
 - `POST /api/v1/scan` — synchronous compatibility scan;
 - `POST /api/v1/staged-publishes/scan` — discover open staged publishes and create scans for newly found stage IDs;
-- `GET /api/v1/scans` — list organization scans;
+- `GET /api/v1/scans` — list organization scans. Supports `filter=undecided|publish|no_publish|all` (default `undecided`), `limit` (default 20, max 100), and `cursor` (opaque `<createdAtMs>:<id>` token). Response includes `nextCursor` for the next page; retries are no longer deduplicated by stage id so every scan appears in the timeline;
 - `GET /api/v1/scans/:id` — scan status/report detail;
+- `POST /api/v1/scans/:id/decision` — record a `publish` or `no_publish` decision on a `complete` scan with an optional `reason` (≤500 chars). Returns the updated scan detail and emits a `scan.decided` audit event. Returns 409 if the scan is not yet complete;
 - `GET /api/v1/npm-connection` — read connection metadata;
 - `POST /api/v1/npm-connection` — create/rotate connection;
 - `POST /api/v1/npm-connection/validate` — validate access;

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -72,7 +72,8 @@ Use cards for interactive containment and lists that need table-like edges. Pref
 - Empty findings do not get full bordered panels; represent them as compact badges or `EmptyLine`s inside an existing section.
 - Dashboard order follows user intent: request a review first, recent reviews second, workspace setup last.
 - Open staged publishes are not displayed directly. Discovery starts scan records for newly found stage IDs, and those records appear in Recent reviews.
-- The recent reviews list returns only the newest scan per stage ID; repeated reviews of the same staged publish should not create duplicate dashboard rows.
+- The recent reviews list paginates with `GET /api/v1/scans?cursor=…&filter=…`. The default filter is `undecided`; filter chips (Undecided / Approved / Blocked / All) sit above the table and re-fetch on change. Retries appear as separate rows — the old "newest-per-stage" dedup is gone now that decisions and pagination both depend on a one-row-per-scan model.
+- The scan detail page renders a publish decision panel above the diff workbench whenever the scan is `complete`. Approve / Block buttons record a decision via `POST /api/v1/scans/:id/decision`; a recorded decision is displayed with timestamp, optional reason, and a "Change decision" affordance that re-opens the form. The dashboard exposes the same decision as a badge column.
 - Connected workspace setup is collapsed by default, but the closed row must look clickable and include an explicit “Open settings” affordance.
 - Connection metadata is displayed as compact label/value rows, while the editable credential form remains inside a card.
 - Marketing hero copy is unboxed; feature claims use cards below the headline.

--- a/drizzle/0006_wise_wiccan.sql
+++ b/drizzle/0006_wise_wiccan.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `scans` ADD `decision` text;--> statement-breakpoint
+ALTER TABLE `scans` ADD `decision_reason` text;--> statement-breakpoint
+ALTER TABLE `scans` ADD `decided_by_user_id` text REFERENCES user(id);--> statement-breakpoint
+ALTER TABLE `scans` ADD `decided_at` integer;--> statement-breakpoint
+CREATE INDEX `scans_org_decision_created_idx` ON `scans` (`organization_id`,`decision`,`created_at`);

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,1245 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c4afa6a5-c383-4d9d-82ea-58962091dc67",
+  "prevId": "12b086ab-0422-4136-baf3-34cb31d6665b",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_unique_idx": {
+          "name": "npm_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        },
+        "scans_org_decision_created_idx": {
+          "name": "scans_org_decision_created_idx",
+          "columns": [
+            "organization_id",
+            "decision",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_decided_by_user_id_user_id_fk": {
+          "name": "scans_decided_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1779401548052,
       "tag": "0005_even_true_believers",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1779473681225,
+      "tag": "0006_wise_wiccan",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1,5 +1,5 @@
 import { drizzle } from "drizzle-orm/d1";
-import { and, desc, eq, inArray, lt, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
 import * as schema from "./schema";
 import {
   npmConnections,
@@ -346,7 +346,72 @@ function chunkForD1<T>(rows: T[], columnsPerRow: number): T[][] {
   return chunks;
 }
 
-export async function listScans(db: AppDb, organizationId: string) {
+export const SCAN_DECISIONS = ["publish", "no_publish"] as const;
+export type ScanDecision = (typeof SCAN_DECISIONS)[number];
+
+export const SCAN_DECISION_FILTERS = ["undecided", "publish", "no_publish", "all"] as const;
+export type ScanDecisionFilter = (typeof SCAN_DECISION_FILTERS)[number];
+
+export interface ListScansOptions {
+  cursor?: { createdAtMs: number; id: string } | null;
+  limit?: number;
+  decisionFilter?: ScanDecisionFilter;
+}
+
+export interface ListScansResult {
+  scans: Array<{
+    id: string;
+    stageId: string;
+    organizationId: string | null;
+    ownerUserId: string | null;
+    packageName: string | null;
+    stagedVersion: string | null;
+    previousVersion: string | null;
+    risk: string;
+    status: string;
+    decision: string | null;
+    decisionReason: string | null;
+    decidedByUserId: string | null;
+    decidedAt: Date | null;
+    reportVersion: number | null;
+    reportDigest: string | null;
+    startedAt: Date | null;
+    completedAt: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }>;
+  nextCursor: { createdAtMs: number; id: string } | null;
+}
+
+export const LIST_SCANS_DEFAULT_LIMIT = 20;
+export const LIST_SCANS_MAX_LIMIT = 100;
+
+export async function listScans(
+  db: AppDb,
+  organizationId: string,
+  options: ListScansOptions = {},
+): Promise<ListScansResult> {
+  const limit = Math.min(
+    LIST_SCANS_MAX_LIMIT,
+    Math.max(1, Math.floor(options.limit ?? LIST_SCANS_DEFAULT_LIMIT)),
+  );
+  const decisionFilter = options.decisionFilter ?? "undecided";
+
+  const conditions = [eq(scans.organizationId, organizationId)];
+  if (decisionFilter === "undecided") conditions.push(isNull(scans.decision));
+  else if (decisionFilter === "publish") conditions.push(eq(scans.decision, "publish"));
+  else if (decisionFilter === "no_publish") conditions.push(eq(scans.decision, "no_publish"));
+
+  if (options.cursor) {
+    const cursorDate = new Date(options.cursor.createdAtMs);
+    conditions.push(
+      or(
+        lt(scans.createdAt, cursorDate),
+        and(eq(scans.createdAt, cursorDate), lt(scans.id, options.cursor.id)),
+      )!,
+    );
+  }
+
   const rows = await db
     .select({
       id: scans.id,
@@ -358,6 +423,10 @@ export async function listScans(db: AppDb, organizationId: string) {
       previousVersion: scans.previousVersion,
       risk: scans.risk,
       status: scans.status,
+      decision: scans.decision,
+      decisionReason: scans.decisionReason,
+      decidedByUserId: scans.decidedByUserId,
+      decidedAt: scans.decidedAt,
       reportVersion: scans.reportVersion,
       reportDigest: scans.reportDigest,
       startedAt: scans.startedAt,
@@ -366,19 +435,59 @@ export async function listScans(db: AppDb, organizationId: string) {
       updatedAt: scans.updatedAt,
     })
     .from(scans)
-    .where(eq(scans.organizationId, organizationId))
-    .orderBy(desc(scans.createdAt))
-    .limit(100);
+    .where(and(...conditions))
+    .orderBy(desc(scans.createdAt), desc(scans.id))
+    .limit(limit + 1);
 
-  const unique: typeof rows = [];
-  const seenStageIds = new Set<string>();
-  for (const row of rows) {
-    if (seenStageIds.has(row.stageId)) continue;
-    seenStageIds.add(row.stageId);
-    unique.push(row);
-    if (unique.length === 50) break;
-  }
-  return unique;
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  const last = page[page.length - 1];
+  const nextCursor =
+    hasMore && last ? { createdAtMs: new Date(last.createdAt).getTime(), id: last.id } : null;
+
+  return { scans: page, nextCursor };
+}
+
+export interface RecordScanDecisionInput {
+  scanId: string;
+  organizationId: string;
+  actorUserId: string;
+  decision: ScanDecision;
+  reason?: string | null;
+}
+
+export async function recordScanDecision(db: AppDb, input: RecordScanDecisionInput) {
+  const now = new Date();
+  const reason = input.reason?.trim() ? input.reason.trim() : null;
+  const updated = await db
+    .update(scans)
+    .set({
+      decision: input.decision,
+      decisionReason: reason,
+      decidedByUserId: input.actorUserId,
+      decidedAt: now,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(scans.id, input.scanId),
+        eq(scans.organizationId, input.organizationId),
+        eq(scans.status, "complete"),
+      ),
+    )
+    .returning({ id: scans.id });
+
+  if (updated.length === 0) return null;
+
+  await recordScanEvent(db, {
+    organizationId: input.organizationId,
+    actorUserId: input.actorUserId,
+    scanId: input.scanId,
+    type: "scan.decided",
+    metadata: { decision: input.decision, reason },
+  });
+
+  return getScan(db, input.scanId, input.organizationId);
 }
 
 export async function getScan(db: AppDb, id: string, organizationId: string) {

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -63,6 +63,12 @@ export const scans = sqliteTable(
     previousVersion: text("previous_version"),
     risk: text("risk").notNull().default("unknown"),
     status: text("status").notNull().default("pending"),
+    decision: text("decision"),
+    decisionReason: text("decision_reason"),
+    decidedByUserId: text("decided_by_user_id").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    decidedAt: integer("decided_at", { mode: "timestamp_ms" }),
     summaryJson: text("summary_json", { mode: "json" }),
     aiJson: text("ai_json", { mode: "json" }),
     errorJson: text("error_json", { mode: "json" }),
@@ -78,6 +84,11 @@ export const scans = sqliteTable(
     ownerIdx: index("scans_owner_idx").on(table.ownerUserId),
     stageIdx: index("scans_stage_id_idx").on(table.stageId),
     packageIdx: index("scans_package_idx").on(table.packageName),
+    orgDecisionCreatedIdx: index("scans_org_decision_created_idx").on(
+      table.organizationId,
+      table.decision,
+      table.createdAt,
+    ),
   }),
 );
 

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -1,12 +1,19 @@
 import { Hono } from "hono";
 import {
+  LIST_SCANS_DEFAULT_LIMIT,
+  LIST_SCANS_MAX_LIMIT,
   RateLimitError,
+  SCAN_DECISIONS,
+  SCAN_DECISION_FILTERS,
+  type ScanDecision,
+  type ScanDecisionFilter,
   createDb,
   createScanJob,
   enforceRateLimit,
   getNpmConnection,
   getScan,
   listScans,
+  recordScanDecision,
   recordScanEvent,
 } from "../db";
 import { requireActiveOrganization } from "../lib/active-organization";
@@ -91,10 +98,83 @@ scansRoutes.post("/", async (c) => {
   }
 });
 
+const DECISION_REASON_MAX = 500;
+const DECISION_FILTER_SET = new Set<ScanDecisionFilter>(SCAN_DECISION_FILTERS);
+const DECISION_SET = new Set<ScanDecision>(SCAN_DECISIONS);
+
+function parseListScansCursor(raw: string | undefined) {
+  if (!raw) return null;
+  const sep = raw.indexOf(":");
+  if (sep <= 0) return null;
+  const createdAtMs = Number(raw.slice(0, sep));
+  const id = raw.slice(sep + 1);
+  if (!Number.isFinite(createdAtMs) || !id) return null;
+  return { createdAtMs, id };
+}
+
+function encodeListScansCursor(cursor: { createdAtMs: number; id: string } | null) {
+  return cursor ? `${cursor.createdAtMs}:${cursor.id}` : null;
+}
+
 scansRoutes.get("/", async (c) => {
   const db = createDb(c.env.DB);
   const organizationId = await requireActiveOrganization(c, db);
-  return c.json({ scans: await listScans(db, organizationId) });
+
+  const rawFilter = c.req.query("filter");
+  const decisionFilter: ScanDecisionFilter = DECISION_FILTER_SET.has(
+    rawFilter as ScanDecisionFilter,
+  )
+    ? (rawFilter as ScanDecisionFilter)
+    : "undecided";
+
+  const rawLimit = Number(c.req.query("limit"));
+  const limit = Number.isFinite(rawLimit)
+    ? Math.min(LIST_SCANS_MAX_LIMIT, Math.max(1, Math.floor(rawLimit)))
+    : LIST_SCANS_DEFAULT_LIMIT;
+
+  const cursor = parseListScansCursor(c.req.query("cursor"));
+
+  const result = await listScans(db, organizationId, { cursor, limit, decisionFilter });
+  return c.json({
+    scans: result.scans,
+    nextCursor: encodeListScansCursor(result.nextCursor),
+    filter: decisionFilter,
+    limit,
+  });
+});
+
+scansRoutes.post("/:id/decision", async (c) => {
+  const body = (await c.req.json().catch(() => ({}))) as Partial<{
+    decision: string;
+    reason: string;
+  }>;
+  if (!DECISION_SET.has(body.decision as ScanDecision)) {
+    return c.json({ error: "decision must be 'publish' or 'no_publish'" }, 400);
+  }
+  const reason = typeof body.reason === "string" ? body.reason : null;
+  if (reason && reason.length > DECISION_REASON_MAX) {
+    return c.json({ error: `reason must be <= ${DECISION_REASON_MAX} characters` }, 400);
+  }
+
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const organizationId = await requireActiveOrganization(c, db);
+
+  const updated = await recordScanDecision(db, {
+    scanId: c.req.param("id"),
+    organizationId,
+    actorUserId: session.userId,
+    decision: body.decision as ScanDecision,
+    reason,
+  });
+
+  if (!updated) {
+    const existing = await getScan(db, c.req.param("id"), organizationId);
+    if (!existing) return c.json({ error: "not found" }, 404);
+    return c.json({ error: "decision can only be set on completed scans" }, 409);
+  }
+
+  return c.json(updated);
 });
 
 scansRoutes.get("/:id", async (c) => {

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -22,6 +22,9 @@ export interface ScanCompareFileResponse {
   file: FileRecord;
 }
 
+export type ScanDecision = "publish" | "no_publish";
+export type ScanDecisionFilter = "undecided" | "publish" | "no_publish" | "all";
+
 export interface ScanListItem {
   id: string;
   stageId: string;
@@ -32,6 +35,10 @@ export interface ScanListItem {
   previousVersion: string | null;
   risk: string;
   status: string;
+  decision?: ScanDecision | string | null;
+  decisionReason?: string | null;
+  decidedByUserId?: string | null;
+  decidedAt?: string | number | Date | null;
   reportVersion?: number | null;
   reportDigest?: string | null;
   startedAt?: string | number | Date | null;
@@ -89,9 +96,34 @@ export function createScan(stageId: string): Promise<{ scan: ScanListItem; queue
   });
 }
 
-export async function listScans(): Promise<ScanListItem[]> {
-  const data = await apiFetch<{ scans: ScanListItem[] }>("/api/v1/scans");
-  return data.scans;
+export interface ListScansResponse {
+  scans: ScanListItem[];
+  nextCursor: string | null;
+  filter: ScanDecisionFilter;
+  limit: number;
+}
+
+export function listScans(
+  options: { cursor?: string | null; filter?: ScanDecisionFilter; limit?: number } = {},
+): Promise<ListScansResponse> {
+  const params = new URLSearchParams();
+  if (options.cursor) params.set("cursor", options.cursor);
+  if (options.filter) params.set("filter", options.filter);
+  if (options.limit) params.set("limit", String(options.limit));
+  const qs = params.toString();
+  return apiFetch<ListScansResponse>(`/api/v1/scans${qs ? `?${qs}` : ""}`);
+}
+
+export function setScanDecision(
+  id: string,
+  decision: ScanDecision,
+  reason: string | null,
+): Promise<PersistedScanDetail> {
+  return apiFetch<PersistedScanDetail>(`/api/v1/scans/${encodeURIComponent(id)}/decision`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ decision, reason }),
+  });
 }
 
 export function getScan(
@@ -126,24 +158,54 @@ export const ScanListModel = createModel(() => {
   const scans = signal<ScanListItem[]>([]);
   const loaded = signal(false);
   const refreshing = signal(false);
+  const loadingMore = signal(false);
+  const filter = signal<ScanDecisionFilter>("undecided");
+  const nextCursor = signal<string | null>(null);
   const error = signal<string | null>(null);
 
   return {
     scans,
     loaded,
     refreshing,
+    loadingMore,
+    filter,
+    nextCursor,
     error,
 
     async refresh(): Promise<void> {
       this.refreshing.value = true;
       try {
-        this.scans.value = await listScans();
+        const data = await listScans({ filter: this.filter.value });
+        this.scans.value = data.scans;
+        this.nextCursor.value = data.nextCursor;
         this.error.value = null;
       } catch (err) {
         this.error.value = err instanceof Error ? err.message : String(err);
       } finally {
         this.loaded.value = true;
         this.refreshing.value = false;
+      }
+    },
+
+    async setFilter(next: ScanDecisionFilter): Promise<void> {
+      if (this.filter.value === next) return;
+      this.filter.value = next;
+      await this.refresh();
+    },
+
+    async loadMore(): Promise<void> {
+      const cursor = this.nextCursor.value;
+      if (!cursor || this.loadingMore.value) return;
+      this.loadingMore.value = true;
+      try {
+        const data = await listScans({ cursor, filter: this.filter.value });
+        this.scans.value = [...this.scans.value, ...data.scans];
+        this.nextCursor.value = data.nextCursor;
+        this.error.value = null;
+      } catch (err) {
+        this.error.value = err instanceof Error ? err.message : String(err);
+      } finally {
+        this.loadingMore.value = false;
       }
     },
   };
@@ -183,6 +245,8 @@ export const ScanRequestModel = createModel(() => {
   };
 });
 
+export type DecisionStatus = "idle" | "saving" | "error";
+
 export const ScanDetailModel = createModel((id: string) => {
   const scanId = signal(id);
   const detail = signal<PersistedScanDetail | null>(null);
@@ -195,6 +259,8 @@ export const ScanDetailModel = createModel((id: string) => {
   const compareLoading = signal(false);
   const fileLoading = signal(false);
   const compareError = signal<string | null>(null);
+  const decisionStatus = signal<DecisionStatus>("idle");
+  const decisionError = signal<string | null>(null);
 
   const status = computed(() => detail.value?.scan.status ?? null);
   const isPolling = computed(() => status.value === "pending" || status.value === "running");
@@ -265,6 +331,8 @@ export const ScanDetailModel = createModel((id: string) => {
     compareLoading,
     fileLoading,
     compareError,
+    decisionStatus,
+    decisionError,
     status,
     isPolling,
     isDefaultComparison,
@@ -305,6 +373,20 @@ export const ScanDetailModel = createModel((id: string) => {
 
     selectVersion(version: string | null) {
       this.selectedVersion.value = version;
+    },
+
+    async setDecision(decision: ScanDecision, reason: string | null): Promise<void> {
+      const id = this.scanId.peek();
+      this.decisionStatus.value = "saving";
+      this.decisionError.value = null;
+      try {
+        const updated = await setScanDecision(id, decision, reason);
+        this.detail.value = updated;
+        this.decisionStatus.value = "idle";
+      } catch (err) {
+        this.decisionError.value = err instanceof Error ? err.message : String(err);
+        this.decisionStatus.value = "error";
+      }
     },
 
     async loadPreviousFile(version: string, path: string): Promise<void> {

--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -3,22 +3,31 @@ import { useEffect } from "preact/hooks";
 import { useComputed, useModel, useSignal, useSignalEffect } from "@preact/signals";
 import { useLocation, useRoute } from "preact-iso";
 import { sessionModel } from "../../models/auth";
-import { ScanDetailModel, type PersistedScanDetail } from "../../models/scan";
+import {
+  ScanDetailModel,
+  type DecisionStatus,
+  type PersistedScanDetail,
+  type ScanDecision,
+} from "../../models/scan";
 import type { AiFinding, AiReview } from "../../../server/lib/ai-review";
 import { createPackageDiff, type DiffEntry, type FileRecord } from "../../../server/lib/review";
 import type { PackageJsonDiff, ScanResult } from "../../../server/types";
 import {
   Alert,
   Badge,
+  Button,
   Card,
   DiffView,
   EmptyLine,
+  Field,
   FileTree,
   FindingCard,
   FindingRow,
+  Input,
   LoadingLine,
   LoadingState,
   MonoDetail,
+  Muted,
   PageShell,
   SectionLabel,
   SeverityBar,
@@ -193,6 +202,17 @@ export default function ScanDetailPage() {
             aiFindings={ai.value?.findings ?? []}
             diffCount={diffEntries.value.filter((entry) => entry.status !== "unchanged").length}
           />
+
+          {detail.scan.status === "complete" ? (
+            <DecisionPanel
+              decision={detail.scan.decision}
+              decisionReason={detail.scan.decisionReason}
+              decidedAt={detail.scan.decidedAt}
+              status={model.decisionStatus.value}
+              error={model.decisionError.value}
+              onSubmit={(decision, reason) => void model.setDecision(decision, reason)}
+            />
+          ) : null}
 
           {versions ? (
             <div class="flex flex-col gap-2 border-y border-border py-3">
@@ -373,6 +393,131 @@ function toDiffSide(file: FileRecord) {
     sha256: file.sha256,
     flags: file.flags,
   };
+}
+
+function DecisionPanel({
+  decision,
+  decisionReason,
+  decidedAt,
+  status,
+  error,
+  onSubmit,
+}: {
+  decision?: string | null;
+  decisionReason?: string | null;
+  decidedAt?: string | number | Date | null;
+  status: DecisionStatus;
+  error: string | null;
+  onSubmit: (decision: ScanDecision, reason: string | null) => void;
+}) {
+  const editing = useSignal(!decision);
+  const reasonDraft = useSignal("");
+  const saving = status === "saving";
+
+  useSignalEffect(() => {
+    if (!decision) {
+      editing.value = true;
+      return;
+    }
+    editing.value = false;
+    reasonDraft.value = "";
+  });
+
+  const submit = (next: ScanDecision) => {
+    const trimmed = reasonDraft.value.trim();
+    onSubmit(next, trimmed.length ? trimmed : null);
+  };
+
+  const showForm = editing.value || !decision;
+
+  return (
+    <Card class="p-5 flex flex-col gap-4 border-accent/40">
+      <div class="flex flex-wrap items-start justify-between gap-3">
+        <div class="flex flex-col gap-1.5">
+          <SectionLabel>Publish decision</SectionLabel>
+          <Muted class="text-[13px] max-w-[640px]">
+            Record whether this staged publish is approved to go live. The decision is part of the
+            audit trail.
+          </Muted>
+        </div>
+        {decision ? (
+          <Badge tone={decision === "publish" ? "ok" : "critical"}>
+            {decision === "publish" ? "approved" : "blocked"}
+          </Badge>
+        ) : (
+          <Badge tone="neutral">undecided</Badge>
+        )}
+      </div>
+
+      {decision && !editing.value ? (
+        <div class="flex flex-col gap-2">
+          <MonoDetail
+            parts={[
+              <span key="kind">
+                {decision === "publish" ? "approved publish" : "blocked publish"}
+              </span>,
+              <span key="at">{decidedAt ? formatDate(decidedAt) : "just now"}</span>,
+            ]}
+          />
+          {decisionReason ? (
+            <p class="m-0 text-[13px] leading-[1.6] text-ink-muted">{decisionReason}</p>
+          ) : null}
+          <div class="flex">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => {
+                reasonDraft.value = decisionReason ?? "";
+                editing.value = true;
+              }}
+            >
+              Change decision
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {showForm ? (
+        <div class="flex flex-col gap-3">
+          <Field label="Reason (optional)" for="decisionReason">
+            <Input
+              id="decisionReason"
+              type="text"
+              value={reasonDraft.value}
+              placeholder="e.g. minor patch, no risk signals"
+              onInput={(e) => (reasonDraft.value = (e.target as HTMLInputElement).value)}
+              disabled={saving}
+              maxLength={500}
+              autoComplete="off"
+              spellcheck={false}
+            />
+          </Field>
+          <div class="flex flex-wrap gap-2">
+            <Button onClick={() => submit("publish")} disabled={saving}>
+              {saving ? "Saving…" : "Approve publish"}
+            </Button>
+            <Button variant="danger" onClick={() => submit("no_publish")} disabled={saving}>
+              {saving ? "Saving…" : "Block publish"}
+            </Button>
+            {decision ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  editing.value = false;
+                  reasonDraft.value = "";
+                }}
+                disabled={saving}
+              >
+                Cancel
+              </Button>
+            ) : null}
+          </div>
+          {error ? <Alert tone="critical">{error}</Alert> : null}
+        </div>
+      ) : null}
+    </Card>
+  );
 }
 
 function ScanFailureAlert({ errorJson }: { errorJson: unknown }) {

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -5,7 +5,12 @@ import { useLocation } from "preact-iso";
 import { sessionModel } from "../../models/auth";
 import { NpmConnectionModel } from "../../models/npm-connection";
 import { OrganizationModel } from "../../models/organization";
-import { ScanListModel, ScanRequestModel, type ScanListItem } from "../../models/scan";
+import {
+  ScanListModel,
+  ScanRequestModel,
+  type ScanDecisionFilter,
+  type ScanListItem,
+} from "../../models/scan";
 import { StagedPublishesModel } from "../../models/staged-publishes";
 import {
   Alert,
@@ -288,19 +293,89 @@ function RecentReviewsSection({
       {discovery && !discoveryError && !discovery.created && !discovery.found ? (
         <Muted class="text-[13px] m-0">No open staged publishes found.</Muted>
       ) : null}
+      <ScanFilterChips
+        active={scans.filter.value}
+        disabled={scans.refreshing.value}
+        onChange={(filter) => void scans.setFilter(filter)}
+      />
       <Card class="p-0 overflow-hidden">
         {scans.scans.value.length ? (
           <ScanTable scans={scans.scans.value} />
         ) : (
           <div class="p-5">
-            <EmptyLine>
-              No reviews yet. Request one above to start building your release history.
-            </EmptyLine>
+            <EmptyLine>{emptyStateMessage(scans.filter.value)}</EmptyLine>
           </div>
         )}
       </Card>
+      {scans.nextCursor.value ? (
+        <div class="flex justify-center pt-1">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => void scans.loadMore()}
+            disabled={scans.loadingMore.value}
+          >
+            {scans.loadingMore.value ? "Loading…" : "Load more"}
+          </Button>
+        </div>
+      ) : null}
     </section>
   );
+}
+
+const FILTER_OPTIONS: Array<{ value: ScanDecisionFilter; label: string }> = [
+  { value: "undecided", label: "Undecided" },
+  { value: "publish", label: "Approved" },
+  { value: "no_publish", label: "Blocked" },
+  { value: "all", label: "All" },
+];
+
+function ScanFilterChips({
+  active,
+  disabled,
+  onChange,
+}: {
+  active: ScanDecisionFilter;
+  disabled: boolean;
+  onChange: (filter: ScanDecisionFilter) => void;
+}) {
+  return (
+    <div class="flex flex-wrap gap-1.5" role="tablist" aria-label="Filter reviews by decision">
+      {FILTER_OPTIONS.map((option) => {
+        const isActive = option.value === active;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            disabled={disabled}
+            onClick={() => onChange(option.value)}
+            class={`font-mono text-[11px] uppercase tracking-[0.08em] px-2.5 py-1.5 rounded-md border transition-colors duration-150 ease-out cursor-pointer disabled:cursor-not-allowed disabled:opacity-60 ${
+              isActive
+                ? "bg-accent text-accent-on border-accent"
+                : "bg-surface-2 text-ink-muted border-border hover:border-border-strong"
+            }`}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function emptyStateMessage(filter: ScanDecisionFilter): string {
+  switch (filter) {
+    case "undecided":
+      return "Nothing waiting on a decision. Switch to All to see decided reviews.";
+    case "publish":
+      return "No reviews approved for publish yet.";
+    case "no_publish":
+      return "No reviews blocked from publish yet.";
+    default:
+      return "No reviews yet. Request one above to start building your release history.";
+  }
 }
 
 function WorkspaceSetupPanel({
@@ -508,6 +583,7 @@ function ScanTable({ scans }: { scans: ScanListItem[] }) {
             <Th>Version</Th>
             <Th>Risk</Th>
             <Th>Status</Th>
+            <Th>Decision</Th>
             <Th>Created</Th>
           </tr>
         </thead>
@@ -526,6 +602,9 @@ function ScanTable({ scans }: { scans: ScanListItem[] }) {
                 <Badge tone={severityTone(scan.risk)}>{scan.risk}</Badge>
               </Td>
               <Td class="font-mono text-xs text-ink-muted">{scan.status}</Td>
+              <Td>
+                <DecisionBadge decision={scan.decision} />
+              </Td>
               <Td class="font-mono text-xs text-ink-muted">{formatDate(scan.createdAt)}</Td>
             </tr>
           ))}
@@ -533,6 +612,12 @@ function ScanTable({ scans }: { scans: ScanListItem[] }) {
       </table>
     </div>
   );
+}
+
+function DecisionBadge({ decision }: { decision?: string | null }) {
+  if (decision === "publish") return <Badge tone="ok">approved</Badge>;
+  if (decision === "no_publish") return <Badge tone="critical">blocked</Badge>;
+  return <Badge tone="neutral">undecided</Badge>;
 }
 
 function Th({ children }: { children: ComponentChildren }) {

--- a/test/workers/cross-org-routes.test.ts
+++ b/test/workers/cross-org-routes.test.ts
@@ -101,7 +101,7 @@ describe("scans routes enforce organization boundaries", () => {
     expect(intruderBody.scans.map((s) => s.id)).not.toContain(scanId);
   });
 
-  test("GET /scans returns only the newest scan for each stage id", async () => {
+  test("GET /scans lists every scan for a stage id with the newest first", async () => {
     const owner = await seedUser();
     const db = createDb(env.DB);
     const stageId = `stage-${crypto.randomUUID().slice(0, 12)}`;
@@ -119,11 +119,118 @@ describe("scans routes enforce organization boundaries", () => {
         .where(eq(schema.scans.id, newerId)),
     ]);
 
-    const res = await fetchWithSession(buildTestApp(owner), "/api/v1/scans");
+    const res = await fetchWithSession(buildTestApp(owner), "/api/v1/scans?filter=all");
     expect(res.status).toBe(200);
     const body = (await res.json()) as { scans: Array<{ id: string; stageId: string }> };
     const matching = body.scans.filter((scan) => scan.stageId === stageId);
-    expect(matching.map((scan) => scan.id)).toEqual([newerId]);
+    expect(matching.map((scan) => scan.id)).toEqual([newerId, olderId]);
+  });
+
+  test("GET /scans paginates with a cursor and defaults to undecided scans", async () => {
+    const owner = await seedUser();
+    const db = createDb(env.DB);
+    const ids: string[] = [];
+    for (let i = 0; i < 3; i += 1) {
+      ids.push(await seedCompletedScan(owner, "@org/page-package"));
+    }
+    // Decide the oldest so it should be filtered out of the default view.
+    const decidedId = ids[0]!;
+    await db
+      .update(schema.scans)
+      .set({ decision: "publish", decidedAt: new Date(), updatedAt: new Date() })
+      .where(eq(schema.scans.id, decidedId));
+
+    const firstPage = await fetchWithSession(
+      buildTestApp(owner),
+      "/api/v1/scans?limit=1&filter=undecided",
+    );
+    expect(firstPage.status).toBe(200);
+    const firstBody = (await firstPage.json()) as {
+      scans: Array<{ id: string }>;
+      nextCursor: string | null;
+    };
+    expect(firstBody.scans).toHaveLength(1);
+    expect(firstBody.scans[0]?.id).not.toBe(decidedId);
+    expect(firstBody.nextCursor).toBeTypeOf("string");
+
+    const secondPage = await fetchWithSession(
+      buildTestApp(owner),
+      `/api/v1/scans?limit=1&filter=undecided&cursor=${encodeURIComponent(firstBody.nextCursor!)}`,
+    );
+    const secondBody = (await secondPage.json()) as {
+      scans: Array<{ id: string }>;
+      nextCursor: string | null;
+    };
+    expect(secondBody.scans).toHaveLength(1);
+    expect(secondBody.scans[0]?.id).not.toBe(firstBody.scans[0]?.id);
+    expect(secondBody.scans[0]?.id).not.toBe(decidedId);
+    expect(secondBody.nextCursor).toBeNull();
+  });
+
+  test("POST /scans/:id/decision records a publish decision on completed scans", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner, "@org/decide-package");
+
+    const ctx = createExecutionContext();
+    const res = await buildTestApp(owner).fetch(
+      new Request(`http://test.local/api/v1/scans/${scanId}/decision`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ decision: "publish", reason: "minor patch" }),
+      }),
+      env,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      scan: { decision: string; decisionReason: string };
+    };
+    expect(body.scan.decision).toBe("publish");
+    expect(body.scan.decisionReason).toBe("minor patch");
+  });
+
+  test("POST /scans/:id/decision rejects invalid decision values", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner, "@org/decide-package");
+
+    const ctx = createExecutionContext();
+    const res = await buildTestApp(owner).fetch(
+      new Request(`http://test.local/api/v1/scans/${scanId}/decision`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ decision: "maybe" }),
+      }),
+      env,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(400);
+  });
+
+  test("POST /scans/:id/decision returns 409 for non-complete scans", async () => {
+    const owner = await seedUser();
+    const db = createDb(env.DB);
+    const scanId = `scan_${crypto.randomUUID()}`;
+    await createScanJob(db, {
+      id: scanId,
+      stageId: `stage-${scanId.slice(-12)}`,
+      organizationId: owner.organizationId,
+      ownerUserId: owner.userId,
+    });
+
+    const ctx = createExecutionContext();
+    const res = await buildTestApp(owner).fetch(
+      new Request(`http://test.local/api/v1/scans/${scanId}/decision`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ decision: "publish" }),
+      }),
+      env,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(409);
   });
 
   test("GET /scans/:id returns 404 for scans owned by another organization", async () => {

--- a/test/workers/staged-publishes-routes.test.ts
+++ b/test/workers/staged-publishes-routes.test.ts
@@ -104,7 +104,7 @@ describe("staged publishes route", () => {
     });
     expect(queue.send).toHaveBeenCalledTimes(1);
     expect(queue.send.mock.calls[0]?.[0]).toMatchObject({ stageId: "stage-new-123" });
-    const scans = await listScans(db, owner.organizationId);
+    const { scans } = await listScans(db, owner.organizationId);
     expect(scans.map((scan) => scan.stageId)).toContain("stage-new-123");
   });
 });


### PR DESCRIPTION
## Summary
- Adds `decision` / `decision_reason` / `decided_by_user_id` / `decided_at` to the `scans` table (migration `0006_wise_wiccan`) and a `POST /api/v1/scans/:id/decision` endpoint that records an approve/block decision on completed scans, emitting a `scan.decided` audit event.
- Drops the latest-per-stage dedup in `GET /api/v1/scans` in favor of cursor pagination (`cursor` + `limit`, max 100) and a `filter` query param (`undecided` | `publish` | `no_publish` | `all`, defaults to `undecided`).
- ScanDetail page renders a publish-decision panel (Approve / Block + optional reason + change-decision affordance) above the diff workbench on complete scans; the dashboard gains filter chips, a Decision column, and a Load more button.
- Docs (`architecture.md`, `ui.md`) describe the new endpoints, filters, and dashboard behavior. Worker tests cover happy-path decision recording, the 400/409 paths, and cursor pagination with the default `undecided` filter.

## Test plan
- [ ] Run `pnpm verify` locally
- [ ] On the dashboard, switch between Undecided / Approved / Blocked / All chips and confirm the list re-fetches each time
- [ ] Load more pulls the next page without losing the active filter
- [ ] On a completed scan, approve and block decisions persist, reappear on reload, and the dashboard badge column reflects them
- [ ] `POST /api/v1/scans/:id/decision` returns 409 on a pending scan and 400 on `decision: "maybe"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)