### PR TITLE
Hold persisted risk summary until compare data lands

### DIFF
--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -300,9 +300,15 @@ export const ScanDetailModel = createModel((id: string) => {
 
   const status = computed(() => detail.value?.scan.status ?? null);
   const isPolling = computed(() => status.value === "pending" || status.value === "running");
-  const isDefaultComparison = computed(
-    () => selectedVersion.value === (versions.value?.defaultPreviousVersion ?? null),
-  );
+  const isDefaultComparison = computed(() => {
+    const selected = selectedVersion.value;
+    const v = versions.value;
+    // Until versions metadata arrives we can't tell what the default is.
+    // Treat the current selection as default so the persisted risk summary
+    // stays in view instead of flickering to computed-from-empty-compare values.
+    if (!v) return true;
+    return selected === (v.defaultPreviousVersion ?? null);
+  });
   const compare = computed(() => {
     const cache = compareCache.value;
     const v = selectedVersion.value;

--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -267,21 +267,25 @@ export default function ScanDetailPage() {
               aiFindings={ai.value?.findings ?? []}
               diffCount={diffEntries.value.filter((entry) => entry.status !== "unchanged").length}
               findingsWithDiffStatus={findingsWithDiffStatus.value}
-              usePersistedRiskSummary={model.isDefaultComparison.value}
+              usePersistedRiskSummary={model.isDefaultComparison.value || !compare}
             />
 
             <ScanTimeline events={detail.events ?? []} />
 
-            {versions ? (
+            {detail.scan.packageName ? (
               <div class="flex flex-col gap-2 border-t border-border pt-3">
-                <VersionPicker
-                  options={versions.versions}
-                  selected={selectedVersion}
-                  defaultVersion={versions.defaultPreviousVersion}
-                  stagedVersion={versions.stagedVersion}
-                  onChange={(value) => model.selectVersion(value)}
-                  disabled={compareLoading}
-                />
+                {versions ? (
+                  <VersionPicker
+                    options={versions.versions}
+                    selected={selectedVersion}
+                    defaultVersion={versions.defaultPreviousVersion}
+                    stagedVersion={versions.stagedVersion}
+                    onChange={(value) => model.selectVersion(value)}
+                    disabled={compareLoading}
+                  />
+                ) : (
+                  <VersionPickerSkeleton stagedVersion={detail.scan.stagedVersion ?? null} />
+                )}
                 {compareLoading ? (
                   <LoadingLine size="inline">Fetching {selectedVersion} via sandbox</LoadingLine>
                 ) : null}
@@ -721,6 +725,20 @@ function ScanDetailHeader({
         </div>
       ) : null}
     </header>
+  );
+}
+
+function VersionPickerSkeleton({ stagedVersion }: { stagedVersion: string | null }) {
+  return (
+    <div class="flex flex-wrap items-center gap-3" aria-busy="true">
+      <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">
+        Compare against
+      </span>
+      <div class="flex items-center bg-bg border border-border rounded-md text-[13px] text-ink-muted pl-3 pr-8 py-2 font-mono min-w-[200px] opacity-60">
+        loading versions<span class="ml-0.5 motion-safe:animate-pulse">…</span>
+      </div>
+      <span class="font-mono text-[11px] text-ink-muted">→ staged {stagedVersion || "—"}</span>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

- On revisit, the scan detail URL rehydrates `?version=…` before `versions` loads, so `isDefaultComparison` momentarily reads `false`, causing the recommendation to fall back to computed-from-empty-compare values (e.g. a flashing "artifact high" neutral badge) until compare finishes.
- Default `isDefaultComparison` to `true` while `versions` is still null, and also hold the persisted summary while `compare` is unresolved, so the recommendation never flickers through stale computed values.
- Reserve space for the compare-against picker by rendering a small skeleton row while versions load, so the section no longer pops in below the recommendation.

## Test plan

- [ ] Open a scan via a URL that contains `?version=<default>` and confirm the recommendation badges no longer flash through "artifact high" before compare lands.
- [ ] Hard-refresh a scan and confirm the compare-against row is in place from first paint, transitioning the skeleton into the real `<select>` without layout shift.
- [ ] Switch to a non-default version and confirm the persisted summary stays put until the sandbox fetch returns, then the recommendation updates to the compared values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)