### PR TITLE
Add global Feedback mailto button to PageShell header

### DIFF
--- a/src/components/PageShell.tsx
+++ b/src/components/PageShell.tsx
@@ -1,6 +1,10 @@
 import type { ComponentChildren } from "preact";
 import { cn } from "./cn";
 import { BrandMark } from "./BrandMark";
+import { LinkButton } from "./Button";
+
+const FEEDBACK_MAILTO =
+  "mailto:drydock@resynapse.dev?subject=Drydock%20feedback&body=Tell%20us%20what%27s%20broken%2C%20confusing%2C%20or%20missing%3A%0A%0A";
 
 export function PageShell({
   class: className,
@@ -26,7 +30,17 @@ export function PageShell({
       {brand ? (
         <div class="flex flex-wrap items-center justify-between gap-3">
           <BrandMark href="/" size="sm" />
-          {headerActions ? <div class="flex items-center gap-2">{headerActions}</div> : null}
+          <div class="flex items-center gap-2">
+            <LinkButton
+              href={FEEDBACK_MAILTO}
+              variant="ghost"
+              size="sm"
+              title="Email drydock@resynapse.dev with any issues"
+            >
+              Feedback
+            </LinkButton>
+            {headerActions}
+          </div>
         </div>
       ) : null}
       {children}


### PR DESCRIPTION
## Summary
- Adds a global `Feedback` link in the `PageShell` header (next to the `drydock` brand mark), so every page that uses the shell exposes a way to reach `drydock@resynapse.dev`.
- The link opens the user's mail client via `mailto:` with a pre-filled `Drydock feedback` subject and a short body prompt; styled as a ghost-variant `LinkButton` per `DESIGN.md` (no icon, restrained tone).
- Page-specific `headerActions` (org switcher, sign-out, etc.) continue to render to the right of the new button unchanged.

## Test plan
- [ ] Visit `/`, `/login`, `/register`, `/dashboard`, and a scan detail page — Feedback button shows in the header on each.
- [ ] Click Feedback — opens default mail client to `drydock@resynapse.dev` with subject `Drydock feedback`.
- [ ] Dashboard still shows the org switcher and sign-out row to the right of the Feedback button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)