### PR TITLE
Hide changed-file badge when count is zero

### DIFF
--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -269,19 +269,10 @@ export default function ScanDetailPage() {
           <ReleaseRecommendation
             detail={detail}
             summary={summary.value}
-            diffCount={diffEntries.value.filter((entry) => entry.status !== "unchanged").length}
-            findingsWithDiffStatus={findingsWithDiffStatus.value}
-            usePersistedRiskSummary={model.isDefaultComparison.value}
-          />
-
-          <ReportOverview
-            detail={detail}
-            summary={summary.value}
             ai={ai.value}
-            findings={detail.findings}
-            findingsWithDiffStatus={findingsWithDiffStatus.value}
             aiFindings={ai.value?.findings ?? []}
             diffCount={diffEntries.value.filter((entry) => entry.status !== "unchanged").length}
+            findingsWithDiffStatus={findingsWithDiffStatus.value}
             usePersistedRiskSummary={model.isDefaultComparison.value}
           />
 
@@ -380,12 +371,16 @@ export default function ScanDetailPage() {
 function ReleaseRecommendation({
   detail,
   summary,
+  ai,
+  aiFindings,
   diffCount,
   findingsWithDiffStatus,
   usePersistedRiskSummary,
 }: {
   detail: PersistedScanDetail;
   summary: PersistedSummary;
+  ai: AiReview | null;
+  aiFindings: AiFinding[];
   diffCount: number;
   findingsWithDiffStatus: FindingWithDiffStatus[];
   usePersistedRiskSummary: boolean;
@@ -406,6 +401,9 @@ function ReleaseRecommendation({
       : changedFindings.length;
   const recommendation = getReleaseRecommendation(artifactRisk, releaseRisk, releaseFindingCount);
   const evidence = buildRecommendationEvidence(detail, summary, diffCount, changedFindings);
+  const severityCounts = countSeverities([...detail.findings, ...aiFindings]);
+  const findingTotal = Object.values(severityCounts).reduce((sum, count) => sum + (count ?? 0), 0);
+  const aiComplete = ai?.status === "complete";
 
   return (
     <section class="flex flex-col gap-3 border-t border-border pt-4">
@@ -416,6 +414,17 @@ function ReleaseRecommendation({
         {artifactRisk !== releaseRisk ? (
           <Badge tone="neutral">artifact {artifactRisk}</Badge>
         ) : null}
+        {ai?.model != null &&
+          (aiComplete ? (
+            <>
+              <Badge tone={ai!.requiresManualReview ? "medium" : "ok"}>
+                {ai!.requiresManualReview ? "manual review" : "no extra review"}
+              </Badge>
+              <Badge tone="neutral">{ai!.releaseAssessment.replaceAll("_", " ")}</Badge>
+            </>
+          ) : (
+            <Badge tone="neutral">assistant unavailable</Badge>
+          ))}
       </div>
       <p class="m-0 max-w-[760px] text-[14px] leading-[1.55] text-ink-muted">
         {recommendation.copy}
@@ -433,6 +442,7 @@ function ReleaseRecommendation({
           </li>
         ))}
       </ul>
+      {findingTotal ? <SeverityBar counts={severityCounts} class="max-w-[520px]" /> : null}
     </section>
   );
 }
@@ -1057,94 +1067,6 @@ function findingDiffStatusLabel(status: FindingDiffStatus): string | null {
   if (status === "unknown") return null;
   if (status === "unchanged") return "existing";
   return status;
-}
-
-function ReportOverview({
-  detail,
-  summary,
-  ai,
-  findings,
-  findingsWithDiffStatus,
-  aiFindings,
-  diffCount,
-  usePersistedRiskSummary,
-}: {
-  detail: PersistedScanDetail;
-  summary: PersistedSummary;
-  ai: AiReview | null;
-  findings: PersistedScanDetail["findings"];
-  findingsWithDiffStatus: FindingWithDiffStatus[];
-  aiFindings: AiFinding[];
-  diffCount: number;
-  usePersistedRiskSummary: boolean;
-}) {
-  const changed =
-    diffCount ||
-    summary.diff?.filter((entry) => entry.status !== "unchanged").length ||
-    detail.files.filter((file) => file.status !== "unchanged").length;
-  const severityCounts = countSeverities([...findings, ...aiFindings]);
-  const findingTotal = Object.values(severityCounts).reduce((sum, count) => sum + (count ?? 0), 0);
-  const isComplete = detail.scan.status === "complete";
-  const riskSummary = isComplete && usePersistedRiskSummary ? detail.riskSummary : null;
-  const releaseRisk = isComplete
-    ? (riskSummary?.releaseRisk ??
-      highestFindingRisk(
-        findingsWithDiffStatus.filter((item) => item.releaseDelta).map((item) => item.finding),
-      ))
-    : detail.scan.risk;
-  const artifactRisk = isComplete
-    ? (detail.riskSummary?.artifactRisk ?? detail.scan.risk)
-    : detail.scan.risk;
-  const changedFindingTotal =
-    riskSummary?.releaseFindingCount ??
-    findingsWithDiffStatus.filter((item) => item.releaseDelta).length;
-  const contextFindingTotal =
-    riskSummary?.contextFindingCount ??
-    findingsWithDiffStatus.filter((item) => !item.releaseDelta).length;
-  const aiComplete = ai?.status === "complete";
-
-  return (
-    <section class="flex flex-col gap-3 border-t border-border pt-4">
-      <div class="flex flex-wrap items-center gap-2">
-        <Badge tone={severityTone(releaseRisk)}>release {releaseRisk}</Badge>
-        {artifactRisk !== releaseRisk ? (
-          <Badge tone="neutral">artifact {artifactRisk}</Badge>
-        ) : null}
-        {ai?.model != null &&
-          (aiComplete ? (
-            <>
-              <Badge tone={ai!.requiresManualReview ? "medium" : "ok"}>
-                {ai!.requiresManualReview ? "manual review" : "no extra review"}
-              </Badge>
-              <Badge tone="neutral">{ai!.releaseAssessment.replaceAll("_", " ")}</Badge>
-            </>
-          ) : (
-            <Badge tone="neutral">assistant unavailable</Badge>
-          ))}
-        <Badge tone={findingTotal ? "medium" : "ok"}>
-          {findingTotal ? `${findingTotal} ${pluralize("finding", findingTotal)}` : "no findings"}
-        </Badge>
-        {changedFindingTotal ? (
-          <Badge tone="medium">{changedFindingTotal} changed-file</Badge>
-        ) : null}
-        {contextFindingTotal ? <Badge tone="neutral">{contextFindingTotal} context</Badge> : null}
-      </div>
-      <MonoDetail
-        parts={[
-          detail.scan.status,
-          <span key="stage">stage {detail.scan.stageId}</span>,
-          <span key="file-count">
-            {detail.files.length} {pluralize("file", detail.files.length)}
-          </span>,
-          <span key="changed">{changed} changed</span>,
-          <span key="report-version">
-            {summary.report?.version ? `report v${summary.report.version}` : "legacy report"}
-          </span>,
-        ]}
-      />
-      {findingTotal ? <SeverityBar counts={severityCounts} class="max-w-[520px]" /> : null}
-    </section>
-  );
 }
 
 const SEVERITY_RANK: Record<SeverityKey, number> = {

--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -1124,10 +1124,8 @@ function ReportOverview({
         <Badge tone={findingTotal ? "medium" : "ok"}>
           {findingTotal ? `${findingTotal} ${pluralize("finding", findingTotal)}` : "no findings"}
         </Badge>
-        {findingTotal ? (
-          <Badge tone={changedFindingTotal ? "medium" : "ok"}>
-            {changedFindingTotal} changed-file
-          </Badge>
+        {changedFindingTotal ? (
+          <Badge tone="medium">{changedFindingTotal} changed-file</Badge>
         ) : null}
         {contextFindingTotal ? <Badge tone="neutral">{contextFindingTotal} context</Badge> : null}
       </div>


### PR DESCRIPTION
## Summary
- The scan-detail header rendered a "0 changed-file" badge whenever there were findings but none of them were tied to the release delta. That read as "0 files were changed", contradicting the diff and changed-file list visible immediately below.
- Mirror the sibling "context" badge logic: only render the changed-file badge when its count is non-zero. The "N context" badge already conveys when all findings are context-only.

## Test plan
- [ ] Open a scan with findings that are all context-only — confirm the "0 changed-file" badge no longer appears.
- [ ] Open a scan with at least one release-delta finding — confirm the badge still renders with the correct count.