### PR TITLE
Flag root-level large JavaScript payloads

### DIFF
--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -58,6 +58,7 @@ The first corpus slice covers:
 - secret-looking file addition;
 - large opaque binary addition;
 - files that appear in the tarball outside a declared `package.json.files` allowlist;
+- unexpected large root-level JavaScript payloads;
 - malformed `package.json` parse failure;
 - dependency and entrypoint package-json diff changes; unusual non-registry dependency specs now raise deterministic findings while entrypoint changes remain a documented coverage gap.
 

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -25,7 +25,7 @@ export interface Finding {
 // way that should invalidate cached scan reports. Stored alongside each
 // finding so historical reports can be traced back to the ruleset that
 // produced them.
-export const DETERMINISTIC_RULES_VERSION = "1.5.0";
+export const DETERMINISTIC_RULES_VERSION = "1.6.0";
 
 export const DETERMINISTIC_RULE_IDS = {
   installScriptPreinstall: "install-script.preinstall",
@@ -39,6 +39,7 @@ export const DETERMINISTIC_RULE_IDS = {
   fileLargeBinary: "file.large-binary",
   fileNativeArtifact: "file.native-artifact",
   fileOutsideFilesList: "file.outside-files-list",
+  fileRootLargeJavaScript: "file.root-large-javascript",
   installScriptImplicitNodeGyp: "install-script.implicit-node-gyp",
   packageJsonParseFailed: "package-json.parse-failed",
   diffCredentialFileAdded: "diff.credential-file-added",
@@ -343,6 +344,17 @@ export function deterministicFindings(
           file: file.path,
           evidence: `${file.size} byte binary`,
           reason: "large binary should be reviewed manually",
+        }),
+      );
+    }
+    if (isUnexpectedRootLargeJavaScript(file.path, file.size)) {
+      findings.push(
+        tag("fileRootLargeJavaScript", {
+          severity: changed === "added" ? "high" : "medium",
+          file: file.path,
+          evidence: `${changedPrefix}${file.size} byte root-level JavaScript payload`,
+          reason:
+            "large root-level JavaScript files are unusual in packed packages and can hide install-time payloads outside normal source/build directories",
         }),
       );
     }
@@ -788,6 +800,10 @@ export function redactJson<T>(value: T): T {
     ) as T;
   }
   return value;
+}
+
+function isUnexpectedRootLargeJavaScript(path: string, size: number): boolean {
+  return !path.includes("/") && /\.[cm]?jsx?$/i.test(path) && size > 512 * 1024;
 }
 
 function isLikelyObfuscatedLargeJavaScript(path: string, size: number, sample: string): boolean {

--- a/test/fixtures/security-corpus/cases/root-large-js-payload.json
+++ b/test/fixtures/security-corpus/cases/root-large-js-payload.json
@@ -1,0 +1,29 @@
+{
+  "id": "root-large-js-payload",
+  "title": "Large JavaScript payload appears at package root",
+  "category": "root-payload",
+  "intent": "Catch large root-level JavaScript files such as init payloads that are not normal package entrypoints.",
+  "previousFiles": [],
+  "stagedFiles": [
+    {
+      "path": "router_init.js",
+      "size": 2341681,
+      "sha256": "router-init-large",
+      "flags": [],
+      "textSample": "console.log('synthetic root payload');\n"
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "file.root-large-javascript",
+      "severity": "high",
+      "file": "router_init.js"
+    },
+    {
+      "ruleId": "diff.large-new-file",
+      "severity": "medium",
+      "file": "router_init.js"
+    }
+  ]
+}

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -296,6 +296,28 @@ describe("review", () => {
     ).toEqual([]);
   });
 
+  test("flags unexpected large root-level JavaScript payloads", () => {
+    const staged = [
+      {
+        path: "router_init.js",
+        size: 2_341_681,
+        sha256: "payload",
+        flags: [],
+        textSample: "console.log('payload');",
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged));
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        severity: "high",
+        file: "router_init.js",
+        evidence: "new/changed added file: 2341681 byte root-level JavaScript payload",
+        ruleId: "file.root-large-javascript",
+      }),
+    );
+  });
+
   test("flags large obfuscator-style JavaScript payloads", () => {
     const obfuscatedSample = `const _0x1111=_0x2222;
 (function(_0x3333,_0x4444){while(!![]){try{parseInt(_0x1111(0x123));break;}catch(e){}}})(_0x5555,0x123);


### PR DESCRIPTION
## Summary

- Flag large root-level JavaScript files as unexpected packed payloads.
- Add unit and corpus coverage for root `router_init.js`-style payloads.

## Stack

5/7 in the TanStack follow-up stack. Base: `tanstack/obfuscated-large-js-findings`.

## Verification

- `pnpm run test:node -- review.test.mjs security-corpus.test.mjs`
- `pnpm run typecheck`
- Full stack verified with `pnpm run verify` on the final branch.
