### PR TITLE
Drop report fingerprint and widen reviewer notes

### DIFF
--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -1138,7 +1138,7 @@ function PersistedReportSections({
       </ReportSection>
 
       {ai?.model != null && (
-        <ReportSection title="Reviewer notes">
+        <ReportSection title="Reviewer notes" class="lg:col-span-2">
           {ai ? (
             ai!.status === "complete" ? (
               <>
@@ -1175,27 +1175,6 @@ function PersistedReportSections({
           )}
         </ReportSection>
       )}
-
-      <ReportSection title="Report fingerprint">
-        {summary.report ? (
-          <div class="flex flex-col gap-2 text-[13px]">
-            <MetadataRow label="version" value={String(summary.report.version ?? "unknown")} />
-            <MetadataRow
-              label="digest"
-              value={`${summary.report.digestAlgorithm || "sha256"}:${summary.report.digest || "missing"}`}
-            />
-            <MetadataRow
-              label="generated"
-              value={
-                summary.report.generatedAt ? formatDate(summary.report.generatedAt) : "unknown"
-              }
-            />
-            <MetadataRow label="rules" value={`v${summary.report.rulesVersion ?? "unknown"}`} />
-          </div>
-        ) : (
-          <EmptyLine>This older review does not include a report fingerprint.</EmptyLine>
-        )}
-      </ReportSection>
     </section>
   );
 }
@@ -1219,7 +1198,7 @@ function ReportSection({
 
 function AiFindingList({ findings }: { findings: AiFinding[] }) {
   return (
-    <ul class="list-none p-0 m-0 flex flex-col gap-2">
+    <ul class="list-none p-0 m-0 grid grid-cols-1 md:grid-cols-2 gap-2">
       {sortFindingsBySeverity(findings).map((finding, index) => (
         <FindingCard
           key={`${finding.file}-${index}`}
@@ -1339,15 +1318,6 @@ function ChangeValue({
         <span class="text-ink-subtle mr-1.5 select-none">+</span>
         {staged || "—"}
       </code>
-    </div>
-  );
-}
-
-function MetadataRow({ label, value }: { label: string; value: string }) {
-  return (
-    <div class="grid grid-cols-[96px_minmax(0,1fr)] gap-3">
-      <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">{label}</span>
-      <code class="text-xs text-ink-muted break-all">{value}</code>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Remove the **Report fingerprint** section (version/digest/generated/rules) from the persisted scan detail, along with the now-unused `MetadataRow` helper.
- Make **Reviewer notes** span the full row (`lg:col-span-2`) so it gets the same width as the manifest changes section.
- Lay out reviewer findings in a two-column grid on `md+` screens so they tile side-by-side instead of stacking.

## Test plan
- [ ] Open a persisted scan with reviewer notes and confirm the fingerprint block is gone and notes fill the row
- [ ] Confirm reviewer findings render in two columns on wider viewports and stack on narrow ones