### PR TITLE
Flag large obfuscated JavaScript payloads

### DIFF
--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -54,7 +54,7 @@ The first corpus slice covers:
 - benign version bump control;
 - preinstall credential/environment collection with command and network capability;
 - implicit `node-gyp rebuild` from root `binding.gyp` plus native artifact review;
-- base64/dynamic evaluation plus network-capable code;
+- base64/dynamic evaluation, obfuscator-style large JavaScript payloads, and network-capable code;
 - secret-looking file addition;
 - large opaque binary addition;
 - files that appear in the tarball outside a declared `package.json.files` allowlist;

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -25,7 +25,7 @@ export interface Finding {
 // way that should invalidate cached scan reports. Stored alongside each
 // finding so historical reports can be traced back to the ruleset that
 // produced them.
-export const DETERMINISTIC_RULES_VERSION = "1.4.0";
+export const DETERMINISTIC_RULES_VERSION = "1.5.0";
 
 export const DETERMINISTIC_RULE_IDS = {
   installScriptPreinstall: "install-script.preinstall",
@@ -33,6 +33,7 @@ export const DETERMINISTIC_RULE_IDS = {
   codeProcessExecution: "code.process-execution",
   codeNetworkAccess: "code.network-access",
   codeDynamicEvaluation: "code.dynamic-evaluation",
+  codeObfuscatedLargeJs: "code.obfuscated-large-js",
   codeCredentialAccess: "code.credential-access",
   fileSecretContent: "file.secret-content",
   fileLargeBinary: "file.large-binary",
@@ -142,6 +143,14 @@ const CREDENTIAL_ACCESS_PATTERNS = [
   /\bGITHUB_TOKEN\b/,
   /\bAWS_SECRET\b/,
   /\bPRIVATE_KEY\b/,
+];
+const HEX_IDENTIFIER_PATTERN = /\b_0x[0-9a-f]{3,}\b/i;
+const HEX_IDENTIFIER_GLOBAL_PATTERN = /\b_0x[0-9a-f]{3,}\b/gi;
+const OBFUSCATED_JAVASCRIPT_PATTERNS = [
+  HEX_IDENTIFIER_PATTERN,
+  /while\s*\(\s*!!\s*\[\s*\]\s*\)/,
+  /parseInt\s*\([^)]*_0x[0-9a-f]{3,}/i,
+  /function\s*\(\s*_0x[0-9a-f]{3,}\s*,\s*_0x[0-9a-f]{3,}/i,
 ];
 
 const SECRET_PATTERNS: Array<[RegExp, string]> = [
@@ -288,6 +297,18 @@ export function deterministicFindings(
           line: firstMatchingLine(sample, DYNAMIC_EVALUATION_PATTERNS),
           evidence: `${changedPrefix}dynamic code or obfuscation primitive`,
           reason: "common malware and obfuscation technique",
+        }),
+      );
+    }
+    if (isLikelyObfuscatedLargeJavaScript(file.path, file.size, sample)) {
+      findings.push(
+        tag("codeObfuscatedLargeJs", {
+          severity: changed === "added" ? "high" : "medium",
+          file: file.path,
+          line: firstObfuscatedJavaScriptLine(sample),
+          evidence: `${changedPrefix}large obfuscated JavaScript payload`,
+          reason:
+            "large single-line or obfuscator-style JavaScript payloads are difficult to review and commonly used to hide credential theft or install-time malware",
         }),
       );
     }
@@ -641,6 +662,8 @@ function patternsForFinding(finding: { ruleId?: string | null }): RegExp[] {
       return NETWORK_ACCESS_PATTERNS;
     case DETERMINISTIC_RULE_IDS.codeDynamicEvaluation:
       return DYNAMIC_EVALUATION_PATTERNS;
+    case DETERMINISTIC_RULE_IDS.codeObfuscatedLargeJs:
+      return OBFUSCATED_JAVASCRIPT_PATTERNS;
     case DETERMINISTIC_RULE_IDS.codeCredentialAccess:
       return CREDENTIAL_ACCESS_PATTERNS;
     case DETERMINISTIC_RULE_IDS.fileSecretContent:
@@ -765,6 +788,29 @@ export function redactJson<T>(value: T): T {
     ) as T;
   }
   return value;
+}
+
+function isLikelyObfuscatedLargeJavaScript(path: string, size: number, sample: string): boolean {
+  if (!/\.[cm]?jsx?$/i.test(path)) return false;
+  if (size < 50 * 1024) return false;
+  const longestLine = sample.split(/\r?\n/).reduce((max, line) => Math.max(max, line.length), 0);
+  if (longestLine > 4_000) return true;
+  const hexIdentifierCount = sample.match(HEX_IDENTIFIER_GLOBAL_PATTERN)?.length ?? 0;
+  const obfuscatorControlFlow = OBFUSCATED_JAVASCRIPT_PATTERNS.slice(1).some((pattern) =>
+    pattern.test(sample),
+  );
+  return hexIdentifierCount >= 8 && obfuscatorControlFlow;
+}
+
+function firstObfuscatedJavaScriptLine(sample: string): number | undefined {
+  const lines = sample.split(/\r?\n/);
+  const longestLine = lines.reduce(
+    (longest, line, index) =>
+      line.length > longest.length ? { index, length: line.length } : longest,
+    { index: -1, length: 0 },
+  );
+  if (longestLine.length > 4_000) return longestLine.index + 1;
+  return firstMatchingLine(sample, OBFUSCATED_JAVASCRIPT_PATTERNS);
 }
 
 function isOutsidePackageFilesAllowlist(

--- a/test/fixtures/security-corpus/cases/obfuscated-dynamic-fetch.json
+++ b/test/fixtures/security-corpus/cases/obfuscated-dynamic-fetch.json
@@ -32,10 +32,10 @@
     },
     {
       "path": "dist/payload.js",
-      "size": 151,
+      "size": 100000,
       "sha256": "payload-js",
       "flags": [],
-      "textSample": "const code = Buffer.from('Y29uc29sZS5sb2coMSk=', 'base64').toString('utf8');\neval(code);\nfetch('https://example.invalid/pixel');\n"
+      "textSample": "const _0x1111=_0x2222;\n(function(_0x3333,_0x4444){while(!![]){try{parseInt(_0x1111(0x123));break;}catch(e){}}})(_0x5555,0x123);\n_0xaaaa();_0xbbbb();_0xcccc();_0xdddd();_0xeeee();_0xffff();_0xabcd();_0xbcde();\nconst code = Buffer.from('Y29uc29sZS5sb2coMSk=', 'base64').toString('utf8');\neval(code);\nfetch('https://example.invalid/pixel');\n"
     }
   ],
   "expectedRisk": "high",
@@ -47,6 +47,11 @@
     },
     {
       "ruleId": "code.dynamic-evaluation",
+      "severity": "high",
+      "file": "dist/payload.js"
+    },
+    {
+      "ruleId": "code.obfuscated-large-js",
       "severity": "high",
       "file": "dist/payload.js"
     }

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -296,6 +296,32 @@ describe("review", () => {
     ).toEqual([]);
   });
 
+  test("flags large obfuscator-style JavaScript payloads", () => {
+    const obfuscatedSample = `const _0x1111=_0x2222;
+(function(_0x3333,_0x4444){while(!![]){try{parseInt(_0x1111(0x123));break;}catch(e){}}})(_0x5555,0x123);
+_0xaaaa();_0xbbbb();_0xcccc();_0xdddd();_0xeeee();_0xffff();_0xabcd();_0xbcde();`;
+    const staged = [
+      {
+        path: "dist/router_init.js",
+        size: 2_341_681,
+        sha256: "payload",
+        flags: [],
+        textSample: obfuscatedSample,
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged));
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        severity: "high",
+        file: "dist/router_init.js",
+        line: 1,
+        evidence: "new/changed added file: large obfuscated JavaScript payload",
+        ruleId: "code.obfuscated-large-js",
+      }),
+    );
+  });
+
   test("flags files outside package.json files allowlist", () => {
     const staged = [
       {


### PR DESCRIPTION
## Summary

- Add a deterministic heuristic for large obfuscator-style JavaScript payloads.
- Cover long single-line JS and common `_0x`/string-array control-flow patterns.
- Update the obfuscation corpus fixture expectation.

## Stack

4/7 in the TanStack follow-up stack. Base: `tanstack/files-allowlist-findings`.

## Verification

- `pnpm run test:node -- review.test.mjs security-corpus.test.mjs`
- `pnpm run typecheck`
- Full stack verified with `pnpm run verify` on the final branch.
