### PR TITLE
Flag tarball files outside package files allowlist

### DIFF
--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -57,6 +57,7 @@ The first corpus slice covers:
 - base64/dynamic evaluation plus network-capable code;
 - secret-looking file addition;
 - large opaque binary addition;
+- files that appear in the tarball outside a declared `package.json.files` allowlist;
 - malformed `package.json` parse failure;
 - dependency and entrypoint package-json diff changes; unusual non-registry dependency specs now raise deterministic findings while entrypoint changes remain a documented coverage gap.
 

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -24,7 +24,7 @@ export interface Finding {
 // way that should invalidate cached scan reports. Stored alongside each
 // finding so historical reports can be traced back to the ruleset that
 // produced them.
-export const DETERMINISTIC_RULES_VERSION = "1.3.0";
+export const DETERMINISTIC_RULES_VERSION = "1.4.0";
 
 export const DETERMINISTIC_RULE_IDS = {
   installScriptPreinstall: "install-script.preinstall",
@@ -36,6 +36,7 @@ export const DETERMINISTIC_RULE_IDS = {
   fileSecretContent: "file.secret-content",
   fileLargeBinary: "file.large-binary",
   fileNativeArtifact: "file.native-artifact",
+  fileOutsideFilesList: "file.outside-files-list",
   installScriptImplicitNodeGyp: "install-script.implicit-node-gyp",
   packageJsonParseFailed: "package-json.parse-failed",
   diffCredentialFileAdded: "diff.credential-file-added",
@@ -55,6 +56,7 @@ export interface PackageJsonSummary {
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
+  files?: string[];
   bin?: string | Record<string, string>;
   main?: string;
   module?: string;
@@ -264,6 +266,17 @@ export function deterministicFindings(
           file: file.path,
           evidence: `${file.size} byte binary`,
           reason: "large binary should be reviewed manually",
+        }),
+      );
+    }
+    if (isOutsidePackageFilesAllowlist(file.path, packageJson) && changed !== "removed") {
+      findings.push(
+        tag("fileOutsideFilesList", {
+          severity: changed === "added" ? "high" : "medium",
+          file: file.path,
+          evidence: `${changedPrefix}file is not matched by package.json files allowlist`,
+          reason:
+            "unexpected files outside the declared package files list can indicate tarball tampering or generated payloads that are not visible in the source/package manifest review",
         }),
       );
     }
@@ -477,6 +490,46 @@ export function redactJson<T>(value: T): T {
     ) as T;
   }
   return value;
+}
+
+function isOutsidePackageFilesAllowlist(
+  path: string,
+  packageJson: PackageJsonSummary | null | undefined,
+): boolean {
+  const files = packageJson?.files?.filter((entry) => entry.trim()) ?? [];
+  if (!files.length) return false;
+  if (isAlwaysIncludedPackageFile(path, packageJson)) return false;
+  return !files.some((entry) => packageFilesEntryMatches(entry, path));
+}
+
+function isAlwaysIncludedPackageFile(
+  path: string,
+  packageJson: PackageJsonSummary | null | undefined,
+): boolean {
+  const lower = path.toLowerCase();
+  if (lower === "package.json") return true;
+  if (/^(?:readme|licen[cs]e|copying|notice)(?:\.|$)/i.test(path)) return true;
+  const entrypoints = [packageJson?.main, packageJson?.module, packageJson?.types];
+  if (entrypoints.includes(path)) return true;
+  const bin = packageJson?.bin;
+  if (typeof bin === "string" && bin === path) return true;
+  if (bin && typeof bin === "object" && Object.values(bin).includes(path)) return true;
+  return false;
+}
+
+function packageFilesEntryMatches(entry: string, path: string): boolean {
+  const normalized = entry.trim().replace(/^\.\//, "").replace(/\/+$/, "");
+  if (!normalized) return false;
+  if (normalized.includes("*")) return globLikePackageFilesEntryMatches(normalized, path);
+  return path === normalized || path.startsWith(`${normalized}/`);
+}
+
+function globLikePackageFilesEntryMatches(entry: string, path: string): boolean {
+  const escaped = entry
+    .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, ".*")
+    .replace(/\*/g, "[^/]*");
+  return new RegExp(`^${escaped}$`).test(path);
 }
 
 function diffDependencySections(

--- a/server/lib/sandbox.ts
+++ b/server/lib/sandbox.ts
@@ -14,6 +14,7 @@ const SANDBOX_TAR_PARSER_EXPORTS = [
   tarParser.decodeText,
   tarParser.isPlainObject,
   tarParser.normalizeStringRecord,
+  tarParser.normalizeStringList,
   tarParser.isRootGypPath,
   tarParser.hasImplicitNodeGypInstall,
   tarParser.isSafePaxPath,

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -289,6 +289,7 @@ function mergeStagedPackageJson(
         stagedMetadataPackageJson?.optionalDependencies,
       ),
     ),
+    files: stagedMetadataPackageJson?.files ?? tarballPackageJson?.files,
     bin: stagedMetadataPackageJson?.bin ?? tarballPackageJson?.bin,
     main: stagedMetadataPackageJson?.main ?? tarballPackageJson?.main,
     module: stagedMetadataPackageJson?.module ?? tarballPackageJson?.module,

--- a/server/lib/staged-publishes.ts
+++ b/server/lib/staged-publishes.ts
@@ -210,6 +210,9 @@ function readPackageJsonSummary(
   const devDependencies = normalizeStringRecord(value.devDependencies);
   const peerDependencies = normalizeStringRecord(value.peerDependencies);
   const optionalDependencies = normalizeStringRecord(value.optionalDependencies);
+  const files = Array.isArray(value.files)
+    ? value.files.filter((item): item is string => typeof item === "string")
+    : [];
   const bin = readBin(value.bin);
   const gypfile = typeof value.gypfile === "boolean" ? value.gypfile : undefined;
   const summary: PackageJsonSummary = {
@@ -222,6 +225,7 @@ function readPackageJsonSummary(
     devDependencies,
     peerDependencies,
     optionalDependencies,
+    ...(files.length ? { files } : {}),
     ...(bin ? { bin } : {}),
     ...(readString(value.main) ? { main: readString(value.main)! } : {}),
     ...(readString(value.module) ? { module: readString(value.module)! } : {}),
@@ -234,6 +238,7 @@ function readPackageJsonSummary(
     Object.keys(devDependencies).length ||
     Object.keys(peerDependencies).length ||
     Object.keys(optionalDependencies).length ||
+    files.length ||
     bin ||
     summary.main ||
     summary.module ||

--- a/server/lib/tar-parser.d.ts
+++ b/server/lib/tar-parser.d.ts
@@ -16,6 +16,7 @@ export interface ParsedPackageJson {
   devDependencies?: Record<string, string>;
   peerDependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
+  files?: string[];
   bin?: unknown;
   main?: string;
   module?: string;
@@ -27,6 +28,7 @@ export function readString(bytes: Uint8Array, start: number, len: number): strin
 export function decodeText(bytes: Uint8Array): string;
 export function isPlainObject(value: unknown): value is Record<string, unknown>;
 export function normalizeStringRecord(value: unknown): Record<string, string>;
+export function normalizeStringList(value: unknown): string[];
 export function isRootGypPath(path: unknown): boolean;
 export function hasImplicitNodeGypInstall(
   files: Array<{ path?: unknown }> | unknown,

--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -42,6 +42,11 @@ export function normalizeStringRecord(value) {
   return out;
 }
 
+export function normalizeStringList(value) {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item) => typeof item === "string");
+}
+
 export function isRootGypPath(path) {
   return typeof path === "string" && !path.includes("/") && /\.gyp$/i.test(path);
 }
@@ -186,6 +191,9 @@ export function parsePackageJson(files) {
       devDependencies: parsed.devDependencies || {},
       peerDependencies: parsed.peerDependencies || {},
       optionalDependencies: parsed.optionalDependencies || {},
+      ...(normalizeStringList(parsed.files).length
+        ? { files: normalizeStringList(parsed.files) }
+        : {}),
       bin: parsed.bin,
       main: parsed.main,
       module: parsed.module,

--- a/test/fixtures/security-corpus/cases/files-allowlist-escape.json
+++ b/test/fixtures/security-corpus/cases/files-allowlist-escape.json
@@ -1,0 +1,63 @@
+{
+  "id": "files-allowlist-escape",
+  "title": "Root payload is included outside package.json files allowlist",
+  "category": "tarball-manifest-mismatch",
+  "intent": "Catch artifacts that appear in the packed tarball even though the manifest only declares dist/src package contents.",
+  "previousPackageJson": {
+    "name": "files-allowlist-escape",
+    "version": "1.0.0",
+    "files": ["dist"]
+  },
+  "stagedPackageJson": {
+    "name": "files-allowlist-escape",
+    "version": "1.0.1",
+    "files": ["dist"]
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 64,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"files-allowlist-escape\",\"version\":\"1.0.0\",\"files\":[\"dist\"]}"
+    },
+    {
+      "path": "dist/index.js",
+      "size": 18,
+      "sha256": "index-v1",
+      "flags": [],
+      "textSample": "export default 1;\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 64,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"files-allowlist-escape\",\"version\":\"1.0.1\",\"files\":[\"dist\"]}"
+    },
+    {
+      "path": "dist/index.js",
+      "size": 18,
+      "sha256": "index-v1",
+      "flags": [],
+      "textSample": "export default 1;\n"
+    },
+    {
+      "path": "router_init.js",
+      "size": 2048,
+      "sha256": "router-init",
+      "flags": [],
+      "textSample": "console.log('unexpected root payload');\n"
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "file.outside-files-list",
+      "severity": "high",
+      "file": "router_init.js"
+    }
+  ]
+}

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -148,6 +148,39 @@ describe("review", () => {
     ).toEqual([]);
   });
 
+  test("flags files outside package.json files allowlist", () => {
+    const staged = [
+      {
+        path: "package.json",
+        size: 72,
+        sha256: "pkg",
+        flags: [],
+        textSample: JSON.stringify({ name: "pkg", version: "1.0.1", files: ["dist"] }),
+      },
+      { path: "dist/index.js", size: 20, sha256: "dist", flags: [], textSample: "export {};" },
+      {
+        path: "router_init.js",
+        size: 2048,
+        sha256: "payload",
+        flags: [],
+        textSample: "console.log('init');",
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged));
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        severity: "high",
+        file: "router_init.js",
+        evidence: "new/changed added file: file is not matched by package.json files allowlist",
+        ruleId: "file.outside-files-list",
+      }),
+    );
+    expect(findings).not.toContainEqual(
+      expect.objectContaining({ file: "dist/index.js", ruleId: "file.outside-files-list" }),
+    );
+  });
+
   test("flags newly added optional dependencies", () => {
     const diff = summarizePackageJsonDiff(
       { name: "pkg", version: "1.0.0", optionalDependencies: { existing: "^1.0.0" } },

--- a/test/tar-parser.test.mjs
+++ b/test/tar-parser.test.mjs
@@ -310,6 +310,7 @@ describe("parsePackageJson", () => {
           version: "1.2.3",
           scripts: { preinstall: "node bad.js" },
           dependencies: { foo: "1.0.0" },
+          files: ["dist", 42, "README.md"],
         }),
       },
     ];
@@ -319,6 +320,7 @@ describe("parsePackageJson", () => {
     expect(parsed?.scripts?.preinstall).toBe("node bad.js");
     expect(parsed?.dependencies?.foo).toBe("1.0.0");
     expect(parsed?.devDependencies).toEqual({});
+    expect(parsed?.files).toEqual(["dist", "README.md"]);
   });
 
   test("models npm's implicit node-gyp install script for root gyp files", () => {


### PR DESCRIPTION
## Summary

- Parse and preserve `package.json.files` from tarball and staged metadata summaries.
- Flag changed tarball files that are outside the declared package files allowlist.
- Add corpus coverage for an allowlist escape payload.

## Stack

3/7 in the TanStack follow-up stack. Base: `tanstack/optional-dependency-additions`.

## Verification

- `pnpm run test:node -- review.test.mjs security-corpus.test.mjs tar-parser.test.mjs`
- `pnpm run typecheck`
- Full stack verified with `pnpm run verify` on the final branch.
