### PR TITLE
Replace dialog cancel button with top-right close glyph

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -55,8 +55,16 @@ export function Dialog({
         className,
       )}
     >
-      <div class="flex flex-col gap-4 p-5">
-        <header class="flex flex-col gap-1">
+      <div class="relative flex flex-col gap-4 p-5">
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          class="absolute top-3 right-3 flex items-center justify-center w-7 h-7 rounded-md text-ink-subtle hover:text-ink hover:bg-surface-2 focus:outline-none focus:ring-2 focus:ring-accent leading-none text-[14px]"
+        >
+          ✕
+        </button>
+        <header class="flex flex-col gap-1 pr-7">
           <h2 class="text-[18px] font-medium tracking-[-0.01em] leading-[1.35] m-0">{title}</h2>
           {description ? (
             <p class="text-[13px] leading-[1.55] text-ink-muted m-0">{description}</p>

--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -797,9 +797,6 @@ function DecisionDialog({
         <Button variant="danger" onClick={() => submit("no_publish")} disabled={saving}>
           {saving ? "Saving…" : "Block publish"}
         </Button>
-        <Button variant="ghost" size="sm" onClick={handleClose} disabled={saving}>
-          Cancel
-        </Button>
       </div>
       {error ? <Alert tone="critical">{error}</Alert> : null}
     </Dialog>


### PR DESCRIPTION
## Summary
- Add a top-right `✕` close button to the shared `Dialog` component (`src/components/Dialog.tsx`), using the allowed text glyph from DESIGN.md and wired to the existing `onClose`.
- Drop the redundant footer Cancel button from the publish decision modal (`src/pages/Dashboard/ScanDetail.tsx`) — save-in-progress closes are still blocked through `handleClose`.

## Test plan
- [ ] Open the publish decision modal and confirm the new `✕` closes it (mouse + keyboard focus + Escape still works).
- [ ] Start a save and verify the `✕` is inert while `saving` is true.
- [ ] Spot-check the OrgSwitcher "New organization" dialog still looks correct with both the new `✕` and its existing footer Cancel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)