### PR TITLE
Flag package size anomalies

### DIFF
--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -59,6 +59,7 @@ The first corpus slice covers:
 - large opaque binary addition;
 - files that appear in the tarball outside a declared `package.json.files` allowlist;
 - unexpected large root-level JavaScript payloads;
+- aggregate package size anomalies compared with the previous release;
 - malformed `package.json` parse failure;
 - dependency and entrypoint package-json diff changes; unusual non-registry dependency specs now raise deterministic findings while entrypoint changes remain a documented coverage gap.
 

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -25,7 +25,7 @@ export interface Finding {
 // way that should invalidate cached scan reports. Stored alongside each
 // finding so historical reports can be traced back to the ruleset that
 // produced them.
-export const DETERMINISTIC_RULES_VERSION = "1.6.0";
+export const DETERMINISTIC_RULES_VERSION = "1.7.0";
 
 export const DETERMINISTIC_RULE_IDS = {
   installScriptPreinstall: "install-script.preinstall",
@@ -44,6 +44,7 @@ export const DETERMINISTIC_RULE_IDS = {
   packageJsonParseFailed: "package-json.parse-failed",
   diffCredentialFileAdded: "diff.credential-file-added",
   diffLargeNewFile: "diff.large-new-file",
+  packageSizeAnomaly: "package.size-anomaly",
   dependencyUnusualSpec: "dependency.unusual-spec",
   dependencyOptionalAdded: "dependency.optional-added",
   stageMetadataMismatch: "stage.metadata-mismatch",
@@ -382,6 +383,19 @@ export function deterministicFindings(
     }
   }
 
+  const sizeAnomaly = packageSizeAnomaly(diff);
+  if (sizeAnomaly) {
+    findings.push(
+      tag("packageSizeAnomaly", {
+        severity: "high",
+        file: "package",
+        evidence: `unpacked size grew from ${sizeAnomaly.previousTotal} to ${sizeAnomaly.stagedTotal} bytes (${sizeAnomaly.ratio.toFixed(1)}x)`,
+        reason:
+          "large package size jumps can indicate injected payloads, vendored binaries, or generated artifacts that were not present in the previous release",
+      }),
+    );
+  }
+
   for (const entry of diff) {
     if (entry.status === "added" && /(^|\/)(\.npmrc|\.env|id_rsa|id_ed25519)$/i.test(entry.path)) {
       findings.push(
@@ -570,6 +584,7 @@ function isReleaseScopedFinding(finding: { ruleId?: string | null }): boolean {
     finding.ruleId?.startsWith("stage.") ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.dependencyUnusualSpec ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.dependencyOptionalAdded ||
+    finding.ruleId === DETERMINISTIC_RULE_IDS.packageSizeAnomaly ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.diffCredentialFileAdded ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.diffLargeNewFile,
   );
@@ -800,6 +815,22 @@ export function redactJson<T>(value: T): T {
     ) as T;
   }
   return value;
+}
+
+function packageSizeAnomaly(
+  diff: DiffEntry[],
+): { previousTotal: number; stagedTotal: number; ratio: number } | null {
+  let previousTotal = 0;
+  let stagedTotal = 0;
+  for (const entry of diff) {
+    previousTotal += entry.previousSize ?? 0;
+    stagedTotal += entry.stagedSize ?? 0;
+  }
+  if (previousTotal <= 0) return null;
+  const delta = stagedTotal - previousTotal;
+  const ratio = stagedTotal / previousTotal;
+  if (delta > 1024 * 1024 && ratio >= 3) return { previousTotal, stagedTotal, ratio };
+  return null;
 }
 
 function isUnexpectedRootLargeJavaScript(path: string, size: number): boolean {

--- a/test/fixtures/security-corpus/cases/large-binary-added.json
+++ b/test/fixtures/security-corpus/cases/large-binary-added.json
@@ -46,6 +46,11 @@
       "ruleId": "diff.large-new-file",
       "severity": "medium",
       "file": "vendor/tool.bin"
+    },
+    {
+      "ruleId": "package.size-anomaly",
+      "severity": "high",
+      "file": "package"
     }
   ]
 }

--- a/test/fixtures/security-corpus/cases/package-size-anomaly.json
+++ b/test/fixtures/security-corpus/cases/package-size-anomaly.json
@@ -1,0 +1,32 @@
+{
+  "id": "package-size-anomaly",
+  "title": "Unpacked package size jumps by more than 3x",
+  "category": "size-anomaly",
+  "intent": "Catch releases whose aggregate unpacked size suddenly grows enough to suggest injected payloads or generated artifacts.",
+  "previousFiles": [
+    {
+      "path": "dist/index.js",
+      "size": 800000,
+      "sha256": "dist-before",
+      "flags": [],
+      "textSample": ""
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "dist/index.js",
+      "size": 3100000,
+      "sha256": "dist-after",
+      "flags": [],
+      "textSample": ""
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "package.size-anomaly",
+      "severity": "high",
+      "file": "package"
+    }
+  ]
+}

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -296,6 +296,25 @@ describe("review", () => {
     ).toEqual([]);
   });
 
+  test("flags large package size anomalies compared to previous version", () => {
+    const previous = [
+      { path: "dist/index.js", size: 800_000, sha256: "before", flags: [], textSample: "" },
+    ];
+    const staged = [
+      { path: "dist/index.js", size: 3_100_000, sha256: "after", flags: [], textSample: "" },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff(previous, staged));
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        severity: "high",
+        file: "package",
+        evidence: "unpacked size grew from 800000 to 3100000 bytes (3.9x)",
+        ruleId: "package.size-anomaly",
+      }),
+    );
+  });
+
   test("flags unexpected large root-level JavaScript payloads", () => {
     const staged = [
       {


### PR DESCRIPTION
## Summary

- Flag aggregate unpacked package size jumps of at least 3x and >1 MiB over the previous version.
- Add corpus coverage for package size anomalies and update affected large-binary expectations.

## Stack

6/7 in the TanStack follow-up stack. Base: `tanstack/root-large-js-findings`.

## Verification

- `pnpm run test:node -- review.test.mjs security-corpus.test.mjs`
- `pnpm run typecheck`
- Full stack verified with `pnpm run verify` on the final branch.
