### PR TITLE
Invite teammates to an organization with share-link invites

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -197,7 +197,16 @@ Organization-owned resources scope by the active org:
 - future report signatures;
 - future artifact retention settings.
 
-Invitations, team membership, RBAC, deletion, audit-log UI, billing, and quotas are deferred (see Phase 12 in `docs/production-roadmap.md`). Until they ship, every member of an organization is effectively an owner, and route guards must continue to verify membership through `organization_members` rather than trusting client-supplied org ids.
+Membership has two roles, persisted on `organization_members.role`:
+
+- `owner` — full control: rename, invite, remove members, manage the npm connection.
+- `member` — read access plus the ability to request scans on behalf of the organization. Members cannot rotate, validate, or remove the org npm connection (route handlers in `server/routes/npm-connection.ts` enforce this).
+
+The primary owner of an organization (`organizations.owner_user_id`) cannot be removed via the members API.
+
+Invitations are share-link based. An owner generates an invite from `POST /api/v1/organizations/:id/invites`; the server returns a one-time URL containing a random token (`inv_…`). Only the SHA-256 hash of the token is persisted (`organization_invites.token_hash`) — losing the link means cutting a new invite. Invites expire after 7 days, are single-use, and can be revoked by an owner. The invitee accepts by visiting `/invites/:token`, which calls `POST /api/v1/invites/:token/accept`. Personal organizations cannot send invites.
+
+Audit-log UI, deletion, billing, and quotas remain deferred (see Phase 12 in `docs/production-roadmap.md`). Invite/accept/revoke/member-remove all emit `scan_events` rows under the `organization.invite_*` and `organization.member_*` types.
 
 ## npm connection model
 
@@ -252,7 +261,14 @@ Current API:
 - `DELETE /api/v1/npm-connection` — remove connection.
 - `GET /api/v1/organizations` — list the caller's organizations (personal first), each with `npmConnectionConfigured`;
 - `POST /api/v1/organizations` — create a new organization owned by the caller;
-- `PATCH /api/v1/organizations/:id` — rename (owner-only).
+- `PATCH /api/v1/organizations/:id` — rename (owner-only);
+- `GET /api/v1/organizations/:id/members` — list members and the viewer's role;
+- `DELETE /api/v1/organizations/:id/members/:userId` — remove a member (owner-only; cannot remove the primary owner);
+- `GET /api/v1/organizations/:id/invites` — list invites (owner-only);
+- `POST /api/v1/organizations/:id/invites` — create a share-link invite (owner-only) and return the one-time URL;
+- `DELETE /api/v1/organizations/:id/invites/:inviteId` — revoke a pending invite (owner-only);
+- `GET /api/v1/invites/:token` — preview an invite (any signed-in user);
+- `POST /api/v1/invites/:token/accept` — accept an invite and join the org.
 
 All other `/api/v1/*` endpoints honor the `x-organization-id` request header to pick the active org; absent or non-member ids silently fall back to the caller's personal org.
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -81,6 +81,7 @@ Use cards for interactive containment and lists that need table-like edges. Pref
 - The scan detail page exposes the publish decision through a single `Decide` button in the top-right of the page header whenever the scan is `complete`. Clicking it opens a modal with Approve / Block buttons and an optional reason input; submitting records the decision via `POST /api/v1/scans/:id/decision`. Once a decision exists the header shows an `approved` / `blocked` Badge with timestamp next to the trigger, and the button label flips to `Update decision`. The modal surfaces the current decision, prior reason, and any save error so the audit trail stays visible without taking up workbench real estate. The dashboard exposes the same decision as a badge column.
 - Connected workspace setup is collapsed by default, but the closed row must look clickable and include an explicit “Open settings” affordance.
 - Connection metadata is displayed as compact label/value rows, while the editable credential form remains inside a card.
+- Members can read npm connection status, but owner-only credential controls are hidden in shared workspaces.
 - Marketing hero copy is unboxed; feature claims use cards below the headline.
 
 ## Anti-patterns

--- a/drizzle/0009_chemical_matthew_murdock.sql
+++ b/drizzle/0009_chemical_matthew_murdock.sql
@@ -1,0 +1,21 @@
+CREATE TABLE `organization_invites` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`role` text NOT NULL,
+	`email` text,
+	`token_hash` text NOT NULL,
+	`token_last4` text,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`invited_by_user_id` text,
+	`accepted_by_user_id` text,
+	`expires_at` integer NOT NULL,
+	`accepted_at` integer,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`invited_by_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`accepted_by_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `organization_invites_token_hash_unique_idx` ON `organization_invites` (`token_hash`);--> statement-breakpoint
+CREATE INDEX `organization_invites_org_status_idx` ON `organization_invites` (`organization_id`,`status`);

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,1418 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a3c32086-0d36-4747-b6ba-7bc0067f814b",
+  "prevId": "ebd340d3-c006-4842-9f5b-374c7418ec5a",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_unique_idx": {
+          "name": "npm_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_invites": {
+      "name": "organization_invites",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_invites_token_hash_unique_idx": {
+          "name": "organization_invites_token_hash_unique_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "organization_invites_org_status_idx": {
+          "name": "organization_invites_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_invites_organization_id_organizations_id_fk": {
+          "name": "organization_invites_organization_id_organizations_id_fk",
+          "tableFrom": "organization_invites",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invites_invited_by_user_id_user_id_fk": {
+          "name": "organization_invites_invited_by_user_id_user_id_fk",
+          "tableFrom": "organization_invites",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_invites_accepted_by_user_id_user_id_fk": {
+          "name": "organization_invites_accepted_by_user_id_user_id_fk",
+          "tableFrom": "organization_invites",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        },
+        "scans_org_decision_created_idx": {
+          "name": "scans_org_decision_created_idx",
+          "columns": [
+            "organization_id",
+            "decision",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_decided_by_user_id_user_id_fk": {
+          "name": "scans_decided_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1779832013081,
       "tag": "0008_nosy_phalanx",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1779900391248,
+      "tag": "0009_chemical_matthew_murdock",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -957,9 +957,15 @@ export async function isOrganizationOwner(
   userId: string,
 ): Promise<boolean> {
   const [row] = await db
-    .select({ id: organizations.id })
-    .from(organizations)
-    .where(and(eq(organizations.id, organizationId), eq(organizations.ownerUserId, userId)))
+    .select({ id: organizationMembers.id })
+    .from(organizationMembers)
+    .where(
+      and(
+        eq(organizationMembers.organizationId, organizationId),
+        eq(organizationMembers.userId, userId),
+        eq(organizationMembers.role, "owner"),
+      ),
+    )
     .limit(1);
   return Boolean(row);
 }

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1111,13 +1111,15 @@ function normalizeInviteRow(row: {
   createdAt: Date | string | number;
   updatedAt: Date | string | number;
 }): OrganizationInviteRow {
+  const expired = row.status === "pending" && new Date(row.expiresAt).getTime() <= Date.now();
   return {
     id: row.id,
     organizationId: row.organizationId,
     role: (row.role === "member" ? "member" : "owner") as OrganizationRole,
     email: row.email,
-    status:
-      row.status === "accepted" || row.status === "revoked" || row.status === "expired"
+    status: expired
+      ? "expired"
+      : row.status === "accepted" || row.status === "revoked" || row.status === "expired"
         ? row.status
         : "pending",
     tokenLast4: row.tokenLast4,

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1,8 +1,9 @@
 import { drizzle } from "drizzle-orm/d1";
-import { and, asc, desc, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gt, inArray, isNull, lt, or, sql } from "drizzle-orm";
 import * as schema from "./schema";
 import {
   npmConnections,
+  organizationInvites,
   organizationMembers,
   organizations,
   rateLimits,
@@ -12,7 +13,11 @@ import {
   scans,
   user,
 } from "./schema";
-import { personalOrganizationId } from "../lib/ownership";
+import {
+  type OrganizationRole,
+  isPersonalOrganizationId,
+  personalOrganizationId,
+} from "../lib/ownership";
 import {
   annotateFindingsWithDiffStatus,
   computeRisk,
@@ -964,4 +969,270 @@ export async function renameOrganization(db: AppDb, organizationId: string, name
     .update(organizations)
     .set({ name, updatedAt: new Date() })
     .where(eq(organizations.id, organizationId));
+}
+
+export interface OrganizationMembership {
+  organizationId: string;
+  userId: string;
+  role: OrganizationRole;
+}
+
+export async function getOrganizationMembership(
+  db: AppDb,
+  organizationId: string,
+  userId: string,
+): Promise<OrganizationMembership | null> {
+  const [row] = await db
+    .select({
+      organizationId: organizationMembers.organizationId,
+      userId: organizationMembers.userId,
+      role: organizationMembers.role,
+    })
+    .from(organizationMembers)
+    .where(
+      and(
+        eq(organizationMembers.organizationId, organizationId),
+        eq(organizationMembers.userId, userId),
+      ),
+    )
+    .limit(1);
+  if (!row) return null;
+  return {
+    organizationId: row.organizationId,
+    userId: row.userId,
+    role: (row.role === "member" ? "member" : "owner") as OrganizationRole,
+  };
+}
+
+export interface OrganizationMemberRow {
+  userId: string;
+  email: string | null;
+  name: string | null;
+  role: OrganizationRole;
+  joinedAt: Date | string | number;
+  isOwner: boolean;
+}
+
+export async function listOrganizationMembers(
+  db: AppDb,
+  organizationId: string,
+): Promise<OrganizationMemberRow[]> {
+  const [orgRow] = await db
+    .select({ ownerUserId: organizations.ownerUserId })
+    .from(organizations)
+    .where(eq(organizations.id, organizationId))
+    .limit(1);
+  if (!orgRow) return [];
+
+  const rows = await db
+    .select({
+      userId: organizationMembers.userId,
+      role: organizationMembers.role,
+      joinedAt: organizationMembers.createdAt,
+      email: user.email,
+      name: user.name,
+    })
+    .from(organizationMembers)
+    .innerJoin(user, eq(user.id, organizationMembers.userId))
+    .where(eq(organizationMembers.organizationId, organizationId))
+    .orderBy(organizationMembers.createdAt);
+
+  return rows.map((row) => ({
+    userId: row.userId,
+    email: row.email ?? null,
+    name: row.name ?? null,
+    role: (row.role === "member" ? "member" : "owner") as OrganizationRole,
+    joinedAt: row.joinedAt,
+    isOwner: row.userId === orgRow.ownerUserId,
+  }));
+}
+
+export async function removeOrganizationMember(db: AppDb, organizationId: string, userId: string) {
+  await db
+    .delete(organizationMembers)
+    .where(
+      and(
+        eq(organizationMembers.organizationId, organizationId),
+        eq(organizationMembers.userId, userId),
+      ),
+    );
+}
+
+export async function addOrganizationMember(
+  db: AppDb,
+  input: { organizationId: string; userId: string; role: OrganizationRole },
+) {
+  const now = new Date();
+  await db
+    .insert(organizationMembers)
+    .values({
+      id: `member:${input.organizationId}:${input.userId}`,
+      organizationId: input.organizationId,
+      userId: input.userId,
+      role: input.role,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing();
+}
+
+export interface OrganizationInviteRow {
+  id: string;
+  organizationId: string;
+  role: OrganizationRole;
+  email: string | null;
+  status: "pending" | "accepted" | "revoked" | "expired";
+  tokenLast4: string | null;
+  invitedByUserId: string | null;
+  acceptedByUserId: string | null;
+  expiresAt: Date | string | number;
+  acceptedAt: Date | string | number | null;
+  createdAt: Date | string | number;
+  updatedAt: Date | string | number;
+}
+
+function normalizeInviteRow(row: {
+  id: string;
+  organizationId: string;
+  role: string;
+  email: string | null;
+  status: string;
+  tokenLast4: string | null;
+  invitedByUserId: string | null;
+  acceptedByUserId: string | null;
+  expiresAt: Date | string | number;
+  acceptedAt: Date | string | number | null;
+  createdAt: Date | string | number;
+  updatedAt: Date | string | number;
+}): OrganizationInviteRow {
+  return {
+    id: row.id,
+    organizationId: row.organizationId,
+    role: (row.role === "member" ? "member" : "owner") as OrganizationRole,
+    email: row.email,
+    status:
+      row.status === "accepted" || row.status === "revoked" || row.status === "expired"
+        ? row.status
+        : "pending",
+    tokenLast4: row.tokenLast4,
+    invitedByUserId: row.invitedByUserId,
+    acceptedByUserId: row.acceptedByUserId,
+    expiresAt: row.expiresAt,
+    acceptedAt: row.acceptedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export async function createOrganizationInvite(
+  db: AppDb,
+  input: {
+    organizationId: string;
+    role: OrganizationRole;
+    email?: string | null;
+    tokenHash: string;
+    tokenLast4: string;
+    invitedByUserId: string;
+    expiresAt: Date;
+  },
+): Promise<OrganizationInviteRow> {
+  if (isPersonalOrganizationId(input.organizationId)) {
+    throw new Error("personal organizations cannot have invites");
+  }
+  const id = crypto.randomUUID();
+  const now = new Date();
+  await db.insert(organizationInvites).values({
+    id,
+    organizationId: input.organizationId,
+    role: input.role,
+    email: input.email ?? null,
+    tokenHash: input.tokenHash,
+    tokenLast4: input.tokenLast4,
+    status: "pending",
+    invitedByUserId: input.invitedByUserId,
+    acceptedByUserId: null,
+    expiresAt: input.expiresAt,
+    acceptedAt: null,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const [row] = await db
+    .select()
+    .from(organizationInvites)
+    .where(eq(organizationInvites.id, id))
+    .limit(1);
+  return normalizeInviteRow(row);
+}
+
+export async function listOrganizationInvites(
+  db: AppDb,
+  organizationId: string,
+): Promise<OrganizationInviteRow[]> {
+  const rows = await db
+    .select()
+    .from(organizationInvites)
+    .where(eq(organizationInvites.organizationId, organizationId))
+    .orderBy(desc(organizationInvites.createdAt));
+  return rows.map(normalizeInviteRow);
+}
+
+export async function getInviteByTokenHash(
+  db: AppDb,
+  tokenHash: string,
+): Promise<OrganizationInviteRow | null> {
+  const [row] = await db
+    .select()
+    .from(organizationInvites)
+    .where(eq(organizationInvites.tokenHash, tokenHash))
+    .limit(1);
+  return row ? normalizeInviteRow(row) : null;
+}
+
+export async function revokeOrganizationInvite(
+  db: AppDb,
+  inviteId: string,
+  organizationId: string,
+): Promise<boolean> {
+  const result = await db
+    .update(organizationInvites)
+    .set({ status: "revoked", updatedAt: new Date() })
+    .where(
+      and(
+        eq(organizationInvites.id, inviteId),
+        eq(organizationInvites.organizationId, organizationId),
+        eq(organizationInvites.status, "pending"),
+      ),
+    )
+    .returning({ id: organizationInvites.id });
+  return result.length > 0;
+}
+
+export async function acceptOrganizationInvite(
+  db: AppDb,
+  input: { invite: OrganizationInviteRow; userId: string },
+): Promise<{ accepted: boolean }> {
+  const now = new Date();
+  const result = await db
+    .update(organizationInvites)
+    .set({
+      status: "accepted",
+      acceptedByUserId: input.userId,
+      acceptedAt: now,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(organizationInvites.id, input.invite.id),
+        eq(organizationInvites.status, "pending"),
+        gt(organizationInvites.expiresAt, now),
+      ),
+    )
+    .returning({ id: organizationInvites.id });
+  if (result.length === 0) return { accepted: false };
+  await addOrganizationMember(db, {
+    organizationId: input.invite.organizationId,
+    userId: input.userId,
+    role: input.invite.role,
+  });
+  return { accepted: true };
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -49,6 +49,36 @@ export const organizationMembers = sqliteTable(
   }),
 );
 
+export const organizationInvites = sqliteTable(
+  "organization_invites",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    role: text("role").notNull(),
+    email: text("email"),
+    tokenHash: text("token_hash").notNull(),
+    tokenLast4: text("token_last4"),
+    status: text("status").notNull().default("pending"),
+    invitedByUserId: text("invited_by_user_id").references(() => user.id, { onDelete: "set null" }),
+    acceptedByUserId: text("accepted_by_user_id").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
+    acceptedAt: integer("accepted_at", { mode: "timestamp_ms" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+  },
+  (table) => ({
+    tokenHashIdx: uniqueIndex("organization_invites_token_hash_unique_idx").on(table.tokenHash),
+    orgStatusIdx: index("organization_invites_org_status_idx").on(
+      table.organizationId,
+      table.status,
+    ),
+  }),
+);
+
 export const scans = sqliteTable(
   "scans",
   {

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,7 +23,7 @@ import {
   StagedPublishesFetchError,
 } from "./lib/staged-publishes-discovery";
 import { npmConnectionRoutes } from "./routes/npm-connection";
-import { organizationsRoutes } from "./routes/organizations";
+import { invitesRoutes, organizationsRoutes } from "./routes/organizations";
 import { scanRoutes } from "./routes/scan";
 import { scansRoutes } from "./routes/scans";
 import { stagedPublishesRoutes } from "./routes/staged-publishes";
@@ -187,6 +187,11 @@ app.get("/api", (c) =>
       npmConnection: "GET/POST/DELETE /api/v1/npm-connection; POST /api/v1/npm-connection/validate",
       organizations:
         "GET /api/v1/organizations; POST /api/v1/organizations; PATCH /api/v1/organizations/:id",
+      members:
+        "GET /api/v1/organizations/:id/members; DELETE /api/v1/organizations/:id/members/:userId",
+      orgInvites:
+        "GET/POST /api/v1/organizations/:id/invites; DELETE /api/v1/organizations/:id/invites/:inviteId",
+      invites: "GET /api/v1/invites/:token; POST /api/v1/invites/:token/accept",
       health: "GET /api/health",
     },
     auth: "Better Auth is required for every non-auth API endpoint.",
@@ -196,6 +201,7 @@ app.get("/api", (c) =>
 
 app.route("/api/v1/npm-connection", npmConnectionRoutes);
 app.route("/api/v1/organizations", organizationsRoutes);
+app.route("/api/v1/invites", invitesRoutes);
 app.route("/api/v1/scan", scanRoutes);
 app.route("/api/v1/scans", scansRoutes);
 app.route("/api/v1/staged-publishes", stagedPublishesRoutes);

--- a/server/lib/active-organization.ts
+++ b/server/lib/active-organization.ts
@@ -3,7 +3,7 @@ import { and, eq } from "drizzle-orm";
 import type { AppDb } from "../db";
 import { ensurePersonalOrganization } from "../db";
 import { organizationMembers } from "../db/schema";
-import { personalOrganizationId } from "./ownership";
+import { type OrganizationRole, personalOrganizationId } from "./ownership";
 import type { Bindings, Variables } from "../types";
 
 export const ACTIVE_ORG_HEADER = "x-organization-id";
@@ -12,11 +12,19 @@ export async function requireActiveOrganization(
   c: Context<{ Bindings: Bindings; Variables: Variables }>,
   db: AppDb,
 ): Promise<string> {
+  const result = await resolveActiveOrganization(c, db);
+  return result.organizationId;
+}
+
+export async function resolveActiveOrganization(
+  c: Context<{ Bindings: Bindings; Variables: Variables }>,
+  db: AppDb,
+): Promise<{ organizationId: string; role: OrganizationRole }> {
   const session = c.get("authSession");
   const requested = c.req.header(ACTIVE_ORG_HEADER)?.trim() || null;
   if (requested) {
     const [membership] = await db
-      .select({ organizationId: organizationMembers.organizationId })
+      .select({ role: organizationMembers.role })
       .from(organizationMembers)
       .where(
         and(
@@ -25,8 +33,13 @@ export async function requireActiveOrganization(
         ),
       )
       .limit(1);
-    if (membership) return requested;
+    if (membership) {
+      return {
+        organizationId: requested,
+        role: (membership.role === "member" ? "member" : "owner") as OrganizationRole,
+      };
+    }
   }
   await ensurePersonalOrganization(db, session);
-  return personalOrganizationId(session.userId);
+  return { organizationId: personalOrganizationId(session.userId), role: "owner" };
 }

--- a/server/lib/invites.ts
+++ b/server/lib/invites.ts
@@ -1,0 +1,40 @@
+const INVITE_TOKEN_PREFIX = "inv_";
+const INVITE_TOKEN_BYTES = 24;
+export const INVITE_DEFAULT_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function generateInviteToken(): string {
+  const bytes = new Uint8Array(INVITE_TOKEN_BYTES);
+  crypto.getRandomValues(bytes);
+  return `${INVITE_TOKEN_PREFIX}${base64UrlEncode(bytes)}`;
+}
+
+export async function hashInviteToken(token: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token));
+  return bytesToHex(new Uint8Array(digest));
+}
+
+export function inviteTokenLast4(token: string): string {
+  return token.slice(-4);
+}
+
+export function buildInviteUrl(baseUrl: string | undefined, token: string): string {
+  const path = `/invites/${encodeURIComponent(token)}`;
+  if (!baseUrl) return path;
+  try {
+    return new URL(path, baseUrl).toString();
+  } catch {
+    return path;
+  }
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/=+$/u, "").replace(/\+/gu, "-").replace(/\//gu, "_");
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let out = "";
+  for (const byte of bytes) out += byte.toString(16).padStart(2, "0");
+  return out;
+}

--- a/server/lib/ownership.ts
+++ b/server/lib/ownership.ts
@@ -1,8 +1,19 @@
 const PERSONAL_ORGANIZATION_PREFIX = "personal:";
 
+export const ORGANIZATION_ROLES = ["owner", "member"] as const;
+export type OrganizationRole = (typeof ORGANIZATION_ROLES)[number];
+
+export function isOrganizationRole(value: unknown): value is OrganizationRole {
+  return typeof value === "string" && (ORGANIZATION_ROLES as readonly string[]).includes(value);
+}
+
 export function personalOrganizationId(userId: string) {
   if (!userId) throw new Error("userId is required for personal organization ownership");
   return `${PERSONAL_ORGANIZATION_PREFIX}${userId}`;
+}
+
+export function isPersonalOrganizationId(id: string) {
+  return id.startsWith(PERSONAL_ORGANIZATION_PREFIX);
 }
 
 export function scanBelongsToOrganization(

--- a/server/routes/npm-connection.ts
+++ b/server/routes/npm-connection.ts
@@ -9,7 +9,7 @@ import {
   updateNpmConnectionValidation,
   upsertNpmConnection,
 } from "../db";
-import { requireActiveOrganization } from "../lib/active-organization";
+import { requireActiveOrganization, resolveActiveOrganization } from "../lib/active-organization";
 import {
   allowInsecureLocalRegistry,
   decryptNpmToken,
@@ -54,7 +54,10 @@ npmConnectionRoutes.post("/", async (c) => {
   try {
     const db = createDb(c.env.DB);
     const session = c.get("authSession");
-    const organizationId = await requireActiveOrganization(c, db);
+    const { organizationId, role } = await resolveActiveOrganization(c, db);
+    if (role !== "owner") {
+      return c.json({ error: "only organization owners can change the npm connection" }, 403);
+    }
     const [, encrypted] = await Promise.all([
       enforceRateLimit(db, {
         key: `npm-connection:save:${organizationId}`,
@@ -109,7 +112,10 @@ npmConnectionRoutes.post("/validate", async (c) => {
   try {
     const db = createDb(c.env.DB);
     const session = c.get("authSession");
-    const organizationId = await requireActiveOrganization(c, db);
+    const { organizationId, role } = await resolveActiveOrganization(c, db);
+    if (role !== "owner") {
+      return c.json({ error: "only organization owners can validate the npm connection" }, 403);
+    }
     await enforceRateLimit(db, {
       key: `npm-connection:validate:${organizationId}`,
       limit: 12,
@@ -160,7 +166,10 @@ npmConnectionRoutes.post("/validate", async (c) => {
 npmConnectionRoutes.delete("/", async (c) => {
   const db = createDb(c.env.DB);
   const session = c.get("authSession");
-  const organizationId = await requireActiveOrganization(c, db);
+  const { organizationId, role } = await resolveActiveOrganization(c, db);
+  if (role !== "owner") {
+    return c.json({ error: "only organization owners can remove the npm connection" }, 403);
+  }
   const existing = await getNpmConnection(db, organizationId);
   await Promise.all([
     deleteNpmConnection(db, organizationId),

--- a/server/routes/organizations.ts
+++ b/server/routes/organizations.ts
@@ -305,6 +305,9 @@ invitesRoutes.post("/:token/accept", async (c) => {
     return c.json({ error: "invite has expired" }, 410);
   }
   if (invite.status !== "pending") return c.json({ error: "invite is no longer pending" }, 409);
+  if (await getOrganizationMembership(db, invite.organizationId, session.userId)) {
+    return c.json({ error: "user is already a member of this organization" }, 409);
+  }
 
   const { accepted } = await acceptOrganizationInvite(db, { invite, userId: session.userId });
   if (!accepted) return c.json({ error: "invite is no longer pending" }, 409);

--- a/server/routes/organizations.ts
+++ b/server/routes/organizations.ts
@@ -1,18 +1,37 @@
 import { Hono } from "hono";
+import { eq } from "drizzle-orm";
 import {
   RateLimitError,
+  acceptOrganizationInvite,
   createDb,
   createOrganization,
+  createOrganizationInvite,
   enforceRateLimit,
   ensurePersonalOrganization,
+  getInviteByTokenHash,
+  getOrganizationMembership,
   isOrganizationOwner,
+  listOrganizationInvites,
+  listOrganizationMembers,
   listUserOrganizations,
   recordScanEvent,
+  removeOrganizationMember,
   renameOrganization,
+  revokeOrganizationInvite,
 } from "../db";
+import { organizations as organizationsTable } from "../db/schema";
+import { isPersonalOrganizationId, isOrganizationRole } from "../lib/ownership";
+import {
+  INVITE_DEFAULT_TTL_MS,
+  buildInviteUrl,
+  generateInviteToken,
+  hashInviteToken,
+  inviteTokenLast4,
+} from "../lib/invites";
 import type { Bindings, Variables } from "../types";
 
 const NAME_RE = /^[\p{L}\p{N}][\p{L}\p{N} _\-./]{0,79}$/u;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/u;
 
 export const organizationsRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
@@ -91,4 +110,213 @@ organizationsRoutes.patch("/:id", async (c) => {
     metadata: { name },
   });
   return c.json({ organization: { id: organizationId, name } });
+});
+
+organizationsRoutes.get("/:id/members", async (c) => {
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const organizationId = c.req.param("id");
+  const membership = await getOrganizationMembership(db, organizationId, session.userId);
+  if (!membership) return c.json({ error: "not found" }, 404);
+  const members = await listOrganizationMembers(db, organizationId);
+  return c.json({ members, viewer: { role: membership.role } });
+});
+
+organizationsRoutes.delete("/:id/members/:userId", async (c) => {
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const organizationId = c.req.param("id");
+  const targetUserId = c.req.param("userId");
+  const owner = await isOrganizationOwner(db, organizationId, session.userId);
+  if (!owner) return c.json({ error: "not found" }, 404);
+  if (isPersonalOrganizationId(organizationId)) {
+    return c.json({ error: "personal organizations cannot have members removed" }, 400);
+  }
+  const members = await listOrganizationMembers(db, organizationId);
+  const target = members.find((member) => member.userId === targetUserId);
+  if (!target) return c.json({ error: "member not found" }, 404);
+  if (target.isOwner) return c.json({ error: "cannot remove the organization owner" }, 400);
+  await removeOrganizationMember(db, organizationId, targetUserId);
+  await recordScanEvent(db, {
+    organizationId,
+    actorUserId: session.userId,
+    type: "organization.member_removed",
+    metadata: { userId: targetUserId },
+  });
+  return c.json({ ok: true });
+});
+
+organizationsRoutes.get("/:id/invites", async (c) => {
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const organizationId = c.req.param("id");
+  const owner = await isOrganizationOwner(db, organizationId, session.userId);
+  if (!owner) return c.json({ error: "not found" }, 404);
+  const invites = await listOrganizationInvites(db, organizationId);
+  return c.json({ invites });
+});
+
+organizationsRoutes.post("/:id/invites", async (c) => {
+  const body = (await c.req.json().catch(() => ({}))) as {
+    role?: unknown;
+    email?: unknown;
+  };
+  const role = isOrganizationRole(body.role) ? body.role : "member";
+  const email =
+    typeof body.email === "string" && body.email.trim() ? body.email.trim().toLowerCase() : null;
+  if (email && !EMAIL_RE.test(email)) {
+    return c.json({ error: "invalid email" }, 400);
+  }
+
+  try {
+    const db = createDb(c.env.DB);
+    const session = c.get("authSession");
+    const organizationId = c.req.param("id");
+    const owner = await isOrganizationOwner(db, organizationId, session.userId);
+    if (!owner) return c.json({ error: "not found" }, 404);
+    if (isPersonalOrganizationId(organizationId)) {
+      return c.json({ error: "personal organizations cannot send invites" }, 400);
+    }
+    await enforceRateLimit(db, {
+      key: `organizations:invite:${organizationId}`,
+      limit: 30,
+      windowMs: 60 * 60 * 1000,
+    });
+
+    const token = generateInviteToken();
+    const tokenHash = await hashInviteToken(token);
+    const expiresAt = new Date(Date.now() + INVITE_DEFAULT_TTL_MS);
+    const invite = await createOrganizationInvite(db, {
+      organizationId,
+      role,
+      email,
+      tokenHash,
+      tokenLast4: inviteTokenLast4(token),
+      invitedByUserId: session.userId,
+      expiresAt,
+    });
+    await recordScanEvent(db, {
+      organizationId,
+      actorUserId: session.userId,
+      type: "organization.invite_created",
+      metadata: { inviteId: invite.id, role, email },
+    });
+
+    const url = buildInviteUrl(c.env.BETTER_AUTH_URL, token);
+    return c.json({ invite, token, url }, 201);
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      return c.json(
+        {
+          error: "invite create rate limit exceeded",
+          retryAfterSeconds: err.retryAfterSeconds,
+        },
+        429,
+        { "retry-after": String(err.retryAfterSeconds) },
+      );
+    }
+    console.error("invite create failed", err);
+    return c.json({ error: "failed to create invite" }, 500);
+  }
+});
+
+organizationsRoutes.delete("/:id/invites/:inviteId", async (c) => {
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const organizationId = c.req.param("id");
+  const inviteId = c.req.param("inviteId");
+  const owner = await isOrganizationOwner(db, organizationId, session.userId);
+  if (!owner) return c.json({ error: "not found" }, 404);
+  const revoked = await revokeOrganizationInvite(db, inviteId, organizationId);
+  if (!revoked) return c.json({ error: "invite not found or already settled" }, 404);
+  await recordScanEvent(db, {
+    organizationId,
+    actorUserId: session.userId,
+    type: "organization.invite_revoked",
+    metadata: { inviteId },
+  });
+  return c.json({ ok: true });
+});
+
+export const invitesRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+invitesRoutes.get("/:token", async (c) => {
+  const token = c.req.param("token");
+  const tokenHash = await hashInviteToken(token);
+  const db = createDb(c.env.DB);
+  const invite = await getInviteByTokenHash(db, tokenHash);
+  if (!invite) return c.json({ error: "invite not found" }, 404);
+
+  const session = c.get("authSession");
+  const expired = new Date(invite.expiresAt).getTime() <= Date.now();
+  const status = expired && invite.status === "pending" ? "expired" : invite.status;
+
+  const [organizationRow] = await db
+    .select({ name: organizationsTable.name })
+    .from(organizationsTable)
+    .where(eq(organizationsTable.id, invite.organizationId))
+    .limit(1);
+  const organizationName = organizationRow?.name ?? "organization";
+
+  const alreadyMember = Boolean(
+    await getOrganizationMembership(db, invite.organizationId, session.userId),
+  );
+
+  return c.json({
+    invite: {
+      id: invite.id,
+      organizationId: invite.organizationId,
+      organizationName,
+      role: invite.role,
+      email: invite.email,
+      status,
+      expiresAt: invite.expiresAt,
+    },
+    viewer: { alreadyMember },
+  });
+});
+
+invitesRoutes.post("/:token/accept", async (c) => {
+  const token = c.req.param("token");
+  const tokenHash = await hashInviteToken(token);
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+
+  try {
+    await enforceRateLimit(db, {
+      key: `invites:accept:${session.userId}`,
+      limit: 20,
+      windowMs: 60 * 60 * 1000,
+    });
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      return c.json(
+        { error: "invite accept rate limit exceeded", retryAfterSeconds: err.retryAfterSeconds },
+        429,
+        { "retry-after": String(err.retryAfterSeconds) },
+      );
+    }
+    throw err;
+  }
+
+  const invite = await getInviteByTokenHash(db, tokenHash);
+  if (!invite) return c.json({ error: "invite not found" }, 404);
+  if (invite.status !== "pending") return c.json({ error: "invite is no longer pending" }, 409);
+  if (new Date(invite.expiresAt).getTime() <= Date.now()) {
+    return c.json({ error: "invite has expired" }, 410);
+  }
+
+  const { accepted } = await acceptOrganizationInvite(db, { invite, userId: session.userId });
+  if (!accepted) return c.json({ error: "invite is no longer pending" }, 409);
+
+  await recordScanEvent(db, {
+    organizationId: invite.organizationId,
+    actorUserId: session.userId,
+    type: "organization.invite_accepted",
+    metadata: { inviteId: invite.id, role: invite.role },
+  });
+  return c.json({
+    organization: { id: invite.organizationId },
+    role: invite.role,
+  });
 });

--- a/server/routes/organizations.ts
+++ b/server/routes/organizations.ts
@@ -301,10 +301,10 @@ invitesRoutes.post("/:token/accept", async (c) => {
 
   const invite = await getInviteByTokenHash(db, tokenHash);
   if (!invite) return c.json({ error: "invite not found" }, 404);
-  if (invite.status !== "pending") return c.json({ error: "invite is no longer pending" }, 409);
-  if (new Date(invite.expiresAt).getTime() <= Date.now()) {
+  if (invite.status === "expired" || new Date(invite.expiresAt).getTime() <= Date.now()) {
     return c.json({ error: "invite has expired" }, 410);
   }
+  if (invite.status !== "pending") return c.json({ error: "invite is no longer pending" }, 409);
 
   const { accepted } = await acceptOrganizationInvite(db, { invite, userId: session.userId });
   if (!accepted) return c.json({ error: "invite is no longer pending" }, 409);

--- a/src/components/OrgSwitcher.tsx
+++ b/src/components/OrgSwitcher.tsx
@@ -15,6 +15,7 @@ interface OrgSwitcherProps {
   error?: string | null;
   onActivate: (id: string) => Promise<unknown> | unknown;
   onCreate: (name: string) => Promise<unknown> | unknown;
+  manageHref?: string;
 }
 
 export function OrgSwitcher({
@@ -24,6 +25,7 @@ export function OrgSwitcher({
   error,
   onActivate,
   onCreate,
+  manageHref,
 }: OrgSwitcherProps) {
   const creating = useSignal(false);
   const draftName = useSignal("");
@@ -92,6 +94,18 @@ export function OrgSwitcher({
           ))
         )}
         <MenuSeparator />
+        {manageHref ? (
+          <>
+            <MenuItem
+              onSelect={() => {
+                window.location.href = manageHref;
+              }}
+            >
+              Manage members →
+            </MenuItem>
+            <MenuSeparator />
+          </>
+        ) : null}
         <MenuItem tone="accent" onSelect={openCreate} disabled={busy}>
           + New organization
         </MenuItem>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,9 @@ const LandingPage = lazy(() => import("./pages/Landing"));
 const LoginPage = lazy(() => import("./pages/Auth/Login"));
 const RegisterPage = lazy(() => import("./pages/Auth/Register"));
 const DashboardPage = lazy(() => import("./pages/Dashboard"));
+const SettingsPage = lazy(() => import("./pages/Dashboard/Settings"));
 const ScanDetailPage = lazy(() => import("./pages/Dashboard/ScanDetail"));
+const InvitePage = lazy(() => import("./pages/Invites"));
 const NotFoundPage = lazy(() => import("./pages/NotFound"));
 
 export function App() {
@@ -18,7 +20,9 @@ export function App() {
           <Route path="/login" component={LoginPage} />
           <Route path="/register" component={RegisterPage} />
           <Route path="/dashboard" component={DashboardPage} />
+          <Route path="/dashboard/settings" component={SettingsPage} />
           <Route path="/dashboard/scans/:id" component={ScanDetailPage} />
+          <Route path="/invites/:token" component={InvitePage} />
           <Route default component={NotFoundPage} />
         </Router>
       </ErrorBoundary>

--- a/src/models/invites.ts
+++ b/src/models/invites.ts
@@ -1,0 +1,81 @@
+import { createModel, signal } from "@preact/signals";
+import { apiFetch } from "./api";
+import type { OrganizationRole } from "./members";
+
+export interface InvitePreview {
+  id: string;
+  organizationId: string;
+  organizationName: string;
+  role: OrganizationRole;
+  email: string | null;
+  status: "pending" | "accepted" | "revoked" | "expired";
+  expiresAt: string | number | Date;
+}
+
+interface PreviewResponse {
+  invite: InvitePreview;
+  viewer: { alreadyMember: boolean };
+}
+
+interface AcceptResponse {
+  organization: { id: string };
+  role: OrganizationRole;
+}
+
+export const InviteAcceptModel = createModel(() => {
+  const token = signal<string | null>(null);
+  const preview = signal<InvitePreview | null>(null);
+  const alreadyMember = signal(false);
+  const loaded = signal(false);
+  const busy = signal(false);
+  const error = signal<string | null>(null);
+  const accepted = signal<AcceptResponse | null>(null);
+
+  return {
+    token,
+    preview,
+    alreadyMember,
+    loaded,
+    busy,
+    error,
+    accepted,
+
+    async load(tokenValue: string): Promise<void> {
+      this.token.value = tokenValue;
+      this.busy.value = true;
+      this.error.value = null;
+      try {
+        const data = await apiFetch<PreviewResponse>(
+          `/api/v1/invites/${encodeURIComponent(tokenValue)}`,
+        );
+        this.preview.value = data.invite;
+        this.alreadyMember.value = data.viewer.alreadyMember;
+      } catch (err) {
+        this.error.value = err instanceof Error ? err.message : String(err);
+      } finally {
+        this.loaded.value = true;
+        this.busy.value = false;
+      }
+    },
+
+    async accept(): Promise<AcceptResponse | null> {
+      const tokenValue = this.token.value;
+      if (!tokenValue) return null;
+      this.busy.value = true;
+      this.error.value = null;
+      try {
+        const data = await apiFetch<AcceptResponse>(
+          `/api/v1/invites/${encodeURIComponent(tokenValue)}/accept`,
+          { method: "POST" },
+        );
+        this.accepted.value = data;
+        return data;
+      } catch (err) {
+        this.error.value = err instanceof Error ? err.message : String(err);
+        return null;
+      } finally {
+        this.busy.value = false;
+      }
+    },
+  };
+});

--- a/src/models/members.ts
+++ b/src/models/members.ts
@@ -1,0 +1,166 @@
+import { createModel, signal } from "@preact/signals";
+import { apiFetch } from "./api";
+
+export type OrganizationRole = "owner" | "member";
+
+export interface OrganizationMember {
+  userId: string;
+  email: string | null;
+  name: string | null;
+  role: OrganizationRole;
+  joinedAt: string | number | Date;
+  isOwner: boolean;
+}
+
+export interface OrganizationInvite {
+  id: string;
+  organizationId: string;
+  role: OrganizationRole;
+  email: string | null;
+  status: "pending" | "accepted" | "revoked" | "expired";
+  tokenLast4: string | null;
+  invitedByUserId: string | null;
+  acceptedByUserId: string | null;
+  expiresAt: string | number | Date;
+  acceptedAt: string | number | Date | null;
+  createdAt: string | number | Date;
+  updatedAt: string | number | Date;
+}
+
+interface MembersResponse {
+  members: OrganizationMember[];
+  viewer: { role: OrganizationRole };
+}
+
+interface InvitesResponse {
+  invites: OrganizationInvite[];
+}
+
+interface CreatedInviteResponse {
+  invite: OrganizationInvite;
+  token: string;
+  url: string;
+}
+
+export const MembersModel = createModel(() => {
+  const organizationId = signal<string | null>(null);
+  const members = signal<OrganizationMember[]>([]);
+  const invites = signal<OrganizationInvite[]>([]);
+  const viewerRole = signal<OrganizationRole | null>(null);
+  const loaded = signal(false);
+  const busy = signal(false);
+  const error = signal<string | null>(null);
+  const lastInviteUrl = signal<string | null>(null);
+
+  return {
+    organizationId,
+    members,
+    invites,
+    viewerRole,
+    loaded,
+    busy,
+    error,
+    lastInviteUrl,
+
+    async load(id: string): Promise<void> {
+      this.organizationId.value = id;
+      this.busy.value = true;
+      this.error.value = null;
+      try {
+        const membersData = await apiFetch<MembersResponse>(
+          `/api/v1/organizations/${encodeURIComponent(id)}/members`,
+        );
+        this.members.value = membersData.members;
+        this.viewerRole.value = membersData.viewer.role;
+        if (membersData.viewer.role === "owner") {
+          const invitesData = await apiFetch<InvitesResponse>(
+            `/api/v1/organizations/${encodeURIComponent(id)}/invites`,
+          );
+          this.invites.value = invitesData.invites;
+        } else {
+          this.invites.value = [];
+        }
+      } catch (err) {
+        this.error.value = err instanceof Error ? err.message : String(err);
+      } finally {
+        this.loaded.value = true;
+        this.busy.value = false;
+      }
+    },
+
+    async invite(role: OrganizationRole, email: string): Promise<CreatedInviteResponse | null> {
+      const id = this.organizationId.value;
+      if (!id) return null;
+      this.busy.value = true;
+      this.error.value = null;
+      this.lastInviteUrl.value = null;
+      try {
+        const trimmed = email.trim().toLowerCase();
+        const data = await apiFetch<CreatedInviteResponse>(
+          `/api/v1/organizations/${encodeURIComponent(id)}/invites`,
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ role, email: trimmed || undefined }),
+          },
+        );
+        this.invites.value = [data.invite, ...this.invites.value];
+        this.lastInviteUrl.value = data.url;
+        return data;
+      } catch (err) {
+        this.error.value = err instanceof Error ? err.message : String(err);
+        return null;
+      } finally {
+        this.busy.value = false;
+      }
+    },
+
+    async revoke(inviteId: string): Promise<boolean> {
+      const id = this.organizationId.value;
+      if (!id) return false;
+      this.busy.value = true;
+      this.error.value = null;
+      try {
+        await apiFetch(
+          `/api/v1/organizations/${encodeURIComponent(id)}/invites/${encodeURIComponent(inviteId)}`,
+          { method: "DELETE" },
+        );
+        this.invites.value = this.invites.value.map((invite) =>
+          invite.id === inviteId
+            ? { ...invite, status: "revoked", updatedAt: new Date().toISOString() }
+            : invite,
+        );
+        return true;
+      } catch (err) {
+        this.error.value = err instanceof Error ? err.message : String(err);
+        return false;
+      } finally {
+        this.busy.value = false;
+      }
+    },
+
+    async remove(userId: string): Promise<boolean> {
+      const id = this.organizationId.value;
+      if (!id) return false;
+      this.busy.value = true;
+      this.error.value = null;
+      try {
+        await apiFetch(
+          `/api/v1/organizations/${encodeURIComponent(id)}/members/${encodeURIComponent(userId)}`,
+          { method: "DELETE" },
+        );
+        this.members.value = this.members.value.filter((member) => member.userId !== userId);
+        return true;
+      } catch (err) {
+        this.error.value = err instanceof Error ? err.message : String(err);
+        return false;
+      } finally {
+        this.busy.value = false;
+      }
+    },
+
+    clearInviteUrl() {
+      this.lastInviteUrl.value = null;
+    },
+  };
+});

--- a/src/models/next-path.ts
+++ b/src/models/next-path.ts
@@ -1,0 +1,8 @@
+const SAFE_PATH_RE = /^\/[A-Za-z0-9_\-./?&=%]*$/u;
+
+export function resolveNextPath(raw: unknown, fallback = "/dashboard"): string {
+  if (typeof raw !== "string" || !raw) return fallback;
+  if (!raw.startsWith("/") || raw.startsWith("//")) return fallback;
+  if (!SAFE_PATH_RE.test(raw)) return fallback;
+  return raw;
+}

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -13,6 +13,8 @@ export default function LoginPage() {
   const loading = useSignal(false);
 
   const next = resolveNextPath(location.query?.next);
+  const registerHref =
+    next === "/dashboard" ? "/register" : `/register?next=${encodeURIComponent(next)}`;
 
   useEffect(() => {
     let cancelled = false;
@@ -81,7 +83,7 @@ export default function LoginPage() {
         </form>
 
         <p class="text-[13px] text-ink-muted m-0">
-          New here? <a href="/register">Create an account</a>
+          New here? <a href={registerHref}>Create an account</a>
         </p>
       </Card>
     </PageShell>

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "preact/hooks";
 import { useSignal } from "@preact/signals";
 import { useLocation } from "preact-iso";
 import { sessionModel } from "../../models/auth";
+import { resolveNextPath } from "../../models/next-path";
 import { Alert, Button, Card, Eyebrow, Field, Input, PageShell, Muted } from "../../components";
 
 export default function LoginPage() {
@@ -11,12 +12,15 @@ export default function LoginPage() {
   const error = useSignal<string | null>(null);
   const loading = useSignal(false);
 
+  const next = resolveNextPath(location.query?.next);
+
   useEffect(() => {
     let cancelled = false;
-    void sessionModel.load().then((session) => {
+    void (async () => {
+      const session = await sessionModel.load();
       if (cancelled) return;
-      if (session?.user) location.route("/dashboard", true);
-    });
+      if (session?.user) location.route(next, true);
+    })();
     return () => {
       cancelled = true;
     };
@@ -30,7 +34,7 @@ export default function LoginPage() {
     error.value = null;
     try {
       await sessionModel.signIn(submittedEmail, submittedPassword);
-      location.route("/dashboard", true);
+      location.route(next, true);
     } catch (err) {
       error.value = err instanceof Error ? err.message : String(err);
     } finally {

--- a/src/pages/Auth/Register.tsx
+++ b/src/pages/Auth/Register.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "preact/hooks";
 import { useSignal } from "@preact/signals";
 import { useLocation } from "preact-iso";
 import { sessionModel } from "../../models/auth";
+import { resolveNextPath } from "../../models/next-path";
 import { Alert, Button, Card, Eyebrow, Field, Input, PageShell, Muted } from "../../components";
 
 export default function RegisterPage() {
@@ -12,12 +13,15 @@ export default function RegisterPage() {
   const error = useSignal<string | null>(null);
   const loading = useSignal(false);
 
+  const next = resolveNextPath(location.query?.next);
+
   useEffect(() => {
     let cancelled = false;
-    void sessionModel.load().then((session) => {
+    void (async () => {
+      const session = await sessionModel.load();
       if (cancelled) return;
-      if (session?.user) location.route("/dashboard", true);
-    });
+      if (session?.user) location.route(next, true);
+    })();
     return () => {
       cancelled = true;
     };
@@ -33,7 +37,7 @@ export default function RegisterPage() {
     try {
       await sessionModel.signUp(submittedName, submittedEmail, submittedPassword);
       await sessionModel.signIn(submittedEmail, submittedPassword).catch(() => undefined);
-      location.route("/dashboard", true);
+      location.route(next, true);
     } catch (err) {
       error.value = err instanceof Error ? err.message : String(err);
     } finally {

--- a/src/pages/Auth/Register.tsx
+++ b/src/pages/Auth/Register.tsx
@@ -14,6 +14,7 @@ export default function RegisterPage() {
   const loading = useSignal(false);
 
   const next = resolveNextPath(location.query?.next);
+  const loginHref = next === "/dashboard" ? "/login" : `/login?next=${encodeURIComponent(next)}`;
 
   useEffect(() => {
     let cancelled = false;
@@ -95,7 +96,7 @@ export default function RegisterPage() {
         </form>
 
         <p class="text-[13px] text-ink-muted m-0">
-          Already have an account? <a href="/login">Sign in</a>
+          Already have an account? <a href={loginHref}>Sign in</a>
         </p>
       </Card>
     </PageShell>

--- a/src/pages/Dashboard/Settings.tsx
+++ b/src/pages/Dashboard/Settings.tsx
@@ -1,0 +1,435 @@
+import type { ComponentChildren } from "preact";
+import { useEffect } from "preact/hooks";
+import { useComputed, useModel, useSignal, useSignalEffect } from "@preact/signals";
+import { useLocation } from "preact-iso";
+import { sessionModel } from "../../models/auth";
+import {
+  MembersModel,
+  type OrganizationInvite,
+  type OrganizationMember,
+  type OrganizationRole,
+} from "../../models/members";
+import { OrganizationModel } from "../../models/organization";
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  EmptyLine,
+  Eyebrow,
+  Field,
+  Input,
+  LoadingState,
+  Muted,
+  PageShell,
+  SectionLabel,
+} from "../../components";
+
+export default function SettingsPage() {
+  const location = useLocation();
+  const organizations = useModel(OrganizationModel);
+  const members = useModel(MembersModel);
+  const sessionChecked = useSignal(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const data = await sessionModel.load();
+      if (cancelled) return;
+      if (!data) {
+        location.route("/login", true);
+        return;
+      }
+      sessionChecked.value = true;
+      await organizations.load();
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useSignalEffect(() => {
+    const active = organizations.active.value;
+    const loadedFor = members.organizationId.value;
+    if (!active) return;
+    if (loadedFor === active.id) return;
+    void members.load(active.id);
+  });
+
+  const onSignOut = async () => {
+    await sessionModel.signOut();
+    location.route("/", true);
+  };
+
+  if (!sessionChecked.value) {
+    return (
+      <PageShell>
+        <LoadingState title="Opening settings" detail="confirming session" />
+      </PageShell>
+    );
+  }
+
+  const user = sessionModel.user.value;
+  const active = organizations.active.value;
+
+  return (
+    <PageShell
+      headerActions={
+        <div class="flex items-center gap-2.5 bg-surface border border-border rounded-lg pl-3.5 pr-1.5 py-1.5">
+          <span class="font-mono text-xs text-ink-muted">
+            {user?.email || user?.name || "signed in"}
+          </span>
+          <Button variant="secondary" size="sm" onClick={onSignOut}>
+            Sign out
+          </Button>
+        </div>
+      }
+    >
+      <header class="flex flex-col gap-2 max-w-[720px]">
+        <Eyebrow>Organization settings</Eyebrow>
+        <h1 class="text-3xl font-semibold tracking-[-0.02em] m-0">
+          {active ? active.name : "Loading organization"}
+        </h1>
+        <Muted class="text-[14px] leading-[1.55] m-0">
+          Manage who can review staged releases in this workspace. Invites are share-link based and
+          expire after 7 days.
+        </Muted>
+        <div class="flex items-center gap-2 mt-1">
+          <a href="/dashboard" class="text-[13px] underline">
+            ← Back to dashboard
+          </a>
+        </div>
+      </header>
+
+      {!active ? (
+        <LoadingState title="Loading organization" detail="fetching members" />
+      ) : active.isPersonal ? (
+        <Card class="p-5">
+          <Alert tone="info">
+            This is your personal workspace. Create a separate organization from the dashboard to
+            invite teammates.
+          </Alert>
+        </Card>
+      ) : !members.loaded.value ? (
+        <LoadingState title="Loading members" detail="fetching membership and invites" />
+      ) : (
+        <SettingsBody members={members} />
+      )}
+    </PageShell>
+  );
+}
+
+function SettingsBody({
+  members,
+}: {
+  members: ReturnType<typeof useModel<typeof MembersModel.prototype>>;
+}) {
+  const isOwner = useComputed(() => members.viewerRole.value === "owner");
+
+  return (
+    <div class="flex flex-col gap-6">
+      {members.error.value ? <Alert tone="critical">{members.error.value}</Alert> : null}
+
+      <MembersTable members={members} canManage={isOwner.value} />
+
+      {isOwner.value ? (
+        <>
+          <InviteForm members={members} />
+          <InvitesTable members={members} />
+        </>
+      ) : (
+        <Card class="p-5">
+          <Muted class="text-[13px] m-0">
+            Only organization owners can invite teammates or remove members.
+          </Muted>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function MembersTable({
+  members,
+  canManage,
+}: {
+  members: ReturnType<typeof useModel<typeof MembersModel.prototype>>;
+  canManage: boolean;
+}) {
+  const rows: OrganizationMember[] = members.members.value;
+  return (
+    <section class="flex flex-col gap-3">
+      <div class="flex items-center justify-between gap-3">
+        <SectionLabel>Members</SectionLabel>
+        <Muted class="text-[12px] m-0">{rows.length} total</Muted>
+      </div>
+      <Card class="p-0 overflow-hidden">
+        {rows.length === 0 ? (
+          <div class="p-5">
+            <EmptyLine>No members yet.</EmptyLine>
+          </div>
+        ) : (
+          <div class="overflow-x-auto">
+            <table class="w-full border-collapse text-[13px]">
+              <thead>
+                <tr class="border-b border-border bg-surface-2">
+                  <Th>Member</Th>
+                  <Th>Role</Th>
+                  <Th>Joined</Th>
+                  {canManage ? <Th>{""}</Th> : null}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((member) => (
+                  <tr key={member.userId} class="border-b border-border last:border-b-0">
+                    <Td>
+                      <div class="flex flex-col gap-0.5 min-w-0">
+                        <span class="text-ink">{member.name || member.email || member.userId}</span>
+                        {member.email && member.name ? (
+                          <span class="font-mono text-xs text-ink-muted">{member.email}</span>
+                        ) : null}
+                      </div>
+                    </Td>
+                    <Td>
+                      <Badge tone={member.isOwner ? "ok" : "info"}>
+                        {member.isOwner ? "owner" : member.role}
+                      </Badge>
+                    </Td>
+                    <Td class="font-mono text-xs text-ink-muted">{formatDate(member.joinedAt)}</Td>
+                    {canManage ? (
+                      <Td class="text-right">
+                        {member.isOwner ? (
+                          <Muted class="text-xs m-0">primary owner</Muted>
+                        ) : (
+                          <Button
+                            variant="danger"
+                            size="sm"
+                            onClick={() => void members.remove(member.userId)}
+                            disabled={members.busy.value}
+                          >
+                            Remove
+                          </Button>
+                        )}
+                      </Td>
+                    ) : null}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </section>
+  );
+}
+
+function InviteForm({
+  members,
+}: {
+  members: ReturnType<typeof useModel<typeof MembersModel.prototype>>;
+}) {
+  const email = useSignal("");
+  const role = useSignal<OrganizationRole>("member");
+
+  const onSubmit = async (event: Event) => {
+    event.preventDefault();
+    const submittedRole = role.value;
+    const submittedEmail = email.value;
+    const created = await members.invite(submittedRole, submittedEmail);
+    if (created) {
+      email.value = "";
+    }
+  };
+
+  return (
+    <Card class="p-5 flex flex-col gap-4 border-accent/40">
+      <div class="flex flex-col gap-1.5">
+        <SectionLabel>Invite a teammate</SectionLabel>
+        <Muted class="text-[13px] max-w-[680px]">
+          We generate a one-time invite link. Send it to the teammate you want to add — when they
+          sign in and open it, they join this organization.
+        </Muted>
+      </div>
+      <form
+        class="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,160px)_auto] gap-3 items-end"
+        onSubmit={onSubmit}
+      >
+        <Field label="Email (optional, just for your records)" for="inviteEmail">
+          <Input
+            id="inviteEmail"
+            type="email"
+            value={email}
+            placeholder="teammate@example.com"
+            onInput={(e) => (email.value = (e.target as HTMLInputElement).value)}
+            disabled={members.busy.value}
+            autoComplete="off"
+            spellcheck={false}
+          />
+        </Field>
+        <Field label="Role" for="inviteRole">
+          <select
+            id="inviteRole"
+            value={role.value}
+            onChange={(e) =>
+              (role.value = (e.target as HTMLSelectElement).value as OrganizationRole)
+            }
+            disabled={members.busy.value}
+            class="bg-bg border border-border rounded-md text-[13px] text-ink px-3 py-2 outline-none focus:border-accent focus:shadow-[0_0_0_3px_var(--color-accent-soft)] disabled:opacity-60 disabled:cursor-not-allowed font-mono"
+          >
+            <option value="member">member</option>
+            <option value="owner">owner</option>
+          </select>
+        </Field>
+        <Button type="submit" disabled={members.busy.value} class="shrink-0">
+          {members.busy.value ? "Creating…" : "Create invite link"}
+        </Button>
+      </form>
+      {members.lastInviteUrl.value ? (
+        <InviteLinkReveal
+          url={members.lastInviteUrl.value}
+          onDismiss={() => members.clearInviteUrl()}
+        />
+      ) : null}
+    </Card>
+  );
+}
+
+function InviteLinkReveal({ url, onDismiss }: { url: string; onDismiss: () => void }) {
+  const copied = useSignal(false);
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      copied.value = true;
+      window.setTimeout(() => {
+        copied.value = false;
+      }, 2000);
+    } catch {
+      copied.value = false;
+    }
+  };
+
+  return (
+    <div class="flex flex-col gap-2 border border-accent/30 bg-accent/5 rounded-md p-3">
+      <div class="flex items-center justify-between gap-2">
+        <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">
+          Share this link once
+        </span>
+        <button
+          type="button"
+          onClick={onDismiss}
+          class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle hover:text-ink"
+        >
+          dismiss
+        </button>
+      </div>
+      <div class="flex items-center gap-2">
+        <code class="flex-1 text-xs text-ink-muted break-all bg-bg border border-border rounded px-2 py-1.5">
+          {url}
+        </code>
+        <Button variant="secondary" size="sm" onClick={() => void onCopy()} class="shrink-0">
+          {copied.value ? "Copied" : "Copy"}
+        </Button>
+      </div>
+      <Muted class="text-xs m-0">
+        We do not store the link itself — only its hash. Save it somewhere safe before you close
+        this view.
+      </Muted>
+    </div>
+  );
+}
+
+function InvitesTable({
+  members,
+}: {
+  members: ReturnType<typeof useModel<typeof MembersModel.prototype>>;
+}) {
+  const rows: OrganizationInvite[] = members.invites.value;
+  return (
+    <section class="flex flex-col gap-3">
+      <div class="flex items-center justify-between gap-3">
+        <SectionLabel>Invites</SectionLabel>
+        <Muted class="text-[12px] m-0">{rows.length} total</Muted>
+      </div>
+      <Card class="p-0 overflow-hidden">
+        {rows.length === 0 ? (
+          <div class="p-5">
+            <EmptyLine>No invites yet. Create one above to bring in a teammate.</EmptyLine>
+          </div>
+        ) : (
+          <div class="overflow-x-auto">
+            <table class="w-full border-collapse text-[13px]">
+              <thead>
+                <tr class="border-b border-border bg-surface-2">
+                  <Th>Email / token</Th>
+                  <Th>Role</Th>
+                  <Th>Status</Th>
+                  <Th>Expires</Th>
+                  <Th>Created</Th>
+                  <Th>{""}</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((invite) => (
+                  <tr key={invite.id} class="border-b border-border last:border-b-0">
+                    <Td>
+                      <div class="flex flex-col gap-0.5 min-w-0">
+                        <span class="text-ink">{invite.email || "—"}</span>
+                        <span class="font-mono text-xs text-ink-muted">
+                          inv_••••{invite.tokenLast4 || "----"}
+                        </span>
+                      </div>
+                    </Td>
+                    <Td>
+                      <Badge tone="info">{invite.role}</Badge>
+                    </Td>
+                    <Td>
+                      <Badge tone={inviteStatusTone(invite.status)}>{invite.status}</Badge>
+                    </Td>
+                    <Td class="font-mono text-xs text-ink-muted">{formatDate(invite.expiresAt)}</Td>
+                    <Td class="font-mono text-xs text-ink-muted">{formatDate(invite.createdAt)}</Td>
+                    <Td class="text-right">
+                      {invite.status === "pending" ? (
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          onClick={() => void members.revoke(invite.id)}
+                          disabled={members.busy.value}
+                        >
+                          Revoke
+                        </Button>
+                      ) : null}
+                    </Td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </section>
+  );
+}
+
+function inviteStatusTone(status: string): "ok" | "info" | "critical" {
+  if (status === "accepted") return "ok";
+  if (status === "revoked" || status === "expired") return "critical";
+  return "info";
+}
+
+function Th({ children }: { children: ComponentChildren }) {
+  return (
+    <th class="text-left font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle px-4 py-2.5">
+      {children}
+    </th>
+  );
+}
+
+function Td({ children, class: className }: { children: ComponentChildren; class?: string }) {
+  return <td class={`px-4 py-2.5 align-middle ${className || ""}`}>{children}</td>;
+}
+
+function formatDate(value: string | number | Date | null | undefined) {
+  if (value === null || value === undefined) return "—";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString();
+}

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -107,6 +107,9 @@ export default function DashboardPage() {
   const npmLoaded = npm.loaded.value;
   const workspaceLoaded = scansLoaded && npmLoaded;
 
+  const activeOrganization = organizations.active.value;
+  const canManageMembers = Boolean(activeOrganization && !activeOrganization.isPersonal);
+
   return (
     <PageShell
       headerActions={
@@ -118,6 +121,7 @@ export default function DashboardPage() {
             error={organizations.error.value}
             onActivate={onSwitchOrganization}
             onCreate={onCreateOrganization}
+            manageHref={canManageMembers ? "/dashboard/settings" : undefined}
           />
           <UserMenu email={user?.email} name={user?.name} onSignOut={onSignOut} />
         </>

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -109,6 +109,7 @@ export default function DashboardPage() {
 
   const activeOrganization = organizations.active.value;
   const canManageMembers = Boolean(activeOrganization && !activeOrganization.isPersonal);
+  const canManageNpm = activeOrganization?.role === "owner";
 
   return (
     <PageShell
@@ -132,7 +133,7 @@ export default function DashboardPage() {
       {workspaceLoaded ? (
         <>
           <RecentReviewsSection scans={scans} stagedPublishes={stagedPublishes} npm={npm} />
-          <WorkspaceSetupPanel npm={npm} />
+          <WorkspaceSetupPanel npm={npm} canManageNpm={canManageNpm} />
         </>
       ) : (
         <LoadingState
@@ -330,8 +331,10 @@ function formatStartedScanLabel(scan: { packageName: string | null; version: str
 
 function WorkspaceSetupPanel({
   npm,
+  canManageNpm,
 }: {
   npm: ReturnType<typeof useModel<typeof NpmConnectionModel.prototype>>;
+  canManageNpm: boolean;
 }) {
   const connection = npm.connection.value;
   return (
@@ -365,7 +368,7 @@ function WorkspaceSetupPanel({
             </div>
           </summary>
           <div class="p-5">
-            <NpmConnectionCard npm={npm} />
+            <NpmConnectionCard npm={npm} canManageNpm={canManageNpm} />
           </div>
         </details>
       </Card>
@@ -375,8 +378,10 @@ function WorkspaceSetupPanel({
 
 function NpmConnectionCard({
   npm,
+  canManageNpm,
 }: {
   npm: ReturnType<typeof useModel<typeof NpmConnectionModel.prototype>>;
+  canManageNpm: boolean;
 }) {
   const connection = npm.connection.value;
   const status = npm.status.value;
@@ -432,86 +437,98 @@ function NpmConnectionCard({
         </div>
       ) : null}
 
-      <form
-        class="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.5fr)_auto] gap-3 items-end"
-        onSubmit={onSave}
-      >
-        <Field label="Connection name" for="npmLabel">
-          <Input
-            id="npmLabel"
-            type="text"
-            value={label}
-            onInput={(e) => (npm.label.value = (e.target as HTMLInputElement).value)}
-            disabled={busy}
-          />
-        </Field>
-        <Field label="Registry" for="npmRegistry">
-          <Input
-            id="npmRegistry"
-            type="url"
-            value={registry}
-            onInput={(e) => (npm.registry.value = (e.target as HTMLInputElement).value)}
-            disabled={busy}
-          />
-        </Field>
-        <Field label={connection ? "New npm token" : "npm token"} for="npmToken">
-          <Input
-            id="npmToken"
-            type="password"
-            value={token}
-            placeholder={connection ? "Paste a new token to rotate" : "npm_..."}
-            onInput={(e) => (npm.token.value = (e.target as HTMLInputElement).value)}
-            disabled={busy}
-            autoComplete="off"
-            spellcheck={false}
-          />
-        </Field>
-        <Button type="submit" disabled={busy || !token.trim()} class="shrink-0">
-          {status === "saving"
-            ? "Saving…"
-            : status === "validating"
-              ? "Checking…"
-              : connection
-                ? "Rotate"
-                : "Save"}
-        </Button>
-      </form>
+      {canManageNpm ? (
+        <>
+          <form
+            class="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.5fr)_auto] gap-3 items-end"
+            onSubmit={onSave}
+          >
+            <Field label="Connection name" for="npmLabel">
+              <Input
+                id="npmLabel"
+                type="text"
+                value={label}
+                onInput={(e) => (npm.label.value = (e.target as HTMLInputElement).value)}
+                disabled={busy}
+              />
+            </Field>
+            <Field label="Registry" for="npmRegistry">
+              <Input
+                id="npmRegistry"
+                type="url"
+                value={registry}
+                onInput={(e) => (npm.registry.value = (e.target as HTMLInputElement).value)}
+                disabled={busy}
+              />
+            </Field>
+            <Field label={connection ? "New npm token" : "npm token"} for="npmToken">
+              <Input
+                id="npmToken"
+                type="password"
+                value={token}
+                placeholder={connection ? "Paste a new token to rotate" : "npm_..."}
+                onInput={(e) => (npm.token.value = (e.target as HTMLInputElement).value)}
+                disabled={busy}
+                autoComplete="off"
+                spellcheck={false}
+              />
+            </Field>
+            <Button type="submit" disabled={busy || !token.trim()} class="shrink-0">
+              {status === "saving"
+                ? "Saving…"
+                : status === "validating"
+                  ? "Checking…"
+                  : connection
+                    ? "Rotate"
+                    : "Save"}
+            </Button>
+          </form>
 
-      <div class="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_auto] gap-3 items-end">
-        <Field label="Stage ID access check" for="validationStageId">
-          <Input
-            id="validationStageId"
-            type="text"
-            value={validationStageId}
-            placeholder="Paste a real stage ID to confirm package access"
-            onInput={(e) => (npm.validationStageId.value = (e.target as HTMLInputElement).value)}
-            disabled={busy || !connection}
-            autoComplete="off"
-            spellcheck={false}
-          />
-        </Field>
-        <Button
-          variant="secondary"
-          onClick={() => void npm.validate()}
-          disabled={busy || !connection}
-          class="shrink-0"
-        >
-          {status === "validating"
-            ? "Checking…"
-            : validationStageId.trim()
-              ? "Check stage access"
-              : "Check npm auth"}
-        </Button>
-      </div>
+          <div class="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_auto] gap-3 items-end">
+            <Field label="Stage ID access check" for="validationStageId">
+              <Input
+                id="validationStageId"
+                type="text"
+                value={validationStageId}
+                placeholder="Paste a real stage ID to confirm package access"
+                onInput={(e) =>
+                  (npm.validationStageId.value = (e.target as HTMLInputElement).value)
+                }
+                disabled={busy || !connection}
+                autoComplete="off"
+                spellcheck={false}
+              />
+            </Field>
+            <Button
+              variant="secondary"
+              onClick={() => void npm.validate()}
+              disabled={busy || !connection}
+              class="shrink-0"
+            >
+              {status === "validating"
+                ? "Checking…"
+                : validationStageId.trim()
+                  ? "Check stage access"
+                  : "Check npm auth"}
+            </Button>
+          </div>
 
-      <Muted class="text-xs">
-        Saving runs the npm auth check automatically. Add a stage ID to prove the token can read
-        that staged release; we do not keep the release archive.
-      </Muted>
+          <Muted class="text-xs">
+            Saving runs the npm auth check automatically. Add a stage ID to prove the token can read
+            that staged release; we do not keep the release archive.
+          </Muted>
+        </>
+      ) : (
+        <Alert tone="info">
+          {connection
+            ? "Only organization owners can rotate, validate, or remove the npm connection."
+            : "Ask an organization owner to connect npm before reviews can run in this workspace."}
+        </Alert>
+      )}
 
       {error ? <Alert tone="critical">{error}</Alert> : null}
 
-      {connection ? (
+      {canManageNpm && connection ? (
         <div class="flex justify-end border-t border-border pt-4">
           <Button variant="danger" size="sm" onClick={() => void npm.remove()} disabled={busy}>
             {status === "deleting" ? "Removing…" : "Disconnect npm"}

--- a/src/pages/Invites/index.tsx
+++ b/src/pages/Invites/index.tsx
@@ -1,0 +1,146 @@
+import { useEffect } from "preact/hooks";
+import { useModel, useSignal } from "@preact/signals";
+import { useLocation, useRoute } from "preact-iso";
+import { sessionModel } from "../../models/auth";
+import { setActiveOrganizationId } from "../../models/active-organization";
+import { InviteAcceptModel } from "../../models/invites";
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Eyebrow,
+  LoadingState,
+  Muted,
+  PageShell,
+} from "../../components";
+
+export default function InvitePage() {
+  const route = useRoute();
+  const location = useLocation();
+  const invite = useModel(InviteAcceptModel);
+  const sessionChecked = useSignal(false);
+
+  const token = route.params.token || "";
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const data = await sessionModel.load();
+      if (cancelled) return;
+      if (!data) {
+        const next = `/invites/${encodeURIComponent(token)}`;
+        location.route(`/login?next=${encodeURIComponent(next)}`, true);
+        return;
+      }
+      sessionChecked.value = true;
+      if (token) await invite.load(token);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const onAccept = async () => {
+    const result = await invite.accept();
+    if (!result) return;
+    setActiveOrganizationId(result.organization.id);
+    location.route("/dashboard", true);
+  };
+
+  const onDecline = () => {
+    location.route("/dashboard", true);
+  };
+
+  if (!sessionChecked.value || !invite.loaded.value) {
+    return (
+      <PageShell width="narrow">
+        <LoadingState title="Loading invite" detail="confirming session" />
+      </PageShell>
+    );
+  }
+
+  if (invite.error.value && !invite.preview.value) {
+    return (
+      <PageShell width="narrow">
+        <Card class="flex flex-col gap-4">
+          <Eyebrow>Invite</Eyebrow>
+          <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">Invite unavailable</h1>
+          <Alert tone="critical">{invite.error.value}</Alert>
+          <Muted class="text-[13px] m-0">
+            <a href="/dashboard">Go to dashboard</a>
+          </Muted>
+        </Card>
+      </PageShell>
+    );
+  }
+
+  const preview = invite.preview.value;
+  if (!preview) {
+    return (
+      <PageShell width="narrow">
+        <Card class="flex flex-col gap-4">
+          <Eyebrow>Invite</Eyebrow>
+          <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">Invite not found</h1>
+          <Muted class="text-[13px] m-0">
+            <a href="/dashboard">Go to dashboard</a>
+          </Muted>
+        </Card>
+      </PageShell>
+    );
+  }
+
+  const status = preview.status;
+  const pending = status === "pending";
+  const alreadyMember = invite.alreadyMember.value;
+
+  return (
+    <PageShell width="narrow">
+      <Card class="flex flex-col gap-4">
+        <Eyebrow>You've been invited</Eyebrow>
+        <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">{preview.organizationName}</h1>
+        <div class="flex flex-wrap items-center gap-2 text-[13px] text-ink-muted">
+          <span>Role</span>
+          <Badge tone="info">{preview.role}</Badge>
+          <span>•</span>
+          <span>Status</span>
+          <Badge tone={status === "accepted" ? "ok" : status === "pending" ? "info" : "critical"}>
+            {status}
+          </Badge>
+        </div>
+        <Muted class="text-[13px] m-0">
+          {pending
+            ? `Accepting this invite adds you to ${preview.organizationName} as a ${preview.role}. The invite expires ${formatDate(preview.expiresAt)}.`
+            : status === "expired"
+              ? "This invite has expired. Ask the organization owner to send a new link."
+              : status === "revoked"
+                ? "This invite was revoked by an owner."
+                : "This invite has already been accepted."}
+        </Muted>
+
+        {alreadyMember ? (
+          <Alert tone="info">You are already a member of this organization.</Alert>
+        ) : null}
+
+        {invite.error.value ? <Alert tone="critical">{invite.error.value}</Alert> : null}
+
+        <div class="flex flex-wrap items-center gap-2 mt-2">
+          <Button
+            onClick={() => void onAccept()}
+            disabled={!pending || alreadyMember || invite.busy.value}
+          >
+            {invite.busy.value ? "Accepting…" : "Accept invite"}
+          </Button>
+          <Button variant="secondary" onClick={onDecline} disabled={invite.busy.value}>
+            {pending ? "Decline" : "Back to dashboard"}
+          </Button>
+        </div>
+      </Card>
+    </PageShell>
+  );
+}
+
+function formatDate(value: string | number | Date) {
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "soon" : date.toLocaleString();
+}

--- a/test/workers/invites-routes.test.ts
+++ b/test/workers/invites-routes.test.ts
@@ -197,6 +197,43 @@ describe("invites routes", () => {
     expect(accept.status).toBe(409);
   });
 
+  test("existing members cannot consume pending invite links", async () => {
+    const owner = await seedUser();
+    const org = await createSharedOrg(owner);
+
+    const create = await call(
+      buildTestApp(owner),
+      "POST",
+      `/api/v1/organizations/${org.id}/invites`,
+      { body: { role: "member" } },
+    );
+    const created = (await create.json()) as { token: string; invite: { id: string } };
+
+    const preview = await call(
+      buildTestApp(owner),
+      "GET",
+      `/api/v1/invites/${encodeURIComponent(created.token)}`,
+    );
+    expect(preview.status).toBe(200);
+    const previewBody = (await preview.json()) as { viewer: { alreadyMember: boolean } };
+    expect(previewBody.viewer.alreadyMember).toBe(true);
+
+    const accept = await call(
+      buildTestApp(owner),
+      "POST",
+      `/api/v1/invites/${encodeURIComponent(created.token)}/accept`,
+    );
+    expect(accept.status).toBe(409);
+
+    const db = createDb(env.DB);
+    const [row] = await db
+      .select({ status: schema.organizationInvites.status })
+      .from(schema.organizationInvites)
+      .where(eq(schema.organizationInvites.id, created.invite.id))
+      .limit(1);
+    expect(row?.status).toBe("pending");
+  });
+
   test("expired invites are not accepted and reported as expired in preview", async () => {
     const owner = await seedUser();
     const invitee = await seedUser();

--- a/test/workers/invites-routes.test.ts
+++ b/test/workers/invites-routes.test.ts
@@ -330,6 +330,58 @@ describe("invites routes", () => {
     expect(memberDelete.status).toBe(403);
   });
 
+  test("invited owners can manage organization membership and invites", async () => {
+    const primaryOwner = await seedUser();
+    const invitedOwner = await seedUser();
+    const member = await seedUser();
+    const org = await createSharedOrg(primaryOwner);
+
+    const ownerInvite = await call(
+      buildTestApp(primaryOwner),
+      "POST",
+      `/api/v1/organizations/${org.id}/invites`,
+      { body: { role: "owner" } },
+    );
+    const ownerInviteBody = (await ownerInvite.json()) as { token: string };
+    await call(
+      buildTestApp(invitedOwner),
+      "POST",
+      `/api/v1/invites/${encodeURIComponent(ownerInviteBody.token)}/accept`,
+    );
+
+    const createdByInvitedOwner = await call(
+      buildTestApp(invitedOwner),
+      "POST",
+      `/api/v1/organizations/${org.id}/invites`,
+      { body: { role: "member" } },
+    );
+    expect(createdByInvitedOwner.status).toBe(201);
+    const memberInviteBody = (await createdByInvitedOwner.json()) as { token: string };
+    await call(
+      buildTestApp(member),
+      "POST",
+      `/api/v1/invites/${encodeURIComponent(memberInviteBody.token)}/accept`,
+    );
+
+    const invites = await call(
+      buildTestApp(invitedOwner),
+      "GET",
+      `/api/v1/organizations/${org.id}/invites`,
+    );
+    expect(invites.status).toBe(200);
+
+    const removeMember = await call(
+      buildTestApp(invitedOwner),
+      "DELETE",
+      `/api/v1/organizations/${org.id}/members/${member.userId}`,
+    );
+    expect(removeMember.status).toBe(200);
+
+    const db = createDb(env.DB);
+    const removedMembership = await getOrganizationMembership(db, org.id, member.userId);
+    expect(removedMembership).toBeNull();
+  });
+
   test("invite token hash is single-use even if the row remains", async () => {
     const owner = await seedUser();
     const invitee = await seedUser();

--- a/test/workers/invites-routes.test.ts
+++ b/test/workers/invites-routes.test.ts
@@ -1,0 +1,365 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { describe, expect, test } from "vitest";
+import { and, eq } from "drizzle-orm";
+import { createDb, ensurePersonalOrganization, getOrganizationMembership } from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { ACTIVE_ORG_HEADER } from "../../server/lib/active-organization";
+import { npmConnectionRoutes } from "../../server/routes/npm-connection";
+import { invitesRoutes, organizationsRoutes } from "../../server/routes/organizations";
+import type { Bindings, Variables } from "../../server/types";
+
+interface SeededUser {
+  userId: string;
+  personalOrganizationId: string;
+  email: string;
+}
+
+async function seedUser(): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  const email = `${userId}@example.com`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const personalOrganizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, personalOrganizationId, email };
+}
+
+function buildTestApp(session: { userId: string }) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.use("*", async (c, next) => {
+    c.set("authSession", { userId: session.userId });
+    await next();
+  });
+  app.route("/api/v1/organizations", organizationsRoutes);
+  app.route("/api/v1/invites", invitesRoutes);
+  app.route("/api/v1/npm-connection", npmConnectionRoutes);
+  return app;
+}
+
+async function call(
+  app: Hono<{ Bindings: Bindings; Variables: Variables }>,
+  method: string,
+  path: string,
+  options: { body?: unknown; activeOrganizationId?: string } = {},
+) {
+  const ctx = createExecutionContext();
+  const headers: Record<string, string> = {};
+  const init: RequestInit = { method };
+  if (options.body !== undefined) {
+    init.body = JSON.stringify(options.body);
+    headers["content-type"] = "application/json";
+  }
+  if (options.activeOrganizationId) {
+    headers[ACTIVE_ORG_HEADER] = options.activeOrganizationId;
+  }
+  init.headers = headers;
+  const res = await app.fetch(new Request(`http://test.local${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+async function createSharedOrg(owner: SeededUser, name = "shared") {
+  const res = await call(buildTestApp(owner), "POST", "/api/v1/organizations", {
+    body: { name },
+  });
+  const body = (await res.json()) as { organization: { id: string; name: string } };
+  return body.organization;
+}
+
+describe("invites routes", () => {
+  test("owner creates a one-time invite link visible only to owners", async () => {
+    const owner = await seedUser();
+    const stranger = await seedUser();
+    const org = await createSharedOrg(owner);
+
+    const create = await call(
+      buildTestApp(owner),
+      "POST",
+      `/api/v1/organizations/${org.id}/invites`,
+      { body: { role: "member", email: "teammate@example.com" } },
+    );
+    expect(create.status).toBe(201);
+    const created = (await create.json()) as {
+      invite: { id: string; status: string; role: string; email: string | null };
+      token: string;
+      url: string;
+    };
+    expect(created.invite.status).toBe("pending");
+    expect(created.invite.role).toBe("member");
+    expect(created.invite.email).toBe("teammate@example.com");
+    expect(created.token).toMatch(/^inv_/);
+    expect(created.url).toContain(encodeURIComponent(created.token));
+
+    const ownerList = await call(
+      buildTestApp(owner),
+      "GET",
+      `/api/v1/organizations/${org.id}/invites`,
+    );
+    expect(ownerList.status).toBe(200);
+    const ownerBody = (await ownerList.json()) as { invites: Array<{ id: string }> };
+    expect(ownerBody.invites.map((i) => i.id)).toContain(created.invite.id);
+
+    const strangerList = await call(
+      buildTestApp(stranger),
+      "GET",
+      `/api/v1/organizations/${org.id}/invites`,
+    );
+    expect(strangerList.status).toBe(404);
+  });
+
+  test("invitee preview + accept adds them as a member with the invited role", async () => {
+    const owner = await seedUser();
+    const invitee = await seedUser();
+    const org = await createSharedOrg(owner, "shared-team");
+
+    const create = await call(
+      buildTestApp(owner),
+      "POST",
+      `/api/v1/organizations/${org.id}/invites`,
+      { body: { role: "member" } },
+    );
+    const created = (await create.json()) as { token: string; invite: { id: string } };
+
+    const preview = await call(
+      buildTestApp(invitee),
+      "GET",
+      `/api/v1/invites/${encodeURIComponent(created.token)}`,
+    );
+    expect(preview.status).toBe(200);
+    const previewBody = (await preview.json()) as {
+      invite: { organizationName: string; role: string; status: string };
+      viewer: { alreadyMember: boolean };
+    };
+    expect(previewBody.invite.organizationName).toBe("shared-team");
+    expect(previewBody.invite.role).toBe("member");
+    expect(previewBody.invite.status).toBe("pending");
+    expect(previewBody.viewer.alreadyMember).toBe(false);
+
+    const accept = await call(
+      buildTestApp(invitee),
+      "POST",
+      `/api/v1/invites/${encodeURIComponent(created.token)}/accept`,
+    );
+    expect(accept.status).toBe(200);
+    const acceptBody = (await accept.json()) as {
+      organization: { id: string };
+      role: string;
+    };
+    expect(acceptBody.organization.id).toBe(org.id);
+    expect(acceptBody.role).toBe("member");
+
+    const db = createDb(env.DB);
+    const membership = await getOrganizationMembership(db, org.id, invitee.userId);
+    expect(membership?.role).toBe("member");
+
+    // second accept on the same token is a no-op
+    const repeat = await call(
+      buildTestApp(invitee),
+      "POST",
+      `/api/v1/invites/${encodeURIComponent(created.token)}/accept`,
+    );
+    expect(repeat.status).toBe(409);
+  });
+
+  test("revoked invites cannot be accepted", async () => {
+    const owner = await seedUser();
+    const invitee = await seedUser();
+    const org = await createSharedOrg(owner);
+
+    const create = await call(
+      buildTestApp(owner),
+      "POST",
+      `/api/v1/organizations/${org.id}/invites`,
+      { body: { role: "member" } },
+    );
+    const created = (await create.json()) as { token: string; invite: { id: string } };
+
+    const revoke = await call(
+      buildTestApp(owner),
+      "DELETE",
+      `/api/v1/organizations/${org.id}/invites/${created.invite.id}`,
+    );
+    expect(revoke.status).toBe(200);
+
+    const accept = await call(
+      buildTestApp(invitee),
+      "POST",
+      `/api/v1/invites/${encodeURIComponent(created.token)}/accept`,
+    );
+    expect(accept.status).toBe(409);
+  });
+
+  test("expired invites are not accepted and reported as expired in preview", async () => {
+    const owner = await seedUser();
+    const invitee = await seedUser();
+    const org = await createSharedOrg(owner);
+
+    const create = await call(
+      buildTestApp(owner),
+      "POST",
+      `/api/v1/organizations/${org.id}/invites`,
+      { body: { role: "member" } },
+    );
+    const created = (await create.json()) as { token: string; invite: { id: string } };
+
+    const db = createDb(env.DB);
+    await db
+      .update(schema.organizationInvites)
+      .set({ expiresAt: new Date(Date.now() - 60 * 1000) })
+      .where(eq(schema.organizationInvites.id, created.invite.id));
+
+    const preview = await call(
+      buildTestApp(invitee),
+      "GET",
+      `/api/v1/invites/${encodeURIComponent(created.token)}`,
+    );
+    const previewBody = (await preview.json()) as { invite: { status: string } };
+    expect(previewBody.invite.status).toBe("expired");
+
+    const accept = await call(
+      buildTestApp(invitee),
+      "POST",
+      `/api/v1/invites/${encodeURIComponent(created.token)}/accept`,
+    );
+    expect(accept.status).toBe(410);
+  });
+
+  test("personal organizations cannot send invites", async () => {
+    const owner = await seedUser();
+    const res = await call(
+      buildTestApp(owner),
+      "POST",
+      `/api/v1/organizations/${owner.personalOrganizationId}/invites`,
+      { body: { role: "member" } },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("owners can remove members but cannot remove themselves", async () => {
+    const owner = await seedUser();
+    const invitee = await seedUser();
+    const org = await createSharedOrg(owner);
+
+    const create = await call(
+      buildTestApp(owner),
+      "POST",
+      `/api/v1/organizations/${org.id}/invites`,
+      { body: { role: "member" } },
+    );
+    const created = (await create.json()) as { token: string };
+    await call(
+      buildTestApp(invitee),
+      "POST",
+      `/api/v1/invites/${encodeURIComponent(created.token)}/accept`,
+    );
+
+    const membersBefore = await call(
+      buildTestApp(owner),
+      "GET",
+      `/api/v1/organizations/${org.id}/members`,
+    );
+    const beforeBody = (await membersBefore.json()) as {
+      members: Array<{ userId: string; role: string }>;
+    };
+    expect(beforeBody.members.map((m) => m.userId)).toContain(invitee.userId);
+
+    const removeSelf = await call(
+      buildTestApp(owner),
+      "DELETE",
+      `/api/v1/organizations/${org.id}/members/${owner.userId}`,
+    );
+    expect(removeSelf.status).toBe(400);
+
+    const remove = await call(
+      buildTestApp(owner),
+      "DELETE",
+      `/api/v1/organizations/${org.id}/members/${invitee.userId}`,
+    );
+    expect(remove.status).toBe(200);
+
+    const db = createDb(env.DB);
+    const membership = await getOrganizationMembership(db, org.id, invitee.userId);
+    expect(membership).toBeNull();
+  });
+
+  test("members cannot write the npm connection but can read it", async () => {
+    const owner = await seedUser();
+    const invitee = await seedUser();
+    const org = await createSharedOrg(owner);
+
+    await call(buildTestApp(owner), "POST", "/api/v1/npm-connection", {
+      body: { token: "npm_owner_token_AAAAAAAA", label: "owner" },
+      activeOrganizationId: org.id,
+    });
+
+    const create = await call(
+      buildTestApp(owner),
+      "POST",
+      `/api/v1/organizations/${org.id}/invites`,
+      { body: { role: "member" } },
+    );
+    const created = (await create.json()) as { token: string };
+    await call(
+      buildTestApp(invitee),
+      "POST",
+      `/api/v1/invites/${encodeURIComponent(created.token)}/accept`,
+    );
+
+    const memberRead = await call(buildTestApp(invitee), "GET", "/api/v1/npm-connection", {
+      activeOrganizationId: org.id,
+    });
+    expect(memberRead.status).toBe(200);
+
+    const memberWrite = await call(buildTestApp(invitee), "POST", "/api/v1/npm-connection", {
+      body: { token: "npm_member_token_BBBBBBBB", label: "intruder" },
+      activeOrganizationId: org.id,
+    });
+    expect(memberWrite.status).toBe(403);
+
+    const memberDelete = await call(buildTestApp(invitee), "DELETE", "/api/v1/npm-connection", {
+      activeOrganizationId: org.id,
+    });
+    expect(memberDelete.status).toBe(403);
+  });
+
+  test("invite token hash is single-use even if the row remains", async () => {
+    const owner = await seedUser();
+    const invitee = await seedUser();
+    const org = await createSharedOrg(owner);
+
+    const create = await call(
+      buildTestApp(owner),
+      "POST",
+      `/api/v1/organizations/${org.id}/invites`,
+      { body: { role: "member" } },
+    );
+    const created = (await create.json()) as { token: string; invite: { id: string } };
+
+    await call(
+      buildTestApp(invitee),
+      "POST",
+      `/api/v1/invites/${encodeURIComponent(created.token)}/accept`,
+    );
+
+    const db = createDb(env.DB);
+    const [row] = await db
+      .select()
+      .from(schema.organizationInvites)
+      .where(
+        and(
+          eq(schema.organizationInvites.id, created.invite.id),
+          eq(schema.organizationInvites.acceptedByUserId, invitee.userId),
+        ),
+      )
+      .limit(1);
+    expect(row?.status).toBe("accepted");
+  });
+});

--- a/test/workers/invites-routes.test.ts
+++ b/test/workers/invites-routes.test.ts
@@ -224,6 +224,12 @@ describe("invites routes", () => {
     const previewBody = (await preview.json()) as { invite: { status: string } };
     expect(previewBody.invite.status).toBe("expired");
 
+    const list = await call(buildTestApp(owner), "GET", `/api/v1/organizations/${org.id}/invites`);
+    const listBody = (await list.json()) as { invites: Array<{ id: string; status: string }> };
+    expect(listBody.invites.find((invite) => invite.id === created.invite.id)?.status).toBe(
+      "expired",
+    );
+
     const accept = await call(
       buildTestApp(invitee),
       "POST",


### PR DESCRIPTION
## Summary
- Adds a share-link invite flow: owners create one-time URLs (SHA-256 hashed at rest, 7-day expiry, single-use), invitees accept at \`/invites/:token\` to join the org, all stored in a new \`organization_invites\` table.
- Introduces a \`member\` role alongside \`owner\` — members can read and run scans, but \`POST\`/\`DELETE\`/\`/validate\` on \`/api/v1/npm-connection\` are now owner-only.
- New settings UI at \`/dashboard/settings\` with member + invite tables; auth pages honor \`?next=\` so deep links to \`/invites/:token\` survive sign-in.
- New worker tests cover create/preview/accept/double-accept/revoke/expiry/personal-org-block/member-npm-write-403/self-removal-block.

## Test plan
- [ ] \`pnpm run verify\` passes locally (it does as of this commit)
- [ ] Owner generates an invite link, copies it, and a second user accepts it and lands in the org
- [ ] Member sees scans but cannot rotate/remove the org npm token (403)
- [ ] Revoked + expired invites can't be accepted; previewing an expired invite reports \`expired\`
- [ ] Personal organization rejects invite creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)