### PR TITLE
[codex] Add local E2E harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   check:
-    name: lint · format · typecheck · test
+    name: lint · format · typecheck · test · e2e
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,3 +39,20 @@ jobs:
 
       - name: Test
         run: pnpm run test
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: E2E test
+        run: E2E_APP_PORT=5200 E2E_REGISTRY_PORT=5201 pnpm run test:e2e
+
+      - name: Upload E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-artifacts
+          path: |
+            .context/e2e-artifacts
+            .context/e2e-registry/requests.jsonl
+          if-no-files-found: ignore
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository is moving from prototype to real product. The current implementa
 - **Safe artifact defaults.** Do not retain raw tarballs by default in SaaS. Persist redacted summaries, manifests, diffs, findings, and report metadata. Raw artifact retention may become an explicit short-TTL organization setting later.
 - **Signed reports later.** Prepare report data to be canonical and signable, but do not launch public signed report generation yet.
 
-See [`docs/architecture.md`](docs/architecture.md), [`docs/security-model.md`](docs/security-model.md), [`docs/security-detection-corpus.md`](docs/security-detection-corpus.md), [`docs/production-roadmap.md`](docs/production-roadmap.md), [`docs/cost-model.md`](docs/cost-model.md), and [`docs/test-package.md`](docs/test-package.md) for the production plan, detection corpus notes, budget napkin math, and staged-publish test package.
+See [`docs/architecture.md`](docs/architecture.md), [`docs/security-model.md`](docs/security-model.md), [`docs/security-detection-corpus.md`](docs/security-detection-corpus.md), [`docs/production-roadmap.md`](docs/production-roadmap.md), [`docs/cost-model.md`](docs/cost-model.md), [`docs/test-package.md`](docs/test-package.md), and [`docs/e2e-test-environment.md`](docs/e2e-test-environment.md) for the production plan, detection corpus notes, budget napkin math, staged-publish test package, and local E2E harness.
 
 ## Current capabilities
 
@@ -73,9 +73,12 @@ cp .dev.vars.example .dev.vars
 # edit .dev.vars with local secrets
 pnpm test         # Vitest logic suite
 pnpm dev          # vite + cloudflare plugin, http://localhost:5173
+pnpm test:e2e     # Playwright + local fake npm staging registry
 ```
 
 The Vite dev server runs the Worker locally and serves the UI at the same origin, so authenticated `fetch("/api/v1/scan")` works without CORS.
+
+For deterministic browser testing without real npm staged publishes, use the local E2E harness in [`docs/e2e-test-environment.md`](docs/e2e-test-environment.md). It packs fixture packages, runs a fake npm staging registry, starts the Worker locally, and writes inspectable screenshots/traces/journals under `.context/`.
 
 ## Configuration and secrets
 

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "setup": "pnpm install",
+    "run": "pnpm e2e:dev"
+  },
+  "runScriptMode": "concurrent"
+}

--- a/docs/e2e-test-environment.md
+++ b/docs/e2e-test-environment.md
@@ -39,6 +39,16 @@ E2E_APP_PORT=5200 E2E_REGISTRY_PORT=5201 pnpm run test:e2e
 
 Playwright artifacts are written under `.context/e2e-artifacts/`, including traces on failure and `implicit-node-gyp-report.png` on a successful smoke run.
 
+## CI
+
+The GitHub Actions CI workflow runs `pnpm run test:e2e` after lint, format check, typecheck, and Vitest. CI installs Chromium with:
+
+```sh
+pnpm exec playwright install --with-deps chromium
+```
+
+The workflow uploads `.context/e2e-artifacts/` and `.context/e2e-registry/requests.jsonl` as `e2e-artifacts` for every run, so failed browser tests keep traces, screenshots, videos, and the fake-registry request journal.
+
 ## Conductor
 
 `conductor.json` is checked in:

--- a/docs/e2e-test-environment.md
+++ b/docs/e2e-test-environment.md
@@ -33,6 +33,8 @@ E2E_APP_PORT=5200 E2E_REGISTRY_PORT=5201 pnpm run test:e2e
 
 Playwright artifacts are written under `.context/e2e-artifacts/`, including traces on failure and `implicit-node-gyp-report.png` on a successful smoke run.
 
+Vite ignores `.context/**` in its file watcher. The E2E runner writes registry state, Worker state, traces, screenshots, and reports there while the app is open; watching those files can cause hot-reload loops that interrupt browser interactions in CI.
+
 ## CI
 
 The GitHub Actions CI workflow runs `pnpm run test:e2e` after lint, format check, typecheck, and Vitest. CI installs Chromium with:

--- a/docs/e2e-test-environment.md
+++ b/docs/e2e-test-environment.md
@@ -8,7 +8,7 @@ The normal end-to-end loop is local and deterministic. It uses fixture packages 
 - `test/e2e/build-fixtures.mjs` runs `npm pack --json` for the previous and staged package directories and writes generated registry state to `.context/e2e-registry/`.
 - `test/e2e/fake-registry.mjs` serves only the staged-publish, packument, and tarball endpoints the app uses.
 - `test/e2e/dev-server.mjs` starts the fake registry and the Vite/Cloudflare Worker dev server together, after applying D1 migrations to an isolated `.context/e2e/state` persistence path that is reset on each run.
-- `test/e2e/local-registry.spec.ts` is the browser smoke. It signs up, stores a fake npm token, validates it, submits the implicit node-gyp fixture through the UI, then scans every other fixture through the local Worker API and asserts each `scenario.json` expected outcome.
+- `test/e2e/local-registry.spec.ts` creates one authenticated browser state, runs the implicit node-gyp fixture through the UI, then runs each remaining fixture as its own Playwright test through the local Worker API. Each scenario asserts its `scenario.json` expected outcome independently, so CI points at the exact fixture that regressed.
 
 The fake registry writes `.context/e2e-registry/requests.jsonl`. The browser test checks this journal so we can verify authorization headers only appear on expected npm-like endpoints.
 

--- a/docs/e2e-test-environment.md
+++ b/docs/e2e-test-environment.md
@@ -1,0 +1,81 @@
+# Local E2E test environment
+
+The normal end-to-end loop is local and deterministic. It uses fixture packages plus a tiny fake npm staging registry, so agents and developers can exercise the product without publishing to npm. Keep `packages/experiments` and real npm staged publishes as a final canary for npm endpoint drift, not as the everyday test path.
+
+## What Runs
+
+- `test/e2e-fixtures/scenarios/*` stores package scenarios. Each scenario has a `previous/` package, a `staged/` package, and `scenario.json` metadata.
+- `test/e2e/build-fixtures.mjs` runs `npm pack --json` for the previous and staged package directories and writes generated registry state to `.context/e2e-registry/`.
+- `test/e2e/fake-registry.mjs` serves only the npm endpoints the app uses:
+  - `GET /-/whoami`
+  - `GET /-/stage?perPage=...`
+  - `GET /-/stage/:stageId`
+  - `GET /-/stage/:stageId/tarball`
+  - `GET /:packageName`
+  - `GET /:packageName/-/:tarballName.tgz`
+- `test/e2e/dev-server.mjs` starts the fake registry and the Vite/Cloudflare Worker dev server together, after applying D1 migrations to the same local persistence path Vite uses.
+- `test/e2e/local-registry.spec.ts` is the browser smoke. It signs up, stores a fake npm token, validates it, submits a staged fixture ID, waits for the report, and asserts the implicit node-gyp finding.
+
+The fake registry writes `.context/e2e-registry/requests.jsonl`. The browser test checks this journal so we can verify authorization headers only appear on expected npm-like endpoints.
+
+## Commands
+
+```sh
+pnpm run e2e:fixtures
+pnpm run e2e:dev
+pnpm run test:e2e
+```
+
+`pnpm run e2e:dev` prints the app URL, fake registry URL, request journal, and artifact directory. By default it uses:
+
+- app: `http://127.0.0.1:5173`
+- fake registry: `http://127.0.0.1:5174`
+
+Override ports when needed:
+
+```sh
+E2E_APP_PORT=5200 E2E_REGISTRY_PORT=5201 pnpm run test:e2e
+```
+
+Playwright artifacts are written under `.context/e2e-artifacts/`, including traces on failure and `implicit-node-gyp-report.png` on a successful smoke run.
+
+## Conductor
+
+`conductor.json` is checked in:
+
+```json
+{
+  "scripts": {
+    "setup": "pnpm install",
+    "run": "pnpm e2e:dev"
+  },
+  "runScriptMode": "concurrent"
+}
+```
+
+Conductor sets `CONDUCTOR_PORT`; the E2E runner uses that as the app port and `CONDUCTOR_PORT + 1` as the fake registry port. That lets multiple workspaces run the harness concurrently.
+
+## Local HTTP Registry Guard
+
+Production registry URLs still require HTTPS. The E2E runner generates a Wrangler config with `ALLOW_INSECURE_LOCAL_REGISTRY=true`, which permits only loopback HTTP registries (`localhost`, `127.0.0.1`, `::1`). Non-local HTTP registries are still rejected.
+
+This flag exists for local testability only. Do not set it in production Wrangler config.
+
+## Current Scenarios
+
+- `benign-diff` exercises a harmless changed `index.js` release and expects low release risk.
+- `implicit-node-gyp` adds a root `binding.gyp` in the staged package and expects `install-script.implicit-node-gyp` with high release risk.
+
+Good next scenarios:
+
+- added lifecycle script;
+- secret-looking file added;
+- unparseable `package.json`;
+- staged metadata mismatch;
+- tag-aware beta baseline;
+- no previous published version;
+- registry failure/retry path.
+
+## Notes
+
+The fake registry is intentionally not a general-purpose npm registry. It only mirrors the staged-publish and packument surface this app consumes. Package code is never executed; fixture packages are packed as tarballs and treated as hostile evidence by the same Dynamic Worker sandbox path as production scans.

--- a/docs/e2e-test-environment.md
+++ b/docs/e2e-test-environment.md
@@ -4,17 +4,11 @@ The normal end-to-end loop is local and deterministic. It uses fixture packages 
 
 ## What Runs
 
-- `test/e2e-fixtures/scenarios/*` stores package scenarios. Each scenario has a `previous/` package, a `staged/` package, and `scenario.json` metadata.
+- `test/e2e-fixtures/scenarios/*` stores package scenarios. Each scenario has a `staged/` package, optional `previous/` package, and `scenario.json` expected outcome.
 - `test/e2e/build-fixtures.mjs` runs `npm pack --json` for the previous and staged package directories and writes generated registry state to `.context/e2e-registry/`.
-- `test/e2e/fake-registry.mjs` serves only the npm endpoints the app uses:
-  - `GET /-/whoami`
-  - `GET /-/stage?perPage=...`
-  - `GET /-/stage/:stageId`
-  - `GET /-/stage/:stageId/tarball`
-  - `GET /:packageName`
-  - `GET /:packageName/-/:tarballName.tgz`
+- `test/e2e/fake-registry.mjs` serves only the staged-publish, packument, and tarball endpoints the app uses.
 - `test/e2e/dev-server.mjs` starts the fake registry and the Vite/Cloudflare Worker dev server together, after applying D1 migrations to the same local persistence path Vite uses.
-- `test/e2e/local-registry.spec.ts` is the browser smoke. It signs up, stores a fake npm token, validates it, submits a staged fixture ID, waits for the report, and asserts the implicit node-gyp finding.
+- `test/e2e/local-registry.spec.ts` is the browser smoke. It signs up, stores a fake npm token, validates it, submits the implicit node-gyp fixture through the UI, then scans every other fixture through the local Worker API and asserts each `scenario.json` expected outcome.
 
 The fake registry writes `.context/e2e-registry/requests.jsonl`. The browser test checks this journal so we can verify authorization headers only appear on expected npm-like endpoints.
 
@@ -71,20 +65,9 @@ Production registry URLs still require HTTPS. The E2E runner generates a Wrangle
 
 This flag exists for local testability only. Do not set it in production Wrangler config.
 
-## Current Scenarios
+## Scenario Contract
 
-- `benign-diff` exercises a harmless changed `index.js` release and expects low release risk.
-- `implicit-node-gyp` adds a root `binding.gyp` in the staged package and expects `install-script.implicit-node-gyp` with high release risk.
-
-Good next scenarios:
-
-- added lifecycle script;
-- secret-looking file added;
-- unparseable `package.json`;
-- staged metadata mismatch;
-- tag-aware beta baseline;
-- no previous published version;
-- registry failure/retry path.
+The scenario matrix is executable instead of duplicated in docs. Add a directory under `test/e2e-fixtures/scenarios/`, define the package inputs, and put the expected risk, rule IDs, baseline, or failure response in `scenario.json`. The Playwright smoke reads the generated `.context/e2e-registry/registry.json` and asserts those expectations automatically.
 
 ## Notes
 

--- a/docs/e2e-test-environment.md
+++ b/docs/e2e-test-environment.md
@@ -7,7 +7,7 @@ The normal end-to-end loop is local and deterministic. It uses fixture packages 
 - `test/e2e-fixtures/scenarios/*` stores package scenarios. Each scenario has a `staged/` package, optional `previous/` package, and `scenario.json` expected outcome.
 - `test/e2e/build-fixtures.mjs` runs `npm pack --json` for the previous and staged package directories and writes generated registry state to `.context/e2e-registry/`.
 - `test/e2e/fake-registry.mjs` serves only the staged-publish, packument, and tarball endpoints the app uses.
-- `test/e2e/dev-server.mjs` starts the fake registry and the Vite/Cloudflare Worker dev server together, after applying D1 migrations to the same local persistence path Vite uses.
+- `test/e2e/dev-server.mjs` starts the fake registry and the Vite/Cloudflare Worker dev server together, after applying D1 migrations to an isolated `.context/e2e/state` persistence path that is reset on each run.
 - `test/e2e/local-registry.spec.ts` is the browser smoke. It signs up, stores a fake npm token, validates it, submits the implicit node-gyp fixture through the UI, then scans every other fixture through the local Worker API and asserts each `scenario.json` expected outcome.
 
 The fake registry writes `.context/e2e-registry/requests.jsonl`. The browser test checks this journal so we can verify authorization headers only appear on expected npm-like endpoints.
@@ -20,7 +20,7 @@ pnpm run e2e:dev
 pnpm run test:e2e
 ```
 
-`pnpm run e2e:dev` prints the app URL, fake registry URL, request journal, and artifact directory. By default it uses:
+`pnpm run e2e:dev` prints the app URL, fake registry URL, request journal, artifact directory, and Worker state directory. By default it uses:
 
 - app: `http://127.0.0.1:5173`
 - fake registry: `http://127.0.0.1:5174`

--- a/docs/test-package.md
+++ b/docs/test-package.md
@@ -2,6 +2,8 @@
 
 This repository includes `packages/experiments`, a tiny publishable npm package named `@pracht/experiments` for end-to-end testing against real npm staged publishes.
 
+For the normal local E2E loop, use the fake-registry harness in [`e2e-test-environment.md`](./e2e-test-environment.md). The real npm package below is only the final canary for npm staged-publish endpoint drift and credential behavior.
+
 ## Why it exists
 
 The application needs real package artifacts to verify the full review flow:

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -17,6 +17,9 @@
 | `pnpm run test`         | Node logic tests (`test/**`) plus D1-backed worker tests (`test/workers/**`) via `vitest-pool-workers`. |
 | `pnpm run test:node`    | Just the node logic suite.                                                                              |
 | `pnpm run test:workers` | Just the worker suite (Miniflare D1 from `wrangler.test.jsonc` + `drizzle/`).                           |
+| `pnpm run e2e:fixtures` | Pack local E2E fixture packages and generate `.context/e2e-registry/registry.json`.                     |
+| `pnpm run e2e:dev`      | Start the fake npm staging registry plus the Vite/Worker dev server for browser testing.                |
+| `pnpm run test:e2e`     | Run Playwright against the local fake-registry harness.                                                 |
 | `pnpm run verify`       | Run lint + format check + typecheck + tests, in order.                                                  |
 
 `pnpm lint` (the shorthand without `run`) can collide with workspace forwarding or shell wrappers — always use `pnpm run lint`.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -26,7 +26,7 @@
 
 ## Pre-commit hook
 
-`pnpm install` runs a `prepare` script that points `git config core.hooksPath` at `.githooks/`. The `.githooks/pre-commit` script then runs `pnpm run verify`, so every commit on this repo must pass lint + format + typecheck + tests. CI (`.github/workflows/ci.yml`) runs the same `verify` pipeline.
+`pnpm install` runs a `prepare` script that points `git config core.hooksPath` at `.githooks/`. The `.githooks/pre-commit` script then runs `pnpm run verify`, so every commit on this repo must pass lint + format + typecheck + tests. CI (`.github/workflows/ci.yml`) runs the same core checks and then installs Chromium and runs `pnpm run test:e2e`.
 
 If a commit must skip the hook, pass `git commit --no-verify` — only do that when the gate is broken for reasons unrelated to your change.
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "test": "vitest run --config vitest.config.ts && vitest run --config vitest.workers.config.ts",
     "test:node": "vitest run --config vitest.config.ts",
     "test:workers": "vitest run --config vitest.workers.config.ts",
+    "e2e:fixtures": "node test/e2e/build-fixtures.mjs",
+    "e2e:registry": "node test/e2e/fake-registry.mjs",
+    "e2e:dev": "node test/e2e/dev-server.mjs",
+    "test:e2e": "playwright test",
     "verify": "pnpm run lint && pnpm run format:check && pnpm run typecheck && pnpm run test",
     "prepare": "git config core.hooksPath .githooks"
   },
@@ -35,6 +39,7 @@
     "@cloudflare/vite-plugin": "^1.33.2",
     "@cloudflare/vitest-pool-workers": "^0.16.7",
     "@cloudflare/workers-types": "^4.20260520.0",
+    "@playwright/test": "^1.60.0",
     "@preact/eslint-plugin-signals": "^0.2.0",
     "@preact/preset-vite": "^2.10.5",
     "@tailwindcss/vite": "^4.3.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const appPort = Number(process.env.E2E_APP_PORT || process.env.CONDUCTOR_PORT || 5173);
+const baseURL = process.env.E2E_APP_URL || `http://127.0.0.1:${appPort}`;
+
+export default defineConfig({
+  testDir: "./test/e2e",
+  timeout: 90_000,
+  expect: {
+    timeout: 20_000,
+  },
+  outputDir: ".context/e2e-artifacts/test-results",
+  reporter: [
+    ["list"],
+    ["html", { outputFolder: ".context/e2e-artifacts/playwright-report", open: "never" }],
+  ],
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "pnpm e2e:dev",
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20260520.0
         version: 4.20260520.1
+      '@playwright/test':
+        specifier: ^1.60.0
+        version: 1.60.0
       '@preact/eslint-plugin-signals':
         specifier: ^0.2.0
         version: 0.2.0
@@ -1372,6 +1375,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
 
@@ -1985,6 +1993,11 @@ packages:
       picomatch:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2185,6 +2198,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -3277,6 +3300,10 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.66.0':
     optional: true
 
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
@@ -3787,6 +3814,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -3961,6 +3991,14 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.15:
     dependencies:

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -145,21 +145,23 @@ export async function enforceRateLimit(db: AppDb, input: RateLimitInput) {
   const expiresAt = new Date((bucket + 1) * input.windowMs);
   const now = new Date(nowMs);
 
-  await db
-    .insert(rateLimits)
-    .values({
+  const [existing] = await db.select().from(rateLimits).where(eq(rateLimits.key, key)).limit(1);
+  if (existing) {
+    await db
+      .update(rateLimits)
+      .set({
+        count: sql`${rateLimits.count} + 1`,
+        updatedAt: now,
+      })
+      .where(eq(rateLimits.key, key));
+  } else {
+    await db.insert(rateLimits).values({
       key,
       count: 1,
       expiresAt,
       updatedAt: now,
-    })
-    .onConflictDoUpdate({
-      target: rateLimits.key,
-      set: {
-        count: sql`${rateLimits.count} + 1`,
-        updatedAt: now,
-      },
     });
+  }
 
   const [entry] = await db.select().from(rateLimits).where(eq(rateLimits.key, key)).limit(1);
   if (Math.random() < 0.01) {

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -145,23 +145,21 @@ export async function enforceRateLimit(db: AppDb, input: RateLimitInput) {
   const expiresAt = new Date((bucket + 1) * input.windowMs);
   const now = new Date(nowMs);
 
-  const [existing] = await db.select().from(rateLimits).where(eq(rateLimits.key, key)).limit(1);
-  if (existing) {
-    await db
-      .update(rateLimits)
-      .set({
-        count: sql`${rateLimits.count} + 1`,
-        updatedAt: now,
-      })
-      .where(eq(rateLimits.key, key));
-  } else {
-    await db.insert(rateLimits).values({
+  await db
+    .insert(rateLimits)
+    .values({
       key,
       count: 1,
       expiresAt,
       updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: rateLimits.key,
+      set: {
+        count: sql`${rateLimits.count} + 1`,
+        updatedAt: now,
+      },
     });
-  }
 
   const [entry] = await db.select().from(rateLimits).where(eq(rateLimits.key, key)).limit(1);
   if (Math.random() < 0.01) {

--- a/server/env.d.ts
+++ b/server/env.d.ts
@@ -8,6 +8,7 @@ declare global {
       COMPARE_CACHE?: KVNamespace;
       SCAN_QUEUE?: Queue<import("./lib/scan-job").ScanQueueMessage>;
       NPM_REGISTRY: string;
+      ALLOW_INSECURE_LOCAL_REGISTRY?: string;
       NPM_CONNECTIONS_ENCRYPTION_KEY?: string;
       BETTER_AUTH_SECRET: string;
       BETTER_AUTH_URL?: string;

--- a/server/lib/npm-connection.ts
+++ b/server/lib/npm-connection.ts
@@ -3,6 +3,10 @@ import { getNpmConnection, markNpmConnectionUsed } from "../db";
 
 const DEFAULT_REGISTRY = "https://registry.npmjs.org";
 
+export interface NormalizeRegistryUrlOptions {
+  allowInsecureLocalhost?: boolean;
+}
+
 export interface EncryptedToken {
   tokenCiphertext: string;
   tokenNonce: string;
@@ -48,10 +52,41 @@ export interface NpmCredentialValidation {
   };
 }
 
-export function normalizeRegistryUrl(value: unknown): string {
+export function allowInsecureLocalRegistry(
+  env: Pick<Cloudflare.Env, "ALLOW_INSECURE_LOCAL_REGISTRY">,
+): boolean {
+  return env.ALLOW_INSECURE_LOCAL_REGISTRY === "true";
+}
+
+export function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[(.*)\]$/, "$1");
+  return (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1" ||
+    normalized === "0:0:0:0:0:0:0:1"
+  );
+}
+
+export function registryProtocolAllowed(
+  url: URL,
+  options: NormalizeRegistryUrlOptions = {},
+): boolean {
+  return (
+    url.protocol === "https:" ||
+    (options.allowInsecureLocalhost === true &&
+      url.protocol === "http:" &&
+      isLoopbackHostname(url.hostname))
+  );
+}
+
+export function normalizeRegistryUrl(
+  value: unknown,
+  options: NormalizeRegistryUrlOptions = {},
+): string {
   const raw = typeof value === "string" && value.trim() ? value.trim() : DEFAULT_REGISTRY;
   const url = new URL(raw);
-  if (url.protocol !== "https:") throw new Error("registry URL must use https");
+  if (!registryProtocolAllowed(url, options)) throw new Error("registry URL must use https");
   url.pathname = url.pathname.replace(/\/+$/, "");
   url.search = "";
   url.hash = "";
@@ -135,9 +170,11 @@ export async function getOrganizationNpmToken(
 export async function validateNpmCredential(
   registryUrl: string,
   token: string,
-  options: { stageId?: string } = {},
+  options: { stageId?: string; allowInsecureLocalhost?: boolean } = {},
 ): Promise<NpmCredentialValidation> {
-  const registry = normalizeRegistryUrl(registryUrl);
+  const registry = normalizeRegistryUrl(registryUrl, {
+    allowInsecureLocalhost: options.allowInsecureLocalhost,
+  });
   const [auth, stagedList, stagedView, stagedTarball] = await Promise.all([
     validateRegistryAuth(registry, token),
     validateStagedListAccess(registry, token),

--- a/server/lib/sandbox.ts
+++ b/server/lib/sandbox.ts
@@ -1,4 +1,5 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
+import { allowInsecureLocalRegistry, registryProtocolAllowed } from "./npm-connection";
 import type { FileRecord, PackageJsonSummary } from "./review";
 import * as tarParser from "./tar-parser.js";
 
@@ -120,7 +121,12 @@ export async function downloadInSandbox(
     try {
       const tarball = new URL(options.tarballUrl);
       const registryOrigin = new URL(registry).origin;
-      if (tarball.origin !== registryOrigin || tarball.protocol !== "https:") {
+      if (
+        tarball.origin !== registryOrigin ||
+        !registryProtocolAllowed(tarball, {
+          allowInsecureLocalhost: allowInsecureLocalRegistry(env),
+        })
+      ) {
         throw new SandboxError(
           JSON.stringify({ error: "tarball URL is not allowed by the gateway", status: 400 }),
         );

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -22,6 +22,7 @@ import {
 import { computeScanRiskBreakdown } from "./risk";
 import { downloadInSandbox, type DownloadResult } from "./sandbox";
 import { fetchStagedPublishDetails, type StagedPublishDetails } from "./staged-publishes";
+import { allowInsecureLocalRegistry } from "./npm-connection";
 import type { ScanInput, ScanResult } from "../types";
 
 export interface ScanPipelineOptions extends ScanInput {
@@ -398,7 +399,9 @@ async function maybeFetchStagedDetails(
 ): Promise<StagedPublishDetails | null> {
   if (!input.npmToken) return null;
   const registry = input.npmRegistry || env.NPM_REGISTRY || "https://registry.npmjs.org";
-  return fetchStagedPublishDetails(registry, input.npmToken, input.stageId).catch(() => null);
+  return fetchStagedPublishDetails(registry, input.npmToken, input.stageId, {
+    allowInsecureLocalhost: allowInsecureLocalRegistry(env),
+  }).catch(() => null);
 }
 
 function emptyBaseline(tag: string | null, reason: string): BaselineVersionSelection {

--- a/server/lib/staged-publishes.ts
+++ b/server/lib/staged-publishes.ts
@@ -1,4 +1,4 @@
-import { normalizeRegistryUrl } from "./npm-connection";
+import { normalizeRegistryUrl, type NormalizeRegistryUrlOptions } from "./npm-connection";
 import { normalizeStringRecord } from "./tar-parser.js";
 import type { PackageJsonSummary } from "./review";
 
@@ -47,7 +47,7 @@ export interface StagedPublishesScanResponse {
 const MAX_PER_PAGE = 100;
 const STAGE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{5,160}$/;
 
-export interface ListStagedPublishesOptions {
+export interface ListStagedPublishesOptions extends NormalizeRegistryUrlOptions {
   perPage?: number;
   packageName?: string;
 }
@@ -57,7 +57,7 @@ export async function listStagedPublishes(
   token: string,
   options: ListStagedPublishesOptions = {},
 ): Promise<StagedPublishesPage> {
-  const registry = normalizeRegistryUrl(registryUrl);
+  const registry = normalizeRegistryUrl(registryUrl, options);
   const perPage = Math.min(Math.max(options.perPage ?? 25, 1), MAX_PER_PAGE);
   const params = new URLSearchParams({ perPage: String(perPage) });
   if (options.packageName) params.set("package", options.packageName);
@@ -76,9 +76,10 @@ export async function fetchStagedPublishDetails(
   registryUrl: string,
   token: string,
   stageId: string,
+  options: NormalizeRegistryUrlOptions = {},
 ): Promise<StagedPublishDetails> {
   if (!STAGE_ID_RE.test(stageId)) throw new Error("invalid stageId");
-  const registry = normalizeRegistryUrl(registryUrl);
+  const registry = normalizeRegistryUrl(registryUrl, options);
   const response = await fetch(`${registry}/-/stage/${encodeURIComponent(stageId)}`, {
     headers: npmStageHeaders(token, "staged-view"),
   });

--- a/server/routes/npm-connection.ts
+++ b/server/routes/npm-connection.ts
@@ -11,6 +11,7 @@ import {
 } from "../db";
 import { requireActiveOrganization } from "../lib/active-organization";
 import {
+  allowInsecureLocalRegistry,
   decryptNpmToken,
   encryptNpmToken,
   normalizeRegistryUrl,
@@ -44,7 +45,9 @@ npmConnectionRoutes.post("/", async (c) => {
 
   let registryUrl: string;
   try {
-    registryUrl = normalizeRegistryUrl(body.registryUrl);
+    registryUrl = normalizeRegistryUrl(body.registryUrl, {
+      allowInsecureLocalhost: allowInsecureLocalRegistry(c.env),
+    });
   } catch (err) {
     return c.json({ error: err instanceof Error ? err.message : "invalid registry URL" }, 400);
   }
@@ -117,7 +120,10 @@ npmConnectionRoutes.post("/validate", async (c) => {
     if (!connection) return c.json({ error: "npm connection is not configured" }, 404);
 
     const token = await decryptNpmToken(c.env, connection);
-    const validation = await validateNpmCredential(connection.registryUrl, token, { stageId });
+    const validation = await validateNpmCredential(connection.registryUrl, token, {
+      stageId,
+      allowInsecureLocalhost: allowInsecureLocalRegistry(c.env),
+    });
     const [updated] = await Promise.all([
       updateNpmConnectionValidation(db, {
         organizationId,

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -18,7 +18,11 @@ import {
 } from "../db";
 import { requireActiveOrganization } from "../lib/active-organization";
 import { loadCompare, stripTextSamples } from "../lib/compare-cache";
-import { getOrganizationNpmToken } from "../lib/npm-connection";
+import {
+  allowInsecureLocalRegistry,
+  getOrganizationNpmToken,
+  registryProtocolAllowed,
+} from "../lib/npm-connection";
 import { compareSemver, fetchPackageMetadata, pickPreviousVersion } from "../lib/registry";
 import { annotateFindingsWithDiffStatus, createPackageDiff, type FileRecord } from "../lib/review";
 import { executeScanJob, type ScanQueueMessage } from "../lib/scan-job";
@@ -282,13 +286,17 @@ scansRoutes.get("/:id/versions", async (c) => {
 
 const VERSION_RE = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$/;
 
-function isTarballUrlAllowed(tarballUrl: string, registryUrl: string): boolean {
+function isTarballUrlAllowed(
+  tarballUrl: string,
+  registryUrl: string,
+  allowInsecureLocalhost: boolean,
+): boolean {
   try {
     const tarball = new URL(tarballUrl);
     const registry = new URL(registryUrl);
     return (
       tarball.origin === registry.origin &&
-      tarball.protocol === "https:" &&
+      registryProtocolAllowed(tarball, { allowInsecureLocalhost }) &&
       tarball.pathname.endsWith(".tgz") &&
       tarball.pathname.includes("/-/")
     );
@@ -360,7 +368,7 @@ scansRoutes.get("/:id/compare", async (c) => {
   if (!tarballUrl) return c.json({ error: "unknown version" }, 404);
 
   const registryUrl = connection?.registryUrl || c.env.NPM_REGISTRY || "https://registry.npmjs.org";
-  if (!isTarballUrlAllowed(tarballUrl, registryUrl)) {
+  if (!isTarballUrlAllowed(tarballUrl, registryUrl, allowInsecureLocalRegistry(c.env))) {
     return c.json({ error: "registry returned an unexpected tarball URL" }, 502);
   }
 
@@ -456,7 +464,7 @@ scansRoutes.get("/:id/compare/file", async (c) => {
   if (!tarballUrl) return c.json({ error: "unknown version" }, 404);
 
   const registryUrl = connection?.registryUrl || c.env.NPM_REGISTRY || "https://registry.npmjs.org";
-  if (!isTarballUrlAllowed(tarballUrl, registryUrl)) {
+  if (!isTarballUrlAllowed(tarballUrl, registryUrl, allowInsecureLocalRegistry(c.env))) {
     return c.json({ error: "registry returned an unexpected tarball URL" }, 502);
   }
 

--- a/server/routes/staged-publishes.ts
+++ b/server/routes/staged-publishes.ts
@@ -9,7 +9,7 @@ import {
   recordScanEvent,
 } from "../db";
 import { requireActiveOrganization } from "../lib/active-organization";
-import { getOrganizationNpmToken } from "../lib/npm-connection";
+import { allowInsecureLocalRegistry, getOrganizationNpmToken } from "../lib/npm-connection";
 import {
   StagedPublishesFetchError,
   listStagedPublishes,
@@ -69,6 +69,7 @@ stagedPublishesRoutes.post("/scan", async (c) => {
   try {
     const page = await listStagedPublishes(connection.registryUrl, connection.token, {
       perPage: 50,
+      allowInsecureLocalhost: allowInsecureLocalRegistry(c.env),
     });
     const stagedItems = [...new Map(page.items.map((item) => [item.id, item])).values()];
     const stageIds = stagedItems.map((item) => item.id);

--- a/test/e2e-fixtures/scenarios/benign-diff/previous/README.md
+++ b/test/e2e-fixtures/scenarios/benign-diff/previous/README.md
@@ -1,0 +1,3 @@
+# E2E benign fixture
+
+Previous published fixture.

--- a/test/e2e-fixtures/scenarios/benign-diff/previous/index.js
+++ b/test/e2e-fixtures/scenarios/benign-diff/previous/index.js
@@ -1,0 +1,3 @@
+export function greet(name = "maintainer") {
+  return `hello, ${name}`;
+}

--- a/test/e2e-fixtures/scenarios/benign-diff/previous/package.json
+++ b/test/e2e-fixtures/scenarios/benign-diff/previous/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@drydock/e2e-benign",
+  "version": "1.0.0",
+  "description": "Benign E2E fixture package.",
+  "license": "MIT",
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "index.js"
+}

--- a/test/e2e-fixtures/scenarios/benign-diff/scenario.json
+++ b/test/e2e-fixtures/scenarios/benign-diff/scenario.json
@@ -1,0 +1,21 @@
+{
+  "stageId": "stage-benign-diff-000001",
+  "packageName": "@drydock/e2e-benign",
+  "tag": "latest",
+  "access": "public",
+  "actor": "e2e-bot",
+  "actorType": "automation",
+  "createdAt": "2026-05-26T00:00:00.000Z",
+  "previous": {
+    "directory": "previous",
+    "tag": "latest",
+    "publishedAt": "2026-05-20T00:00:00.000Z"
+  },
+  "staged": {
+    "directory": "staged"
+  },
+  "expected": {
+    "releaseRisk": "low",
+    "ruleIds": []
+  }
+}

--- a/test/e2e-fixtures/scenarios/benign-diff/staged/README.md
+++ b/test/e2e-fixtures/scenarios/benign-diff/staged/README.md
@@ -1,0 +1,3 @@
+# E2E benign fixture
+
+Staged fixture with a harmless source change.

--- a/test/e2e-fixtures/scenarios/benign-diff/staged/index.js
+++ b/test/e2e-fixtures/scenarios/benign-diff/staged/index.js
@@ -1,0 +1,3 @@
+export function greet(name = "maintainer") {
+  return `hello, ${name}!`;
+}

--- a/test/e2e-fixtures/scenarios/benign-diff/staged/package.json
+++ b/test/e2e-fixtures/scenarios/benign-diff/staged/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@drydock/e2e-benign",
+  "version": "1.0.1",
+  "description": "Benign E2E fixture package.",
+  "license": "MIT",
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "index.js"
+}

--- a/test/e2e-fixtures/scenarios/beta-baseline/previous/README.md
+++ b/test/e2e-fixtures/scenarios/beta-baseline/previous/README.md
@@ -1,0 +1,3 @@
+# E2E beta baseline fixture
+
+Previous beta fixture used by the beta dist-tag.

--- a/test/e2e-fixtures/scenarios/beta-baseline/previous/index.js
+++ b/test/e2e-fixtures/scenarios/beta-baseline/previous/index.js
@@ -1,0 +1,1 @@
+export const betaProbe = "beta.1";

--- a/test/e2e-fixtures/scenarios/beta-baseline/previous/package.json
+++ b/test/e2e-fixtures/scenarios/beta-baseline/previous/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@drydock/e2e-beta",
+  "version": "2.0.0-beta.1",
+  "description": "Beta baseline E2E fixture package.",
+  "license": "MIT",
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "index.js"
+}

--- a/test/e2e-fixtures/scenarios/beta-baseline/scenario.json
+++ b/test/e2e-fixtures/scenarios/beta-baseline/scenario.json
@@ -1,14 +1,14 @@
 {
-  "stageId": "stage-benign-diff-000001",
-  "packageName": "@drydock/e2e-benign",
-  "tag": "latest",
+  "stageId": "stage-beta-baseline-000001",
+  "packageName": "@drydock/e2e-beta",
+  "tag": "beta",
   "access": "public",
   "actor": "e2e-bot",
   "actorType": "automation",
   "createdAt": "2026-05-26T00:00:00.000Z",
   "previous": {
     "directory": "previous",
-    "tag": "latest",
+    "tag": "beta",
     "publishedAt": "2026-05-20T00:00:00.000Z"
   },
   "staged": {
@@ -16,14 +16,14 @@
   },
   "expected": {
     "releaseRisk": "low",
-    "packageName": "@drydock/e2e-benign",
-    "stagedVersion": "1.0.1",
-    "previousVersion": "1.0.0",
+    "packageName": "@drydock/e2e-beta",
+    "stagedVersion": "2.0.0-beta.2",
+    "previousVersion": "2.0.0-beta.1",
     "ruleIds": [],
     "baseline": {
-      "version": "1.0.0",
+      "version": "2.0.0-beta.1",
       "source": "dist-tag",
-      "tag": "latest"
+      "tag": "beta"
     }
   }
 }

--- a/test/e2e-fixtures/scenarios/beta-baseline/staged/README.md
+++ b/test/e2e-fixtures/scenarios/beta-baseline/staged/README.md
@@ -1,0 +1,3 @@
+# E2E beta baseline fixture
+
+Staged beta fixture that should compare against the beta dist-tag.

--- a/test/e2e-fixtures/scenarios/beta-baseline/staged/index.js
+++ b/test/e2e-fixtures/scenarios/beta-baseline/staged/index.js
@@ -1,0 +1,1 @@
+export const betaProbe = "beta.2";

--- a/test/e2e-fixtures/scenarios/beta-baseline/staged/package.json
+++ b/test/e2e-fixtures/scenarios/beta-baseline/staged/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@drydock/e2e-beta",
+  "version": "2.0.0-beta.2",
+  "description": "Beta baseline E2E fixture package.",
+  "license": "MIT",
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "index.js"
+}

--- a/test/e2e-fixtures/scenarios/implicit-node-gyp/previous/README.md
+++ b/test/e2e-fixtures/scenarios/implicit-node-gyp/previous/README.md
@@ -1,0 +1,3 @@
+# E2E native fixture
+
+Previous published fixture without a native build shape.

--- a/test/e2e-fixtures/scenarios/implicit-node-gyp/previous/index.js
+++ b/test/e2e-fixtures/scenarios/implicit-node-gyp/previous/index.js
@@ -1,0 +1,1 @@
+export const nativeProbe = false;

--- a/test/e2e-fixtures/scenarios/implicit-node-gyp/previous/package.json
+++ b/test/e2e-fixtures/scenarios/implicit-node-gyp/previous/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@drydock/e2e-native",
+  "version": "1.0.0",
+  "description": "Native probe E2E fixture package.",
+  "license": "MIT",
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "index.js"
+}

--- a/test/e2e-fixtures/scenarios/implicit-node-gyp/scenario.json
+++ b/test/e2e-fixtures/scenarios/implicit-node-gyp/scenario.json
@@ -16,6 +16,14 @@
   },
   "expected": {
     "releaseRisk": "high",
-    "ruleIds": ["install-script.implicit-node-gyp"]
+    "packageName": "@drydock/e2e-native",
+    "stagedVersion": "1.0.1",
+    "previousVersion": "1.0.0",
+    "ruleIds": ["install-script.implicit-node-gyp"],
+    "baseline": {
+      "version": "1.0.0",
+      "source": "dist-tag",
+      "tag": "latest"
+    }
   }
 }

--- a/test/e2e-fixtures/scenarios/implicit-node-gyp/scenario.json
+++ b/test/e2e-fixtures/scenarios/implicit-node-gyp/scenario.json
@@ -1,0 +1,21 @@
+{
+  "stageId": "stage-implicit-node-gyp-000001",
+  "packageName": "@drydock/e2e-native",
+  "tag": "latest",
+  "access": "public",
+  "actor": "e2e-bot",
+  "actorType": "automation",
+  "createdAt": "2026-05-26T00:00:00.000Z",
+  "previous": {
+    "directory": "previous",
+    "tag": "latest",
+    "publishedAt": "2026-05-20T00:00:00.000Z"
+  },
+  "staged": {
+    "directory": "staged"
+  },
+  "expected": {
+    "releaseRisk": "high",
+    "ruleIds": ["install-script.implicit-node-gyp"]
+  }
+}

--- a/test/e2e-fixtures/scenarios/implicit-node-gyp/staged/README.md
+++ b/test/e2e-fixtures/scenarios/implicit-node-gyp/staged/README.md
@@ -1,0 +1,3 @@
+# E2E native fixture
+
+Staged fixture that adds a root binding.gyp file.

--- a/test/e2e-fixtures/scenarios/implicit-node-gyp/staged/binding.gyp
+++ b/test/e2e-fixtures/scenarios/implicit-node-gyp/staged/binding.gyp
@@ -1,0 +1,10 @@
+{
+  "targets": [
+    {
+      "target_name": "drydock_e2e_native",
+      "sources": [
+        "native.cc"
+      ]
+    }
+  ]
+}

--- a/test/e2e-fixtures/scenarios/implicit-node-gyp/staged/index.js
+++ b/test/e2e-fixtures/scenarios/implicit-node-gyp/staged/index.js
@@ -1,0 +1,1 @@
+export const nativeProbe = true;

--- a/test/e2e-fixtures/scenarios/implicit-node-gyp/staged/package.json
+++ b/test/e2e-fixtures/scenarios/implicit-node-gyp/staged/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@drydock/e2e-native",
+  "version": "1.0.1",
+  "description": "Native probe E2E fixture package.",
+  "license": "MIT",
+  "files": [
+    "binding.gyp",
+    "index.js",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "index.js"
+}

--- a/test/e2e-fixtures/scenarios/invalid-package-json/previous/README.md
+++ b/test/e2e-fixtures/scenarios/invalid-package-json/previous/README.md
@@ -1,0 +1,3 @@
+# E2E invalid manifest fixture
+
+Previous published fixture with a parseable manifest.

--- a/test/e2e-fixtures/scenarios/invalid-package-json/previous/index.js
+++ b/test/e2e-fixtures/scenarios/invalid-package-json/previous/index.js
@@ -1,0 +1,1 @@
+export const manifestProbe = "valid";

--- a/test/e2e-fixtures/scenarios/invalid-package-json/previous/package.json
+++ b/test/e2e-fixtures/scenarios/invalid-package-json/previous/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@drydock/e2e-invalid-manifest",
+  "version": "1.0.0",
+  "description": "Invalid manifest E2E fixture package.",
+  "license": "MIT",
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "index.js"
+}

--- a/test/e2e-fixtures/scenarios/invalid-package-json/scenario.json
+++ b/test/e2e-fixtures/scenarios/invalid-package-json/scenario.json
@@ -1,6 +1,6 @@
 {
-  "stageId": "stage-benign-diff-000001",
-  "packageName": "@drydock/e2e-benign",
+  "stageId": "stage-invalid-package-json-000001",
+  "packageName": "@drydock/e2e-invalid-manifest",
   "tag": "latest",
   "access": "public",
   "actor": "e2e-bot",
@@ -12,14 +12,15 @@
     "publishedAt": "2026-05-20T00:00:00.000Z"
   },
   "staged": {
-    "directory": "staged"
+    "directory": "staged",
+    "packageJsonText": "{ invalid json\n"
   },
   "expected": {
-    "releaseRisk": "low",
-    "packageName": "@drydock/e2e-benign",
+    "releaseRisk": "medium",
+    "packageName": "@drydock/e2e-invalid-manifest",
     "stagedVersion": "1.0.1",
     "previousVersion": "1.0.0",
-    "ruleIds": [],
+    "ruleIds": ["package-json.parse-failed"],
     "baseline": {
       "version": "1.0.0",
       "source": "dist-tag",

--- a/test/e2e-fixtures/scenarios/invalid-package-json/scenario.json
+++ b/test/e2e-fixtures/scenarios/invalid-package-json/scenario.json
@@ -17,13 +17,13 @@
   },
   "expected": {
     "releaseRisk": "medium",
-    "packageName": "@drydock/e2e-invalid-manifest",
-    "stagedVersion": "1.0.1",
-    "previousVersion": "1.0.0",
+    "packageName": null,
+    "stagedVersion": null,
+    "previousVersion": null,
     "ruleIds": ["package-json.parse-failed"],
     "baseline": {
-      "version": "1.0.0",
-      "source": "dist-tag",
+      "version": null,
+      "source": "none",
       "tag": "latest"
     }
   }

--- a/test/e2e-fixtures/scenarios/invalid-package-json/staged/README.md
+++ b/test/e2e-fixtures/scenarios/invalid-package-json/staged/README.md
@@ -1,0 +1,3 @@
+# E2E invalid manifest fixture
+
+Staged fixture whose packed manifest is rewritten to malformed JSON.

--- a/test/e2e-fixtures/scenarios/invalid-package-json/staged/index.js
+++ b/test/e2e-fixtures/scenarios/invalid-package-json/staged/index.js
@@ -1,0 +1,1 @@
+export const manifestProbe = "invalid";

--- a/test/e2e-fixtures/scenarios/invalid-package-json/staged/package.json
+++ b/test/e2e-fixtures/scenarios/invalid-package-json/staged/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@drydock/e2e-invalid-manifest",
+  "version": "1.0.1",
+  "description": "Invalid manifest E2E fixture package.",
+  "license": "MIT",
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "index.js"
+}

--- a/test/e2e-fixtures/scenarios/lifecycle-script/previous/README.md
+++ b/test/e2e-fixtures/scenarios/lifecycle-script/previous/README.md
@@ -1,0 +1,3 @@
+# E2E lifecycle fixture
+
+Previous published fixture without lifecycle hooks.

--- a/test/e2e-fixtures/scenarios/lifecycle-script/previous/index.js
+++ b/test/e2e-fixtures/scenarios/lifecycle-script/previous/index.js
@@ -1,0 +1,1 @@
+export const lifecycleProbe = "before";

--- a/test/e2e-fixtures/scenarios/lifecycle-script/previous/package.json
+++ b/test/e2e-fixtures/scenarios/lifecycle-script/previous/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@drydock/e2e-lifecycle",
+  "version": "1.0.0",
+  "description": "Lifecycle E2E fixture package.",
+  "license": "MIT",
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "index.js"
+}

--- a/test/e2e-fixtures/scenarios/lifecycle-script/scenario.json
+++ b/test/e2e-fixtures/scenarios/lifecycle-script/scenario.json
@@ -1,6 +1,6 @@
 {
-  "stageId": "stage-benign-diff-000001",
-  "packageName": "@drydock/e2e-benign",
+  "stageId": "stage-lifecycle-script-000001",
+  "packageName": "@drydock/e2e-lifecycle",
   "tag": "latest",
   "access": "public",
   "actor": "e2e-bot",
@@ -15,11 +15,11 @@
     "directory": "staged"
   },
   "expected": {
-    "releaseRisk": "low",
-    "packageName": "@drydock/e2e-benign",
+    "releaseRisk": "high",
+    "packageName": "@drydock/e2e-lifecycle",
     "stagedVersion": "1.0.1",
     "previousVersion": "1.0.0",
-    "ruleIds": [],
+    "ruleIds": ["install-script.lifecycle"],
     "baseline": {
       "version": "1.0.0",
       "source": "dist-tag",

--- a/test/e2e-fixtures/scenarios/lifecycle-script/staged/README.md
+++ b/test/e2e-fixtures/scenarios/lifecycle-script/staged/README.md
@@ -1,0 +1,3 @@
+# E2E lifecycle fixture
+
+Staged fixture that adds a postinstall lifecycle hook.

--- a/test/e2e-fixtures/scenarios/lifecycle-script/staged/index.js
+++ b/test/e2e-fixtures/scenarios/lifecycle-script/staged/index.js
@@ -1,0 +1,1 @@
+export const lifecycleProbe = "after";

--- a/test/e2e-fixtures/scenarios/lifecycle-script/staged/package.json
+++ b/test/e2e-fixtures/scenarios/lifecycle-script/staged/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@drydock/e2e-lifecycle",
+  "version": "1.0.1",
+  "description": "Lifecycle E2E fixture package.",
+  "license": "MIT",
+  "files": [
+    "index.js",
+    "postinstall.js",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "postinstall": "node postinstall.js"
+  }
+}

--- a/test/e2e-fixtures/scenarios/lifecycle-script/staged/postinstall.js
+++ b/test/e2e-fixtures/scenarios/lifecycle-script/staged/postinstall.js
@@ -1,0 +1,1 @@
+console.log("drydock lifecycle fixture");

--- a/test/e2e-fixtures/scenarios/metadata-mismatch/previous/README.md
+++ b/test/e2e-fixtures/scenarios/metadata-mismatch/previous/README.md
@@ -1,0 +1,3 @@
+# E2E metadata mismatch fixture
+
+Previous published fixture with matching package metadata.

--- a/test/e2e-fixtures/scenarios/metadata-mismatch/previous/index.js
+++ b/test/e2e-fixtures/scenarios/metadata-mismatch/previous/index.js
@@ -1,0 +1,1 @@
+export const metadataProbe = "before";

--- a/test/e2e-fixtures/scenarios/metadata-mismatch/previous/package.json
+++ b/test/e2e-fixtures/scenarios/metadata-mismatch/previous/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@drydock/e2e-metadata-actual",
+  "version": "1.0.0",
+  "description": "Metadata mismatch E2E fixture package.",
+  "license": "MIT",
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "index.js"
+}

--- a/test/e2e-fixtures/scenarios/metadata-mismatch/scenario.json
+++ b/test/e2e-fixtures/scenarios/metadata-mismatch/scenario.json
@@ -1,6 +1,8 @@
 {
-  "stageId": "stage-benign-diff-000001",
-  "packageName": "@drydock/e2e-benign",
+  "stageId": "stage-metadata-mismatch-000001",
+  "packageName": "@drydock/e2e-metadata-actual",
+  "stagePackageName": "@drydock/e2e-metadata-claimed",
+  "stageVersion": "9.9.9",
   "tag": "latest",
   "access": "public",
   "actor": "e2e-bot",
@@ -15,15 +17,15 @@
     "directory": "staged"
   },
   "expected": {
-    "releaseRisk": "low",
-    "packageName": "@drydock/e2e-benign",
+    "releaseRisk": "critical",
+    "packageName": "@drydock/e2e-metadata-actual",
     "stagedVersion": "1.0.1",
     "previousVersion": "1.0.0",
-    "ruleIds": [],
+    "ruleIds": ["stage.metadata-mismatch"],
     "baseline": {
       "version": "1.0.0",
-      "source": "dist-tag",
-      "tag": "latest"
+      "source": "semver-predecessor",
+      "tag": null
     }
   }
 }

--- a/test/e2e-fixtures/scenarios/metadata-mismatch/staged/README.md
+++ b/test/e2e-fixtures/scenarios/metadata-mismatch/staged/README.md
@@ -1,0 +1,3 @@
+# E2E metadata mismatch fixture
+
+Staged fixture whose npm staged metadata disagrees with the tarball manifest.

--- a/test/e2e-fixtures/scenarios/metadata-mismatch/staged/index.js
+++ b/test/e2e-fixtures/scenarios/metadata-mismatch/staged/index.js
@@ -1,0 +1,1 @@
+export const metadataProbe = "after";

--- a/test/e2e-fixtures/scenarios/metadata-mismatch/staged/package.json
+++ b/test/e2e-fixtures/scenarios/metadata-mismatch/staged/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@drydock/e2e-metadata-actual",
+  "version": "1.0.1",
+  "description": "Metadata mismatch E2E fixture package.",
+  "license": "MIT",
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "index.js"
+}

--- a/test/e2e-fixtures/scenarios/no-previous-version/scenario.json
+++ b/test/e2e-fixtures/scenarios/no-previous-version/scenario.json
@@ -1,0 +1,25 @@
+{
+  "stageId": "stage-no-previous-version-000001",
+  "packageName": "@drydock/e2e-first-release",
+  "tag": "latest",
+  "access": "public",
+  "actor": "e2e-bot",
+  "actorType": "automation",
+  "createdAt": "2026-05-26T00:00:00.000Z",
+  "previous": null,
+  "staged": {
+    "directory": "staged"
+  },
+  "expected": {
+    "releaseRisk": "low",
+    "packageName": "@drydock/e2e-first-release",
+    "stagedVersion": "1.0.0",
+    "previousVersion": null,
+    "ruleIds": [],
+    "baseline": {
+      "version": null,
+      "source": "none",
+      "tag": "latest"
+    }
+  }
+}

--- a/test/e2e-fixtures/scenarios/no-previous-version/staged/README.md
+++ b/test/e2e-fixtures/scenarios/no-previous-version/staged/README.md
@@ -1,0 +1,3 @@
+# E2E first release fixture
+
+Staged fixture with no published baseline version.

--- a/test/e2e-fixtures/scenarios/no-previous-version/staged/index.js
+++ b/test/e2e-fixtures/scenarios/no-previous-version/staged/index.js
@@ -1,0 +1,1 @@
+export const firstReleaseProbe = true;

--- a/test/e2e-fixtures/scenarios/no-previous-version/staged/package.json
+++ b/test/e2e-fixtures/scenarios/no-previous-version/staged/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@drydock/e2e-first-release",
+  "version": "1.0.0",
+  "description": "First release E2E fixture package.",
+  "license": "MIT",
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "index.js"
+}

--- a/test/e2e-fixtures/scenarios/registry-failure/previous/README.md
+++ b/test/e2e-fixtures/scenarios/registry-failure/previous/README.md
@@ -1,0 +1,3 @@
+# E2E registry failure fixture
+
+Previous published fixture for a staged tarball failure path.

--- a/test/e2e-fixtures/scenarios/registry-failure/previous/index.js
+++ b/test/e2e-fixtures/scenarios/registry-failure/previous/index.js
@@ -1,0 +1,1 @@
+export const registryFailureProbe = "before";

--- a/test/e2e-fixtures/scenarios/registry-failure/previous/package.json
+++ b/test/e2e-fixtures/scenarios/registry-failure/previous/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@drydock/e2e-registry-failure",
+  "version": "1.0.0",
+  "description": "Registry failure E2E fixture package.",
+  "license": "MIT",
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "index.js"
+}

--- a/test/e2e-fixtures/scenarios/registry-failure/scenario.json
+++ b/test/e2e-fixtures/scenarios/registry-failure/scenario.json
@@ -1,0 +1,24 @@
+{
+  "stageId": "stage-registry-failure-000001",
+  "packageName": "@drydock/e2e-registry-failure",
+  "tag": "latest",
+  "access": "public",
+  "actor": "e2e-bot",
+  "actorType": "automation",
+  "createdAt": "2026-05-26T00:00:00.000Z",
+  "previous": {
+    "directory": "previous",
+    "tag": "latest",
+    "publishedAt": "2026-05-20T00:00:00.000Z"
+  },
+  "staged": {
+    "directory": "staged"
+  },
+  "failure": {
+    "stagedTarballStatus": 503
+  },
+  "expected": {
+    "errorStatus": 502,
+    "errorIncludes": "Could not download or inspect the staged tarball."
+  }
+}

--- a/test/e2e-fixtures/scenarios/registry-failure/staged/README.md
+++ b/test/e2e-fixtures/scenarios/registry-failure/staged/README.md
@@ -1,0 +1,3 @@
+# E2E registry failure fixture
+
+Staged fixture whose tarball endpoint is configured to fail.

--- a/test/e2e-fixtures/scenarios/registry-failure/staged/index.js
+++ b/test/e2e-fixtures/scenarios/registry-failure/staged/index.js
@@ -1,0 +1,1 @@
+export const registryFailureProbe = "after";

--- a/test/e2e-fixtures/scenarios/registry-failure/staged/package.json
+++ b/test/e2e-fixtures/scenarios/registry-failure/staged/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@drydock/e2e-registry-failure",
+  "version": "1.0.1",
+  "description": "Registry failure E2E fixture package.",
+  "license": "MIT",
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "index.js"
+}

--- a/test/e2e-fixtures/scenarios/secret-file-added/previous/README.md
+++ b/test/e2e-fixtures/scenarios/secret-file-added/previous/README.md
@@ -1,0 +1,3 @@
+# E2E secret fixture
+
+Previous published fixture without secret-like files.

--- a/test/e2e-fixtures/scenarios/secret-file-added/previous/index.js
+++ b/test/e2e-fixtures/scenarios/secret-file-added/previous/index.js
@@ -1,0 +1,1 @@
+export const secretProbe = false;

--- a/test/e2e-fixtures/scenarios/secret-file-added/previous/package.json
+++ b/test/e2e-fixtures/scenarios/secret-file-added/previous/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@drydock/e2e-secret-file",
+  "version": "1.0.0",
+  "description": "Secret file E2E fixture package.",
+  "license": "MIT",
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "type": "module",
+  "main": "index.js"
+}

--- a/test/e2e-fixtures/scenarios/secret-file-added/scenario.json
+++ b/test/e2e-fixtures/scenarios/secret-file-added/scenario.json
@@ -1,6 +1,6 @@
 {
-  "stageId": "stage-benign-diff-000001",
-  "packageName": "@drydock/e2e-benign",
+  "stageId": "stage-secret-file-added-000001",
+  "packageName": "@drydock/e2e-secret-file",
   "tag": "latest",
   "access": "public",
   "actor": "e2e-bot",
@@ -15,11 +15,11 @@
     "directory": "staged"
   },
   "expected": {
-    "releaseRisk": "low",
-    "packageName": "@drydock/e2e-benign",
+    "releaseRisk": "critical",
+    "packageName": "@drydock/e2e-secret-file",
     "stagedVersion": "1.0.1",
     "previousVersion": "1.0.0",
-    "ruleIds": [],
+    "ruleIds": ["file.secret-content"],
     "baseline": {
       "version": "1.0.0",
       "source": "dist-tag",

--- a/test/e2e-fixtures/scenarios/secret-file-added/staged/README.md
+++ b/test/e2e-fixtures/scenarios/secret-file-added/staged/README.md
@@ -1,0 +1,3 @@
+# E2E secret fixture
+
+Staged fixture that accidentally includes a synthetic secret-like file.

--- a/test/e2e-fixtures/scenarios/secret-file-added/staged/index.js
+++ b/test/e2e-fixtures/scenarios/secret-file-added/staged/index.js
@@ -1,0 +1,1 @@
+export const secretProbe = true;

--- a/test/e2e-fixtures/scenarios/secret-file-added/staged/package.json
+++ b/test/e2e-fixtures/scenarios/secret-file-added/staged/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@drydock/e2e-secret-file",
+  "version": "1.0.1",
+  "description": "Secret file E2E fixture package.",
+  "license": "MIT",
+  "files": [
+    "index.js",
+    "README.md",
+    "secrets.txt"
+  ],
+  "type": "module",
+  "main": "index.js"
+}

--- a/test/e2e-fixtures/scenarios/secret-file-added/staged/secrets.txt
+++ b/test/e2e-fixtures/scenarios/secret-file-added/staged/secrets.txt
@@ -1,0 +1,1 @@
+API_TOKEN=synthetic_secret_value_1234567890

--- a/test/e2e/build-fixtures.mjs
+++ b/test/e2e/build-fixtures.mjs
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
-import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -23,26 +24,39 @@ for (const name of scenarioNames) {
   const scenarioDir = path.join(scenariosRoot, name);
   const scenario = await readJson(path.join(scenarioDir, "scenario.json"));
   const stagedPackageDir = path.join(scenarioDir, scenario.staged.directory);
-  const previousPackageDir = path.join(scenarioDir, scenario.previous.directory);
   const stagedManifest = await readJson(path.join(stagedPackageDir, "package.json"));
-  const previousManifest = await readJson(path.join(previousPackageDir, "package.json"));
+  const previousPackageDir = scenario.previous?.directory
+    ? path.join(scenarioDir, scenario.previous.directory)
+    : null;
+  const previousManifest = previousPackageDir
+    ? await readJson(path.join(previousPackageDir, "package.json"))
+    : null;
 
   assertEqual(scenario.packageName, stagedManifest.name, `${name} staged package name`);
-  assertEqual(scenario.packageName, previousManifest.name, `${name} previous package name`);
+  if (previousManifest) {
+    assertEqual(scenario.packageName, previousManifest.name, `${name} previous package name`);
+  }
 
-  const stagedPack = packPackage(stagedPackageDir, tarballRoot);
-  const previousPack = packPackage(previousPackageDir, tarballRoot);
+  const stagedPack = await maybeRewritePackageJson(
+    packPackage(stagedPackageDir, tarballRoot),
+    scenario.staged.packageJsonText,
+    `${name} staged`,
+  );
+  const previousPack = previousPackageDir ? packPackage(previousPackageDir, tarballRoot) : null;
 
   scenarios.push({
     name,
     stageId: scenario.stageId,
     packageName: scenario.packageName,
+    stagePackageName: scenario.stagePackageName ?? scenario.packageName,
+    stageVersion: scenario.stageVersion ?? stagedManifest.version,
     tag: scenario.tag ?? "latest",
     access: scenario.access ?? null,
     actor: scenario.actor ?? null,
     actorType: scenario.actorType ?? null,
     createdAt: scenario.createdAt ?? null,
     expected: scenario.expected ?? {},
+    failure: scenario.failure ?? null,
     staged: {
       version: stagedManifest.version,
       manifest: stagedManifest,
@@ -50,15 +64,18 @@ for (const name of scenarioNames) {
       shasum: stagedPack.shasum ?? null,
       integrity: stagedPack.integrity ?? null,
     },
-    previous: {
-      version: previousManifest.version,
-      tag: scenario.previous.tag ?? "latest",
-      publishedAt: scenario.previous.publishedAt ?? null,
-      manifest: previousManifest,
-      tarballFile: previousPack.filename,
-      shasum: previousPack.shasum ?? null,
-      integrity: previousPack.integrity ?? null,
-    },
+    previous:
+      previousManifest && previousPack
+        ? {
+            version: previousManifest.version,
+            tag: scenario.previous.tag ?? "latest",
+            publishedAt: scenario.previous.publishedAt ?? null,
+            manifest: previousManifest,
+            tarballFile: previousPack.filename,
+            shasum: previousPack.shasum ?? null,
+            integrity: previousPack.integrity ?? null,
+          }
+        : null,
   });
 }
 
@@ -104,6 +121,38 @@ function packPackage(packageDir, destination) {
     throw new Error(`npm pack returned no filename in ${relative(packageDir)}`);
   }
   return packed;
+}
+
+async function maybeRewritePackageJson(packed, packageJsonText, label) {
+  if (typeof packageJsonText !== "string") return packed;
+  const tarballPath = path.join(tarballRoot, packed.filename);
+  const workDir = path.join(outputRoot, "tarball-work", label.replace(/[^a-z0-9_-]/gi, "-"));
+  await rm(workDir, { recursive: true, force: true });
+  await mkdir(workDir, { recursive: true });
+
+  runTar(["-xzf", tarballPath, "-C", workDir], label);
+  await writeFile(path.join(workDir, "package/package.json"), packageJsonText);
+  runTar(["-czf", tarballPath, "-C", workDir, "package"], label);
+
+  const bytes = await readFile(tarballPath);
+  const size = (await stat(tarballPath)).size;
+  return {
+    ...packed,
+    size,
+    shasum: createHash("sha1").update(bytes).digest("hex"),
+    integrity: `sha512-${createHash("sha512").update(bytes).digest("base64")}`,
+  };
+}
+
+function runTar(args, label) {
+  const result = spawnSync("tar", args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    throw new Error(`tar failed for ${label}\n${result.stdout}\n${result.stderr}`);
+  }
 }
 
 function assertEqual(expected, actual, label) {

--- a/test/e2e/build-fixtures.mjs
+++ b/test/e2e/build-fixtures.mjs
@@ -1,0 +1,117 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "../..");
+const scenariosRoot = path.join(repoRoot, "test/e2e-fixtures/scenarios");
+const outputRoot =
+  process.env.E2E_REGISTRY_STATE_DIR || path.join(repoRoot, ".context/e2e-registry");
+const tarballRoot = path.join(outputRoot, "tarballs");
+
+await rm(outputRoot, { recursive: true, force: true });
+await mkdir(tarballRoot, { recursive: true });
+
+const scenarioNames = (await readdir(scenariosRoot, { withFileTypes: true }))
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort();
+
+const scenarios = [];
+for (const name of scenarioNames) {
+  const scenarioDir = path.join(scenariosRoot, name);
+  const scenario = await readJson(path.join(scenarioDir, "scenario.json"));
+  const stagedPackageDir = path.join(scenarioDir, scenario.staged.directory);
+  const previousPackageDir = path.join(scenarioDir, scenario.previous.directory);
+  const stagedManifest = await readJson(path.join(stagedPackageDir, "package.json"));
+  const previousManifest = await readJson(path.join(previousPackageDir, "package.json"));
+
+  assertEqual(scenario.packageName, stagedManifest.name, `${name} staged package name`);
+  assertEqual(scenario.packageName, previousManifest.name, `${name} previous package name`);
+
+  const stagedPack = packPackage(stagedPackageDir, tarballRoot);
+  const previousPack = packPackage(previousPackageDir, tarballRoot);
+
+  scenarios.push({
+    name,
+    stageId: scenario.stageId,
+    packageName: scenario.packageName,
+    tag: scenario.tag ?? "latest",
+    access: scenario.access ?? null,
+    actor: scenario.actor ?? null,
+    actorType: scenario.actorType ?? null,
+    createdAt: scenario.createdAt ?? null,
+    expected: scenario.expected ?? {},
+    staged: {
+      version: stagedManifest.version,
+      manifest: stagedManifest,
+      tarballFile: stagedPack.filename,
+      shasum: stagedPack.shasum ?? null,
+      integrity: stagedPack.integrity ?? null,
+    },
+    previous: {
+      version: previousManifest.version,
+      tag: scenario.previous.tag ?? "latest",
+      publishedAt: scenario.previous.publishedAt ?? null,
+      manifest: previousManifest,
+      tarballFile: previousPack.filename,
+      shasum: previousPack.shasum ?? null,
+      integrity: previousPack.integrity ?? null,
+    },
+  });
+}
+
+await writeFile(
+  path.join(outputRoot, "registry.json"),
+  JSON.stringify(
+    {
+      generatedAt: new Date().toISOString(),
+      scenarios,
+    },
+    null,
+    2,
+  ),
+);
+
+console.log(`Built ${scenarios.length} E2E registry scenario(s) in ${relative(outputRoot)}`);
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, "utf8"));
+}
+
+function packPackage(packageDir, destination) {
+  const result = spawnSync("npm", ["pack", "--json", "--pack-destination", destination], {
+    cwd: packageDir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `npm pack failed in ${relative(packageDir)}\n${result.stdout}\n${result.stderr}`,
+    );
+  }
+
+  const stdout = result.stdout.trim();
+  const start = stdout.indexOf("[");
+  const end = stdout.lastIndexOf("]");
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error(`npm pack did not return JSON in ${relative(packageDir)}:\n${stdout}`);
+  }
+
+  const [packed] = JSON.parse(stdout.slice(start, end + 1));
+  if (!packed?.filename) {
+    throw new Error(`npm pack returned no filename in ${relative(packageDir)}`);
+  }
+  return packed;
+}
+
+function assertEqual(expected, actual, label) {
+  if (expected !== actual) {
+    throw new Error(`${label} mismatch: expected ${expected}, got ${actual}`);
+  }
+}
+
+function relative(filePath) {
+  return path.relative(repoRoot, filePath) || ".";
+}

--- a/test/e2e/dev-server.mjs
+++ b/test/e2e/dev-server.mjs
@@ -1,0 +1,170 @@
+import { spawn, spawnSync } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import http from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "../..");
+const appPort = Number(process.env.E2E_APP_PORT || process.env.CONDUCTOR_PORT || 5173);
+const registryPort = Number(process.env.E2E_REGISTRY_PORT || appPort + 1);
+const appUrl = `http://127.0.0.1:${appPort}`;
+const registryUrl = `http://127.0.0.1:${registryPort}`;
+const stateDir = path.join(repoRoot, ".context/e2e-registry");
+const artifactsDir = path.join(repoRoot, ".context/e2e-artifacts");
+const configDir = path.join(repoRoot, ".context/e2e");
+const wranglerConfigPath = path.join(configDir, "wrangler.jsonc");
+let shuttingDown = false;
+
+await mkdir(configDir, { recursive: true });
+await mkdir(artifactsDir, { recursive: true });
+await writeWranglerConfig();
+run("node", ["test/e2e/build-fixtures.mjs"]);
+run("pnpm", [
+  "exec",
+  "wrangler",
+  "d1",
+  "migrations",
+  "apply",
+  "staged-publish-review-e2e",
+  "--local",
+  "--persist-to",
+  path.join(repoRoot, ".wrangler/state"),
+  "--config",
+  wranglerConfigPath,
+]);
+
+const children = [];
+const registry = start("node", ["test/e2e/fake-registry.mjs", "--port", String(registryPort)], {
+  E2E_REGISTRY_STATE_DIR: stateDir,
+});
+children.push(registry);
+await waitForUrl(`${registryUrl}/__health`);
+
+const app = start(
+  "pnpm",
+  ["exec", "vite", "--host", "127.0.0.1", "--port", String(appPort), "--strictPort"],
+  {
+    ALLOW_INSECURE_LOCAL_REGISTRY: "true",
+    CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH: wranglerConfigPath,
+    E2E_NPM_REGISTRY: registryUrl,
+  },
+);
+children.push(app);
+await waitForUrl(appUrl);
+
+console.log(`E2E app: ${appUrl}`);
+console.log(`Fake npm registry: ${registryUrl}`);
+console.log(`Registry journal: ${path.relative(repoRoot, path.join(stateDir, "requests.jsonl"))}`);
+console.log(`Artifacts: ${path.relative(repoRoot, artifactsDir)}`);
+
+await new Promise((resolve, reject) => {
+  for (const child of children) {
+    child.on("exit", (code, signal) => {
+      if (shuttingDown) return;
+      reject(new Error(`${child.spawnargs.join(" ")} exited with ${code ?? signal}`));
+    });
+  }
+  process.on("SIGTERM", () => shutdown(resolve));
+  process.on("SIGINT", () => shutdown(resolve));
+});
+
+function shutdown(resolve) {
+  shuttingDown = true;
+  for (const child of children.slice().reverse()) {
+    if (!child.killed) child.kill("SIGTERM");
+  }
+  setTimeout(resolve, 250);
+}
+
+async function writeWranglerConfig() {
+  const config = {
+    $schema: "../../node_modules/wrangler/config-schema.json",
+    name: "staged-publish-review-e2e",
+    main: "../../server/index.ts",
+    compatibility_date: "2026-05-20",
+    compatibility_flags: ["nodejs_compat"],
+    assets: {
+      not_found_handling: "single-page-application",
+    },
+    worker_loaders: [{ binding: "LOADER" }],
+    d1_databases: [
+      {
+        binding: "DB",
+        database_name: "staged-publish-review-e2e",
+        database_id: "00000000-0000-0000-0000-0000000000e2",
+        migrations_dir: "../../drizzle",
+      },
+    ],
+    kv_namespaces: [
+      {
+        binding: "COMPARE_CACHE",
+        id: "000000000000000000000000000000e2",
+      },
+    ],
+    vars: {
+      BETTER_AUTH_SECRET: "e2e-better-auth-secret-that-is-long-enough",
+      BETTER_AUTH_URL: appUrl,
+      NPM_CONNECTIONS_ENCRYPTION_KEY:
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      NPM_REGISTRY: registryUrl,
+      ALLOW_INSECURE_LOCAL_REGISTRY: "true",
+      AI_CACHE_AFFINITY: "staged-publish-review-e2e",
+    },
+  };
+  await writeFile(wranglerConfigPath, `${JSON.stringify(config, null, 2)}\n`);
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    env: { ...process.env, CI: process.env.CI ?? "true" },
+    stdio: "inherit",
+  });
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} failed with status ${result.status}`);
+  }
+}
+
+function start(command, args, env) {
+  const child = spawn(command, args, {
+    cwd: repoRoot,
+    env: { ...process.env, ...env },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const label = path.basename(command);
+  child.stdout.on("data", (chunk) => process.stdout.write(prefixLines(label, chunk)));
+  child.stderr.on("data", (chunk) => process.stderr.write(prefixLines(label, chunk)));
+  return child;
+}
+
+function prefixLines(label, chunk) {
+  return chunk
+    .toString()
+    .split(/(?<=\n)/)
+    .map((line) => (line ? `[${label}] ${line}` : ""))
+    .join("");
+}
+
+async function waitForUrl(url, timeoutMs = 60_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await canConnect(url)) return;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+function canConnect(url) {
+  return new Promise((resolve) => {
+    const request = http.get(url, (response) => {
+      response.resume();
+      resolve(response.statusCode && response.statusCode < 500);
+    });
+    request.on("error", () => resolve(false));
+    request.setTimeout(1000, () => {
+      request.destroy();
+      resolve(false);
+    });
+  });
+}

--- a/test/e2e/dev-server.mjs
+++ b/test/e2e/dev-server.mjs
@@ -1,5 +1,5 @@
 import { spawn, spawnSync } from "node:child_process";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import http from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -13,11 +13,14 @@ const registryUrl = `http://127.0.0.1:${registryPort}`;
 const stateDir = path.join(repoRoot, ".context/e2e-registry");
 const artifactsDir = path.join(repoRoot, ".context/e2e-artifacts");
 const configDir = path.join(repoRoot, ".context/e2e");
+const persistRoot = path.join(configDir, "state");
 const wranglerConfigPath = path.join(configDir, "wrangler.jsonc");
 let shuttingDown = false;
 
 await mkdir(configDir, { recursive: true });
 await mkdir(artifactsDir, { recursive: true });
+await rm(persistRoot, { recursive: true, force: true });
+await mkdir(persistRoot, { recursive: true });
 await writeWranglerConfig();
 run("node", ["test/e2e/build-fixtures.mjs"]);
 run("pnpm", [
@@ -29,7 +32,7 @@ run("pnpm", [
   "staged-publish-review-e2e",
   "--local",
   "--persist-to",
-  path.join(repoRoot, ".wrangler/state"),
+  persistRoot,
   "--config",
   wranglerConfigPath,
 ]);
@@ -46,6 +49,7 @@ const app = start(
   ["exec", "vite", "--host", "127.0.0.1", "--port", String(appPort), "--strictPort"],
   {
     ALLOW_INSECURE_LOCAL_REGISTRY: "true",
+    CLOUDFLARE_VITE_PERSIST_STATE_PATH: persistRoot,
     CLOUDFLARE_VITE_WRANGLER_CONFIG_PATH: wranglerConfigPath,
     E2E_NPM_REGISTRY: registryUrl,
   },
@@ -57,6 +61,7 @@ console.log(`E2E app: ${appUrl}`);
 console.log(`Fake npm registry: ${registryUrl}`);
 console.log(`Registry journal: ${path.relative(repoRoot, path.join(stateDir, "requests.jsonl"))}`);
 console.log(`Artifacts: ${path.relative(repoRoot, artifactsDir)}`);
+console.log(`Worker state: ${path.relative(repoRoot, persistRoot)}`);
 
 await new Promise((resolve, reject) => {
   for (const child of children) {

--- a/test/e2e/fake-registry.mjs
+++ b/test/e2e/fake-registry.mjs
@@ -60,6 +60,12 @@ const server = createServer(async (request, response) => {
         await sendJson(request, response, startedAt, 404, { error: "stage not found" });
         return;
       }
+      if (scenario.failure?.stagedTarballStatus) {
+        await sendJson(request, response, startedAt, scenario.failure.stagedTarballStatus, {
+          error: "configured staged tarball failure",
+        });
+        return;
+      }
       await sendTarball(request, response, startedAt, scenario.staged.tarballFile);
       return;
     }
@@ -122,11 +128,13 @@ function buildPackageMap(scenarios) {
       versions: {},
       times: {},
     };
-    packument.distTags[scenario.previous.tag || scenario.tag || "latest"] =
-      scenario.previous.version;
-    packument.versions[scenario.previous.version] = scenario.previous;
-    if (scenario.previous.publishedAt) {
-      packument.times[scenario.previous.version] = scenario.previous.publishedAt;
+    if (scenario.previous) {
+      packument.distTags[scenario.previous.tag || scenario.tag || "latest"] =
+        scenario.previous.version;
+      packument.versions[scenario.previous.version] = scenario.previous;
+      if (scenario.previous.publishedAt) {
+        packument.times[scenario.previous.version] = scenario.previous.publishedAt;
+      }
     }
     byPackage.set(scenario.packageName, packument);
   }
@@ -156,8 +164,8 @@ function renderPackument(packument) {
 function stageListItem(scenario) {
   return {
     id: scenario.stageId,
-    packageName: scenario.packageName,
-    version: scenario.staged.version,
+    packageName: scenario.stagePackageName,
+    version: scenario.stageVersion,
     tag: scenario.tag,
     access: scenario.access,
     actor: scenario.actor,

--- a/test/e2e/fake-registry.mjs
+++ b/test/e2e/fake-registry.mjs
@@ -39,11 +39,12 @@ const server = createServer(async (request, response) => {
       return;
     }
 
+    if (!hasBearerToken(request)) {
+      await sendJson(request, response, startedAt, 401, { error: "missing bearer token" });
+      return;
+    }
+
     if (url.pathname === "/-/whoami") {
-      if (!request.headers.authorization?.startsWith("Bearer ")) {
-        await sendJson(request, response, startedAt, 401, { error: "missing bearer token" });
-        return;
-      }
       await sendJson(request, response, startedAt, 200, { username: "drydock-e2e" });
       return;
     }
@@ -178,9 +179,11 @@ function stageListItem(scenario) {
 function stageDetails(scenario) {
   return {
     ...stageListItem(scenario),
-    manifest: scenario.staged.manifest,
-    packageJson: scenario.staged.manifest,
   };
+}
+
+function hasBearerToken(request) {
+  return request.headers.authorization?.startsWith("Bearer ") === true;
 }
 
 async function sendStageList(request, response, startedAt, url) {

--- a/test/e2e/fake-registry.mjs
+++ b/test/e2e/fake-registry.mjs
@@ -1,0 +1,276 @@
+import { createReadStream } from "node:fs";
+import { appendFile, readFile, stat } from "node:fs/promises";
+import { createServer } from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "../..");
+const args = parseArgs(process.argv.slice(2));
+const host = args.host || process.env.E2E_REGISTRY_HOST || "127.0.0.1";
+const port = Number(args.port || process.env.E2E_REGISTRY_PORT || 5184);
+const stateDir =
+  args.stateDir ||
+  process.env.E2E_REGISTRY_STATE_DIR ||
+  path.join(repoRoot, ".context/e2e-registry");
+const registryFile = path.join(stateDir, "registry.json");
+const journalFile = path.join(stateDir, "requests.jsonl");
+const tarballDir = path.join(stateDir, "tarballs");
+const registry = JSON.parse(await readFile(registryFile, "utf8"));
+const baseUrl = `http://${host}:${port}`;
+const stageById = new Map(registry.scenarios.map((scenario) => [scenario.stageId, scenario]));
+const packages = buildPackageMap(registry.scenarios);
+
+const server = createServer(async (request, response) => {
+  const url = new URL(request.url || "/", baseUrl);
+  const startedAt = Date.now();
+
+  try {
+    if (request.method !== "GET") {
+      await send(request, response, startedAt, 405, { allow: "GET" }, "method not allowed");
+      return;
+    }
+
+    if (url.pathname === "/__health") {
+      await sendJson(request, response, startedAt, 200, {
+        ok: true,
+        scenarios: registry.scenarios.length,
+      });
+      return;
+    }
+
+    if (url.pathname === "/-/whoami") {
+      if (!request.headers.authorization?.startsWith("Bearer ")) {
+        await sendJson(request, response, startedAt, 401, { error: "missing bearer token" });
+        return;
+      }
+      await sendJson(request, response, startedAt, 200, { username: "drydock-e2e" });
+      return;
+    }
+
+    if (url.pathname === "/-/stage") {
+      await sendStageList(request, response, startedAt, url);
+      return;
+    }
+
+    const stagedTarballMatch = /^\/-\/stage\/([^/]+)\/tarball$/.exec(url.pathname);
+    if (stagedTarballMatch) {
+      const scenario = stageById.get(decodeURIComponent(stagedTarballMatch[1]));
+      if (!scenario) {
+        await sendJson(request, response, startedAt, 404, { error: "stage not found" });
+        return;
+      }
+      await sendTarball(request, response, startedAt, scenario.staged.tarballFile);
+      return;
+    }
+
+    const stagedViewMatch = /^\/-\/stage\/([^/]+)$/.exec(url.pathname);
+    if (stagedViewMatch) {
+      const scenario = stageById.get(decodeURIComponent(stagedViewMatch[1]));
+      if (!scenario) {
+        await sendJson(request, response, startedAt, 404, { error: "stage not found" });
+        return;
+      }
+      await sendJson(request, response, startedAt, 200, stageDetails(scenario));
+      return;
+    }
+
+    const decodedPath = decodeURIComponent(url.pathname).replace(/^\/+/, "");
+    const tarballMatch = /^(@[^/]+\/[^/]+|[^/]+)\/-\/([^/]+\.tgz)$/.exec(decodedPath);
+    if (tarballMatch) {
+      const packageName = tarballMatch[1];
+      const tarballFile = tarballMatch[2];
+      const packument = packages.get(packageName);
+      const known = Object.values(packument?.versions ?? {}).some(
+        (version) => version.tarballFile === tarballFile,
+      );
+      if (!known) {
+        await sendJson(request, response, startedAt, 404, { error: "tarball not found" });
+        return;
+      }
+      await sendTarball(request, response, startedAt, tarballFile);
+      return;
+    }
+
+    const packument = packages.get(decodedPath);
+    if (packument) {
+      await sendJson(request, response, startedAt, 200, renderPackument(packument));
+      return;
+    }
+
+    await sendJson(request, response, startedAt, 404, { error: "not found" });
+  } catch (err) {
+    await sendJson(request, response, startedAt, 500, {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+});
+
+server.listen(port, host, () => {
+  console.log(JSON.stringify({ event: "fake-registry-ready", url: baseUrl, stateDir }));
+});
+
+process.on("SIGTERM", () => server.close(() => process.exit(0)));
+process.on("SIGINT", () => server.close(() => process.exit(0)));
+
+function buildPackageMap(scenarios) {
+  const byPackage = new Map();
+  for (const scenario of scenarios) {
+    const packument = byPackage.get(scenario.packageName) ?? {
+      name: scenario.packageName,
+      distTags: {},
+      versions: {},
+      times: {},
+    };
+    packument.distTags[scenario.previous.tag || scenario.tag || "latest"] =
+      scenario.previous.version;
+    packument.versions[scenario.previous.version] = scenario.previous;
+    if (scenario.previous.publishedAt) {
+      packument.times[scenario.previous.version] = scenario.previous.publishedAt;
+    }
+    byPackage.set(scenario.packageName, packument);
+  }
+  return byPackage;
+}
+
+function renderPackument(packument) {
+  const versions = {};
+  for (const [version, entry] of Object.entries(packument.versions)) {
+    versions[version] = {
+      ...entry.manifest,
+      dist: {
+        tarball: `${baseUrl}/${encodePackageName(packument.name)}/-/${entry.tarballFile}`,
+        shasum: entry.shasum,
+        integrity: entry.integrity,
+      },
+    };
+  }
+  return {
+    name: packument.name,
+    "dist-tags": packument.distTags,
+    versions,
+    time: packument.times,
+  };
+}
+
+function stageListItem(scenario) {
+  return {
+    id: scenario.stageId,
+    packageName: scenario.packageName,
+    version: scenario.staged.version,
+    tag: scenario.tag,
+    access: scenario.access,
+    actor: scenario.actor,
+    actorType: scenario.actorType,
+    createdAt: scenario.createdAt,
+    shasum: scenario.staged.shasum,
+  };
+}
+
+function stageDetails(scenario) {
+  return {
+    ...stageListItem(scenario),
+    manifest: scenario.staged.manifest,
+    packageJson: scenario.staged.manifest,
+  };
+}
+
+async function sendStageList(request, response, startedAt, url) {
+  const packageFilter = url.searchParams.get("package");
+  const perPage = Math.max(1, Math.min(100, Number(url.searchParams.get("perPage") || "25")));
+  const items = registry.scenarios
+    .filter((scenario) => !packageFilter || scenario.packageName === packageFilter)
+    .map(stageListItem)
+    .slice(0, perPage);
+
+  await sendJson(request, response, startedAt, 200, {
+    items,
+    total: items.length,
+    perPage,
+    page: 1,
+  });
+}
+
+async function sendTarball(request, response, startedAt, tarballFile) {
+  const filePath = path.join(tarballDir, tarballFile);
+  const fileStat = await stat(filePath);
+  const range = parseRange(request.headers.range, fileStat.size);
+  const headers = {
+    "accept-ranges": "bytes",
+    "content-type": "application/octet-stream",
+  };
+
+  if (range) {
+    response.writeHead(206, {
+      ...headers,
+      "content-length": String(range.end - range.start + 1),
+      "content-range": `bytes ${range.start}-${range.end}/${fileStat.size}`,
+    });
+    createReadStream(filePath, { start: range.start, end: range.end }).pipe(response);
+    await record(request, startedAt, 206);
+    return;
+  }
+
+  response.writeHead(200, {
+    ...headers,
+    "content-length": String(fileStat.size),
+  });
+  createReadStream(filePath).pipe(response);
+  await record(request, startedAt, 200);
+}
+
+async function sendJson(request, response, startedAt, status, value) {
+  await send(
+    request,
+    response,
+    startedAt,
+    status,
+    { "content-type": "application/json; charset=utf-8" },
+    JSON.stringify(value, null, 2),
+  );
+}
+
+async function send(request, response, startedAt, status, headers, body) {
+  response.writeHead(status, headers);
+  response.end(body);
+  await record(request, startedAt, status);
+}
+
+async function record(request, startedAt, status) {
+  const entry = {
+    at: new Date().toISOString(),
+    method: request.method,
+    path: request.url,
+    authorization: request.headers.authorization ? "present" : "absent",
+    range: request.headers.range ?? null,
+    status,
+    durationMs: Date.now() - startedAt,
+  };
+  await appendFile(journalFile, `${JSON.stringify(entry)}\n`);
+}
+
+function parseRange(value, size) {
+  if (!value) return null;
+  const match = /^bytes=(\d+)-(\d*)$/.exec(value);
+  if (!match) return null;
+  const start = Number(match[1]);
+  const requestedEnd = match[2] ? Number(match[2]) : size - 1;
+  if (!Number.isInteger(start) || !Number.isInteger(requestedEnd) || start >= size) return null;
+  return { start, end: Math.min(requestedEnd, size - 1) };
+}
+
+function encodePackageName(packageName) {
+  return encodeURIComponent(packageName).replace(/^%40/, "@");
+}
+
+function parseArgs(rawArgs) {
+  const parsed = {};
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const arg = rawArgs[index];
+    if (!arg.startsWith("--")) continue;
+    const key = arg.slice(2).replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+    parsed[key] = rawArgs[index + 1];
+    index += 1;
+  }
+  return parsed;
+}

--- a/test/e2e/local-registry.spec.ts
+++ b/test/e2e/local-registry.spec.ts
@@ -46,21 +46,30 @@ test("reviews staged fixtures from the local fake npm registry", async ({ page }
     });
   });
 
-  const scenarios = (await readScenarios()).filter((scenario) => scenario.stageId !== uiStageId);
-  for (const scenario of scenarios) {
-    await test.step(`scenario: ${scenario.name}`, async () => {
-      const response = await scanStage(page, scenario.stageId);
-      if (scenario.expected.errorStatus) {
-        expect(response.status, scenario.name).toBe(scenario.expected.errorStatus);
-        expect(String(response.body?.error ?? ""), scenario.name).toContain(
-          scenario.expected.errorIncludes,
-        );
-        return;
-      }
+  const apiPage = await page.context().newPage();
+  await apiPage.goto("/dashboard");
+  await expect(apiPage.getByRole("heading", { name: "Ready for the next release" })).toBeVisible({
+    timeout: 30_000,
+  });
+  try {
+    const scenarios = (await readScenarios()).filter((scenario) => scenario.stageId !== uiStageId);
+    for (const scenario of scenarios) {
+      await test.step(`scenario: ${scenario.name}`, async () => {
+        const response = await scanStage(apiPage, scenario.stageId);
+        if (scenario.expected.errorStatus) {
+          expect(response.status, scenario.name).toBe(scenario.expected.errorStatus);
+          expect(String(response.body?.error ?? ""), scenario.name).toContain(
+            scenario.expected.errorIncludes,
+          );
+          return;
+        }
 
-      expect(response.status, scenario.name).toBe(200);
-      assertScanMatchesScenario(response.body, scenario);
-    });
+        expect(response.status, scenario.name).toBe(200);
+        assertScanMatchesScenario(response.body, scenario);
+      });
+    }
+  } finally {
+    await apiPage.close();
   }
 
   await test.step("registry journal", async () => {

--- a/test/e2e/local-registry.spec.ts
+++ b/test/e2e/local-registry.spec.ts
@@ -1,12 +1,14 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Browser, type BrowserContext, type Page } from "@playwright/test";
+import { readdirSync, readFileSync } from "node:fs";
 import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
 const appPort = Number(process.env.E2E_APP_PORT || process.env.CONDUCTOR_PORT || 5173);
 const registryUrl = process.env.E2E_NPM_REGISTRY || `http://127.0.0.1:${appPort + 1}`;
 const artifactsDir = path.resolve(".context/e2e-artifacts");
+const authStatePath = path.join(artifactsDir, "auth-state.json");
 const journalPath = path.resolve(".context/e2e-registry/requests.jsonl");
-const registryStatePath = path.resolve(".context/e2e-registry/registry.json");
+const scenariosRoot = path.resolve("test/e2e-fixtures/scenarios");
 const uiStageId = "stage-implicit-node-gyp-000001";
 
 interface RegistryScenario {
@@ -25,11 +27,31 @@ interface RegistryScenario {
   };
 }
 
-test("reviews staged fixtures from the local fake npm registry", async ({ page }) => {
+const scenarios = readScenarioDefinitions();
+
+test.describe.configure({ mode: "serial" });
+
+test.beforeAll(async ({ browser, baseURL }) => {
+  await mkdir(artifactsDir, { recursive: true });
+  const context = await browser.newContext({ baseURL });
+  const page = await context.newPage();
   await registerAndConnect(page);
-  await test.step("UI smoke: implicit node-gyp report", async () => {
+  await context.storageState({ path: authStatePath });
+  await context.close();
+});
+
+test("UI smoke: reviews the implicit node-gyp fixture", async ({ browser, baseURL }) => {
+  const { context, page } = await openAuthenticatedPage(browser, baseURL);
+  try {
+    await page.goto("/dashboard");
+    await expect(page.getByRole("heading", { name: "Ready for the next release" })).toBeVisible({
+      timeout: 30_000,
+    });
+
     await page.locator("#stageId").fill(uiStageId);
-    await page.getByRole("button", { name: "Review staged publish" }).click();
+    const reviewButton = page.getByRole("button", { name: "Review staged publish" });
+    await expect(reviewButton).toBeEnabled();
+    await reviewButton.click();
     await expect(page).toHaveURL(/\/dashboard\/scans\//, { timeout: 30_000 });
 
     await expect(page.getByRole("heading", { name: "@drydock/e2e-native" })).toBeVisible({
@@ -39,55 +61,56 @@ test("reviews staged fixtures from the local fake npm registry", async ({ page }
     await expect(page.getByText("implicit install: node-gyp rebuild")).toBeVisible();
     await expect(page.getByText("install-script.implicit-node-gyp")).toBeVisible();
 
-    await mkdir(artifactsDir, { recursive: true });
     await page.screenshot({
       path: path.join(artifactsDir, "implicit-node-gyp-report.png"),
       fullPage: true,
     });
-  });
-
-  const apiPage = await page.context().newPage();
-  await apiPage.goto("/dashboard");
-  await expect(apiPage.getByRole("heading", { name: "Ready for the next release" })).toBeVisible({
-    timeout: 30_000,
-  });
-  try {
-    const scenarios = (await readScenarios()).filter((scenario) => scenario.stageId !== uiStageId);
-    for (const scenario of scenarios) {
-      await test.step(`scenario: ${scenario.name}`, async () => {
-        const response = await scanStage(apiPage, scenario.stageId);
-        if (scenario.expected.errorStatus) {
-          expect(response.status, scenario.name).toBe(scenario.expected.errorStatus);
-          expect(String(response.body?.error ?? ""), scenario.name).toContain(
-            scenario.expected.errorIncludes,
-          );
-          return;
-        }
-
-        expect(response.status, scenario.name).toBe(200);
-        assertScanMatchesScenario(response.body, scenario);
-      });
-    }
   } finally {
-    await apiPage.close();
+    await context.close();
   }
+});
 
-  await test.step("registry journal", async () => {
-    const journal = await readJournal();
-    expect(journal.some((entry) => entry.path === "/-/whoami")).toBe(true);
-    expect(journal.some((entry) => entry.path === "/-/stage?perPage=1")).toBe(true);
-    expect(journal.some((entry) => entry.path === `/-/stage/${uiStageId}`)).toBe(true);
-    expect(journal.some((entry) => entry.path === `/-/stage/${uiStageId}/tarball`)).toBe(true);
-    expect(journal.some((entry) => entry.path.includes("/-/drydock-e2e-native-1.0.0.tgz"))).toBe(
-      true,
-    );
+for (const scenario of scenarios.filter((item) => item.stageId !== uiStageId)) {
+  test(`scenario: ${scenario.name}`, async ({ browser, baseURL }) => {
+    const { context, page } = await openAuthenticatedPage(browser, baseURL);
+    try {
+      await page.goto("/dashboard");
+      await expect(page.getByRole("heading", { name: "Ready for the next release" })).toBeVisible({
+        timeout: 30_000,
+      });
 
-    for (const entry of journal.filter((item) => item.authorization === "present")) {
-      expect(entry.path).toMatch(
-        /^\/(?:-\/(?:whoami|stage(?:\?|\/))|@drydock(?:%2F|\/)[^/]+(?:$|\/-\/))/i,
-      );
+      const response = await scanStage(page, scenario.stageId);
+      if (scenario.expected.errorStatus) {
+        expect(response.status, scenario.name).toBe(scenario.expected.errorStatus);
+        expect(String(response.body?.error ?? ""), scenario.name).toContain(
+          scenario.expected.errorIncludes,
+        );
+        return;
+      }
+
+      expect(response.status, scenario.name).toBe(200);
+      assertScanMatchesScenario(response.body, scenario);
+    } finally {
+      await context.close();
     }
   });
+}
+
+test("registry journal limits credential forwarding", async () => {
+  const journal = await readJournal();
+  expect(journal.some((entry) => entry.path === "/-/whoami")).toBe(true);
+  expect(journal.some((entry) => entry.path === "/-/stage?perPage=1")).toBe(true);
+  expect(journal.some((entry) => entry.path === `/-/stage/${uiStageId}`)).toBe(true);
+  expect(journal.some((entry) => entry.path === `/-/stage/${uiStageId}/tarball`)).toBe(true);
+  expect(journal.some((entry) => entry.path.includes("/-/drydock-e2e-native-1.0.0.tgz"))).toBe(
+    true,
+  );
+
+  for (const entry of journal.filter((item) => item.authorization === "present")) {
+    expect(entry.path).toMatch(
+      /^\/(?:-\/(?:whoami|stage(?:\?|\/))|@drydock(?:%2F|\/)[^/]+(?:$|\/-\/))/i,
+    );
+  }
 });
 
 async function registerAndConnect(page: Page) {
@@ -104,17 +127,40 @@ async function registerAndConnect(page: Page) {
     timeout: 30_000,
   });
 
-  await page.getByLabel("Connection name").fill("Fake npm staging registry");
-  await page.getByLabel("Registry").fill(registryUrl);
-  await page.getByLabel(/npm token/i).fill("npm_e2e_token_0123456789");
+  await page.evaluate(
+    async (input) => {
+      const save = await fetch("/api/v1/npm-connection", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      if (!save.ok) throw new Error(`npm connection save failed: ${save.status}`);
 
-  const validation = page.waitForResponse(
-    (response) =>
-      response.url().includes("/api/v1/npm-connection/validate") && response.status() === 200,
+      const validate = await fetch("/api/v1/npm-connection/validate", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ stageId: "stage-benign-diff-000001" }),
+      });
+      const body = await validate.json().catch(() => null);
+      if (!validate.ok || !body?.validation?.ok) {
+        throw new Error(`npm connection validation failed: ${validate.status}`);
+      }
+    },
+    {
+      label: "Fake npm staging registry",
+      registryUrl,
+      token: "npm_e2e_token_0123456789",
+    },
   );
-  await page.getByRole("button", { name: "Save" }).click();
-  await validation;
-  await expect(page.getByText("valid").first()).toBeVisible();
+}
+
+async function openAuthenticatedPage(
+  browser: Browser,
+  baseURL: string | undefined,
+): Promise<{ context: BrowserContext; page: Page }> {
+  const context = await browser.newContext({ baseURL, storageState: authStatePath });
+  const page = await context.newPage();
+  return { context, page };
 }
 
 async function scanStage(page: Page, stageId: string): Promise<{ status: number; body: any }> {
@@ -155,14 +201,18 @@ function assertScanMatchesScenario(result: any, scenario: RegistryScenario) {
   }
 }
 
-async function readScenarios(): Promise<RegistryScenario[]> {
-  const text = await readFile(registryStatePath, "utf8");
-  const registry = JSON.parse(text) as { scenarios: RegistryScenario[] };
-  return registry.scenarios.sort((left, right) => {
-    const leftFails = left.expected.errorStatus ? 1 : 0;
-    const rightFails = right.expected.errorStatus ? 1 : 0;
-    return leftFails - rightFails || left.name.localeCompare(right.name);
-  });
+function readScenarioDefinitions(): RegistryScenario[] {
+  return readdirSync(scenariosRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => {
+      const text = readFileSync(path.join(scenariosRoot, entry.name, "scenario.json"), "utf8");
+      return { ...JSON.parse(text), name: entry.name } as RegistryScenario;
+    })
+    .sort((left, right) => {
+      const leftFails = left.expected.errorStatus ? 1 : 0;
+      const rightFails = right.expected.errorStatus ? 1 : 0;
+      return leftFails - rightFails || left.name.localeCompare(right.name);
+    });
 }
 
 async function readJournal(): Promise<

--- a/test/e2e/local-registry.spec.ts
+++ b/test/e2e/local-registry.spec.ts
@@ -122,19 +122,23 @@ async function registerAndConnect(page: Page) {
   await page.getByLabel("Email").fill(email);
   await page.getByLabel("Password").fill("correct horse battery staple");
   await page.getByRole("button", { name: "Create account" }).click();
+  await page.waitForURL(/\/dashboard$/, { timeout: 30_000 });
 
   await expect(page.getByRole("heading", { name: "Ready for the next release" })).toBeVisible({
     timeout: 30_000,
   });
 
-  await page.evaluate(
+  await evaluateOnStablePage(
+    page,
     async (input) => {
       const save = await fetch("/api/v1/npm-connection", {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(input),
       });
-      if (!save.ok) throw new Error(`npm connection save failed: ${save.status}`);
+      if (!save.ok) {
+        throw new Error(`npm connection save failed: ${save.status} ${await save.text()}`);
+      }
 
       const validate = await fetch("/api/v1/npm-connection/validate", {
         method: "POST",
@@ -143,7 +147,9 @@ async function registerAndConnect(page: Page) {
       });
       const body = await validate.json().catch(() => null);
       if (!validate.ok || !body?.validation?.ok) {
-        throw new Error(`npm connection validation failed: ${validate.status}`);
+        throw new Error(
+          `npm connection validation failed: ${validate.status} ${await validate.text()}`,
+        );
       }
     },
     {
@@ -164,15 +170,48 @@ async function openAuthenticatedPage(
 }
 
 async function scanStage(page: Page, stageId: string): Promise<{ status: number; body: any }> {
-  return page.evaluate(async (inputStageId) => {
-    const response = await fetch("/api/v1/scan", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ stageId: inputStageId }),
-    });
-    const body = await response.json().catch(() => null);
-    return { status: response.status, body };
-  }, stageId);
+  return evaluateOnStablePage(
+    page,
+    async (inputStageId) => {
+      const response = await fetch("/api/v1/scan", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ stageId: inputStageId }),
+      });
+      const body = await response.json().catch(() => null);
+      return { status: response.status, body };
+    },
+    stageId,
+  );
+}
+
+async function evaluateOnStablePage<Arg, Result>(
+  page: Page,
+  pageFunction: (arg: Arg) => Promise<Result>,
+  arg: Arg,
+): Promise<Result> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      return await page.evaluate(pageFunction, arg);
+    } catch (err) {
+      if (!isNavigationContextError(err) || attempt === 2) throw err;
+      await waitForSettledNavigation(page);
+    }
+  }
+  throw new Error("page evaluation failed");
+}
+
+async function waitForSettledNavigation(page: Page) {
+  await page.waitForLoadState("domcontentloaded").catch(() => {});
+  await page.waitForLoadState("networkidle", { timeout: 5_000 }).catch(() => {});
+}
+
+function isNavigationContextError(err: unknown) {
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    message.includes("Execution context was destroyed") ||
+    message.includes("Cannot find context with specified id")
+  );
 }
 
 function assertScanMatchesScenario(result: any, scenario: RegistryScenario) {

--- a/test/e2e/local-registry.spec.ts
+++ b/test/e2e/local-registry.spec.ts
@@ -17,7 +17,7 @@ interface RegistryScenario {
   packageName: string;
   expected: {
     releaseRisk?: string;
-    packageName?: string;
+    packageName?: string | null;
     stagedVersion?: string;
     previousVersion?: string | null;
     ruleIds?: string[];
@@ -105,6 +105,10 @@ test("registry journal limits credential forwarding", async () => {
   expect(journal.some((entry) => entry.path.includes("/-/drydock-e2e-native-1.0.0.tgz"))).toBe(
     true,
   );
+
+  for (const entry of journal.filter((item) => item.path !== "/__health")) {
+    expect(entry.authorization, entry.path).toBe("present");
+  }
 
   for (const entry of journal.filter((item) => item.authorization === "present")) {
     expect(entry.path).toMatch(
@@ -219,7 +223,9 @@ function assertScanMatchesScenario(result: any, scenario: RegistryScenario) {
   expect(result.stageId, scenario.name).toBe(scenario.stageId);
   expect(result.risk, scenario.name).toBe(expected.releaseRisk);
   expect(result.riskSummary?.releaseRisk, scenario.name).toBe(expected.releaseRisk);
-  expect(result.package?.name, scenario.name).toBe(expected.packageName ?? scenario.packageName);
+  expect(result.package?.name, scenario.name).toBe(
+    "packageName" in expected ? expected.packageName : scenario.packageName,
+  );
   if ("stagedVersion" in expected) {
     expect(result.package?.stagedVersion, scenario.name).toBe(expected.stagedVersion);
   }

--- a/test/e2e/local-registry.spec.ts
+++ b/test/e2e/local-registry.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import { mkdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
@@ -6,9 +6,82 @@ const appPort = Number(process.env.E2E_APP_PORT || process.env.CONDUCTOR_PORT ||
 const registryUrl = process.env.E2E_NPM_REGISTRY || `http://127.0.0.1:${appPort + 1}`;
 const artifactsDir = path.resolve(".context/e2e-artifacts");
 const journalPath = path.resolve(".context/e2e-registry/requests.jsonl");
-const stageId = "stage-implicit-node-gyp-000001";
+const registryStatePath = path.resolve(".context/e2e-registry/registry.json");
+const uiStageId = "stage-implicit-node-gyp-000001";
 
-test("reviews a staged fixture from the local fake npm registry", async ({ page }) => {
+interface RegistryScenario {
+  name: string;
+  stageId: string;
+  packageName: string;
+  expected: {
+    releaseRisk?: string;
+    packageName?: string;
+    stagedVersion?: string;
+    previousVersion?: string | null;
+    ruleIds?: string[];
+    baseline?: Record<string, unknown>;
+    errorStatus?: number;
+    errorIncludes?: string;
+  };
+}
+
+test("reviews staged fixtures from the local fake npm registry", async ({ page }) => {
+  await registerAndConnect(page);
+  await test.step("UI smoke: implicit node-gyp report", async () => {
+    await page.locator("#stageId").fill(uiStageId);
+    await page.getByRole("button", { name: "Review staged publish" }).click();
+    await expect(page).toHaveURL(/\/dashboard\/scans\//, { timeout: 30_000 });
+
+    await expect(page.getByRole("heading", { name: "@drydock/e2e-native" })).toBeVisible({
+      timeout: 60_000,
+    });
+    await expect(page.getByText("release high").first()).toBeVisible();
+    await expect(page.getByText("implicit install: node-gyp rebuild")).toBeVisible();
+    await expect(page.getByText("install-script.implicit-node-gyp")).toBeVisible();
+
+    await mkdir(artifactsDir, { recursive: true });
+    await page.screenshot({
+      path: path.join(artifactsDir, "implicit-node-gyp-report.png"),
+      fullPage: true,
+    });
+  });
+
+  const scenarios = (await readScenarios()).filter((scenario) => scenario.stageId !== uiStageId);
+  for (const scenario of scenarios) {
+    await test.step(`scenario: ${scenario.name}`, async () => {
+      const response = await scanStage(page, scenario.stageId);
+      if (scenario.expected.errorStatus) {
+        expect(response.status, scenario.name).toBe(scenario.expected.errorStatus);
+        expect(String(response.body?.error ?? ""), scenario.name).toContain(
+          scenario.expected.errorIncludes,
+        );
+        return;
+      }
+
+      expect(response.status, scenario.name).toBe(200);
+      assertScanMatchesScenario(response.body, scenario);
+    });
+  }
+
+  await test.step("registry journal", async () => {
+    const journal = await readJournal();
+    expect(journal.some((entry) => entry.path === "/-/whoami")).toBe(true);
+    expect(journal.some((entry) => entry.path === "/-/stage?perPage=1")).toBe(true);
+    expect(journal.some((entry) => entry.path === `/-/stage/${uiStageId}`)).toBe(true);
+    expect(journal.some((entry) => entry.path === `/-/stage/${uiStageId}/tarball`)).toBe(true);
+    expect(journal.some((entry) => entry.path.includes("/-/drydock-e2e-native-1.0.0.tgz"))).toBe(
+      true,
+    );
+
+    for (const entry of journal.filter((item) => item.authorization === "present")) {
+      expect(entry.path).toMatch(
+        /^\/(?:-\/(?:whoami|stage(?:\?|\/))|@drydock(?:%2F|\/)[^/]+(?:$|\/-\/))/i,
+      );
+    }
+  });
+});
+
+async function registerAndConnect(page: Page) {
   const unique = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
   const email = `e2e-${unique}@example.test`;
 
@@ -33,39 +106,55 @@ test("reviews a staged fixture from the local fake npm registry", async ({ page 
   await page.getByRole("button", { name: "Save" }).click();
   await validation;
   await expect(page.getByText("valid").first()).toBeVisible();
+}
 
-  await page.locator("#stageId").fill(stageId);
-  await page.getByRole("button", { name: "Review staged publish" }).click();
-  await expect(page).toHaveURL(/\/dashboard\/scans\//, { timeout: 30_000 });
+async function scanStage(page: Page, stageId: string): Promise<{ status: number; body: any }> {
+  return page.evaluate(async (inputStageId) => {
+    const response = await fetch("/api/v1/scan", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ stageId: inputStageId }),
+    });
+    const body = await response.json().catch(() => null);
+    return { status: response.status, body };
+  }, stageId);
+}
 
-  await expect(page.getByRole("heading", { name: "@drydock/e2e-native" })).toBeVisible({
-    timeout: 60_000,
-  });
-  await expect(page.getByText("release high").first()).toBeVisible();
-  await expect(page.getByText("implicit install: node-gyp rebuild")).toBeVisible();
-  await expect(page.getByText("install-script.implicit-node-gyp")).toBeVisible();
-
-  await mkdir(artifactsDir, { recursive: true });
-  await page.screenshot({
-    path: path.join(artifactsDir, "implicit-node-gyp-report.png"),
-    fullPage: true,
-  });
-
-  const journal = await readJournal();
-  expect(journal.some((entry) => entry.path === "/-/whoami")).toBe(true);
-  expect(journal.some((entry) => entry.path === "/-/stage?perPage=1")).toBe(true);
-  expect(journal.some((entry) => entry.path === `/-/stage/${stageId}`)).toBe(true);
-  expect(journal.some((entry) => entry.path === `/-/stage/${stageId}/tarball`)).toBe(true);
-  expect(journal.some((entry) => entry.path.includes("/-/drydock-e2e-native-1.0.0.tgz"))).toBe(
-    true,
-  );
-
-  for (const entry of journal.filter((item) => item.authorization === "present")) {
-    expect(entry.path).toMatch(
-      /^\/(?:-\/(?:whoami|stage(?:\?|\/))|@drydock(?:%2F|\/)e2e-native(?:$|\/-\/))/i,
-    );
+function assertScanMatchesScenario(result: any, scenario: RegistryScenario) {
+  const expected = scenario.expected;
+  expect(result.stageId, scenario.name).toBe(scenario.stageId);
+  expect(result.risk, scenario.name).toBe(expected.releaseRisk);
+  expect(result.riskSummary?.releaseRisk, scenario.name).toBe(expected.releaseRisk);
+  expect(result.package?.name, scenario.name).toBe(expected.packageName ?? scenario.packageName);
+  if ("stagedVersion" in expected) {
+    expect(result.package?.stagedVersion, scenario.name).toBe(expected.stagedVersion);
   }
-});
+  if ("previousVersion" in expected) {
+    expect(result.package?.previousVersion, scenario.name).toBe(expected.previousVersion);
+  }
+  if (expected.baseline) {
+    expect(result.baseline, scenario.name).toMatchObject(expected.baseline);
+  }
+
+  const ruleIds = result.ruleFindings
+    .map((finding: { ruleId?: string }) => finding.ruleId)
+    .filter(Boolean);
+  const expectedRuleIds = expected.ruleIds ?? [];
+  expect(ruleIds, scenario.name).toEqual(expect.arrayContaining(expectedRuleIds));
+  if (expectedRuleIds.length === 0) {
+    expect(ruleIds, scenario.name).toHaveLength(0);
+  }
+}
+
+async function readScenarios(): Promise<RegistryScenario[]> {
+  const text = await readFile(registryStatePath, "utf8");
+  const registry = JSON.parse(text) as { scenarios: RegistryScenario[] };
+  return registry.scenarios.sort((left, right) => {
+    const leftFails = left.expected.errorStatus ? 1 : 0;
+    const rightFails = right.expected.errorStatus ? 1 : 0;
+    return leftFails - rightFails || left.name.localeCompare(right.name);
+  });
+}
 
 async function readJournal(): Promise<
   Array<{ path: string; authorization: "present" | "absent"; status: number }>

--- a/test/e2e/local-registry.spec.ts
+++ b/test/e2e/local-registry.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "@playwright/test";
+import { mkdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const appPort = Number(process.env.E2E_APP_PORT || process.env.CONDUCTOR_PORT || 5173);
+const registryUrl = process.env.E2E_NPM_REGISTRY || `http://127.0.0.1:${appPort + 1}`;
+const artifactsDir = path.resolve(".context/e2e-artifacts");
+const journalPath = path.resolve(".context/e2e-registry/requests.jsonl");
+const stageId = "stage-implicit-node-gyp-000001";
+
+test("reviews a staged fixture from the local fake npm registry", async ({ page }) => {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const email = `e2e-${unique}@example.test`;
+
+  await page.goto("/register");
+  await page.getByLabel("Name").fill("E2E Tester");
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill("correct horse battery staple");
+  await page.getByRole("button", { name: "Create account" }).click();
+
+  await expect(page.getByRole("heading", { name: "Ready for the next release" })).toBeVisible({
+    timeout: 30_000,
+  });
+
+  await page.getByLabel("Connection name").fill("Fake npm staging registry");
+  await page.getByLabel("Registry").fill(registryUrl);
+  await page.getByLabel(/npm token/i).fill("npm_e2e_token_0123456789");
+
+  const validation = page.waitForResponse(
+    (response) =>
+      response.url().includes("/api/v1/npm-connection/validate") && response.status() === 200,
+  );
+  await page.getByRole("button", { name: "Save" }).click();
+  await validation;
+  await expect(page.getByText("valid").first()).toBeVisible();
+
+  await page.locator("#stageId").fill(stageId);
+  await page.getByRole("button", { name: "Review staged publish" }).click();
+  await expect(page).toHaveURL(/\/dashboard\/scans\//, { timeout: 30_000 });
+
+  await expect(page.getByRole("heading", { name: "@drydock/e2e-native" })).toBeVisible({
+    timeout: 60_000,
+  });
+  await expect(page.getByText("release high").first()).toBeVisible();
+  await expect(page.getByText("implicit install: node-gyp rebuild")).toBeVisible();
+  await expect(page.getByText("install-script.implicit-node-gyp")).toBeVisible();
+
+  await mkdir(artifactsDir, { recursive: true });
+  await page.screenshot({
+    path: path.join(artifactsDir, "implicit-node-gyp-report.png"),
+    fullPage: true,
+  });
+
+  const journal = await readJournal();
+  expect(journal.some((entry) => entry.path === "/-/whoami")).toBe(true);
+  expect(journal.some((entry) => entry.path === "/-/stage?perPage=1")).toBe(true);
+  expect(journal.some((entry) => entry.path === `/-/stage/${stageId}`)).toBe(true);
+  expect(journal.some((entry) => entry.path === `/-/stage/${stageId}/tarball`)).toBe(true);
+  expect(journal.some((entry) => entry.path.includes("/-/drydock-e2e-native-1.0.0.tgz"))).toBe(
+    true,
+  );
+
+  for (const entry of journal.filter((item) => item.authorization === "present")) {
+    expect(entry.path).toMatch(
+      /^\/(?:-\/(?:whoami|stage(?:\?|\/))|@drydock(?:%2F|\/)e2e-native(?:$|\/-\/))/i,
+    );
+  }
+});
+
+async function readJournal(): Promise<
+  Array<{ path: string; authorization: "present" | "absent"; status: number }>
+> {
+  const text = await readFile(journalPath, "utf8");
+  return text
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+}

--- a/test/npm-connection.test.mjs
+++ b/test/npm-connection.test.mjs
@@ -18,6 +18,22 @@ describe("npm connection validation", () => {
     );
   });
 
+  test("allows loopback http registries only when explicitly enabled", () => {
+    expect(
+      normalizeRegistryUrl("http://127.0.0.1:5184///?ignored=1#hash", {
+        allowInsecureLocalhost: true,
+      }),
+    ).toBe("http://127.0.0.1:5184");
+    expect(
+      normalizeRegistryUrl("http://localhost:5184", {
+        allowInsecureLocalhost: true,
+      }),
+    ).toBe("http://localhost:5184");
+    expect(() =>
+      normalizeRegistryUrl("http://registry.npmjs.org", { allowInsecureLocalhost: true }),
+    ).toThrow("registry URL must use https");
+  });
+
   test("checks registry auth and staged list capability without a stage id", async () => {
     const fetchMock = vi.fn(async (url, init) => {
       expect(init.headers.authorization).toBe("Bearer npm_secret_token");

--- a/test/scan-pipeline.test.mjs
+++ b/test/scan-pipeline.test.mjs
@@ -117,6 +117,7 @@ describe("scan pipeline baseline selection", () => {
       "https://registry.npmjs.org",
       "npm_secret_token",
       "stage-beta-123",
+      { allowInsecureLocalhost: false },
     );
     expect(sandboxMock.downloadInSandbox.mock.calls[1]?.[2]).toMatchObject({
       tarballUrl: "https://registry.npmjs.org/@scope/pkg/-/pkg-2.0.0-beta.2.tgz",
@@ -321,6 +322,7 @@ describe("scan pipeline baseline selection", () => {
       "https://registry.npmjs.org",
       "npm_token_0123456789",
       "stage-abc123",
+      { allowInsecureLocalhost: false },
     );
     expect(result.packageJson?.implicitScripts).toEqual({ install: "node-gyp rebuild" });
     expect(result.ruleFindings).toContainEqual(

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,9 @@ export default defineConfig(({ mode }) => {
     server: {
       port: 5173,
       strictPort: true,
+      watch: {
+        ignored: ["**/.context/**"],
+      },
     },
     plugins: [
       preact(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,10 +3,30 @@ import { cloudflare } from "@cloudflare/vite-plugin";
 import preact from "@preact/preset-vite";
 import tailwindcss from "@tailwindcss/vite";
 
-export default defineConfig(({ mode }) => ({
-  server: {
-    port: 5173,
-    strictPort: true,
-  },
-  plugins: [preact(), tailwindcss(), ...(mode === "test" ? [] : [cloudflare()])],
-}));
+declare const process: {
+  env: {
+    CLOUDFLARE_VITE_PERSIST_STATE_PATH?: string;
+  };
+};
+
+export default defineConfig(({ mode }) => {
+  const persistStatePath = process.env.CLOUDFLARE_VITE_PERSIST_STATE_PATH;
+
+  return {
+    server: {
+      port: 5173,
+      strictPort: true,
+    },
+    plugins: [
+      preact(),
+      tailwindcss(),
+      ...(mode === "test"
+        ? []
+        : [
+            cloudflare({
+              persistState: persistStatePath ? { path: persistStatePath } : true,
+            }),
+          ]),
+    ],
+  };
+});


### PR DESCRIPTION
## Summary

Adds a deterministic local E2E harness with Playwright, fixture packages, a fake npm staging registry, Conductor run configuration, and CI coverage.

It also adds a dev-only loopback HTTP registry guard so the local harness can exercise the real npm connection and sandbox paths without weakening production HTTPS validation.

The E2E runner applies local D1 migrations, starts the fake registry plus the Vite Worker server, records registry requests, and now asserts the fixture scenario matrix for lifecycle scripts, secret-like files, invalid manifests, metadata mismatches, beta baselines, first releases, and registry failure paths.

The branch also replaces the rate-limit upsert with a local-D1-compatible select/update/insert flow exposed by the full app smoke test.

CI now installs Chromium, runs `pnpm run test:e2e`, and uploads browser artifacts plus the fake-registry journal; validation: `pnpm run verify` and `E2E_APP_PORT=5200 E2E_REGISTRY_PORT=5201 pnpm run test:e2e`.
