### PR TITLE
Lock down sandbox egress and isolate ambient surfaces

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,7 +72,8 @@ The dynamic Worker's archive parser is defined in `server/lib/tar-parser.js` and
 It should:
 
 - accept an organization-scoped credential context from the parent Worker;
-- attach auth only to allowed npm registry endpoints;
+- accept a per-call `allowedUrl` and reject anything that is not a `GET` to that exact URL;
+- attach auth only when the request matches the pinned URL;
 - never forward auth to arbitrary origins;
 - record token-use audit events at the parent layer;
 - keep the sandbox ignorant of credentials.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -100,13 +100,9 @@ Redaction is a defense-in-depth feature, not a proof that data is safe. Redact k
 
 ## Sandbox egress policy
 
-Allowed credentialed egress through `NpmStageGateway`:
+The gateway is pinned per-call to the exact URL the parent intends to fetch. The parent computes the target URL (staged tarball for a stage ID, or a registry-issued previous-version `.tgz`) and passes it to `NpmStageGateway` as the `allowedUrl` prop. The gateway accepts only a `GET` whose protocol, origin, pathname, and search exactly match `allowedUrl`; everything else is rejected with `403`.
 
-- `GET` staged npm tarball endpoint;
-- `GET` npm package metadata JSON endpoint;
-- `GET` published npm `.tgz` tarballs for previous-version diffing.
-
-The trusted parent Worker may also call npm's staged list/view endpoints (`/-/stage`, `/-/stage/:id`) with organization credentials for discovery, validation, tag-aware baseline selection, and shasum/mismatch checks. Current staged-view responses are metadata-only, not prepared manifests. Those responses are treated as registry metadata and are not fetched from inside the sandbox; token material still never enters the sandbox.
+The trusted parent Worker may also call npm's staged list/view endpoints (`/-/stage`, `/-/stage/:id`) and package metadata with organization credentials for discovery, validation, tag-aware baseline selection, and shasum/mismatch checks. Those responses are never fetched from inside the sandbox; token material still never enters the sandbox.
 
 This matches Cloudflare's [outbound Worker sandbox-auth model](https://blog.cloudflare.com/sandbox-auth/): auth injection happens in a trusted WorkerEntrypoint using parent-provided props, not inside the sandboxed workload.
 
@@ -115,9 +111,15 @@ Blocked:
 - arbitrary origins;
 - package-controlled URLs;
 - install-time network calls;
-- any request where npm auth would be forwarded to a non-registry origin.
+- any URL other than the per-call pinned target — even other endpoints on the configured registry origin.
 
-The gateway compares URL origins against the configured npm registry and attaches credentials only for the minimal endpoint set requiring auth. For the PyPI foundation, it can also allow exact public artifact URLs without credentials; those URLs must be explicitly listed and are intended for `files.pythonhosted.org` release artifacts. Previous-version compare cache entries are scoped by organization so cached private-package evidence is not shared across tenants.
+Sandbox isolate posture:
+
+- `globalThis.caches` is redefined to `undefined` in the sandbox preamble so a parser regression cannot accidentally cache untrusted bytes;
+- `compatibilityFlags: []` is passed explicitly to `LOADER.load` so date bumps cannot quietly enable new ambient APIs in the sandbox;
+- `subRequests` is capped at `1` — the sandbox fetches exactly one artifact.
+
+For the PyPI foundation, the parent can also pin exact public artifact URLs without credentials; those URLs must be explicitly listed and are intended for `files.pythonhosted.org` release artifacts. Previous-version compare cache entries are scoped by organization so cached private-package evidence is not shared across tenants.
 
 ## PyPI workflow-gate posture
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -100,7 +100,7 @@ Redaction is a defense-in-depth feature, not a proof that data is safe. Redact k
 
 ## Sandbox egress policy
 
-The gateway is pinned per-call to the exact URL the parent intends to fetch. The parent computes the target URL (staged tarball for a stage ID, or a registry-issued previous-version `.tgz`) and passes it to `NpmStageGateway` as the `allowedUrl` prop. Metadata-provided previous-version URLs must still be HTTPS, same-origin with the configured registry, and published tarball-shaped (`/-/` path ending in `.tgz`) before they are pinned. The gateway accepts only a `GET` whose protocol, origin, pathname, and search exactly match `allowedUrl`; everything else is rejected with `403`.
+The gateway is pinned per-call to the exact URL the parent intends to fetch. The parent computes the target URL (staged tarball for a stage ID, or a registry-issued previous-version `.tgz`) and passes it to `NpmStageGateway` as the `allowedUrl` prop. Metadata-provided previous-version URLs must still be HTTPS, same-origin with the configured registry, and published tarball-shaped (`/-/` path ending in `.tgz`) before they are pinned. The gateway accepts only a `GET` whose protocol, origin, pathname, and search exactly match `allowedUrl`; everything else is rejected with `403`. Gateway fetches use manual redirect handling so a registry redirect cannot create a second unpinned outbound request.
 
 The trusted parent Worker may also call npm's staged list/view endpoints (`/-/stage`, `/-/stage/:id`) and package metadata with organization credentials for discovery, validation, tag-aware baseline selection, and shasum/mismatch checks. Those responses are never fetched from inside the sandbox; token material still never enters the sandbox.
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -100,7 +100,7 @@ Redaction is a defense-in-depth feature, not a proof that data is safe. Redact k
 
 ## Sandbox egress policy
 
-The gateway is pinned per-call to the exact URL the parent intends to fetch. The parent computes the target URL (staged tarball for a stage ID, or a registry-issued previous-version `.tgz`) and passes it to `NpmStageGateway` as the `allowedUrl` prop. The gateway accepts only a `GET` whose protocol, origin, pathname, and search exactly match `allowedUrl`; everything else is rejected with `403`.
+The gateway is pinned per-call to the exact URL the parent intends to fetch. The parent computes the target URL (staged tarball for a stage ID, or a registry-issued previous-version `.tgz`) and passes it to `NpmStageGateway` as the `allowedUrl` prop. Metadata-provided previous-version URLs must still be HTTPS, same-origin with the configured registry, and published tarball-shaped (`/-/` path ending in `.tgz`) before they are pinned. The gateway accepts only a `GET` whose protocol, origin, pathname, and search exactly match `allowedUrl`; everything else is rejected with `403`.
 
 The trusted parent Worker may also call npm's staged list/view endpoints (`/-/stage`, `/-/stage/:id`) and package metadata with organization credentials for discovery, validation, tag-aware baseline selection, and shasum/mismatch checks. Those responses are never fetched from inside the sandbox; token material still never enters the sandbox.
 

--- a/server/env.d.ts
+++ b/server/env.d.ts
@@ -34,6 +34,7 @@ declare global {
   interface WorkerLoader {
     load(code: {
       compatibilityDate: string;
+      compatibilityFlags?: string[];
       mainModule: string;
       modules: Record<string, string>;
       env?: Record<string, unknown>;

--- a/server/lib/sandbox.ts
+++ b/server/lib/sandbox.ts
@@ -8,6 +8,7 @@ import type { TarSuspiciousEntry } from "./tar-parser.js";
 const MAX_FILES = 250;
 const MAX_BYTES_PER_FILE = 64 * 1024;
 const MAX_TAR_BYTES = 25 * 1024 * 1024;
+const STAGE_ID_RE = new RegExp(`^${STAGE_ID_PATTERN}$`);
 
 // Functions whose source text is concatenated into the sandbox worker module.
 // They must remain referenced only by lexical name (no closures) so the order
@@ -46,68 +47,90 @@ function renderTarParserSource() {
 
 interface NpmStageGatewayProps {
   npmToken?: string;
-  npmRegistry?: string;
-  publicArtifactUrls?: string[];
+  allowedUrl: string;
+  credentialed?: boolean;
 }
 
-export interface NpmStageGatewayPolicy {
+export interface NpmStageGatewayDecision {
   allowed: boolean;
-  credentialed: boolean;
-  kind: "staged-tarball" | "published-tarball" | "package-metadata" | "public-artifact" | "blocked";
 }
 
-export function evaluateNpmStageGatewayRequest(
+export function matchAllowedRequest(
   requestUrl: string,
   method: string,
-  registryUrl: string,
-  publicArtifactUrls: string[] = [],
-): NpmStageGatewayPolicy {
-  const url = new URL(requestUrl);
-  const registry = new URL(registryUrl || "https://registry.npmjs.org");
-  const sameOrigin = url.origin === registry.origin;
-  const normalizedMethod = method.toUpperCase();
-  const isPublicArtifact =
-    normalizedMethod === "GET" &&
-    url.protocol === "https:" &&
-    publicArtifactUrls.some((allowedUrl) => requestUrl === allowedUrl);
-  const packageMetadataPath = /^\/(?:@[^/]+%2[fF][^/]+|[^/@-][^/]*)$/.test(url.pathname);
-  const isStagedTarball =
-    sameOrigin &&
-    normalizedMethod === "GET" &&
-    url.pathname.startsWith("/-/stage/") &&
-    url.pathname.endsWith("/tarball");
-  const isPublishedTarball =
-    sameOrigin &&
-    normalizedMethod === "GET" &&
-    url.pathname.endsWith(".tgz") &&
-    url.pathname.includes("/-/");
-  const isRegistryMetadata = sameOrigin && normalizedMethod === "GET" && packageMetadataPath;
+  allowedUrl: string,
+  options: { allowInsecureLocalhost?: boolean } = {},
+): NpmStageGatewayDecision {
+  if (method.toUpperCase() !== "GET") return { allowed: false };
+  let request: URL;
+  let allowed: URL;
+  try {
+    request = new URL(requestUrl);
+    allowed = new URL(allowedUrl);
+  } catch {
+    return { allowed: false };
+  }
+  if (!registryProtocolAllowed(request, options) || !registryProtocolAllowed(allowed, options)) {
+    return { allowed: false };
+  }
+  if (request.origin !== allowed.origin) return { allowed: false };
+  if (request.pathname !== allowed.pathname) return { allowed: false };
+  if (request.search !== allowed.search) return { allowed: false };
+  return { allowed: true };
+}
 
-  if (isPublicArtifact) return { allowed: true, credentialed: false, kind: "public-artifact" };
-  if (isStagedTarball) return { allowed: true, credentialed: true, kind: "staged-tarball" };
-  if (isPublishedTarball) return { allowed: true, credentialed: true, kind: "published-tarball" };
-  if (isRegistryMetadata) return { allowed: true, credentialed: true, kind: "package-metadata" };
-  return { allowed: false, credentialed: false, kind: "blocked" };
+export function isAllowedPublishedTarballUrl(
+  tarballUrl: string,
+  registryUrl: string,
+  options: { allowInsecureLocalhost?: boolean } = {},
+): boolean {
+  try {
+    const tarball = new URL(tarballUrl);
+    const registry = new URL(registryUrl);
+    return (
+      tarball.origin === registry.origin &&
+      registryProtocolAllowed(tarball, options) &&
+      tarball.pathname.endsWith(".tgz") &&
+      tarball.pathname.includes("/-/")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function isAllowedPublicArtifactUrl(
+  artifactUrl: string,
+  publicArtifactUrls: readonly string[] = [],
+): boolean {
+  try {
+    const artifact = new URL(artifactUrl);
+    if (artifact.protocol !== "https:") return false;
+    return publicArtifactUrls.some((allowedUrl) => {
+      try {
+        return new URL(allowedUrl).toString() === artifact.toString();
+      } catch {
+        return false;
+      }
+    });
+  } catch {
+    return false;
+  }
 }
 
 export class NpmStageGateway extends WorkerEntrypoint<Cloudflare.Env, NpmStageGatewayProps> {
   async fetch(request: Request): Promise<Response> {
-    const registry =
-      this.ctx.props.npmRegistry || this.env.NPM_REGISTRY || "https://registry.npmjs.org";
-    const policy = evaluateNpmStageGatewayRequest(
-      request.url,
-      request.method,
-      registry,
-      this.ctx.props.publicArtifactUrls,
-    );
-
-    if (!policy.allowed) {
+    const decision = matchAllowedRequest(request.url, request.method, this.ctx.props.allowedUrl, {
+      allowInsecureLocalhost: allowInsecureLocalRegistry(this.env),
+    });
+    if (!decision.allowed) {
       return new Response("blocked by stage gateway", { status: 403 });
     }
 
     const token = this.ctx.props.npmToken;
-    const forwarded = new Request(request);
-    if (token && policy.credentialed) forwarded.headers.set("authorization", `Bearer ${token}`);
+    const forwarded = new Request(request, { redirect: "manual" });
+    if (token && this.ctx.props.credentialed !== false) {
+      forwarded.headers.set("authorization", `Bearer ${token}`);
+    }
     forwarded.headers.set("user-agent", "staged-publish-review/0.3");
 
     return fetch(forwarded);
@@ -172,34 +195,15 @@ export async function downloadInSandbox(
   options: DownloadOptions,
 ): Promise<DownloadResult> {
   const registry = options.npmRegistry || env.NPM_REGISTRY || "https://registry.npmjs.org";
-  if (options.tarballUrl) {
-    try {
-      const tarball = new URL(options.tarballUrl);
-      const registryOrigin = new URL(registry).origin;
-      const isRegistryArtifact =
-        tarball.origin === registryOrigin &&
-        registryProtocolAllowed(tarball, {
-          allowInsecureLocalhost: allowInsecureLocalRegistry(env),
-        });
-      const isPublicArtifact =
-        tarball.protocol === "https:" &&
-        (options.publicArtifactUrls ?? []).some((allowedUrl) => allowedUrl === options.tarballUrl);
-      if (!isRegistryArtifact && !isPublicArtifact) {
-        throw new SandboxError(
-          JSON.stringify({ error: "tarball URL is not allowed by the gateway", status: 400 }),
-        );
-      }
-    } catch (err) {
-      if (err instanceof SandboxError) throw err;
-      throw new SandboxError(JSON.stringify({ error: "invalid tarball URL", status: 400 }));
-    }
-  }
+  const target = resolveTargetUrl(registry, options, {
+    allowInsecureLocalhost: allowInsecureLocalRegistry(env),
+  });
   const sandbox = env.LOADER.load({
     compatibilityDate: "2026-05-20",
+    compatibilityFlags: [],
     mainModule: "sandbox.js",
     modules: { "sandbox.js": sandboxSource() },
     env: {
-      NPM_REGISTRY: options.npmRegistry || env.NPM_REGISTRY || "https://registry.npmjs.org",
       ARCHIVE_FORMAT: options.archiveFormat || "tgz",
       MAX_FILES: Math.min(options.maxFiles ?? MAX_FILES, MAX_FILES),
       MAX_BYTES_PER_FILE: Math.min(
@@ -215,17 +219,17 @@ export async function downloadInSandbox(
     ).exports.NpmStageGateway({
       props: {
         npmToken: options.npmToken,
-        npmRegistry: options.npmRegistry,
-        publicArtifactUrls: options.publicArtifactUrls,
+        allowedUrl: target.url,
+        credentialed: target.credentialed,
       },
     }),
-    limits: { cpuMs: 2_000, subRequests: 4 },
+    limits: { cpuMs: 2_000, subRequests: 1 },
   });
 
   const response = await sandbox.getEntrypoint().fetch(
     new Request("https://sandbox.local/download", {
       method: "POST",
-      body: JSON.stringify({ stageId: options.stageId, tarballUrl: options.tarballUrl }),
+      body: JSON.stringify({ targetUrl: target.url }),
       headers: { "content-type": "application/json" },
     }),
   );
@@ -236,19 +240,60 @@ export async function downloadInSandbox(
   return (await response.json()) as DownloadResult;
 }
 
-function sandboxSource() {
-  return `${renderTarParserSource()}
+function resolveTargetUrl(
+  registry: string,
+  options: DownloadOptions,
+  protocolOptions: { allowInsecureLocalhost?: boolean },
+): { url: string; credentialed: boolean } {
+  if (options.tarballUrl) {
+    if (isAllowedPublishedTarballUrl(options.tarballUrl, registry, protocolOptions)) {
+      return { url: new URL(options.tarballUrl).toString(), credentialed: true };
+    }
+    if (isAllowedPublicArtifactUrl(options.tarballUrl, options.publicArtifactUrls)) {
+      return { url: new URL(options.tarballUrl).toString(), credentialed: false };
+    }
+    throw new SandboxError(
+      JSON.stringify({ error: "tarball URL is not allowed by the gateway", status: 400 }),
+    );
+  }
+  if (!options.stageId || !STAGE_ID_RE.test(options.stageId)) {
+    throw new SandboxError(JSON.stringify({ error: "invalid stageId", status: 400 }));
+  }
+  let registryUrl: URL;
+  try {
+    registryUrl = new URL(registry);
+  } catch {
+    throw new SandboxError(JSON.stringify({ error: "invalid registry URL", status: 400 }));
+  }
+  if (!registryProtocolAllowed(registryUrl, protocolOptions)) {
+    throw new SandboxError(
+      JSON.stringify({ error: "registry URL is not allowed by the gateway", status: 400 }),
+    );
+  }
+  return {
+    url: `${registry.replace(/\/$/, "")}/-/stage/${encodeURIComponent(options.stageId)}/tarball`,
+    credentialed: true,
+  };
+}
 
-const STAGE_ID_RE = new RegExp(${JSON.stringify(`^${STAGE_ID_PATTERN}$`)});
+function sandboxSource() {
+  return `// Lock down ambient capabilities the parser doesn't need so a parser
+// regression cannot reach them. caches would let untrusted bytes be cached
+// across scans; the sandbox never needs it.
+try {
+  Object.defineProperty(globalThis, "caches", { value: undefined, configurable: true });
+} catch {}
+
+${renderTarParserSource()}
 
 export default {
   async fetch(request, env) {
-    const { stageId, tarballUrl } = await request.json();
-    if (!tarballUrl && !STAGE_ID_RE.test(stageId)) return json({ error: "invalid stageId" }, 400);
+    const { targetUrl } = await request.json();
+    if (typeof targetUrl !== "string" || !targetUrl) {
+      return json({ error: "missing targetUrl", status: 400 }, 400);
+    }
 
-    const registry = env.NPM_REGISTRY || "https://registry.npmjs.org";
-    const url = tarballUrl || registry.replace(/\\/$/, "") + "/-/stage/" + encodeURIComponent(stageId) + "/tarball";
-    const res = await fetch(url, { headers: { accept: "application/octet-stream" } });
+    const res = await fetch(targetUrl, { headers: { accept: "application/octet-stream" } });
     if (!res.ok) return json({ error: "download failed", status: res.status }, 502);
 
     const maxTarBytes = env.MAX_TAR_BYTES || 26214400;

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -105,7 +105,7 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
       tokenExposedToSandbox: false,
       directSandboxNetwork: false,
       outboundPolicy:
-        "sandbox uses the gateway only for npm staged tarball, published tarball, and package metadata endpoints; parent fetches staged metadata with the organization credential",
+        "sandbox uses the gateway only for the parent-pinned tarball URL for each download; parent fetches staged and package metadata with the organization credential",
       aiInputPolicy:
         "package bytes are untrusted evidence, not instructions; static safety prompt is prefix-cache friendly and AI cannot downgrade deterministic findings",
       fileExplorerPolicy:

--- a/test/sandbox-gateway.test.mjs
+++ b/test/sandbox-gateway.test.mjs
@@ -73,8 +73,6 @@ describe("npm stage gateway URL pinning", () => {
         [artifact],
       ),
     ).toBe(false);
-    expect(isAllowedPublicArtifactUrl(artifact.replace("https:", "http:"), [artifact])).toBe(
-      false,
-    );
+    expect(isAllowedPublicArtifactUrl(artifact.replace("https:", "http:"), [artifact])).toBe(false);
   });
 });

--- a/test/sandbox-gateway.test.mjs
+++ b/test/sandbox-gateway.test.mjs
@@ -4,87 +4,77 @@ vi.mock("cloudflare:workers", () => ({
   WorkerEntrypoint: class {},
 }));
 
-const { evaluateNpmStageGatewayRequest } = await import("../server/lib/sandbox.ts");
+const { isAllowedPublicArtifactUrl, isAllowedPublishedTarballUrl, matchAllowedRequest } =
+  await import("../server/lib/sandbox.ts");
 
-describe("npm stage gateway policy", () => {
-  const registry = "https://registry.npmjs.org";
+describe("npm stage gateway URL pinning", () => {
+  const stagedTarball = "https://registry.npmjs.org/-/stage/stage-abc123/tarball";
 
-  test("allows only expected credentialed npm GET endpoints", () => {
-    expect(
-      evaluateNpmStageGatewayRequest(
-        "https://registry.npmjs.org/-/stage/stage-123/tarball",
-        "GET",
-        registry,
-      ),
-    ).toMatchObject({
-      allowed: true,
-      credentialed: true,
-      kind: "staged-tarball",
-    });
-    expect(
-      evaluateNpmStageGatewayRequest("https://registry.npmjs.org/@scope%2fpkg", "GET", registry),
-    ).toMatchObject({
-      allowed: true,
-      credentialed: true,
-      kind: "package-metadata",
-    });
-    expect(
-      evaluateNpmStageGatewayRequest(
-        "https://registry.npmjs.org/pkg/-/pkg-1.2.3.tgz",
-        "GET",
-        registry,
-      ),
-    ).toMatchObject({
-      allowed: true,
-      credentialed: true,
-      kind: "published-tarball",
-    });
+  test("allows the exact pinned URL via GET", () => {
+    expect(matchAllowedRequest(stagedTarball, "GET", stagedTarball)).toEqual({ allowed: true });
   });
 
-  test("blocks non-registry origins, non-GETs, and npm endpoints outside the allowlist", () => {
-    const blocked = [
-      ["https://example.com/-/stage/stage-123/tarball", "GET"],
-      ["https://registry.npmjs.org/-/stage/stage-123/tarball", "POST"],
-      ["https://registry.npmjs.org/-/stage", "GET"],
+  test("blocks anything that is not the pinned URL", () => {
+    const cases = [
+      // different path on the same origin
+      ["https://registry.npmjs.org/-/stage/stage-other/tarball", "GET"],
       ["https://registry.npmjs.org/-/whoami", "GET"],
-      ["https://registry.npmjs.org/pkg", "PUT"],
-      ["https://registry.npmjs.org/pkg/readme", "GET"],
+      ["https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz", "GET"],
+      ["https://registry.npmjs.org/@scope%2fpkg", "GET"],
+      // different origin
+      ["https://example.com/-/stage/stage-abc123/tarball", "GET"],
+      // different protocol
+      ["http://registry.npmjs.org/-/stage/stage-abc123/tarball", "GET"],
+      // any non-GET on the pinned URL
+      [stagedTarball, "POST"],
+      [stagedTarball, "PUT"],
+      [stagedTarball, "DELETE"],
+      // appended query string the parent didn't authorise
+      [`${stagedTarball}?x=1`, "GET"],
     ];
 
-    for (const [url, method] of blocked) {
-      expect(evaluateNpmStageGatewayRequest(url, method, registry)).toEqual({
-        allowed: false,
-        credentialed: false,
-        kind: "blocked",
-      });
+    for (const [url, method] of cases) {
+      expect(matchAllowedRequest(url, method, stagedTarball)).toEqual({ allowed: false });
     }
   });
 
-  test("allows exact public artifact URLs without credentials", () => {
-    expect(
-      evaluateNpmStageGatewayRequest(
-        "https://files.pythonhosted.org/packages/aa/bb/demo-1.0.0-py3-none-any.whl",
-        "GET",
-        registry,
-        ["https://files.pythonhosted.org/packages/aa/bb/demo-1.0.0-py3-none-any.whl"],
-      ),
-    ).toEqual({
-      allowed: true,
-      credentialed: false,
-      kind: "public-artifact",
-    });
+  test("rejects malformed URLs without throwing", () => {
+    expect(matchAllowedRequest("not a url", "GET", stagedTarball)).toEqual({ allowed: false });
+    expect(matchAllowedRequest(stagedTarball, "GET", "not a url")).toEqual({ allowed: false });
+  });
 
+  test("requires https on the pinned URL too", () => {
+    const httpAllowed = "http://registry.npmjs.org/-/stage/stage-abc123/tarball";
+    expect(matchAllowedRequest(httpAllowed, "GET", httpAllowed)).toEqual({ allowed: false });
+  });
+
+  test("only lets registry-issued published tarballs become pinned tarball URLs", () => {
+    const registry = "https://registry.npmjs.org";
     expect(
-      evaluateNpmStageGatewayRequest(
+      isAllowedPublishedTarballUrl("https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz", registry),
+    ).toBe(true);
+    expect(isAllowedPublishedTarballUrl("https://registry.npmjs.org/-/whoami", registry)).toBe(
+      false,
+    );
+    expect(isAllowedPublishedTarballUrl("https://registry.npmjs.org/@scope%2fpkg", registry)).toBe(
+      false,
+    );
+    expect(isAllowedPublishedTarballUrl("https://example.com/pkg/-/pkg-1.0.0.tgz", registry)).toBe(
+      false,
+    );
+  });
+
+  test("allows exact public artifact URLs to be pinned without credentials", () => {
+    const artifact = "https://files.pythonhosted.org/packages/aa/bb/demo-1.0.0-py3-none-any.whl";
+    expect(isAllowedPublicArtifactUrl(artifact, [artifact])).toBe(true);
+    expect(
+      isAllowedPublicArtifactUrl(
         "https://files.pythonhosted.org/packages/aa/bb/other-1.0.0-py3-none-any.whl",
-        "GET",
-        registry,
-        ["https://files.pythonhosted.org/packages/aa/bb/demo-1.0.0-py3-none-any.whl"],
+        [artifact],
       ),
-    ).toEqual({
-      allowed: false,
-      credentialed: false,
-      kind: "blocked",
-    });
+    ).toBe(false);
+    expect(isAllowedPublicArtifactUrl(artifact.replace("https:", "http:"), [artifact])).toBe(
+      false,
+    );
   });
 });

--- a/test/workers/sandbox-gateway-runtime.test.ts
+++ b/test/workers/sandbox-gateway-runtime.test.ts
@@ -5,21 +5,19 @@ import { NpmStageGateway } from "../../server/lib/sandbox";
 interface CapturedRequest {
   url: string;
   method: string;
+  redirect: RequestRedirect;
   authorization: string | null;
   userAgent: string | null;
 }
 
-function setupGateway(props: {
-  npmToken?: string;
-  npmRegistry?: string;
-  publicArtifactUrls?: string[];
-}) {
+function setupGateway(props: { npmToken?: string; allowedUrl: string; credentialed?: boolean }) {
   const captured: CapturedRequest[] = [];
   const fetchSpy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = input instanceof Request ? input : new Request(input, init);
     captured.push({
       url: request.url,
       method: request.method,
+      redirect: request.redirect,
       authorization: request.headers.get("authorization"),
       userAgent: request.headers.get("user-agent"),
     });
@@ -28,7 +26,7 @@ function setupGateway(props: {
   vi.stubGlobal("fetch", fetchSpy);
 
   const ctx = createExecutionContext() as ExecutionContext & {
-    props: { npmToken?: string; npmRegistry?: string; publicArtifactUrls?: string[] };
+    props: { npmToken?: string; allowedUrl: string; credentialed?: boolean };
   };
   ctx.props = props;
   const gateway = new (NpmStageGateway as unknown as new (
@@ -43,68 +41,58 @@ afterEach(() => {
 });
 
 describe("NpmStageGateway runtime credential injection", () => {
-  test("attaches Authorization on staged-tarball requests", async () => {
-    const { gateway, captured } = setupGateway({ npmToken: "npm_secret_token_123" });
-    const res = await gateway.fetch(
-      new Request("https://registry.npmjs.org/-/stage/stage-abc123/tarball"),
-    );
+  test("attaches Authorization on the pinned URL", async () => {
+    const allowedUrl = "https://registry.npmjs.org/-/stage/stage-abc123/tarball";
+    const { gateway, captured } = setupGateway({
+      npmToken: "npm_secret_token_123",
+      allowedUrl,
+    });
+    const res = await gateway.fetch(new Request(allowedUrl));
     expect(res.status).toBe(200);
     expect(captured).toHaveLength(1);
     expect(captured[0].authorization).toBe("Bearer npm_secret_token_123");
+    expect(captured[0].redirect).toBe("manual");
     expect(captured[0].userAgent).toBe("staged-publish-review/0.3");
   });
 
-  test("attaches Authorization on published-tarball requests", async () => {
-    const { gateway, captured } = setupGateway({ npmToken: "npm_secret_token_xyz" });
-    const res = await gateway.fetch(new Request("https://registry.npmjs.org/pkg/-/pkg-1.2.3.tgz"));
-    expect(res.status).toBe(200);
-    expect(captured).toHaveLength(1);
-    expect(captured[0].authorization).toBe("Bearer npm_secret_token_xyz");
-  });
+  test("blocks any URL other than the pinned one", async () => {
+    const allowedUrl = "https://registry.npmjs.org/-/stage/stage-abc123/tarball";
+    const { gateway, captured } = setupGateway({
+      npmToken: "npm_should_not_leak",
+      allowedUrl,
+    });
 
-  test("attaches Authorization on package-metadata requests", async () => {
-    const { gateway, captured } = setupGateway({ npmToken: "npm_secret_meta" });
-    const res = await gateway.fetch(new Request("https://registry.npmjs.org/@scope%2fpkg"));
-    expect(res.status).toBe(200);
-    expect(captured).toHaveLength(1);
-    expect(captured[0].authorization).toBe("Bearer npm_secret_meta");
-  });
+    const otherStage = await gateway.fetch(
+      new Request("https://registry.npmjs.org/-/stage/stage-other/tarball"),
+    );
+    expect(otherStage.status).toBe(403);
 
-  test("blocks foreign origins without forwarding or sending the token", async () => {
-    const { gateway, captured } = setupGateway({ npmToken: "npm_should_not_leak" });
-    const res = await gateway.fetch(
+    const metadata = await gateway.fetch(new Request("https://registry.npmjs.org/@scope%2fpkg"));
+    expect(metadata.status).toBe(403);
+
+    const foreign = await gateway.fetch(
       new Request("https://example.com/-/stage/stage-abc123/tarball"),
     );
-    expect(res.status).toBe(403);
+    expect(foreign.status).toBe(403);
+
     expect(captured).toHaveLength(0);
   });
 
-  test("blocks state-changing methods even on allowed paths", async () => {
-    const { gateway, captured } = setupGateway({ npmToken: "npm_should_not_leak" });
-    const res = await gateway.fetch(
-      new Request("https://registry.npmjs.org/-/stage/stage-abc123/tarball", { method: "POST" }),
-    );
+  test("blocks state-changing methods on the pinned URL", async () => {
+    const allowedUrl = "https://registry.npmjs.org/-/stage/stage-abc123/tarball";
+    const { gateway, captured } = setupGateway({
+      npmToken: "npm_should_not_leak",
+      allowedUrl,
+    });
+    const res = await gateway.fetch(new Request(allowedUrl, { method: "POST" }));
     expect(res.status).toBe(403);
-    expect(captured).toHaveLength(0);
-  });
-
-  test("blocks /-/whoami and other unrelated registry paths", async () => {
-    const { gateway, captured } = setupGateway({ npmToken: "npm_should_not_leak" });
-
-    const whoami = await gateway.fetch(new Request("https://registry.npmjs.org/-/whoami"));
-    expect(whoami.status).toBe(403);
-
-    const readme = await gateway.fetch(new Request("https://registry.npmjs.org/pkg/readme"));
-    expect(readme.status).toBe(403);
-
     expect(captured).toHaveLength(0);
   });
 
   test("omits Authorization when no npm token is configured", async () => {
-    const { gateway, captured } = setupGateway({});
-    const res = await gateway.fetch(
-      new Request("https://registry.npmjs.org/-/stage/stage-no-token/tarball"),
-    );
+    const allowedUrl = "https://registry.npmjs.org/-/stage/stage-no-token/tarball";
+    const { gateway, captured } = setupGateway({ allowedUrl });
+    const res = await gateway.fetch(new Request(allowedUrl));
     expect(res.status).toBe(200);
     expect(captured).toHaveLength(1);
     expect(captured[0].authorization).toBeNull();
@@ -115,7 +103,8 @@ describe("NpmStageGateway runtime credential injection", () => {
     const publicUrl = "https://files.pythonhosted.org/packages/aa/bb/demo-1.0.0-py3-none-any.whl";
     const { gateway, captured } = setupGateway({
       npmToken: "npm_should_not_reach_public_artifact",
-      publicArtifactUrls: [publicUrl],
+      allowedUrl: publicUrl,
+      credentialed: false,
     });
 
     const res = await gateway.fetch(new Request(publicUrl));
@@ -128,9 +117,8 @@ describe("NpmStageGateway runtime credential injection", () => {
   test("blocks non-exact public artifact URLs without forwarding npm credentials", async () => {
     const { gateway, captured } = setupGateway({
       npmToken: "npm_should_not_leak",
-      publicArtifactUrls: [
-        "https://files.pythonhosted.org/packages/aa/bb/demo-1.0.0-py3-none-any.whl",
-      ],
+      allowedUrl: "https://files.pythonhosted.org/packages/aa/bb/demo-1.0.0-py3-none-any.whl",
+      credentialed: false,
     });
 
     const res = await gateway.fetch(
@@ -141,15 +129,14 @@ describe("NpmStageGateway runtime credential injection", () => {
     expect(captured).toHaveLength(0);
   });
 
-  test("respects custom registry origins supplied via props", async () => {
+  test("pins independently for custom registry origins", async () => {
+    const allowedUrl = "https://registry.example.com/-/stage/stage-custom/tarball";
     const { gateway, captured } = setupGateway({
       npmToken: "npm_custom_registry_token",
-      npmRegistry: "https://registry.example.com",
+      allowedUrl,
     });
 
-    const allowed = await gateway.fetch(
-      new Request("https://registry.example.com/-/stage/stage-custom/tarball"),
-    );
+    const allowed = await gateway.fetch(new Request(allowedUrl));
     expect(allowed.status).toBe(200);
     expect(captured[0].authorization).toBe("Bearer npm_custom_registry_token");
 


### PR DESCRIPTION
## Summary
- Pin `NpmStageGateway` to the exact per-call target URL via an `allowedUrl` prop — only a `GET` whose protocol, origin, pathname, and search match exactly is allowed; everything else (including other endpoints on the same registry origin) gets a 403.
- Tighten the sandbox isolate: drop `LOADER.load` `subRequests` budget from 4 to 1, pass an explicit empty `compatibilityFlags` list so date bumps cannot quietly enable new ambient APIs, and clobber `globalThis.caches` in the sandbox preamble.
- Move staged-tarball URL construction into the parent (`resolveTargetUrl`) so the sandbox no longer builds URLs or knows about stage IDs, and update gateway tests + security/architecture docs to reflect the pinning contract.

## Test plan
- [x] `pnpm run verify` (lint + format + typecheck + both vitest suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)