### PR TITLE
Skip inaccessible-tarball auto-discoveries silently

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,6 +113,8 @@ A `*/15 * * * *` cron trigger runs `runStagedPublishesDiscoveryCron` in `server/
 
 Scans created by the cron are marked `scans.source = "auto_discovery"` (manual scans default to `"manual"`). The actor is the npm connection creator when present, otherwise the organization owner. When `executeScanJob` finishes — successfully or as a terminal failure — and the queue message carries `source: "auto_discovery"`, the worker sends an email notification through the `SEND_EMAIL` binding (`server/lib/email.ts` + `server/lib/notify.ts`) to that Better Auth user's email, linking to `/dashboard/scans/:id`. Email authentication for `resynapse.dev` (SPF/DKIM/DMARC) is configured at the Cloudflare account level; the worker only needs the `send_email` binding plus `EMAIL_FROM_ADDRESS` / `EMAIL_FROM_NAME` vars.
 
+Discovery dedupes stage IDs against both the current org's scans and any completed scan in another organization, so a stage that has already been successfully scanned elsewhere never triggers another npm fetch. When an auto-discovered scan terminally fails with `staged_tarball_unavailable` (npm returned 401/403/404 to this org's token), the worker deletes the scan row via `discardScanAttempt`, records a `scan.skipped` audit event, and suppresses the failure email — the package likely belongs to a different organization and shouldn't show up as a failure in this one's dashboard.
+
 ## Data stores
 
 ### D1

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -224,7 +224,12 @@ export async function listExistingScanStageIds(
   const rows = await db
     .select({ stageId: scans.stageId })
     .from(scans)
-    .where(and(eq(scans.organizationId, organizationId), inArray(scans.stageId, stageIds)));
+    .where(
+      and(
+        inArray(scans.stageId, stageIds),
+        or(eq(scans.organizationId, organizationId), eq(scans.status, "complete")),
+      ),
+    );
   return new Set(rows.map((row) => row.stageId));
 }
 
@@ -268,6 +273,10 @@ export async function markScanFailed(
         inArray(scans.status, [...NON_TERMINAL_STATUSES]),
       ),
     );
+}
+
+export async function discardScanAttempt(db: AppDb, scanId: string, organizationId: string) {
+  await db.delete(scans).where(and(eq(scans.id, scanId), eq(scans.organizationId, organizationId)));
 }
 
 export async function persistScan(db: AppDb, input: PersistedScanInput) {

--- a/server/lib/scan-job.ts
+++ b/server/lib/scan-job.ts
@@ -1,6 +1,7 @@
 import {
   claimScanForRun,
   createDb,
+  discardScanAttempt,
   getNpmConnection,
   markNpmConnectionUsed,
   markScanFailed,
@@ -112,28 +113,45 @@ export async function executeScanJob(
   } catch (err) {
     const safe = classifyScanError(err);
     if (!safe.retryable || options.finalAttempt) {
-      await Promise.all([
-        markScanFailed(db, message.scanId, message.organizationId, safe),
-        recordScanEvent(db, {
+      const skip =
+        message.source === "auto_discovery" && safe.code === "staged_tarball_unavailable";
+      if (skip) {
+        await recordScanEvent(db, {
           organizationId: message.organizationId,
           actorUserId: message.actorUserId,
-          scanId: message.scanId,
-          type: "scan.failed",
-          metadata: { stageId: message.stageId, attempt: options.attempt ?? 1, error: safe },
-        }),
-      ]);
-      if (message.source === "auto_discovery") {
-        executionCtx.waitUntil(
-          notifyScanCompletion({
-            env,
-            db,
+          type: "scan.skipped",
+          metadata: {
             scanId: message.scanId,
-            organizationId: message.organizationId,
-            ownerUserId: message.actorUserId,
-            outcome: "failed",
+            stageId: message.stageId,
+            attempt: options.attempt ?? 1,
             error: safe,
+          },
+        });
+        await discardScanAttempt(db, message.scanId, message.organizationId);
+      } else {
+        await Promise.all([
+          markScanFailed(db, message.scanId, message.organizationId, safe),
+          recordScanEvent(db, {
+            organizationId: message.organizationId,
+            actorUserId: message.actorUserId,
+            scanId: message.scanId,
+            type: "scan.failed",
+            metadata: { stageId: message.stageId, attempt: options.attempt ?? 1, error: safe },
           }),
-        );
+        ]);
+        if (message.source === "auto_discovery") {
+          executionCtx.waitUntil(
+            notifyScanCompletion({
+              env,
+              db,
+              scanId: message.scanId,
+              organizationId: message.organizationId,
+              ownerUserId: message.actorUserId,
+              outcome: "failed",
+              error: safe,
+            }),
+          );
+        }
       }
     } else {
       await recordScanEvent(db, {

--- a/test/scan-job.test.mjs
+++ b/test/scan-job.test.mjs
@@ -7,6 +7,7 @@ vi.mock("cloudflare:workers", () => ({
 const dbMock = vi.hoisted(() => ({
   claimScanForRun: vi.fn(),
   createDb: vi.fn(() => ({})),
+  discardScanAttempt: vi.fn(),
   getNpmConnection: vi.fn(),
   markNpmConnectionUsed: vi.fn(),
   markScanFailed: vi.fn(),
@@ -14,10 +15,14 @@ const dbMock = vi.hoisted(() => ({
 }));
 const pipelineMock = vi.hoisted(() => ({ runScanPipeline: vi.fn() }));
 const npmConnectionMock = vi.hoisted(() => ({ decryptNpmToken: vi.fn() }));
+const notifyMock = vi.hoisted(() => ({
+  notifyScanCompletion: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock("../server/db/index.ts", () => dbMock);
 vi.mock("../server/lib/scan-pipeline.ts", () => pipelineMock);
 vi.mock("../server/lib/npm-connection.ts", () => npmConnectionMock);
+vi.mock("../server/lib/notify.ts", () => notifyMock);
 
 const { classifyScanError, executeScanJob, retryDelaySeconds } =
   await import("../server/lib/scan-job.ts");
@@ -116,6 +121,7 @@ describe("executeScanJob idempotency", () => {
     for (const fn of Object.values(dbMock)) if (typeof fn?.mockReset === "function") fn.mockReset();
     pipelineMock.runScanPipeline.mockReset();
     npmConnectionMock.decryptNpmToken.mockReset();
+    notifyMock.notifyScanCompletion.mockClear();
   });
 
   test("returns null without running the pipeline when claim is rejected", async () => {
@@ -178,6 +184,67 @@ describe("executeScanJob idempotency", () => {
       message: "Validate the organization npm token before scanning staged publishes.",
       retryable: false,
     });
+  });
+
+  test("discards auto-discovered scans when the org's token cannot access the tarball", async () => {
+    dbMock.claimScanForRun.mockResolvedValue(true);
+    pipelineMock.runScanPipeline.mockRejectedValue(
+      new SandboxError(JSON.stringify({ error: "denied", status: 403 })),
+    );
+
+    await expect(
+      executeScanJob(
+        env,
+        ctx,
+        { ...message, source: "auto_discovery" },
+        {},
+        { attempt: 1, finalAttempt: true },
+      ),
+    ).rejects.toBeInstanceOf(SandboxError);
+
+    expect(dbMock.markScanFailed).not.toHaveBeenCalled();
+    expect(dbMock.discardScanAttempt).toHaveBeenCalledWith(
+      {},
+      message.scanId,
+      message.organizationId,
+    );
+    const failed = dbMock.recordScanEvent.mock.calls.filter(
+      ([, payload]) => payload?.type === "scan.failed",
+    );
+    expect(failed).toHaveLength(0);
+    const skipped = dbMock.recordScanEvent.mock.calls.filter(
+      ([, payload]) => payload?.type === "scan.skipped",
+    );
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]?.[1]?.scanId).toBeUndefined();
+    expect(skipped[0]?.[1]?.metadata).toMatchObject({
+      scanId: message.scanId,
+      stageId: message.stageId,
+    });
+    expect(notifyMock.notifyScanCompletion).not.toHaveBeenCalled();
+  });
+
+  test("still marks auto-discovered scans failed for non-tarball-access errors", async () => {
+    dbMock.claimScanForRun.mockResolvedValue(true);
+    pipelineMock.runScanPipeline.mockRejectedValue(
+      new SandboxError(JSON.stringify({ error: "archive contains too many files", status: 413 })),
+    );
+
+    await expect(
+      executeScanJob(
+        env,
+        ctx,
+        { ...message, source: "auto_discovery" },
+        {},
+        { attempt: 1, finalAttempt: true },
+      ),
+    ).rejects.toBeInstanceOf(SandboxError);
+
+    expect(dbMock.discardScanAttempt).not.toHaveBeenCalled();
+    expect(dbMock.markScanFailed).toHaveBeenCalledTimes(1);
+    expect(notifyMock.notifyScanCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: "failed" }),
+    );
   });
 
   test("records scan.retryable_failed without marking failed when a retryable error fires before exhaustion", async () => {

--- a/test/workers/scan-idempotency.test.ts
+++ b/test/workers/scan-idempotency.test.ts
@@ -6,6 +6,7 @@ import {
   createDb,
   createScanJob,
   ensurePersonalOrganization,
+  listExistingScanStageIds,
   markScanFailed,
   persistScan,
 } from "../../server/db";
@@ -143,6 +144,61 @@ describe("scan persistence idempotency", () => {
     expect(second.persisted).toBe(false);
     const final = await readStatus(db, scanId);
     expect(final?.reportDigest).toBe("first");
+  });
+
+  test("listExistingScanStageIds dedupes against another org's completed scan", async () => {
+    const ownerA = await seedUserAndOrg();
+    const ownerB = await seedUserAndOrg();
+    const sharedStageId = `stage-${crypto.randomUUID()}`;
+    const inProgressStageId = `stage-${crypto.randomUUID()}`;
+    const orgBOnlyStageId = `stage-${crypto.randomUUID()}`;
+    const untouchedStageId = `stage-${crypto.randomUUID()}`;
+
+    const completedScanId = `scan_${crypto.randomUUID()}`;
+    await createScanJob(ownerA.db, {
+      id: completedScanId,
+      stageId: sharedStageId,
+      organizationId: ownerA.organizationId,
+      ownerUserId: ownerA.userId,
+    });
+    await claimScanForRun(ownerA.db, completedScanId, ownerA.organizationId);
+    await persistScan(ownerA.db, {
+      ...baseScan,
+      id: completedScanId,
+      stageId: sharedStageId,
+      organizationId: ownerA.organizationId,
+      ownerUserId: ownerA.userId,
+      risk: "low",
+      status: "complete",
+    });
+
+    const inProgressScanId = `scan_${crypto.randomUUID()}`;
+    await createScanJob(ownerA.db, {
+      id: inProgressScanId,
+      stageId: inProgressStageId,
+      organizationId: ownerA.organizationId,
+      ownerUserId: ownerA.userId,
+    });
+
+    const orgBOwnScanId = `scan_${crypto.randomUUID()}`;
+    await createScanJob(ownerB.db, {
+      id: orgBOwnScanId,
+      stageId: orgBOnlyStageId,
+      organizationId: ownerB.organizationId,
+      ownerUserId: ownerB.userId,
+    });
+
+    const known = await listExistingScanStageIds(ownerB.db, ownerB.organizationId, [
+      sharedStageId,
+      inProgressStageId,
+      orgBOnlyStageId,
+      untouchedStageId,
+    ]);
+
+    expect(known.has(sharedStageId)).toBe(true);
+    expect(known.has(orgBOnlyStageId)).toBe(true);
+    expect(known.has(inProgressStageId)).toBe(false);
+    expect(known.has(untouchedStageId)).toBe(false);
   });
 
   test("cross-organization claims and mutations are rejected", async () => {


### PR DESCRIPTION
## Summary
- Auto-discovered scans that terminally fail with `staged_tarball_unavailable` now delete the scan row (`discardScanAttempt`), record a `scan.skipped` audit event, and suppress the failure email — the package likely lives in a different organization.
- Discovery dedupes stage IDs against any organization's completed scan, so a successful report elsewhere prevents redundant npm fetches.
- Tests cover both the skip path and the cross-org dedupe via a new D1 integration test.

## Test plan
- [ ] `pnpm run verify`
- [ ] Confirm an auto-discovered 401/403/404 from npm no longer produces a failed scan row or email
- [ ] Confirm a stage already completed in another org is skipped at discovery time

🤖 Generated with [Claude Code](https://claude.com/claude-code)