### PR TITLE
[codex] Add PyPI workflow gate foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ This repository is moving from prototype to real product. The current implementa
 - **SaaS, organization-scoped.** Scans belong to an organization boundary. RBAC is intentionally deferred for the first production slice, but the data model should keep organization ownership explicit.
 - **Per-organization npm credentials.** Production SaaS should not use a deployment-wide npm token. Each organization will connect its own npm credential, scoped as narrowly as npm permits, and the credential will only be used by the gateway that talks to npm.
 - **Manual publish approval.** The product reviews and explains a staged publish. It does not run `npm stage approve`, does not bypass npm 2FA, and does not become the final publisher.
+- **Workflow-gate expansion.** PyPI support is being introduced as a GitHub Environment gate rather than a registry-staged publish clone. See [`docs/pypi-workflow-gate.md`](docs/pypi-workflow-gate.md) for the implemented backend foundation and remaining GitHub App work.
 - **AI review paused.** Cloudflare Workers AI was the production reviewer, but AI review is currently disabled in the pipeline. We plan to re-introduce it as a paid-tier feature; until then, scans rely entirely on deterministic findings. AI findings will remain advisory and unable to downgrade deterministic findings when they return.
 - **Safe artifact defaults.** Do not retain raw tarballs by default in SaaS. Persist redacted summaries, manifests, diffs, findings, and report metadata. Raw artifact retention may become an explicit short-TTL organization setting later.
 - **Signed reports later.** Prepare report data to be canonical and signable, but do not launch public signed report generation yet.
 
 See [`docs/architecture.md`](docs/architecture.md), [`docs/security-model.md`](docs/security-model.md), [`docs/security-detection-corpus.md`](docs/security-detection-corpus.md), [`docs/production-roadmap.md`](docs/production-roadmap.md), [`docs/cost-model.md`](docs/cost-model.md), [`docs/test-package.md`](docs/test-package.md), and [`docs/e2e-test-environment.md`](docs/e2e-test-environment.md) for the production plan, detection corpus notes, budget napkin math, staged-publish test package, and local E2E harness.
+See [`docs/pypi-workflow-gate.md`](docs/pypi-workflow-gate.md) for the PyPI workflow-gate direction.
 
 ## Current capabilities
 
@@ -26,6 +28,7 @@ See [`docs/architecture.md`](docs/architecture.md), [`docs/security-model.md`](d
   - staged tarball: `https://registry.npmjs.org/-/stage/<stage-id>/tarball`
   - package metadata JSON
   - published `.tgz` tarballs for previous-version diffing
+- The sandbox parser can also parse ZIP wheel artifacts for the PyPI workflow-gate review foundation. End-to-end PyPI gating is not wired to routes or persistence yet.
 - The sandbox gunzips/parses tarballs, returns bounded file metadata and text samples, and the parent Worker runs deterministic checks.
 - AI triage (Workers AI JSON-mode review of changed files only) is **disabled for now**. The reviewer module — a single-model (Kimi K2.5) policy and prompt-injection-resistant system prompt — lives in `server/lib/ai-review.ts` so it can return behind a paid tier without re-engineering.
 - The service diffs the staged tarball against the currently published previous version when package metadata is available.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -258,7 +258,7 @@ Keep `POST /api/v1/scan` only as a compatibility shim during migration.
 
 ## PyPI workflow-gate foundation
 
-PyPI support is intentionally modeled as a separate workflow-gate mode because PyPI does not have npm's staged-publish review primitive. The current backend foundation lives in `server/lib/pypi.ts` and is not yet mounted as a route or persisted scan type.
+PyPI support is intentionally modeled as a separate workflow-gate mode because PyPI does not have npm's staged-publish review primitive. The current backend foundation lives in `server/lib/adapters/pypi/index.ts` as a `PackageAdapter` implementation, but it is not yet mounted as a route or persisted scan type.
 
 Implemented pieces:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,7 +61,7 @@ The Dynamic Worker handles untrusted package bytes. It:
 
 The sandbox must stay small and boring. Do not add package execution, dependency installation, build steps, import resolution, or rendering.
 
-The dynamic Worker's tar parser is defined in `server/lib/tar-parser.js` and concatenated into the sandbox module by `server/lib/sandbox.ts` via `Function.prototype.toString()`. This keeps the parser code path the one exercised by the unit tests in `test/tar-parser.test.mjs` instead of a sibling string copy that could drift.
+The dynamic Worker's archive parser is defined in `server/lib/tar-parser.js` and concatenated into the sandbox module by `server/lib/sandbox.ts` via `Function.prototype.toString()`. It covers gzipped tar archives for npm/sdist flows and ZIP archives for PyPI wheels. This keeps the parser code path the one exercised by the unit tests in `test/tar-parser.test.mjs` and `test/zip-parser.test.mjs` instead of sibling string copies that could drift.
 
 ### NpmStageGateway
 
@@ -255,3 +255,17 @@ Current API:
 All other `/api/v1/*` endpoints honor the `x-organization-id` request header to pick the active org; absent or non-member ids silently fall back to the caller's personal org.
 
 Keep `POST /api/v1/scan` only as a compatibility shim during migration.
+
+## PyPI workflow-gate foundation
+
+PyPI support is intentionally modeled as a separate workflow-gate mode because PyPI does not have npm's staged-publish review primitive. The current backend foundation lives in `server/lib/pypi.ts` and is not yet mounted as a route or persisted scan type.
+
+Implemented pieces:
+
+- `drydock.release-artifacts.v1` manifest validation for `ecosystem: "pypi"`;
+- PyPI wheel/sdist artifact normalization and metadata extraction;
+- safe ZIP parsing for `.whl` archives in the sandbox parser;
+- PyPI-specific deterministic findings for manifest/metadata mismatches, missing wheel `RECORD`, `.pth` startup hooks, custom `setup.py` install commands, and `.pyd` native extensions;
+- PyPI project JSON metadata helpers for baseline release selection and wheel/sdist download metadata.
+
+The target gate is a GitHub custom deployment protection rule on the same GitHub Environment configured in PyPI Trusted Publishers. CI must build artifacts before the gate, Drydock must review those exact artifact digests, and the publish job must verify the digest manifest immediately before invoking PyPI trusted publishing. See [`pypi-workflow-gate.md`](./pypi-workflow-gate.md).

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -18,6 +18,8 @@ The prototype-to-product foundation is in place: authenticated organization-scop
 
 Closed: tenant-boundary, sandbox-gateway, and archive-parser regression tests now have route- and unit-level coverage (`test/workers/cross-org-routes.test.ts`, `test/workers/cross-org-npm-connection.test.ts`, `test/workers/sandbox-gateway-runtime.test.ts`, `test/tar-parser.test.mjs`).
 
+PyPI workflow-gate support has a backend foundation only: manifest validation, PyPI metadata helpers, safe wheel ZIP parsing, and deterministic PyPI artifact findings. It is not yet a routed or persisted product workflow. See [`pypi-workflow-gate.md`](./pypi-workflow-gate.md).
+
 ## Phase 3 — Per-organization npm connections (open follow-up)
 
 Open validation question:
@@ -242,6 +244,38 @@ Exit criteria:
 - Detection changes are evaluated before release.
 - Security claims are backed by tests, fixtures, and documented limitations.
 - The product earns trust as a release-security tool, not just a scanner UI.
+
+## Phase 14 — PyPI workflow gate
+
+Priority: after the npm review loop is stable enough for a second operating mode.
+
+Goals:
+
+- Review PyPI release candidates before the trusted-publishing job uploads them.
+- Preserve the invariant that the publish job uploads the exact wheel/sdist bytes Drydock reviewed.
+- Keep PyPI credentials and OIDC token exchange outside Drydock.
+
+Implemented foundation:
+
+- `server/lib/pypi.ts` validates `drydock.release-artifacts.v1` PyPI manifests, reads PyPI project JSON metadata, selects a published baseline, and creates PyPI deterministic findings.
+- `server/lib/tar-parser.js` now supports safe ZIP parsing for wheel archives.
+- `NpmStageGateway` can allow exact public artifact URLs without attaching npm credentials.
+
+Remaining tasks:
+
+- Add GitHub App installation, repository, workflow, and environment mapping.
+- Handle GitHub `deployment_protection_rule` webhooks for the PyPI environment.
+- Fetch GitHub Actions artifacts and the required `drydock-manifest.json`.
+- Verify artifact SHA-256 digests before review and before publish.
+- Persist workflow-gate reviews without overloading npm `stage_id`.
+- Download previous PyPI release artifacts from `files.pythonhosted.org` for comparison.
+- Add UI for PyPI setup, gate status, and review reports.
+
+Exit criteria:
+
+- A GitHub Actions PyPI publish job waits on Drydock through a GitHub Environment gate.
+- Drydock reviews all candidate wheels/sdists and compares them to the selected previous PyPI release.
+- The publish job verifies the reviewed manifest digest and publishes with PyPI Trusted Publishing only after gate approval.
 
 ## Deferred work
 

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -257,7 +257,7 @@ Goals:
 
 Implemented foundation:
 
-- `server/lib/pypi.ts` validates `drydock.release-artifacts.v1` PyPI manifests, reads PyPI project JSON metadata, selects a published baseline, and creates PyPI deterministic findings.
+- `server/lib/adapters/pypi/index.ts` validates `drydock.release-artifacts.v1` PyPI manifests, reads PyPI project JSON metadata, selects a published baseline, and creates PyPI deterministic findings through the shared `PackageAdapter` contract.
 - `server/lib/tar-parser.js` now supports safe ZIP parsing for wheel archives.
 - `NpmStageGateway` can allow exact public artifact URLs without attaching npm credentials.
 

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -13,9 +13,10 @@ Official references:
 
 ## Implemented foundation
 
-The repo now has a backend-only PyPI foundation in `server/lib/pypi.ts`:
+The repo now has a backend-only PyPI foundation in `server/lib/adapters/pypi/index.ts`:
 
 - validates `drydock.release-artifacts.v1` manifests for `ecosystem: "pypi"`;
+- exposes a `PackageAdapter` implementation compatible with the pluggable scan pipeline introduced for npm;
 - normalizes PyPI project names using the PEP 503-style `[-_.]+ -> -` convention;
 - recognizes wheel (`.whl`) and sdist (`.tar.gz`, `.tgz`) artifacts;
 - parses wheel `METADATA`, `WHEEL`, and `RECORD` evidence from ZIP archives;

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -1,0 +1,103 @@
+# PyPI Workflow-Gate Support
+
+PyPI support uses a different product shape from npm staged publishing.
+
+npm owns a pending staged tarball, so Drydock can fetch `/-/stage/<stage-id>/tarball` and leave final approval in npm. PyPI does not expose an equivalent registry-staged artifact. The PyPI path is therefore **workflow gate mode**: CI builds wheels/sdists first, uploads a manifest plus artifacts for review, and a GitHub Environment blocks the publish job until the reviewed artifact digests are approved.
+
+Official references:
+
+- PyPI Trusted Publishers: `https://docs.pypi.org/trusted-publishers/`
+- PyPI GitHub Actions publishing setup: `https://docs.pypi.org/trusted-publishers/using-a-publisher/`
+- PyPI project JSON API: `https://docs.pypi.org/api/json/`
+- Python wheel format: `https://packaging.python.org/specifications/binary-distribution-format/`
+
+## Implemented foundation
+
+The repo now has a backend-only PyPI foundation in `server/lib/pypi.ts`:
+
+- validates `drydock.release-artifacts.v1` manifests for `ecosystem: "pypi"`;
+- normalizes PyPI project names using the PEP 503-style `[-_.]+ -> -` convention;
+- recognizes wheel (`.whl`) and sdist (`.tar.gz`, `.tgz`) artifacts;
+- parses wheel `METADATA`, `WHEEL`, and `RECORD` evidence from ZIP archives;
+- strips the common root directory from sdists before reading `PKG-INFO`;
+- compares flattened candidate artifact files against optional previous artifacts;
+- adds PyPI-specific deterministic findings for metadata mismatches, missing wheel `RECORD`, `.pth` startup hooks, custom `setup.py` install commands, and `.pyd` native extensions;
+- fetches PyPI project metadata from `GET /pypi/<project>/json`;
+- selects a default PyPI baseline release from `info.version`, falling back to newest non-yanked upload time;
+- extracts wheel/sdist download metadata and SHA-256 digests from PyPI release files;
+- restricts public PyPI artifact downloads to `https://files.pythonhosted.org`.
+
+The sandbox parser now supports safe ZIP archive parsing for wheels in addition to npm-style gzipped tar archives. ZIP parsing reads the central directory, accepts stored and deflated entries, rejects traversal paths and Zip64, enforces file/expanded-size caps, and keeps package contents as bounded text samples or binary metadata.
+
+## Manifest contract
+
+The manifest is the boundary between the GitHub workflow and Drydock:
+
+```json
+{
+  "schema": "drydock.release-artifacts.v1",
+  "ecosystem": "pypi",
+  "package": "example-package",
+  "version": "1.2.3",
+  "artifacts": [
+    {
+      "path": "dist/example_package-1.2.3-py3-none-any.whl",
+      "sha256": "..."
+    },
+    {
+      "path": "dist/example_package-1.2.3.tar.gz",
+      "sha256": "..."
+    }
+  ]
+}
+```
+
+The publish job must verify these digests immediately before publishing. A reviewed wheel/sdist must be the exact file uploaded to PyPI; rebuilding after the gate breaks the security boundary.
+
+## Target workflow
+
+```yaml
+jobs:
+  build-release-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python -m build
+      - run: sha256sum dist/* > drydock-sha256.txt
+      - run: python scripts/write-drydock-manifest.py
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pypi-release-candidate
+          path: |
+            dist/*
+            drydock-manifest.json
+            drydock-sha256.txt
+
+  publish:
+    needs: build-release-artifacts
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: pypi-release-candidate
+      - run: sha256sum --check drydock-sha256.txt
+      - uses: pypa/gh-action-pypi-publish@release/v1
+```
+
+PyPI strongly encourages configuring a GitHub Environment for Trusted Publishers. Drydock should attach to that same environment as a GitHub custom deployment protection rule when the GitHub App work lands.
+
+## Remaining work
+
+- Add the GitHub App installation model and repository/environment mapping.
+- Handle `deployment_protection_rule` webhooks.
+- Fetch GitHub Actions artifacts and `drydock-manifest.json` with installation credentials.
+- Run the existing PyPI candidate review helper from the gate handler.
+- Persist workflow-gate reviews separately from npm `stageId` scans or generalize the scan schema around `release_candidate` records.
+- Add UI for workflow-gate reviews and GitHub/PyPI setup guidance.
+- Verify artifact digests in the gate path before scanning and record those digests in the report payload.
+- Compare against prior PyPI release artifacts by downloading selected `files.pythonhosted.org` URLs through the exact public-artifact allowlist.
+
+Until those items land, the PyPI code is a review engine foundation and testable backend slice, not an end-to-end publish gate.

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -20,7 +20,8 @@ The repo now has a backend-only PyPI foundation in `server/lib/pypi.ts`:
 - recognizes wheel (`.whl`) and sdist (`.tar.gz`, `.tgz`) artifacts;
 - parses wheel `METADATA`, `WHEEL`, and `RECORD` evidence from ZIP archives;
 - strips the common root directory from sdists before reading `PKG-INFO`;
-- compares flattened candidate artifact files against optional previous artifacts;
+- compares flattened candidate artifact files against optional previous artifacts using stable wheel/sdist namespaces instead of versioned artifact filenames;
+- requires the reviewed artifact path set to exactly match the manifest artifact path set;
 - adds PyPI-specific deterministic findings for metadata mismatches, missing wheel `RECORD`, `.pth` startup hooks, custom `setup.py` install commands, and `.pyd` native extensions;
 - fetches PyPI project metadata from `GET /pypi/<project>/json`;
 - selects a default PyPI baseline release from `info.version`, falling back to newest non-yanked upload time;

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -28,7 +28,7 @@ The repo now has a backend-only PyPI foundation in `server/lib/pypi.ts`:
 - extracts wheel/sdist download metadata and SHA-256 digests from PyPI release files;
 - restricts public PyPI artifact downloads to `https://files.pythonhosted.org`.
 
-The sandbox parser now supports safe ZIP archive parsing for wheels in addition to npm-style gzipped tar archives. ZIP parsing reads the central directory, accepts stored and deflated entries, rejects traversal paths and Zip64, enforces file/expanded-size caps, and keeps package contents as bounded text samples or binary metadata.
+The sandbox parser now supports safe ZIP archive parsing for wheels in addition to npm-style gzipped tar archives. ZIP downloads are read through a bounded stream before parsing; ZIP parsing then reads the central directory, accepts stored and deflated entries, rejects traversal paths and Zip64, enforces file/expanded-size caps, and keeps package contents as bounded text samples or binary metadata.
 
 ## Manifest contract
 

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -25,7 +25,7 @@ The repo now has a backend-only PyPI foundation in `server/lib/pypi.ts`:
 - adds PyPI-specific deterministic findings for metadata mismatches, missing wheel `RECORD`, `.pth` startup hooks, custom `setup.py` install commands, and `.pyd` native extensions;
 - fetches PyPI project metadata from `GET /pypi/<project>/json`;
 - selects a default PyPI baseline release from `info.version`, falling back to newest non-yanked upload time;
-- extracts wheel/sdist download metadata and SHA-256 digests from PyPI release files;
+- extracts wheel/sdist download metadata and SHA-256 digests from non-yanked PyPI release files;
 - restricts public PyPI artifact downloads to `https://files.pythonhosted.org`.
 
 The sandbox parser now supports safe ZIP archive parsing for wheels in addition to npm-style gzipped tar archives. ZIP downloads are read through a bounded stream before parsing; ZIP parsing then reads the central directory, accepts stored and deflated entries, rejects traversal paths and Zip64, enforces file/expanded-size caps, and keeps package contents as bounded text samples or binary metadata.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -117,7 +117,20 @@ Blocked:
 - install-time network calls;
 - any request where npm auth would be forwarded to a non-registry origin.
 
-The gateway compares URL origins against the configured npm registry and attaches credentials only for the minimal endpoint set requiring auth. Previous-version compare cache entries are scoped by organization so cached private-package evidence is not shared across tenants.
+The gateway compares URL origins against the configured npm registry and attaches credentials only for the minimal endpoint set requiring auth. For the PyPI foundation, it can also allow exact public artifact URLs without credentials; those URLs must be explicitly listed and are intended for `files.pythonhosted.org` release artifacts. Previous-version compare cache entries are scoped by organization so cached private-package evidence is not shared across tenants.
+
+## PyPI workflow-gate posture
+
+PyPI support is a workflow-gate mode, not an approval bot and not a registry credential path. PyPI Trusted Publishers use OIDC from GitHub Actions, and PyPI strongly encourages binding the publisher to a GitHub Environment. Drydock's future GitHub App should review the built wheel/sdist artifacts while that environment is pending, then approve or reject the GitHub gate.
+
+Additional boundaries for PyPI:
+
+- Do not mint PyPI OIDC tokens or upload to PyPI.
+- Do not rebuild artifacts after review.
+- Require a manifest with package name, version, artifact path, and SHA-256 digest.
+- Verify the reviewed digests immediately before the publish action.
+- Treat wheel ZIP and sdist tar contents as hostile evidence, with the same no-execution and bounded-sample rules as npm tarballs.
+- Keep GitHub Actions artifact credentials in the trusted parent/GitHub integration path; do not pass them into the sandbox.
 
 ## AI prompt-injection posture (paused)
 

--- a/server/lib/adapters/pypi/index.ts
+++ b/server/lib/adapters/pypi/index.ts
@@ -563,9 +563,6 @@ function pyPiReleaseFindings(
 ): Finding[] {
   const findings: Finding[] = [];
   const manifestName = normalizePyPiProjectName(manifest.package);
-  const firstSummary = artifacts.find(
-    (artifact) => artifact.summary.name && artifact.summary.version,
-  )?.summary;
 
   for (const artifact of artifacts) {
     const { summary } = artifact;
@@ -599,24 +596,6 @@ function pyPiReleaseFindings(
           file: metadataEvidencePath,
           evidence: `${artifact.path} metadata Version ${summary.version} != manifest version ${manifest.version}`,
           reason: "the release artifact version does not match the reviewed PyPI manifest",
-        }),
-      );
-    }
-    if (
-      firstSummary &&
-      summary.name &&
-      summary.version &&
-      (normalizePyPiProjectName(summary.name) !==
-        normalizePyPiProjectName(firstSummary.name ?? "") ||
-        summary.version !== firstSummary.version)
-    ) {
-      findings.push(
-        tag("metadataMismatch", {
-          severity: "critical",
-          file: metadataEvidencePath,
-          evidence: `${artifact.path} metadata does not match the other candidate artifacts`,
-          reason:
-            "all PyPI artifacts in one gated release must describe the same package name and version",
         }),
       );
     }

--- a/server/lib/adapters/pypi/index.ts
+++ b/server/lib/adapters/pypi/index.ts
@@ -3,11 +3,22 @@ import {
   createPackageDiff,
   deterministicFindings,
   redactFindings,
+  summarizePackageJsonDiff,
   type DiffEntry,
   type FileRecord,
   type Finding,
+  type PackageJsonSummary,
   type RiskLevel,
-} from "./review";
+} from "../../review";
+import type {
+  AcquiredArtifact,
+  AdapterBroker,
+  AdapterConnectionRef,
+  AdapterContext,
+  BaselineInfo,
+  PackageAdapter,
+  StagedDetails,
+} from "../types";
 
 export const PYPI_RELEASE_MANIFEST_SCHEMA = "drydock.release-artifacts.v1";
 export const PYPI_RULES_VERSION = "0.1.0";
@@ -78,6 +89,21 @@ export interface PyPiReleaseCandidateReview {
   risk: RiskLevel;
 }
 
+export interface PyPiAdapterInput {
+  manifest: PyPiReleaseManifest;
+  artifacts: PyPiArtifactInput[];
+  previousArtifacts?: PyPiArtifactInput[];
+  metadata?: PyPiProjectMetadata;
+}
+
+export interface PyPiAdapterDetails {
+  manifest: PyPiReleaseManifest;
+  artifacts: PyPiArtifactSummary[];
+  preparedArtifacts: PyPiPreparedArtifact[];
+}
+
+export type PyPiBroker = AdapterBroker;
+
 export interface PyPiProjectMetadata {
   info?: { name?: string; version?: string };
   releases?: Record<string, PyPiReleaseFile[]>;
@@ -115,6 +141,59 @@ const PYPI_PROJECT_NAME_RE = /^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/;
 const SAFE_VERSION_RE = /^[A-Za-z0-9][A-Za-z0-9._!+-]{0,127}$/;
 const SHA256_RE = /^[a-f0-9]{64}$/i;
 const PYPI_ARTIFACT_LIMIT = 20;
+
+export const pypiAdapter: PackageAdapter<PyPiAdapterInput, PyPiBroker> = {
+  id: "pypi",
+
+  parseInput(raw: unknown): PyPiAdapterInput {
+    return parsePyPiAdapterInput(raw);
+  },
+
+  createBroker(ctx, ref) {
+    return createPyPiBroker(ctx, ref);
+  },
+
+  async acquireStaged(_ctx, input, _broker) {
+    return acquireStagedPyPi(input);
+  },
+
+  async acquireBaseline(_ctx, input, _broker) {
+    return acquireBaselinePyPi(input);
+  },
+
+  runFindings(args) {
+    const details = args.details as PyPiAdapterDetails;
+    return [
+      ...deterministicFindings(args.staged.files, args.fileDiff, null),
+      ...pyPiReleaseFindings(details.manifest, details.preparedArtifacts),
+    ];
+  },
+
+  describe({ details, previous }) {
+    const d = details as PyPiAdapterDetails;
+    const identity = pickPackageIdentity(d.manifest, d.preparedArtifacts);
+    return {
+      name: identity.name,
+      stagedVersion: identity.version,
+      stagedTag: null,
+      previousVersion: previous?.manifest?.version ?? null,
+    };
+  },
+
+  summarizeDetails(details) {
+    const d = details as PyPiAdapterDetails;
+    return {
+      manifest: d.manifest,
+      artifacts: d.artifacts,
+    };
+  },
+};
+
+export function createPyPiBroker(_ctx: AdapterContext, _ref: AdapterConnectionRef): PyPiBroker {
+  return {
+    dispose(): void {},
+  };
+}
 
 export function normalizePyPiProjectName(name: string): string {
   return name.toLowerCase().replace(/[-_.]+/g, "-");
@@ -178,6 +257,63 @@ export function parsePyPiReleaseManifest(value: unknown): PyPiReleaseManifest {
   };
 }
 
+export function parsePyPiAdapterInput(raw: unknown): PyPiAdapterInput {
+  if (!isRecord(raw)) throw new Error("PyPI adapter input must be an object");
+  const manifest = parsePyPiReleaseManifest(raw.manifest ?? raw);
+  return {
+    manifest,
+    artifacts: parsePyPiArtifactInputs(raw.artifacts, "artifacts"),
+    previousArtifacts:
+      raw.previousArtifacts === undefined
+        ? undefined
+        : parsePyPiArtifactInputs(raw.previousArtifacts, "previousArtifacts"),
+    metadata: isRecord(raw.metadata) ? (raw.metadata as PyPiProjectMetadata) : undefined,
+  };
+}
+
+function parsePyPiArtifactInputs(raw: unknown, field: string): PyPiArtifactInput[] {
+  if (!Array.isArray(raw) || !raw.length) {
+    throw new Error(`PyPI adapter input must include ${field}`);
+  }
+  return raw.map((artifact, index) => {
+    if (!isRecord(artifact)) throw new Error(`${field}[${index}] must be an object`);
+    const path = typeof artifact.path === "string" ? artifact.path : "";
+    if (!isSafeManifestPath(path)) throw new Error(`${field}[${index}] path is not safe`);
+    if (!Array.isArray(artifact.files))
+      throw new Error(`${field}[${index}] files must be an array`);
+    return {
+      path,
+      files: artifact.files.map((file, fileIndex) =>
+        parseFileRecord(file, field, index, fileIndex),
+      ),
+    };
+  });
+}
+
+function parseFileRecord(
+  raw: unknown,
+  field: string,
+  artifactIndex: number,
+  fileIndex: number,
+): FileRecord {
+  if (!isRecord(raw)) {
+    throw new Error(`${field}[${artifactIndex}].files[${fileIndex}] must be an object`);
+  }
+  const path = typeof raw.path === "string" ? raw.path : "";
+  const size = typeof raw.size === "number" ? raw.size : 0;
+  const sha256 = typeof raw.sha256 === "string" ? raw.sha256 : "";
+  const flags = Array.isArray(raw.flags)
+    ? raw.flags.filter((flag): flag is string => typeof flag === "string")
+    : [];
+  return {
+    path,
+    size,
+    sha256,
+    flags,
+    ...(typeof raw.textSample === "string" ? { textSample: raw.textSample } : {}),
+  };
+}
+
 export function preparePyPiArtifact(input: PyPiArtifactInput): PyPiPreparedArtifact {
   const kind = inferPyPiArtifactKind(input.path);
   if (!kind) throw new Error("PyPI artifact must be a wheel or sdist");
@@ -195,29 +331,109 @@ export function createPyPiReleaseCandidateReview(input: {
   artifacts: PyPiArtifactInput[];
   previousArtifacts?: PyPiArtifactInput[];
 }): PyPiReleaseCandidateReview {
-  assertManifestArtifactSet(input.manifest, input.artifacts);
-  const artifacts = input.artifacts.map(preparePyPiArtifact);
-  const previousArtifacts = (input.previousArtifacts ?? []).map(preparePyPiArtifact);
-  const stagedFiles = flattenPyPiArtifactFiles(artifacts);
-  const previousFiles = flattenPyPiArtifactFiles(previousArtifacts);
-  const diff = createPackageDiff(previousFiles, stagedFiles);
-  const packageIdentity = pickPackageIdentity(input.manifest, artifacts);
-  const ruleFindings = redactFindings([
-    ...deterministicFindings(stagedFiles, diff, null),
-    ...pyPiReleaseFindings(input.manifest, artifacts),
-  ]);
+  const adapterInput = pypiAdapter.parseInput(input);
+  const staged = acquireStagedPyPi(adapterInput);
+  const baseline = acquireBaselinePyPi(adapterInput);
+  const diff = createPackageDiff(baseline.artifact?.files ?? [], staged.artifact.files);
+  const ruleFindings = redactFindings(
+    pypiAdapter.runFindings({
+      staged: staged.artifact,
+      baseline: baseline.artifact,
+      details: staged.details,
+      fileDiff: diff,
+      manifestDiff: summarizePackageJsonDiff(baseline.artifact?.manifest, staged.artifact.manifest),
+      stagedManifestText: null,
+    }),
+  );
+  const packageIdentity = pypiAdapter.describe({
+    input: adapterInput,
+    staged: staged.artifact,
+    details: staged.details,
+    baseline: baseline.baseline,
+    previous: baseline.artifact,
+  });
+  const details = staged.details as PyPiAdapterDetails;
 
   return {
     ecosystem: "pypi",
-    manifest: input.manifest,
-    package: packageIdentity,
-    artifactCount: artifacts.length,
-    fileCount: stagedFiles.length,
-    previousFileCount: previousFiles.length,
-    artifacts: artifacts.map((artifact) => artifact.summary),
+    manifest: adapterInput.manifest,
+    package: {
+      name: packageIdentity.name,
+      version: packageIdentity.stagedVersion,
+    },
+    artifactCount: details.preparedArtifacts.length,
+    fileCount: staged.artifact.files.length,
+    previousFileCount: baseline.artifact?.files.length ?? 0,
+    artifacts: details.artifacts,
     diff,
     ruleFindings,
     risk: computeRisk(ruleFindings),
+  };
+}
+
+function acquireStagedPyPi(input: PyPiAdapterInput): {
+  artifact: AcquiredArtifact;
+  details: StagedDetails;
+} {
+  assertManifestArtifactSet(input.manifest, input.artifacts);
+  const preparedArtifacts = input.artifacts.map(preparePyPiArtifact);
+  const files = flattenPyPiArtifactFiles(preparedArtifacts);
+  const manifest = packageJsonSummaryFor(input.manifest, preparedArtifacts);
+  return {
+    artifact: { files, manifest },
+    details: {
+      manifest: input.manifest,
+      artifacts: preparedArtifacts.map((artifact) => artifact.summary),
+      preparedArtifacts,
+    } satisfies PyPiAdapterDetails,
+  };
+}
+
+function acquireBaselinePyPi(input: PyPiAdapterInput): {
+  artifact: AcquiredArtifact | null;
+  baseline: BaselineInfo;
+} {
+  if (input.previousArtifacts?.length) {
+    const preparedArtifacts = input.previousArtifacts.map(preparePyPiArtifact);
+    const manifest = packageJsonSummaryFor(input.manifest, preparedArtifacts);
+    return {
+      artifact: {
+        files: flattenPyPiArtifactFiles(preparedArtifacts),
+        manifest,
+      },
+      baseline: {
+        version: manifest.version ?? null,
+        tag: null,
+        source: "latest-published",
+        distTagVersion: null,
+        reason: "provided-previous-artifacts",
+      },
+    };
+  }
+
+  if (input.metadata) {
+    const selection = pickPyPiBaselineRelease(input.metadata, input.manifest.version);
+    return {
+      artifact: null,
+      baseline: {
+        version: selection.version,
+        tag: null,
+        source: selection.source,
+        distTagVersion: null,
+        reason: `${selection.reason}:not-downloaded`,
+      },
+    };
+  }
+
+  return {
+    artifact: null,
+    baseline: {
+      version: null,
+      tag: null,
+      source: "none",
+      distTagVersion: null,
+      reason: "no-previous-artifacts",
+    },
   };
 }
 
@@ -544,6 +760,17 @@ function pickPackageIdentity(manifest: PyPiReleaseManifest, artifacts: PyPiPrepa
   return {
     name: summary?.name ?? manifest.package ?? null,
     version: summary?.version ?? manifest.version ?? null,
+  };
+}
+
+function packageJsonSummaryFor(
+  manifest: PyPiReleaseManifest,
+  artifacts: PyPiPreparedArtifact[],
+): PackageJsonSummary {
+  const identity = pickPackageIdentity(manifest, artifacts);
+  return {
+    name: identity.name ?? undefined,
+    version: identity.version ?? undefined,
   };
 }
 

--- a/server/lib/adapters/types.ts
+++ b/server/lib/adapters/types.ts
@@ -37,6 +37,8 @@ export type BaselineSelectionSource =
   | "dist-tag"
   | "semver-predecessor"
   | "highest-published"
+  | "latest-published"
+  | "upload-time"
   | "none";
 
 export interface BaselineInfo {

--- a/server/lib/pypi.ts
+++ b/server/lib/pypi.ts
@@ -2,7 +2,6 @@ import {
   computeRisk,
   createPackageDiff,
   deterministicFindings,
-  redactFileRecords,
   redactFindings,
   type DiffEntry,
   type FileRecord,
@@ -199,8 +198,8 @@ export function createPyPiReleaseCandidateReview(input: {
   assertManifestArtifactSet(input.manifest, input.artifacts);
   const artifacts = input.artifacts.map(preparePyPiArtifact);
   const previousArtifacts = (input.previousArtifacts ?? []).map(preparePyPiArtifact);
-  const stagedFiles = redactFileRecords(flattenPyPiArtifactFiles(artifacts));
-  const previousFiles = redactFileRecords(flattenPyPiArtifactFiles(previousArtifacts));
+  const stagedFiles = flattenPyPiArtifactFiles(artifacts);
+  const previousFiles = flattenPyPiArtifactFiles(previousArtifacts);
   const diff = createPackageDiff(previousFiles, stagedFiles);
   const packageIdentity = pickPackageIdentity(input.manifest, artifacts);
   const ruleFindings = redactFindings([

--- a/server/lib/pypi.ts
+++ b/server/lib/pypi.ts
@@ -1,0 +1,616 @@
+import {
+  computeRisk,
+  createPackageDiff,
+  deterministicFindings,
+  redactFileRecords,
+  redactFindings,
+  type DiffEntry,
+  type FileRecord,
+  type Finding,
+  type RiskLevel,
+} from "./review";
+
+export const PYPI_RELEASE_MANIFEST_SCHEMA = "drydock.release-artifacts.v1";
+export const PYPI_RULES_VERSION = "0.1.0";
+
+export const PYPI_RULE_IDS = {
+  metadataMissing: "pypi.metadata-missing",
+  metadataMismatch: "pypi.metadata-mismatch",
+  wheelRecordMissing: "pypi.wheel-record-missing",
+  pthExecution: "pypi.pth-execution",
+  setupInstallCommand: "pypi.setup-install-command",
+  nativeArtifact: "pypi.native-artifact",
+} as const;
+
+export type PyPiArtifactKind = "wheel" | "sdist";
+
+export interface PyPiReleaseManifestArtifact {
+  path: string;
+  sha256: string;
+  url?: string;
+  kind: PyPiArtifactKind;
+}
+
+export interface PyPiReleaseManifest {
+  schema: typeof PYPI_RELEASE_MANIFEST_SCHEMA;
+  ecosystem: "pypi";
+  package: string;
+  version: string;
+  artifacts: PyPiReleaseManifestArtifact[];
+}
+
+export interface PyPiArtifactInput {
+  path: string;
+  files: FileRecord[];
+}
+
+export interface PyPiArtifactSummary {
+  path: string;
+  kind: PyPiArtifactKind;
+  metadataPath: string | null;
+  name: string | null;
+  version: string | null;
+  requiresDist: string[];
+  wheel: {
+    recordPath: string | null;
+    tags: string[];
+    rootIsPurelib: boolean | null;
+  } | null;
+}
+
+export interface PyPiPreparedArtifact extends PyPiArtifactInput {
+  kind: PyPiArtifactKind;
+  summary: PyPiArtifactSummary;
+}
+
+export interface PyPiReleaseCandidateReview {
+  ecosystem: "pypi";
+  manifest: PyPiReleaseManifest;
+  package: {
+    name: string | null;
+    version: string | null;
+  };
+  artifactCount: number;
+  fileCount: number;
+  previousFileCount: number;
+  artifacts: PyPiArtifactSummary[];
+  diff: DiffEntry[];
+  ruleFindings: Finding[];
+  risk: RiskLevel;
+}
+
+export interface PyPiProjectMetadata {
+  info?: { name?: string; version?: string };
+  releases?: Record<string, PyPiReleaseFile[]>;
+  urls?: PyPiReleaseFile[];
+}
+
+export interface PyPiReleaseFile {
+  filename?: string;
+  packagetype?: string;
+  url?: string;
+  size?: number;
+  upload_time_iso_8601?: string;
+  digests?: { sha256?: string };
+  yanked?: boolean;
+}
+
+export type PyPiBaselineSelectionSource = "latest-published" | "upload-time" | "none";
+
+export interface PyPiBaselineSelection {
+  version: string | null;
+  source: PyPiBaselineSelectionSource;
+  reason: string;
+}
+
+export interface PyPiRemoteArtifact {
+  filename: string;
+  url: string;
+  sha256: string | null;
+  packagetype: string | null;
+  kind: PyPiArtifactKind;
+  size: number | null;
+}
+
+const PYPI_PROJECT_NAME_RE = /^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/;
+const SAFE_VERSION_RE = /^[A-Za-z0-9][A-Za-z0-9._!+-]{0,127}$/;
+const SHA256_RE = /^[a-f0-9]{64}$/i;
+const PYPI_ARTIFACT_LIMIT = 20;
+
+export function normalizePyPiProjectName(name: string): string {
+  return name.toLowerCase().replace(/[-_.]+/g, "-");
+}
+
+export function isValidPyPiProjectName(name: string): boolean {
+  return (
+    typeof name === "string" &&
+    name.length > 0 &&
+    name.length <= 214 &&
+    PYPI_PROJECT_NAME_RE.test(name)
+  );
+}
+
+export function inferPyPiArtifactKind(path: string): PyPiArtifactKind | null {
+  const lower = path.toLowerCase();
+  if (lower.endsWith(".whl")) return "wheel";
+  if (lower.endsWith(".tar.gz") || lower.endsWith(".tgz")) return "sdist";
+  return null;
+}
+
+export function parsePyPiReleaseManifest(value: unknown): PyPiReleaseManifest {
+  if (!isRecord(value)) throw new Error("manifest must be an object");
+  if (value.schema !== PYPI_RELEASE_MANIFEST_SCHEMA) {
+    throw new Error(`manifest schema must be ${PYPI_RELEASE_MANIFEST_SCHEMA}`);
+  }
+  if (value.ecosystem !== "pypi") throw new Error("manifest ecosystem must be pypi");
+  const packageName = String(value.package || "");
+  const version = String(value.version || "");
+  if (!isValidPyPiProjectName(packageName))
+    throw new Error("manifest package is not a valid PyPI project name");
+  if (!SAFE_VERSION_RE.test(version))
+    throw new Error("manifest version is not a safe PyPI version string");
+  if (!Array.isArray(value.artifacts) || !value.artifacts.length) {
+    throw new Error("manifest must include at least one artifact");
+  }
+  if (value.artifacts.length > PYPI_ARTIFACT_LIMIT) {
+    throw new Error(`manifest must include no more than ${PYPI_ARTIFACT_LIMIT} artifacts`);
+  }
+
+  const artifacts = value.artifacts.map((artifact, index) => {
+    if (!isRecord(artifact)) throw new Error(`artifact ${index + 1} must be an object`);
+    const path = String(artifact.path || "");
+    if (!isSafeManifestPath(path)) throw new Error(`artifact ${index + 1} path is not safe`);
+    const kind = inferPyPiArtifactKind(path);
+    if (!kind) throw new Error(`artifact ${index + 1} must be a wheel or sdist`);
+    const sha256 = String(artifact.sha256 || "");
+    if (!SHA256_RE.test(sha256))
+      throw new Error(`artifact ${index + 1} sha256 must be a hex SHA-256 digest`);
+    const url = typeof artifact.url === "string" && artifact.url ? artifact.url : undefined;
+    if (url && !isSafeHttpsUrl(url)) throw new Error(`artifact ${index + 1} url must be https`);
+    return { path, sha256: sha256.toLowerCase(), url, kind };
+  });
+
+  return {
+    schema: PYPI_RELEASE_MANIFEST_SCHEMA,
+    ecosystem: "pypi",
+    package: packageName,
+    version,
+    artifacts,
+  };
+}
+
+export function preparePyPiArtifact(input: PyPiArtifactInput): PyPiPreparedArtifact {
+  const kind = inferPyPiArtifactKind(input.path);
+  if (!kind) throw new Error("PyPI artifact must be a wheel or sdist");
+  const files = kind === "sdist" ? stripCommonArchiveRoot(input.files) : input.files;
+  return {
+    path: input.path,
+    kind,
+    files,
+    summary: summarizePyPiArtifact(input.path, kind, files),
+  };
+}
+
+export function createPyPiReleaseCandidateReview(input: {
+  manifest: PyPiReleaseManifest;
+  artifacts: PyPiArtifactInput[];
+  previousArtifacts?: PyPiArtifactInput[];
+}): PyPiReleaseCandidateReview {
+  const artifacts = input.artifacts.map(preparePyPiArtifact);
+  const previousArtifacts = (input.previousArtifacts ?? []).map(preparePyPiArtifact);
+  const stagedFiles = redactFileRecords(flattenPyPiArtifactFiles(artifacts));
+  const previousFiles = redactFileRecords(flattenPyPiArtifactFiles(previousArtifacts));
+  const diff = createPackageDiff(previousFiles, stagedFiles);
+  const packageIdentity = pickPackageIdentity(input.manifest, artifacts);
+  const ruleFindings = redactFindings([
+    ...deterministicFindings(stagedFiles, diff, null),
+    ...pyPiReleaseFindings(input.manifest, artifacts),
+  ]);
+
+  return {
+    ecosystem: "pypi",
+    manifest: input.manifest,
+    package: packageIdentity,
+    artifactCount: artifacts.length,
+    fileCount: stagedFiles.length,
+    previousFileCount: previousFiles.length,
+    artifacts: artifacts.map((artifact) => artifact.summary),
+    diff,
+    ruleFindings,
+    risk: computeRisk(ruleFindings),
+  };
+}
+
+export async function fetchPyPiProjectMetadata(
+  projectName: string,
+  options: { registryUrl?: string } = {},
+): Promise<PyPiProjectMetadata> {
+  if (!isValidPyPiProjectName(projectName)) throw new Error("invalid PyPI project name");
+  const registry = (options.registryUrl || "https://pypi.org/pypi").replace(/\/$/, "");
+  const res = await fetch(`${registry}/${encodeURIComponent(projectName)}/json`, {
+    headers: { accept: "application/json" },
+  });
+  if (!res.ok) throw new Error(`PyPI metadata fetch failed: ${res.status}`);
+  return (await res.json()) as PyPiProjectMetadata;
+}
+
+export function pickPyPiBaselineRelease(
+  metadata: PyPiProjectMetadata,
+  candidateVersion: string,
+): PyPiBaselineSelection {
+  const releases = metadata.releases ?? {};
+  const latest = metadata.info?.version ?? null;
+  if (latest && latest !== candidateVersion && hasUsableReleaseFiles(releases[latest])) {
+    return {
+      version: latest,
+      source: "latest-published",
+      reason: "project-json-info-version",
+    };
+  }
+
+  const byUploadTime = Object.entries(releases)
+    .filter(([version, files]) => version !== candidateVersion && hasUsableReleaseFiles(files))
+    .map(([version, files]) => ({
+      version,
+      uploadedAt: newestUploadTimestamp(files),
+    }))
+    .filter((entry) => entry.uploadedAt > 0)
+    .sort((a, b) => a.uploadedAt - b.uploadedAt)
+    .at(-1);
+
+  if (byUploadTime) {
+    return {
+      version: byUploadTime.version,
+      source: "upload-time",
+      reason: "newest-uploaded-release",
+    };
+  }
+
+  return {
+    version: null,
+    source: "none",
+    reason: "no-published-baseline",
+  };
+}
+
+export function selectPyPiReleaseArtifacts(
+  metadata: PyPiProjectMetadata,
+  version: string,
+): PyPiRemoteArtifact[] {
+  return (metadata.releases?.[version] ?? [])
+    .map((file) => {
+      const filename = file.filename ?? "";
+      const kind = inferPyPiArtifactKind(filename);
+      if (!filename || !kind || !file.url) return null;
+      return {
+        filename,
+        url: file.url,
+        sha256: file.digests?.sha256 ?? null,
+        packagetype: file.packagetype ?? null,
+        kind,
+        size: typeof file.size === "number" ? file.size : null,
+      };
+    })
+    .filter((artifact): artifact is PyPiRemoteArtifact => artifact !== null);
+}
+
+export function isAllowedPyPiArtifactUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" && parsed.hostname === "files.pythonhosted.org";
+  } catch {
+    return false;
+  }
+}
+
+function summarizePyPiArtifact(
+  artifactPath: string,
+  kind: PyPiArtifactKind,
+  files: FileRecord[],
+): PyPiArtifactSummary {
+  const metadataFile = findPyPiMetadataFile(files, kind);
+  const headers = metadataFile?.textSample
+    ? parseMetadataHeaders(metadataFile.textSample)
+    : new Map();
+  const wheelFile =
+    kind === "wheel" ? files.find((file) => /\.dist-info\/WHEEL$/i.test(file.path)) : undefined;
+  const wheelHeaders = wheelFile?.textSample
+    ? parseMetadataHeaders(wheelFile.textSample)
+    : new Map();
+  const recordPath =
+    kind === "wheel"
+      ? (files.find((file) => /\.dist-info\/RECORD$/i.test(file.path))?.path ?? null)
+      : null;
+
+  return {
+    path: artifactPath,
+    kind,
+    metadataPath: metadataFile?.path ?? null,
+    name: firstHeader(headers, "name"),
+    version: firstHeader(headers, "version"),
+    requiresDist: headers.get("requires-dist") ?? [],
+    wheel:
+      kind === "wheel"
+        ? {
+            recordPath,
+            tags: wheelHeaders.get("tag") ?? [],
+            rootIsPurelib: parseWheelBoolean(firstHeader(wheelHeaders, "root-is-purelib")),
+          }
+        : null,
+  };
+}
+
+function pyPiReleaseFindings(
+  manifest: PyPiReleaseManifest,
+  artifacts: PyPiPreparedArtifact[],
+): Finding[] {
+  const findings: Finding[] = [];
+  const manifestName = normalizePyPiProjectName(manifest.package);
+  const firstSummary = artifacts.find(
+    (artifact) => artifact.summary.name && artifact.summary.version,
+  )?.summary;
+
+  for (const artifact of artifacts) {
+    const { summary } = artifact;
+    const metadataEvidencePath = namespacedPath(artifact.path, summary.metadataPath ?? "METADATA");
+    if (!summary.metadataPath || !summary.name || !summary.version) {
+      findings.push(
+        tag("metadataMissing", {
+          severity: "medium",
+          file: metadataEvidencePath,
+          evidence: `${artifact.path} does not expose complete PyPI metadata`,
+          reason:
+            "release gates need package name and version metadata to prove the artifact matches the reviewed manifest",
+        }),
+      );
+      continue;
+    }
+    if (normalizePyPiProjectName(summary.name) !== manifestName) {
+      findings.push(
+        tag("metadataMismatch", {
+          severity: "critical",
+          file: metadataEvidencePath,
+          evidence: `${artifact.path} metadata Name ${summary.name} != manifest package ${manifest.package}`,
+          reason: "the release artifact package name does not match the reviewed PyPI manifest",
+        }),
+      );
+    }
+    if (summary.version !== manifest.version) {
+      findings.push(
+        tag("metadataMismatch", {
+          severity: "critical",
+          file: metadataEvidencePath,
+          evidence: `${artifact.path} metadata Version ${summary.version} != manifest version ${manifest.version}`,
+          reason: "the release artifact version does not match the reviewed PyPI manifest",
+        }),
+      );
+    }
+    if (
+      firstSummary &&
+      summary.name &&
+      summary.version &&
+      (normalizePyPiProjectName(summary.name) !==
+        normalizePyPiProjectName(firstSummary.name ?? "") ||
+        summary.version !== firstSummary.version)
+    ) {
+      findings.push(
+        tag("metadataMismatch", {
+          severity: "critical",
+          file: metadataEvidencePath,
+          evidence: `${artifact.path} metadata does not match the other candidate artifacts`,
+          reason:
+            "all PyPI artifacts in one gated release must describe the same package name and version",
+        }),
+      );
+    }
+    if (artifact.kind === "wheel" && !summary.wheel?.recordPath) {
+      findings.push(
+        tag("wheelRecordMissing", {
+          severity: "medium",
+          file: namespacedPath(artifact.path, "RECORD"),
+          evidence: `${artifact.path} has no .dist-info/RECORD file`,
+          reason: "wheel RECORD metadata is needed to audit the installed file manifest",
+        }),
+      );
+    }
+  }
+
+  for (const artifact of artifacts) {
+    for (const file of artifact.files) {
+      const filePath = namespacedPath(artifact.path, file.path);
+      if (/\.pth$/i.test(file.path)) {
+        const hasImportLine = Boolean(
+          file.textSample?.split(/\r?\n/).some((line) => /^\s*import\s+/.test(line)),
+        );
+        findings.push(
+          tag("pthExecution", {
+            severity: hasImportLine ? "high" : "medium",
+            file: filePath,
+            line: hasImportLine ? firstMatchingLine(file.textSample, [/^\s*import\s+/]) : undefined,
+            evidence: hasImportLine
+              ? ".pth file contains an import line"
+              : ".pth file included in wheel",
+            reason:
+              "Python .pth files can alter interpreter startup behavior when the package is installed",
+          }),
+        );
+      }
+      if (
+        /(^|\/)setup\.py$/i.test(file.path) &&
+        /\b(cmdclass|setuptools\.command\.install|distutils\.command\.install)\b/.test(
+          file.textSample ?? "",
+        )
+      ) {
+        findings.push(
+          tag("setupInstallCommand", {
+            severity: "high",
+            file: filePath,
+            line: firstMatchingLine(file.textSample, [
+              /\bcmdclass\b/,
+              /\bsetuptools\.command\.install\b/,
+              /\bdistutils\.command\.install\b/,
+            ]),
+            evidence: "setup.py custom install command",
+            reason:
+              "custom Python install commands can run maintainer-controlled code during package installation",
+          }),
+        );
+      }
+      if (/\.(pyd)$/i.test(file.path)) {
+        findings.push(
+          tag("nativeArtifact", {
+            severity: "high",
+            file: filePath,
+            evidence: "Python native extension artifact",
+            reason:
+              "native Python extensions are hard to audit and execute outside source-level policy checks",
+          }),
+        );
+      }
+    }
+  }
+
+  return findings;
+}
+
+function tag(
+  rule: keyof typeof PYPI_RULE_IDS,
+  finding: Omit<Finding, "ruleId" | "ruleVersion">,
+): Finding {
+  return {
+    ...finding,
+    ruleId: PYPI_RULE_IDS[rule],
+    ruleVersion: PYPI_RULES_VERSION,
+  };
+}
+
+function flattenPyPiArtifactFiles(artifacts: PyPiPreparedArtifact[]): FileRecord[] {
+  return artifacts.flatMap((artifact) =>
+    artifact.files.map((file) => ({
+      ...file,
+      path: namespacedPath(artifact.path, file.path),
+    })),
+  );
+}
+
+function pickPackageIdentity(manifest: PyPiReleaseManifest, artifacts: PyPiPreparedArtifact[]) {
+  const summary = artifacts.find(
+    (artifact) => artifact.summary.name && artifact.summary.version,
+  )?.summary;
+  return {
+    name: summary?.name ?? manifest.package ?? null,
+    version: summary?.version ?? manifest.version ?? null,
+  };
+}
+
+function stripCommonArchiveRoot(files: FileRecord[]): FileRecord[] {
+  const pathParts = files.map((file) => file.path.split("/"));
+  if (!pathParts.length || pathParts.some((parts) => parts.length < 2)) return files;
+  const root = pathParts[0][0];
+  if (!root || pathParts.some((parts) => parts[0] !== root)) return files;
+  return files.map((file) => ({
+    ...file,
+    path: file.path.split("/").slice(1).join("/"),
+  }));
+}
+
+function findPyPiMetadataFile(files: FileRecord[], kind: PyPiArtifactKind): FileRecord | undefined {
+  if (kind === "wheel") return files.find((file) => /\.dist-info\/METADATA$/i.test(file.path));
+  return (
+    files.find((file) => file.path === "PKG-INFO") ??
+    files.find((file) => /(^|\/)[^/]+\.egg-info\/PKG-INFO$/i.test(file.path))
+  );
+}
+
+function parseMetadataHeaders(text: string): Map<string, string[]> {
+  const headers = new Map<string, string[]>();
+  let currentKey: string | null = null;
+  let currentValue = "";
+  const commit = () => {
+    if (!currentKey) return;
+    const list = headers.get(currentKey) ?? [];
+    list.push(currentValue.trim());
+    headers.set(currentKey, list);
+  };
+
+  for (const line of text.replace(/\r\n/g, "\n").split("\n")) {
+    if (!line) break;
+    if (/^[ \t]/.test(line) && currentKey) {
+      currentValue += ` ${line.trim()}`;
+      continue;
+    }
+    commit();
+    const colon = line.indexOf(":");
+    if (colon <= 0) {
+      currentKey = null;
+      currentValue = "";
+      continue;
+    }
+    currentKey = line.slice(0, colon).toLowerCase();
+    currentValue = line.slice(colon + 1).trim();
+  }
+  commit();
+  return headers;
+}
+
+function firstHeader(headers: Map<string, string[]>, key: string): string | null {
+  return headers.get(key.toLowerCase())?.[0] ?? null;
+}
+
+function parseWheelBoolean(value: string | null): boolean | null {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return null;
+}
+
+function namespacedPath(artifactPath: string, filePath: string): string {
+  return `${artifactPath.replace(/\/+$/, "")}/${filePath.replace(/^\/+/, "")}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSafeManifestPath(path: string): boolean {
+  if (!path || path.length > 512 || path.includes("\0") || path.includes("\\")) return false;
+  if (path.startsWith("/") || path.startsWith("../") || path.includes("/../")) return false;
+  if (/^[A-Za-z]:/.test(path)) return false;
+  return path.split("/").every((part) => part && part !== "." && part !== "..");
+}
+
+function isSafeHttpsUrl(url: string): boolean {
+  try {
+    return new URL(url).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function hasUsableReleaseFiles(files: PyPiReleaseFile[] | undefined): boolean {
+  return Boolean(files?.some((file) => file.url && !file.yanked));
+}
+
+function newestUploadTimestamp(files: PyPiReleaseFile[]): number {
+  return Math.max(
+    0,
+    ...files
+      .filter((file) => !file.yanked)
+      .map((file) => Date.parse(file.upload_time_iso_8601 ?? ""))
+      .filter((time) => Number.isFinite(time)),
+  );
+}
+
+function firstMatchingLine(
+  text: string | undefined | null,
+  patterns: RegExp[],
+): number | undefined {
+  if (!text) return undefined;
+  const lines = text.split("\n");
+  for (let index = 0; index < lines.length; index += 1) {
+    for (const pattern of patterns) {
+      pattern.lastIndex = 0;
+      if (pattern.test(lines[index])) return index + 1;
+    }
+  }
+  return undefined;
+}

--- a/server/lib/pypi.ts
+++ b/server/lib/pypi.ts
@@ -196,6 +196,7 @@ export function createPyPiReleaseCandidateReview(input: {
   artifacts: PyPiArtifactInput[];
   previousArtifacts?: PyPiArtifactInput[];
 }): PyPiReleaseCandidateReview {
+  assertManifestArtifactSet(input.manifest, input.artifacts);
   const artifacts = input.artifacts.map(preparePyPiArtifact);
   const previousArtifacts = (input.previousArtifacts ?? []).map(preparePyPiArtifact);
   const stagedFiles = redactFileRecords(flattenPyPiArtifactFiles(artifacts));
@@ -488,9 +489,52 @@ function flattenPyPiArtifactFiles(artifacts: PyPiPreparedArtifact[]): FileRecord
   return artifacts.flatMap((artifact) =>
     artifact.files.map((file) => ({
       ...file,
-      path: namespacedPath(artifact.path, file.path),
+      path: namespacedPath(artifactDiffNamespace(artifact), normalizePyPiDiffFilePath(file.path)),
     })),
   );
+}
+
+function assertManifestArtifactSet(
+  manifest: PyPiReleaseManifest,
+  artifacts: PyPiArtifactInput[],
+): void {
+  const manifestPaths = sortedUnique(manifest.artifacts.map((artifact) => artifact.path));
+  const artifactPaths = sortedUnique(artifacts.map((artifact) => artifact.path));
+  if (
+    manifestPaths.length !== manifest.artifacts.length ||
+    artifactPaths.length !== artifacts.length ||
+    manifestPaths.length !== artifactPaths.length ||
+    manifestPaths.some((path, index) => path !== artifactPaths[index])
+  ) {
+    throw new Error("review artifacts must exactly match manifest artifacts");
+  }
+}
+
+function sortedUnique(values: string[]): string[] {
+  return [...new Set(values)].sort();
+}
+
+function artifactDiffNamespace(artifact: PyPiPreparedArtifact): string {
+  if (artifact.kind === "sdist") return "sdist";
+  const tags = artifact.summary.wheel?.tags ?? [];
+  if (tags.length) return `wheel/${tags.slice().sort().map(safeDiffPathPart).join("+")}`;
+  const filename = artifact.path.split("/").at(-1) ?? "";
+  const wheelTags = filename
+    .replace(/\.whl$/i, "")
+    .split("-")
+    .slice(-3);
+  if (wheelTags.length === 3) return `wheel/${wheelTags.map(safeDiffPathPart).join("-")}`;
+  return "wheel/unknown";
+}
+
+function normalizePyPiDiffFilePath(path: string): string {
+  return path
+    .replace(/(^|\/)[^/]+\.dist-info\//gi, "$1.dist-info/")
+    .replace(/(^|\/)[^/]+\.egg-info\//gi, "$1.egg-info/");
+}
+
+function safeDiffPathPart(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]+/g, "_") || "unknown";
 }
 
 function pickPackageIdentity(manifest: PyPiReleaseManifest, artifacts: PyPiPreparedArtifact[]) {

--- a/server/lib/pypi.ts
+++ b/server/lib/pypi.ts
@@ -278,6 +278,7 @@ export function selectPyPiReleaseArtifacts(
   version: string,
 ): PyPiRemoteArtifact[] {
   return (metadata.releases?.[version] ?? [])
+    .filter((file) => !file.yanked)
     .map((file) => {
       const filename = file.filename ?? "";
       const kind = inferPyPiArtifactKind(filename);

--- a/server/lib/sandbox.ts
+++ b/server/lib/sandbox.ts
@@ -20,10 +20,16 @@ const SANDBOX_TAR_PARSER_EXPORTS = [
   tarParser.hasImplicitNodeGypInstall,
   tarParser.isSafePaxPath,
   tarParser.normalizeTarPath,
+  tarParser.normalizeZipPath,
   tarParser.parsePax,
   tarParser.sha256Hex,
   tarParser.summarizeFile,
   tarParser.readTar,
+  tarParser.readUint16Le,
+  tarParser.readUint32Le,
+  tarParser.findZipEndOfCentralDirectory,
+  tarParser.inflateRawBounded,
+  tarParser.readZipArchive,
   tarParser.parsePackageJson,
   tarParser.gunzipBounded,
 ];
@@ -35,23 +41,29 @@ function renderTarParserSource() {
 interface NpmStageGatewayProps {
   npmToken?: string;
   npmRegistry?: string;
+  publicArtifactUrls?: string[];
 }
 
 export interface NpmStageGatewayPolicy {
   allowed: boolean;
   credentialed: boolean;
-  kind: "staged-tarball" | "published-tarball" | "package-metadata" | "blocked";
+  kind: "staged-tarball" | "published-tarball" | "package-metadata" | "public-artifact" | "blocked";
 }
 
 export function evaluateNpmStageGatewayRequest(
   requestUrl: string,
   method: string,
   registryUrl: string,
+  publicArtifactUrls: string[] = [],
 ): NpmStageGatewayPolicy {
   const url = new URL(requestUrl);
   const registry = new URL(registryUrl || "https://registry.npmjs.org");
   const sameOrigin = url.origin === registry.origin;
   const normalizedMethod = method.toUpperCase();
+  const isPublicArtifact =
+    normalizedMethod === "GET" &&
+    url.protocol === "https:" &&
+    publicArtifactUrls.some((allowedUrl) => requestUrl === allowedUrl);
   const packageMetadataPath = /^\/(?:@[^/]+%2[fF][^/]+|[^/@-][^/]*)$/.test(url.pathname);
   const isStagedTarball =
     sameOrigin &&
@@ -65,6 +77,7 @@ export function evaluateNpmStageGatewayRequest(
     url.pathname.includes("/-/");
   const isRegistryMetadata = sameOrigin && normalizedMethod === "GET" && packageMetadataPath;
 
+  if (isPublicArtifact) return { allowed: true, credentialed: false, kind: "public-artifact" };
   if (isStagedTarball) return { allowed: true, credentialed: true, kind: "staged-tarball" };
   if (isPublishedTarball) return { allowed: true, credentialed: true, kind: "published-tarball" };
   if (isRegistryMetadata) return { allowed: true, credentialed: true, kind: "package-metadata" };
@@ -75,7 +88,12 @@ export class NpmStageGateway extends WorkerEntrypoint<Cloudflare.Env, NpmStageGa
   async fetch(request: Request): Promise<Response> {
     const registry =
       this.ctx.props.npmRegistry || this.env.NPM_REGISTRY || "https://registry.npmjs.org";
-    const policy = evaluateNpmStageGatewayRequest(request.url, request.method, registry);
+    const policy = evaluateNpmStageGatewayRequest(
+      request.url,
+      request.method,
+      registry,
+      this.ctx.props.publicArtifactUrls,
+    );
 
     if (!policy.allowed) {
       return new Response("blocked by stage gateway", { status: 403 });
@@ -98,6 +116,8 @@ export interface DownloadResult {
 export interface DownloadOptions {
   stageId?: string;
   tarballUrl?: string;
+  archiveFormat?: "tgz" | "zip";
+  publicArtifactUrls?: string[];
   maxFiles?: number;
   maxBytesPerFile?: number;
   npmToken?: string;
@@ -149,11 +169,17 @@ export async function downloadInSandbox(
     try {
       const tarball = new URL(options.tarballUrl);
       const registryOrigin = new URL(registry).origin;
-      if (
-        tarball.origin !== registryOrigin ||
-        !registryProtocolAllowed(tarball, {
+      const isRegistryArtifact =
+        tarball.origin === registryOrigin &&
+        registryProtocolAllowed(tarball, {
           allowInsecureLocalhost: allowInsecureLocalRegistry(env),
-        })
+        });
+      const isPublicArtifact =
+        tarball.protocol === "https:" &&
+        (options.publicArtifactUrls ?? []).some((allowedUrl) => allowedUrl === options.tarballUrl);
+      if (
+        !isRegistryArtifact &&
+        !isPublicArtifact
       ) {
         throw new SandboxError(
           JSON.stringify({ error: "tarball URL is not allowed by the gateway", status: 400 }),
@@ -170,6 +196,7 @@ export async function downloadInSandbox(
     modules: { "sandbox.js": sandboxSource() },
     env: {
       NPM_REGISTRY: options.npmRegistry || env.NPM_REGISTRY || "https://registry.npmjs.org",
+      ARCHIVE_FORMAT: options.archiveFormat || "tgz",
       MAX_FILES: Math.min(options.maxFiles ?? MAX_FILES, MAX_FILES),
       MAX_BYTES_PER_FILE: Math.min(
         options.maxBytesPerFile ?? MAX_BYTES_PER_FILE,
@@ -182,7 +209,11 @@ export async function downloadInSandbox(
         exports: { NpmStageGateway(options: { props: NpmStageGatewayProps }): Fetcher };
       }
     ).exports.NpmStageGateway({
-      props: { npmToken: options.npmToken, npmRegistry: options.npmRegistry },
+      props: {
+        npmToken: options.npmToken,
+        npmRegistry: options.npmRegistry,
+        publicArtifactUrls: options.publicArtifactUrls,
+      },
     }),
     limits: { cpuMs: 2_000, subRequests: 4 },
   });
@@ -219,6 +250,27 @@ export default {
     const maxTarBytes = env.MAX_TAR_BYTES || 26214400;
     const contentLength = Number(res.headers.get("content-length") || "0");
     if (contentLength > maxTarBytes) return json({ error: "tarball too large", status: 413 }, 413);
+    const archiveFormat = env.ARCHIVE_FORMAT || "tgz";
+    if (archiveFormat === "zip") {
+      const zip = await res.arrayBuffer();
+      if (zip.byteLength > maxTarBytes) return json({ error: "archive too large", status: 413 }, 413);
+      let files;
+      try {
+        files = await readZipArchive(zip, env.MAX_FILES || 250, env.MAX_BYTES_PER_FILE || 65536, maxTarBytes);
+      } catch (err) {
+        const reason = err && err.message === "archive contains too many files"
+          ? "archive contains too many files"
+          : err && err.message === "archive expands beyond safety limit"
+            ? "archive expands beyond safety limit"
+            : err && err.message
+              ? err.message
+              : "zip parse failed";
+        const status = reason === "archive contains too many files" || reason === "archive expands beyond safety limit" ? 413 : 400;
+        return json({ error: reason, status }, status);
+      }
+      return json({ files, packageJson: null });
+    }
+
     let tar;
     try {
       tar = await gunzipBounded(res.body, maxTarBytes);

--- a/server/lib/sandbox.ts
+++ b/server/lib/sandbox.ts
@@ -178,10 +178,7 @@ export async function downloadInSandbox(
       const isPublicArtifact =
         tarball.protocol === "https:" &&
         (options.publicArtifactUrls ?? []).some((allowedUrl) => allowedUrl === options.tarballUrl);
-      if (
-        !isRegistryArtifact &&
-        !isPublicArtifact
-      ) {
+      if (!isRegistryArtifact && !isPublicArtifact) {
         throw new SandboxError(
           JSON.stringify({ error: "tarball URL is not allowed by the gateway", status: 400 }),
         );

--- a/server/lib/sandbox.ts
+++ b/server/lib/sandbox.ts
@@ -30,6 +30,7 @@ const SANDBOX_TAR_PARSER_EXPORTS = [
   tarParser.findZipEndOfCentralDirectory,
   tarParser.inflateRawBounded,
   tarParser.readZipArchive,
+  tarParser.readStreamBounded,
   tarParser.parsePackageJson,
   tarParser.gunzipBounded,
 ];
@@ -252,8 +253,14 @@ export default {
     if (contentLength > maxTarBytes) return json({ error: "tarball too large", status: 413 }, 413);
     const archiveFormat = env.ARCHIVE_FORMAT || "tgz";
     if (archiveFormat === "zip") {
-      const zip = await res.arrayBuffer();
-      if (zip.byteLength > maxTarBytes) return json({ error: "archive too large", status: 413 }, 413);
+      let zip;
+      try {
+        zip = await readStreamBounded(res.body, maxTarBytes);
+      } catch (err) {
+        const reason = err && err.message === "archive too large" ? "archive too large" : "archive download failed";
+        const status = reason === "archive too large" ? 413 : 400;
+        return json({ error: reason, status }, status);
+      }
       let files;
       try {
         files = await readZipArchive(zip, env.MAX_FILES || 250, env.MAX_BYTES_PER_FILE || 65536, maxTarBytes);

--- a/server/lib/tar-parser.d.ts
+++ b/server/lib/tar-parser.d.ts
@@ -36,6 +36,7 @@ export function hasImplicitNodeGypInstall(
 ): boolean;
 export function isSafePaxPath(value: unknown): boolean;
 export function normalizeTarPath(rawPath: string | null | undefined): string | null;
+export function normalizeZipPath(rawPath: string | null | undefined): string | null;
 export function parsePax(body: Uint8Array): Record<string, string>;
 export function sha256Hex(bytes: Uint8Array): Promise<string>;
 export function summarizeFile(
@@ -48,6 +49,16 @@ export function readTar(
   maxFiles: number,
   maxBytesPerFile: number,
   maxTarBytes: number,
+): Promise<ParsedFile[]>;
+export function readUint16Le(bytes: Uint8Array, offset: number): number;
+export function readUint32Le(bytes: Uint8Array, offset: number): number;
+export function findZipEndOfCentralDirectory(bytes: Uint8Array): number;
+export function inflateRawBounded(bytes: Uint8Array, maxBytes: number): Promise<Uint8Array>;
+export function readZipArchive(
+  buffer: ArrayBuffer | Uint8Array,
+  maxFiles: number,
+  maxBytesPerFile: number,
+  maxArchiveBytes: number,
 ): Promise<ParsedFile[]>;
 export function parsePackageJson(files: ParsedFile[]): ParsedPackageJson | null;
 export function gunzipBounded(

--- a/server/lib/tar-parser.d.ts
+++ b/server/lib/tar-parser.d.ts
@@ -60,6 +60,10 @@ export function readZipArchive(
   maxBytesPerFile: number,
   maxArchiveBytes: number,
 ): Promise<ParsedFile[]>;
+export function readStreamBounded(
+  body: ReadableStream<Uint8Array> | null,
+  maxBytes: number,
+): Promise<Uint8Array>;
 export function parsePackageJson(files: ParsedFile[]): ParsedPackageJson | null;
 export function gunzipBounded(
   body: ReadableStream<Uint8Array> | null,

--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -308,6 +308,30 @@ export async function readZipArchive(buffer, maxFiles, maxBytesPerFile, maxArchi
   return files;
 }
 
+export async function readStreamBounded(body, maxBytes) {
+  if (!body) throw new Error("archive download failed");
+  const reader = body.getReader();
+  const chunks = [];
+  let total = 0;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      reader.cancel().catch(() => undefined);
+      throw new Error("archive too large");
+    }
+    chunks.push(value);
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
 export function parsePackageJson(files) {
   const pkg = files.find((f) => f.path === "package.json" && f.textSample);
   if (!pkg || !pkg.textSample) return null;

--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -76,6 +76,19 @@ export function normalizeTarPath(rawPath) {
   return path;
 }
 
+export function normalizeZipPath(rawPath) {
+  const nul = String.fromCharCode(0);
+  if (!rawPath || rawPath.includes(nul) || rawPath.includes("\\")) return null;
+  let path = rawPath.replace(/^\/+/, "");
+  if (!path || path.endsWith("/") || path.startsWith("../") || path.includes("/../")) return null;
+  if (/^[A-Za-z]:/.test(path)) return null;
+  const parts = path.split("/").filter(Boolean);
+  if (!parts.length || parts.some((part) => part === "." || part === "..")) return null;
+  path = parts.join("/");
+  if (path.length > 512) return null;
+  return path;
+}
+
 export function parsePax(body) {
   const text = decodeText(body.subarray(0, Math.min(body.length, 8192)));
   const out = {};
@@ -167,6 +180,130 @@ export async function readTar(buffer, maxFiles, maxBytesPerFile, maxTarBytes) {
     }
 
     offset += Math.ceil(size / 512) * 512;
+  }
+  return files;
+}
+
+export function readUint16Le(bytes, offset) {
+  return bytes[offset] | (bytes[offset + 1] << 8);
+}
+
+export function readUint32Le(bytes, offset) {
+  return (
+    (bytes[offset] |
+      (bytes[offset + 1] << 8) |
+      (bytes[offset + 2] << 16) |
+      (bytes[offset + 3] << 24)) >>>
+    0
+  );
+}
+
+export function findZipEndOfCentralDirectory(bytes) {
+  const minOffset = Math.max(0, bytes.length - 65557);
+  for (let offset = bytes.length - 22; offset >= minOffset; offset -= 1) {
+    if (readUint32Le(bytes, offset) === 0x06054b50) return offset;
+  }
+  return -1;
+}
+
+export async function inflateRawBounded(bytes, maxBytes) {
+  const reader = new Response(bytes).body
+    .pipeThrough(new DecompressionStream("deflate-raw"))
+    .getReader();
+  const chunks = [];
+  let total = 0;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    total += value.byteLength;
+    if (total > maxBytes) {
+      reader.cancel().catch(() => undefined);
+      throw new Error("archive expands beyond safety limit");
+    }
+    chunks.push(value);
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return out;
+}
+
+export async function readZipArchive(buffer, maxFiles, maxBytesPerFile, maxArchiveBytes) {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  const eocd = findZipEndOfCentralDirectory(bytes);
+  if (eocd < 0) throw new Error("zip central directory not found");
+
+  const entryCount = readUint16Le(bytes, eocd + 10);
+  const centralDirectorySize = readUint32Le(bytes, eocd + 12);
+  const centralDirectoryOffset = readUint32Le(bytes, eocd + 16);
+  if (
+    entryCount === 0xffff ||
+    centralDirectorySize === 0xffffffff ||
+    centralDirectoryOffset === 0xffffffff
+  ) {
+    throw new Error("zip64 archives are not supported");
+  }
+  if (centralDirectoryOffset + centralDirectorySize > bytes.length) {
+    throw new Error("truncated zip central directory");
+  }
+
+  const files = [];
+  let expandedBytes = 0;
+  let offset = centralDirectoryOffset;
+  for (let index = 0; index < entryCount; index += 1) {
+    if (offset + 46 > bytes.length || readUint32Le(bytes, offset) !== 0x02014b50) {
+      throw new Error("invalid zip central directory");
+    }
+    const compressionMethod = readUint16Le(bytes, offset + 10);
+    const compressedSize = readUint32Le(bytes, offset + 20);
+    const uncompressedSize = readUint32Le(bytes, offset + 24);
+    const fileNameLength = readUint16Le(bytes, offset + 28);
+    const extraLength = readUint16Le(bytes, offset + 30);
+    const commentLength = readUint16Le(bytes, offset + 32);
+    const localHeaderOffset = readUint32Le(bytes, offset + 42);
+    const fileNameStart = offset + 46;
+    const fileNameEnd = fileNameStart + fileNameLength;
+    if (fileNameEnd > bytes.length) throw new Error("truncated zip filename");
+
+    const rawPath = new TextDecoder("utf-8", { fatal: false }).decode(
+      bytes.subarray(fileNameStart, fileNameEnd),
+    );
+    const path = normalizeZipPath(rawPath);
+    offset = fileNameEnd + extraLength + commentLength;
+
+    if (!path) continue;
+    if (files.length >= maxFiles) throw new Error("archive contains too many files");
+    if (uncompressedSize > maxArchiveBytes || expandedBytes + uncompressedSize > maxArchiveBytes) {
+      throw new Error("archive expands beyond safety limit");
+    }
+    if (
+      localHeaderOffset + 30 > bytes.length ||
+      readUint32Le(bytes, localHeaderOffset) !== 0x04034b50
+    ) {
+      throw new Error("invalid zip local header");
+    }
+    const localFileNameLength = readUint16Le(bytes, localHeaderOffset + 26);
+    const localExtraLength = readUint16Le(bytes, localHeaderOffset + 28);
+    const dataOffset = localHeaderOffset + 30 + localFileNameLength + localExtraLength;
+    if (dataOffset + compressedSize > bytes.length) throw new Error("truncated zip entry");
+
+    let body;
+    if (compressionMethod === 0) {
+      body = bytes.subarray(dataOffset, dataOffset + compressedSize);
+    } else if (compressionMethod === 8) {
+      body = await inflateRawBounded(
+        bytes.subarray(dataOffset, dataOffset + compressedSize),
+        maxArchiveBytes,
+      );
+    } else {
+      throw new Error("unsupported zip compression method");
+    }
+    if (body.length !== uncompressedSize) throw new Error("zip entry size mismatch");
+    expandedBytes += body.length;
+    files.push(await summarizeFile(path, body, maxBytesPerFile));
   }
   return files;
 }

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,6 +1,6 @@
 import type { Auth, AuthSession } from "./lib/auth";
+import type { BaselineInfo } from "./lib/adapters/types";
 import type { AiReview } from "./lib/ai-review";
-import type { BaselineVersionSelection } from "./lib/registry";
 import type { ScanRiskBreakdown } from "./lib/risk";
 import type {
   DiffEntry,
@@ -34,7 +34,7 @@ export interface ScanResult {
     stagedTag: string | null;
     previousVersion: string | null;
   };
-  baseline: BaselineVersionSelection;
+  baseline: BaselineInfo;
   fileCount: number;
   previousFileCount: number;
   packageJson: PackageJsonSummary | null;

--- a/test/pypi.test.mjs
+++ b/test/pypi.test.mjs
@@ -366,6 +366,14 @@ describe("PyPI registry metadata helpers", () => {
             digests: { sha256: "d".repeat(64) },
             upload_time_iso_8601: "2026-02-01T00:00:00.000Z",
           },
+          {
+            filename: "demo-1.1.0-yanked.tar.gz",
+            packagetype: "sdist",
+            url: "https://files.pythonhosted.org/packages/demo-1.1.0-yanked.tar.gz",
+            digests: { sha256: "e".repeat(64) },
+            upload_time_iso_8601: "2026-02-01T00:00:00.000Z",
+            yanked: true,
+          },
         ],
       },
     };

--- a/test/pypi.test.mjs
+++ b/test/pypi.test.mjs
@@ -178,6 +178,105 @@ describe("PyPI artifact summaries and review", () => {
       }),
     );
   });
+
+  test("requires reviewed artifacts to exactly match the manifest", () => {
+    const manifest = parsePyPiReleaseManifest({
+      schema: "drydock.release-artifacts.v1",
+      ecosystem: "pypi",
+      package: "demo-package",
+      version: "1.2.0",
+      artifacts: [
+        { path: "dist/demo_package-1.2.0-py3-none-any.whl", sha256: "a".repeat(64) },
+        { path: "dist/demo_package-1.2.0.tar.gz", sha256: "b".repeat(64) },
+      ],
+    });
+
+    expect(() =>
+      createPyPiReleaseCandidateReview({
+        manifest,
+        artifacts: [
+          {
+            path: "dist/demo_package-1.2.0-py3-none-any.whl",
+            files: [
+              file(
+                "demo_package-1.2.0.dist-info/METADATA",
+                "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n",
+              ),
+            ],
+          },
+        ],
+      }),
+    ).toThrow(/exactly match manifest artifacts/);
+  });
+
+  test("compares PyPI files through stable artifact namespaces across versions", () => {
+    const manifest = parsePyPiReleaseManifest({
+      schema: "drydock.release-artifacts.v1",
+      ecosystem: "pypi",
+      package: "demo-package",
+      version: "1.2.0",
+      artifacts: [
+        { path: "dist/demo_package-1.2.0-py3-none-any.whl", sha256: "a".repeat(64) },
+        { path: "dist/demo_package-1.2.0.tar.gz", sha256: "b".repeat(64) },
+      ],
+    });
+    const wheelFiles = (version) => [
+      file(
+        `demo_package-${version}.dist-info/METADATA`,
+        `Metadata-Version: 2.3\nName: demo-package\nVersion: ${version}\n`,
+      ),
+      file(
+        `demo_package-${version}.dist-info/WHEEL`,
+        "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+        { sha256: "sha-wheel-metadata" },
+      ),
+      file(`demo_package-${version}.dist-info/RECORD`, "demo_package/__init__.py,,\n", {
+        sha256: "sha-wheel-record",
+      }),
+      file("demo_package/__init__.py", "VALUE = 1\n"),
+    ];
+    const sdistFiles = (version) => [
+      file(
+        `demo_package-${version}/PKG-INFO`,
+        `Metadata-Version: 2.3\nName: demo-package\nVersion: ${version}\n`,
+      ),
+      file(`demo_package-${version}/demo_package/__init__.py`, "VALUE = 1\n", {
+        sha256: "sha-sdist-init",
+      }),
+    ];
+
+    const review = createPyPiReleaseCandidateReview({
+      manifest,
+      artifacts: [
+        { path: "dist/demo_package-1.2.0-py3-none-any.whl", files: wheelFiles("1.2.0") },
+        { path: "dist/demo_package-1.2.0.tar.gz", files: sdistFiles("1.2.0") },
+      ],
+      previousArtifacts: [
+        { path: "dist/demo_package-1.1.0-py3-none-any.whl", files: wheelFiles("1.1.0") },
+        { path: "dist/demo_package-1.1.0.tar.gz", files: sdistFiles("1.1.0") },
+      ],
+    });
+
+    expect(review.diff).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "wheel/py3-none-any/demo_package/__init__.py",
+          status: "unchanged",
+        }),
+        expect.objectContaining({
+          path: "wheel/py3-none-any/.dist-info/METADATA",
+          status: "modified",
+        }),
+        expect.objectContaining({
+          path: "sdist/demo_package/__init__.py",
+          status: "unchanged",
+        }),
+      ]),
+    );
+    expect(
+      review.diff.some((entry) => entry.path.includes("demo_package-1.2.0-py3-none-any.whl")),
+    ).toBe(false);
+  });
 });
 
 describe("PyPI registry metadata helpers", () => {

--- a/test/pypi.test.mjs
+++ b/test/pypi.test.mjs
@@ -179,6 +179,44 @@ describe("PyPI artifact summaries and review", () => {
     );
   });
 
+  test("detects secret-looking content before redacting PyPI evidence", () => {
+    const manifest = parsePyPiReleaseManifest({
+      schema: "drydock.release-artifacts.v1",
+      ecosystem: "pypi",
+      package: "demo-package",
+      version: "1.2.0",
+      artifacts: [{ path: "dist/demo_package-1.2.0-py3-none-any.whl", sha256: "a".repeat(64) }],
+    });
+    const review = createPyPiReleaseCandidateReview({
+      manifest,
+      artifacts: [
+        {
+          path: "dist/demo_package-1.2.0-py3-none-any.whl",
+          files: [
+            file(
+              "demo_package-1.2.0.dist-info/METADATA",
+              "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n",
+            ),
+            file(
+              "demo_package-1.2.0.dist-info/WHEEL",
+              "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+            ),
+            file("demo_package-1.2.0.dist-info/RECORD", "demo_package/secret.py,,\n"),
+            file("demo_package/secret.py", "TOKEN = 'ghp_aaaaaaaaaaaaaaaaaaaa'\n"),
+          ],
+        },
+      ],
+    });
+
+    expect(review.ruleFindings).toContainEqual(
+      expect.objectContaining({
+        severity: "critical",
+        ruleId: "file.secret-content",
+        file: "wheel/py3-none-any/demo_package/secret.py",
+      }),
+    );
+  });
+
   test("requires reviewed artifacts to exactly match the manifest", () => {
     const manifest = parsePyPiReleaseManifest({
       schema: "drydock.release-artifacts.v1",

--- a/test/pypi.test.mjs
+++ b/test/pypi.test.mjs
@@ -1,0 +1,265 @@
+import { describe, expect, test } from "vitest";
+import {
+  createPyPiReleaseCandidateReview,
+  inferPyPiArtifactKind,
+  isAllowedPyPiArtifactUrl,
+  normalizePyPiProjectName,
+  parsePyPiReleaseManifest,
+  pickPyPiBaselineRelease,
+  preparePyPiArtifact,
+  selectPyPiReleaseArtifacts,
+} from "../server/lib/pypi.ts";
+
+function file(path, textSample, extra = {}) {
+  return {
+    path,
+    size: textSample.length,
+    sha256: `sha-${path}`,
+    flags: [],
+    textSample,
+    ...extra,
+  };
+}
+
+describe("PyPI release manifests", () => {
+  test("validates PyPI manifest shape and artifact kinds", () => {
+    const manifest = parsePyPiReleaseManifest({
+      schema: "drydock.release-artifacts.v1",
+      ecosystem: "pypi",
+      package: "Demo_Package",
+      version: "1.2.0",
+      artifacts: [
+        {
+          path: "dist/demo_package-1.2.0-py3-none-any.whl",
+          sha256: "a".repeat(64),
+          url: "https://example.com/artifacts/demo_package-1.2.0-py3-none-any.whl",
+        },
+        {
+          path: "dist/demo_package-1.2.0.tar.gz",
+          sha256: "b".repeat(64),
+        },
+      ],
+    });
+
+    expect(normalizePyPiProjectName(manifest.package)).toBe("demo-package");
+    expect(manifest.artifacts.map((artifact) => artifact.kind)).toEqual(["wheel", "sdist"]);
+    expect(inferPyPiArtifactKind("demo-1.0.0.zip")).toBeNull();
+  });
+
+  test("rejects unsafe manifest artifact paths", () => {
+    expect(() =>
+      parsePyPiReleaseManifest({
+        schema: "drydock.release-artifacts.v1",
+        ecosystem: "pypi",
+        package: "demo",
+        version: "1.0.0",
+        artifacts: [{ path: "../demo-1.0.0.whl", sha256: "a".repeat(64) }],
+      }),
+    ).toThrow(/path is not safe/);
+  });
+});
+
+describe("PyPI artifact summaries and review", () => {
+  test("strips the common sdist root and reads PKG-INFO metadata", () => {
+    const prepared = preparePyPiArtifact({
+      path: "dist/demo_package-1.2.0.tar.gz",
+      files: [
+        file(
+          "demo_package-1.2.0/PKG-INFO",
+          "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n",
+        ),
+        file("demo_package-1.2.0/demo_package/__init__.py", "VALUE = 1\n"),
+      ],
+    });
+
+    expect(prepared.files.map((entry) => entry.path)).toEqual([
+      "PKG-INFO",
+      "demo_package/__init__.py",
+    ]);
+    expect(prepared.summary).toMatchObject({
+      kind: "sdist",
+      metadataPath: "PKG-INFO",
+      name: "demo-package",
+      version: "1.2.0",
+    });
+  });
+
+  test("creates deterministic PyPI findings for wheel startup hooks and setup.py install commands", () => {
+    const manifest = parsePyPiReleaseManifest({
+      schema: "drydock.release-artifacts.v1",
+      ecosystem: "pypi",
+      package: "demo-package",
+      version: "1.2.0",
+      artifacts: [
+        { path: "dist/demo_package-1.2.0-py3-none-any.whl", sha256: "a".repeat(64) },
+        { path: "dist/demo_package-1.2.0.tar.gz", sha256: "b".repeat(64) },
+      ],
+    });
+    const review = createPyPiReleaseCandidateReview({
+      manifest,
+      artifacts: [
+        {
+          path: "dist/demo_package-1.2.0-py3-none-any.whl",
+          files: [
+            file(
+              "demo_package-1.2.0.dist-info/METADATA",
+              "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\nRequires-Dist: requests>=2\n",
+            ),
+            file(
+              "demo_package-1.2.0.dist-info/WHEEL",
+              "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+            ),
+            file("demo_package-1.2.0.dist-info/RECORD", "demo_package/__init__.py,,\n"),
+            file("demo_package/sitecustomize.pth", "import demo_package.bootstrap\n"),
+          ],
+        },
+        {
+          path: "dist/demo_package-1.2.0.tar.gz",
+          files: [
+            file(
+              "demo_package-1.2.0/PKG-INFO",
+              "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n",
+            ),
+            file(
+              "demo_package-1.2.0/setup.py",
+              "from setuptools.command.install import install\nsetup(cmdclass={'install': install})\n",
+            ),
+          ],
+        },
+      ],
+    });
+
+    expect(review.package).toEqual({ name: "demo-package", version: "1.2.0" });
+    expect(review.risk).toBe("high");
+    expect(review.ruleFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: "high",
+          ruleId: "pypi.pth-execution",
+          file: "dist/demo_package-1.2.0-py3-none-any.whl/demo_package/sitecustomize.pth",
+        }),
+        expect.objectContaining({
+          severity: "high",
+          ruleId: "pypi.setup-install-command",
+          file: "dist/demo_package-1.2.0.tar.gz/setup.py",
+        }),
+      ]),
+    );
+  });
+
+  test("marks manifest and artifact metadata mismatches as critical", () => {
+    const manifest = parsePyPiReleaseManifest({
+      schema: "drydock.release-artifacts.v1",
+      ecosystem: "pypi",
+      package: "demo-package",
+      version: "1.2.0",
+      artifacts: [{ path: "dist/demo_package-1.2.0-py3-none-any.whl", sha256: "a".repeat(64) }],
+    });
+    const review = createPyPiReleaseCandidateReview({
+      manifest,
+      artifacts: [
+        {
+          path: "dist/demo_package-1.2.0-py3-none-any.whl",
+          files: [
+            file(
+              "demo_package-1.2.0.dist-info/METADATA",
+              "Metadata-Version: 2.3\nName: other-package\nVersion: 1.2.0\n",
+            ),
+          ],
+        },
+      ],
+    });
+
+    expect(review.risk).toBe("critical");
+    expect(review.ruleFindings).toContainEqual(
+      expect.objectContaining({
+        severity: "critical",
+        ruleId: "pypi.metadata-mismatch",
+      }),
+    );
+  });
+});
+
+describe("PyPI registry metadata helpers", () => {
+  test("picks the latest published release as the default baseline", () => {
+    const metadata = {
+      info: { version: "1.1.0" },
+      releases: {
+        "1.0.0": [
+          {
+            filename: "demo-1.0.0.tar.gz",
+            url: "https://files.pythonhosted.org/packages/demo-1.0.0.tar.gz",
+            upload_time_iso_8601: "2026-01-01T00:00:00.000Z",
+          },
+        ],
+        "1.1.0": [
+          {
+            filename: "demo-1.1.0-py3-none-any.whl",
+            url: "https://files.pythonhosted.org/packages/demo-1.1.0-py3-none-any.whl",
+            upload_time_iso_8601: "2026-02-01T00:00:00.000Z",
+          },
+        ],
+      },
+    };
+
+    expect(pickPyPiBaselineRelease(metadata, "1.2.0")).toEqual({
+      version: "1.1.0",
+      source: "latest-published",
+      reason: "project-json-info-version",
+    });
+  });
+
+  test("falls back to upload time and selects wheel/sdist artifact metadata", () => {
+    const metadata = {
+      info: { version: "2.0.0" },
+      releases: {
+        "1.1.0": [
+          {
+            filename: "demo-1.1.0-py3-none-any.whl",
+            packagetype: "bdist_wheel",
+            url: "https://files.pythonhosted.org/packages/demo-1.1.0-py3-none-any.whl",
+            digests: { sha256: "c".repeat(64) },
+            upload_time_iso_8601: "2026-02-01T00:00:00.000Z",
+            size: 1234,
+          },
+          {
+            filename: "demo-1.1.0.tar.gz",
+            packagetype: "sdist",
+            url: "https://files.pythonhosted.org/packages/demo-1.1.0.tar.gz",
+            digests: { sha256: "d".repeat(64) },
+            upload_time_iso_8601: "2026-02-01T00:00:00.000Z",
+          },
+        ],
+      },
+    };
+
+    expect(pickPyPiBaselineRelease(metadata, "2.0.0")).toMatchObject({
+      version: "1.1.0",
+      source: "upload-time",
+    });
+    expect(selectPyPiReleaseArtifacts(metadata, "1.1.0")).toEqual([
+      {
+        filename: "demo-1.1.0-py3-none-any.whl",
+        url: "https://files.pythonhosted.org/packages/demo-1.1.0-py3-none-any.whl",
+        sha256: "c".repeat(64),
+        packagetype: "bdist_wheel",
+        kind: "wheel",
+        size: 1234,
+      },
+      {
+        filename: "demo-1.1.0.tar.gz",
+        url: "https://files.pythonhosted.org/packages/demo-1.1.0.tar.gz",
+        sha256: "d".repeat(64),
+        packagetype: "sdist",
+        kind: "sdist",
+        size: null,
+      },
+    ]);
+  });
+
+  test("allows only files.pythonhosted.org artifact URLs for public PyPI downloads", () => {
+    expect(isAllowedPyPiArtifactUrl("https://files.pythonhosted.org/packages/demo.whl")).toBe(true);
+    expect(isAllowedPyPiArtifactUrl("https://example.com/packages/demo.whl")).toBe(false);
+    expect(isAllowedPyPiArtifactUrl("http://files.pythonhosted.org/packages/demo.whl")).toBe(false);
+  });
+});

--- a/test/pypi.test.mjs
+++ b/test/pypi.test.mjs
@@ -6,9 +6,10 @@ import {
   normalizePyPiProjectName,
   parsePyPiReleaseManifest,
   pickPyPiBaselineRelease,
+  pypiAdapter,
   preparePyPiArtifact,
   selectPyPiReleaseArtifacts,
-} from "../server/lib/pypi.ts";
+} from "../server/lib/adapters/pypi/index.ts";
 
 function file(path, textSample, extra = {}) {
   return {
@@ -314,6 +315,64 @@ describe("PyPI artifact summaries and review", () => {
     expect(
       review.diff.some((entry) => entry.path.includes("demo_package-1.2.0-py3-none-any.whl")),
     ).toBe(false);
+  });
+
+  test("exposes PyPI review through the package adapter contract", async () => {
+    const manifest = parsePyPiReleaseManifest({
+      schema: "drydock.release-artifacts.v1",
+      ecosystem: "pypi",
+      package: "demo-package",
+      version: "1.2.0",
+      artifacts: [{ path: "dist/demo_package-1.2.0-py3-none-any.whl", sha256: "a".repeat(64) }],
+    });
+    const input = pypiAdapter.parseInput({
+      manifest,
+      artifacts: [
+        {
+          path: "dist/demo_package-1.2.0-py3-none-any.whl",
+          files: [
+            file(
+              "demo_package-1.2.0.dist-info/METADATA",
+              "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n",
+            ),
+            file(
+              "demo_package-1.2.0.dist-info/WHEEL",
+              "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+            ),
+            file("demo_package-1.2.0.dist-info/RECORD", "demo_package/__init__.py,,\n"),
+          ],
+        },
+      ],
+    });
+    const ctx = { env: {}, executionCtx: {}, db: {}, session: { userId: "user_1" } };
+    const broker = pypiAdapter.createBroker(ctx, { organizationId: "org_1" });
+    const staged = await pypiAdapter.acquireStaged(ctx, input, broker);
+    const baseline = await pypiAdapter.acquireBaseline(ctx, input, broker, staged);
+    const summary = pypiAdapter.describe({
+      input,
+      staged: staged.artifact,
+      details: staged.details,
+      baseline: baseline.baseline,
+      previous: baseline.artifact,
+    });
+
+    expect(pypiAdapter.id).toBe("pypi");
+    expect(summary).toMatchObject({
+      name: "demo-package",
+      stagedVersion: "1.2.0",
+      stagedTag: null,
+      previousVersion: null,
+    });
+    expect(staged.artifact.files.map((entry) => entry.path)).toEqual([
+      "wheel/py3-none-any/.dist-info/METADATA",
+      "wheel/py3-none-any/.dist-info/WHEEL",
+      "wheel/py3-none-any/.dist-info/RECORD",
+    ]);
+    expect(baseline.baseline).toMatchObject({
+      version: null,
+      source: "none",
+      reason: "no-previous-artifacts",
+    });
   });
 });
 

--- a/test/sandbox-gateway.test.mjs
+++ b/test/sandbox-gateway.test.mjs
@@ -59,4 +59,32 @@ describe("npm stage gateway policy", () => {
       });
     }
   });
+
+  test("allows exact public artifact URLs without credentials", () => {
+    expect(
+      evaluateNpmStageGatewayRequest(
+        "https://files.pythonhosted.org/packages/aa/bb/demo-1.0.0-py3-none-any.whl",
+        "GET",
+        registry,
+        ["https://files.pythonhosted.org/packages/aa/bb/demo-1.0.0-py3-none-any.whl"],
+      ),
+    ).toEqual({
+      allowed: true,
+      credentialed: false,
+      kind: "public-artifact",
+    });
+
+    expect(
+      evaluateNpmStageGatewayRequest(
+        "https://files.pythonhosted.org/packages/aa/bb/other-1.0.0-py3-none-any.whl",
+        "GET",
+        registry,
+        ["https://files.pythonhosted.org/packages/aa/bb/demo-1.0.0-py3-none-any.whl"],
+      ),
+    ).toEqual({
+      allowed: false,
+      credentialed: false,
+      kind: "blocked",
+    });
+  });
 });

--- a/test/zip-parser.test.mjs
+++ b/test/zip-parser.test.mjs
@@ -1,0 +1,136 @@
+// @ts-nocheck
+import { deflateRawSync } from "node:zlib";
+import { describe, expect, test } from "vitest";
+import { normalizeZipPath, readZipArchive } from "../server/lib/tar-parser.js";
+
+const encoder = new TextEncoder();
+
+function u16(view, offset, value) {
+  view.setUint16(offset, value, true);
+}
+
+function u32(view, offset, value) {
+  view.setUint32(offset, value, true);
+}
+
+function concat(parts) {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+function zipEntry(entry, localOffset) {
+  const name = encoder.encode(entry.path);
+  const body = entry.body instanceof Uint8Array ? entry.body : encoder.encode(entry.body ?? "");
+  const compressed = entry.deflate ? new Uint8Array(deflateRawSync(body)) : body;
+  const method = entry.deflate ? 8 : 0;
+
+  const local = new Uint8Array(30 + name.length + compressed.length);
+  const localView = new DataView(local.buffer);
+  u32(localView, 0, 0x04034b50);
+  u16(localView, 4, 20);
+  u16(localView, 6, 0x0800);
+  u16(localView, 8, method);
+  u32(localView, 14, 0);
+  u32(localView, 18, compressed.length);
+  u32(localView, 22, body.length);
+  u16(localView, 26, name.length);
+  local.set(name, 30);
+  local.set(compressed, 30 + name.length);
+
+  const central = new Uint8Array(46 + name.length);
+  const centralView = new DataView(central.buffer);
+  u32(centralView, 0, 0x02014b50);
+  u16(centralView, 4, 20);
+  u16(centralView, 6, 20);
+  u16(centralView, 8, 0x0800);
+  u16(centralView, 10, method);
+  u32(centralView, 16, 0);
+  u32(centralView, 20, compressed.length);
+  u32(centralView, 24, body.length);
+  u16(centralView, 28, name.length);
+  u32(centralView, 42, localOffset);
+  central.set(name, 46);
+
+  return { local, central };
+}
+
+function buildZip(entries) {
+  const locals = [];
+  const centrals = [];
+  let localOffset = 0;
+  for (const entry of entries) {
+    const built = zipEntry(entry, localOffset);
+    locals.push(built.local);
+    centrals.push(built.central);
+    localOffset += built.local.length;
+  }
+  const centralDirectory = concat(centrals);
+  const eocd = new Uint8Array(22);
+  const view = new DataView(eocd.buffer);
+  u32(view, 0, 0x06054b50);
+  u16(view, 8, entries.length);
+  u16(view, 10, entries.length);
+  u32(view, 12, centralDirectory.length);
+  u32(view, 16, localOffset);
+  return concat([...locals, centralDirectory, eocd]);
+}
+
+const LIMITS = {
+  maxFiles: 250,
+  maxBytesPerFile: 64 * 1024,
+  maxArchiveBytes: 25 * 1024 * 1024,
+};
+
+function parse(zip, limits = LIMITS) {
+  return readZipArchive(
+    zip.buffer,
+    limits.maxFiles,
+    limits.maxBytesPerFile,
+    limits.maxArchiveBytes,
+  );
+}
+
+describe("normalizeZipPath", () => {
+  test("accepts relative archive paths and rejects traversal", () => {
+    expect(normalizeZipPath("pkg/__init__.py")).toBe("pkg/__init__.py");
+    expect(normalizeZipPath("../escape.py")).toBeNull();
+    expect(normalizeZipPath("pkg/../escape.py")).toBeNull();
+    expect(normalizeZipPath("C:escape.py")).toBeNull();
+    expect(normalizeZipPath("pkg\\escape.py")).toBeNull();
+  });
+});
+
+describe("readZipArchive", () => {
+  test("reads stored and deflated wheel entries", async () => {
+    const zip = buildZip([
+      { path: "demo/__init__.py", body: "__version__ = '1.0.0'\n" },
+      {
+        path: "demo-1.0.0.dist-info/METADATA",
+        body: "Metadata-Version: 2.3\nName: demo\nVersion: 1.0.0\n",
+        deflate: true,
+      },
+    ]);
+    const files = await parse(zip);
+    expect(files.map((file) => file.path)).toEqual([
+      "demo/__init__.py",
+      "demo-1.0.0.dist-info/METADATA",
+    ]);
+    expect(files[1].textSample).toContain("Name: demo");
+    expect(files[1].flags).toEqual([]);
+  });
+
+  test("drops unsafe zip entry paths while keeping safe siblings", async () => {
+    const zip = buildZip([
+      { path: "../escape.py", body: "bad\n" },
+      { path: "demo/good.py", body: "ok\n" },
+    ]);
+    const files = await parse(zip);
+    expect(files.map((file) => file.path)).toEqual(["demo/good.py"]);
+  });
+});

--- a/test/zip-parser.test.mjs
+++ b/test/zip-parser.test.mjs
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import { deflateRawSync } from "node:zlib";
 import { describe, expect, test } from "vitest";
-import { normalizeZipPath, readZipArchive } from "../server/lib/tar-parser.js";
+import { normalizeZipPath, readStreamBounded, readZipArchive } from "../server/lib/tar-parser.js";
 
 const encoder = new TextEncoder();
 
@@ -132,5 +132,19 @@ describe("readZipArchive", () => {
     ]);
     const files = await parse(zip);
     expect(files.map((file) => file.path)).toEqual(["demo/good.py"]);
+  });
+});
+
+describe("readStreamBounded", () => {
+  test("rejects downloads that exceed the configured cap while reading", async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new Uint8Array(8));
+        controller.enqueue(new Uint8Array(8));
+        controller.close();
+      },
+    });
+
+    await expect(readStreamBounded(stream, 12)).rejects.toThrow(/archive too large/);
   });
 });


### PR DESCRIPTION
Adds a backend PyPI workflow-gate foundation on top of PR 87’s pluggable package adapter contract, with manifest validation, PyPI registry metadata helpers, artifact summaries, and deterministic findings for wheel/sdist release candidates.
Extends the sandbox archive parser with safe ZIP wheel parsing and exact public-artifact allowlisting so future PyPI artifact downloads do not receive npm credentials.
Documents the PyPI gate model, security boundaries, and remaining GitHub App/persistence/UI work so this is clearly a review-engine slice rather than an end-to-end gate.
Rebased on PR 87 and validated with `pnpm run verify`.