### PR TITLE
[codex] Add tag-aware staged publish baseline

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,8 @@ Dynamic Worker sandbox
 
 Scan orchestration lives in `server/lib/scan-pipeline.ts` and is shared by both entrypoints. The product path is the queued/background lifecycle: `POST /api/v1/scans` creates a scan, a Queue consumer or local `waitUntil()` job runs the pipeline, and the UI reads status/report data from `GET /api/v1/scans/:id`. `POST /api/v1/scan` remains only as a synchronous compatibility shim during the migration.
 
+Baseline selection should be tag-aware rather than simply highest-semver. See [`diff-baseline.md`](./diff-baseline.md) for the staged metadata constraints and the recommended default comparison strategy.
+
 ## Trust boundaries
 
 ### Browser/UI
@@ -79,11 +81,11 @@ Current high-level flow:
 
 1. User submits a `stageId`.
 2. API validates input and resolves the authenticated user's active organization via `requireActiveOrganization`.
-3. Parent Worker loads the staged tarball in a Dynamic Worker.
-4. Gateway attaches npm auth only for allowed npm registry endpoints.
+3. Parent Worker loads the staged tarball in a Dynamic Worker and fetches staged metadata (`GET /-/stage/{stageId}`) in parallel.
+4. Gateway attaches npm auth only for allowed sandbox npm registry endpoints.
 5. Sandbox extracts bounded file records and package metadata.
-6. Parent Worker fetches npm package metadata and the previous published tarball when available.
-7. Sandbox extracts the previous tarball.
+6. Parent Worker fetches npm package metadata, chooses a tag-aware comparison baseline, and downloads the selected previous published tarball when available.
+7. Sandbox extracts the selected previous tarball.
 8. Parent Worker computes:
    - package file diff;
    - package.json diff;

--- a/docs/cost-model.md
+++ b/docs/cost-model.md
@@ -51,7 +51,7 @@ Workers AI is ~90% of the variable cost at every scale above the smallest tier.
 
 ## Where the money goes
 
-- **Workers AI**: dominant at scale. Biggest levers: (a) keep only changed files in the input (already enforced in [`ai-review.ts`](../server/lib/ai-review.ts)); (b) keep the system prompt cache-friendly via `AI_CACHE_AFFINITY`; (c) pick the cheapest model that still produces useful structured output.
+- **Workers AI**: dominant at scale. Biggest levers: (a) choose the correct tag-aware comparison baseline so changed files reflect the release channel under review; (b) keep only changed files in the input (already enforced in [`ai-review.ts`](../server/lib/ai-review.ts)); (c) keep the system prompt cache-friendly via `AI_CACHE_AFFINITY`; (d) pick the cheapest model that still produces useful structured output. See [`diff-baseline.md`](./diff-baseline.md).
 - **D1 storage growth**: ~500 KB–2 MB per scan retained. At 50k scans/mo that's 25–100 GB/mo accumulating. Add a retention/GC policy before this becomes a line item.
 - **KV storage**: trivial. The added `COMPARE_CACHE` is essentially free across any realistic catalog of cached versions; it primarily saves sandbox CPU and tarball egress.
 - **Sandbox compute**: bounded per scan (2 Dynamic Workers, ~3s CPU each). The KV cache means alternate-version diffs in the detail page no longer linearly multiply this cost.

--- a/docs/diff-baseline.md
+++ b/docs/diff-baseline.md
@@ -1,0 +1,60 @@
+# Diff Baseline Strategy
+
+This note records the baseline-selection decision for staged publish review.
+
+## Implemented behavior
+
+The scan pipeline downloads the staged tarball and fetches staged metadata in parallel. It reads `package.json`, fetches registry package metadata, then diffs the staged artifact against `pickBaselineVersion(metadata, stagedVersion, stagedTag)`.
+
+The baseline selector is intentionally tag-aware:
+
+1. If the staged metadata has a tag and current package metadata has `dist-tags[tag]` pointing at a published version other than the staged version, the scan diffs against that version.
+2. Otherwise, it falls back to the highest semver predecessor lower than the staged version.
+3. If there is no lower predecessor, it falls back to the highest published semver-like version.
+4. If no baseline can be selected or downloaded, the scan proceeds as an all-added diff and records the baseline reason in `summary_json.baseline`.
+
+This avoids forcing `2.0.0-beta.3 --tag beta` against `latest` and keeps maintenance or custom-channel releases from being compared with an unrelated highest-semver channel. A wrong baseline inflates changed-file count, which makes human review noisier and will increase AI input size when AI review returns.
+
+## npm staged metadata
+
+As of the npm stage API/CLI docs published with npm CLI 11.15, staged publish metadata exposes the staged package's package name, version, dist-tag, actor, access, and shasum through both the staged list endpoint and the staged detail endpoint:
+
+- `GET /-/stage`
+- `GET /-/stage/{stage-id}`
+
+The CLI docs also state that the staged tag follows normal publish tag behavior, defaults to `latest` when omitted, and is immutable for the staged package.
+
+The API gives us the staged tag. It does not document an explicit "previous version", nor a snapshot of the tag target at stage creation time. Because npm allows normal publishes while staged packages are pending, the tag target can theoretically move between stage creation and our scan. Therefore, tag-following baseline selection should be treated as an inference from current registry metadata, not as a registry-provided historical fact.
+
+## Baseline data stored on reports
+
+Completed scans persist:
+
+- `summary_json.stagedPublish` with the parsed staged metadata (`id`, package name, version, tag, actor/access/timestamp, and npm shasum when present);
+- `summary_json.baseline` with selected version, staged tag, selection source, current dist-tag target, and reason;
+- the existing `scans.previous_version` column as the actual parsed version of the downloaded comparison tarball.
+
+The pipeline cross-checks staged detail package name/version against the staged tarball's `package.json`. A mismatch produces a critical deterministic finding (`stage.metadata-mismatch`) and suppresses tag-based baseline selection for that scan. The staged API also exposes a shasum, but the current sandbox does not hash the compressed tarball bytes, so shasum verification is recorded as future hardening rather than implemented.
+
+## AI token impact
+
+AI review is disabled in the current pipeline, but when it returns it should remain diff-first:
+
+- deterministic findings stay authoritative and are computed before AI;
+- AI sees package-json diff, deterministic findings, changed-file diff, and bounded samples for changed files only;
+- unchanged files should not be sent as AI review evidence unless a deterministic rule needs context;
+- changed files should be ranked so high-signal files are kept when caps are hit.
+
+Tag-aware baseline selection is the largest low-risk token reducer because it prevents channel releases from appearing as a broad diff against the wrong published artifact. It improves the evidence for both humans and models without reducing deterministic coverage of the staged artifact itself.
+
+## Deterministic findings and diff status
+
+Do not make deterministic safety depend only on the diff. The staged artifact is still the package under review, so risky install hooks, native artifacts, credential access, and secrets must be detected even if they existed before.
+
+However, report presentation and AI payload construction should distinguish:
+
+- new or modified risky evidence, which is release-blocking signal;
+- removed risky evidence, which may be positive but still deserves context;
+- unchanged risky evidence, which is pre-existing package risk and should not dominate "what changed" unless policy says the product blocks any release containing that behavior.
+
+This avoids hiding persistent risk while keeping the staged-publish review centered on the actual release delta.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -105,6 +105,8 @@ Allowed credentialed egress through `NpmStageGateway`:
 - `GET` npm package metadata JSON endpoint;
 - `GET` published npm `.tgz` tarballs for previous-version diffing.
 
+The trusted parent Worker also fetches staged metadata (`GET /-/stage/{stageId}`) with the organization credential so it can select the comparison baseline from the staged dist-tag. That metadata is not fetched from inside the sandbox.
+
 This matches Cloudflare's [outbound Worker sandbox-auth model](https://blog.cloudflare.com/sandbox-auth/): auth injection happens in a trusted WorkerEntrypoint using parent-provided props, not inside the sandboxed workload.
 
 Blocked:

--- a/server/lib/registry.ts
+++ b/server/lib/registry.ts
@@ -4,6 +4,20 @@ export interface RegistryMetadata {
   time?: Record<string, string>;
 }
 
+export type BaselineSelectionSource =
+  | "dist-tag"
+  | "semver-predecessor"
+  | "highest-published"
+  | "none";
+
+export interface BaselineVersionSelection {
+  version: string | null;
+  tag: string | null;
+  source: BaselineSelectionSource;
+  distTagVersion: string | null;
+  reason: string;
+}
+
 const NPM_PACKAGE_NAME_RE = /^(?:@[a-z0-9][a-z0-9._~-]*\/)?[a-z0-9][a-z0-9._~-]*$/;
 
 export function isValidNpmPackageName(name: string): boolean {
@@ -38,19 +52,129 @@ export function pickPreviousVersion(
   metadata: { versions?: Record<string, unknown> },
   stagedVersion: string,
 ) {
-  const versions = Object.keys(metadata.versions || {}).filter(
-    (version) => version !== stagedVersion && /^\d+\.\d+\.\d+/.test(version),
-  );
-  versions.sort(compareSemver);
-  return versions.at(-1) || null;
+  return pickBaselineVersion(metadata, stagedVersion).version;
+}
+
+export function pickBaselineVersion(
+  metadata: { versions?: Record<string, unknown>; "dist-tags"?: Record<string, string> },
+  stagedVersion: string,
+  stagedTag?: string | null,
+): BaselineVersionSelection {
+  const tag = stagedTag?.trim() || null;
+  const versionsByName = metadata.versions || {};
+  const distTagVersion = tag ? metadata["dist-tags"]?.[tag] || null : null;
+
+  if (tag && distTagVersion && distTagVersion !== stagedVersion && versionsByName[distTagVersion]) {
+    return {
+      version: distTagVersion,
+      tag,
+      source: "dist-tag",
+      distTagVersion,
+      reason: `dist-tag:${tag}`,
+    };
+  }
+
+  const fallback = pickSemverFallbackVersion(versionsByName, stagedVersion);
+  if (fallback) {
+    return {
+      version: fallback.version,
+      tag,
+      source: fallback.source,
+      distTagVersion,
+      reason: fallback.reason,
+    };
+  }
+
+  return {
+    version: null,
+    tag,
+    source: "none",
+    distTagVersion,
+    reason: tag && distTagVersion === stagedVersion ? "dist-tag-points-at-staged-version" : "none",
+  };
 }
 
 export function compareSemver(a: string, b: string) {
-  const pa = a.split(/[.-]/).map((part) => Number(part) || 0);
-  const pb = b.split(/[.-]/).map((part) => Number(part) || 0);
-  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-    const diff = (pa[i] || 0) - (pb[i] || 0);
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (pa && pb) return compareParsedSemver(pa, pb);
+  return a.localeCompare(b);
+}
+
+function pickSemverFallbackVersion(
+  versionsByName: Record<string, unknown>,
+  stagedVersion: string,
+): { version: string; source: "semver-predecessor" | "highest-published"; reason: string } | null {
+  const candidates = Object.keys(versionsByName).filter(
+    (version) => version !== stagedVersion && parseSemver(version),
+  );
+  if (!candidates.length) return null;
+  candidates.sort(compareSemver);
+
+  const staged = parseSemver(stagedVersion);
+  if (staged) {
+    const predecessors = candidates.filter((version) => compareSemver(version, stagedVersion) < 0);
+    const previous = predecessors.at(-1);
+    if (previous) {
+      return {
+        version: previous,
+        source: "semver-predecessor",
+        reason: "semver-predecessor",
+      };
+    }
+  }
+
+  return {
+    version: candidates.at(-1)!,
+    source: "highest-published",
+    reason: "highest-published-fallback",
+  };
+}
+
+interface ParsedSemver {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+}
+
+function parseSemver(version: string): ParsedSemver | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+.+)?$/.exec(version);
+  if (!match) return null;
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ? match[4].split(".") : [],
+  };
+}
+
+function compareParsedSemver(a: ParsedSemver, b: ParsedSemver) {
+  for (const key of ["major", "minor", "patch"] as const) {
+    const diff = a[key] - b[key];
     if (diff) return diff;
+  }
+  if (!a.prerelease.length && !b.prerelease.length) return 0;
+  if (!a.prerelease.length) return 1;
+  if (!b.prerelease.length) return -1;
+  for (let i = 0; i < Math.max(a.prerelease.length, b.prerelease.length); i++) {
+    const left = a.prerelease[i];
+    const right = b.prerelease[i];
+    if (left === undefined) return -1;
+    if (right === undefined) return 1;
+    const leftNumber = /^\d+$/.test(left) ? Number(left) : null;
+    const rightNumber = /^\d+$/.test(right) ? Number(right) : null;
+    if (leftNumber !== null && rightNumber !== null) {
+      const diff = leftNumber - rightNumber;
+      if (diff) return diff;
+    } else if (leftNumber !== null) {
+      return -1;
+    } else if (rightNumber !== null) {
+      return 1;
+    } else {
+      const diff = left.localeCompare(right);
+      if (diff) return diff;
+    }
   }
   return 0;
 }

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -36,6 +36,7 @@ export const DETERMINISTIC_RULE_IDS = {
   fileNativeArtifact: "file.native-artifact",
   diffCredentialFileAdded: "diff.credential-file-added",
   diffLargeNewFile: "diff.large-new-file",
+  stageMetadataMismatch: "stage.metadata-mismatch",
 } as const;
 
 export interface PackageJsonSummary {

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -1,18 +1,25 @@
 import { persistScan, recordScanEvent, type AppDb, type WorkspaceSession } from "../db";
 import { runSelectiveAiReview, type AiReview } from "./ai-review";
-import { fetchPackageMetadata, pickPreviousVersion } from "./registry";
+import {
+  fetchPackageMetadata,
+  pickBaselineVersion,
+  type BaselineVersionSelection,
+} from "./registry";
 import {
   createPackageDiff,
   deterministicFindings,
+  DETERMINISTIC_RULE_IDS,
   DETERMINISTIC_RULES_VERSION,
   redactFileRecords,
   redactFindings,
   redactJson,
   summarizePackageJsonDiff,
+  type Finding,
   type PackageJsonSummary,
 } from "./review";
 import { computeScanRisk } from "./risk";
-import { downloadInSandbox } from "./sandbox";
+import { downloadInSandbox, type DownloadResult } from "./sandbox";
+import { fetchStagedPublishDetails, type StagedPublishDetails } from "./staged-publishes";
 import type { ScanInput, ScanResult } from "../types";
 
 export interface ScanPipelineOptions extends ScanInput {
@@ -35,30 +42,45 @@ export async function runScanPipeline(
 ): Promise<ScanResult> {
   const { env, executionCtx, db, session } = context;
 
-  const staged = await downloadInSandbox(env, executionCtx, {
-    stageId: input.stageId,
-    maxFiles: input.maxFiles,
-    maxBytesPerFile: input.maxBytesPerFile,
-    npmToken: input.npmToken,
-    npmRegistry: input.npmRegistry,
-  });
+  const [staged, stagedDetails] = await Promise.all([
+    downloadInSandbox(env, executionCtx, {
+      stageId: input.stageId,
+      maxFiles: input.maxFiles,
+      maxBytesPerFile: input.maxBytesPerFile,
+      npmToken: input.npmToken,
+      npmRegistry: input.npmRegistry,
+    }),
+    maybeFetchStagedDetails(env, input),
+  ]);
 
-  const previous = await maybeDownloadPreviousVersion(
+  const stagedMetadataFindings = createStagedMetadataFindings(
+    stagedDetails,
+    staged.packageJson ?? null,
+  );
+  const stagedTag = stagedMetadataFindings.length ? null : (stagedDetails?.tag ?? null);
+  const previousResult = await maybeDownloadPreviousVersion(
     env,
     executionCtx,
     staged.packageJson ?? null,
+    stagedTag,
     input,
   );
+  const previous = previousResult.previous;
+  const baseline = previousResult.baseline;
   const diff = previous
     ? createPackageDiff(previous.files, staged.files)
     : createPackageDiff([], staged.files);
   const packageJsonDiff = redactJson(
     summarizePackageJsonDiff(previous?.packageJson, staged.packageJson),
   );
-  const ruleFindings = redactFindings(deterministicFindings(staged.files, diff));
+  const ruleFindings = redactFindings([
+    ...deterministicFindings(staged.files, diff),
+    ...stagedMetadataFindings,
+  ]);
   const redactedStagedFiles = redactFileRecords(staged.files);
   const redactedPackageJson = redactJson(staged.packageJson ?? null);
   const redactedPreviousPackageJson = redactJson(previous?.packageJson ?? null);
+  const redactedStagedDetails = redactJson(summarizeStagedDetails(stagedDetails));
   const scanId = input.scanId || crypto.randomUUID();
   // AI review is disabled while we work toward a paid-tier offering. The call,
   // escalation logging, and risk wiring below stay intact (gated by `if (false)`)
@@ -101,7 +123,7 @@ export async function runScanPipeline(
     tokenExposedToSandbox: false,
     directSandboxNetwork: false,
     outboundPolicy:
-      "only npm staged tarball, published tarball, and package metadata endpoints via gateway",
+      "sandbox uses the gateway only for npm staged tarball, published tarball, and package metadata endpoints; parent fetches staged metadata with the organization credential",
     aiInputPolicy:
       "package bytes are untrusted evidence, not instructions; static safety prompt is prefix-cache friendly and AI cannot downgrade deterministic findings",
     fileExplorerPolicy:
@@ -114,8 +136,10 @@ export async function runScanPipeline(
     package: {
       name: staged.packageJson?.name ?? null,
       stagedVersion: staged.packageJson?.version ?? null,
+      stagedTag: stagedDetails?.tag ?? null,
       previousVersion: previous?.packageJson?.version ?? null,
     },
+    baseline,
     fileCount: staged.files.length,
     previousFileCount: previous?.files.length ?? 0,
     packageJson: redactedPackageJson,
@@ -131,7 +155,9 @@ export async function runScanPipeline(
     version: 1,
     rulesVersion: DETERMINISTIC_RULES_VERSION,
     stageId: input.stageId,
+    stagedPublish: redactedStagedDetails,
     package: result.package,
+    baseline,
     fileCount: result.fileCount,
     previousFileCount: result.previousFileCount,
     packageJson: redactedPackageJson,
@@ -163,6 +189,8 @@ export async function runScanPipeline(
       },
       packageJsonDiff,
       diff,
+      stagedPublish: redactedStagedDetails,
+      baseline,
       safety: result.safety,
     },
     ai: aiFindings,
@@ -182,6 +210,8 @@ export async function runScanPipeline(
         stageId: input.stageId,
         packageName: result.package.name,
         stagedVersion: result.package.stagedVersion,
+        stagedTag: result.package.stagedTag,
+        baseline,
         risk,
       },
     });
@@ -208,22 +238,98 @@ async function maybeDownloadPreviousVersion(
   env: Cloudflare.Env,
   ctx: ExecutionContext,
   pkg: PackageJsonSummary | null,
+  stagedTag: string | null,
   input: ScanInput & { npmToken?: string; npmRegistry?: string },
-) {
-  if (!pkg?.name || !pkg.version) return null;
+): Promise<{ previous: DownloadResult | null; baseline: BaselineVersionSelection }> {
+  if (!pkg?.name || !pkg.version) {
+    return {
+      previous: null,
+      baseline: emptyBaseline(stagedTag, "package-json-missing-name-or-version"),
+    };
+  }
   const metadata = await fetchPackageMetadata(env, pkg.name, {
     npmToken: input.npmToken,
     npmRegistry: input.npmRegistry,
   }).catch(() => null);
-  if (!metadata) return null;
-  const version = pickPreviousVersion(metadata, pkg.version);
-  const tarballUrl = version ? metadata.versions?.[version]?.dist?.tarball : null;
-  if (!version || !tarballUrl) return null;
-  return downloadInSandbox(env, ctx, {
+  if (!metadata) {
+    return { previous: null, baseline: emptyBaseline(stagedTag, "metadata-unavailable") };
+  }
+  const baseline = pickBaselineVersion(metadata, pkg.version, stagedTag);
+  const tarballUrl = baseline.version ? metadata.versions?.[baseline.version]?.dist?.tarball : null;
+  if (!baseline.version || !tarballUrl) {
+    return {
+      previous: null,
+      baseline: baseline.version
+        ? { ...baseline, reason: `${baseline.reason}:no-tarball` }
+        : baseline,
+    };
+  }
+  const previous = await downloadInSandbox(env, ctx, {
     tarballUrl,
     maxFiles: input.maxFiles,
     maxBytesPerFile: input.maxBytesPerFile,
     npmToken: input.npmToken,
     npmRegistry: input.npmRegistry,
   });
+  return { previous, baseline };
+}
+
+async function maybeFetchStagedDetails(
+  env: Cloudflare.Env,
+  input: ScanPipelineOptions,
+): Promise<StagedPublishDetails | null> {
+  if (!input.npmToken) return null;
+  const registry = input.npmRegistry || env.NPM_REGISTRY || "https://registry.npmjs.org";
+  return fetchStagedPublishDetails(registry, input.npmToken, input.stageId).catch(() => null);
+}
+
+function emptyBaseline(tag: string | null, reason: string): BaselineVersionSelection {
+  return {
+    version: null,
+    tag,
+    source: "none",
+    distTagVersion: null,
+    reason,
+  };
+}
+
+function summarizeStagedDetails(details: StagedPublishDetails | null) {
+  if (!details) return null;
+  return {
+    id: details.id,
+    packageName: details.packageName,
+    version: details.version,
+    tag: details.tag,
+    access: details.access,
+    actor: details.actor,
+    actorType: details.actorType,
+    createdAt: details.createdAt,
+    shasum: details.shasum,
+  };
+}
+
+function createStagedMetadataFindings(
+  details: StagedPublishDetails | null,
+  pkg: PackageJsonSummary | null,
+): Finding[] {
+  if (!details || !pkg) return [];
+  const mismatches: string[] = [];
+  if (details.packageName && pkg.name && details.packageName !== pkg.name) {
+    mismatches.push(`packageName ${details.packageName} != package.json name ${pkg.name}`);
+  }
+  if (details.version && pkg.version && details.version !== pkg.version) {
+    mismatches.push(`version ${details.version} != package.json version ${pkg.version}`);
+  }
+  if (!mismatches.length) return [];
+  return [
+    {
+      severity: "critical",
+      file: "package.json",
+      evidence: mismatches.join("; "),
+      reason:
+        "npm staged metadata does not match the staged tarball package.json, so the release target cannot be trusted",
+      ruleId: DETERMINISTIC_RULE_IDS.stageMetadataMismatch,
+      ruleVersion: DETERMINISTIC_RULES_VERSION,
+    },
+  ];
 }

--- a/server/lib/staged-publishes.ts
+++ b/server/lib/staged-publishes.ts
@@ -7,8 +7,12 @@ export interface StagedPublishItem {
   tag: string | null;
   access: string | null;
   actor: string | null;
+  actorType: string | null;
   createdAt: string | null;
+  shasum: string | null;
 }
+
+export type StagedPublishDetails = StagedPublishItem;
 
 export interface StagedPublishesPage {
   items: StagedPublishItem[];
@@ -62,6 +66,30 @@ export async function listStagedPublishes(
   return parseStagedPublishesResponse(data);
 }
 
+export async function fetchStagedPublishDetails(
+  registryUrl: string,
+  token: string,
+  stageId: string,
+): Promise<StagedPublishDetails> {
+  if (!STAGE_ID_RE.test(stageId)) throw new Error("invalid stageId");
+  const registry = normalizeRegistryUrl(registryUrl);
+  const response = await fetch(`${registry}/-/stage/${encodeURIComponent(stageId)}`, {
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${token}`,
+      "user-agent": "staged-publish-review/staged-view",
+    },
+  });
+  if (!response.ok) {
+    const detail = await response.text().catch(() => "");
+    throw new StagedPublishesFetchError(response.status, detail.slice(0, 200));
+  }
+  const data = (await response.json().catch(() => null)) as unknown;
+  const parsed = parseStagedPublishDetails(data, stageId);
+  if (!parsed) throw new StagedPublishesFetchError(response.status, "invalid staged details");
+  return parsed;
+}
+
 export class StagedPublishesFetchError extends Error {
   constructor(
     readonly status: number,
@@ -78,23 +106,34 @@ export function parseStagedPublishesResponse(data: unknown): StagedPublishesPage
   const items: StagedPublishItem[] = [];
   for (const entry of rawItems) {
     if (!isRecord(entry)) continue;
-    const id = readString(entry.id);
-    if (!id || !STAGE_ID_RE.test(id)) continue;
-    items.push({
-      id,
-      packageName: readString(entry.packageName) ?? readString(entry.name),
-      version: readString(entry.version),
-      tag: readString(entry.tag),
-      access: readString(entry.access),
-      actor: readString(entry.actor),
-      createdAt: readString(entry.createdAt) ?? readString(entry.created_at),
-    });
+    const item = parseStagedPublishDetails(entry);
+    if (item) items.push(item);
   }
   return {
     items,
     total: readNumber(root.total),
     perPage: readNumber(root.perPage),
     page: readNumber(root.page),
+  };
+}
+
+export function parseStagedPublishDetails(
+  data: unknown,
+  fallbackId?: string,
+): StagedPublishDetails | null {
+  if (!isRecord(data)) return null;
+  const id = readString(data.id) ?? fallbackId ?? null;
+  if (!id || !STAGE_ID_RE.test(id)) return null;
+  return {
+    id,
+    packageName: readString(data.packageName) ?? readString(data.name),
+    version: readString(data.version),
+    tag: readString(data.tag),
+    access: readString(data.access),
+    actor: readString(data.actor),
+    actorType: readString(data.actorType) ?? readString(data.actor_type),
+    createdAt: readString(data.createdAt) ?? readString(data.created_at),
+    shasum: readString(data.shasum),
   };
 }
 

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,5 +1,6 @@
 import type { Auth, AuthSession } from "./lib/auth";
 import type { AiReview } from "./lib/ai-review";
+import type { BaselineVersionSelection } from "./lib/registry";
 import type {
   DiffEntry,
   Finding,
@@ -29,8 +30,10 @@ export interface ScanResult {
   package: {
     name: string | null;
     stagedVersion: string | null;
+    stagedTag: string | null;
     previousVersion: string | null;
   };
+  baseline: BaselineVersionSelection;
   fileCount: number;
   previousFileCount: number;
   packageJson: PackageJsonSummary | null;

--- a/test/registry.test.mjs
+++ b/test/registry.test.mjs
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { isValidNpmPackageName } from "../server/lib/registry.ts";
+import {
+  compareSemver,
+  isValidNpmPackageName,
+  pickBaselineVersion,
+  pickPreviousVersion,
+} from "../server/lib/registry.ts";
 
 describe("npm package name validation", () => {
   test("accepts well-formed unscoped and scoped names", () => {
@@ -18,5 +23,86 @@ describe("npm package name validation", () => {
     expect(isValidNpmPackageName("FOO")).toBe(false);
     expect(isValidNpmPackageName("")).toBe(false);
     expect(isValidNpmPackageName("a".repeat(215))).toBe(false);
+  });
+});
+
+describe("registry baseline selection", () => {
+  test("prefers the staged dist-tag target when it is published", () => {
+    const metadata = {
+      versions: {
+        "1.4.0": {},
+        "2.0.0-beta.2": {},
+      },
+      "dist-tags": {
+        latest: "1.4.0",
+        beta: "2.0.0-beta.2",
+      },
+    };
+
+    expect(pickBaselineVersion(metadata, "2.0.0-beta.3", "beta")).toMatchObject({
+      version: "2.0.0-beta.2",
+      tag: "beta",
+      source: "dist-tag",
+      distTagVersion: "2.0.0-beta.2",
+    });
+  });
+
+  test("falls back to the semver predecessor instead of a newer published channel", () => {
+    const metadata = {
+      versions: {
+        "1.0.0": {},
+        "1.1.0": {},
+        "2.0.0": {},
+      },
+      "dist-tags": {
+        latest: "2.0.0",
+      },
+    };
+
+    expect(pickBaselineVersion(metadata, "1.2.0", "maintenance")).toMatchObject({
+      version: "1.1.0",
+      source: "semver-predecessor",
+      distTagVersion: null,
+    });
+  });
+
+  test("falls back when the staged tag points at the staged version", () => {
+    const metadata = {
+      versions: {
+        "1.0.0": {},
+        "1.1.0": {},
+      },
+      "dist-tags": {
+        latest: "1.1.0",
+      },
+    };
+
+    expect(pickBaselineVersion(metadata, "1.1.0", "latest")).toMatchObject({
+      version: "1.0.0",
+      tag: "latest",
+      source: "semver-predecessor",
+      distTagVersion: "1.1.0",
+    });
+  });
+
+  test("keeps the legacy helper as an untagged predecessor picker", () => {
+    expect(
+      pickPreviousVersion(
+        {
+          versions: {
+            "1.0.0": {},
+            "1.1.0-beta.2": {},
+            "1.1.0-beta.10": {},
+            "2.0.0": {},
+          },
+        },
+        "1.1.0-beta.11",
+      ),
+    ).toBe("1.1.0-beta.10");
+  });
+
+  test("sorts semver prereleases before releases and numeric prerelease ids numerically", () => {
+    expect(compareSemver("1.0.0-beta.10", "1.0.0-beta.2")).toBeGreaterThan(0);
+    expect(compareSemver("1.0.0", "1.0.0-beta.10")).toBeGreaterThan(0);
   });
 });

--- a/test/scan-pipeline.test.mjs
+++ b/test/scan-pipeline.test.mjs
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const dbMock = vi.hoisted(() => ({
+  persistScan: vi.fn(async () => ({ persisted: true })),
+  recordScanEvent: vi.fn(async () => undefined),
+}));
+const registryMock = vi.hoisted(() => ({
+  fetchPackageMetadata: vi.fn(),
+}));
+const sandboxMock = vi.hoisted(() => ({
+  downloadInSandbox: vi.fn(),
+}));
+const stagedMock = vi.hoisted(() => ({
+  fetchStagedPublishDetails: vi.fn(),
+}));
+
+vi.mock("../server/db/index.ts", () => dbMock);
+vi.mock("../server/lib/registry.ts", async () => ({
+  ...(await vi.importActual("../server/lib/registry.ts")),
+  fetchPackageMetadata: registryMock.fetchPackageMetadata,
+}));
+vi.mock("../server/lib/sandbox.ts", () => sandboxMock);
+vi.mock("../server/lib/staged-publishes.ts", async () => ({
+  ...(await vi.importActual("../server/lib/staged-publishes.ts")),
+  fetchStagedPublishDetails: stagedMock.fetchStagedPublishDetails,
+}));
+
+const { runScanPipeline } = await import("../server/lib/scan-pipeline.ts");
+
+describe("scan pipeline baseline selection", () => {
+  beforeEach(() => {
+    stagedMock.fetchStagedPublishDetails.mockResolvedValue({
+      id: "stage-beta-123",
+      packageName: "@scope/pkg",
+      version: "2.0.0-beta.3",
+      tag: "beta",
+      access: "public",
+      actor: "octocat",
+      actorType: "user",
+      createdAt: "2026-03-16T09:00:00.000Z",
+      shasum: "4f7f5f1d5bcf2f72f6e4d6c4f3b2812d8a2f6c19",
+    });
+    registryMock.fetchPackageMetadata.mockResolvedValue({
+      versions: {
+        "1.4.0": { dist: { tarball: "https://registry.npmjs.org/@scope/pkg/-/pkg-1.4.0.tgz" } },
+        "2.0.0-beta.2": {
+          dist: { tarball: "https://registry.npmjs.org/@scope/pkg/-/pkg-2.0.0-beta.2.tgz" },
+        },
+      },
+      "dist-tags": {
+        latest: "1.4.0",
+        beta: "2.0.0-beta.2",
+      },
+    });
+    sandboxMock.downloadInSandbox.mockImplementation(async (_env, _ctx, options) => {
+      if (options.stageId) {
+        return {
+          files: [
+            {
+              path: "package.json",
+              size: 64,
+              sha256: "staged-pkg",
+              flags: [],
+              textSample: JSON.stringify({
+                name: "@scope/pkg",
+                version: "2.0.0-beta.3",
+              }),
+            },
+          ],
+          packageJson: { name: "@scope/pkg", version: "2.0.0-beta.3" },
+        };
+      }
+      return {
+        files: [
+          {
+            path: "package.json",
+            size: 64,
+            sha256: "previous-pkg",
+            flags: [],
+            textSample: JSON.stringify({
+              name: "@scope/pkg",
+              version: "2.0.0-beta.2",
+            }),
+          },
+        ],
+        packageJson: { name: "@scope/pkg", version: "2.0.0-beta.2" },
+      };
+    });
+  });
+
+  afterEach(() => {
+    dbMock.persistScan.mockClear();
+    dbMock.recordScanEvent.mockClear();
+    registryMock.fetchPackageMetadata.mockReset();
+    sandboxMock.downloadInSandbox.mockReset();
+    stagedMock.fetchStagedPublishDetails.mockReset();
+  });
+
+  test("diffs a staged beta release against the current beta dist-tag target", async () => {
+    const result = await runScanPipeline(
+      {
+        env: { NPM_REGISTRY: "https://registry.npmjs.org" },
+        executionCtx: {},
+        db: {},
+        session: { userId: "user_1" },
+      },
+      {
+        scanId: "scan_1",
+        stageId: "stage-beta-123",
+        organizationId: "org_1",
+        npmToken: "npm_secret_token",
+      },
+    );
+
+    expect(stagedMock.fetchStagedPublishDetails).toHaveBeenCalledWith(
+      "https://registry.npmjs.org",
+      "npm_secret_token",
+      "stage-beta-123",
+    );
+    expect(sandboxMock.downloadInSandbox.mock.calls[1]?.[2]).toMatchObject({
+      tarballUrl: "https://registry.npmjs.org/@scope/pkg/-/pkg-2.0.0-beta.2.tgz",
+    });
+    expect(result.baseline).toMatchObject({
+      version: "2.0.0-beta.2",
+      tag: "beta",
+      source: "dist-tag",
+      distTagVersion: "2.0.0-beta.2",
+    });
+    expect(dbMock.persistScan.mock.calls[0]?.[1]).toMatchObject({
+      previousPackageJson: { name: "@scope/pkg", version: "2.0.0-beta.2" },
+      summary: {
+        baseline: {
+          version: "2.0.0-beta.2",
+          tag: "beta",
+          source: "dist-tag",
+        },
+      },
+    });
+  });
+
+  test("suppresses tag baseline selection when staged metadata disagrees with the tarball", async () => {
+    stagedMock.fetchStagedPublishDetails.mockResolvedValue({
+      id: "stage-beta-123",
+      packageName: "@other/pkg",
+      version: "2.0.0-beta.3",
+      tag: "beta",
+      access: "public",
+      actor: "octocat",
+      actorType: "user",
+      createdAt: "2026-03-16T09:00:00.000Z",
+      shasum: "4f7f5f1d5bcf2f72f6e4d6c4f3b2812d8a2f6c19",
+    });
+    registryMock.fetchPackageMetadata.mockResolvedValue({
+      versions: {
+        "2.0.0-beta.2": {
+          dist: { tarball: "https://registry.npmjs.org/@scope/pkg/-/pkg-2.0.0-beta.2.tgz" },
+        },
+        "9.0.0": { dist: { tarball: "https://registry.npmjs.org/@scope/pkg/-/pkg-9.0.0.tgz" } },
+      },
+      "dist-tags": {
+        beta: "9.0.0",
+      },
+    });
+
+    const result = await runScanPipeline(
+      {
+        env: { NPM_REGISTRY: "https://registry.npmjs.org" },
+        executionCtx: {},
+        db: {},
+        session: { userId: "user_1" },
+      },
+      {
+        scanId: "scan_1",
+        stageId: "stage-beta-123",
+        organizationId: "org_1",
+        npmToken: "npm_secret_token",
+      },
+    );
+
+    expect(result.baseline).toMatchObject({
+      version: "2.0.0-beta.2",
+      tag: null,
+      source: "semver-predecessor",
+    });
+    expect(result.ruleFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: "critical",
+          ruleId: "stage.metadata-mismatch",
+          evidence: "packageName @other/pkg != package.json name @scope/pkg",
+        }),
+      ]),
+    );
+  });
+});

--- a/test/staged-publishes.test.mjs
+++ b/test/staged-publishes.test.mjs
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  fetchStagedPublishDetails,
+  parseStagedPublishDetails,
+  parseStagedPublishesResponse,
+} from "../server/lib/staged-publishes.ts";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("staged publish metadata", () => {
+  test("parses list items with tag and shasum metadata", () => {
+    const parsed = parseStagedPublishesResponse({
+      items: [
+        {
+          id: "stage-beta-123",
+          packageName: "@npmcli/example-package",
+          version: "2.0.0-beta.3",
+          tag: "beta",
+          createdAt: "2026-03-16T09:00:00.000Z",
+          actor: "octocat",
+          actorType: "user",
+          access: "public",
+          shasum: "4f7f5f1d5bcf2f72f6e4d6c4f3b2812d8a2f6c19",
+        },
+      ],
+      total: 1,
+      perPage: 10,
+      page: 0,
+    });
+
+    expect(parsed.items).toEqual([
+      {
+        id: "stage-beta-123",
+        packageName: "@npmcli/example-package",
+        version: "2.0.0-beta.3",
+        tag: "beta",
+        createdAt: "2026-03-16T09:00:00.000Z",
+        actor: "octocat",
+        actorType: "user",
+        access: "public",
+        shasum: "4f7f5f1d5bcf2f72f6e4d6c4f3b2812d8a2f6c19",
+      },
+    ]);
+  });
+
+  test("parses detail responses with a fallback id", () => {
+    expect(
+      parseStagedPublishDetails(
+        {
+          packageName: "example-lib",
+          version: "0.4.0",
+          tag: "next",
+          actor_type: "trusted automation",
+        },
+        "stage-next-123",
+      ),
+    ).toMatchObject({
+      id: "stage-next-123",
+      packageName: "example-lib",
+      version: "0.4.0",
+      tag: "next",
+      actorType: "trusted automation",
+    });
+  });
+
+  test("fetches staged details from the stage view endpoint", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      expect(String(url)).toBe("https://registry.npmjs.org/-/stage/stage-next-123");
+      expect(init.headers.authorization).toBe("Bearer npm_secret_token");
+      expect(init.headers["user-agent"]).toBe("staged-publish-review/staged-view");
+      return Response.json({
+        id: "stage-next-123",
+        packageName: "example-lib",
+        version: "0.4.0",
+        tag: "next",
+      });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      fetchStagedPublishDetails("https://registry.npmjs.org", "npm_secret_token", "stage-next-123"),
+    ).resolves.toMatchObject({
+      id: "stage-next-123",
+      packageName: "example-lib",
+      version: "0.4.0",
+      tag: "next",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a tag-aware comparison baseline for staged publish scans. The scan pipeline now fetches staged metadata, uses the staged dist-tag target as the preferred previous version, and falls back to semver predecessor behavior when tag metadata is unavailable or unsuitable.

## Details

- Fetch and parse `GET /-/stage/{stageId}` metadata, including package name, version, tag, actor/access, and shasum.
- Select the diff baseline from the staged tag's current `dist-tags` target before falling back to semver predecessor selection.
- Persist staged metadata and baseline selection details in report summary JSON.
- Add a deterministic `stage.metadata-mismatch` finding when staged metadata disagrees with the tarball `package.json`.
- Document the baseline strategy, npm metadata constraints, and security boundary changes.

## Validation

- `pnpm run verify`