### PR TITLE
[codex] Refactor duplicated request helpers

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -238,6 +238,8 @@ Do not expose public signed report generation until the report payload is stable
 
 ## API direction
 
+Stage ID validation is centralized in `server/lib/stage-id.ts` and reused by scan routes, staged-publish helpers, npm-token validation, and the Dynamic Worker source renderer. Keep the accepted shape in that module so route and sandbox behavior cannot drift.
+
 Current API:
 
 - `POST /api/v1/scans` — create queued/background scan;

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -75,7 +75,7 @@ Use `apiFetch` from `src/models/api.ts` for same-origin JSON requests so active 
 
 ## Server route helpers
 
-Use `rateLimitResponse` from `server/lib/http.ts` for 429 JSON responses so `retryAfterSeconds` and `retry-after` headers stay consistent. Use `errorMessage(err)` from `server/lib/errors.ts` for server-side caught-error stringification instead of repeating `err instanceof Error ? err.message : String(err)`.
+Use `rateLimitResponse` from `server/lib/http.ts` for 429 JSON responses so `retryAfterSeconds` and `retry-after` headers stay consistent. Use `errorMessage(err)` from `server/lib/errors.ts` for server-side caught-error stringification instead of repeating local branches; it also preserves `message` from Worker RPC-serialized error objects.
 
 ## Related skills
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -69,6 +69,10 @@ The following rules from `@preact/eslint-plugin-signals` are enforced (see [`pre
 - `no-conditional-value-read` (error)
 - `no-signal-truthiness` (warn)
 
+## Client API helpers
+
+Use `apiFetch` from `src/models/api.ts` for same-origin JSON requests so active organization headers and `ApiError` handling stay consistent. Use `apiJson` for JSON request bodies instead of repeating `content-type` and `JSON.stringify` at call sites. Use `errorMessage(err)` when model actions need to surface caught errors into a signal.
+
 ## Related skills
 
 The `.claude/skills/` directory ships the canonical signals/models reference set used by Claude Code during this migration. The same skills are exposed to agents through the `.agents/skills` symlink:

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -73,6 +73,10 @@ The following rules from `@preact/eslint-plugin-signals` are enforced (see [`pre
 
 Use `apiFetch` from `src/models/api.ts` for same-origin JSON requests so active organization headers and `ApiError` handling stay consistent. Use `apiJson` for JSON request bodies instead of repeating `content-type` and `JSON.stringify` at call sites. Use `errorMessage(err)` when model actions need to surface caught errors into a signal.
 
+## Server route helpers
+
+Use `rateLimitResponse` from `server/lib/http.ts` for 429 JSON responses so `retryAfterSeconds` and `retry-after` headers stay consistent. Use `errorMessage(err)` from `server/lib/errors.ts` for server-side caught-error stringification instead of repeating `err instanceof Error ? err.message : String(err)`.
+
 ## Related skills
 
 The `.claude/skills/` directory ships the canonical signals/models reference set used by Claude Code during this migration. The same skills are exposed to agents through the `.agents/skills` symlink:

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,6 +7,8 @@ import {
   RateLimitError,
 } from "./db";
 import { createAuth, getAuthSession } from "./lib/auth";
+import { errorMessage } from "./lib/errors";
+import { rateLimitResponse } from "./lib/http";
 import { allowInsecureLocalRegistry } from "./lib/npm-connection";
 import { durationMsSince, emitOperationalEvent } from "./lib/observability";
 import {
@@ -130,11 +132,7 @@ app.use("/api/auth/*", async (c, next) => {
     });
   } catch (err) {
     if (err instanceof RateLimitError) {
-      return c.json(
-        { error: "too many authentication attempts", retryAfterSeconds: err.retryAfterSeconds },
-        429,
-        { "retry-after": String(err.retryAfterSeconds) },
-      );
+      return rateLimitResponse(c, "too many authentication attempts", err);
     }
     throw err;
   }
@@ -207,7 +205,7 @@ app.onError((err, c) => {
     method: c.req.method,
     path: c.req.path,
     name: err instanceof Error ? err.name : "UnknownError",
-    message: err instanceof Error ? err.message : String(err),
+    message: errorMessage(err),
     stack: err instanceof Error ? err.stack : undefined,
   });
   return c.json({ error: "internal error" }, 500);

--- a/server/lib/ai-review.ts
+++ b/server/lib/ai-review.ts
@@ -8,6 +8,7 @@ import {
 } from "./ai-review-contract";
 import { buildAiReviewPayload, createAiReviewTools } from "./ai-review-evidence";
 import type { AiReview, AiReviewStatus, SelectiveAiReviewOptions } from "./ai-review-types";
+import { errorMessage } from "./errors";
 
 export type {
   AiFinding,
@@ -81,7 +82,7 @@ export async function analyzeWithAi(
     return fallbackReview(
       model,
       "unavailable",
-      `Assistant review didn't run: ${err instanceof Error ? err.message : String(err)}`,
+      `Assistant review didn't run: ${errorMessage(err)}`,
     );
   }
 }

--- a/server/lib/email.ts
+++ b/server/lib/email.ts
@@ -1,3 +1,5 @@
+import { errorMessage } from "./errors";
+
 export interface SendEmailInput {
   to: string;
   subject: string;
@@ -45,7 +47,7 @@ export async function sendNotificationEmail(
     await binding.send(new EmailMessage(fromAddress, recipient, raw));
     return { ok: true };
   } catch (err) {
-    const reason = err instanceof Error ? err.message : String(err);
+    const reason = errorMessage(err);
     return { ok: false, reason };
   }
 }

--- a/server/lib/errors.ts
+++ b/server/lib/errors.ts
@@ -1,0 +1,3 @@
+export function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/server/lib/errors.ts
+++ b/server/lib/errors.ts
@@ -1,3 +1,8 @@
 export function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  if (err instanceof Error) return err.message;
+  if (err && typeof err === "object") {
+    const message = (err as Record<string, unknown>).message;
+    if (typeof message === "string") return message;
+  }
+  return String(err);
 }

--- a/server/lib/http.ts
+++ b/server/lib/http.ts
@@ -1,0 +1,11 @@
+import type { Context } from "hono";
+import type { RateLimitError } from "../db";
+import type { Bindings, Variables } from "../types";
+
+type AppContext = Context<{ Bindings: Bindings; Variables: Variables }>;
+
+export function rateLimitResponse(c: AppContext, error: string, err: RateLimitError) {
+  return c.json({ error, retryAfterSeconds: err.retryAfterSeconds }, 429, {
+    "retry-after": String(err.retryAfterSeconds),
+  });
+}

--- a/server/lib/npm-connection.ts
+++ b/server/lib/npm-connection.ts
@@ -1,5 +1,6 @@
 import type { AppDb } from "../db";
 import { getNpmConnection, markNpmConnectionUsed } from "../db";
+import { errorMessage } from "./errors";
 
 const DEFAULT_REGISTRY = "https://registry.npmjs.org";
 
@@ -228,7 +229,7 @@ async function validateRegistryAuth(registry: string, token: string) {
   } catch (err) {
     return {
       registryAuth: false,
-      detail: err instanceof Error ? err.message : String(err),
+      detail: errorMessage(err),
     };
   }
 }
@@ -247,7 +248,7 @@ async function validateStagedListAccess(registry: string, token: string) {
   } catch (err) {
     return {
       stagedListAccess: false,
-      stagedListDetail: err instanceof Error ? err.message : String(err),
+      stagedListDetail: errorMessage(err),
     };
   }
 }
@@ -269,7 +270,7 @@ async function validateStagedViewAccess(registry: string, token: string, stageId
     return {
       stageId,
       stagedViewAccess: false,
-      stagedViewDetail: err instanceof Error ? err.message : String(err),
+      stagedViewDetail: errorMessage(err),
     };
   }
 }
@@ -294,7 +295,7 @@ async function validateStagedTarballAccess(registry: string, token: string, stag
     return {
       stageId,
       stagedTarballAccess: false,
-      stagedTarballDetail: err instanceof Error ? err.message : String(err),
+      stagedTarballDetail: errorMessage(err),
     };
   }
 }

--- a/server/lib/sandbox.ts
+++ b/server/lib/sandbox.ts
@@ -1,6 +1,7 @@
 import { WorkerEntrypoint } from "cloudflare:workers";
 import { allowInsecureLocalRegistry, registryProtocolAllowed } from "./npm-connection";
 import type { FileRecord, PackageJsonSummary } from "./review";
+import { STAGE_ID_PATTERN } from "./stage-id";
 import * as tarParser from "./tar-parser.js";
 
 const MAX_FILES = 250;
@@ -233,7 +234,7 @@ export async function downloadInSandbox(
 function sandboxSource() {
   return `${renderTarParserSource()}
 
-const STAGE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{5,160}$/;
+const STAGE_ID_RE = new RegExp(${JSON.stringify(`^${STAGE_ID_PATTERN}$`)});
 
 export default {
   async fetch(request, env) {

--- a/server/lib/scan-input.ts
+++ b/server/lib/scan-input.ts
@@ -1,0 +1,17 @@
+import type { ScanInput } from "../types";
+import { isValidStageId } from "./stage-id";
+
+export type ScanInputParseResult =
+  | { ok: true; input: ScanInput }
+  | { ok: false; error: string; status: 400 };
+
+export function parseScanInput(body: Partial<ScanInput>): ScanInputParseResult {
+  if (body.maxFiles !== undefined || body.maxBytesPerFile !== undefined) {
+    return { ok: false, error: "scan limits are controlled by the server", status: 400 };
+  }
+
+  const stageId = String(body.stageId || "");
+  if (!isValidStageId(stageId)) return { ok: false, error: "invalid stageId", status: 400 };
+
+  return { ok: true, input: { stageId } };
+}

--- a/server/lib/scan-job.ts
+++ b/server/lib/scan-job.ts
@@ -11,6 +11,7 @@ import {
   type WorkspaceSession,
 } from "../db";
 import { npmAdapter } from "./adapters/npm";
+import { errorMessage } from "./errors";
 import { notifyScanCompletion } from "./notify";
 import { describeOperationalError, durationMsSince, emitOperationalEvent } from "./observability";
 import { runScanPipeline } from "./scan-pipeline";
@@ -240,15 +241,6 @@ export function classifyScanError(err: unknown): SafeScanError {
     message: "The scan failed before a report could be generated.",
     retryable: true,
   };
-}
-
-function errorMessage(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  if (err && typeof err === "object") {
-    const message = (err as Record<string, unknown>).message;
-    if (typeof message === "string") return message;
-  }
-  return String(err);
 }
 
 function parseSandboxDetail(detail: string) {

--- a/server/lib/stage-id.ts
+++ b/server/lib/stage-id.ts
@@ -1,0 +1,7 @@
+export const STAGE_ID_PATTERN = "[A-Za-z0-9][A-Za-z0-9._:-]{5,160}";
+
+const STAGE_ID_RE = new RegExp(`^${STAGE_ID_PATTERN}$`);
+
+export function isValidStageId(value: unknown): value is string {
+  return typeof value === "string" && STAGE_ID_RE.test(value);
+}

--- a/server/lib/staged-publishes.ts
+++ b/server/lib/staged-publishes.ts
@@ -1,6 +1,7 @@
 import { normalizeRegistryUrl, type NormalizeRegistryUrlOptions } from "./npm-connection";
 import { normalizeStringRecord } from "./tar-parser.js";
 import type { PackageJsonSummary } from "./review";
+import { isValidStageId } from "./stage-id";
 
 export interface StagedPublishItem {
   id: string;
@@ -45,7 +46,6 @@ export interface StagedPublishesScanResponse {
 }
 
 const MAX_PER_PAGE = 100;
-const STAGE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{5,160}$/;
 
 export interface ListStagedPublishesOptions extends NormalizeRegistryUrlOptions {
   perPage?: number;
@@ -82,7 +82,7 @@ export async function fetchStagedPublishDetails(
   stageId: string,
   options: NormalizeRegistryUrlOptions = {},
 ): Promise<StagedPublishDetails> {
-  if (!STAGE_ID_RE.test(stageId)) throw new Error("invalid stageId");
+  if (!isValidStageId(stageId)) throw new Error("invalid stageId");
   const registry = normalizeRegistryUrl(registryUrl, options);
   const response = await fetch(`${registry}/-/stage/${encodeURIComponent(stageId)}`, {
     headers: npmStageHeaders(token, "staged-view"),
@@ -139,7 +139,7 @@ export function parseStagedPublishDetails(
 function parseStagedPublishItem(value: unknown, fallbackId?: string): StagedPublishItem | null {
   if (!isRecord(value)) return null;
   const id = readString(value.id) ?? readString(value.stageId) ?? fallbackId ?? null;
-  if (!id || !STAGE_ID_RE.test(id)) return null;
+  if (!isValidStageId(id)) return null;
   return {
     id,
     packageName: readString(value.packageName) ?? readString(value.name),

--- a/server/routes/npm-connection.ts
+++ b/server/routes/npm-connection.ts
@@ -18,9 +18,8 @@ import {
   publicNpmConnection,
   validateNpmCredential,
 } from "../lib/npm-connection";
+import { isValidStageId } from "../lib/stage-id";
 import type { Bindings, Variables } from "../types";
-
-const STAGE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{5,160}$/;
 
 export const npmConnectionRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
@@ -104,7 +103,7 @@ npmConnectionRoutes.post("/validate", async (c) => {
   const body = (await c.req.json().catch(() => ({}))) as { stageId?: unknown };
   const stageId =
     typeof body.stageId === "string" && body.stageId.trim() ? body.stageId.trim() : undefined;
-  if (stageId && !STAGE_ID_RE.test(stageId)) return c.json({ error: "invalid stageId" }, 400);
+  if (stageId && !isValidStageId(stageId)) return c.json({ error: "invalid stageId" }, 400);
 
   try {
     const db = createDb(c.env.DB);

--- a/server/routes/npm-connection.ts
+++ b/server/routes/npm-connection.ts
@@ -19,6 +19,8 @@ import {
   validateNpmCredential,
 } from "../lib/npm-connection";
 import { isValidStageId } from "../lib/stage-id";
+import { errorMessage } from "../lib/errors";
+import { rateLimitResponse } from "../lib/http";
 import type { Bindings, Variables } from "../types";
 
 export const npmConnectionRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
@@ -48,7 +50,10 @@ npmConnectionRoutes.post("/", async (c) => {
       allowInsecureLocalhost: allowInsecureLocalRegistry(c.env),
     });
   } catch (err) {
-    return c.json({ error: err instanceof Error ? err.message : "invalid registry URL" }, 400);
+    return c.json(
+      { error: err instanceof Error ? errorMessage(err) : "invalid registry URL" },
+      400,
+    );
   }
   try {
     const db = createDb(c.env.DB);
@@ -85,14 +90,7 @@ npmConnectionRoutes.post("/", async (c) => {
     return c.json({ connection: publicNpmConnection(connection) });
   } catch (err) {
     if (err instanceof RateLimitError) {
-      return c.json(
-        {
-          error: "npm connection save rate limit exceeded",
-          retryAfterSeconds: err.retryAfterSeconds,
-        },
-        429,
-        { "retry-after": String(err.retryAfterSeconds) },
-      );
+      return rateLimitResponse(c, "npm connection save rate limit exceeded", err);
     }
     console.error("npm connection upsert failed", err);
     return c.json({ error: "failed to store npm connection" }, 400);
@@ -145,11 +143,7 @@ npmConnectionRoutes.post("/validate", async (c) => {
     return c.json({ validation, connection: publicNpmConnection(updated) });
   } catch (err) {
     if (err instanceof RateLimitError) {
-      return c.json(
-        { error: "npm validation rate limit exceeded", retryAfterSeconds: err.retryAfterSeconds },
-        429,
-        { "retry-after": String(err.retryAfterSeconds) },
-      );
+      return rateLimitResponse(c, "npm validation rate limit exceeded", err);
     }
     console.error("npm connection validation failed", err);
     return c.json({ error: "failed to validate npm connection" }, 400);

--- a/server/routes/organizations.ts
+++ b/server/routes/organizations.ts
@@ -13,6 +13,8 @@ import {
 import type { Bindings, Variables } from "../types";
 
 const NAME_RE = /^[\p{L}\p{N}][\p{L}\p{N} _\-./]{0,79}$/u;
+const ORGANIZATION_NAME_ERROR =
+  "organization name must be 1-80 characters of letters, digits, or _-./";
 
 export const organizationsRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
@@ -26,14 +28,9 @@ organizationsRoutes.get("/", async (c) => {
 
 organizationsRoutes.post("/", async (c) => {
   const body = (await c.req.json().catch(() => ({}))) as { name?: unknown };
-  const name = typeof body.name === "string" ? body.name.trim() : "";
-  if (!name) return c.json({ error: "organization name is required" }, 400);
-  if (!NAME_RE.test(name)) {
-    return c.json(
-      { error: "organization name must be 1-80 characters of letters, digits, or _-./" },
-      400,
-    );
-  }
+  const parsed = parseOrganizationName(body.name);
+  if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+  const { name } = parsed;
 
   try {
     const db = createDb(c.env.DB);
@@ -69,14 +66,9 @@ organizationsRoutes.post("/", async (c) => {
 
 organizationsRoutes.patch("/:id", async (c) => {
   const body = (await c.req.json().catch(() => ({}))) as { name?: unknown };
-  const name = typeof body.name === "string" ? body.name.trim() : "";
-  if (!name) return c.json({ error: "organization name is required" }, 400);
-  if (!NAME_RE.test(name)) {
-    return c.json(
-      { error: "organization name must be 1-80 characters of letters, digits, or _-./" },
-      400,
-    );
-  }
+  const parsed = parseOrganizationName(body.name);
+  if (!parsed.ok) return c.json({ error: parsed.error }, 400);
+  const { name } = parsed;
 
   const db = createDb(c.env.DB);
   const session = c.get("authSession");
@@ -92,3 +84,14 @@ organizationsRoutes.patch("/:id", async (c) => {
   });
   return c.json({ organization: { id: organizationId, name } });
 });
+
+function parseOrganizationName(
+  value: unknown,
+):
+  | { ok: true; name: string }
+  | { ok: false; error: "organization name is required" | typeof ORGANIZATION_NAME_ERROR } {
+  const name = typeof value === "string" ? value.trim() : "";
+  if (!name) return { ok: false, error: "organization name is required" };
+  if (!NAME_RE.test(name)) return { ok: false, error: ORGANIZATION_NAME_ERROR };
+  return { ok: true, name };
+}

--- a/server/routes/organizations.ts
+++ b/server/routes/organizations.ts
@@ -10,6 +10,7 @@ import {
   recordScanEvent,
   renameOrganization,
 } from "../db";
+import { rateLimitResponse } from "../lib/http";
 import type { Bindings, Variables } from "../types";
 
 const NAME_RE = /^[\p{L}\p{N}][\p{L}\p{N} _\-./]{0,79}$/u;
@@ -50,14 +51,7 @@ organizationsRoutes.post("/", async (c) => {
     return c.json({ organization: { id, name } }, 201);
   } catch (err) {
     if (err instanceof RateLimitError) {
-      return c.json(
-        {
-          error: "organization create rate limit exceeded",
-          retryAfterSeconds: err.retryAfterSeconds,
-        },
-        429,
-        { "retry-after": String(err.retryAfterSeconds) },
-      );
+      return rateLimitResponse(c, "organization create rate limit exceeded", err);
     }
     console.error("organization create failed", err);
     return c.json({ error: "failed to create organization" }, 500);

--- a/server/routes/scan.ts
+++ b/server/routes/scan.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { RateLimitError, createDb, createScanJob, enforceRateLimit, getNpmConnection } from "../db";
 import { requireActiveOrganization } from "../lib/active-organization";
+import { rateLimitResponse } from "../lib/http";
 import { parseScanInput } from "../lib/scan-input";
 import { executeScanJob } from "../lib/scan-job";
 import { sandboxErrorDetail } from "../lib/sandbox";
@@ -56,11 +57,7 @@ scanRoutes.post("/", async (c) => {
     return c.json(result);
   } catch (err) {
     if (err instanceof RateLimitError) {
-      return c.json(
-        { error: "scan rate limit exceeded", retryAfterSeconds: err.retryAfterSeconds },
-        429,
-        { "retry-after": String(err.retryAfterSeconds) },
-      );
+      return rateLimitResponse(c, "scan rate limit exceeded", err);
     }
     const detail = sandboxErrorDetail(err);
     if (detail !== null) {

--- a/server/routes/scan.ts
+++ b/server/routes/scan.ts
@@ -1,25 +1,18 @@
 import { Hono } from "hono";
 import { RateLimitError, createDb, createScanJob, enforceRateLimit, getNpmConnection } from "../db";
 import { requireActiveOrganization } from "../lib/active-organization";
+import { parseScanInput } from "../lib/scan-input";
 import { executeScanJob } from "../lib/scan-job";
 import { sandboxErrorDetail } from "../lib/sandbox";
 import type { Bindings, ScanInput, Variables } from "../types";
-
-const STAGE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{5,160}$/;
 
 export const scanRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
 scanRoutes.post("/", async (c) => {
   const body = (await c.req.json().catch(() => ({}))) as Partial<ScanInput>;
-  if (body.maxFiles !== undefined || body.maxBytesPerFile !== undefined) {
-    return c.json({ error: "scan limits are controlled by the server" }, 400);
-  }
-  const input: ScanInput = {
-    stageId: String(body.stageId || ""),
-  };
-  if (!STAGE_ID_RE.test(input.stageId)) {
-    return c.json({ error: "invalid stageId" }, 400);
-  }
+  const parsed = parseScanInput(body);
+  if (!parsed.ok) return c.json({ error: parsed.error }, parsed.status);
+  const { input } = parsed;
 
   try {
     const db = createDb(c.env.DB);

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -18,6 +18,7 @@ import {
 } from "../db";
 import { requireActiveOrganization } from "../lib/active-organization";
 import { loadCompare, stripTextSamples } from "../lib/compare-cache";
+import { rateLimitResponse } from "../lib/http";
 import {
   allowInsecureLocalRegistry,
   getOrganizationNpmToken,
@@ -95,11 +96,7 @@ scansRoutes.post("/", async (c) => {
     return c.json({ scan: detail?.scan, queued: Boolean(c.env.SCAN_QUEUE) }, 202);
   } catch (err) {
     if (err instanceof RateLimitError) {
-      return c.json(
-        { error: "scan rate limit exceeded", retryAfterSeconds: err.retryAfterSeconds },
-        429,
-        { "retry-after": String(err.retryAfterSeconds) },
-      );
+      return rateLimitResponse(c, "scan rate limit exceeded", err);
     }
     throw err;
   }
@@ -229,11 +226,7 @@ scansRoutes.get("/:id/versions", async (c) => {
     ]);
   } catch (err) {
     if (err instanceof RateLimitError) {
-      return c.json(
-        { error: "rate limit exceeded", retryAfterSeconds: err.retryAfterSeconds },
-        429,
-        { "retry-after": String(err.retryAfterSeconds) },
-      );
+      return rateLimitResponse(c, "rate limit exceeded", err);
     }
     throw err;
   }
@@ -375,11 +368,7 @@ async function loadCompareArchive(
   } catch (err) {
     if (err instanceof RateLimitError) {
       return {
-        error: c.json(
-          { error: "rate limit exceeded", retryAfterSeconds: err.retryAfterSeconds },
-          429,
-          { "retry-after": String(err.retryAfterSeconds) },
-        ),
+        error: rateLimitResponse(c, "rate limit exceeded", err),
       } as const;
     }
     throw err;

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -25,22 +25,17 @@ import {
 } from "../lib/npm-connection";
 import { compareSemver, fetchPackageMetadata, pickPreviousVersion } from "../lib/registry";
 import { annotateFindingsWithDiffStatus, createPackageDiff, type FileRecord } from "../lib/review";
+import { parseScanInput } from "../lib/scan-input";
 import { executeScanJob, type ScanQueueMessage } from "../lib/scan-job";
 import type { Bindings, ScanInput, Variables } from "../types";
-
-const STAGE_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:-]{5,160}$/;
 
 export const scansRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
 scansRoutes.post("/", async (c) => {
   const body = (await c.req.json().catch(() => ({}))) as Partial<ScanInput>;
-  if (body.maxFiles !== undefined || body.maxBytesPerFile !== undefined) {
-    return c.json({ error: "scan limits are controlled by the server" }, 400);
-  }
-  const input: ScanInput = {
-    stageId: String(body.stageId || ""),
-  };
-  if (!STAGE_ID_RE.test(input.stageId)) return c.json({ error: "invalid stageId" }, 400);
+  const parsed = parseScanInput(body);
+  if (!parsed.ok) return c.json({ error: parsed.error }, parsed.status);
+  const { input } = parsed;
 
   try {
     const db = createDb(c.env.DB);
@@ -337,60 +332,82 @@ async function resolveCompareContext(
 scansRoutes.get("/:id/compare", async (c) => {
   const ctx = await resolveCompareContext(c);
   if ("error" in ctx) return ctx.error;
-  const { version, db, session, packageName } = ctx;
 
+  const loaded = await loadCompareArchive(c, ctx, {
+    rateLimitKey: `compare-fetch:${ctx.session.userId}`,
+    rateLimit: 30,
+  });
+  if ("error" in loaded) return loaded.error;
+
+  return c.json(
+    {
+      version: loaded.cached.version,
+      files: stripTextSamples(loaded.cached.files),
+      packageJson: loaded.cached.packageJson,
+      findingAnnotations: buildCompareFindingAnnotations(ctx.scan, loaded.cached.files),
+      cachedAt: loaded.cached.cachedAt,
+    },
+    200,
+    { "cache-control": "private, max-age=300" },
+  );
+});
+
+type CompareContext = Extract<
+  Awaited<ReturnType<typeof resolveCompareContext>>,
+  { version: string }
+>;
+
+async function loadCompareArchive(
+  c: import("hono").Context<{ Bindings: Bindings; Variables: Variables }>,
+  ctx: CompareContext,
+  options: { rateLimitKey: string; rateLimit: number },
+) {
   let connection: Awaited<ReturnType<typeof getOrganizationNpmToken>> = null;
   try {
     [, connection] = await Promise.all([
-      enforceRateLimit(db, {
-        key: `compare-fetch:${session.userId}`,
-        limit: 30,
+      enforceRateLimit(ctx.db, {
+        key: options.rateLimitKey,
+        limit: options.rateLimit,
         windowMs: 60 * 1000,
       }),
-      getOrganizationNpmToken(db, c.env, ctx.organizationId).catch(() => null),
+      getOrganizationNpmToken(ctx.db, c.env, ctx.organizationId).catch(() => null),
     ]);
   } catch (err) {
     if (err instanceof RateLimitError) {
-      return c.json(
-        { error: "rate limit exceeded", retryAfterSeconds: err.retryAfterSeconds },
-        429,
-        { "retry-after": String(err.retryAfterSeconds) },
-      );
+      return {
+        error: c.json(
+          { error: "rate limit exceeded", retryAfterSeconds: err.retryAfterSeconds },
+          429,
+          { "retry-after": String(err.retryAfterSeconds) },
+        ),
+      } as const;
     }
     throw err;
   }
 
-  const metadata = await fetchPackageMetadata(c.env, packageName, {
+  const metadata = await fetchPackageMetadata(c.env, ctx.packageName, {
     npmToken: connection?.token,
     npmRegistry: connection?.registryUrl,
   }).catch(() => null);
-  const tarballUrl = metadata?.versions?.[version]?.dist?.tarball;
-  if (!tarballUrl) return c.json({ error: "unknown version" }, 404);
+  const tarballUrl = metadata?.versions?.[ctx.version]?.dist?.tarball;
+  if (!tarballUrl) return { error: c.json({ error: "unknown version" }, 404) } as const;
 
   const registryUrl = connection?.registryUrl || c.env.NPM_REGISTRY || "https://registry.npmjs.org";
   if (!isTarballUrlAllowed(tarballUrl, registryUrl, allowInsecureLocalRegistry(c.env))) {
-    return c.json({ error: "registry returned an unexpected tarball URL" }, 502);
+    return {
+      error: c.json({ error: "registry returned an unexpected tarball URL" }, 502),
+    } as const;
   }
 
-  const cached = await loadCompare(c.env, c.executionCtx, version, {
+  const cached = await loadCompare(c.env, c.executionCtx, ctx.version, {
     tarballUrl,
     registryUrl,
     npmToken: connection?.token,
     cacheScope: `org:${ctx.organizationId}`,
   });
 
-  return c.json(
-    {
-      version: cached.version,
-      files: stripTextSamples(cached.files),
-      packageJson: cached.packageJson,
-      findingAnnotations: buildCompareFindingAnnotations(ctx.scan, cached.files),
-      cachedAt: cached.cachedAt,
-    },
-    200,
-    { "cache-control": "private, max-age=300" },
-  );
-});
+  return { cached } as const;
+}
 
 function buildCompareFindingAnnotations(
   scan: NonNullable<Awaited<ReturnType<typeof getScan>>>,
@@ -431,54 +448,19 @@ function scanFilesToFileRecords(
 scansRoutes.get("/:id/compare/file", async (c) => {
   const ctx = await resolveCompareContext(c);
   if ("error" in ctx) return ctx.error;
-  const { version, db, session, packageName } = ctx;
   const path = c.req.query("path") || "";
   if (!path) return c.json({ error: "path is required" }, 400);
 
-  let connection: Awaited<ReturnType<typeof getOrganizationNpmToken>> = null;
-  try {
-    [, connection] = await Promise.all([
-      enforceRateLimit(db, {
-        key: `compare-file:${session.userId}`,
-        limit: 240,
-        windowMs: 60 * 1000,
-      }),
-      getOrganizationNpmToken(db, c.env, ctx.organizationId).catch(() => null),
-    ]);
-  } catch (err) {
-    if (err instanceof RateLimitError) {
-      return c.json(
-        { error: "rate limit exceeded", retryAfterSeconds: err.retryAfterSeconds },
-        429,
-        { "retry-after": String(err.retryAfterSeconds) },
-      );
-    }
-    throw err;
-  }
-
-  const metadata = await fetchPackageMetadata(c.env, packageName, {
-    npmToken: connection?.token,
-    npmRegistry: connection?.registryUrl,
-  }).catch(() => null);
-  const tarballUrl = metadata?.versions?.[version]?.dist?.tarball;
-  if (!tarballUrl) return c.json({ error: "unknown version" }, 404);
-
-  const registryUrl = connection?.registryUrl || c.env.NPM_REGISTRY || "https://registry.npmjs.org";
-  if (!isTarballUrlAllowed(tarballUrl, registryUrl, allowInsecureLocalRegistry(c.env))) {
-    return c.json({ error: "registry returned an unexpected tarball URL" }, 502);
-  }
-
-  const cached = await loadCompare(c.env, c.executionCtx, version, {
-    tarballUrl,
-    registryUrl,
-    npmToken: connection?.token,
-    cacheScope: `org:${ctx.organizationId}`,
+  const loaded = await loadCompareArchive(c, ctx, {
+    rateLimitKey: `compare-file:${ctx.session.userId}`,
+    rateLimit: 240,
   });
+  if ("error" in loaded) return loaded.error;
 
-  const file = cached.files.find((entry) => entry.path === path);
+  const file = loaded.cached.files.find((entry) => entry.path === path);
   if (!file) return c.json({ error: "file not found in version" }, 404);
 
-  return c.json({ version: cached.version, file }, 200, {
+  return c.json({ version: loaded.cached.version, file }, 200, {
     "cache-control": "private, max-age=300",
   });
 });

--- a/server/routes/staged-publishes.ts
+++ b/server/routes/staged-publishes.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { RateLimitError, createDb, enforceRateLimit, getNpmConnection } from "../db";
 import { requireActiveOrganization } from "../lib/active-organization";
+import { rateLimitResponse } from "../lib/http";
 import { allowInsecureLocalRegistry } from "../lib/npm-connection";
 import {
   InvalidNpmConnectionError,
@@ -25,14 +26,7 @@ stagedPublishesRoutes.post("/scan", async (c) => {
     });
   } catch (err) {
     if (err instanceof RateLimitError) {
-      return c.json(
-        {
-          error: "staged publish discovery rate limit exceeded",
-          retryAfterSeconds: err.retryAfterSeconds,
-        },
-        429,
-        { "retry-after": String(err.retryAfterSeconds) },
-      );
+      return rateLimitResponse(c, "staged publish discovery rate limit exceeded", err);
     }
     throw err;
   }

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -34,3 +34,23 @@ export async function apiFetch<T>(input: RequestInfo | URL, init?: RequestInit):
   }
   return data as T;
 }
+
+export function apiJson<T>(
+  input: RequestInfo | URL,
+  body: unknown,
+  init: RequestInit = {},
+): Promise<T> {
+  return apiFetch<T>(input, {
+    method: init.method ?? "POST",
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      ...(init.headers as Record<string, string> | undefined),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+export function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -52,5 +52,10 @@ export function apiJson<T>(
 }
 
 export function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  if (err instanceof Error) return err.message;
+  if (err && typeof err === "object") {
+    const message = (err as Record<string, unknown>).message;
+    if (typeof message === "string") return message;
+  }
+  return String(err);
 }

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -1,4 +1,5 @@
 import { computed, createModel, signal } from "@preact/signals";
+import { errorMessage } from "./api";
 
 export interface SessionUser {
   id: string;
@@ -32,7 +33,7 @@ export const SessionModel = createModel(() => {
         this.error.value = null;
         return data;
       } catch (err) {
-        this.error.value = err instanceof Error ? err.message : String(err);
+        this.error.value = errorMessage(err);
         this.session.value = null;
         return null;
       } finally {

--- a/src/models/npm-connection.ts
+++ b/src/models/npm-connection.ts
@@ -1,5 +1,5 @@
 import { computed, createModel, signal } from "@preact/signals";
-import { apiFetch } from "./api";
+import { apiFetch, apiJson, errorMessage } from "./api";
 
 export interface PublicNpmConnection {
   id: string;
@@ -113,7 +113,7 @@ export const NpmConnectionModel = createModel(() => {
           }
         }
       } catch (err) {
-        this.error.value = err instanceof Error ? err.message : String(err);
+        this.error.value = errorMessage(err);
         await this.load();
       } finally {
         this.status.value = "idle";
@@ -131,7 +131,7 @@ export const NpmConnectionModel = createModel(() => {
           this.error.value = "Npm validation reported invalid access.";
         }
       } catch (err) {
-        this.error.value = err instanceof Error ? err.message : String(err);
+        this.error.value = errorMessage(err);
         await this.load();
       } finally {
         this.status.value = "idle";
@@ -146,7 +146,7 @@ export const NpmConnectionModel = createModel(() => {
         this.connection.value = null;
         this.token.value = "";
       } catch (err) {
-        this.error.value = err instanceof Error ? err.message : String(err);
+        this.error.value = errorMessage(err);
       } finally {
         this.status.value = "idle";
       }
@@ -159,23 +159,15 @@ function saveNpmConnection(input: {
   label: string;
   registryUrl: string;
 }): Promise<{ connection: PublicNpmConnection | null }> {
-  return apiFetch<{ connection: PublicNpmConnection | null }>("/api/v1/npm-connection", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(input),
-  });
+  return apiJson<{ connection: PublicNpmConnection | null }>("/api/v1/npm-connection", input);
 }
 
 function validateNpmConnection(stageId?: string): Promise<{
   validation: NpmCredentialValidation;
   connection: PublicNpmConnection | null;
 }> {
-  return apiFetch<{
+  return apiJson<{
     validation: NpmCredentialValidation;
     connection: PublicNpmConnection | null;
-  }>("/api/v1/npm-connection/validate", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ stageId }),
-  });
+  }>("/api/v1/npm-connection/validate", { stageId });
 }

--- a/src/models/organization.ts
+++ b/src/models/organization.ts
@@ -1,6 +1,6 @@
 import { computed, createModel, signal } from "@preact/signals";
 import { activeOrganizationId, setActiveOrganizationId } from "./active-organization";
-import { apiFetch } from "./api";
+import { apiFetch, apiJson, errorMessage } from "./api";
 
 export interface Organization {
   id: string;
@@ -57,7 +57,7 @@ export const OrganizationModel = createModel(() => {
         }
         this.error.value = null;
       } catch (err) {
-        this.error.value = err instanceof Error ? err.message : String(err);
+        this.error.value = errorMessage(err);
       } finally {
         this.loaded.value = true;
         this.status.value = "idle";
@@ -73,19 +73,15 @@ export const OrganizationModel = createModel(() => {
       this.status.value = "creating";
       this.error.value = null;
       try {
-        const data = await apiFetch<{ organization: { id: string; name: string } }>(
+        const data = await apiJson<{ organization: { id: string; name: string } }>(
           "/api/v1/organizations",
-          {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({ name: trimmed }),
-          },
+          { name: trimmed },
         );
         await this.load();
         setActiveOrganizationId(data.organization.id);
         return this.organizations.value.find((org) => org.id === data.organization.id) ?? null;
       } catch (err) {
-        this.error.value = err instanceof Error ? err.message : String(err);
+        this.error.value = errorMessage(err);
         return null;
       } finally {
         this.status.value = "idle";
@@ -111,18 +107,17 @@ export const OrganizationModel = createModel(() => {
       this.status.value = "renaming";
       this.error.value = null;
       try {
-        await apiFetch<{ organization: { id: string; name: string } }>(
+        await apiJson<{ organization: { id: string; name: string } }>(
           `/api/v1/organizations/${encodeURIComponent(organizationId)}`,
+          { name: trimmed },
           {
             method: "PATCH",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({ name: trimmed }),
           },
         );
         await this.load();
         return true;
       } catch (err) {
-        this.error.value = err instanceof Error ? err.message : String(err);
+        this.error.value = errorMessage(err);
         return false;
       } finally {
         this.status.value = "idle";

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -5,7 +5,7 @@ import type {
   FindingDiffStatus,
   PackageJsonSummary,
 } from "../../server/lib/review";
-import { apiFetch } from "./api";
+import { apiFetch, apiJson, errorMessage } from "./api";
 
 export interface ScanVersionsResponse {
   packageName: string | null;
@@ -133,10 +133,9 @@ export function setScanDecision(
   decision: ScanDecision,
   reason: string | null,
 ): Promise<PersistedScanDetail> {
-  return apiFetch<PersistedScanDetail>(`/api/v1/scans/${encodeURIComponent(id)}/decision`, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ decision, reason }),
+  return apiJson<PersistedScanDetail>(`/api/v1/scans/${encodeURIComponent(id)}/decision`, {
+    decision,
+    reason,
   });
 }
 
@@ -186,7 +185,7 @@ export const ScanListModel = createModel(() => {
       nextCursor.value = data.nextCursor;
       error.value = null;
     } catch (err) {
-      error.value = err instanceof Error ? err.message : String(err);
+      error.value = errorMessage(err);
     } finally {
       loaded.value = true;
       refreshing.value = false;
@@ -222,7 +221,7 @@ export const ScanListModel = createModel(() => {
         this.nextCursor.value = data.nextCursor;
         this.error.value = null;
       } catch (err) {
-        this.error.value = err instanceof Error ? err.message : String(err);
+        this.error.value = errorMessage(err);
       } finally {
         this.loadingMore.value = false;
       }
@@ -292,7 +291,7 @@ export const ScanDetailModel = createModel((id: string) => {
         selectedPath.value = pickInitialPath(data);
       }
     } catch (err) {
-      error.value = err instanceof Error ? err.message : String(err);
+      error.value = errorMessage(err);
     }
   }
 
@@ -304,7 +303,7 @@ export const ScanDetailModel = createModel((id: string) => {
       const data = await getScanCompare(id, version);
       compareCache.value = { ...compareCache.peek(), [version]: data };
     } catch (err) {
-      compareError.value = err instanceof Error ? err.message : String(err);
+      compareError.value = errorMessage(err);
     } finally {
       compareLoading.value = false;
     }
@@ -338,7 +337,7 @@ export const ScanDetailModel = createModel((id: string) => {
           this.selectedPath.value = pickInitialPath(data);
         }
       } catch (err) {
-        this.error.value = err instanceof Error ? err.message : String(err);
+        this.error.value = errorMessage(err);
       }
     },
 
@@ -357,7 +356,7 @@ export const ScanDetailModel = createModel((id: string) => {
           }
         });
       } catch (err) {
-        this.compareError.value = err instanceof Error ? err.message : String(err);
+        this.compareError.value = errorMessage(err);
       }
     },
 
@@ -378,7 +377,7 @@ export const ScanDetailModel = createModel((id: string) => {
         this.detail.value = updated;
         this.decisionStatus.value = "idle";
       } catch (err) {
-        this.decisionError.value = err instanceof Error ? err.message : String(err);
+        this.decisionError.value = errorMessage(err);
         this.decisionStatus.value = "error";
       }
     },
@@ -392,7 +391,7 @@ export const ScanDetailModel = createModel((id: string) => {
         const data = await getScanCompareFile(id, version, path);
         this.fileContentCache.value = { ...this.fileContentCache.peek(), [key]: data.file };
       } catch (err) {
-        this.compareError.value = err instanceof Error ? err.message : String(err);
+        this.compareError.value = errorMessage(err);
       } finally {
         this.fileLoading.value = false;
       }

--- a/src/models/staged-publishes.ts
+++ b/src/models/staged-publishes.ts
@@ -1,6 +1,6 @@
 import { createModel, signal } from "@preact/signals";
 import type { StagedPublishesScanResponse } from "../../server/lib/staged-publishes";
-import { apiFetch } from "./api";
+import { apiFetch, errorMessage } from "./api";
 
 export type { StagedPublishesScanResponse };
 
@@ -40,7 +40,7 @@ export const StagedPublishesModel = createModel(() => {
         this.error.value = null;
         return result;
       } catch (err) {
-        this.error.value = err instanceof Error ? err.message : String(err);
+        this.error.value = errorMessage(err);
         return null;
       } finally {
         this.loaded.value = true;

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "preact/hooks";
 import { useSignal } from "@preact/signals";
 import { useLocation } from "preact-iso";
 import { sessionModel } from "../../models/auth";
+import { errorMessage } from "../../models/api";
 import { Alert, Button, Card, Eyebrow, Field, Input, PageShell, Muted } from "../../components";
 
 export default function LoginPage() {
@@ -32,7 +33,7 @@ export default function LoginPage() {
       await sessionModel.signIn(submittedEmail, submittedPassword);
       location.route("/dashboard", true);
     } catch (err) {
-      error.value = err instanceof Error ? err.message : String(err);
+      error.value = errorMessage(err);
     } finally {
       loading.value = false;
     }

--- a/src/pages/Auth/Register.tsx
+++ b/src/pages/Auth/Register.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "preact/hooks";
 import { useSignal } from "@preact/signals";
 import { useLocation } from "preact-iso";
 import { sessionModel } from "../../models/auth";
+import { errorMessage } from "../../models/api";
 import { Alert, Button, Card, Eyebrow, Field, Input, PageShell, Muted } from "../../components";
 
 export default function RegisterPage() {
@@ -35,7 +36,7 @@ export default function RegisterPage() {
       await sessionModel.signIn(submittedEmail, submittedPassword).catch(() => undefined);
       location.route("/dashboard", true);
     } catch (err) {
-      error.value = err instanceof Error ? err.message : String(err);
+      error.value = errorMessage(err);
     } finally {
       loading.value = false;
     }


### PR DESCRIPTION
Centralizes staged publish stage ID and scan input validation across route, helper, and sandbox paths.

Refactors compare archive loading and organization name parsing to remove repeated route logic.

Adds client API helpers for JSON POST bodies and error formatting, then documents the new conventions.

Validation: `pnpm run verify`.