### PR TITLE
Remove safety model dropdown from scan detail

### DIFF
--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -20,7 +20,7 @@ import {
   type FileRecord,
   type FindingDiffStatus,
 } from "../../../server/lib/review";
-import type { PackageJsonDiff, ScanResult } from "../../../server/types";
+import type { PackageJsonDiff } from "../../../server/types";
 import {
   Alert,
   Badge,
@@ -57,7 +57,6 @@ interface PersistedSummary {
   };
   packageJsonDiff?: PackageJsonDiff;
   diff?: DiffEntry[];
-  safety?: ScanResult["safety"];
 }
 
 type PersistedFinding = PersistedScanDetail["findings"][number];
@@ -1276,16 +1275,6 @@ function PersistedReportSections({
         ) : (
           <EmptyLine>This older review does not include a report fingerprint.</EmptyLine>
         )}
-        {summary.safety ? (
-          <details class="group mt-1">
-            <summary class="cursor-pointer font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle list-none">
-              Safety model
-            </summary>
-            <pre class="bg-surface-2 rounded-lg p-3 overflow-x-auto text-xs leading-[1.5] mt-3 mb-0">
-              {JSON.stringify(summary.safety, null, 2)}
-            </pre>
-          </details>
-        ) : null}
       </ReportSection>
     </section>
   );


### PR DESCRIPTION
## Summary
- Drop the raw JSON "Safety model" disclosure on the persisted scan detail page.
- Remove the now-unused `safety` field on `PersistedSummary` and the dangling `ScanResult` import.

## Test plan
- [ ] Open a persisted scan with `safety` in its report and confirm the dropdown is gone while the rest of the report metadata renders unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)