### PR TITLE
Flag unusual dependency specs

### DIFF
--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -58,13 +58,13 @@ The first corpus slice covers:
 - secret-looking file addition;
 - large opaque binary addition;
 - malformed `package.json` parse failure;
-- dependency and entrypoint package-json diff changes that are currently tracked as coverage gaps.
+- dependency and entrypoint package-json diff changes; unusual non-registry dependency specs now raise deterministic findings while entrypoint changes remain a documented coverage gap.
 
 ## Known coverage gaps
 
 The corpus deliberately records some product gaps instead of hiding them:
 
-- Dependency additions and unusual specs are visible in `packageJsonDiff`, but they do not yet raise deterministic findings or risk.
+- Plain dependency additions are visible in `packageJsonDiff`, but they do not yet raise deterministic findings unless they use unusual specs such as `github:`, `git+ssh:`, `http(s):`, `file:`, or `npm:` aliases.
 - Entrypoint changes are visible in `packageJsonDiff`, but they do not yet raise deterministic findings or risk.
 - Maintainer/package transfer signals, new publisher signals, package reputation, and OpenSSF/package intelligence integrations are not implemented.
 - Behavior-chain detection is regex-based and does not yet prove source-to-sink intent.

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -24,7 +24,7 @@ export interface Finding {
 // way that should invalidate cached scan reports. Stored alongside each
 // finding so historical reports can be traced back to the ruleset that
 // produced them.
-export const DETERMINISTIC_RULES_VERSION = "1.1.0";
+export const DETERMINISTIC_RULES_VERSION = "1.2.0";
 
 export const DETERMINISTIC_RULE_IDS = {
   installScriptPreinstall: "install-script.preinstall",
@@ -40,6 +40,7 @@ export const DETERMINISTIC_RULE_IDS = {
   packageJsonParseFailed: "package-json.parse-failed",
   diffCredentialFileAdded: "diff.credential-file-added",
   diffLargeNewFile: "diff.large-new-file",
+  dependencyUnusualSpec: "dependency.unusual-spec",
   stageMetadataMismatch: "stage.metadata-mismatch",
 } as const;
 
@@ -392,6 +393,25 @@ export function summarizePackageJsonDiff(
   };
 }
 
+export function packageJsonDiffFindings(packageJsonDiff: PackageJsonDiff): Finding[] {
+  const findings: Finding[] = [];
+  for (const entry of packageJsonDiff.dependencies) {
+    if (entry.status !== "added" && entry.status !== "modified") continue;
+    if (!entry.staged) continue;
+    const kind = unusualDependencySpecKind(entry.staged);
+    if (!kind) continue;
+    findings.push({
+      severity: "high",
+      file: "package.json",
+      evidence: `${entry.key}: ${entry.staged}`,
+      reason: `${kind} dependency specs resolve code outside normal npm semver ranges and can introduce unreviewed install-time behavior`,
+      ruleId: DETERMINISTIC_RULE_IDS.dependencyUnusualSpec,
+      ruleVersion: DETERMINISTIC_RULES_VERSION,
+    });
+  }
+  return findings;
+}
+
 export function computeRisk(findings: Finding[]): RiskLevel {
   if (findings.some((f) => f.severity === "critical")) return "critical";
   if (findings.some((f) => f.severity === "high")) return "high";
@@ -453,6 +473,17 @@ export function redactJson<T>(value: T): T {
     ) as T;
   }
   return value;
+}
+
+function unusualDependencySpecKind(spec: string): string | null {
+  const normalized = spec.trim().toLowerCase();
+  if (/^(?:github|gitlab|bitbucket):/.test(normalized)) return "git-hosted";
+  if (/^(?:git\+ssh|git\+https|git\+http|git|ssh):/.test(normalized)) return "git";
+  if (/^https?:/.test(normalized))
+    return normalized.endsWith(".tgz") ? "remote tarball" : "remote URL";
+  if (normalized.startsWith("file:")) return "local file";
+  if (normalized.startsWith("npm:")) return "npm alias";
+  return null;
 }
 
 function diffObject(

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -8,6 +8,7 @@ import {
 import {
   createPackageDiff,
   deterministicFindings,
+  packageJsonDiffFindings,
   DETERMINISTIC_RULE_IDS,
   DETERMINISTIC_RULES_VERSION,
   redactFileRecords,
@@ -79,6 +80,7 @@ export async function runScanPipeline(
   );
   const ruleFindings = redactFindings([
     ...deterministicFindings(staged.files, diff, stagedPackageJson),
+    ...packageJsonDiffFindings(packageJsonDiff),
     ...stagedMetadataFindings,
   ]);
   const redactedStagedFiles = redactFileRecords(staged.files);

--- a/test/fixtures/security-corpus/cases/dependency-entrypoint-diff-only.json
+++ b/test/fixtures/security-corpus/cases/dependency-entrypoint-diff-only.json
@@ -4,7 +4,6 @@
   "category": "package-json-diff-coverage-gap",
   "intent": "Track release-review-sensitive package.json changes that are currently diff-only and should become richer findings later.",
   "coverageGaps": [
-    "unusual dependency specs are visible in packageJsonDiff but do not yet raise deterministic findings",
     "entrypoint changes are visible in packageJsonDiff but do not yet raise deterministic findings"
   ],
   "previousPackageJson": {
@@ -57,8 +56,19 @@
       "textSample": "export default 1;\n"
     }
   ],
-  "expectedRisk": "low",
-  "expectedFindings": [],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "dependency.unusual-spec",
+      "severity": "high",
+      "file": "package.json"
+    },
+    {
+      "ruleId": "dependency.unusual-spec",
+      "severity": "high",
+      "file": "package.json"
+    }
+  ],
   "expectedPackageJsonDiff": {
     "entrypointsChanged": true,
     "dependencies": [

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -3,6 +3,7 @@ import {
   computeRisk,
   createPackageDiff,
   deterministicFindings,
+  packageJsonDiffFindings,
   summarizePackageJsonDiff,
 } from "../server/lib/review.ts";
 
@@ -100,6 +101,51 @@ describe("review", () => {
       { key: "postinstall", status: "added", staged: "node install.js" },
     ]);
     expect(summary.entrypointsChanged).toBe(true);
+  });
+
+  test("flags unusual dependency specs in package json diffs", () => {
+    const diff = summarizePackageJsonDiff(
+      { name: "pkg", version: "1.0.0", dependencies: { safe: "^1.0.0" } },
+      {
+        name: "pkg",
+        version: "1.0.1",
+        dependencies: {
+          safe: "github:example/safe#main",
+          remote: "https://example.invalid/pkg.tgz",
+          local: "file:../local.tgz",
+          alias: "npm:other-package@^1.0.0",
+        },
+      },
+    );
+
+    const findings = packageJsonDiffFindings(diff);
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        severity: "high",
+        file: "package.json",
+        evidence: "alias: npm:other-package@^1.0.0",
+        ruleId: "dependency.unusual-spec",
+      }),
+      expect.objectContaining({
+        evidence: "local: file:../local.tgz",
+        ruleId: "dependency.unusual-spec",
+      }),
+      expect.objectContaining({
+        evidence: "remote: https://example.invalid/pkg.tgz",
+        ruleId: "dependency.unusual-spec",
+      }),
+      expect.objectContaining({
+        evidence: "safe: github:example/safe#main",
+        ruleId: "dependency.unusual-spec",
+      }),
+    ]);
+    expect(
+      packageJsonDiffFindings({
+        ...diff,
+        dependencies: [{ key: "safe", status: "added", staged: "^1.0.0" }],
+      }),
+    ).toEqual([]);
   });
 
   test("flags npm's implicit node-gyp install hook from root gyp files", () => {

--- a/test/security-corpus.test.mjs
+++ b/test/security-corpus.test.mjs
@@ -7,6 +7,7 @@ import {
   createPackageDiff,
   deterministicFindings,
   DETERMINISTIC_RULES_VERSION,
+  packageJsonDiffFindings,
   summarizePackageJsonDiff,
 } from "../server/lib/review.ts";
 
@@ -40,7 +41,14 @@ describe("security detection golden corpus", () => {
       const previousFiles = fixture.previousFiles ?? [];
       const stagedFiles = fixture.stagedFiles ?? [];
       const diff = createPackageDiff(previousFiles, stagedFiles);
-      const findings = deterministicFindings(stagedFiles, diff, fixture.stagedPackageJson);
+      const packageJsonDiff = summarizePackageJsonDiff(
+        fixture.previousPackageJson,
+        fixture.stagedPackageJson,
+      );
+      const findings = [
+        ...deterministicFindings(stagedFiles, diff, fixture.stagedPackageJson),
+        ...packageJsonDiffFindings(packageJsonDiff),
+      ];
 
       expect(computeRisk(findings)).toBe(fixture.expectedRisk);
       expect(comparableFindings(findings)).toEqual(
@@ -51,10 +59,6 @@ describe("security detection golden corpus", () => {
       }
 
       if (fixture.expectedPackageJsonDiff) {
-        const packageJsonDiff = summarizePackageJsonDiff(
-          fixture.previousPackageJson,
-          fixture.stagedPackageJson,
-        );
         expect(packageJsonDiff).toMatchObject(fixture.expectedPackageJsonDiff);
       }
     });


### PR DESCRIPTION
## Summary

- Flag added/modified dependency specs that resolve outside normal npm semver ranges (`github:`, `git+ssh:`, `http(s):`, `file:`, and `npm:` aliases).
- Persist these as deterministic findings in scan reports.
- Update the golden corpus harness so package-json diff findings are evaluated alongside file findings.

## Stack

1/7 in the TanStack follow-up stack. Base: `main`.

## Verification

- `pnpm run test:node -- review.test.mjs security-corpus.test.mjs`
- `pnpm run typecheck`
- Full stack verified with `pnpm run verify` on the final branch.
