### PR TITLE
Configure Better Auth client IP from Cloudflare header

### DIFF
--- a/server/lib/auth.ts
+++ b/server/lib/auth.ts
@@ -32,6 +32,9 @@ export function createAuth(env: Cloudflare.Env) {
     },
     advanced: {
       cookiePrefix: "spr",
+      ipAddress: {
+        ipAddressHeaders: ["cf-connecting-ip", "x-forwarded-for"],
+      },
       defaultCookieAttributes: {
         httpOnly: true,
         secure: true,


### PR DESCRIPTION
## Summary
- Rate limiting on `/api/auth/*` was being skipped because Better Auth couldn't determine the client IP on Cloudflare Workers, producing repeated `Rate limiting skipped: could not determine client IP address` warnings.
- Configure `advanced.ipAddress.ipAddressHeaders` to read `cf-connecting-ip` (with `x-forwarded-for` as fallback) so Better Auth can identify clients and enforce rate limits.

## Test plan
- [ ] Deploy and confirm the "Rate limiting skipped" warnings stop appearing for `/api/auth/get-session` requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)