### PR TITLE
Route AI runs through drydock-gateway

### DIFF
--- a/server/lib/ai-review.ts
+++ b/server/lib/ai-review.ts
@@ -230,6 +230,7 @@ export async function analyzeWithAi(
         },
       },
       {
+        gateway: { id: "drydock-gateway" },
         extraHeaders: {
           "x-session-affinity":
             env.AI_CACHE_AFFINITY || "staged-publish-review-release-reviewer-v1",


### PR DESCRIPTION
## Summary
- Pass `gateway: { id: "drydock-gateway" }` to `env.AI.run` in `server/lib/ai-review.ts` so reviewer calls route through the Cloudflare AI Gateway when the AI reviewer is re-enabled.

## Test plan
- [ ] Verify gateway routing in Cloudflare dashboard once AI reviewer is re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)