### PR TITLE
Make npm_connections schema multi-connection ready

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,7 +166,7 @@ Organization-owned resources scope by the active org:
 
 - scans;
 - audit events;
-- npm connections (one per organization — `UNIQUE(organization_id)` on `npm_connections`);
+- npm connections (one active connection per organization; inactive rows are retained for future multi-connection support);
 - future report signatures;
 - future artifact retention settings.
 
@@ -186,7 +186,7 @@ Implemented `npm_connections` responsibilities:
 - support rotation/removal;
 - emit audit events for add, validate, use, and delete.
 
-Credential validation is empirical where possible: it checks registry auth through `/-/whoami`, staged list access through `GET /-/stage?perPage=1`, and when the user supplies a real stage ID it checks staged view plus ranged staged-tarball access without retaining the tarball. Before launch, confirm the least-privilege token shape with real npm tokens. Do not rely solely on broad token labels.
+Credential validation is empirical where possible: it checks registry auth through `/-/whoami`, staged list access through `GET /-/stage?perPage=1`, and when a staged publish is available (from the list response or a user-supplied stage ID) it checks staged view plus ranged staged-tarball access without retaining the tarball. Before launch, confirm the least-privilege token shape with real npm tokens. Do not rely solely on broad token labels.
 
 ## Report model and future signing
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -105,7 +105,7 @@ Scans and staged-publish discovery require the organization npm connection to be
 
 ### Multiple connections per organization
 
-The `npm_connections` schema carries an `is_active` boolean and a partial unique index `(organization_id) WHERE is_active = 1`, so the database can hold many rows per org but enforces at most one active row. Today's `upsertNpmConnection` updates the active row in place — there is one connection per org from a UX perspective — but `listNpmConnections` and the row layout are ready for a future "multiple named connections" feature without another migration.
+The `npm_connections` schema carries an `is_active` boolean and a partial unique index `(organization_id) WHERE is_active = 1`, so the database can hold many rows per org but enforces at most one active row. Today's `upsertNpmConnection` updates the active row in place — there is one connection per org from a UX perspective — while organization listing and scan gates only treat active rows as configured connections. `listNpmConnections` and the row layout are ready for a future "multiple named connections" feature without another migration.
 
 ## Package artifact handling
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -56,9 +56,17 @@ Implementation requirements:
 - Store token material encrypted at rest.
 - Show only a label/fingerprint/last-used timestamp after storage.
 - Validate credentials before use.
-- Record audit events for add, validate, use, rotate, and remove.
+- Record audit events across the full lifecycle:
+  - `npm_connection.created` — first save for an organization.
+  - `npm_connection.rotated` — subsequent saves; metadata includes the previous and new token fingerprint plus the previous validation status.
+  - `npm_connection.registry_changed` — a rotate that also changes the stored registry URL.
+  - `npm_connection.validated` — validation passed.
+  - `npm_connection.validation_failed` — validation rejected; metadata records the structured reasons (`registry_auth_failed`, `staged_list_denied`, `staged_view_denied`, `staged_tarball_denied`, `no_stages_to_probe`).
+  - `npm_connection.validation_downgraded` — a token previously marked `valid` has been rejected on revalidation.
+  - `npm_connection.used` — a scan worker decrypted the token to run a scan.
+  - `npm_connection.deleted` — connection removed.
 - Never return token material from an API.
-- Redact credential metadata fields from scan lifecycle events before returning them to the UI.
+- Redact credential metadata fields (`tokenCiphertext`, `tokenNonce`, `tokenFingerprint`, `tokenLast4`, `previousTokenFingerprint`) from scan lifecycle events before returning them to the UI.
 - Never include token material in scan errors, AI inputs, logs, or persisted reports.
 
 Current code has encrypted per-organization npm connections only. SaaS production must configure `NPM_CONNECTIONS_ENCRYPTION_KEY`; scans require an organization-owned npm token.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -63,7 +63,36 @@ Implementation requirements:
 
 Current code has encrypted per-organization npm connections only. SaaS production must configure `NPM_CONNECTIONS_ENCRYPTION_KEY`; scans require an organization-owned npm token.
 
-Scans and staged-publish discovery require the organization npm connection to be validated first. The dashboard automatically runs the baseline npm auth/list validation after token save, and users can still run a stage-ID-specific validation check afterwards. Queued scan workers re-check validation immediately before decrypting and using the current token, so token rotation cannot bypass the validation gate. Custom npm registries are supported for organization npm connections and should be paired with explicit abuse controls in production operations.
+### Minimum viable npm token capability set
+
+Drydock needs these registry endpoints to function. Customers should grant exactly this set and no more on granular npm tokens:
+
+- `GET /-/whoami` — identity probe used by validation only.
+- `GET /-/stage?perPage=N` — list open staged publishes for discovery.
+- `GET /-/stage/:id` — fetch staged publish metadata (manifest/diff inputs).
+- `GET /-/stage/:id/tarball` — download the staged artifact for scanning. The validation probe uses a `Range: bytes=0-0` request to confirm download capability without consuming bandwidth.
+- `GET <registry>/:package` and `GET <registry>/:package/-/<tarball>` — public/private package metadata + previous-version tarballs for diffing. Required only when scanning private packages.
+
+Tokens that authenticate at `/-/whoami` and list `/-/stage` but cannot view or download an individual stage are marked **capability-limited** and rejected for scanning.
+
+### Validation status taxonomy
+
+A stored npm connection is always in one of these states; the scan pipeline and staged-publish discovery refuse anything other than `valid`:
+
+- `missing` — no row stored for the organization.
+- `unvalidated` — token row present, validation has never been run (or was reset after rotation).
+- `invalid` — `/-/whoami` or `/-/stage` denied the token. The connection is unusable.
+- `capability_limited` — auth + list succeeded, but the staged-publish view/download probe failed (capability gap), or the staged list was empty so view/download could not be confirmed. The connection is rejected by scans; the user must either wait for a staged publish, paste a stage ID, or fix the token's capability set.
+- `valid` — all probed capabilities passed.
+
+API error responses for credential-dependent routes include a stable `code` field — `token_missing`, `token_unvalidated`, `token_invalid`, `token_capability_limited`, or `rate_limited` — alongside the human-readable `error` string. The UI parses `code`, not the message, so wording can change without breaking automation.
+
+Validation runs:
+
+1. Always: `/-/whoami` + `/-/stage?perPage=1`.
+2. When a stage exists (auto-pick from list, or caller-supplied stage ID): `GET /-/stage/:id` + `GET /-/stage/:id/tarball` with a one-byte range.
+
+Scans and staged-publish discovery require the organization npm connection to be `valid`. The dashboard automatically runs the baseline npm auth/list validation after token save and probes a representative stage from the list response when one exists. Users can still re-run a stage-ID-specific validation check from workspace setup. Queued scan workers re-check validation immediately before decrypting and using the current token, so token rotation cannot bypass the validation gate. Custom npm registries are supported for organization npm connections and should be paired with explicit abuse controls in production operations.
 
 ## Package artifact handling
 
@@ -186,7 +215,7 @@ Do not expose signed report URLs until access controls, report canonicalization,
 
 ## Known gaps
 
-- Per-organization encrypted npm connections exist, and validation can check staged-tarball access when supplied a real stage ID; npm list/view capability checks still need confirmation before launch.
+- Per-organization encrypted npm connections exist with a four-state validation taxonomy (`unvalidated` / `invalid` / `capability_limited` / `valid`) and the validator auto-probes staged view + download against a representative stage when one is available. Multi-connection support, rotate-without-revalidate hardening, and per-token audit metrics are still open follow-ups for production hardening (tracked in [`production-roadmap.md`](production-roadmap.md)).
 - Queue-backed scan retry/dead-letter behavior exists in code and Wrangler config, but production queue resources and operational metrics still need deployment validation.
 - Persisted detail UI now renders core report data, but finding grouping and lifecycle timelines still need polish.
 - Tar parsing now rejects traversal paths, skips symlinks/hardlinks, handles long-name/PAX paths, caps expanded size, and fails closed when the safe file-count limit is exceeded, but it still needs deeper archive-bomb fuzzing before broad public launch.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -65,6 +65,7 @@ Implementation requirements:
   - `npm_connection.validation_downgraded` — a token previously marked `valid` has been rejected on revalidation.
   - `npm_connection.used` — a scan worker decrypted the token to run a scan.
   - `npm_connection.deleted` — connection removed.
+  - `npm_connection.suspicious_use` — three or more validation failures recorded for the organization within a 15-minute window. Idempotent within the window; surfaces as a signal that an org's token may be leaking, rotating without cleanup, or under brute-force attempt.
 - Never return token material from an API.
 - Redact credential metadata fields (`tokenCiphertext`, `tokenNonce`, `tokenFingerprint`, `tokenLast4`, `previousTokenFingerprint`) from scan lifecycle events before returning them to the UI.
 - Never include token material in scan errors, AI inputs, logs, or persisted reports.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -103,6 +103,10 @@ Validation runs:
 
 Scans and staged-publish discovery require the organization npm connection to be `valid`. The dashboard automatically runs the baseline npm auth/list validation after token save and probes a representative stage from the list response when one exists. Users can still re-run a stage-ID-specific validation check from workspace setup. Queued scan workers re-check validation immediately before decrypting and using the current token, so token rotation cannot bypass the validation gate. Custom npm registries are supported for organization npm connections and should be paired with explicit abuse controls in production operations.
 
+### Multiple connections per organization
+
+The `npm_connections` schema carries an `is_active` boolean and a partial unique index `(organization_id) WHERE is_active = 1`, so the database can hold many rows per org but enforces at most one active row. Today's `upsertNpmConnection` updates the active row in place — there is one connection per org from a UX perspective — but `listNpmConnections` and the row layout are ready for a future "multiple named connections" feature without another migration.
+
 ## Package artifact handling
 
 ### Default retention policy

--- a/drizzle/0008_spotty_fallen_one.sql
+++ b/drizzle/0008_spotty_fallen_one.sql
@@ -1,0 +1,4 @@
+DROP INDEX `npm_connections_org_unique_idx`;--> statement-breakpoint
+ALTER TABLE `npm_connections` ADD `is_active` integer DEFAULT true NOT NULL;--> statement-breakpoint
+CREATE UNIQUE INDEX `npm_connections_org_active_unique_idx` ON `npm_connections` (`organization_id`) WHERE "npm_connections"."is_active" = 1;--> statement-breakpoint
+CREATE INDEX `npm_connections_org_idx` ON `npm_connections` (`organization_id`);

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1268 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8741882a-6c34-4966-a6e2-3eacca46e00b",
+  "prevId": "efdae053-6f48-499e-9bee-5d5b0b885d9c",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_active_unique_idx": {
+          "name": "npm_connections_org_active_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true,
+          "where": "\"npm_connections\".\"is_active\" = 1"
+        },
+        "npm_connections_org_idx": {
+          "name": "npm_connections_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        },
+        "scans_org_decision_created_idx": {
+          "name": "scans_org_decision_created_idx",
+          "columns": [
+            "organization_id",
+            "decision",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_decided_by_user_id_user_id_fk": {
+          "name": "scans_decided_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1779690699332,
       "tag": "0007_brainy_marrow",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1779819670125,
+      "tag": "0008_spotty_fallen_one",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -1,5 +1,5 @@
 import { drizzle } from "drizzle-orm/d1";
-import { and, asc, desc, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, gte, inArray, isNull, lt, or, sql } from "drizzle-orm";
 import * as schema from "./schema";
 import {
   npmConnections,
@@ -180,6 +180,24 @@ export async function recordScanEvent(db: AppDb, input: AuditEventInput) {
     metadataJson: input.metadata ?? null,
     createdAt: new Date(),
   });
+}
+
+export async function countRecentScanEvents(
+  db: AppDb,
+  input: { organizationId: string; type: string; windowMs: number },
+): Promise<number> {
+  const since = new Date(Date.now() - input.windowMs);
+  const rows = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(scanEvents)
+    .where(
+      and(
+        eq(scanEvents.organizationId, input.organizationId),
+        eq(scanEvents.type, input.type),
+        gte(scanEvents.createdAt, since),
+      ),
+    );
+  return Number(rows[0]?.count ?? 0);
 }
 
 export async function createScanJob(db: AppDb, input: CreateScanJobInput) {

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -85,7 +85,7 @@ export interface NpmConnectionInput {
 
 export interface NpmConnectionValidationInput {
   organizationId: string;
-  validationStatus: "valid" | "invalid" | "unvalidated";
+  validationStatus: "valid" | "invalid" | "capability_limited" | "unvalidated";
   capabilities?: unknown;
   validatedAt?: Date | null;
 }

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -724,6 +724,7 @@ const SENSITIVE_EVENT_METADATA_KEYS = new Set([
   "tokenFingerprint",
   "tokenLast4",
   "tokenNonce",
+  "previousTokenFingerprint",
 ]);
 
 function redactScanEventForClient<T extends { metadataJson: unknown }>(event: T): T {

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -761,28 +761,7 @@ function redactScanEventMetadata(value: unknown): unknown {
 
 export async function upsertNpmConnection(db: AppDb, input: NpmConnectionInput) {
   const now = new Date();
-  const existing = await getNpmConnection(db, input.organizationId);
-
-  if (existing) {
-    await db
-      .update(npmConnections)
-      .set({
-        registryUrl: input.registryUrl,
-        label: input.label,
-        tokenCiphertext: input.tokenCiphertext,
-        tokenNonce: input.tokenNonce,
-        tokenFingerprint: input.tokenFingerprint,
-        tokenLast4: input.tokenLast4 || null,
-        validationStatus: "unvalidated",
-        capabilitiesJson: null,
-        validatedAt: null,
-        updatedAt: now,
-      })
-      .where(eq(npmConnections.id, existing.id));
-    return getNpmConnection(db, input.organizationId);
-  }
-
-  await db.insert(npmConnections).values({
+  const values = {
     id: crypto.randomUUID(),
     organizationId: input.organizationId,
     registryUrl: input.registryUrl,
@@ -799,7 +778,27 @@ export async function upsertNpmConnection(db: AppDb, input: NpmConnectionInput) 
     createdByUserId: input.createdByUserId,
     createdAt: now,
     updatedAt: now,
-  });
+  };
+
+  await db
+    .insert(npmConnections)
+    .values(values)
+    .onConflictDoUpdate({
+      target: npmConnections.organizationId,
+      targetWhere: sql`${npmConnections.isActive} = 1`,
+      set: {
+        registryUrl: values.registryUrl,
+        label: values.label,
+        tokenCiphertext: values.tokenCiphertext,
+        tokenNonce: values.tokenNonce,
+        tokenFingerprint: values.tokenFingerprint,
+        tokenLast4: values.tokenLast4,
+        validationStatus: values.validationStatus,
+        capabilitiesJson: values.capabilitiesJson,
+        validatedAt: values.validatedAt,
+        updatedAt: now,
+      },
+    });
 
   return getNpmConnection(db, input.organizationId);
 }
@@ -885,7 +884,10 @@ export async function listUserOrganizations(
     })
     .from(organizationMembers)
     .innerJoin(organizations, eq(organizations.id, organizationMembers.organizationId))
-    .leftJoin(npmConnections, eq(npmConnections.organizationId, organizations.id))
+    .leftJoin(
+      npmConnections,
+      and(eq(npmConnections.organizationId, organizations.id), eq(npmConnections.isActive, true)),
+    )
     .where(eq(organizationMembers.userId, userId));
 
   return rows

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -761,7 +761,28 @@ function redactScanEventMetadata(value: unknown): unknown {
 
 export async function upsertNpmConnection(db: AppDb, input: NpmConnectionInput) {
   const now = new Date();
-  const values = {
+  const existing = await getNpmConnection(db, input.organizationId);
+
+  if (existing) {
+    await db
+      .update(npmConnections)
+      .set({
+        registryUrl: input.registryUrl,
+        label: input.label,
+        tokenCiphertext: input.tokenCiphertext,
+        tokenNonce: input.tokenNonce,
+        tokenFingerprint: input.tokenFingerprint,
+        tokenLast4: input.tokenLast4 || null,
+        validationStatus: "unvalidated",
+        capabilitiesJson: null,
+        validatedAt: null,
+        updatedAt: now,
+      })
+      .where(eq(npmConnections.id, existing.id));
+    return getNpmConnection(db, input.organizationId);
+  }
+
+  await db.insert(npmConnections).values({
     id: crypto.randomUUID(),
     organizationId: input.organizationId,
     registryUrl: input.registryUrl,
@@ -774,29 +795,11 @@ export async function upsertNpmConnection(db: AppDb, input: NpmConnectionInput) 
     capabilitiesJson: null,
     validatedAt: null,
     lastUsedAt: null,
+    isActive: true,
     createdByUserId: input.createdByUserId,
     createdAt: now,
     updatedAt: now,
-  };
-
-  await db
-    .insert(npmConnections)
-    .values(values)
-    .onConflictDoUpdate({
-      target: npmConnections.organizationId,
-      set: {
-        registryUrl: values.registryUrl,
-        label: values.label,
-        tokenCiphertext: values.tokenCiphertext,
-        tokenNonce: values.tokenNonce,
-        tokenFingerprint: values.tokenFingerprint,
-        tokenLast4: values.tokenLast4,
-        validationStatus: values.validationStatus,
-        capabilitiesJson: values.capabilitiesJson,
-        validatedAt: values.validatedAt,
-        updatedAt: now,
-      },
-    });
+  });
 
   return getNpmConnection(db, input.organizationId);
 }
@@ -805,9 +808,19 @@ export async function getNpmConnection(db: AppDb, organizationId: string) {
   const [connection] = await db
     .select()
     .from(npmConnections)
-    .where(eq(npmConnections.organizationId, organizationId))
+    .where(
+      and(eq(npmConnections.organizationId, organizationId), eq(npmConnections.isActive, true)),
+    )
     .limit(1);
   return connection ?? null;
+}
+
+export async function listNpmConnections(db: AppDb, organizationId: string) {
+  return db
+    .select()
+    .from(npmConnections)
+    .where(eq(npmConnections.organizationId, organizationId))
+    .orderBy(desc(npmConnections.isActive), desc(npmConnections.createdAt));
 }
 
 export async function updateNpmConnectionValidation(
@@ -822,7 +835,12 @@ export async function updateNpmConnectionValidation(
       validatedAt: input.validatedAt ?? null,
       updatedAt: new Date(),
     })
-    .where(eq(npmConnections.organizationId, input.organizationId));
+    .where(
+      and(
+        eq(npmConnections.organizationId, input.organizationId),
+        eq(npmConnections.isActive, true),
+      ),
+    );
   return getNpmConnection(db, input.organizationId);
 }
 
@@ -830,7 +848,9 @@ export async function markNpmConnectionUsed(db: AppDb, organizationId: string) {
   await db
     .update(npmConnections)
     .set({ lastUsedAt: new Date(), updatedAt: new Date() })
-    .where(eq(npmConnections.organizationId, organizationId));
+    .where(
+      and(eq(npmConnections.organizationId, organizationId), eq(npmConnections.isActive, true)),
+    );
 }
 
 export async function deleteNpmConnection(db: AppDb, organizationId: string) {

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { sqliteTable, text, integer, index, uniqueIndex } from "drizzle-orm/sqlite-core";
 
 export const user = sqliteTable("user", {
@@ -175,12 +176,16 @@ export const npmConnections = sqliteTable(
     capabilitiesJson: text("capabilities_json", { mode: "json" }),
     validatedAt: integer("validated_at", { mode: "timestamp_ms" }),
     lastUsedAt: integer("last_used_at", { mode: "timestamp_ms" }),
+    isActive: integer("is_active", { mode: "boolean" }).notNull().default(true),
     createdByUserId: text("created_by_user_id").references(() => user.id, { onDelete: "set null" }),
     createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
     updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
   },
   (table) => ({
-    orgUniqueIdx: uniqueIndex("npm_connections_org_unique_idx").on(table.organizationId),
+    orgActiveUniqueIdx: uniqueIndex("npm_connections_org_active_unique_idx")
+      .on(table.organizationId)
+      .where(sql`${table.isActive} = 1`),
+    orgIdx: index("npm_connections_org_idx").on(table.organizationId),
     fingerprintIdx: index("npm_connections_fingerprint_idx").on(table.tokenFingerprint),
   }),
 );

--- a/server/lib/npm-connection.ts
+++ b/server/lib/npm-connection.ts
@@ -30,9 +30,19 @@ export interface PublicNpmConnection {
   updatedAt: Date | string | number;
 }
 
+export type NpmCredentialStatus = "valid" | "invalid" | "capability_limited";
+
+export type NpmCredentialReason =
+  | "registry_auth_failed"
+  | "staged_list_denied"
+  | "staged_view_denied"
+  | "staged_tarball_denied"
+  | "no_stages_to_probe";
+
 export interface NpmCredentialValidation {
   ok: boolean;
-  status: "valid" | "invalid";
+  status: NpmCredentialStatus;
+  reasons: NpmCredentialReason[];
   capabilities: {
     registryAuth: boolean;
     stagedListAccess: boolean;
@@ -41,6 +51,7 @@ export interface NpmCredentialValidation {
     whoami?: string | null;
     registryUrl: string;
     stageId?: string;
+    probedStageSource?: "caller" | "list";
     status?: number;
     stagedListStatus?: number;
     stagedViewStatus?: number;
@@ -175,30 +186,56 @@ export async function validateNpmCredential(
   const registry = normalizeRegistryUrl(registryUrl, {
     allowInsecureLocalhost: options.allowInsecureLocalhost,
   });
-  const [auth, stagedList, stagedView, stagedTarball] = await Promise.all([
+  const [auth, stagedList] = await Promise.all([
     validateRegistryAuth(registry, token),
     validateStagedListAccess(registry, token),
-    options.stageId
-      ? validateStagedViewAccess(registry, token, options.stageId)
-      : Promise.resolve(null),
-    options.stageId
-      ? validateStagedTarballAccess(registry, token, options.stageId)
-      : Promise.resolve(null),
   ]);
-  const ok =
-    auth.registryAuth &&
-    stagedList.stagedListAccess &&
-    (stagedView ? stagedView.stagedViewAccess : true) &&
-    (stagedTarball ? stagedTarball.stagedTarballAccess : true);
+
+  const reasons: NpmCredentialReason[] = [];
+  if (!auth.registryAuth) reasons.push("registry_auth_failed");
+  if (!stagedList.stagedListAccess) reasons.push("staged_list_denied");
+
+  const callerStageId = options.stageId;
+  const listedStageId =
+    !callerStageId && stagedList.stagedListAccess ? stagedList.firstStageId : null;
+  const probedStageId = callerStageId ?? listedStageId;
+
+  let stagedView: Awaited<ReturnType<typeof validateStagedViewAccess>> | null = null;
+  let stagedTarball: Awaited<ReturnType<typeof validateStagedTarballAccess>> | null = null;
+
+  if (auth.registryAuth && stagedList.stagedListAccess && probedStageId) {
+    [stagedView, stagedTarball] = await Promise.all([
+      validateStagedViewAccess(registry, token, probedStageId),
+      validateStagedTarballAccess(registry, token, probedStageId),
+    ]);
+    if (stagedView && !stagedView.stagedViewAccess) reasons.push("staged_view_denied");
+    if (stagedTarball && !stagedTarball.stagedTarballAccess) reasons.push("staged_tarball_denied");
+  } else if (auth.registryAuth && stagedList.stagedListAccess) {
+    reasons.push("no_stages_to_probe");
+  }
+
+  const status: NpmCredentialStatus =
+    !auth.registryAuth || !stagedList.stagedListAccess
+      ? "invalid"
+      : reasons.length === 0
+        ? "valid"
+        : "capability_limited";
 
   return {
-    ok,
-    status: ok ? "valid" : "invalid",
+    ok: status === "valid",
+    status,
+    reasons,
     capabilities: {
       ...auth,
-      ...stagedList,
+      registryAuth: auth.registryAuth,
+      stagedListAccess: stagedList.stagedListAccess,
+      stagedListStatus: stagedList.stagedListStatus,
+      stagedListDetail: stagedList.stagedListDetail,
       ...stagedView,
       ...stagedTarball,
+      ...(probedStageId
+        ? { probedStageSource: callerStageId ? "caller" : "list", stageId: probedStageId }
+        : {}),
       registryUrl: registry,
     },
   };
@@ -238,18 +275,48 @@ async function validateStagedListAccess(registry: string, token: string) {
     const response = await fetch(`${registry}/-/stage?perPage=1`, {
       headers: npmAuthHeaders(token, "application/json"),
     });
-    await response.body?.cancel();
+    if (!response.ok) {
+      await response.body?.cancel();
+      return {
+        stagedListAccess: false,
+        stagedListStatus: response.status,
+        stagedListDetail: response.statusText,
+        firstStageId: null as string | null,
+      };
+    }
+    const data = (await response.json().catch(() => null)) as unknown;
+    const firstStageId = extractFirstStageId(data);
     return {
-      stagedListAccess: response.ok,
+      stagedListAccess: true,
       stagedListStatus: response.status,
-      stagedListDetail: response.ok ? undefined : response.statusText,
+      stagedListDetail: undefined as string | undefined,
+      firstStageId,
     };
   } catch (err) {
     return {
       stagedListAccess: false,
       stagedListDetail: err instanceof Error ? err.message : String(err),
+      firstStageId: null as string | null,
     };
   }
+}
+
+function extractFirstStageId(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const root = payload as { items?: unknown };
+  if (!Array.isArray(root.items)) return null;
+  for (const entry of root.items) {
+    if (!entry || typeof entry !== "object") continue;
+    const record = entry as { id?: unknown; stageId?: unknown };
+    const candidate =
+      typeof record.id === "string" && record.id.trim()
+        ? record.id.trim()
+        : typeof record.stageId === "string" && record.stageId.trim()
+          ? record.stageId.trim()
+          : null;
+    if (candidate) return candidate;
+  }
+  return null;
 }
 
 async function validateStagedViewAccess(registry: string, token: string, stageId: string) {

--- a/server/lib/scan-job.ts
+++ b/server/lib/scan-job.ts
@@ -62,7 +62,15 @@ export async function executeScanJob(
       throw new Error("Connect an organization npm token before scanning staged publishes.");
     }
     if (npmConnection.validationStatus !== "valid") {
-      throw new Error("Validate the organization npm token before scanning staged publishes.");
+      const detail =
+        npmConnection.validationStatus === "capability_limited"
+          ? "Capability check failed; rerun validation with a real stage ID."
+          : npmConnection.validationStatus === "invalid"
+            ? "Token failed npm validation; rotate the token and revalidate."
+            : "Run validation before scanning.";
+      throw new Error(
+        `Validate the organization npm token before scanning staged publishes. ${detail}`,
+      );
     }
 
     const [orgNpmToken] = await Promise.all([

--- a/server/routes/npm-connection.ts
+++ b/server/routes/npm-connection.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import {
   RateLimitError,
+  countRecentScanEvents,
   createDb,
   deleteNpmConnection,
   enforceRateLimit,
@@ -21,6 +22,8 @@ import {
 import type { Bindings, Variables } from "../types";
 
 const STAGE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{5,160}$/;
+const SUSPICIOUS_USE_WINDOW_MS = 15 * 60 * 1000;
+const SUSPICIOUS_USE_THRESHOLD = 3;
 
 export const npmConnectionRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
@@ -188,6 +191,35 @@ npmConnectionRoutes.post("/validate", async (c) => {
       );
     }
     await Promise.all(auditEvents);
+
+    if (!validation.ok) {
+      const [recentFailures, recentSuspicious] = await Promise.all([
+        countRecentScanEvents(db, {
+          organizationId,
+          type: "npm_connection.validation_failed",
+          windowMs: SUSPICIOUS_USE_WINDOW_MS,
+        }),
+        countRecentScanEvents(db, {
+          organizationId,
+          type: "npm_connection.suspicious_use",
+          windowMs: SUSPICIOUS_USE_WINDOW_MS,
+        }),
+      ]);
+      if (recentFailures >= SUSPICIOUS_USE_THRESHOLD && recentSuspicious === 0) {
+        await recordScanEvent(db, {
+          organizationId,
+          actorUserId: session.userId,
+          type: "npm_connection.suspicious_use",
+          metadata: {
+            reason: "repeated_validation_failures",
+            failureCount: recentFailures,
+            windowMs: SUSPICIOUS_USE_WINDOW_MS,
+            status: validation.status,
+            tokenFingerprint: connection.tokenFingerprint,
+          },
+        });
+      }
+    }
 
     return c.json({ validation, connection: publicNpmConnection(updated) });
   } catch (err) {

--- a/server/routes/npm-connection.ts
+++ b/server/routes/npm-connection.ts
@@ -89,6 +89,7 @@ npmConnectionRoutes.post("/", async (c) => {
       return c.json(
         {
           error: "npm connection save rate limit exceeded",
+          code: "rate_limited",
           retryAfterSeconds: err.retryAfterSeconds,
         },
         429,
@@ -117,7 +118,8 @@ npmConnectionRoutes.post("/validate", async (c) => {
     });
 
     const connection = await getNpmConnection(db, organizationId);
-    if (!connection) return c.json({ error: "npm connection is not configured" }, 404);
+    if (!connection)
+      return c.json({ error: "npm connection is not configured", code: "token_missing" }, 404);
 
     const token = await decryptNpmToken(c.env, connection);
     const validation = await validateNpmCredential(connection.registryUrl, token, {
@@ -128,7 +130,7 @@ npmConnectionRoutes.post("/validate", async (c) => {
       updateNpmConnectionValidation(db, {
         organizationId,
         validationStatus: validation.status,
-        capabilities: validation.capabilities,
+        capabilities: { ...validation.capabilities, reasons: validation.reasons },
         validatedAt: validation.ok ? new Date() : null,
       }),
       recordScanEvent(db, {
@@ -138,6 +140,7 @@ npmConnectionRoutes.post("/validate", async (c) => {
         metadata: {
           ok: validation.ok,
           status: validation.status,
+          reasons: validation.reasons,
           capabilities: validation.capabilities,
         },
       }),
@@ -147,13 +150,17 @@ npmConnectionRoutes.post("/validate", async (c) => {
   } catch (err) {
     if (err instanceof RateLimitError) {
       return c.json(
-        { error: "npm validation rate limit exceeded", retryAfterSeconds: err.retryAfterSeconds },
+        {
+          error: "npm validation rate limit exceeded",
+          code: "rate_limited",
+          retryAfterSeconds: err.retryAfterSeconds,
+        },
         429,
         { "retry-after": String(err.retryAfterSeconds) },
       );
     }
     console.error("npm connection validation failed", err);
-    return c.json({ error: "failed to validate npm connection" }, 400);
+    return c.json({ error: "failed to validate npm connection", code: "validation_failed" }, 400);
   }
 });
 

--- a/server/routes/npm-connection.ts
+++ b/server/routes/npm-connection.ts
@@ -63,25 +63,49 @@ npmConnectionRoutes.post("/", async (c) => {
       }),
       encryptNpmToken(c.env, token),
     ]);
-    const [connection] = await Promise.all([
-      upsertNpmConnection(db, {
-        organizationId,
-        registryUrl,
-        label,
-        createdByUserId: session.userId,
-        ...encrypted,
-      }),
+    const previous = await getNpmConnection(db, organizationId);
+    const isRotate = Boolean(previous);
+    const registryChanged = previous ? previous.registryUrl !== registryUrl : false;
+    const connection = await upsertNpmConnection(db, {
+      organizationId,
+      registryUrl,
+      label,
+      createdByUserId: session.userId,
+      ...encrypted,
+    });
+    const auditEvents: Promise<unknown>[] = [
       recordScanEvent(db, {
         organizationId,
         actorUserId: session.userId,
-        type: "npm_connection.upserted",
+        type: isRotate ? "npm_connection.rotated" : "npm_connection.created",
         metadata: {
           registryUrl,
           label,
           tokenFingerprint: encrypted.tokenFingerprint,
+          ...(isRotate && previous
+            ? {
+                previousTokenFingerprint: previous.tokenFingerprint,
+                previousValidationStatus: previous.validationStatus,
+              }
+            : {}),
         },
       }),
-    ]);
+    ];
+    if (registryChanged && previous) {
+      auditEvents.push(
+        recordScanEvent(db, {
+          organizationId,
+          actorUserId: session.userId,
+          type: "npm_connection.registry_changed",
+          metadata: {
+            previousRegistryUrl: previous.registryUrl,
+            registryUrl,
+            tokenFingerprint: encrypted.tokenFingerprint,
+          },
+        }),
+      );
+    }
+    await Promise.all(auditEvents);
 
     return c.json({ connection: publicNpmConnection(connection) });
   } catch (err) {
@@ -126,25 +150,44 @@ npmConnectionRoutes.post("/validate", async (c) => {
       stageId,
       allowInsecureLocalhost: allowInsecureLocalRegistry(c.env),
     });
-    const [updated] = await Promise.all([
-      updateNpmConnectionValidation(db, {
-        organizationId,
-        validationStatus: validation.status,
-        capabilities: { ...validation.capabilities, reasons: validation.reasons },
-        validatedAt: validation.ok ? new Date() : null,
-      }),
+    const wasValid = connection.validationStatus === "valid";
+    const isDowngrade = wasValid && validation.status !== "valid";
+    const updated = await updateNpmConnectionValidation(db, {
+      organizationId,
+      validationStatus: validation.status,
+      capabilities: { ...validation.capabilities, reasons: validation.reasons },
+      validatedAt: validation.ok ? new Date() : null,
+    });
+    const auditEvents: Promise<unknown>[] = [
       recordScanEvent(db, {
         organizationId,
         actorUserId: session.userId,
-        type: "npm_connection.validated",
+        type: validation.ok ? "npm_connection.validated" : "npm_connection.validation_failed",
         metadata: {
           ok: validation.ok,
           status: validation.status,
           reasons: validation.reasons,
           capabilities: validation.capabilities,
+          ...(stageId ? { probedStageSource: "caller" } : {}),
         },
       }),
-    ]);
+    ];
+    if (isDowngrade) {
+      auditEvents.push(
+        recordScanEvent(db, {
+          organizationId,
+          actorUserId: session.userId,
+          type: "npm_connection.validation_downgraded",
+          metadata: {
+            previousStatus: "valid",
+            status: validation.status,
+            reasons: validation.reasons,
+            tokenFingerprint: connection.tokenFingerprint,
+          },
+        }),
+      );
+    }
+    await Promise.all(auditEvents);
 
     return c.json({ validation, connection: publicNpmConnection(updated) });
   } catch (err) {

--- a/server/routes/scan.ts
+++ b/server/routes/scan.ts
@@ -34,13 +34,26 @@ scanRoutes.post("/", async (c) => {
     const npmConnection = await getNpmConnection(db, organizationId);
     if (!npmConnection) {
       return c.json(
-        { error: "Connect an organization npm token before scanning staged publishes." },
+        {
+          error: "Connect an organization npm token before scanning staged publishes.",
+          code: "token_missing",
+        },
         400,
       );
     }
     if (npmConnection.validationStatus !== "valid") {
+      const code =
+        npmConnection.validationStatus === "invalid"
+          ? "token_invalid"
+          : npmConnection.validationStatus === "capability_limited"
+            ? "token_capability_limited"
+            : "token_unvalidated";
       return c.json(
-        { error: "Validate the organization npm token before scanning staged publishes." },
+        {
+          error: "Validate the organization npm token before scanning staged publishes.",
+          code,
+          validationStatus: npmConnection.validationStatus,
+        },
         400,
       );
     }

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -55,13 +55,26 @@ scansRoutes.post("/", async (c) => {
     const npmConnection = await getNpmConnection(db, organizationId);
     if (!npmConnection) {
       return c.json(
-        { error: "Connect an organization npm token before scanning staged publishes." },
+        {
+          error: "Connect an organization npm token before scanning staged publishes.",
+          code: "token_missing",
+        },
         400,
       );
     }
     if (npmConnection.validationStatus !== "valid") {
+      const code =
+        npmConnection.validationStatus === "invalid"
+          ? "token_invalid"
+          : npmConnection.validationStatus === "capability_limited"
+            ? "token_capability_limited"
+            : "token_unvalidated";
       return c.json(
-        { error: "Validate the organization npm token before scanning staged publishes." },
+        {
+          error: "Validate the organization npm token before scanning staged publishes.",
+          code,
+          validationStatus: npmConnection.validationStatus,
+        },
         400,
       );
     }

--- a/server/routes/staged-publishes.ts
+++ b/server/routes/staged-publishes.ts
@@ -48,20 +48,36 @@ stagedPublishesRoutes.post("/scan", async (c) => {
   const savedConnection = await getNpmConnection(db, organizationId);
   if (!savedConnection) {
     return c.json(
-      { error: "Connect an organization npm token before discovering staged publishes." },
+      {
+        error: "Connect an organization npm token before discovering staged publishes.",
+        code: "token_missing",
+      },
       400,
     );
   }
   if (savedConnection.validationStatus !== "valid") {
+    const code =
+      savedConnection.validationStatus === "invalid"
+        ? "token_invalid"
+        : savedConnection.validationStatus === "capability_limited"
+          ? "token_capability_limited"
+          : "token_unvalidated";
     return c.json(
-      { error: "Validate the organization npm token before discovering staged publishes." },
+      {
+        error: "Validate the organization npm token before discovering staged publishes.",
+        code,
+        validationStatus: savedConnection.validationStatus,
+      },
       400,
     );
   }
   const connection = await getOrganizationNpmToken(db, c.env, organizationId);
   if (!connection) {
     return c.json(
-      { error: "Connect an organization npm token before discovering staged publishes." },
+      {
+        error: "Connect an organization npm token before discovering staged publishes.",
+        code: "token_missing",
+      },
       400,
     );
   }

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -5,6 +5,7 @@ export class ApiError extends Error {
     message: string,
     readonly status: number,
     readonly detail?: string,
+    readonly code?: string,
   ) {
     super(message);
     this.name = "ApiError";
@@ -24,13 +25,14 @@ export async function apiFetch<T>(input: RequestInfo | URL, init?: RequestInit):
     headers,
   });
   const data = (await res.json().catch(() => null)) as
-    | (Partial<T> & { error?: string; detail?: string; message?: string })
+    | (Partial<T> & { error?: string; detail?: string; message?: string; code?: string })
     | null;
   if (!res.ok) {
     if (res.status === 401) throw new ApiError("Please sign in to continue.", 401);
     const detail = typeof data?.detail === "string" ? data.detail : undefined;
+    const code = typeof data?.code === "string" ? data.code : undefined;
     const message = data?.message || data?.error || "request failed";
-    throw new ApiError(detail ? `${message}: ${detail}` : message, res.status, detail);
+    throw new ApiError(detail ? `${message}: ${detail}` : message, res.status, detail, code);
   }
   return data as T;
 }

--- a/src/models/npm-connection.ts
+++ b/src/models/npm-connection.ts
@@ -17,18 +17,35 @@ export interface PublicNpmConnection {
   updatedAt: string | number | Date;
 }
 
+export type NpmCredentialStatus = "valid" | "invalid" | "capability_limited";
+
+export type NpmCredentialReason =
+  | "registry_auth_failed"
+  | "staged_list_denied"
+  | "staged_view_denied"
+  | "staged_tarball_denied"
+  | "no_stages_to_probe";
+
 export interface NpmCredentialValidation {
   ok: boolean;
-  status: "valid" | "invalid";
+  status: NpmCredentialStatus;
+  reasons: NpmCredentialReason[];
   capabilities: {
     registryAuth: boolean;
+    stagedListAccess: boolean;
     stagedTarballAccess?: boolean;
+    stagedViewAccess?: boolean;
     whoami?: string | null;
     registryUrl: string;
     stageId?: string;
+    probedStageSource?: "caller" | "list";
     status?: number;
+    stagedListStatus?: number;
+    stagedViewStatus?: number;
     stagedTarballStatus?: number;
     detail?: string;
+    stagedListDetail?: string;
+    stagedViewDetail?: string;
     stagedTarballDetail?: string;
   };
 }
@@ -52,6 +69,28 @@ export const NpmConnectionModel = createModel(() => {
   const busy = computed(() => status.value !== "idle");
   const isConnected = computed(() => connection.value !== null);
   const validated = computed(() => connection.value?.validationStatus === "valid");
+  const validationState = computed<
+    "missing" | "unvalidated" | "valid" | "invalid" | "capability_limited"
+  >(() => {
+    const next = connection.value;
+    if (!next) return "missing";
+    switch (next.validationStatus) {
+      case "valid":
+      case "invalid":
+      case "capability_limited":
+        return next.validationStatus;
+      default:
+        return "unvalidated";
+    }
+  });
+  const validationReasons = computed<NpmCredentialReason[]>(() => {
+    const caps = connection.value?.capabilitiesJson;
+    if (!caps || typeof caps !== "object") return [];
+    const list = (caps as { reasons?: unknown }).reasons;
+    return Array.isArray(list)
+      ? (list.filter((entry) => typeof entry === "string") as NpmCredentialReason[])
+      : [];
+  });
 
   return {
     connection,
@@ -65,6 +104,8 @@ export const NpmConnectionModel = createModel(() => {
     busy,
     isConnected,
     validated,
+    validationState,
+    validationReasons,
 
     async load(): Promise<void> {
       try {
@@ -109,7 +150,7 @@ export const NpmConnectionModel = createModel(() => {
           const validation = await validateNpmConnection();
           this.applyConnection(validation.connection);
           if (!validation.validation.ok) {
-            this.error.value = "Saved token, but npm validation reported invalid access.";
+            this.error.value = "Saved token. " + describeValidationFailure(validation.validation);
           }
         }
       } catch (err) {
@@ -128,7 +169,7 @@ export const NpmConnectionModel = createModel(() => {
         const data = await validateNpmConnection(stageId);
         this.applyConnection(data.connection);
         if (!data.validation.ok) {
-          this.error.value = "Npm validation reported invalid access.";
+          this.error.value = describeValidationFailure(data.validation);
         }
       } catch (err) {
         this.error.value = err instanceof Error ? err.message : String(err);
@@ -153,6 +194,30 @@ export const NpmConnectionModel = createModel(() => {
     },
   };
 });
+
+export function describeValidationFailure(validation: NpmCredentialValidation): string {
+  if (validation.status === "invalid") {
+    if (validation.reasons.includes("registry_auth_failed")) {
+      return "npm rejected the token — check it has registry access and try again.";
+    }
+    if (validation.reasons.includes("staged_list_denied")) {
+      return "npm rejected staged-publish list access — the token needs staged-publish list/view/download capability.";
+    }
+    return "npm validation failed.";
+  }
+  if (validation.status === "capability_limited") {
+    if (validation.reasons.includes("no_stages_to_probe")) {
+      return "Auth and staged-list access look good, but no open staged publishes were available to confirm view + download. Create a stage or paste a stage ID below to finish validation.";
+    }
+    const missing: string[] = [];
+    if (validation.reasons.includes("staged_view_denied")) missing.push("view");
+    if (validation.reasons.includes("staged_tarball_denied")) missing.push("download");
+    return missing.length
+      ? `Token is missing staged-publish ${missing.join(" + ")} capability — grant it before scanning.`
+      : "Token capability check did not complete.";
+  }
+  return "";
+}
 
 function saveNpmConnection(input: {
   token: string;

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -201,6 +201,7 @@ function ReviewRequestCard({
   const stageId = request.stageId.value;
   const hasConnection = npm.isConnected.value;
   const hasValidatedConnection = npm.validated.value;
+  const validationState = npm.validationState.value;
 
   return (
     <Card class="p-5 md:p-6 flex flex-col gap-4 border-accent/40">
@@ -226,8 +227,13 @@ function ReviewRequestCard({
           </div>
         </Alert>
       ) : !hasValidatedConnection ? (
-        <Alert tone="info">
-          Validate npm access in workspace setup before reviewing staged packages.
+        <Alert tone={validationState === "invalid" ? "critical" : "info"}>
+          <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <span>{reviewBannerCopy(validationState)}</span>
+            <LinkButton href="#workspace-setup" variant="secondary" size="sm" class="shrink-0">
+              Open settings
+            </LinkButton>
+          </div>
         </Alert>
       ) : null}
       <form class="flex flex-col gap-3" onSubmit={onSubmit}>
@@ -415,6 +421,77 @@ function formatStartedScanLabel(scan: { packageName: string | null; version: str
   return scan.packageName || scan.version || null;
 }
 
+type ValidationState = "missing" | "unvalidated" | "valid" | "invalid" | "capability_limited";
+
+function summaryBadgeTone(state: ValidationState): "ok" | "info" | "critical" | "medium" {
+  switch (state) {
+    case "valid":
+      return "ok";
+    case "invalid":
+      return "critical";
+    case "capability_limited":
+      return "medium";
+    default:
+      return "info";
+  }
+}
+
+function summaryBadgeLabel(state: ValidationState): string {
+  switch (state) {
+    case "missing":
+      return "connect npm";
+    case "unvalidated":
+      return "unvalidated";
+    case "valid":
+      return "valid";
+    case "invalid":
+      return "invalid";
+    case "capability_limited":
+      return "capability limited";
+  }
+}
+
+function reviewBannerCopy(state: ValidationState): string {
+  switch (state) {
+    case "invalid":
+      return "npm token failed validation. Rotate or refresh it in workspace setup before reviewing staged packages.";
+    case "capability_limited":
+      return "npm token validated for auth but is missing staged-publish view/download capability. Update capabilities in workspace setup.";
+    default:
+      return "Validate npm access in workspace setup before reviewing staged packages.";
+  }
+}
+
+function describeValidationStateForCard(
+  state: ValidationState,
+  reasons: ReadonlyArray<string>,
+): string {
+  if (state === "invalid") {
+    if (reasons.includes("registry_auth_failed")) {
+      return "npm rejected the token at /-/whoami. Rotate it or paste a new one above, then save to revalidate.";
+    }
+    if (reasons.includes("staged_list_denied")) {
+      return "npm rejected staged-publish list access. The token needs staged-publish list/view/download capability.";
+    }
+    return "npm validation failed. Rotate or refresh the token above.";
+  }
+  if (state === "capability_limited") {
+    if (reasons.includes("no_stages_to_probe")) {
+      return "Auth and staged-list access look good, but no open staged publishes were available to confirm view + download. Paste a real stage ID below or wait until one is staged.";
+    }
+    const missing: string[] = [];
+    if (reasons.includes("staged_view_denied")) missing.push("view");
+    if (reasons.includes("staged_tarball_denied")) missing.push("download");
+    return missing.length
+      ? `Token is missing staged-publish ${missing.join(" + ")} capability. Grant it on the npm side and revalidate.`
+      : "Token capability check did not complete.";
+  }
+  if (state === "unvalidated") {
+    return "Token saved but not yet validated. Click 'Check npm auth' below to confirm access.";
+  }
+  return "";
+}
+
 function WorkspaceSetupPanel({
   npm,
 }: {
@@ -441,8 +518,8 @@ function WorkspaceSetupPanel({
                 />
               </div>
               <div class="flex flex-wrap items-center justify-end gap-2">
-                <Badge tone={connection ? "ok" : "info"}>
-                  {connection ? connection.validationStatus : "connect npm"}
+                <Badge tone={summaryBadgeTone(npm.validationState.value)}>
+                  {summaryBadgeLabel(npm.validationState.value)}
                 </Badge>
                 <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
                   <span class="group-open:hidden">open settings</span>
@@ -468,12 +545,13 @@ function NpmConnectionCard({
   const connection = npm.connection.value;
   const status = npm.status.value;
   const busy = npm.busy.value;
-  const validated = npm.validated.value;
   const token = npm.token.value;
   const label = npm.label.value;
   const registry = npm.registry.value;
   const validationStageId = npm.validationStageId.value;
   const error = npm.error.value;
+  const state = npm.validationState.value;
+  const reasons = npm.validationReasons.value;
 
   const onSave = async (event: Event) => {
     event.preventDefault();
@@ -491,17 +569,19 @@ function NpmConnectionCard({
           </Muted>
         </div>
         {connection ? (
-          <Badge
-            tone={
-              validated ? "ok" : connection.validationStatus === "invalid" ? "critical" : "info"
-            }
-          >
-            {connection.validationStatus}
-          </Badge>
+          <Badge tone={summaryBadgeTone(state)}>{summaryBadgeLabel(state)}</Badge>
         ) : (
           <Badge tone="info">not connected</Badge>
         )}
       </div>
+
+      {connection && state !== "valid" ? (
+        <Alert
+          tone={state === "invalid" ? "critical" : state === "capability_limited" ? "warn" : "info"}
+        >
+          {describeValidationStateForCard(state, reasons)}
+        </Alert>
+      ) : null}
 
       {connection ? (
         <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-x-6 gap-y-2 border-y border-border py-3">

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -202,6 +202,7 @@ function ReviewRequestCard({
   const hasConnection = npm.isConnected.value;
   const hasValidatedConnection = npm.validated.value;
   const validationState = npm.validationState.value;
+  const validationReasons = npm.validationReasons.value;
 
   return (
     <Card class="p-5 md:p-6 flex flex-col gap-4 border-accent/40">
@@ -229,7 +230,7 @@ function ReviewRequestCard({
       ) : !hasValidatedConnection ? (
         <Alert tone={validationState === "invalid" ? "critical" : "info"}>
           <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <span>{reviewBannerCopy(validationState)}</span>
+            <span>{reviewBannerCopy(validationState, validationReasons)}</span>
             <LinkButton href="#workspace-setup" variant="secondary" size="sm" class="shrink-0">
               Open settings
             </LinkButton>
@@ -451,11 +452,14 @@ function summaryBadgeLabel(state: ValidationState): string {
   }
 }
 
-function reviewBannerCopy(state: ValidationState): string {
+function reviewBannerCopy(state: ValidationState, reasons: ReadonlyArray<string>): string {
   switch (state) {
     case "invalid":
       return "npm token failed validation. Rotate or refresh it in workspace setup before reviewing staged packages.";
     case "capability_limited":
+      if (reasons.includes("no_stages_to_probe")) {
+        return "npm auth and staged-list access passed, but no staged publish was available to confirm package access. Paste a stage ID in workspace setup.";
+      }
       return "npm token validated for auth but is missing staged-publish view/download capability. Update capabilities in workspace setup.";
     default:
       return "Validate npm access in workspace setup before reviewing staged packages.";

--- a/test/npm-connection.test.mjs
+++ b/test/npm-connection.test.mjs
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { normalizeRegistryUrl, validateNpmCredential } from "../server/lib/npm-connection.ts";
+import {
+  normalizeRegistryUrl,
+  publicNpmConnection,
+  validateNpmCredential,
+} from "../server/lib/npm-connection.ts";
 
 const originalFetch = globalThis.fetch;
 
@@ -34,9 +38,44 @@ describe("npm connection validation", () => {
     ).toThrow("registry URL must use https");
   });
 
-  test("checks registry auth and staged list capability without a stage id", async () => {
+  test("auto-probes a representative stage from the list response when no stageId is supplied", async () => {
+    const seen = [];
     const fetchMock = vi.fn(async (url, init) => {
+      seen.push(String(url));
       expect(init.headers.authorization).toBe("Bearer npm_secret_token");
+      if (String(url).endsWith("/-/whoami")) return Response.json({ username: "maintainer" });
+      if (String(url).endsWith("/-/stage?perPage=1"))
+        return Response.json({ items: [{ id: "stage-from-list" }], page: 0, perPage: 1, total: 1 });
+      if (String(url).endsWith("/-/stage/stage-from-list"))
+        return Response.json({ id: "stage-from-list" });
+      if (String(url).endsWith("/-/stage/stage-from-list/tarball"))
+        return new Response("x", { status: 206 });
+      return new Response("unexpected", { status: 500 });
+    });
+    globalThis.fetch = fetchMock;
+
+    const validation = await validateNpmCredential(
+      "https://registry.npmjs.org",
+      "npm_secret_token",
+    );
+
+    expect(validation.ok).toBe(true);
+    expect(validation.status).toBe("valid");
+    expect(validation.reasons).toEqual([]);
+    expect(validation.capabilities).toMatchObject({
+      registryAuth: true,
+      stagedListAccess: true,
+      stagedViewAccess: true,
+      stagedTarballAccess: true,
+      probedStageSource: "list",
+      stageId: "stage-from-list",
+      whoami: "maintainer",
+    });
+    expect(seen).toContain("https://registry.npmjs.org/-/stage/stage-from-list/tarball");
+  });
+
+  test("marks validation capability_limited when the staged list is empty", async () => {
+    const fetchMock = vi.fn(async (url) => {
       if (String(url).endsWith("/-/whoami")) return Response.json({ username: "maintainer" });
       if (String(url).endsWith("/-/stage?perPage=1"))
         return Response.json({ items: [], page: 0, perPage: 1, total: 0 });
@@ -49,13 +88,12 @@ describe("npm connection validation", () => {
       "npm_secret_token",
     );
 
-    expect(validation.ok).toBe(true);
-    expect(validation.status).toBe("valid");
+    expect(validation.ok).toBe(false);
+    expect(validation.status).toBe("capability_limited");
+    expect(validation.reasons).toEqual(["no_stages_to_probe"]);
     expect(validation.capabilities).toMatchObject({
       registryAuth: true,
       stagedListAccess: true,
-      whoami: "maintainer",
-      registryUrl: "https://registry.npmjs.org",
     });
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
@@ -65,9 +103,8 @@ describe("npm connection validation", () => {
     const fetchMock = vi.fn(async (url, init) => {
       seen.push({ url: String(url), headers: init.headers });
       if (String(url).endsWith("/-/whoami")) return Response.json({ username: "maintainer" });
-      if (String(url).endsWith("/-/stage?perPage=1")) return Response.json({ items: [] });
-      if (String(url).endsWith("/-/stage/stage-123/details"))
-        return new Response("unexpected", { status: 500 });
+      if (String(url).endsWith("/-/stage?perPage=1"))
+        return Response.json({ items: [{ id: "list-stage" }] });
       if (String(url).endsWith("/-/stage/stage-123")) return Response.json({ id: "stage-123" });
       if (String(url).endsWith("/-/stage/stage-123/tarball"))
         return new Response("x", { status: 206 });
@@ -82,21 +119,19 @@ describe("npm connection validation", () => {
     );
 
     expect(validation.ok).toBe(true);
+    expect(validation.status).toBe("valid");
     expect(validation.capabilities).toMatchObject({
       registryAuth: true,
       stagedListAccess: true,
       stagedViewAccess: true,
       stagedTarballAccess: true,
+      probedStageSource: "caller",
       stageId: "stage-123",
       stagedTarballStatus: 206,
     });
-    expect(seen.map((entry) => entry.url)).toEqual([
-      "https://registry.npmjs.org/-/whoami",
-      "https://registry.npmjs.org/-/stage?perPage=1",
-      "https://registry.npmjs.org/-/stage/stage-123",
-      "https://registry.npmjs.org/-/stage/stage-123/tarball",
-    ]);
-    expect(seen.at(-1).headers.range).toBe("bytes=0-0");
+    const probedTarball = seen.find((entry) => entry.url.endsWith("/-/stage/stage-123/tarball"));
+    expect(probedTarball?.headers.range).toBe("bytes=0-0");
+    expect(seen.find((entry) => entry.url.endsWith("/-/stage/list-stage"))).toBeUndefined();
   });
 
   test("marks validation invalid when staged list access is denied", async () => {
@@ -114,10 +149,68 @@ describe("npm connection validation", () => {
 
     expect(validation.ok).toBe(false);
     expect(validation.status).toBe("invalid");
+    expect(validation.reasons).toContain("staged_list_denied");
     expect(validation.capabilities).toMatchObject({
       registryAuth: true,
       stagedListAccess: false,
       stagedListStatus: 403,
+    });
+  });
+
+  test("publicNpmConnection never returns token ciphertext or nonce material", () => {
+    const sensitive = {
+      id: "conn_1",
+      organizationId: "org_a",
+      registryUrl: "https://registry.npmjs.org",
+      label: "npm registry",
+      tokenCiphertext: "v1:secret_ciphertext_blob",
+      tokenNonce: "secret_nonce_blob",
+      tokenFingerprint: "fp_abc",
+      tokenLast4: "1234",
+      validationStatus: "valid",
+      capabilitiesJson: { registryAuth: true },
+      validatedAt: new Date(0),
+      lastUsedAt: null,
+      createdByUserId: "user_a",
+      createdAt: new Date(0),
+      updatedAt: new Date(0),
+    };
+
+    const safe = publicNpmConnection(sensitive);
+    expect(safe).not.toBeNull();
+    const serialized = JSON.stringify(safe);
+    expect(serialized).not.toContain("secret_ciphertext_blob");
+    expect(serialized).not.toContain("secret_nonce_blob");
+    expect(safe).not.toHaveProperty("tokenCiphertext");
+    expect(safe).not.toHaveProperty("tokenNonce");
+  });
+
+  test("marks validation capability_limited when the auto-probed tarball is denied", async () => {
+    globalThis.fetch = vi.fn(async (url) => {
+      if (String(url).endsWith("/-/whoami")) return Response.json({ username: "maintainer" });
+      if (String(url).endsWith("/-/stage?perPage=1"))
+        return Response.json({ items: [{ id: "probe-stage" }] });
+      if (String(url).endsWith("/-/stage/probe-stage")) return Response.json({ id: "probe-stage" });
+      if (String(url).endsWith("/-/stage/probe-stage/tarball"))
+        return new Response("denied", { status: 403, statusText: "Forbidden" });
+      return new Response("unexpected", { status: 500 });
+    });
+
+    const validation = await validateNpmCredential(
+      "https://registry.npmjs.org",
+      "npm_secret_token",
+    );
+
+    expect(validation.ok).toBe(false);
+    expect(validation.status).toBe("capability_limited");
+    expect(validation.reasons).toEqual(["staged_tarball_denied"]);
+    expect(validation.capabilities).toMatchObject({
+      registryAuth: true,
+      stagedListAccess: true,
+      stagedViewAccess: true,
+      stagedTarballAccess: false,
+      probedStageSource: "list",
+      stageId: "probe-stage",
     });
   });
 });

--- a/test/scan-job.test.mjs
+++ b/test/scan-job.test.mjs
@@ -180,6 +180,28 @@ describe("executeScanJob idempotency", () => {
     });
   });
 
+  test("fails closed when the stored connection is capability_limited", async () => {
+    dbMock.claimScanForRun.mockResolvedValue(true);
+    dbMock.getNpmConnection.mockResolvedValue({
+      registryUrl: "https://registry.npmjs.org",
+      tokenFingerprint: "fp",
+      validationStatus: "capability_limited",
+    });
+
+    await expect(
+      executeScanJob(env, ctx, message, {}, { attempt: 1, finalAttempt: true }),
+    ).rejects.toThrow("Validate the organization npm token");
+
+    expect(npmConnectionMock.decryptNpmToken).not.toHaveBeenCalled();
+    expect(dbMock.markNpmConnectionUsed).not.toHaveBeenCalled();
+    expect(pipelineMock.runScanPipeline).not.toHaveBeenCalled();
+    expect(dbMock.markScanFailed).toHaveBeenCalledWith({}, message.scanId, message.organizationId, {
+      code: "npm_connection_unvalidated",
+      message: "Validate the organization npm token before scanning staged publishes.",
+      retryable: false,
+    });
+  });
+
   test("records scan.retryable_failed without marking failed when a retryable error fires before exhaustion", async () => {
     dbMock.claimScanForRun.mockResolvedValue(true);
     pipelineMock.runScanPipeline.mockRejectedValue(

--- a/test/workers/npm-connection-audit.test.ts
+++ b/test/workers/npm-connection-audit.test.ts
@@ -1,0 +1,229 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { describe, expect, test, vi } from "vitest";
+import {
+  createDb,
+  ensurePersonalOrganization,
+  updateNpmConnectionValidation,
+} from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { npmConnectionRoutes } from "../../server/routes/npm-connection";
+import type { Bindings, Variables } from "../../server/types";
+
+interface SeededUser {
+  userId: string;
+  organizationId: string;
+}
+
+async function seedUser(): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+function buildTestApp(session: { userId: string }) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.use("*", async (c, next) => {
+    c.set("authSession", { userId: session.userId });
+    await next();
+  });
+  app.route("/api/v1/npm-connection", npmConnectionRoutes);
+  return app;
+}
+
+async function call(
+  app: Hono<{ Bindings: Bindings; Variables: Variables }>,
+  method: string,
+  path: string,
+  body?: unknown,
+) {
+  const ctx = createExecutionContext();
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+    init.headers = { "content-type": "application/json" };
+  }
+  const res = await app.fetch(new Request(`http://test.local${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+async function eventsFor(organizationId: string) {
+  const db = createDb(env.DB);
+  const rows = await db
+    .select()
+    .from(schema.scanEvents)
+    .where(eq(schema.scanEvents.organizationId, organizationId));
+  return rows.map((row) => ({
+    type: row.type,
+    metadata: row.metadataJson as Record<string, unknown> | null,
+  }));
+}
+
+const OWNER_TOKEN_A = "npm_audit_token_AAAAAAAAAAAAAAAA";
+const OWNER_TOKEN_B = "npm_audit_token_BBBBBBBBBBBBBBBB";
+
+describe("npm-connection audit events", () => {
+  test("first save emits npm_connection.created with the new token fingerprint", async () => {
+    const owner = await seedUser();
+
+    await call(buildTestApp(owner), "POST", "/api/v1/npm-connection", {
+      token: OWNER_TOKEN_A,
+      label: "primary",
+    });
+
+    const events = await eventsFor(owner.organizationId);
+    const created = events.find((e) => e.type === "npm_connection.created");
+    expect(created).toBeTruthy();
+    expect(created?.metadata).toMatchObject({ label: "primary" });
+    expect(events.find((e) => e.type === "npm_connection.rotated")).toBeUndefined();
+  });
+
+  test("second save emits npm_connection.rotated with previous fingerprint", async () => {
+    const owner = await seedUser();
+
+    await call(buildTestApp(owner), "POST", "/api/v1/npm-connection", {
+      token: OWNER_TOKEN_A,
+      label: "primary",
+    });
+    await call(buildTestApp(owner), "POST", "/api/v1/npm-connection", {
+      token: OWNER_TOKEN_B,
+      label: "primary",
+    });
+
+    const events = await eventsFor(owner.organizationId);
+    const rotated = events.find((e) => e.type === "npm_connection.rotated");
+    expect(rotated).toBeTruthy();
+    expect(rotated?.metadata).toMatchObject({
+      previousValidationStatus: "unvalidated",
+    });
+    expect(typeof rotated?.metadata?.previousTokenFingerprint).toBe("string");
+  });
+
+  test("changing registryUrl on rotate emits npm_connection.registry_changed", async () => {
+    const owner = await seedUser();
+
+    await call(buildTestApp(owner), "POST", "/api/v1/npm-connection", {
+      token: OWNER_TOKEN_A,
+      label: "primary",
+      registryUrl: "https://registry.npmjs.org",
+    });
+    await call(buildTestApp(owner), "POST", "/api/v1/npm-connection", {
+      token: OWNER_TOKEN_B,
+      label: "primary",
+      registryUrl: "https://custom.registry.example.com",
+    });
+
+    const events = await eventsFor(owner.organizationId);
+    const changed = events.find((e) => e.type === "npm_connection.registry_changed");
+    expect(changed).toBeTruthy();
+    expect(changed?.metadata).toMatchObject({
+      previousRegistryUrl: "https://registry.npmjs.org",
+      registryUrl: "https://custom.registry.example.com",
+    });
+  });
+
+  test("validation failure emits validation_failed with reasons, not validated", async () => {
+    const owner = await seedUser();
+
+    await call(buildTestApp(owner), "POST", "/api/v1/npm-connection", {
+      token: OWNER_TOKEN_A,
+      label: "primary",
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url) => {
+        if (String(url).endsWith("/-/whoami")) return Response.json({ username: "user" });
+        if (String(url).endsWith("/-/stage?perPage=1"))
+          return new Response("denied", { status: 403 });
+        return new Response("unexpected", { status: 500 });
+      }),
+    );
+    try {
+      await call(buildTestApp(owner), "POST", "/api/v1/npm-connection/validate", {});
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    const events = await eventsFor(owner.organizationId);
+    const failure = events.find((e) => e.type === "npm_connection.validation_failed");
+    expect(failure).toBeTruthy();
+    expect(failure?.metadata).toMatchObject({
+      ok: false,
+      status: "invalid",
+    });
+    const reasons = (failure?.metadata?.reasons ?? []) as string[];
+    expect(Array.isArray(reasons)).toBe(true);
+    expect(reasons.includes("staged_list_denied")).toBe(true);
+  });
+
+  test("validation downgrade from valid emits validation_downgraded", async () => {
+    const owner = await seedUser();
+    const db = createDb(env.DB);
+
+    await call(buildTestApp(owner), "POST", "/api/v1/npm-connection", {
+      token: OWNER_TOKEN_A,
+      label: "primary",
+    });
+    await updateNpmConnectionValidation(db, {
+      organizationId: owner.organizationId,
+      validationStatus: "valid",
+      validatedAt: new Date(),
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url) => {
+        if (String(url).endsWith("/-/whoami")) return Response.json({ username: "user" });
+        if (String(url).endsWith("/-/stage?perPage=1"))
+          return new Response("denied", { status: 403 });
+        return new Response("unexpected", { status: 500 });
+      }),
+    );
+    try {
+      await call(buildTestApp(owner), "POST", "/api/v1/npm-connection/validate", {});
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    const events = await eventsFor(owner.organizationId);
+    const downgrade = events.find((e) => e.type === "npm_connection.validation_downgraded");
+    expect(downgrade).toBeTruthy();
+    expect(downgrade?.metadata).toMatchObject({
+      previousStatus: "valid",
+      status: "invalid",
+    });
+  });
+
+  test("audit metadata never contains tokenCiphertext, tokenNonce, or raw token", async () => {
+    const owner = await seedUser();
+
+    await call(buildTestApp(owner), "POST", "/api/v1/npm-connection", {
+      token: OWNER_TOKEN_A,
+      label: "primary",
+    });
+    await call(buildTestApp(owner), "POST", "/api/v1/npm-connection", {
+      token: OWNER_TOKEN_B,
+      label: "primary",
+    });
+
+    const events = await eventsFor(owner.organizationId);
+    const serialized = JSON.stringify(events);
+    expect(serialized).not.toContain("tokenCiphertext");
+    expect(serialized).not.toContain("tokenNonce");
+    expect(serialized).not.toContain(OWNER_TOKEN_A);
+    expect(serialized).not.toContain(OWNER_TOKEN_B);
+  });
+});

--- a/test/workers/npm-connection-audit.test.ts
+++ b/test/workers/npm-connection-audit.test.ts
@@ -207,6 +207,69 @@ describe("npm-connection audit events", () => {
     });
   });
 
+  test("repeated validation failures emit a single npm_connection.suspicious_use event", async () => {
+    const owner = await seedUser();
+
+    await call(buildTestApp(owner), "POST", "/api/v1/npm-connection", {
+      token: OWNER_TOKEN_A,
+      label: "primary",
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url) => {
+        if (String(url).endsWith("/-/whoami")) return Response.json({ username: "user" });
+        if (String(url).endsWith("/-/stage?perPage=1"))
+          return new Response("denied", { status: 403 });
+        return new Response("unexpected", { status: 500 });
+      }),
+    );
+    try {
+      for (let i = 0; i < 4; i += 1) {
+        await call(buildTestApp(owner), "POST", "/api/v1/npm-connection/validate", {});
+      }
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    const events = await eventsFor(owner.organizationId);
+    const failures = events.filter((e) => e.type === "npm_connection.validation_failed");
+    expect(failures).toHaveLength(4);
+    const suspicious = events.filter((e) => e.type === "npm_connection.suspicious_use");
+    expect(suspicious).toHaveLength(1);
+    expect(suspicious[0]?.metadata).toMatchObject({
+      reason: "repeated_validation_failures",
+      failureCount: 3,
+    });
+  });
+
+  test("a single validation failure does not emit suspicious_use", async () => {
+    const owner = await seedUser();
+
+    await call(buildTestApp(owner), "POST", "/api/v1/npm-connection", {
+      token: OWNER_TOKEN_A,
+      label: "primary",
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url) => {
+        if (String(url).endsWith("/-/whoami")) return Response.json({ username: "user" });
+        if (String(url).endsWith("/-/stage?perPage=1"))
+          return new Response("denied", { status: 403 });
+        return new Response("unexpected", { status: 500 });
+      }),
+    );
+    try {
+      await call(buildTestApp(owner), "POST", "/api/v1/npm-connection/validate", {});
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    const events = await eventsFor(owner.organizationId);
+    expect(events.find((e) => e.type === "npm_connection.suspicious_use")).toBeUndefined();
+  });
+
   test("audit metadata never contains tokenCiphertext, tokenNonce, or raw token", async () => {
     const owner = await seedUser();
 

--- a/test/workers/npm-connection-multi-ready.test.ts
+++ b/test/workers/npm-connection-multi-ready.test.ts
@@ -6,6 +6,7 @@ import {
   ensurePersonalOrganization,
   getNpmConnection,
   listNpmConnections,
+  listUserOrganizations,
   upsertNpmConnection,
 } from "../../server/db";
 import * as schema from "../../server/db/schema";
@@ -91,6 +92,33 @@ describe("npm-connection multi-connection schema", () => {
     expect(all).toHaveLength(1);
   });
 
+  test("concurrent first saves settle on a single active connection", async () => {
+    const owner = await seedUser();
+
+    await Promise.all([
+      saveConnection({
+        organizationId: owner.organizationId,
+        userId: owner.userId,
+        token: "npm_multi_token_AAAAAAAAAAAAAA",
+        label: "first",
+      }),
+      saveConnection({
+        organizationId: owner.organizationId,
+        userId: owner.userId,
+        token: "npm_multi_token_BBBBBBBBBBBBBB",
+        label: "second",
+      }),
+    ]);
+
+    const db = createDb(env.DB);
+    const all = await listNpmConnections(db, owner.organizationId);
+    expect(all).toHaveLength(1);
+    expect(all[0]?.isActive).toBe(true);
+
+    const active = await getNpmConnection(db, owner.organizationId);
+    expect(active?.id).toBe(all[0]?.id);
+  });
+
   test("getNpmConnection ignores rows where isActive=false", async () => {
     const owner = await seedUser();
     await saveConnection({
@@ -114,5 +142,10 @@ describe("npm-connection multi-connection schema", () => {
     const all = await listNpmConnections(db, owner.organizationId);
     expect(all).toHaveLength(1);
     expect(all[0]?.isActive).toBe(false);
+
+    const organizations = await listUserOrganizations(db, owner.userId);
+    const listed = organizations.filter((org) => org.id === owner.organizationId);
+    expect(listed).toHaveLength(1);
+    expect(listed[0]?.npmConnectionConfigured).toBe(false);
   });
 });

--- a/test/workers/npm-connection-multi-ready.test.ts
+++ b/test/workers/npm-connection-multi-ready.test.ts
@@ -1,0 +1,118 @@
+import { env } from "cloudflare:test";
+import { eq } from "drizzle-orm";
+import { describe, expect, test } from "vitest";
+import {
+  createDb,
+  ensurePersonalOrganization,
+  getNpmConnection,
+  listNpmConnections,
+  upsertNpmConnection,
+} from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { encryptNpmToken } from "../../server/lib/npm-connection";
+
+async function seedUser() {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+async function saveConnection(input: {
+  organizationId: string;
+  userId: string;
+  token: string;
+  registryUrl?: string;
+  label?: string;
+}) {
+  const db = createDb(env.DB);
+  const encrypted = await encryptNpmToken(env, input.token);
+  await upsertNpmConnection(db, {
+    organizationId: input.organizationId,
+    registryUrl: input.registryUrl ?? "https://registry.npmjs.org",
+    label: input.label ?? "npm registry",
+    createdByUserId: input.userId,
+    ...encrypted,
+  });
+}
+
+describe("npm-connection multi-connection schema", () => {
+  test("first save creates a single active connection", async () => {
+    const owner = await seedUser();
+    await saveConnection({
+      organizationId: owner.organizationId,
+      userId: owner.userId,
+      token: "npm_multi_token_AAAAAAAAAAAAAA",
+    });
+
+    const db = createDb(env.DB);
+    const connections = await listNpmConnections(db, owner.organizationId);
+    expect(connections).toHaveLength(1);
+    expect(connections[0]?.isActive).toBe(true);
+
+    const active = await getNpmConnection(db, owner.organizationId);
+    expect(active?.id).toBe(connections[0]?.id);
+  });
+
+  test("rotate updates the existing active row in place (no stale rows)", async () => {
+    const owner = await seedUser();
+
+    await saveConnection({
+      organizationId: owner.organizationId,
+      userId: owner.userId,
+      token: "npm_multi_token_AAAAAAAAAAAAAA",
+      label: "first",
+    });
+    const db = createDb(env.DB);
+    const beforeRotate = await getNpmConnection(db, owner.organizationId);
+
+    await saveConnection({
+      organizationId: owner.organizationId,
+      userId: owner.userId,
+      token: "npm_multi_token_BBBBBBBBBBBBBB",
+      label: "second",
+    });
+    const afterRotate = await getNpmConnection(db, owner.organizationId);
+
+    expect(afterRotate?.id).toBe(beforeRotate?.id);
+    expect(afterRotate?.label).toBe("second");
+    expect(afterRotate?.tokenFingerprint).not.toBe(beforeRotate?.tokenFingerprint);
+
+    const all = await listNpmConnections(db, owner.organizationId);
+    expect(all).toHaveLength(1);
+  });
+
+  test("getNpmConnection ignores rows where isActive=false", async () => {
+    const owner = await seedUser();
+    await saveConnection({
+      organizationId: owner.organizationId,
+      userId: owner.userId,
+      token: "npm_multi_token_AAAAAAAAAAAAAA",
+    });
+
+    const db = createDb(env.DB);
+    const active = await getNpmConnection(db, owner.organizationId);
+    expect(active).not.toBeNull();
+
+    await db
+      .update(schema.npmConnections)
+      .set({ isActive: false })
+      .where(eq(schema.npmConnections.organizationId, owner.organizationId));
+
+    const after = await getNpmConnection(db, owner.organizationId);
+    expect(after).toBeNull();
+
+    const all = await listNpmConnections(db, owner.organizationId);
+    expect(all).toHaveLength(1);
+    expect(all[0]?.isActive).toBe(false);
+  });
+});

--- a/test/workers/scans-routes.test.ts
+++ b/test/workers/scans-routes.test.ts
@@ -1,0 +1,115 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { describe, expect, test } from "vitest";
+import {
+  createDb,
+  ensurePersonalOrganization,
+  updateNpmConnectionValidation,
+  upsertNpmConnection,
+} from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { encryptNpmToken } from "../../server/lib/npm-connection";
+import { scansRoutes } from "../../server/routes/scans";
+import type { Bindings, Variables } from "../../server/types";
+
+type NpmValidationStatus = "valid" | "invalid" | "capability_limited" | "unvalidated";
+
+async function seedUser() {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+function buildTestApp(session: { userId: string }) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.use("*", async (c, next) => {
+    c.set("authSession", { userId: session.userId });
+    await next();
+  });
+  app.route("/api/v1/scans", scansRoutes);
+  return app;
+}
+
+async function seedNpmConnection(input: {
+  organizationId: string;
+  userId: string;
+  validationStatus: NpmValidationStatus;
+}) {
+  const db = createDb(env.DB);
+  const encrypted = await encryptNpmToken(env, "npm_test_token_0123456789");
+  await upsertNpmConnection(db, {
+    organizationId: input.organizationId,
+    registryUrl: "https://registry.npmjs.org",
+    label: "npm registry",
+    createdByUserId: input.userId,
+    ...encrypted,
+  });
+  await updateNpmConnectionValidation(db, {
+    organizationId: input.organizationId,
+    validationStatus: input.validationStatus,
+    validatedAt: input.validationStatus === "valid" ? new Date() : null,
+  });
+}
+
+async function requestScan(session: { userId: string }) {
+  const app = buildTestApp(session);
+  const ctx = createExecutionContext();
+  const res = await app.fetch(
+    new Request("http://test.local/api/v1/scans", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ stageId: "stage-token-123" }),
+    }),
+    env,
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+describe("scans route credential errors", () => {
+  test("POST /api/v1/scans returns token_missing when no npm connection exists", async () => {
+    const owner = await seedUser();
+
+    const res = await requestScan(owner);
+
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      code: "token_missing",
+    });
+  });
+
+  test.each([
+    ["unvalidated", "token_unvalidated"],
+    ["invalid", "token_invalid"],
+    ["capability_limited", "token_capability_limited"],
+  ] satisfies Array<[NpmValidationStatus, string]>)(
+    "POST /api/v1/scans returns %s credential code",
+    async (validationStatus, code) => {
+      const owner = await seedUser();
+      await seedNpmConnection({
+        organizationId: owner.organizationId,
+        userId: owner.userId,
+        validationStatus,
+      });
+
+      const res = await requestScan(owner);
+
+      expect(res.status).toBe(400);
+      await expect(res.json()).resolves.toMatchObject({
+        code,
+        validationStatus,
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes the multi-connection prep bullet of #46. Stacks on #86.

## Summary

- New \`is_active\` boolean column on \`npm_connections\` (default true) plus a partial unique index \`(organization_id) WHERE is_active = 1\`. The org-unique index is dropped; the database can now hold many rows per org but still enforces at most one active.
- \`upsertNpmConnection\` updates the active row in place (no stale rows accumulate). \`getNpmConnection\`, \`updateNpmConnectionValidation\`, and \`markNpmConnectionUsed\` filter by \`isActive = true\` so a future deactivated row can't be picked up by mistake.
- New \`listNpmConnections(db, orgId)\` returns all rows for the org ordered by \`isActive desc, createdAt desc\` — ready for a multi-connection UI surface.
- Migration generated via \`pnpm db:generate\` (\`drizzle/0008_spotty_fallen_one.sql\`).

## Why not multi-active

The issue explicitly asked to "prepare the model/API for multiple npm connections per org later, even if this issue keeps one active connection." Storage is multi-ready; behaviour stays single-active so the existing UX, validation gate, and audit events keep working unchanged.

## With this PR, #46 is fully addressed

This is the fourth and final PR in the #46 stack:
- #80 — fail closed on capability-limited tokens (ACs #1, #2, #3, #6).
- #82 — lifecycle audit events (ACs #4, #5).
- #86 — suspicious-use threshold.
- This PR — multi-connection schema prep.

## Test plan

- [ ] \`pnpm run verify\` — 108 node tests + 56 worker tests (3 new in \`npm-connection-multi-ready.test.ts\`).
- [ ] First save creates exactly one row, marked active.
- [ ] Rotate updates the existing active row in place — no second row.
- [ ] Manually setting \`is_active = false\` causes \`getNpmConnection\` to return null while \`listNpmConnections\` still finds the row.
- [ ] Existing audit, validate, scan, and discovery tests still pass with the new schema.

## Migration

- [ ] Apply \`drizzle/0008_spotty_fallen_one.sql\` locally (\`pnpm db:migrate:local\`) and to remote D1 (\`pnpm db:migrate:remote\`).