### PR TITLE
Pad right side of compare-against select for chevron

### DIFF
--- a/src/components/VersionPicker.tsx
+++ b/src/components/VersionPicker.tsx
@@ -40,7 +40,7 @@ export function VersionPicker({
         onChange={handleChange}
         disabled={disabled || options.length === 0}
         class={cn(
-          "bg-bg border border-border rounded-md text-[13px] text-ink px-3 py-2 outline-none",
+          "bg-bg border border-border rounded-md text-[13px] text-ink pl-3 pr-8 py-2 outline-none",
           "focus:border-accent focus:shadow-[0_0_0_3px_var(--color-accent-soft)]",
           "disabled:opacity-60 disabled:cursor-not-allowed",
           "font-mono min-w-[200px]",


### PR DESCRIPTION
## Summary
- Swap `px-3` for `pl-3 pr-8` on the `VersionPicker` select so the native chevron has breathing room instead of crowding the option text.

## Test plan
- [ ] Open a scan detail and confirm the compare-against dropdown chevron no longer overlaps the selected version label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)