### PR TITLE
[codex] Focus scan risk on release delta

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,8 +90,10 @@ Current high-level flow:
    - package file diff;
    - package.json diff;
    - deterministic findings, including implicit npm lifecycle hooks surfaced from tarball shape and warnings when `package.json` cannot be parsed;
+   - release/context annotations for deterministic findings, using package-to-package diff status and changed-line checks where text samples are available;
+   - a risk breakdown where `releaseRisk` is the primary saved scan risk, while `artifactRisk` and `contextRisk` keep full-artifact safety context visible;
    - redacted package/file records.
-9. Parent Worker derives risk from deterministic findings, persists the scan, records audit events, and returns/report renders the result. (AI review is disabled — see "Workers AI" below.)
+9. Parent Worker persists the scan, records audit events, and returns/report renders the result. (AI review is disabled — see "Workers AI" below.)
 
 Current async-capable flow:
 
@@ -145,7 +147,7 @@ When AI review returns it will continue to:
 
 - see changed files only;
 - see redacted bounded text samples;
-- receive deterministic findings as authoritative evidence;
+- receive release-delta deterministic findings as authoritative evidence;
 - treat every package-derived string as hostile evidence, not instructions;
 - explicitly check npm supply-chain hazards such as lifecycle scripts, added dependencies whose own postinstall/install hooks are not visible in the staged tarball, entrypoint changes, credential access, network/process execution, obfuscation, and native artifacts;
 - return schema-constrained JSON;
@@ -194,6 +196,7 @@ Implemented foundation:
 
 - newly completed scans store report metadata inside `summary_json.report`;
 - `digest` is SHA-256 over stable canonical report JSON built from redacted scan evidence, including the deterministic rules version and release/context finding annotations so digests change when the ruleset or visible risk interpretation changes;
+- newly completed scans store `summary_json.risk` with release, artifact, and context risk; `scans.risk` stores the primary release risk for new reports, while old reports without the breakdown are treated as legacy artifact-risk rows;
 - each deterministic finding carries `ruleId` and `ruleVersion` (see `DETERMINISTIC_RULES_VERSION` in `server/lib/review.ts`), persisted on `scan_findings.rule_id` / `rule_version`;
 - persisted scan detail renders report version, digest, rules version, package diff, and safety posture (AI review is disabled — see the Workers AI section).
 

--- a/docs/diff-baseline.md
+++ b/docs/diff-baseline.md
@@ -41,7 +41,7 @@ The pipeline cross-checks staged detail package name/version against the staged 
 AI review is disabled in the current pipeline, but when it returns it should remain diff-first:
 
 - deterministic findings stay authoritative and are computed before AI;
-- AI sees package-json diff, deterministic findings, changed-file diff, and bounded samples for changed files only;
+- AI sees package-json diff, release-delta deterministic findings, changed-file diff, and bounded samples for changed files only;
 - unchanged files should not be sent as AI review evidence unless a deterministic rule needs context;
 - changed files should be ranked so high-signal files are kept when caps are hit.
 
@@ -56,5 +56,13 @@ However, report payloads, report presentation, and AI payload construction shoul
 - new or modified risky evidence, which is release-blocking signal;
 - removed risky evidence, which may be positive but still deserves context;
 - unchanged risky evidence, which is pre-existing package risk and should not dominate "what changed" unless policy says the product blocks any release containing that behavior.
+
+New scan reports persist this split as a risk breakdown in `summary_json.risk`:
+
+- `releaseRisk` is the primary scan risk and is computed from findings annotated as part of the package-to-package delta, plus any complete AI review result when AI review is enabled;
+- `artifactRisk` is computed from the full staged artifact findings, plus any complete AI review result when AI review is enabled, and remains visible as package context;
+- `contextRisk` covers findings that were not part of the release delta.
+
+The `scans.risk` column now stores `releaseRisk` for new reports. Older reports without `summary_json.risk` are interpreted with the previous behavior, where `scans.risk` is the artifact risk and release/context risk is derived from persisted finding annotations.
 
 This avoids hiding persistent risk while keeping the staged-publish review centered on the actual release delta.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -79,7 +79,7 @@ Persist by default:
 - package.json summary and diff;
 - deterministic findings;
 - AI findings (paused — persisted as `null` while AI review is disabled);
-- risk summary;
+- risk summary split into release, artifact, and context risk so unchanged package hazards do not dominate the package-to-package release verdict;
 - safety posture;
 - audit events;
 - future canonical report JSON.

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -19,6 +19,7 @@ import {
   normalizeFindingDiffStatus,
   normalizeRisk,
 } from "../lib/review";
+import { normalizeScanRiskBreakdown } from "../lib/risk";
 import type { DiffEntry, FileRecord, Finding, PackageJsonSummary } from "../lib/review";
 
 export type AppDb = ReturnType<typeof drizzle<typeof schema>>;
@@ -549,6 +550,7 @@ export async function listScans(
                   diffForFindingAnnotations(summaryJson, filesByScan.get(row.id) ?? []),
                   { persistedAnnotations: readFindingAnnotations(summaryJson) },
                 ),
+                summaryJson,
               )
             : null,
       };
@@ -639,28 +641,38 @@ export async function getScan(db: AppDb, id: string, organizationId: string) {
     files,
     findings: annotatedFindings,
     riskSummary:
-      scan.status === "complete" ? summarizeScanRisk(scan.risk, annotatedFindings) : null,
+      scan.status === "complete"
+        ? summarizeScanRisk(scan.risk, annotatedFindings, scan.summaryJson)
+        : null,
     events: events.map(redactScanEventForClient),
   };
 }
 
 function summarizeScanRisk(
-  artifactRisk: string,
+  persistedRisk: string,
   findings: Array<{ severity?: string | null; releaseDelta: boolean; diffStatus: string }>,
+  summaryJson?: unknown,
 ): ScanRiskSummary {
   const releaseFindings = findings.filter((finding) => finding.releaseDelta);
   const contextFindings = findings.filter((finding) => !finding.releaseDelta);
   const unknownFindingCount = contextFindings.filter(
     (finding) => finding.diffStatus === "unknown",
   ).length;
+  const persistedBreakdown = readPersistedRiskBreakdown(summaryJson);
   return {
-    artifactRisk: normalizeRisk(artifactRisk),
-    releaseRisk: computeRisk(releaseFindings),
-    contextRisk: computeRisk(contextFindings),
-    releaseFindingCount: releaseFindings.length,
-    contextFindingCount: contextFindings.length,
-    unknownFindingCount,
+    artifactRisk: persistedBreakdown?.artifactRisk ?? normalizeRisk(persistedRisk),
+    releaseRisk: persistedBreakdown?.releaseRisk ?? computeRisk(releaseFindings),
+    contextRisk: persistedBreakdown?.contextRisk ?? computeRisk(contextFindings),
+    releaseFindingCount: persistedBreakdown?.releaseFindingCount ?? releaseFindings.length,
+    contextFindingCount: persistedBreakdown?.contextFindingCount ?? contextFindings.length,
+    unknownFindingCount: persistedBreakdown?.unknownFindingCount ?? unknownFindingCount,
   };
+}
+
+function readPersistedRiskBreakdown(summaryJson: unknown) {
+  const summary = summaryJson && typeof summaryJson === "object" ? summaryJson : null;
+  const risk = summary && !Array.isArray(summary) ? (summary as { risk?: unknown }).risk : null;
+  return normalizeScanRiskBreakdown(risk);
 }
 
 function readFindingAnnotations(summaryJson: unknown): Map<string, FindingDiffAnnotation> {

--- a/server/lib/risk.ts
+++ b/server/lib/risk.ts
@@ -1,5 +1,19 @@
 import type { AiReview } from "./ai-review";
-import { combineRisk, computeRisk, type Finding, type RiskLevel } from "./review";
+import { combineRisk, computeRisk, normalizeRisk, type Finding, type RiskLevel } from "./review";
+
+export interface ScanRiskBreakdown {
+  artifactRisk: RiskLevel;
+  releaseRisk: RiskLevel;
+  contextRisk: RiskLevel;
+  releaseFindingCount: number;
+  contextFindingCount: number;
+  unknownFindingCount: number;
+}
+
+type RiskFinding = Finding & {
+  diffStatus?: string | null;
+  releaseDelta?: boolean | null;
+};
 
 export function computeScanRisk(ruleFindings: Finding[], aiFindings: AiReview): RiskLevel {
   const aiReviewCompleted = aiFindings.status === "complete";
@@ -9,4 +23,40 @@ export function computeScanRisk(ruleFindings: Finding[], aiFindings: AiReview): 
     aiReviewCompleted && aiHasEvidence ? aiFindings.risk : "low",
     aiReviewCompleted && aiFindings.requiresManualReview ? "medium" : "low",
   );
+}
+
+export function computeScanRiskBreakdown(
+  ruleFindings: RiskFinding[],
+  aiFindings: AiReview,
+): ScanRiskBreakdown {
+  const releaseFindings = ruleFindings.filter((finding) => finding.releaseDelta === true);
+  const contextFindings = ruleFindings.filter((finding) => finding.releaseDelta !== true);
+  return {
+    artifactRisk: computeScanRisk(ruleFindings, aiFindings),
+    releaseRisk: computeScanRisk(releaseFindings, aiFindings),
+    contextRisk: computeRisk(contextFindings),
+    releaseFindingCount: releaseFindings.length,
+    contextFindingCount: contextFindings.length,
+    unknownFindingCount: contextFindings.filter((finding) => finding.diffStatus === "unknown")
+      .length,
+  };
+}
+
+export function normalizeScanRiskBreakdown(value: unknown): Partial<ScanRiskBreakdown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const item = value as Partial<Record<keyof ScanRiskBreakdown, unknown>>;
+  const out: Partial<ScanRiskBreakdown> = {};
+  if (typeof item.artifactRisk === "string") out.artifactRisk = normalizeRisk(item.artifactRisk);
+  if (typeof item.releaseRisk === "string") out.releaseRisk = normalizeRisk(item.releaseRisk);
+  if (typeof item.contextRisk === "string") out.contextRisk = normalizeRisk(item.contextRisk);
+  if (typeof item.releaseFindingCount === "number") {
+    out.releaseFindingCount = Math.max(0, Math.floor(item.releaseFindingCount));
+  }
+  if (typeof item.contextFindingCount === "number") {
+    out.contextFindingCount = Math.max(0, Math.floor(item.contextFindingCount));
+  }
+  if (typeof item.unknownFindingCount === "number") {
+    out.unknownFindingCount = Math.max(0, Math.floor(item.unknownFindingCount));
+  }
+  return Object.keys(out).length ? out : null;
 }

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -19,7 +19,7 @@ import {
   type Finding,
   type PackageJsonSummary,
 } from "./review";
-import { computeScanRisk } from "./risk";
+import { computeScanRiskBreakdown } from "./risk";
 import { downloadInSandbox, type DownloadResult } from "./sandbox";
 import { fetchStagedPublishDetails, type StagedPublishDetails } from "./staged-publishes";
 import type { ScanInput, ScanResult } from "../types";
@@ -94,7 +94,11 @@ export async function runScanPipeline(
   const reportFindingAnnotations = annotateFindingsWithDiffStatus(ruleFindings, diff, {
     previousFiles: redactedPreviousFiles,
     stagedFiles: redactedStagedFiles,
-  }).map((finding, index) => ({
+  });
+  const releaseRuleFindings = stripFindingAnnotations(
+    reportFindingAnnotations.filter((finding) => finding.releaseDelta),
+  );
+  const findingAnnotations = reportFindingAnnotations.map((finding, index) => ({
     findingIndex: index,
     diffStatus: finding.diffStatus,
     releaseDelta: finding.releaseDelta,
@@ -119,7 +123,7 @@ export async function runScanPipeline(
       files: redactedStagedFiles,
       diff,
       packageJsonDiff,
-      ruleFindings,
+      ruleFindings: releaseRuleFindings,
       previousVersionAvailable: previous !== null,
     });
     if (aiFindings.escalated) {
@@ -134,7 +138,8 @@ export async function runScanPipeline(
       });
     }
   }
-  const risk = computeScanRisk(ruleFindings, aiFindings);
+  const riskSummary = computeScanRiskBreakdown(reportFindingAnnotations, aiFindings);
+  const risk = riskSummary.releaseRisk;
 
   const safety: ScanResult["safety"] = {
     tokenExposedToSandbox: false,
@@ -165,6 +170,7 @@ export async function runScanPipeline(
     ruleFindings,
     aiFindings,
     risk,
+    riskSummary,
     safety,
   };
 
@@ -181,9 +187,9 @@ export async function runScanPipeline(
     packageJsonDiff,
     diff,
     ruleFindings,
-    findingAnnotations: reportFindingAnnotations,
+    findingAnnotations,
     aiFindings,
-    risk,
+    risk: riskSummary,
     safety,
   };
   const reportDigest = await sha256Hex(stableJson(reportPayload));
@@ -207,6 +213,7 @@ export async function runScanPipeline(
       },
       packageJsonDiff,
       diff,
+      risk: riskSummary,
       stagedPublish: redactedStagedDetails,
       baseline,
       safety: result.safety,
@@ -232,11 +239,28 @@ export async function runScanPipeline(
         stagedTag: result.package.stagedTag,
         baseline,
         risk,
+        releaseRisk: risk,
+        artifactRisk: riskSummary.artifactRisk,
+        contextRisk: riskSummary.contextRisk,
       },
     });
   }
 
   return result;
+}
+
+function stripFindingAnnotations(
+  findings: Array<Finding & { diffStatus?: string; releaseDelta?: boolean }>,
+): Finding[] {
+  return findings.map((finding) => ({
+    severity: finding.severity,
+    file: finding.file,
+    evidence: finding.evidence,
+    reason: finding.reason,
+    ...(finding.line !== undefined ? { line: finding.line } : {}),
+    ...(finding.ruleId !== undefined ? { ruleId: finding.ruleId } : {}),
+    ...(finding.ruleVersion !== undefined ? { ruleVersion: finding.ruleVersion } : {}),
+  }));
 }
 
 async function sha256Hex(value: string) {

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,6 +1,7 @@
 import type { Auth, AuthSession } from "./lib/auth";
 import type { AiReview } from "./lib/ai-review";
 import type { BaselineVersionSelection } from "./lib/registry";
+import type { ScanRiskBreakdown } from "./lib/risk";
 import type {
   DiffEntry,
   Finding,
@@ -42,6 +43,7 @@ export interface ScanResult {
   ruleFindings: Finding[];
   aiFindings: AiReview;
   risk: RiskLevel;
+  riskSummary: ScanRiskBreakdown;
   safety: {
     tokenExposedToSandbox: boolean;
     directSandboxNetwork: boolean;

--- a/test/scan-pipeline.test.mjs
+++ b/test/scan-pipeline.test.mjs
@@ -423,4 +423,111 @@ describe("scan pipeline baseline selection", () => {
     expect(releaseDigest).toBeDefined();
     expect(contextDigest).not.toBe(releaseDigest);
   });
+
+  test("persists release risk from the package-to-package delta while keeping artifact context", async () => {
+    stagedMock.fetchStagedPublishDetails.mockResolvedValue({
+      id: "stage-context123",
+      packageName: "pkg",
+      version: "1.0.1",
+      tag: "latest",
+      access: null,
+      actor: null,
+      actorType: null,
+      createdAt: null,
+      shasum: null,
+      packageJson: null,
+    });
+    registryMock.fetchPackageMetadata.mockResolvedValue({
+      versions: {
+        "1.0.0": { dist: { tarball: "https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz" } },
+      },
+      "dist-tags": { latest: "1.0.0" },
+    });
+    sandboxMock.downloadInSandbox.mockImplementation(async (_env, _ctx, options) => {
+      if (options.stageId) {
+        return {
+          files: [
+            {
+              path: "package.json",
+              size: 40,
+              sha256: "staged-pkg",
+              flags: [],
+              textSample: JSON.stringify({ name: "pkg", version: "1.0.1" }),
+            },
+            {
+              path: "index.js",
+              size: 80,
+              sha256: "same-risk",
+              flags: [],
+              textSample: "require('child_process').execSync('true');\n",
+            },
+          ],
+          packageJson: { name: "pkg", version: "1.0.1" },
+        };
+      }
+      return {
+        files: [
+          {
+            path: "package.json",
+            size: 40,
+            sha256: "previous-pkg",
+            flags: [],
+            textSample: JSON.stringify({ name: "pkg", version: "1.0.0" }),
+          },
+          {
+            path: "index.js",
+            size: 80,
+            sha256: "same-risk",
+            flags: [],
+            textSample: "require('child_process').execSync('true');\n",
+          },
+        ],
+        packageJson: { name: "pkg", version: "1.0.0" },
+      };
+    });
+
+    const result = await runScanPipeline(
+      {
+        env: { NPM_REGISTRY: "https://registry.npmjs.org" },
+        executionCtx: {},
+        db: {},
+        session: { userId: "user_1" },
+      },
+      {
+        scanId: "scan_context",
+        stageId: "stage-context123",
+        organizationId: "org_1",
+        npmToken: "npm_token_0123456789",
+        npmRegistry: "https://registry.npmjs.org",
+      },
+    );
+
+    const persistedInput = dbMock.persistScan.mock.calls[0]?.[1];
+
+    expect(result.risk).toBe("low");
+    expect(result.riskSummary).toMatchObject({
+      artifactRisk: "high",
+      releaseRisk: "low",
+      contextRisk: "high",
+      releaseFindingCount: 0,
+      contextFindingCount: 1,
+    });
+    expect(result.ruleFindings).toContainEqual(
+      expect.objectContaining({
+        severity: "high",
+        file: "index.js",
+        ruleId: "code.process-execution",
+      }),
+    );
+    expect(persistedInput).toMatchObject({
+      risk: "low",
+      summary: {
+        risk: {
+          artifactRisk: "high",
+          releaseRisk: "low",
+          contextRisk: "high",
+        },
+      },
+    });
+  });
 });

--- a/test/workers/cross-org-routes.test.ts
+++ b/test/workers/cross-org-routes.test.ts
@@ -269,10 +269,18 @@ describe("scans routes enforce organization boundaries", () => {
       organizationId: owner.organizationId,
       ownerUserId: owner.userId,
       packageJson: { name: "@org/list-risk-summary", version: "1.2.3" },
-      risk: "high",
+      risk: "low",
       status: "complete",
       summary: {
         diff: [{ path: "src/server.ts", status: "modified" }],
+        risk: {
+          artifactRisk: "high",
+          releaseRisk: "low",
+          contextRisk: "high",
+          releaseFindingCount: 0,
+          contextFindingCount: 1,
+          unknownFindingCount: 0,
+        },
       },
       ai: null,
       files: [


### PR DESCRIPTION
Changes the scan pipeline so new reports use release-delta findings as the primary saved risk while preserving full-artifact findings as artifact/context risk. Persists the risk breakdown in `summary_json.risk`, reads it back for scan detail and dashboard rows, and keeps legacy reports compatible. Narrows future AI review inputs to release-delta deterministic findings plus changed-file evidence. Updates architecture/security/diff-baseline docs and adds pipeline and route coverage for unchanged risky context. Validated with `pnpm run verify`.