### PR TITLE
Disable ligatures in code blocks so CLI flag spaces render correctly

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -99,6 +99,7 @@
   samp {
     font-family: var(--font-mono);
     font-feature-settings: "ss01", "tnum";
+    font-variant-ligatures: none;
   }
 
   a {


### PR DESCRIPTION
## Summary
- Geist Mono's contextual alternates were tightening glyphs around `--`, making script commands like `npm publish --access public` look like `publish--access public` in the manifest diff.
- Added `font-variant-ligatures: none` to `code, pre, kbd, samp` so each character keeps full monospace width.

## Test plan
- [ ] Open a scan detail view and confirm `--` flags in the Scripts diff render with a visible space before them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)