### PR TITLE
Fail closed on capability-limited npm tokens

### DIFF
--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -63,7 +63,36 @@ Implementation requirements:
 
 Current code has encrypted per-organization npm connections only. SaaS production must configure `NPM_CONNECTIONS_ENCRYPTION_KEY`; scans require an organization-owned npm token.
 
-Scans and staged-publish discovery require the organization npm connection to be validated first. The dashboard automatically runs the baseline npm auth/list validation after token save, and users can still run a stage-ID-specific validation check afterwards. Queued scan workers re-check validation immediately before decrypting and using the current token, so token rotation cannot bypass the validation gate. Custom npm registries are supported for organization npm connections and should be paired with explicit abuse controls in production operations.
+### Minimum viable npm token capability set
+
+Drydock needs these registry endpoints to function. Customers should grant exactly this set and no more on granular npm tokens:
+
+- `GET /-/whoami` — identity probe used by validation only.
+- `GET /-/stage?perPage=N` — list open staged publishes for discovery.
+- `GET /-/stage/:id` — fetch staged publish metadata (manifest/diff inputs).
+- `GET /-/stage/:id/tarball` — download the staged artifact for scanning. The validation probe uses a `Range: bytes=0-0` request to confirm download capability without consuming bandwidth.
+- `GET <registry>/:package` and `GET <registry>/:package/-/<tarball>` — public/private package metadata + previous-version tarballs for diffing. Required only when scanning private packages.
+
+Tokens that authenticate at `/-/whoami` and list `/-/stage` but cannot view or download an individual stage are marked **capability-limited** and rejected for scanning.
+
+### Validation status taxonomy
+
+A stored npm connection is always in one of these states; the scan pipeline and staged-publish discovery refuse anything other than `valid`:
+
+- `missing` — no row stored for the organization.
+- `unvalidated` — token row present, validation has never been run (or was reset after rotation).
+- `invalid` — `/-/whoami` or `/-/stage` denied the token. The connection is unusable.
+- `capability_limited` — auth + list succeeded, but the staged-publish view/download probe failed (capability gap), or the staged list was empty so view/download could not be confirmed. The connection is rejected by scans; the user must either wait for a staged publish, paste a stage ID, or fix the token's capability set.
+- `valid` — all probed capabilities passed.
+
+API error responses for credential-dependent routes include a stable `code` field — `token_missing`, `token_unvalidated`, `token_invalid`, `token_capability_limited`, or `rate_limited` — alongside the human-readable `error` string. The UI parses `code`, not the message, so wording can change without breaking automation.
+
+Validation runs:
+
+1. Always: `/-/whoami` + `/-/stage?perPage=1`.
+2. When a stage exists (auto-pick from list, or caller-supplied stage ID): `GET /-/stage/:id` + `GET /-/stage/:id/tarball` with a one-byte range.
+
+Scans and staged-publish discovery require the organization npm connection to be `valid`. The dashboard automatically runs the baseline npm auth/list validation after token save and probes a representative stage from the list response when one exists. Users can still re-run a stage-ID-specific validation check from workspace setup. Queued scan workers re-check validation immediately before decrypting and using the current token, so token rotation cannot bypass the validation gate. Custom npm registries are supported for organization npm connections and should be paired with explicit abuse controls in production operations.
 
 ## Package artifact handling
 
@@ -202,7 +231,7 @@ Do not expose signed report URLs until access controls, report canonicalization,
 
 ## Known gaps
 
-- Per-organization encrypted npm connections exist, and validation can check staged-tarball access when supplied a real stage ID; npm list/view capability checks still need confirmation before launch.
+- Per-organization encrypted npm connections exist with a four-state validation taxonomy (`unvalidated` / `invalid` / `capability_limited` / `valid`) and the validator auto-probes staged view + download against a representative stage when one is available. Multi-connection support, rotate-without-revalidate hardening, and per-token audit metrics are still open follow-ups for production hardening (tracked in [`production-roadmap.md`](production-roadmap.md)).
 - Queue-backed scan retry/dead-letter behavior exists in code and Wrangler config, and scan/queue paths now emit structured secret-redacted operational events. Production queue resources, DLQ visibility, metrics dashboards, and alerts still need deployment validation.
 - Persisted detail UI now renders core report data, but finding grouping and lifecycle timelines still need polish.
 - Tar parsing now rejects traversal paths, skips symlinks/hardlinks, handles long-name/PAX paths, caps expanded size, and fails closed when the safe file-count limit is exceeded, but it still needs deeper archive-bomb fuzzing before broad public launch.

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -91,7 +91,7 @@ export interface NpmConnectionInput {
 
 export interface NpmConnectionValidationInput {
   organizationId: string;
-  validationStatus: "valid" | "invalid" | "unvalidated";
+  validationStatus: "valid" | "invalid" | "capability_limited" | "unvalidated";
   capabilities?: unknown;
   validatedAt?: Date | null;
 }

--- a/server/lib/npm-connection.ts
+++ b/server/lib/npm-connection.ts
@@ -31,9 +31,19 @@ export interface PublicNpmConnection {
   updatedAt: Date | string | number;
 }
 
+export type NpmCredentialStatus = "valid" | "invalid" | "capability_limited";
+
+export type NpmCredentialReason =
+  | "registry_auth_failed"
+  | "staged_list_denied"
+  | "staged_view_denied"
+  | "staged_tarball_denied"
+  | "no_stages_to_probe";
+
 export interface NpmCredentialValidation {
   ok: boolean;
-  status: "valid" | "invalid";
+  status: NpmCredentialStatus;
+  reasons: NpmCredentialReason[];
   capabilities: {
     registryAuth: boolean;
     stagedListAccess: boolean;
@@ -42,6 +52,7 @@ export interface NpmCredentialValidation {
     whoami?: string | null;
     registryUrl: string;
     stageId?: string;
+    probedStageSource?: "caller" | "list";
     status?: number;
     stagedListStatus?: number;
     stagedViewStatus?: number;
@@ -176,30 +187,56 @@ export async function validateNpmCredential(
   const registry = normalizeRegistryUrl(registryUrl, {
     allowInsecureLocalhost: options.allowInsecureLocalhost,
   });
-  const [auth, stagedList, stagedView, stagedTarball] = await Promise.all([
+  const [auth, stagedList] = await Promise.all([
     validateRegistryAuth(registry, token),
     validateStagedListAccess(registry, token),
-    options.stageId
-      ? validateStagedViewAccess(registry, token, options.stageId)
-      : Promise.resolve(null),
-    options.stageId
-      ? validateStagedTarballAccess(registry, token, options.stageId)
-      : Promise.resolve(null),
   ]);
-  const ok =
-    auth.registryAuth &&
-    stagedList.stagedListAccess &&
-    (stagedView ? stagedView.stagedViewAccess : true) &&
-    (stagedTarball ? stagedTarball.stagedTarballAccess : true);
+
+  const reasons: NpmCredentialReason[] = [];
+  if (!auth.registryAuth) reasons.push("registry_auth_failed");
+  if (!stagedList.stagedListAccess) reasons.push("staged_list_denied");
+
+  const callerStageId = options.stageId;
+  const listedStageId =
+    !callerStageId && stagedList.stagedListAccess ? stagedList.firstStageId : null;
+  const probedStageId = callerStageId ?? listedStageId;
+
+  let stagedView: Awaited<ReturnType<typeof validateStagedViewAccess>> | null = null;
+  let stagedTarball: Awaited<ReturnType<typeof validateStagedTarballAccess>> | null = null;
+
+  if (auth.registryAuth && stagedList.stagedListAccess && probedStageId) {
+    [stagedView, stagedTarball] = await Promise.all([
+      validateStagedViewAccess(registry, token, probedStageId),
+      validateStagedTarballAccess(registry, token, probedStageId),
+    ]);
+    if (stagedView && !stagedView.stagedViewAccess) reasons.push("staged_view_denied");
+    if (stagedTarball && !stagedTarball.stagedTarballAccess) reasons.push("staged_tarball_denied");
+  } else if (auth.registryAuth && stagedList.stagedListAccess) {
+    reasons.push("no_stages_to_probe");
+  }
+
+  const status: NpmCredentialStatus =
+    !auth.registryAuth || !stagedList.stagedListAccess
+      ? "invalid"
+      : reasons.length === 0
+        ? "valid"
+        : "capability_limited";
 
   return {
-    ok,
-    status: ok ? "valid" : "invalid",
+    ok: status === "valid",
+    status,
+    reasons,
     capabilities: {
       ...auth,
-      ...stagedList,
+      registryAuth: auth.registryAuth,
+      stagedListAccess: stagedList.stagedListAccess,
+      stagedListStatus: stagedList.stagedListStatus,
+      stagedListDetail: stagedList.stagedListDetail,
       ...stagedView,
       ...stagedTarball,
+      ...(probedStageId
+        ? { probedStageSource: callerStageId ? "caller" : "list", stageId: probedStageId }
+        : {}),
       registryUrl: registry,
     },
   };
@@ -239,18 +276,48 @@ async function validateStagedListAccess(registry: string, token: string) {
     const response = await fetch(`${registry}/-/stage?perPage=1`, {
       headers: npmAuthHeaders(token, "application/json"),
     });
-    await response.body?.cancel();
+    if (!response.ok) {
+      await response.body?.cancel();
+      return {
+        stagedListAccess: false,
+        stagedListStatus: response.status,
+        stagedListDetail: response.statusText,
+        firstStageId: null as string | null,
+      };
+    }
+    const data = (await response.json().catch(() => null)) as unknown;
+    const firstStageId = extractFirstStageId(data);
     return {
-      stagedListAccess: response.ok,
+      stagedListAccess: true,
       stagedListStatus: response.status,
-      stagedListDetail: response.ok ? undefined : response.statusText,
+      stagedListDetail: undefined as string | undefined,
+      firstStageId,
     };
   } catch (err) {
     return {
       stagedListAccess: false,
       stagedListDetail: errorMessage(err),
+      firstStageId: null as string | null,
     };
   }
+}
+
+function extractFirstStageId(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const root = payload as { items?: unknown };
+  if (!Array.isArray(root.items)) return null;
+  for (const entry of root.items) {
+    if (!entry || typeof entry !== "object") continue;
+    const record = entry as { id?: unknown; stageId?: unknown };
+    const candidate =
+      typeof record.id === "string" && record.id.trim()
+        ? record.id.trim()
+        : typeof record.stageId === "string" && record.stageId.trim()
+          ? record.stageId.trim()
+          : null;
+    if (candidate) return candidate;
+  }
+  return null;
 }
 
 async function validateStagedViewAccess(registry: string, token: string, stageId: string) {

--- a/server/lib/scan-job.ts
+++ b/server/lib/scan-job.ts
@@ -75,7 +75,15 @@ export async function executeScanJob(
       throw new Error("Connect an organization npm token before scanning staged publishes.");
     }
     if (npmConnection.validationStatus !== "valid") {
-      throw new Error("Validate the organization npm token before scanning staged publishes.");
+      const detail =
+        npmConnection.validationStatus === "capability_limited"
+          ? "Capability check failed; rerun validation with a real stage ID."
+          : npmConnection.validationStatus === "invalid"
+            ? "Token failed npm validation; rotate the token and revalidate."
+            : "Run validation before scanning.";
+      throw new Error(
+        `Validate the organization npm token before scanning staged publishes. ${detail}`,
+      );
     }
 
     await Promise.all([

--- a/server/routes/npm-connection.ts
+++ b/server/routes/npm-connection.ts
@@ -20,7 +20,6 @@ import {
 } from "../lib/npm-connection";
 import { isValidStageId } from "../lib/stage-id";
 import { errorMessage } from "../lib/errors";
-import { rateLimitResponse } from "../lib/http";
 import type { Bindings, Variables } from "../types";
 
 export const npmConnectionRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
@@ -90,7 +89,15 @@ npmConnectionRoutes.post("/", async (c) => {
     return c.json({ connection: publicNpmConnection(connection) });
   } catch (err) {
     if (err instanceof RateLimitError) {
-      return rateLimitResponse(c, "npm connection save rate limit exceeded", err);
+      return c.json(
+        {
+          error: "npm connection save rate limit exceeded",
+          code: "rate_limited",
+          retryAfterSeconds: err.retryAfterSeconds,
+        },
+        429,
+        { "retry-after": String(err.retryAfterSeconds) },
+      );
     }
     console.error("npm connection upsert failed", err);
     return c.json({ error: "failed to store npm connection" }, 400);
@@ -114,7 +121,8 @@ npmConnectionRoutes.post("/validate", async (c) => {
     });
 
     const connection = await getNpmConnection(db, organizationId);
-    if (!connection) return c.json({ error: "npm connection is not configured" }, 404);
+    if (!connection)
+      return c.json({ error: "npm connection is not configured", code: "token_missing" }, 404);
 
     const token = await decryptNpmToken(c.env, connection);
     const validation = await validateNpmCredential(connection.registryUrl, token, {
@@ -125,7 +133,7 @@ npmConnectionRoutes.post("/validate", async (c) => {
       updateNpmConnectionValidation(db, {
         organizationId,
         validationStatus: validation.status,
-        capabilities: validation.capabilities,
+        capabilities: { ...validation.capabilities, reasons: validation.reasons },
         validatedAt: validation.ok ? new Date() : null,
       }),
       recordScanEvent(db, {
@@ -135,6 +143,7 @@ npmConnectionRoutes.post("/validate", async (c) => {
         metadata: {
           ok: validation.ok,
           status: validation.status,
+          reasons: validation.reasons,
           capabilities: validation.capabilities,
         },
       }),
@@ -143,10 +152,18 @@ npmConnectionRoutes.post("/validate", async (c) => {
     return c.json({ validation, connection: publicNpmConnection(updated) });
   } catch (err) {
     if (err instanceof RateLimitError) {
-      return rateLimitResponse(c, "npm validation rate limit exceeded", err);
+      return c.json(
+        {
+          error: "npm validation rate limit exceeded",
+          code: "rate_limited",
+          retryAfterSeconds: err.retryAfterSeconds,
+        },
+        429,
+        { "retry-after": String(err.retryAfterSeconds) },
+      );
     }
     console.error("npm connection validation failed", err);
-    return c.json({ error: "failed to validate npm connection" }, 400);
+    return c.json({ error: "failed to validate npm connection", code: "validation_failed" }, 400);
   }
 });
 

--- a/server/routes/scan.ts
+++ b/server/routes/scan.ts
@@ -28,13 +28,26 @@ scanRoutes.post("/", async (c) => {
     const npmConnection = await getNpmConnection(db, organizationId);
     if (!npmConnection) {
       return c.json(
-        { error: "Connect an organization npm token before scanning staged publishes." },
+        {
+          error: "Connect an organization npm token before scanning staged publishes.",
+          code: "token_missing",
+        },
         400,
       );
     }
     if (npmConnection.validationStatus !== "valid") {
+      const code =
+        npmConnection.validationStatus === "invalid"
+          ? "token_invalid"
+          : npmConnection.validationStatus === "capability_limited"
+            ? "token_capability_limited"
+            : "token_unvalidated";
       return c.json(
-        { error: "Validate the organization npm token before scanning staged publishes." },
+        {
+          error: "Validate the organization npm token before scanning staged publishes.",
+          code,
+          validationStatus: npmConnection.validationStatus,
+        },
         400,
       );
     }

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -51,13 +51,26 @@ scansRoutes.post("/", async (c) => {
     const npmConnection = await getNpmConnection(db, organizationId);
     if (!npmConnection) {
       return c.json(
-        { error: "Connect an organization npm token before scanning staged publishes." },
+        {
+          error: "Connect an organization npm token before scanning staged publishes.",
+          code: "token_missing",
+        },
         400,
       );
     }
     if (npmConnection.validationStatus !== "valid") {
+      const code =
+        npmConnection.validationStatus === "invalid"
+          ? "token_invalid"
+          : npmConnection.validationStatus === "capability_limited"
+            ? "token_capability_limited"
+            : "token_unvalidated";
       return c.json(
-        { error: "Validate the organization npm token before scanning staged publishes." },
+        {
+          error: "Validate the organization npm token before scanning staged publishes.",
+          code,
+          validationStatus: npmConnection.validationStatus,
+        },
         400,
       );
     }

--- a/server/routes/staged-publishes.ts
+++ b/server/routes/staged-publishes.ts
@@ -34,13 +34,26 @@ stagedPublishesRoutes.post("/scan", async (c) => {
   const savedConnection = await getNpmConnection(db, organizationId);
   if (!savedConnection) {
     return c.json(
-      { error: "Connect an organization npm token before discovering staged publishes." },
+      {
+        error: "Connect an organization npm token before discovering staged publishes.",
+        code: "token_missing",
+      },
       400,
     );
   }
   if (savedConnection.validationStatus !== "valid") {
+    const code =
+      savedConnection.validationStatus === "invalid"
+        ? "token_invalid"
+        : savedConnection.validationStatus === "capability_limited"
+          ? "token_capability_limited"
+          : "token_unvalidated";
     return c.json(
-      { error: "Validate the organization npm token before discovering staged publishes." },
+      {
+        error: "Validate the organization npm token before discovering staged publishes.",
+        code,
+        validationStatus: savedConnection.validationStatus,
+      },
       400,
     );
   }

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -5,6 +5,7 @@ export class ApiError extends Error {
     message: string,
     readonly status: number,
     readonly detail?: string,
+    readonly code?: string,
   ) {
     super(message);
     this.name = "ApiError";
@@ -24,13 +25,14 @@ export async function apiFetch<T>(input: RequestInfo | URL, init?: RequestInit):
     headers,
   });
   const data = (await res.json().catch(() => null)) as
-    | (Partial<T> & { error?: string; detail?: string; message?: string })
+    | (Partial<T> & { error?: string; detail?: string; message?: string; code?: string })
     | null;
   if (!res.ok) {
     if (res.status === 401) throw new ApiError("Please sign in to continue.", 401);
     const detail = typeof data?.detail === "string" ? data.detail : undefined;
+    const code = typeof data?.code === "string" ? data.code : undefined;
     const message = data?.message || data?.error || "request failed";
-    throw new ApiError(detail ? `${message}: ${detail}` : message, res.status, detail);
+    throw new ApiError(detail ? `${message}: ${detail}` : message, res.status, detail, code);
   }
   return data as T;
 }

--- a/src/models/npm-connection.ts
+++ b/src/models/npm-connection.ts
@@ -17,18 +17,35 @@ export interface PublicNpmConnection {
   updatedAt: string | number | Date;
 }
 
+export type NpmCredentialStatus = "valid" | "invalid" | "capability_limited";
+
+export type NpmCredentialReason =
+  | "registry_auth_failed"
+  | "staged_list_denied"
+  | "staged_view_denied"
+  | "staged_tarball_denied"
+  | "no_stages_to_probe";
+
 export interface NpmCredentialValidation {
   ok: boolean;
-  status: "valid" | "invalid";
+  status: NpmCredentialStatus;
+  reasons: NpmCredentialReason[];
   capabilities: {
     registryAuth: boolean;
+    stagedListAccess: boolean;
     stagedTarballAccess?: boolean;
+    stagedViewAccess?: boolean;
     whoami?: string | null;
     registryUrl: string;
     stageId?: string;
+    probedStageSource?: "caller" | "list";
     status?: number;
+    stagedListStatus?: number;
+    stagedViewStatus?: number;
     stagedTarballStatus?: number;
     detail?: string;
+    stagedListDetail?: string;
+    stagedViewDetail?: string;
     stagedTarballDetail?: string;
   };
 }
@@ -52,6 +69,28 @@ export const NpmConnectionModel = createModel(() => {
   const busy = computed(() => status.value !== "idle");
   const isConnected = computed(() => connection.value !== null);
   const validated = computed(() => connection.value?.validationStatus === "valid");
+  const validationState = computed<
+    "missing" | "unvalidated" | "valid" | "invalid" | "capability_limited"
+  >(() => {
+    const next = connection.value;
+    if (!next) return "missing";
+    switch (next.validationStatus) {
+      case "valid":
+      case "invalid":
+      case "capability_limited":
+        return next.validationStatus;
+      default:
+        return "unvalidated";
+    }
+  });
+  const validationReasons = computed<NpmCredentialReason[]>(() => {
+    const caps = connection.value?.capabilitiesJson;
+    if (!caps || typeof caps !== "object") return [];
+    const list = (caps as { reasons?: unknown }).reasons;
+    return Array.isArray(list)
+      ? (list.filter((entry) => typeof entry === "string") as NpmCredentialReason[])
+      : [];
+  });
 
   return {
     connection,
@@ -65,6 +104,8 @@ export const NpmConnectionModel = createModel(() => {
     busy,
     isConnected,
     validated,
+    validationState,
+    validationReasons,
 
     async load(): Promise<void> {
       try {
@@ -109,7 +150,7 @@ export const NpmConnectionModel = createModel(() => {
           const validation = await validateNpmConnection();
           this.applyConnection(validation.connection);
           if (!validation.validation.ok) {
-            this.error.value = "Saved token, but npm validation reported invalid access.";
+            this.error.value = "Saved token. " + describeValidationFailure(validation.validation);
           }
         }
       } catch (err) {
@@ -128,7 +169,7 @@ export const NpmConnectionModel = createModel(() => {
         const data = await validateNpmConnection(stageId);
         this.applyConnection(data.connection);
         if (!data.validation.ok) {
-          this.error.value = "Npm validation reported invalid access.";
+          this.error.value = describeValidationFailure(data.validation);
         }
       } catch (err) {
         this.error.value = errorMessage(err);
@@ -153,6 +194,30 @@ export const NpmConnectionModel = createModel(() => {
     },
   };
 });
+
+export function describeValidationFailure(validation: NpmCredentialValidation): string {
+  if (validation.status === "invalid") {
+    if (validation.reasons.includes("registry_auth_failed")) {
+      return "npm rejected the token — check it has registry access and try again.";
+    }
+    if (validation.reasons.includes("staged_list_denied")) {
+      return "npm rejected staged-publish list access — the token needs staged-publish list/view/download capability.";
+    }
+    return "npm validation failed.";
+  }
+  if (validation.status === "capability_limited") {
+    if (validation.reasons.includes("no_stages_to_probe")) {
+      return "Auth and staged-list access look good, but no open staged publishes were available to confirm view + download. Create a stage or paste a stage ID below to finish validation.";
+    }
+    const missing: string[] = [];
+    if (validation.reasons.includes("staged_view_denied")) missing.push("view");
+    if (validation.reasons.includes("staged_tarball_denied")) missing.push("download");
+    return missing.length
+      ? `Token is missing staged-publish ${missing.join(" + ")} capability — grant it before scanning.`
+      : "Token capability check did not complete.";
+  }
+  return "";
+}
 
 function saveNpmConnection(input: {
   token: string;

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -324,6 +324,66 @@ function formatStartedScanLabel(scan: { packageName: string | null; version: str
   return scan.packageName || scan.version || null;
 }
 
+type ValidationState = "missing" | "unvalidated" | "valid" | "invalid" | "capability_limited";
+
+function summaryBadgeTone(state: ValidationState): "ok" | "info" | "critical" | "medium" {
+  switch (state) {
+    case "valid":
+      return "ok";
+    case "invalid":
+      return "critical";
+    case "capability_limited":
+      return "medium";
+    default:
+      return "info";
+  }
+}
+
+function summaryBadgeLabel(state: ValidationState): string {
+  switch (state) {
+    case "missing":
+      return "connect npm";
+    case "unvalidated":
+      return "unvalidated";
+    case "valid":
+      return "valid";
+    case "invalid":
+      return "invalid";
+    case "capability_limited":
+      return "capability limited";
+  }
+}
+
+function describeValidationStateForCard(
+  state: ValidationState,
+  reasons: ReadonlyArray<string>,
+): string {
+  if (state === "invalid") {
+    if (reasons.includes("registry_auth_failed")) {
+      return "npm rejected the token at /-/whoami. Rotate it or paste a new one above, then save to revalidate.";
+    }
+    if (reasons.includes("staged_list_denied")) {
+      return "npm rejected staged-publish list access. The token needs staged-publish list/view/download capability.";
+    }
+    return "npm validation failed. Rotate or refresh the token above.";
+  }
+  if (state === "capability_limited") {
+    if (reasons.includes("no_stages_to_probe")) {
+      return "Auth and staged-list access look good, but no open staged publishes were available to confirm view + download. Paste a real stage ID below or wait until one is staged.";
+    }
+    const missing: string[] = [];
+    if (reasons.includes("staged_view_denied")) missing.push("view");
+    if (reasons.includes("staged_tarball_denied")) missing.push("download");
+    return missing.length
+      ? `Token is missing staged-publish ${missing.join(" + ")} capability. Grant it on the npm side and revalidate.`
+      : "Token capability check did not complete.";
+  }
+  if (state === "unvalidated") {
+    return "Token saved but not yet validated. Click 'Check npm auth' below to confirm access.";
+  }
+  return "";
+}
+
 function WorkspaceSetupPanel({
   npm,
 }: {
@@ -350,8 +410,8 @@ function WorkspaceSetupPanel({
                 />
               </div>
               <div class="flex flex-wrap items-center justify-end gap-2">
-                <Badge tone={connection ? "ok" : "info"}>
-                  {connection ? connection.validationStatus : "connect npm"}
+                <Badge tone={summaryBadgeTone(npm.validationState.value)}>
+                  {summaryBadgeLabel(npm.validationState.value)}
                 </Badge>
                 <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
                   <span class="group-open:hidden">open settings</span>
@@ -377,12 +437,13 @@ function NpmConnectionCard({
   const connection = npm.connection.value;
   const status = npm.status.value;
   const busy = npm.busy.value;
-  const validated = npm.validated.value;
   const token = npm.token.value;
   const label = npm.label.value;
   const registry = npm.registry.value;
   const validationStageId = npm.validationStageId.value;
   const error = npm.error.value;
+  const state = npm.validationState.value;
+  const reasons = npm.validationReasons.value;
 
   const onSave = async (event: Event) => {
     event.preventDefault();
@@ -400,17 +461,19 @@ function NpmConnectionCard({
           </Muted>
         </div>
         {connection ? (
-          <Badge
-            tone={
-              validated ? "ok" : connection.validationStatus === "invalid" ? "critical" : "info"
-            }
-          >
-            {connection.validationStatus}
-          </Badge>
+          <Badge tone={summaryBadgeTone(state)}>{summaryBadgeLabel(state)}</Badge>
         ) : (
           <Badge tone="info">not connected</Badge>
         )}
       </div>
+
+      {connection && state !== "valid" ? (
+        <Alert
+          tone={state === "invalid" ? "critical" : state === "capability_limited" ? "warn" : "info"}
+        >
+          {describeValidationStateForCard(state, reasons)}
+        </Alert>
+      ) : null}
 
       {connection ? (
         <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-x-6 gap-y-2 border-y border-border py-3">

--- a/test/npm-connection.test.mjs
+++ b/test/npm-connection.test.mjs
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { normalizeRegistryUrl, validateNpmCredential } from "../server/lib/npm-connection.ts";
+import {
+  normalizeRegistryUrl,
+  publicNpmConnection,
+  validateNpmCredential,
+} from "../server/lib/npm-connection.ts";
 
 const originalFetch = globalThis.fetch;
 
@@ -34,9 +38,44 @@ describe("npm connection validation", () => {
     ).toThrow("registry URL must use https");
   });
 
-  test("checks registry auth and staged list capability without a stage id", async () => {
+  test("auto-probes a representative stage from the list response when no stageId is supplied", async () => {
+    const seen = [];
     const fetchMock = vi.fn(async (url, init) => {
+      seen.push(String(url));
       expect(init.headers.authorization).toBe("Bearer npm_secret_token");
+      if (String(url).endsWith("/-/whoami")) return Response.json({ username: "maintainer" });
+      if (String(url).endsWith("/-/stage?perPage=1"))
+        return Response.json({ items: [{ id: "stage-from-list" }], page: 0, perPage: 1, total: 1 });
+      if (String(url).endsWith("/-/stage/stage-from-list"))
+        return Response.json({ id: "stage-from-list" });
+      if (String(url).endsWith("/-/stage/stage-from-list/tarball"))
+        return new Response("x", { status: 206 });
+      return new Response("unexpected", { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    const validation = await validateNpmCredential(
+      "https://registry.npmjs.org",
+      "npm_secret_token",
+    );
+
+    expect(validation.ok).toBe(true);
+    expect(validation.status).toBe("valid");
+    expect(validation.reasons).toEqual([]);
+    expect(validation.capabilities).toMatchObject({
+      registryAuth: true,
+      stagedListAccess: true,
+      stagedViewAccess: true,
+      stagedTarballAccess: true,
+      probedStageSource: "list",
+      stageId: "stage-from-list",
+      whoami: "maintainer",
+    });
+    expect(seen).toContain("https://registry.npmjs.org/-/stage/stage-from-list/tarball");
+  });
+
+  test("marks validation capability_limited when the staged list is empty", async () => {
+    const fetchMock = vi.fn(async (url) => {
       if (String(url).endsWith("/-/whoami")) return Response.json({ username: "maintainer" });
       if (String(url).endsWith("/-/stage?perPage=1"))
         return Response.json({ items: [], page: 0, perPage: 1, total: 0 });
@@ -49,13 +88,12 @@ describe("npm connection validation", () => {
       "npm_secret_token",
     );
 
-    expect(validation.ok).toBe(true);
-    expect(validation.status).toBe("valid");
+    expect(validation.ok).toBe(false);
+    expect(validation.status).toBe("capability_limited");
+    expect(validation.reasons).toEqual(["no_stages_to_probe"]);
     expect(validation.capabilities).toMatchObject({
       registryAuth: true,
       stagedListAccess: true,
-      whoami: "maintainer",
-      registryUrl: "https://registry.npmjs.org",
     });
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
@@ -65,9 +103,8 @@ describe("npm connection validation", () => {
     const fetchMock = vi.fn(async (url, init) => {
       seen.push({ url: String(url), headers: init.headers });
       if (String(url).endsWith("/-/whoami")) return Response.json({ username: "maintainer" });
-      if (String(url).endsWith("/-/stage?perPage=1")) return Response.json({ items: [] });
-      if (String(url).endsWith("/-/stage/stage-123/details"))
-        return new Response("unexpected", { status: 500 });
+      if (String(url).endsWith("/-/stage?perPage=1"))
+        return Response.json({ items: [{ id: "list-stage" }] });
       if (String(url).endsWith("/-/stage/stage-123")) return Response.json({ id: "stage-123" });
       if (String(url).endsWith("/-/stage/stage-123/tarball"))
         return new Response("x", { status: 206 });
@@ -82,21 +119,19 @@ describe("npm connection validation", () => {
     );
 
     expect(validation.ok).toBe(true);
+    expect(validation.status).toBe("valid");
     expect(validation.capabilities).toMatchObject({
       registryAuth: true,
       stagedListAccess: true,
       stagedViewAccess: true,
       stagedTarballAccess: true,
+      probedStageSource: "caller",
       stageId: "stage-123",
       stagedTarballStatus: 206,
     });
-    expect(seen.map((entry) => entry.url)).toEqual([
-      "https://registry.npmjs.org/-/whoami",
-      "https://registry.npmjs.org/-/stage?perPage=1",
-      "https://registry.npmjs.org/-/stage/stage-123",
-      "https://registry.npmjs.org/-/stage/stage-123/tarball",
-    ]);
-    expect(seen.at(-1).headers.range).toBe("bytes=0-0");
+    const probedTarball = seen.find((entry) => entry.url.endsWith("/-/stage/stage-123/tarball"));
+    expect(probedTarball?.headers.range).toBe("bytes=0-0");
+    expect(seen.find((entry) => entry.url.endsWith("/-/stage/list-stage"))).toBeUndefined();
   });
 
   test("marks validation invalid when staged list access is denied", async () => {
@@ -114,10 +149,68 @@ describe("npm connection validation", () => {
 
     expect(validation.ok).toBe(false);
     expect(validation.status).toBe("invalid");
+    expect(validation.reasons).toContain("staged_list_denied");
     expect(validation.capabilities).toMatchObject({
       registryAuth: true,
       stagedListAccess: false,
       stagedListStatus: 403,
+    });
+  });
+
+  test("publicNpmConnection never returns token ciphertext or nonce material", () => {
+    const sensitive = {
+      id: "conn_1",
+      organizationId: "org_a",
+      registryUrl: "https://registry.npmjs.org",
+      label: "npm registry",
+      tokenCiphertext: "v1:secret_ciphertext_blob",
+      tokenNonce: "secret_nonce_blob",
+      tokenFingerprint: "fp_abc",
+      tokenLast4: "1234",
+      validationStatus: "valid",
+      capabilitiesJson: { registryAuth: true },
+      validatedAt: new Date(0),
+      lastUsedAt: null,
+      createdByUserId: "user_a",
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    };
+
+    const safe = publicNpmConnection(sensitive);
+    expect(safe).not.toBeNull();
+    const serialized = JSON.stringify(safe);
+    expect(serialized).not.toContain("secret_ciphertext_blob");
+    expect(serialized).not.toContain("secret_nonce_blob");
+    expect(safe).not.toHaveProperty("tokenCiphertext");
+    expect(safe).not.toHaveProperty("tokenNonce");
+  });
+
+  test("marks validation capability_limited when the auto-probed tarball is denied", async () => {
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).endsWith("/-/whoami")) return Response.json({ username: "maintainer" });
+      if (String(url).endsWith("/-/stage?perPage=1"))
+        return Response.json({ items: [{ id: "probe-stage" }] });
+      if (String(url).endsWith("/-/stage/probe-stage")) return Response.json({ id: "probe-stage" });
+      if (String(url).endsWith("/-/stage/probe-stage/tarball"))
+        return new Response("denied", { status: 403, statusText: "Forbidden" });
+      return new Response("unexpected", { status: 500 });
+    });
+
+    const validation = await validateNpmCredential(
+      "https://registry.npmjs.org",
+      "npm_secret_token",
+    );
+
+    expect(validation.ok).toBe(false);
+    expect(validation.status).toBe("capability_limited");
+    expect(validation.reasons).toEqual(["staged_tarball_denied"]);
+    expect(validation.capabilities).toMatchObject({
+      registryAuth: true,
+      stagedListAccess: true,
+      stagedViewAccess: true,
+      stagedTarballAccess: false,
+      probedStageSource: "list",
+      stageId: "probe-stage",
     });
   });
 });

--- a/test/scan-job.test.mjs
+++ b/test/scan-job.test.mjs
@@ -272,6 +272,28 @@ describe("executeScanJob idempotency", () => {
     });
   });
 
+  test("fails closed when the stored connection is capability_limited", async () => {
+    dbMock.claimScanForRun.mockResolvedValue(true);
+    dbMock.getNpmConnection.mockResolvedValue({
+      registryUrl: "https://registry.npmjs.org",
+      tokenFingerprint: "fp",
+      validationStatus: "capability_limited",
+    });
+
+    await expect(
+      executeScanJob(env, ctx, message, {}, { attempt: 1, finalAttempt: true }),
+    ).rejects.toThrow("Validate the organization npm token");
+
+    expect(npmConnectionMock.decryptNpmToken).not.toHaveBeenCalled();
+    expect(dbMock.markNpmConnectionUsed).not.toHaveBeenCalled();
+    expect(pipelineMock.runScanPipeline).not.toHaveBeenCalled();
+    expect(dbMock.markScanFailed).toHaveBeenCalledWith({}, message.scanId, message.organizationId, {
+      code: "npm_connection_unvalidated",
+      message: "Validate the organization npm token before scanning staged publishes.",
+      retryable: false,
+    });
+  });
+
   test("discards auto-discovered scans when the org's token cannot access the tarball", async () => {
     dbMock.claimScanForRun.mockResolvedValue(true);
     pipelineMock.runScanPipeline.mockRejectedValue(

--- a/test/workers/scans-routes.test.ts
+++ b/test/workers/scans-routes.test.ts
@@ -1,0 +1,115 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { describe, expect, test } from "vitest";
+import {
+  createDb,
+  ensurePersonalOrganization,
+  updateNpmConnectionValidation,
+  upsertNpmConnection,
+} from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { encryptNpmToken } from "../../server/lib/npm-connection";
+import { scansRoutes } from "../../server/routes/scans";
+import type { Bindings, Variables } from "../../server/types";
+
+type NpmValidationStatus = "valid" | "invalid" | "capability_limited" | "unvalidated";
+
+async function seedUser() {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+function buildTestApp(session: { userId: string }) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.use("*", async (c, next) => {
+    c.set("authSession", { userId: session.userId });
+    await next();
+  });
+  app.route("/api/v1/scans", scansRoutes);
+  return app;
+}
+
+async function seedNpmConnection(input: {
+  organizationId: string;
+  userId: string;
+  validationStatus: NpmValidationStatus;
+}) {
+  const db = createDb(env.DB);
+  const encrypted = await encryptNpmToken(env, "npm_test_token_0123456789");
+  await upsertNpmConnection(db, {
+    organizationId: input.organizationId,
+    registryUrl: "https://registry.npmjs.org",
+    label: "npm registry",
+    createdByUserId: input.userId,
+    ...encrypted,
+  });
+  await updateNpmConnectionValidation(db, {
+    organizationId: input.organizationId,
+    validationStatus: input.validationStatus,
+    validatedAt: input.validationStatus === "valid" ? new Date() : null,
+  });
+}
+
+async function requestScan(session: { userId: string }) {
+  const app = buildTestApp(session);
+  const ctx = createExecutionContext();
+  const res = await app.fetch(
+    new Request("http://test.local/api/v1/scans", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ stageId: "stage-token-123" }),
+    }),
+    env,
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+describe("scans route credential errors", () => {
+  test("POST /api/v1/scans returns token_missing when no npm connection exists", async () => {
+    const owner = await seedUser();
+
+    const res = await requestScan(owner);
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      code: "token_missing",
+    });
+  });
+
+  test.each([
+    ["unvalidated", "token_unvalidated"],
+    ["invalid", "token_invalid"],
+    ["capability_limited", "token_capability_limited"],
+  ] satisfies Array<[NpmValidationStatus, string]>)(
+    "POST /api/v1/scans returns %s credential code",
+    async (validationStatus, code) => {
+      const owner = await seedUser();
+      await seedNpmConnection({
+        organizationId: owner.organizationId,
+        userId: owner.userId,
+        validationStatus,
+      });
+
+      const res = await requestScan(owner);
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toMatchObject({
+        code,
+        validationStatus,
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes part of #46 — covers ACs #1, #2, #3, and #6.

## Summary

- Validation auto-probes a representative stage from `/-/stage?perPage=1` (or a caller-supplied stage ID) so a list-only token can no longer be marked `valid`. Empty list + no caller stage ID downgrades to `capability_limited` with reason `no_stages_to_probe`.
- New `validation_status` taxonomy: `unvalidated`, `invalid`, `capability_limited`, `valid`. The scan pipeline and staged-publish discovery refuse anything other than `valid` and now expose typed error codes (`token_missing`, `token_invalid`, `token_unvalidated`, `token_capability_limited`, `rate_limited`).
- `ApiError` carries the typed `code` to the client. Dashboard banner + workspace setup badge distinguish the four states with tailored copy that names the failing capability.
- `docs/security-model.md` enumerates the empirical min-cap set (`/-/whoami`, `/-/stage`, `/-/stage/:id`, `/-/stage/:id/tarball` + private package metadata) and documents the four-state taxonomy.

## Not in this PR

Deferred to follow-ups against #46:
- Audit events for rotate/remove/validation-failure + suspicious-use hooks (AC #5).
- Code-wide no-leak sweep beyond `publicNpmConnection` — logs, AI inputs, report exports (AC #4).
- Multi-connection schema preparation (scope bullet 7).

## Test plan

- [ ] `pnpm run verify` — lint + format + typecheck + 108 node tests + 45 worker tests.
- [ ] New: `validateNpmCredential` auto-probes a list stage and confirms tarball/view access.
- [ ] New: empty staged list yields `capability_limited` (`no_stages_to_probe`).
- [ ] New: scan job rejects `capability_limited` before decryption.
- [ ] New: `/api/v1/scans` returns the four typed credential codes (`scans-routes.test.ts`).
- [ ] New: `publicNpmConnection` never serializes ciphertext/nonce material.