### PR TITLE
Align decision badge and button on flex-start

### DIFF
--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -612,7 +612,7 @@ function ScanDetailHeader({
         )}
       </div>
       {onDecideClick ? (
-        <div class="flex flex-wrap items-center gap-3">
+        <div class="flex flex-wrap items-start gap-3">
           {decision ? (
             <div class="flex flex-col items-end gap-1">
               <Badge tone={decision === "publish" ? "ok" : "critical"}>


### PR DESCRIPTION
## Summary
- Switch the scan-detail header's decision cluster from `items-center` to `items-start` so the `APPROVED` badge aligns with the top of the `Update decision` button instead of centering on the badge+date stack.

## Test plan
- [ ] Open a scan with a saved decision and confirm the badge top aligns with the button top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)