### PR TITLE
Move AI review gate to Cloudflare Flagship (drydock/ai-review)

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -18,6 +18,6 @@ NPM_CONNECTIONS_ENCRYPTION_KEY=replace-with-a-random-32-byte-secret
 # NPM_REGISTRY=https://registry.npmjs.org
 # AI_CACHE_AFFINITY=staged-publish-review-release-reviewer-v1
 
-# Feature flag for the Workers AI reviewer. Off by default while the AI review is
-# being staged for paid-tier re-introduction. Set to "true" to run the reviewer pass.
-# AI_REVIEW_ENABLED=false
+# The AI reviewer is gated by the Cloudflare Flagship flag `ai-review` in the
+# `drydock` app (see the `flagship` binding in wrangler.jsonc). Toggle it from
+# the Cloudflare dashboard; there is no .dev.vars override.

--- a/server/env.d.ts
+++ b/server/env.d.ts
@@ -12,7 +12,7 @@ declare global {
       BETTER_AUTH_SECRET: string;
       BETTER_AUTH_URL?: string;
       AUTH_REQUIRED?: string;
-      AI_REVIEW_ENABLED?: string;
+      FLAGS?: Flagship;
     }
   }
 
@@ -35,6 +35,18 @@ declare global {
       input: unknown,
       options?: { extraHeaders?: Record<string, string>; gateway?: { id: string } },
     ): Promise<{ response?: unknown; usage?: unknown } | unknown>;
+  }
+
+  interface FlagshipEvaluationContext {
+    [key: string]: string | number | boolean | undefined;
+  }
+
+  interface Flagship {
+    getBooleanValue(
+      flagKey: string,
+      defaultValue: boolean,
+      context?: FlagshipEvaluationContext,
+    ): Promise<boolean>;
   }
 }
 

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -100,9 +100,9 @@ export async function runScanPipeline(
     releaseDelta: finding.releaseDelta,
   }));
   const scanId = input.scanId || crypto.randomUUID();
-  // AI review is gated behind AI_REVIEW_ENABLED while we work toward a paid-tier
-  // offering. Default-off so the call, escalation logging, and risk wiring below
-  // stay dormant until an operator opts in.
+  // AI review is gated by the Cloudflare Flagship `ai-review` flag in the
+  // `drydock` app, evaluated per-organization. Default-off until Flagship
+  // returns true for the organization placing the scan.
   let aiFindings: AiReview = {
     status: "unavailable",
     risk: "low",
@@ -114,7 +114,13 @@ export async function runScanPipeline(
     escalated: false,
     escalationReasons: [],
   };
-  if (env.AI_REVIEW_ENABLED === "true") {
+  const aiReviewEnabled = env.FLAGS
+    ? await env.FLAGS.getBooleanValue("ai-review", false, {
+        targetingKey: input.organizationId,
+        organizationId: input.organizationId,
+      })
+    : false;
+  if (aiReviewEnabled) {
     aiFindings = await runSelectiveAiReview(env, {
       files: redactedStagedFiles,
       diff,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -22,7 +22,7 @@
 	"flagship": [
 		{
 			"binding": "FLAGS",
-			"app_id": "drydock"
+			"app_id": "ba0fc327-0ea4-4c39-ad70-7ee70a33c6e3"
 		}
 	],
 	"worker_loaders": [

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -19,6 +19,12 @@
 	"ai": {
 		"binding": "AI"
 	},
+	"flagship": [
+		{
+			"binding": "FLAGS",
+			"app_id": "drydock"
+		}
+	],
 	"worker_loaders": [
 		{
 			"binding": "LOADER"
@@ -69,7 +75,6 @@
 	"vars": {
 		"BETTER_AUTH_URL": "https://drydock.resynapse.dev",
 		"AI_CACHE_AFFINITY": "staged-publish-review-release-reviewer-v1",
-		"AI_REVIEW_ENABLED": "false",
 		"NPM_REGISTRY": "https://registry.npmjs.org",
 		"PNPM_VERSION": "11.1.1"
 	}

--- a/wrangler.test.jsonc
+++ b/wrangler.test.jsonc
@@ -8,7 +8,6 @@
     "BETTER_AUTH_SECRET": "test-secret-that-is-long-enough-for-better-auth",
     "BETTER_AUTH_URL": "http://example.com",
     "AI_CACHE_AFFINITY": "staged-publish-review-test",
-    "AI_REVIEW_ENABLED": "false",
     "NPM_REGISTRY": "https://registry.npmjs.org",
     "NPM_CONNECTIONS_ENCRYPTION_KEY": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
   },


### PR DESCRIPTION
## Summary
- Swap the static `AI_REVIEW_ENABLED` env var for the new [Cloudflare Flagship](https://developers.cloudflare.com/changelog/post/2026-05-26-public-beta/) binding (`flagship.binding=FLAGS`, `app_id=drydock`).
- Evaluate `ai-review` per-scan with the scan's `organizationId` as the targeting subject, so the reviewer can be ramped by tenant from the Cloudflare dashboard with no deploy.
- Drops the AI_REVIEW_ENABLED entries from both wrangler configs and \`.dev.vars.example\`; adds a minimal \`Flagship\` typing in \`server/env.d.ts\` until \`@cloudflare/workers-types\` ships it.

## Test plan
- [x] pnpm run verify (lint + format + typecheck + 142 tests)
- [ ] Create the `ai-review` flag in the `drydock` Flagship app and confirm a scan toggles AI on/off per organizationId