### PR TITLE
Make FileTree indentation read as folder structure

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -274,7 +274,7 @@ Split-view diff inside an 8px-radius border shell.
 Document-shaped tree, rendered with `<details>` + `<ul>`, not a custom widget.
 
 - **Type:** Geist Mono `13px`.
-- **Indent:** `8px base + 14px per depth`. Indent is expressed as `padding-left` so the hover/selection background reaches the leftmost edge.
+- **Indent:** `8px base + 20px per depth`. Indent is expressed as `padding-left` so the hover/selection background reaches the leftmost edge. Children should read as clearly nested under their parent folder.
 - **Folder marker:** the text glyph `▸` (collapsed) or `▾` (expanded), `10px / ink-subtle`. Files do not get a marker.
 - **Auto-expand:** folders open by default when `status ≠ unchanged` and `depth < 2`.
 - **Name color follows aggregate status:** `added → text-ok`, `removed → text-danger`, `modified → text-warn`, `mixed → text-accent`, `unchanged → text-ink-muted`. Selected file overrides to `text-ink`.

--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -100,6 +100,13 @@ function statusToText(status: FolderStatus): string {
   return "text-ink-muted";
 }
 
+const INDENT_BASE = 8;
+const INDENT_PER_DEPTH = 20;
+
+function rowPaddingLeft(depth: number): string {
+  return `${INDENT_BASE + depth * INDENT_PER_DEPTH}px`;
+}
+
 export function FileTree({
   entries,
   selectedPath,
@@ -150,10 +157,10 @@ function TreeNode({
         <details open={initiallyOpen} class="group">
           <summary
             class={cn(
-              "list-none cursor-pointer flex items-center gap-2 py-1 px-2 rounded hover:bg-surface-2",
+              "list-none cursor-pointer flex items-center gap-2 py-1 pr-2 rounded hover:bg-surface-2",
               "text-[13px] font-mono",
             )}
-            style={{ paddingLeft: `${8 + depth * 14}px` }}
+            style={{ paddingLeft: rowPaddingLeft(depth) }}
           >
             <span
               aria-hidden
@@ -193,7 +200,7 @@ function TreeNode({
           "text-[13px] font-mono",
           isSelected ? "bg-surface-2 text-ink" : "text-ink-muted hover:bg-surface-2 hover:text-ink",
         )}
-        style={{ paddingLeft: `${8 + depth * 14}px` }}
+        style={{ paddingLeft: rowPaddingLeft(depth) }}
       >
         <span class={cn("flex-1 truncate", isSelected ? "text-ink" : statusToText(node.status))}>
           {node.name}


### PR DESCRIPTION
## Summary
- Bumped `FileTree` per-depth indent from `14px` to `20px` so nested files clearly sit under their parent folder instead of looking sibling to it.
- Synced the `FileTree` indent rule in `DESIGN.md` to match.

## Test plan
- [ ] Open a scan detail page, expand `dist/` and `src/`, and confirm children read as nested under the parent folder.