### PR TITLE
Log unhandled request errors

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -187,6 +187,17 @@ app.route("/api/v1/staged-publishes", stagedPublishesRoutes);
 
 app.notFound((c) => c.json({ error: "not found" }, 404));
 
+app.onError((err, c) => {
+  console.error("unhandled request error", {
+    method: c.req.method,
+    path: c.req.path,
+    name: err instanceof Error ? err.name : "UnknownError",
+    message: err instanceof Error ? err.message : String(err),
+    stack: err instanceof Error ? err.stack : undefined,
+  });
+  return c.json({ error: "internal error" }, 500);
+});
+
 export default {
   fetch: app.fetch,
   async queue(batch: MessageBatch<ScanQueueMessage>, env: Cloudflare.Env, ctx: ExecutionContext) {


### PR DESCRIPTION
## Summary
- Adds a global `app.onError` handler in `server/index.ts` that emits a structured `console.error` (method, path, error name/message/stack) and returns a generic `{ error: "internal error" }` 500.
- Before this, uncaught errors thrown by route handlers became opaque 500s with no log trail; now they show up in the Cloudflare Workers Logs dashboard (already enabled via `observability.logs` in `wrangler.jsonc`).

## Test plan
- [x] `pnpm run verify` (lint + format + typecheck + 114 tests) passes
- [ ] After deploy, trigger a route error and confirm the structured entry appears in Workers Logs