### PR TITLE
Flag added optional dependencies

### DIFF
--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -57,6 +57,7 @@ The first corpus slice covers:
 - base64/dynamic evaluation plus network-capable code;
 - secret-looking file addition;
 - large opaque binary addition;
+- files that appear in the tarball outside a declared `package.json.files` allowlist;
 - malformed `package.json` parse failure;
 - dependency and entrypoint package-json diff changes; unusual non-registry dependency specs now raise deterministic findings while entrypoint changes remain a documented coverage gap.
 

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -64,7 +64,7 @@ The first corpus slice covers:
 
 The corpus deliberately records some product gaps instead of hiding them:
 
-- Plain dependency additions are visible in `packageJsonDiff`, but they do not yet raise deterministic findings unless they use unusual specs such as `github:`, `git+ssh:`, `http(s):`, `file:`, or `npm:` aliases.
+- Plain dependency additions are visible in `packageJsonDiff`, but they do not yet raise deterministic findings unless they use unusual specs such as `github:`, `git+ssh:`, `http(s):`, `file:`, or `npm:` aliases. Newly added optional dependencies also raise deterministic findings because they can fail softly while still running install-time lifecycle hooks.
 - Entrypoint changes are visible in `packageJsonDiff`, but they do not yet raise deterministic findings or risk.
 - Maintainer/package transfer signals, new publisher signals, package reputation, and OpenSSF/package intelligence integrations are not implemented.
 - Behavior-chain detection is regex-based and does not yet prove source-to-sink intent.

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -25,7 +25,7 @@ export interface Finding {
 // way that should invalidate cached scan reports. Stored alongside each
 // finding so historical reports can be traced back to the ruleset that
 // produced them.
-export const DETERMINISTIC_RULES_VERSION = "1.3.0";
+export const DETERMINISTIC_RULES_VERSION = "1.4.0";
 
 export const DETERMINISTIC_RULE_IDS = {
   installScriptPreinstall: "install-script.preinstall",
@@ -37,6 +37,7 @@ export const DETERMINISTIC_RULE_IDS = {
   fileSecretContent: "file.secret-content",
   fileLargeBinary: "file.large-binary",
   fileNativeArtifact: "file.native-artifact",
+  fileOutsideFilesList: "file.outside-files-list",
   installScriptImplicitNodeGyp: "install-script.implicit-node-gyp",
   packageJsonParseFailed: "package-json.parse-failed",
   diffCredentialFileAdded: "diff.credential-file-added",
@@ -56,6 +57,7 @@ export interface PackageJsonSummary {
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
+  files?: string[];
   bin?: string | Record<string, string>;
   main?: string;
   module?: string;
@@ -320,6 +322,17 @@ export function deterministicFindings(
           file: file.path,
           evidence: `${file.size} byte binary`,
           reason: "large binary should be reviewed manually",
+        }),
+      );
+    }
+    if (isOutsidePackageFilesAllowlist(file.path, packageJson) && changed !== "removed") {
+      findings.push(
+        tag("fileOutsideFilesList", {
+          severity: changed === "added" ? "high" : "medium",
+          file: file.path,
+          evidence: `${changedPrefix}file is not matched by package.json files allowlist`,
+          reason:
+            "unexpected files outside the declared package files list can indicate tarball tampering or generated payloads that are not visible in the source/package manifest review",
         }),
       );
     }
@@ -752,6 +765,46 @@ export function redactJson<T>(value: T): T {
     ) as T;
   }
   return value;
+}
+
+function isOutsidePackageFilesAllowlist(
+  path: string,
+  packageJson: PackageJsonSummary | null | undefined,
+): boolean {
+  const files = packageJson?.files?.filter((entry) => entry.trim()) ?? [];
+  if (!files.length) return false;
+  if (isAlwaysIncludedPackageFile(path, packageJson)) return false;
+  return !files.some((entry) => packageFilesEntryMatches(entry, path));
+}
+
+function isAlwaysIncludedPackageFile(
+  path: string,
+  packageJson: PackageJsonSummary | null | undefined,
+): boolean {
+  const lower = path.toLowerCase();
+  if (lower === "package.json") return true;
+  if (/^(?:readme|licen[cs]e|copying|notice)(?:\.|$)/i.test(path)) return true;
+  const entrypoints = [packageJson?.main, packageJson?.module, packageJson?.types];
+  if (entrypoints.includes(path)) return true;
+  const bin = packageJson?.bin;
+  if (typeof bin === "string" && bin === path) return true;
+  if (bin && typeof bin === "object" && Object.values(bin).includes(path)) return true;
+  return false;
+}
+
+function packageFilesEntryMatches(entry: string, path: string): boolean {
+  const normalized = entry.trim().replace(/^\.\//, "").replace(/\/+$/, "");
+  if (!normalized) return false;
+  if (normalized.includes("*")) return globLikePackageFilesEntryMatches(normalized, path);
+  return path === normalized || path.startsWith(`${normalized}/`);
+}
+
+function globLikePackageFilesEntryMatches(entry: string, path: string): boolean {
+  const escaped = entry
+    .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, ".*")
+    .replace(/\*/g, "[^/]*");
+  return new RegExp(`^${escaped}$`).test(path);
 }
 
 function diffDependencySections(

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -25,7 +25,7 @@ export interface Finding {
 // way that should invalidate cached scan reports. Stored alongside each
 // finding so historical reports can be traced back to the ruleset that
 // produced them.
-export const DETERMINISTIC_RULES_VERSION = "1.2.0";
+export const DETERMINISTIC_RULES_VERSION = "1.3.0";
 
 export const DETERMINISTIC_RULE_IDS = {
   installScriptPreinstall: "install-script.preinstall",
@@ -42,6 +42,7 @@ export const DETERMINISTIC_RULE_IDS = {
   diffCredentialFileAdded: "diff.credential-file-added",
   diffLargeNewFile: "diff.large-new-file",
   dependencyUnusualSpec: "dependency.unusual-spec",
+  dependencyOptionalAdded: "dependency.optional-added",
   stageMetadataMismatch: "stage.metadata-mismatch",
 } as const;
 
@@ -62,11 +63,14 @@ export interface PackageJsonSummary {
   exports?: unknown;
 }
 
+export type DependencySection = "dependencies" | "optionalDependencies" | "peerDependencies";
+
 export interface PackageJsonDiffEntry {
   key: string;
   status: "added" | "removed" | "modified";
   previous?: string;
   staged?: string;
+  section?: DependencySection;
 }
 
 export interface PackageJsonDiff {
@@ -414,18 +418,7 @@ export function summarizePackageJsonDiff(
   stagedPkg: PackageJsonSummary | null | undefined,
 ): PackageJsonDiff {
   const changedScripts = diffObject(previousPkg?.scripts || {}, stagedPkg?.scripts || {});
-  const changedDependencies = diffObject(
-    {
-      ...previousPkg?.dependencies,
-      ...previousPkg?.optionalDependencies,
-      ...previousPkg?.peerDependencies,
-    },
-    {
-      ...stagedPkg?.dependencies,
-      ...stagedPkg?.optionalDependencies,
-      ...stagedPkg?.peerDependencies,
-    },
-  );
+  const changedDependencies = diffDependencySections(previousPkg, stagedPkg);
   return {
     name: stagedPkg?.name || previousPkg?.name || null,
     previousVersion: previousPkg?.version || null,
@@ -457,6 +450,18 @@ export function packageJsonDiffFindings(
   const findings: Finding[] = [];
   for (const entry of packageJsonDiff.dependencies) {
     if (entry.status !== "added" && entry.status !== "modified") continue;
+    if (entry.section === "optionalDependencies" && entry.status === "added") {
+      findings.push({
+        severity: "high",
+        file: "package.json",
+        line: firstJsonPropertyLine(stagedPackageJsonText, entry.key, entry.staged),
+        evidence: `${entry.key}: ${entry.staged}`,
+        reason:
+          "optional dependencies can execute install lifecycle hooks while failing softly on unsupported platforms, so newly added optional dependencies require manual review",
+        ruleId: DETERMINISTIC_RULE_IDS.dependencyOptionalAdded,
+        ruleVersion: DETERMINISTIC_RULES_VERSION,
+      });
+    }
     if (!entry.staged) continue;
     const kind = unusualDependencySpecKind(entry.staged);
     if (!kind) continue;
@@ -518,6 +523,7 @@ function isReleaseScopedFinding(finding: { ruleId?: string | null }): boolean {
   return Boolean(
     finding.ruleId?.startsWith("stage.") ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.dependencyUnusualSpec ||
+    finding.ruleId === DETERMINISTIC_RULE_IDS.dependencyOptionalAdded ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.diffCredentialFileAdded ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.diffLargeNewFile,
   );
@@ -746,6 +752,23 @@ export function redactJson<T>(value: T): T {
     ) as T;
   }
   return value;
+}
+
+function diffDependencySections(
+  previousPkg: PackageJsonSummary | null | undefined,
+  stagedPkg: PackageJsonSummary | null | undefined,
+): PackageJsonDiffEntry[] {
+  const sectionEntries = (section: DependencySection) =>
+    diffObject(previousPkg?.[section] || {}, stagedPkg?.[section] || {}).map((entry) => ({
+      ...entry,
+      section,
+    }));
+
+  return [
+    ...sectionEntries("dependencies"),
+    ...sectionEntries("optionalDependencies"),
+    ...sectionEntries("peerDependencies"),
+  ].sort((a, b) => a.key.localeCompare(b.key) || a.section.localeCompare(b.section));
 }
 
 function unusualDependencySpecKind(spec: string): string | null {

--- a/server/lib/sandbox.ts
+++ b/server/lib/sandbox.ts
@@ -14,6 +14,7 @@ const SANDBOX_TAR_PARSER_EXPORTS = [
   tarParser.decodeText,
   tarParser.isPlainObject,
   tarParser.normalizeStringRecord,
+  tarParser.normalizeStringList,
   tarParser.isRootGypPath,
   tarParser.hasImplicitNodeGypInstall,
   tarParser.isSafePaxPath,

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -303,6 +303,7 @@ function mergeStagedPackageJson(
         stagedMetadataPackageJson?.optionalDependencies,
       ),
     ),
+    files: stagedMetadataPackageJson?.files ?? tarballPackageJson?.files,
     bin: stagedMetadataPackageJson?.bin ?? tarballPackageJson?.bin,
     main: stagedMetadataPackageJson?.main ?? tarballPackageJson?.main,
     module: stagedMetadataPackageJson?.module ?? tarballPackageJson?.module,

--- a/server/lib/staged-publishes.ts
+++ b/server/lib/staged-publishes.ts
@@ -210,6 +210,9 @@ function readPackageJsonSummary(
   const devDependencies = normalizeStringRecord(value.devDependencies);
   const peerDependencies = normalizeStringRecord(value.peerDependencies);
   const optionalDependencies = normalizeStringRecord(value.optionalDependencies);
+  const files = Array.isArray(value.files)
+    ? value.files.filter((item): item is string => typeof item === "string")
+    : [];
   const bin = readBin(value.bin);
   const gypfile = typeof value.gypfile === "boolean" ? value.gypfile : undefined;
   const summary: PackageJsonSummary = {
@@ -222,6 +225,7 @@ function readPackageJsonSummary(
     devDependencies,
     peerDependencies,
     optionalDependencies,
+    ...(files.length ? { files } : {}),
     ...(bin ? { bin } : {}),
     ...(readString(value.main) ? { main: readString(value.main)! } : {}),
     ...(readString(value.module) ? { module: readString(value.module)! } : {}),
@@ -234,6 +238,7 @@ function readPackageJsonSummary(
     Object.keys(devDependencies).length ||
     Object.keys(peerDependencies).length ||
     Object.keys(optionalDependencies).length ||
+    files.length ||
     bin ||
     summary.main ||
     summary.module ||

--- a/server/lib/tar-parser.d.ts
+++ b/server/lib/tar-parser.d.ts
@@ -16,6 +16,7 @@ export interface ParsedPackageJson {
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
+  files?: string[];
   bin?: unknown;
   main?: string;
   module?: string;
@@ -27,6 +28,7 @@ export function readString(bytes: Uint8Array, start: number, len: number): strin
 export function decodeText(bytes: Uint8Array): string;
 export function isPlainObject(value: unknown): value is Record<string, unknown>;
 export function normalizeStringRecord(value: unknown): Record<string, string>;
+export function normalizeStringList(value: unknown): string[];
 export function isRootGypPath(path: unknown): boolean;
 export function hasImplicitNodeGypInstall(
   files: Array<{ path?: unknown }> | unknown,

--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -42,6 +42,11 @@ export function normalizeStringRecord(value) {
   return out;
 }
 
+export function normalizeStringList(value) {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item) => typeof item === "string");
+}
+
 export function isRootGypPath(path) {
   return typeof path === "string" && !path.includes("/") && /\.gyp$/i.test(path);
 }
@@ -186,6 +191,9 @@ export function parsePackageJson(files) {
       devDependencies: parsed.devDependencies || {},
       peerDependencies: parsed.peerDependencies || {},
       optionalDependencies: parsed.optionalDependencies || {},
+      ...(normalizeStringList(parsed.files).length
+        ? { files: normalizeStringList(parsed.files) }
+        : {}),
       bin: parsed.bin,
       main: parsed.main,
       module: parsed.module,

--- a/test/fixtures/security-corpus/cases/files-allowlist-escape.json
+++ b/test/fixtures/security-corpus/cases/files-allowlist-escape.json
@@ -1,0 +1,63 @@
+{
+  "id": "files-allowlist-escape",
+  "title": "Root payload is included outside package.json files allowlist",
+  "category": "tarball-manifest-mismatch",
+  "intent": "Catch artifacts that appear in the packed tarball even though the manifest only declares dist/src package contents.",
+  "previousPackageJson": {
+    "name": "files-allowlist-escape",
+    "version": "1.0.0",
+    "files": ["dist"]
+  },
+  "stagedPackageJson": {
+    "name": "files-allowlist-escape",
+    "version": "1.0.1",
+    "files": ["dist"]
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 64,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"files-allowlist-escape\",\"version\":\"1.0.0\",\"files\":[\"dist\"]}"
+    },
+    {
+      "path": "dist/index.js",
+      "size": 18,
+      "sha256": "index-v1",
+      "flags": [],
+      "textSample": "export default 1;\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 64,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"files-allowlist-escape\",\"version\":\"1.0.1\",\"files\":[\"dist\"]}"
+    },
+    {
+      "path": "dist/index.js",
+      "size": 18,
+      "sha256": "index-v1",
+      "flags": [],
+      "textSample": "export default 1;\n"
+    },
+    {
+      "path": "router_init.js",
+      "size": 2048,
+      "sha256": "router-init",
+      "flags": [],
+      "textSample": "console.log('unexpected root payload');\n"
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "file.outside-files-list",
+      "severity": "high",
+      "file": "router_init.js"
+    }
+  ]
+}

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -296,6 +296,39 @@ describe("review", () => {
     ).toEqual([]);
   });
 
+  test("flags files outside package.json files allowlist", () => {
+    const staged = [
+      {
+        path: "package.json",
+        size: 72,
+        sha256: "pkg",
+        flags: [],
+        textSample: JSON.stringify({ name: "pkg", version: "1.0.1", files: ["dist"] }),
+      },
+      { path: "dist/index.js", size: 20, sha256: "dist", flags: [], textSample: "export {};" },
+      {
+        path: "router_init.js",
+        size: 2048,
+        sha256: "payload",
+        flags: [],
+        textSample: "console.log('init');",
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged));
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        severity: "high",
+        file: "router_init.js",
+        evidence: "new/changed added file: file is not matched by package.json files allowlist",
+        ruleId: "file.outside-files-list",
+      }),
+    );
+    expect(findings).not.toContainEqual(
+      expect.objectContaining({ file: "dist/index.js", ruleId: "file.outside-files-list" }),
+    );
+  });
+
   test("flags newly added optional dependencies", () => {
     const stagedPackageJsonText = `{
   "name": "pkg",

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -296,6 +296,39 @@ describe("review", () => {
     ).toEqual([]);
   });
 
+  test("flags newly added optional dependencies", () => {
+    const stagedPackageJsonText = `{
+  "name": "pkg",
+  "version": "1.0.1",
+  "optionalDependencies": {
+    "existing": "^1.0.0",
+    "maybe": "^2.0.0"
+  }
+}`;
+    const diff = summarizePackageJsonDiff(
+      { name: "pkg", version: "1.0.0", optionalDependencies: { existing: "^1.0.0" } },
+      JSON.parse(stagedPackageJsonText),
+    );
+
+    const findings = packageJsonDiffFindings(diff, stagedPackageJsonText);
+
+    expect(diff.dependencies).toContainEqual({
+      key: "maybe",
+      status: "added",
+      staged: "^2.0.0",
+      section: "optionalDependencies",
+    });
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        severity: "high",
+        file: "package.json",
+        line: 6,
+        evidence: "maybe: ^2.0.0",
+        ruleId: "dependency.optional-added",
+      }),
+    );
+  });
+
   test("flags npm's implicit node-gyp install hook from root gyp files", () => {
     const staged = [
       {

--- a/test/tar-parser.test.mjs
+++ b/test/tar-parser.test.mjs
@@ -310,6 +310,7 @@ describe("parsePackageJson", () => {
           version: "1.2.3",
           scripts: { preinstall: "node bad.js" },
           dependencies: { foo: "1.0.0" },
+          files: ["dist", 42, "README.md"],
         }),
       },
     ];
@@ -319,6 +320,7 @@ describe("parsePackageJson", () => {
     expect(parsed?.scripts?.preinstall).toBe("node bad.js");
     expect(parsed?.dependencies?.foo).toBe("1.0.0");
     expect(parsed?.devDependencies).toEqual({});
+    expect(parsed?.files).toEqual(["dist", "README.md"]);
   });
 
   test("models npm's implicit node-gyp install script for root gyp files", () => {


### PR DESCRIPTION
## Summary

- Preserve dependency section metadata in `packageJsonDiff.dependencies`.
- Flag newly added `optionalDependencies` as high-risk deterministic findings.
- Document optional dependency review behavior in the security corpus notes.

## Stack

2/7 in the TanStack follow-up stack. Base: `tanstack/unusual-dependency-specs`.

## Verification

- `pnpm run test:node -- review.test.mjs security-corpus.test.mjs`
- `pnpm run typecheck`
- Full stack verified with `pnpm run verify` on the final branch.
