### PR TITLE
[codex] Prototype signal boundary guardrails

### DIFF
--- a/.claude/skills/preact-signals-eslint-plugin/SKILL.md
+++ b/.claude/skills/preact-signals-eslint-plugin/SKILL.md
@@ -9,6 +9,8 @@ description: Use when configuring, extending, or debugging @preact/eslint-plugin
 
 Use lint rules for common static signal misuse that issue history shows humans and agents repeat. The plugin supports projects using `@preact/signals-core`, `@preact/signals`, `@preact/signals-react`, and `@preact/signals-react/runtime`.
 
+In this repo these rules are the non-negotiable correctness floor. Do not weaken or remove them while making signal changes; add narrower repo checks on top when a pattern is about granularity rather than correctness.
+
 ## Configuration
 
 Oxlint:
@@ -65,6 +67,10 @@ export default [
 | `no-signal-truthiness` | `if (signal)` and similar always-truthy checks |
 | `no-signal-in-component-body` | `signal()`, `computed()`, `effect()` created on every render |
 | `no-conditional-value-read` | `.value` reads hidden behind non-reactive guards |
+
+## Repo-Specific Boundary Check
+
+Run `pnpm run signals:check` for the local AST prototype that flags over-eager `.value` reads in native DOM text and signal-friendly DOM props. This complements the plugin: the plugin catches incorrect signal semantics, while the repo check catches clear missed direct-DOM granularity opportunities.
 
 ## Common Limitations
 

--- a/.claude/skills/preact-signals-preact-integration/SKILL.md
+++ b/.claude/skills/preact-signals-preact-integration/SKILL.md
@@ -60,6 +60,14 @@ function NameField() {
 
 Do not apply the React adapter limitation to Preact; React does not support signal DOM attributes, but Preact does.
 
+## Review Checklist
+
+- Locate where each signal is unboxed. The surrounding component, computed, effect, text node, or DOM prop is the subscriber.
+- Keep signals boxed through props, context, and models when a downstream consumer can subscribe more narrowly.
+- Prefer `{signal}` in DOM text and DOM props such as `value={signal}`, `checked={signal}`, and `disabled={signal}` when the current component does not need to branch on the value.
+- Use `.value` when the current component must branch, derive a plain value, call an API, or pass a deliberate snapshot.
+- Run `pnpm run signals:check` after signal-heavy UI work; use `// signals-boundary-ok: <reason>` only for intentional DOM-boundary snapshots.
+
 ## Show And For
 
 `Show` and `For` optimize around signals. They should not be used to smuggle non-signal parent values into cached children.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Signal boundary check
+        run: pnpm run signals:check
+
       - name: Format check
         run: pnpm run format:check
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,9 @@
 - **Read [`DESIGN.md`](DESIGN.md) before making any visual or UI decision.** It is the source of truth for fonts, colors, spacing, iconography (text glyphs only — no SVG icons), data viz (severity stacked bar only), state patterns, and marketing-surface rules. Do not deviate without explicit user approval. Anti-patterns there are not suggestions — they're prohibitions.
 - We use `preact`, `preact-iso`, and `signals`.
 - `useState` and `useReducer` are banned (oxlint `no-restricted-imports` enforces it). Component-local state goes through `useSignal`/`useComputed` or `createModel`/`useModel`. See `docs/tooling.md` and the skills under `.claude/skills/preact-signals-*` (also surfaced as `.agents/preact-signals-*`).
+- Signal-heavy UI changes must keep the official `@preact/eslint-plugin-signals` rule floor enabled and pass `pnpm run signals:check`, which catches clear DOM-boundary `.value` unboxing that should stay boxed for granular updates.
 - Lint with `pnpm run lint` (oxlint) and format with `pnpm run format` (oxfmt). Configs live in `.oxlintrc.json` and `.oxfmtrc.json`.
-- Before every commit, run `pnpm run verify` (lint + format check + typecheck + tests). The pre-commit hook in `.githooks/pre-commit` runs it automatically; `pnpm install` wires `core.hooksPath` for you. Don't bypass it with `--no-verify` unless you have a real reason.
+- Before every commit, run `pnpm run verify` (lint + signal boundary check + format check + typecheck + tests). The pre-commit hook in `.githooks/pre-commit` runs it automatically; `pnpm install` wires `core.hooksPath` for you. Don't bypass it with `--no-verify` unless you have a real reason.
 - Never write SQL migrations by hand; use `pnpm db:generate` to create migrations from `server/db/schema.ts`.
 - Before you start work read up on `docs/`, when you are done working update `docs/` with relevant information
 - WE NEVER USE `preact/compat`
@@ -41,7 +42,8 @@
 - `npm run build` — Build the UI bundle into `dist/`.
 - `npm run typecheck` — `tsc --noEmit`.
 - `npm run lint` / `npm run lint:fix` — oxlint over `src/`, `server/`, `test/`. Use `:fix` to apply autofixes.
+- `npm run signals:check` — local AST prototype that catches clear DOM-boundary `.value` unboxing in Preact UI.
 - `npm run format` / `npm run format:check` — oxfmt write / check-only.
 - `npm run test` — Vitest logic suite.
-- `npm run verify` — runs lint, format check, typecheck, and tests in order. CI and the pre-commit hook both call this.
+- `npm run verify` — runs lint, signal boundary check, format check, typecheck, and tests in order. CI and the pre-commit hook both call this.
 - `npm run db:generate` — Drizzle migration from `server/db/schema.ts`.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -8,16 +8,17 @@
 
 ## Scripts
 
-| Command                 | What it does                                                                                            |
-| ----------------------- | ------------------------------------------------------------------------------------------------------- |
-| `pnpm run lint`         | Run oxlint over the repo. Exit non-zero on errors.                                                      |
-| `pnpm run lint:fix`     | Apply oxlint autofixes.                                                                                 |
-| `pnpm run format`       | Rewrite files with oxfmt.                                                                               |
-| `pnpm run format:check` | Report files that would change without writing.                                                         |
-| `pnpm run test`         | Node logic tests (`test/**`) plus D1-backed worker tests (`test/workers/**`) via `vitest-pool-workers`. |
-| `pnpm run test:node`    | Just the node logic suite.                                                                              |
-| `pnpm run test:workers` | Just the worker suite (Miniflare D1 from `wrangler.test.jsonc` + `drizzle/`).                           |
-| `pnpm run verify`       | Run lint + format check + typecheck + tests, in order.                                                  |
+| Command                  | What it does                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `pnpm run lint`          | Run oxlint over the repo. Exit non-zero on errors.                                                      |
+| `pnpm run lint:fix`      | Apply oxlint autofixes.                                                                                 |
+| `pnpm run signals:check` | Run the repo-specific signal boundary check over `src/**/*.tsx`.                                        |
+| `pnpm run format`        | Rewrite files with oxfmt.                                                                               |
+| `pnpm run format:check`  | Report files that would change without writing.                                                         |
+| `pnpm run test`          | Node logic tests (`test/**`) plus D1-backed worker tests (`test/workers/**`) via `vitest-pool-workers`. |
+| `pnpm run test:node`     | Just the node logic suite.                                                                              |
+| `pnpm run test:workers`  | Just the worker suite (Miniflare D1 from `wrangler.test.jsonc` + `drizzle/`).                           |
+| `pnpm run verify`        | Run lint + signal boundary check + format check + typecheck + tests, in order.                          |
 
 `pnpm lint` (the shorthand without `run`) can collide with workspace forwarding or shell wrappers — always use `pnpm run lint`.
 
@@ -38,13 +39,30 @@ Reach for a signal when the state is one value; reach for a model when the state
 
 ## Signal plugin rules
 
-The following rules from `@preact/eslint-plugin-signals` are enforced (see [`preact-signals-eslint-plugin`](../.claude/skills/preact-signals-eslint-plugin/SKILL.md) for intent):
+The following rules from `@preact/eslint-plugin-signals` are the repo's correctness floor and must stay enabled (see [`preact-signals-eslint-plugin`](../.claude/skills/preact-signals-eslint-plugin/SKILL.md) for intent):
 
 - `no-signal-write-in-computed` (error)
 - `no-value-after-await` (error)
 - `no-signal-in-component-body` (error)
 - `no-conditional-value-read` (error)
 - `no-signal-truthiness` (warn)
+
+## Signal boundary check
+
+`pnpm run signals:check` runs [`scripts/check-signal-boundaries.mjs`](../scripts/check-signal-boundaries.mjs). This prototype catches locally-created signals that are unboxed too early in native DOM JSX:
+
+- DOM text such as `<span>{count.value}</span>` should usually be `<span>{count}</span>`.
+- DOM props such as `<input value={query.value}>` should usually be `<input value={query}>`.
+
+The check intentionally does not block every `.value` read. Parent components still need `.value` for branching, deriving values, calling APIs that expect plain values, and passing deliberate snapshots. For an intentional snapshot at a DOM boundary, add `// signals-boundary-ok: <reason>` on the same or previous line.
+
+## Signal review checklist
+
+- Is the official signal lint-rule floor still enabled?
+- Where is each signal unboxed, and does that scope need to subscribe?
+- Could a DOM text node, DOM prop, leaf component, or context consumer receive the signal object instead?
+- Are async effects reading `.value` before `await`, or intentionally using `untracked()` after it?
+- Are object and array signal updates assigning a new `.value` reference?
 
 ## Related skills
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
+    "signals:check": "node scripts/check-signal-boundaries.mjs",
     "format": "oxfmt",
     "format:check": "oxfmt --check",
     "db:generate": "drizzle-kit generate",
@@ -19,7 +20,7 @@
     "test": "vitest run --config vitest.config.ts && vitest run --config vitest.workers.config.ts",
     "test:node": "vitest run --config vitest.config.ts",
     "test:workers": "vitest run --config vitest.workers.config.ts",
-    "verify": "pnpm run lint && pnpm run format:check && pnpm run typecheck && pnpm run test",
+    "verify": "pnpm run lint && pnpm run signals:check && pnpm run format:check && pnpm run typecheck && pnpm run test",
     "prepare": "git config core.hooksPath .githooks"
   },
   "dependencies": {

--- a/scripts/check-signal-boundaries.mjs
+++ b/scripts/check-signal-boundaries.mjs
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import ts from "typescript";
+
+const ROOT = process.cwd();
+const DEFAULT_TARGETS = ["src"];
+const EXTENSIONS = new Set([".tsx"]);
+const ESCAPE_COMMENT = "signals-boundary-ok";
+const SIGNAL_IMPORT_SOURCES = new Set(["@preact/signals", "@preact/signals-core"]);
+const SIGNAL_FACTORIES = new Set(["signal", "computed", "useSignal", "useComputed"]);
+const DOM_SIGNAL_ATTRIBUTES = new Set(["checked", "disabled", "open", "selected", "value"]);
+
+const findings = [];
+
+for (const file of collectFiles(process.argv.slice(2))) {
+  checkFile(file);
+}
+
+if (findings.length > 0) {
+  console.error("Signal boundary check found over-eager .value reads:\n");
+  for (const finding of findings) {
+    console.error(`${finding.file}:${finding.line}:${finding.column} ${finding.message}`);
+  }
+  console.error(
+    `\nUse // ${ESCAPE_COMMENT}: <reason> on the same or previous line for intentional snapshots.`,
+  );
+  process.exit(1);
+}
+
+function collectFiles(args) {
+  const targets = args.length > 0 ? args : DEFAULT_TARGETS;
+  const files = [];
+
+  for (const target of targets) {
+    const absolute = path.resolve(ROOT, target);
+    if (!fs.existsSync(absolute)) continue;
+    const stat = fs.statSync(absolute);
+    if (stat.isDirectory()) {
+      walk(absolute, files);
+    } else if (EXTENSIONS.has(path.extname(absolute))) {
+      files.push(absolute);
+    }
+  }
+
+  return files.sort();
+}
+
+function walk(dir, files) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === "dist" || entry.name === ".wrangler") {
+      continue;
+    }
+
+    const absolute = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(absolute, files);
+    } else if (EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(absolute);
+    }
+  }
+}
+
+function checkFile(file) {
+  const text = fs.readFileSync(file, "utf8");
+  const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const lines = text.split(/\r?\n/);
+  const importedFactories = new Set();
+  const signals = new Set();
+
+  collectSignalNames(source, importedFactories, signals);
+  inspectJsx(source, lines, signals, file);
+}
+
+function collectSignalNames(source, importedFactories, signals) {
+  function visit(node) {
+    if (ts.isImportDeclaration(node) && SIGNAL_IMPORT_SOURCES.has(moduleName(node))) {
+      const bindings = node.importClause?.namedBindings;
+      if (bindings && ts.isNamedImports(bindings)) {
+        for (const element of bindings.elements) {
+          const imported = element.propertyName?.text ?? element.name.text;
+          if (SIGNAL_FACTORIES.has(imported)) importedFactories.add(element.name.text);
+        }
+      }
+    }
+
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+      if (
+        isSignalFactoryCall(node.initializer, importedFactories) ||
+        isSignalType(node.type, source)
+      ) {
+        signals.add(node.name.text);
+      }
+    }
+
+    if (ts.isParameter(node) && ts.isIdentifier(node.name) && isSignalType(node.type, source)) {
+      signals.add(node.name.text);
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(source);
+}
+
+function inspectJsx(source, lines, signals, file) {
+  function visit(node) {
+    if (ts.isJsxAttribute(node)) {
+      inspectAttribute(node, source, lines, signals, file);
+    } else if (ts.isJsxExpression(node)) {
+      inspectTextExpression(node, source, lines, signals, file);
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(source);
+}
+
+function inspectAttribute(node, source, lines, signals, file) {
+  const attrName = node.name.getText(source);
+  if (!DOM_SIGNAL_ATTRIBUTES.has(attrName)) return;
+  if (!node.initializer || !ts.isJsxExpression(node.initializer)) return;
+  if (!isDomTag(attributeTag(node, source))) return;
+
+  const signalName = signalValueName(node.initializer.expression, signals);
+  if (!signalName || hasEscape(lines, source, node)) return;
+
+  report(file, source, node, `pass signal '${signalName}' directly to DOM prop '${attrName}'`);
+}
+
+function inspectTextExpression(node, source, lines, signals, file) {
+  if (!isDomTextExpression(node, source)) return;
+
+  const signalName = signalValueName(node.expression, signals);
+  if (!signalName || hasEscape(lines, source, node)) return;
+
+  report(file, source, node, `render signal '${signalName}' directly as JSX text`);
+}
+
+function moduleName(node) {
+  return ts.isStringLiteral(node.moduleSpecifier) ? node.moduleSpecifier.text : "";
+}
+
+function isSignalFactoryCall(node, importedFactories) {
+  if (!node || !ts.isCallExpression(node)) return false;
+  const expression = unwrap(node.expression);
+  return ts.isIdentifier(expression) && importedFactories.has(expression.text);
+}
+
+function isSignalType(node, source) {
+  if (!node) return false;
+  return /\b(?:Readonly)?Signal\s*</.test(node.getText(source));
+}
+
+function signalValueName(node, signals) {
+  const expression = unwrap(node);
+  if (!expression || !ts.isPropertyAccessExpression(expression)) return null;
+  if (expression.name.text !== "value") return null;
+  const target = unwrap(expression.expression);
+  return target && ts.isIdentifier(target) && signals.has(target.text) ? target.text : null;
+}
+
+function unwrap(node) {
+  let current = node;
+  while (
+    current &&
+    (ts.isParenthesizedExpression(current) ||
+      ts.isAsExpression(current) ||
+      ts.isNonNullExpression(current) ||
+      ts.isTypeAssertionExpression(current))
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function attributeTag(node, source) {
+  const parent = node.parent.parent;
+  if (ts.isJsxOpeningElement(parent) || ts.isJsxSelfClosingElement(parent)) {
+    return parent.tagName.getText(source);
+  }
+  return "";
+}
+
+function isDomTextExpression(node, source) {
+  if (!ts.isJsxElement(node.parent)) return false;
+  return isDomTag(node.parent.openingElement.tagName.getText(source));
+}
+
+function isDomTag(name) {
+  return /^[a-z][\w-]*$/.test(name);
+}
+
+function hasEscape(lines, source, node) {
+  const position = source.getLineAndCharacterOfPosition(node.getStart(source));
+  return lineHasEscape(lines, position.line) || lineHasEscape(lines, position.line - 1);
+}
+
+function lineHasEscape(lines, index) {
+  return index >= 0 && index < lines.length && lines[index].includes(ESCAPE_COMMENT);
+}
+
+function report(file, source, node, message) {
+  const position = source.getLineAndCharacterOfPosition(node.getStart(source));
+  findings.push({
+    file: path.relative(ROOT, file),
+    line: position.line + 1,
+    column: position.character + 1,
+    message,
+  });
+}

--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -286,7 +286,7 @@ export default function ScanDetailPage() {
               <SectionLabel>Release tree</SectionLabel>
               <Input
                 type="search"
-                value={fileFilter.value}
+                value={fileFilter}
                 placeholder="Filter files"
                 onInput={(e) => (fileFilter.value = (e.target as HTMLInputElement).value)}
                 autoComplete="off"
@@ -296,7 +296,7 @@ export default function ScanDetailPage() {
                 <label class="flex items-center gap-2 text-[13px] text-ink-muted">
                   <input
                     type="checkbox"
-                    checked={changedFilesOnly.value}
+                    checked={changedFilesOnly}
                     onChange={(e) =>
                       (changedFilesOnly.value = (e.target as HTMLInputElement).checked)
                     }
@@ -833,7 +833,7 @@ function DecisionDialog({
         <Input
           id="decisionReason"
           type="text"
-          value={reasonDraft.value}
+          value={reasonDraft}
           placeholder="e.g. minor patch, no risk signals"
           onInput={(e) => (reasonDraft.value = (e.target as HTMLInputElement).value)}
           disabled={saving}

--- a/test/signal-boundary-check.test.mjs
+++ b/test/signal-boundary-check.test.mjs
@@ -1,0 +1,63 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, test } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const scriptPath = path.join(process.cwd(), "scripts/check-signal-boundaries.mjs");
+
+describe("signal boundary check", () => {
+  test("flags locally-created signals unboxed in DOM text and props", async () => {
+    const result = await runFixture(`
+      import { useSignal } from "@preact/signals";
+
+      export function Example() {
+        const count = useSignal(0);
+        return <label><span>{count.value}</span><input value={count.value} /></label>;
+      }
+    `);
+
+    expect(result.ok).toBe(false);
+    expect(result.stderr).toContain("render signal 'count' directly as JSX text");
+    expect(result.stderr).toContain("pass signal 'count' directly to DOM prop 'value'");
+  });
+
+  test("allows direct signal boundaries and explicit snapshot escapes", async () => {
+    const result = await runFixture(`
+      import { useSignal } from "@preact/signals";
+
+      export function Example() {
+        const count = useSignal(0);
+        return (
+          <label>
+            <span>{count}</span>
+            <input value={count} />
+            {/* signals-boundary-ok: exercising a deliberate DOM snapshot */}
+            <input value={count.value} />
+          </label>
+        );
+      }
+    `);
+
+    expect(result.ok).toBe(true);
+  });
+});
+
+async function runFixture(source) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "signal-boundary-"));
+  const file = path.join(dir, "fixture.tsx");
+
+  try {
+    await writeFile(file, source);
+    const output = await execFileAsync(process.execPath, [scriptPath, file], {
+      cwd: process.cwd(),
+    });
+    return { ok: true, stdout: output.stdout, stderr: output.stderr };
+  } catch (error) {
+    return { ok: false, stdout: error.stdout ?? "", stderr: error.stderr ?? "" };
+  } finally {
+    await rm(dir, { force: true, recursive: true });
+  }
+}


### PR DESCRIPTION
Adds a repo-specific `signals:check` script that flags locally-created signals unboxed too early in native DOM text and signal-friendly DOM props, with a documented `signals-boundary-ok` escape hatch.

The check is wired into `pnpm run verify` and CI, with Vitest coverage for failure and escape behavior.

The signal skills and tooling docs now include the official lint-rule floor and a review checklist for subscription boundaries.

The scan detail inputs now pass signal objects directly where the new guardrail applies.

Validation: `pnpm run verify`.