### PR TITLE
Drop redundant release badge and batch version writes

### DIFF
--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -1,4 +1,4 @@
-import { computed, createModel, effect, signal } from "@preact/signals";
+import { batch, computed, createModel, effect, signal } from "@preact/signals";
 import type {
   FileRecord,
   FindingDiffAnnotation,
@@ -395,10 +395,12 @@ export const ScanDetailModel = createModel((id: string) => {
       this.compareError.value = null;
       try {
         const data = await getScanVersions(id);
-        this.versions.value = data;
-        if (this.selectedVersion.peek() === null) {
-          this.selectedVersion.value = data.defaultPreviousVersion ?? null;
-        }
+        batch(() => {
+          this.versions.value = data;
+          if (this.selectedVersion.peek() === null) {
+            this.selectedVersion.value = data.defaultPreviousVersion ?? null;
+          }
+        });
       } catch (err) {
         this.compareError.value = err instanceof Error ? err.message : String(err);
       }

--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -414,7 +414,6 @@ function ReleaseRecommendation({
       <SectionLabel>Recommendation</SectionLabel>
       <div class="flex flex-wrap items-center gap-2">
         <Badge tone={recommendation.tone}>{recommendation.label}</Badge>
-        <Badge tone={severityTone(releaseRisk)}>release {releaseRisk}</Badge>
         {artifactRisk !== releaseRisk ? (
           <Badge tone="neutral">artifact {artifactRisk}</Badge>
         ) : null}


### PR DESCRIPTION
Removes the duplicate `release {risk}` badge from the Recommendation row since the same badge already renders next to the page title. Also wraps the two signal writes in `ScanDetailModel.loadVersions()` (`versions.value` + `selectedVersion.value`) in `batch()` so subscribers no longer see the transient state where `isDefaultComparison` is briefly `false`, which was making the recommendation flicker between its computed and persisted risk summary on load.

## Test plan
- [ ] Open a completed scan detail page; the Recommendation row no longer contains a second `release …` badge — the only one is in the header beside the title.
- [ ] Reload a scan detail page and watch the Recommendation row — label/tone is stable from first paint, no flicker as version metadata loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)