### PR TITLE
Keep loading indicator visible while scan is pending/running

### DIFF
--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -249,12 +249,6 @@ export default function ScanDetailPage() {
       />
 
       {error ? <Alert tone="critical">{error}</Alert> : null}
-      {detail?.scan.status === "pending" || detail?.scan.status === "running" ? (
-        <Alert tone="info">
-          Review is {detail.scan.status}. This page refreshes automatically until the report is
-          ready.
-        </Alert>
-      ) : null}
       {detail?.scan.status === "failed" ? (
         <ScanFailureAlert errorJson={detail.scan.errorJson} />
       ) : null}
@@ -352,6 +346,11 @@ export default function ScanDetailPage() {
 
             <PersistedReportSections summary={summary.value} ai={ai.value} />
           </>
+        ) : detail.scan.status === "pending" || detail.scan.status === "running" ? (
+          <LoadingState
+            title={detail.scan.status === "pending" ? "Review queued" : "Reviewing release"}
+            detail="auto-refreshes when the report is ready"
+          />
         ) : (
           <ScanTimeline events={detail.events ?? []} />
         )


### PR DESCRIPTION
## Summary
- On the scan detail page, the initial `LoadingState` was replaced by a small info alert + collapsed timeline as soon as the detail arrived, even when status was still `pending`/`running` — that read as a finished state rather than ongoing work.
- Folded pending/running into the same `LoadingState` block, with the title flipping between "Review queued" and "Reviewing release" and a subline noting the page auto-refreshes.

## Test plan
- [ ] Open a scan that is still `pending`/`running` and confirm the loading indicator stays visible until the report renders
- [ ] Open a `failed` scan and confirm the failure alert + timeline still render
- [ ] Open a `complete` scan and confirm the full report renders unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)