### PR TITLE
Gate AI review behind AI_REVIEW_ENABLED flag

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -17,3 +17,7 @@ NPM_CONNECTIONS_ENCRYPTION_KEY=replace-with-a-random-32-byte-secret
 # Optional local overrides for non-secret vars that are also defined in wrangler.jsonc.
 # NPM_REGISTRY=https://registry.npmjs.org
 # AI_CACHE_AFFINITY=staged-publish-review-release-reviewer-v1
+
+# Feature flag for the Workers AI reviewer. Off by default while the AI review is
+# being staged for paid-tier re-introduction. Set to "true" to run the reviewer pass.
+# AI_REVIEW_ENABLED=false

--- a/server/env.d.ts
+++ b/server/env.d.ts
@@ -12,6 +12,7 @@ declare global {
       BETTER_AUTH_SECRET: string;
       BETTER_AUTH_URL?: string;
       AUTH_REQUIRED?: string;
+      AI_REVIEW_ENABLED?: string;
     }
   }
 

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -100,9 +100,9 @@ export async function runScanPipeline(
     releaseDelta: finding.releaseDelta,
   }));
   const scanId = input.scanId || crypto.randomUUID();
-  // AI review is disabled while we work toward a paid-tier offering. The call,
-  // escalation logging, and risk wiring below stay intact (gated by `if (false)`)
-  // so the feature can be re-enabled without rebuilding the contract.
+  // AI review is gated behind AI_REVIEW_ENABLED while we work toward a paid-tier
+  // offering. Default-off so the call, escalation logging, and risk wiring below
+  // stay dormant until an operator opts in.
   let aiFindings: AiReview = {
     status: "unavailable",
     risk: "low",
@@ -114,8 +114,7 @@ export async function runScanPipeline(
     escalated: false,
     escalationReasons: [],
   };
-  // eslint-disable-next-line no-constant-condition -- AI review is intentionally disabled; the call below remains wired up for paid-tier re-introduction.
-  if (false) {
+  if (env.AI_REVIEW_ENABLED === "true") {
     aiFindings = await runSelectiveAiReview(env, {
       files: redactedStagedFiles,
       diff,

--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -1084,8 +1084,7 @@ function ReportOverview({
         {artifactRisk !== releaseRisk ? (
           <Badge tone="neutral">artifact {artifactRisk}</Badge>
         ) : null}
-        {/* eslint-disable-next-line no-constant-binary-expression -- AI review intentionally disabled; JSX preserved for paid-tier re-introduction. */}
-        {false &&
+        {ai?.model != null &&
           (aiComplete ? (
             <>
               <Badge tone={ai!.requiresManualReview ? "medium" : "ok"}>
@@ -1193,8 +1192,7 @@ function PersistedReportSections({
         )}
       </ReportSection>
 
-      {/* eslint-disable-next-line no-constant-binary-expression -- AI review intentionally disabled; JSX preserved for paid-tier re-introduction. */}
-      {false && (
+      {ai?.model != null && (
         <ReportSection title="Reviewer notes">
           {ai ? (
             ai!.status === "complete" ? (

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -69,6 +69,7 @@
 	"vars": {
 		"BETTER_AUTH_URL": "https://drydock.resynapse.dev",
 		"AI_CACHE_AFFINITY": "staged-publish-review-release-reviewer-v1",
+		"AI_REVIEW_ENABLED": "false",
 		"NPM_REGISTRY": "https://registry.npmjs.org",
 		"PNPM_VERSION": "11.1.1"
 	}

--- a/wrangler.test.jsonc
+++ b/wrangler.test.jsonc
@@ -8,6 +8,7 @@
     "BETTER_AUTH_SECRET": "test-secret-that-is-long-enough-for-better-auth",
     "BETTER_AUTH_URL": "http://example.com",
     "AI_CACHE_AFFINITY": "staged-publish-review-test",
+    "AI_REVIEW_ENABLED": "false",
     "NPM_REGISTRY": "https://registry.npmjs.org",
     "NPM_CONNECTIONS_ENCRYPTION_KEY": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
   },


### PR DESCRIPTION
## Summary
- Replace the hardcoded `if (false)` guard around the Workers AI reviewer in `server/lib/scan-pipeline.ts` with `env.AI_REVIEW_ENABLED === "true"`, default off via wrangler vars.
- Add `AI_REVIEW_ENABLED` to `Cloudflare.Env`, both wrangler configs, and `.dev.vars.example` so operators can flip the flag without code changes.
- Switch the dashboard's AI badges and "Reviewer notes" section to gate on `ai?.model != null`, so they stay hidden when the flag is off and reappear once a real reviewer pass runs.

## Test plan
- [x] pnpm run verify (lint + format + typecheck + 142 tests)
- [ ] Smoke-test a scan locally with `AI_REVIEW_ENABLED=true` to confirm badges and reviewer notes render

🤖 Generated with [Claude Code](https://claude.com/claude-code)