### PR TITLE
Collapse dashboard header into one row with menus

### DIFF
--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,0 +1,135 @@
+import type { ComponentChildren, JSX } from "preact";
+import { useRef } from "preact/hooks";
+import { useSignal, useSignalEffect } from "@preact/signals";
+import { cn } from "./cn";
+
+interface MenuProps {
+  trigger: (open: boolean) => ComponentChildren;
+  children: ComponentChildren;
+  align?: "start" | "end";
+  triggerClass?: string;
+  triggerAriaLabel?: string;
+  panelClass?: string;
+  disabled?: boolean;
+}
+
+export function Menu({
+  trigger,
+  children,
+  align = "start",
+  triggerClass,
+  triggerAriaLabel,
+  panelClass,
+  disabled,
+}: MenuProps) {
+  const open = useSignal(false);
+  const rootRef = useRef<HTMLDivElement | null>(null);
+
+  useSignalEffect(() => {
+    if (!open.value) return;
+    const onPointer = (event: PointerEvent) => {
+      const node = rootRef.current;
+      if (!node) return;
+      if (event.target instanceof Node && !node.contains(event.target)) {
+        open.value = false;
+      }
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") open.value = false;
+    };
+    document.addEventListener("pointerdown", onPointer);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("pointerdown", onPointer);
+      document.removeEventListener("keydown", onKey);
+    };
+  });
+
+  const onPanelClick = (event: MouseEvent) => {
+    const target = event.target as HTMLElement | null;
+    if (target?.closest("[data-menu-item]")) open.value = false;
+  };
+
+  return (
+    <div ref={rootRef} class="relative inline-block">
+      <button
+        type="button"
+        onClick={() => {
+          if (disabled) return;
+          open.value = !open.value;
+        }}
+        disabled={disabled}
+        aria-haspopup="menu"
+        aria-expanded={open.value}
+        aria-label={triggerAriaLabel}
+        class={cn("cursor-pointer disabled:cursor-not-allowed disabled:opacity-60", triggerClass)}
+      >
+        {trigger(open.value)}
+      </button>
+      {open.value ? (
+        <div
+          role="menu"
+          onClick={onPanelClick}
+          class={cn(
+            "absolute z-20 mt-1 min-w-[200px] bg-surface border border-border rounded-md shadow-md py-1",
+            align === "end" ? "right-0" : "left-0",
+            panelClass,
+          )}
+        >
+          {children}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+type MenuItemProps = Omit<JSX.ButtonHTMLAttributes<HTMLButtonElement>, "class" | "onClick"> & {
+  onSelect?: () => void;
+  tone?: "default" | "accent";
+  active?: boolean;
+  class?: string;
+  children: ComponentChildren;
+};
+
+export function MenuItem({
+  onSelect,
+  tone = "default",
+  active = false,
+  class: className,
+  children,
+  type = "button",
+  disabled,
+  ...props
+}: MenuItemProps) {
+  return (
+    <button
+      type={type}
+      data-menu-item
+      role="menuitem"
+      onClick={onSelect}
+      disabled={disabled}
+      class={cn(
+        "w-full text-left text-[13px] px-3 py-1.5 cursor-pointer",
+        "hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent",
+        tone === "accent" ? "text-accent" : "text-ink",
+        active ? "font-medium" : "",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function MenuSeparator() {
+  return <div class="my-1 border-t border-border" />;
+}
+
+export function MenuLabel({ children }: { children: ComponentChildren }) {
+  return (
+    <div class="px-3 py-1.5 text-[11px] font-mono text-ink-subtle uppercase tracking-[0.08em]">
+      {children}
+    </div>
+  );
+}

--- a/src/components/OrgSwitcher.tsx
+++ b/src/components/OrgSwitcher.tsx
@@ -1,4 +1,3 @@
-import type { JSX } from "preact";
 import { useSignal } from "@preact/signals";
 import type { Organization } from "../models/organization";
 import { Alert } from "./Alert";
@@ -6,6 +5,7 @@ import { Button } from "./Button";
 import { Dialog } from "./Dialog";
 import { Field } from "./Field";
 import { Input } from "./Input";
+import { Menu, MenuItem, MenuLabel, MenuSeparator } from "./Menu";
 import { cn } from "./cn";
 
 interface OrgSwitcherProps {
@@ -28,10 +28,12 @@ export function OrgSwitcher({
   const creating = useSignal(false);
   const draftName = useSignal("");
 
-  const handleChange: JSX.GenericEventHandler<HTMLSelectElement> = (event) => {
-    const value = (event.currentTarget as HTMLSelectElement).value;
-    if (value && value !== activeOrganizationId) void onActivate(value);
-  };
+  const active = organizations.find((org) => org.id === activeOrganizationId);
+  const triggerLabel = active
+    ? active.name
+    : organizations.length === 0
+      ? "no organizations"
+      : "select organization";
 
   const openCreate = () => {
     draftName.value = "";
@@ -52,36 +54,54 @@ export function OrgSwitcher({
   };
 
   return (
-    <div class="flex flex-col gap-2">
-      <div class="flex flex-wrap items-center gap-3">
-        <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">
-          Organization
-        </span>
-        <select
-          value={activeOrganizationId ?? ""}
-          onChange={handleChange}
-          disabled={busy || organizations.length === 0}
-          class={cn(
-            "bg-bg border border-border rounded-md text-[13px] text-ink px-3 py-2 outline-none",
-            "focus:border-accent focus:shadow-[0_0_0_3px_var(--color-accent-soft)]",
-            "disabled:opacity-60 disabled:cursor-not-allowed",
-            "font-mono min-w-[200px]",
-          )}
-        >
-          {organizations.length === 0 ? <option value="">no organizations</option> : null}
-          {organizations.map((org) => (
-            <option key={org.id} value={org.id}>
-              {org.name}
-              {org.isPersonal ? " (personal)" : ""}
-            </option>
-          ))}
-        </select>
-        <Button variant="secondary" size="sm" onClick={openCreate} disabled={busy} class="shrink-0">
-          New organization
-        </Button>
-      </div>
+    <div class="relative">
+      <Menu
+        align="end"
+        disabled={busy}
+        triggerAriaLabel="Switch organization"
+        triggerClass={cn(
+          "inline-flex items-center gap-2 bg-surface border border-border rounded-md px-3 py-1.5",
+          "text-[13px] text-ink font-mono transition-colors duration-150",
+          "hover:border-border-strong",
+        )}
+        trigger={() => (
+          <>
+            <span class="truncate max-w-[180px]">{triggerLabel}</span>
+            {active?.isPersonal ? (
+              <span class="text-ink-subtle text-[11px]">(personal)</span>
+            ) : null}
+            <span class="text-ink-subtle text-[10px] leading-none ml-1">▾</span>
+          </>
+        )}
+        panelClass="min-w-[240px]"
+      >
+        {organizations.length === 0 ? (
+          <MenuLabel>no organizations</MenuLabel>
+        ) : (
+          organizations.map((org) => (
+            <MenuItem
+              key={org.id}
+              active={org.id === activeOrganizationId}
+              onSelect={() => {
+                if (org.id !== activeOrganizationId) void onActivate(org.id);
+              }}
+            >
+              <span>{org.name}</span>
+              {org.isPersonal ? <span class="text-ink-subtle"> (personal)</span> : null}
+            </MenuItem>
+          ))
+        )}
+        <MenuSeparator />
+        <MenuItem tone="accent" onSelect={openCreate} disabled={busy}>
+          + New organization
+        </MenuItem>
+      </Menu>
 
-      {error ? <Alert tone="critical">{error}</Alert> : null}
+      {error ? (
+        <div class="absolute right-0 top-full mt-2 z-10 w-[280px]">
+          <Alert tone="critical">{error}</Alert>
+        </div>
+      ) : null}
 
       <Dialog
         open={creating.value}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,0 +1,45 @@
+import { Menu, MenuItem, MenuLabel, MenuSeparator } from "./Menu";
+import { cn } from "./cn";
+
+interface UserMenuProps {
+  email?: string | null;
+  name?: string | null;
+  onSignOut: () => void;
+}
+
+function initialsFor(email?: string | null, name?: string | null): string {
+  if (name) {
+    const parts = name.trim().split(/\s+/).filter(Boolean);
+    if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  }
+  if (email) {
+    const local = email.split("@")[0] ?? "";
+    if (local) return local.slice(0, 2).toUpperCase();
+  }
+  return "··";
+}
+
+export function UserMenu({ email, name, onSignOut }: UserMenuProps) {
+  const label = email || name || "signed in";
+  const initials = initialsFor(email, name);
+
+  return (
+    <Menu
+      align="end"
+      triggerAriaLabel={`Account menu for ${label}`}
+      triggerClass={cn(
+        "inline-flex items-center justify-center h-8 w-8 rounded-md",
+        "text-[11px] font-mono font-medium tracking-[0.04em]",
+        "bg-surface border border-border text-ink hover:border-border-strong transition-colors duration-150",
+      )}
+      trigger={() => initials}
+      panelClass="min-w-[220px]"
+    >
+      <MenuLabel>signed in</MenuLabel>
+      <div class="px-3 pb-1.5 text-[13px] text-ink font-mono break-all">{label}</div>
+      <MenuSeparator />
+      <MenuItem onSelect={onSignOut}>Sign out</MenuItem>
+    </Menu>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -31,3 +31,5 @@ export type { SeverityCounts, SeverityKey } from "./SeverityBar";
 export { StatusStrip, StatusStripItem } from "./StatusStrip";
 export { FindingCard, FindingRow } from "./FindingCard";
 export { OrgSwitcher } from "./OrgSwitcher";
+export { UserMenu } from "./UserMenu";
+export { Menu, MenuItem, MenuLabel, MenuSeparator } from "./Menu";

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -28,6 +28,7 @@ import {
   OrgSwitcher,
   PageShell,
   SectionLabel,
+  UserMenu,
   severityTone,
 } from "../../components";
 
@@ -115,7 +116,7 @@ export default function DashboardPage() {
   return (
     <PageShell
       headerActions={
-        <div class="flex flex-col items-end gap-3">
+        <>
           <OrgSwitcher
             organizations={organizations.organizations.value}
             activeOrganizationId={organizations.activeOrganizationId.value}
@@ -124,15 +125,8 @@ export default function DashboardPage() {
             onActivate={onSwitchOrganization}
             onCreate={onCreateOrganization}
           />
-          <div class="flex items-center gap-2.5 bg-surface border border-border rounded-lg pl-3.5 pr-1.5 py-1.5">
-            <span class="font-mono text-xs text-ink-muted">
-              {user?.email || user?.name || "signed in"}
-            </span>
-            <Button variant="secondary" size="sm" onClick={onSignOut}>
-              Sign out
-            </Button>
-          </div>
-        </div>
+          <UserMenu email={user?.email} name={user?.name} onSignOut={onSignOut} />
+        </>
       }
     >
       <DashboardHeader />


### PR DESCRIPTION
## Summary
- Folds the org switcher and user pill into a single inline row in the dashboard header — the org dropdown is now a custom menu with `+ New organization` as its last item, and a compact initials-avatar button opens a menu containing the signed-in email and Sign out.
- Adds a small `Menu` primitive (`Menu`, `MenuItem`, `MenuLabel`, `MenuSeparator`) with outside-click + Escape close, `aria-haspopup`/`aria-expanded`, and reliance on the global `:focus-visible` rule instead of the persistent orange glow the old native `<select>` left behind.
- Sits cleanly alongside the existing `Feedback` button in `PageShell` — header now reads `Feedback | org ▾ | JD` on a single row.

## Test plan
- [x] `pnpm run verify` (lint, format, typecheck, 97 + 38 tests)
- [ ] Dogfood the dashboard: switch orgs, create org via the in-menu entry, hit Sign out from the avatar menu, confirm Escape and outside-click both close

🤖 Generated with [Claude Code](https://claude.com/claude-code)