### PR TITLE
Drop qwen tier, always use Kimi for AI review

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [`docs/architecture.md`](docs/architecture.md), [`docs/security-model.md`](d
   - package metadata JSON
   - published `.tgz` tarballs for previous-version diffing
 - The sandbox gunzips/parses tarballs, returns bounded file metadata and text samples, and the parent Worker runs deterministic checks.
-- AI triage (Workers AI JSON-mode review of changed files only) is **disabled for now**. The reviewer module — including the two-tier escalation policy and prompt-injection-resistant system prompt — lives in `server/lib/ai-review.ts` so it can return behind a paid tier without re-engineering.
+- AI triage (Workers AI JSON-mode review of changed files only) is **disabled for now**. The reviewer module — a single-model (Kimi K2.5) policy and prompt-injection-resistant system prompt — lives in `server/lib/ai-review.ts` so it can return behind a paid tier without re-engineering.
 - The service diffs the staged tarball against the currently published previous version when package metadata is available.
 - Package files are treated as hostile evidence even with AI disabled — file previews are escaped/redacted before persistence, and the planned AI reviewer will not downgrade deterministic findings when it returns.
 - Review results are persisted in Cloudflare D1 through Drizzle ORM.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -147,7 +147,7 @@ Raw tarballs should not be retained by default in SaaS. If needed later, make ra
 
 ### Workers AI (disabled)
 
-Workers AI review is currently **disabled in the scan pipeline**. The reviewer module — `server/lib/ai-review.ts`, its two-tier escalation policy (default `@cf/qwen/qwen3-30b-a3b-fp8`, escalation `@cf/moonshotai/kimi-k2.5`), the prompt-injection-resistant system prompt, the AI SDK evidence-tool loop, and the test suite (skipped) — is kept on disk so it can be re-introduced behind a paid tier without re-engineering the contract.
+Workers AI review is currently **disabled in the scan pipeline**. The reviewer module — `server/lib/ai-review.ts`, its single-model policy (`AI_MODEL` = `@cf/moonshotai/kimi-k2.5`), the prompt-injection-resistant system prompt, the AI SDK evidence-tool loop, and the test suite (skipped) — is kept on disk so it can be re-introduced behind a paid tier without re-engineering the contract.
 
 Scans persist `scan.aiJson = null` while AI review is disabled, and the UI omits the reviewer-notes section entirely. Risk is computed exclusively from deterministic findings.
 

--- a/docs/cost-model.md
+++ b/docs/cost-model.md
@@ -60,22 +60,14 @@ Workers AI is ~90% of the variable cost at every scale above the smallest tier.
 
 AI review is currently disabled in the pipeline; this section documents the design that will return behind a paid tier. The module — `server/lib/ai-review.ts` — and its skipped test suite remain in tree so it can be re-enabled by importing `runSelectiveAiReview` from `scan-pipeline.ts` again.
 
-Kimi is valuable for deep package-security review, but it should not necessarily be the always-on model for every staged release. The scanner's actual security boundary is deterministic analysis plus human npm approval; AI is advisory triage. The intended production posture, implemented in [`server/lib/ai-review.ts`](../server/lib/ai-review.ts), is:
+The scanner's actual security boundary is deterministic analysis plus human npm approval; AI is advisory triage. The intended production posture, implemented in [`server/lib/ai-review.ts`](../server/lib/ai-review.ts), is:
 
 1. run deterministic rules first;
-2. use a cheaper capable model (`DEFAULT_AI_MODEL` = `@cf/qwen/qwen3-30b-a3b-fp8`) for default AI triage;
-3. escalate to Kimi (`ESCALATION_AI_MODEL` = `@cf/moonshotai/kimi-k2.5`) for risky or ambiguous scans.
+2. send the resulting evidence to Kimi (`AI_MODEL` = `@cf/moonshotai/kimi-k2.5`) for AI review.
 
 The reviewer in [`server/lib/ai-review.ts`](../server/lib/ai-review.ts) uses the Vercel AI SDK with the Workers AI provider. The first prompt contains deterministic findings, package.json/package.json diff, and a changed-file manifest. The model can then call app-owned tools to read bounded redacted file samples, read text diffs when previous-version samples are available, search changed/package.json text literally, list focused file subsets, and finally submit the review through a schema-validated `submit_review` tool. The controller enforces max steps, per-tool character caps, a total evidence budget, and scan-ID-suffixed cache affinity; the model never gets raw tarballs, arbitrary filesystem access, network access, or package execution.
 
-`runSelectiveAiReview` decides escalation in two stages:
-
-- **Pre-AI**, based on deterministic signals and request shape: any rule finding at medium or higher, an install-lifecycle script add/modify (`preinstall`, `install`, `postinstall`, `prepare`, `prepack`, `postpack`, `publish`, `prepublish`, `prepublishOnly`), any dependency / peerDep / optionalDep change, any entrypoint change (`bin`, `main`, `module`, `types`, `exports`), a scan where no previous version was available to compare against, or an estimated initial AI manifest that exceeds the default model's context budget. When any pre-AI trigger fires we skip the default model and call the escalation model directly to avoid paying for both passes.
-- **Post-default**, based on the default model's output: a `suspicious` or `blocked` release assessment, `requiresManualReview === true`, or a non-`complete` review status. When any post-default trigger fires we run the escalation model with the same payload and return its review.
-
-The persisted `aiJson` records the model that produced the final review, whether escalation occurred, and the trigger reasons.
-
-Avoid using the cheapest micro model as the primary security reviewer. A very small model can summarize deterministic findings, but supply-chain review needs enough reasoning to notice prompt injection, install-time behavior, dependency lifecycle risk, and entrypoint/package-shape surprises.
+Every scan that opts into AI review goes straight to Kimi — there is no cheaper triage tier and no escalation logic. Avoid swapping in a micro model as the primary security reviewer. Supply-chain review needs enough reasoning to notice prompt injection, install-time behavior, dependency lifecycle risk, and entrypoint/package-shape surprises, and the persisted `aiJson` records which model produced the review.
 
 ## Pricing for margin
 

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -126,7 +126,7 @@ Tasks:
 - Store scanner version, deterministic rules version, prompt version, model/provider metadata, and report schema version.
 - Add a report provenance section: package name, staged version, previous version, selected comparison version, stage ID, generated timestamp, artifact digests, and review limitations.
 - Add AI failure states that preserve deterministic findings when AI is unavailable.
-- Store AI latency and provider/model metadata where available, including whether the default model or escalation model reviewed the scan.
+- Store AI latency and provider/model metadata where available.
 - Keep signed/public report URLs deferred, but design exports so signing can wrap the same canonical artifact later.
 
 Exit criteria:

--- a/server/lib/ai-review-contract.ts
+++ b/server/lib/ai-review-contract.ts
@@ -45,7 +45,6 @@ export const DEFAULT_TOOL_CHARS = 8_000;
 export const MAX_SEARCH_RESULTS = 20;
 export const SEARCH_SNIPPET_RADIUS = 140;
 export const LARGE_FILE_BYTES = 64 * 1024;
-export const TOOL_PROMPT_OVERHEAD_CHARS = 5_000;
 
 const severitySchema = z.enum(["info", "low", "medium", "high", "critical"]);
 const riskSchema = z.enum(["low", "medium", "high", "critical"]);

--- a/server/lib/ai-review-types.ts
+++ b/server/lib/ai-review-types.ts
@@ -23,8 +23,6 @@ export interface AiReview {
   findings: AiFinding[];
   requiresManualReview: boolean;
   model: string | null;
-  escalated: boolean;
-  escalationReasons: string[];
 }
 
 export interface SelectiveAiReviewOptions {
@@ -35,11 +33,4 @@ export interface SelectiveAiReviewOptions {
   packageJsonDiff: PackageJsonDiff;
   ruleFindings: Finding[];
   previousVersionAvailable: boolean;
-}
-
-export interface PreAiEscalationInput {
-  ruleFindings: Finding[];
-  packageJsonDiff: PackageJsonDiff;
-  previousVersionAvailable: boolean;
-  defaultInputTokenEstimate?: number;
 }

--- a/server/lib/ai-review.ts
+++ b/server/lib/ai-review.ts
@@ -4,121 +4,28 @@ import {
   aiReviewSubmissionSchema,
   MAX_AGENT_STEPS,
   REVIEWER_SYSTEM_PROMPT,
-  TOOL_PROMPT_OVERHEAD_CHARS,
   type AiReviewSubmission,
 } from "./ai-review-contract";
 import { buildAiReviewPayload, createAiReviewTools } from "./ai-review-evidence";
-import type {
-  AiReview,
-  AiReviewStatus,
-  PreAiEscalationInput,
-  SelectiveAiReviewOptions,
-} from "./ai-review-types";
+import type { AiReview, AiReviewStatus, SelectiveAiReviewOptions } from "./ai-review-types";
 
 export type {
   AiFinding,
   AiReview,
   AiReviewStatus,
-  PreAiEscalationInput,
   SelectiveAiReviewOptions,
 } from "./ai-review-types";
 
-// Cheaper triage model used for the default AI review pass. See docs/cost-model.md.
-export const DEFAULT_AI_MODEL = "@cf/qwen/qwen3-30b-a3b-fp8";
-// Stronger reviewer escalated to for risky/ambiguous scans. See docs/cost-model.md.
-export const ESCALATION_AI_MODEL = "@cf/moonshotai/kimi-k2.5";
+// Single reviewer model. See docs/cost-model.md.
+export const AI_MODEL = "@cf/moonshotai/kimi-k2.5";
 
-const LIFECYCLE_SCRIPT_KEYS = new Set([
-  "preinstall",
-  "install",
-  "postinstall",
-  "prepare",
-  "prepack",
-  "postpack",
-  "publish",
-  "prepublish",
-  "prepublishOnly",
-]);
-
-const RISKY_SEVERITIES = new Set(["medium", "high", "critical"]);
-const DEFAULT_AI_INPUT_TOKEN_BUDGET = 24_000;
-const APPROX_CHARS_PER_TOKEN = 4;
 const DEFAULT_CACHE_AFFINITY = "staged-publish-review-agentic-release-reviewer-v1";
-
-export function decidePreAiEscalation(input: PreAiEscalationInput): string[] {
-  const reasons: string[] = [];
-
-  if (input.ruleFindings.some((finding) => RISKY_SEVERITIES.has(finding.severity))) {
-    reasons.push("deterministic finding at medium or higher severity");
-  }
-  if (input.packageJsonDiff.scripts.some((entry) => LIFECYCLE_SCRIPT_KEYS.has(entry.key))) {
-    reasons.push("install-lifecycle script added or modified");
-  }
-  if (input.packageJsonDiff.dependencies.length > 0) {
-    reasons.push("dependency, peer dependency, or optional dependency changed");
-  }
-  if (input.packageJsonDiff.entrypointsChanged) {
-    reasons.push("package entrypoints changed");
-  }
-  if (!input.previousVersionAvailable) {
-    reasons.push("previous-version comparison unavailable");
-  }
-  if (
-    input.defaultInputTokenEstimate &&
-    input.defaultInputTokenEstimate > DEFAULT_AI_INPUT_TOKEN_BUDGET
-  ) {
-    reasons.push("default model context budget exceeded");
-  }
-
-  return reasons;
-}
-
-export function estimateAiReviewInputTokens(options: SelectiveAiReviewOptions): number {
-  const userPayload = JSON.stringify(buildAiReviewPayload(options));
-  return Math.ceil(
-    (REVIEWER_SYSTEM_PROMPT.length + userPayload.length + TOOL_PROMPT_OVERHEAD_CHARS) /
-      APPROX_CHARS_PER_TOKEN,
-  );
-}
-
-export function decidePostDefaultEscalation(review: AiReview): string[] {
-  const reasons: string[] = [];
-  if (review.status !== "complete") {
-    reasons.push(`default model review ${review.status}`);
-  }
-  if (review.releaseAssessment === "suspicious" || review.releaseAssessment === "blocked") {
-    reasons.push(`default model marked release ${review.releaseAssessment}`);
-  }
-  if (review.status === "complete" && review.requiresManualReview) {
-    reasons.push("default model requested manual review");
-  }
-  return reasons;
-}
 
 export async function runSelectiveAiReview(
   env: Cloudflare.Env,
   options: SelectiveAiReviewOptions,
 ): Promise<AiReview> {
-  const preReasons = decidePreAiEscalation({
-    ruleFindings: options.ruleFindings,
-    packageJsonDiff: options.packageJsonDiff,
-    previousVersionAvailable: options.previousVersionAvailable,
-    defaultInputTokenEstimate: estimateAiReviewInputTokens(options),
-  });
-
-  if (preReasons.length > 0) {
-    const escalated = await analyzeWithAi(env, ESCALATION_AI_MODEL, options);
-    return { ...escalated, escalated: true, escalationReasons: preReasons };
-  }
-
-  const defaultReview = await analyzeWithAi(env, DEFAULT_AI_MODEL, options);
-  const postReasons = decidePostDefaultEscalation(defaultReview);
-  if (postReasons.length === 0) {
-    return defaultReview;
-  }
-
-  const escalated = await analyzeWithAi(env, ESCALATION_AI_MODEL, options);
-  return { ...escalated, escalated: true, escalationReasons: postReasons };
+  return analyzeWithAi(env, AI_MODEL, options);
 }
 
 export async function analyzeWithAi(
@@ -238,8 +145,6 @@ function normalizeParsedReview(model: string, value: unknown): AiReview {
     findings: review.findings,
     requiresManualReview: review.requiresManualReview,
     model,
-    escalated: false,
-    escalationReasons: [],
   };
 }
 
@@ -256,7 +161,5 @@ function fallbackReview(
     findings: [],
     requiresManualReview: false,
     model,
-    escalated: false,
-    escalationReasons: [],
   };
 }

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -116,8 +116,6 @@ export async function runScanPipeline(
     findings: [],
     requiresManualReview: false,
     model: null,
-    escalated: false,
-    escalationReasons: [],
   };
   const aiReviewEnabled = env.FLAGS
     ? await env.FLAGS.getBooleanValue("ai-review", false, {
@@ -135,17 +133,6 @@ export async function runScanPipeline(
       ruleFindings: releaseRuleFindings,
       previousVersionAvailable: previous !== null,
     });
-    if (aiFindings.escalated) {
-      console.log("ai review escalated to stronger model", {
-        scanId,
-        stageId: input.stageId,
-        organizationId: input.organizationId,
-        packageName: stagedPackageJson?.name ?? null,
-        stagedVersion: stagedPackageJson?.version ?? null,
-        model: aiFindings.model,
-        reasons: aiFindings.escalationReasons,
-      });
-    }
   }
   const riskSummary = computeScanRiskBreakdown(reportFindingAnnotations, aiFindings);
   const risk = riskSummary.releaseRisk;

--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -1,13 +1,5 @@
 import { describe, expect, test } from "vitest";
-import {
-  analyzeWithAi,
-  decidePostDefaultEscalation,
-  decidePreAiEscalation,
-  DEFAULT_AI_MODEL,
-  ESCALATION_AI_MODEL,
-  estimateAiReviewInputTokens,
-  runSelectiveAiReview,
-} from "../server/lib/ai-review.ts";
+import { AI_MODEL, analyzeWithAi, runSelectiveAiReview } from "../server/lib/ai-review.ts";
 import { computeScanRisk } from "../server/lib/risk.ts";
 
 const EMPTY_PACKAGE_JSON_DIFF = {
@@ -37,7 +29,7 @@ function completeResponse(overrides = {}) {
 }
 
 // AI review is disabled in production while we work toward a paid-tier offering.
-// Keep the suite here but skipped so the prompt + escalation contract is preserved
+// Keep the suite here but skipped so the prompt + single-model contract is preserved
 // for the eventual re-introduction.
 describe.skip("ai review normalization", () => {
   test("review prompt explicitly treats package contents and dependency changes as hostile evidence", async () => {
@@ -232,127 +224,8 @@ describe.skip("ai review normalization", () => {
     expect(ai.status).toBe("complete");
     expect(computeScanRisk([], ai)).toBe("medium");
   });
-});
 
-describe.skip("escalation decision", () => {
-  test("nothing-unusual input does not pre-escalate", () => {
-    const reasons = decidePreAiEscalation({
-      ruleFindings: [{ severity: "low", file: "a", evidence: "", reason: "" }],
-      packageJsonDiff: EMPTY_PACKAGE_JSON_DIFF,
-      previousVersionAvailable: true,
-    });
-    expect(reasons).toEqual([]);
-  });
-
-  test("medium-or-higher deterministic finding triggers pre-escalation", () => {
-    const reasons = decidePreAiEscalation({
-      ruleFindings: [{ severity: "medium", file: "a", evidence: "", reason: "" }],
-      packageJsonDiff: EMPTY_PACKAGE_JSON_DIFF,
-      previousVersionAvailable: true,
-    });
-    expect(reasons).toContain("deterministic finding at medium or higher severity");
-  });
-
-  test("install lifecycle script change triggers pre-escalation", () => {
-    const reasons = decidePreAiEscalation({
-      ruleFindings: [],
-      packageJsonDiff: {
-        ...EMPTY_PACKAGE_JSON_DIFF,
-        scripts: [{ key: "postinstall", status: "added", staged: "node ./hook.js" }],
-      },
-      previousVersionAvailable: true,
-    });
-    expect(reasons).toContain("install-lifecycle script added or modified");
-  });
-
-  test("non-lifecycle script change does not pre-escalate on its own", () => {
-    const reasons = decidePreAiEscalation({
-      ruleFindings: [],
-      packageJsonDiff: {
-        ...EMPTY_PACKAGE_JSON_DIFF,
-        scripts: [{ key: "test", status: "modified", previous: "vitest", staged: "vitest --run" }],
-      },
-      previousVersionAvailable: true,
-    });
-    expect(reasons).toEqual([]);
-  });
-
-  test("dependency change triggers pre-escalation", () => {
-    const reasons = decidePreAiEscalation({
-      ruleFindings: [],
-      packageJsonDiff: {
-        ...EMPTY_PACKAGE_JSON_DIFF,
-        dependencies: [{ key: "lodash", status: "added", staged: "^4.17.21" }],
-      },
-      previousVersionAvailable: true,
-    });
-    expect(reasons).toContain("dependency, peer dependency, or optional dependency changed");
-  });
-
-  test("entrypoint changes trigger pre-escalation", () => {
-    const reasons = decidePreAiEscalation({
-      ruleFindings: [],
-      packageJsonDiff: { ...EMPTY_PACKAGE_JSON_DIFF, entrypointsChanged: true },
-      previousVersionAvailable: true,
-    });
-    expect(reasons).toContain("package entrypoints changed");
-  });
-
-  test("missing previous version triggers pre-escalation", () => {
-    const reasons = decidePreAiEscalation({
-      ruleFindings: [],
-      packageJsonDiff: EMPTY_PACKAGE_JSON_DIFF,
-      previousVersionAvailable: false,
-    });
-    expect(reasons).toContain("previous-version comparison unavailable");
-  });
-
-  test("post-default escalates when default model marks suspicious", () => {
-    const reasons = decidePostDefaultEscalation({
-      status: "complete",
-      risk: "medium",
-      releaseAssessment: "suspicious",
-      summary: "",
-      findings: [],
-      requiresManualReview: false,
-      model: DEFAULT_AI_MODEL,
-      escalated: false,
-      escalationReasons: [],
-    });
-    expect(reasons).toContain("default model marked release suspicious");
-  });
-
-  test("post-default escalates when default model requests manual review", () => {
-    const reasons = decidePostDefaultEscalation({
-      status: "complete",
-      risk: "medium",
-      releaseAssessment: "review_recommended",
-      summary: "",
-      findings: [],
-      requiresManualReview: true,
-      model: DEFAULT_AI_MODEL,
-      escalated: false,
-      escalationReasons: [],
-    });
-    expect(reasons).toContain("default model requested manual review");
-  });
-
-  test("post-default escalates when default model fails to produce a review", () => {
-    const reasons = decidePostDefaultEscalation({
-      status: "unavailable",
-      risk: "low",
-      releaseAssessment: "not_assessed",
-      summary: "",
-      findings: [],
-      requiresManualReview: false,
-      model: DEFAULT_AI_MODEL,
-      escalated: false,
-      escalationReasons: [],
-    });
-    expect(reasons).toContain("default model review unavailable");
-  });
-
-  test("calm scan uses default model without escalation", async () => {
+  test("runSelectiveAiReview always uses the single Kimi model", async () => {
     const calls = [];
     const review = await runSelectiveAiReview(
       reviewerEnv({
@@ -369,114 +242,7 @@ describe.skip("escalation decision", () => {
         previousVersionAvailable: true,
       },
     );
-    expect(calls).toEqual([DEFAULT_AI_MODEL]);
-    expect(review.model).toBe(DEFAULT_AI_MODEL);
-    expect(review.escalated).toBe(false);
-    expect(review.escalationReasons).toEqual([]);
-  });
-
-  test("large calm scan skips default model when prompt estimate exceeds its context budget", async () => {
-    const files = Array.from({ length: 80 }, (_, index) => ({
-      path: `src/generated-${index}.js`,
-      size: 4096,
-      sha256: `sha-${index}`,
-      flags: [],
-      textSample: "export const value = 1;\n".repeat(200),
-    }));
-    const diff = files.map((file) => ({ path: file.path, status: "modified", flags: [] }));
-    const options = {
-      files,
-      diff,
-      packageJsonDiff: EMPTY_PACKAGE_JSON_DIFF,
-      ruleFindings: [],
-      previousVersionAvailable: true,
-    };
-    const calls = [];
-    const review = await runSelectiveAiReview(
-      reviewerEnv({
-        run: async (model) => {
-          calls.push(model);
-          return completeResponse();
-        },
-      }),
-      options,
-    );
-
-    expect(estimateAiReviewInputTokens(options)).toBeGreaterThan(24_000);
-    expect(calls).toEqual([ESCALATION_AI_MODEL]);
-    expect(review.model).toBe(ESCALATION_AI_MODEL);
-    expect(review.escalated).toBe(true);
-    expect(review.escalationReasons).toContain("default model context budget exceeded");
-  });
-
-  test("risky deterministic signal skips the default model and runs escalation only", async () => {
-    const calls = [];
-    const review = await runSelectiveAiReview(
-      reviewerEnv({
-        run: async (model) => {
-          calls.push(model);
-          return completeResponse({ risk: "high", releaseAssessment: "review_recommended" });
-        },
-      }),
-      {
-        files: [],
-        diff: [],
-        packageJsonDiff: {
-          ...EMPTY_PACKAGE_JSON_DIFF,
-          scripts: [{ key: "preinstall", status: "added", staged: "curl ..." }],
-        },
-        ruleFindings: [
-          {
-            severity: "critical",
-            file: "package.json",
-            evidence: "preinstall: curl ...",
-            reason: "lifecycle hook",
-          },
-        ],
-        previousVersionAvailable: true,
-      },
-    );
-    expect(calls).toEqual([ESCALATION_AI_MODEL]);
-    expect(review.model).toBe(ESCALATION_AI_MODEL);
-    expect(review.escalated).toBe(true);
-    expect(review.escalationReasons).toContain(
-      "deterministic finding at medium or higher severity",
-    );
-    expect(review.escalationReasons).toContain("install-lifecycle script added or modified");
-  });
-
-  test("default model suspicious assessment triggers a second escalation call", async () => {
-    const calls = [];
-    const review = await runSelectiveAiReview(
-      reviewerEnv({
-        run: async (model) => {
-          calls.push(model);
-          if (model === DEFAULT_AI_MODEL) {
-            return completeResponse({
-              risk: "medium",
-              releaseAssessment: "suspicious",
-              summary: "Something is off.",
-            });
-          }
-          return completeResponse({
-            risk: "high",
-            releaseAssessment: "blocked",
-            summary: "Escalated reviewer confirms.",
-            requiresManualReview: true,
-          });
-        },
-      }),
-      {
-        files: [],
-        diff: [],
-        packageJsonDiff: EMPTY_PACKAGE_JSON_DIFF,
-        ruleFindings: [],
-        previousVersionAvailable: true,
-      },
-    );
-    expect(calls).toEqual([DEFAULT_AI_MODEL, ESCALATION_AI_MODEL]);
-    expect(review.model).toBe(ESCALATION_AI_MODEL);
-    expect(review.escalated).toBe(true);
-    expect(review.escalationReasons).toContain("default model marked release suspicious");
+    expect(calls).toEqual([AI_MODEL]);
+    expect(review.model).toBe(AI_MODEL);
   });
 });


### PR DESCRIPTION
## Summary
- Collapse the two-tier AI reviewer (qwen default + Kimi escalation) into a single Kimi K2.5 model
- Remove escalation decision logic, `escalated`/`escalationReasons` fields, and the now-unused token-estimation helpers
- Update README, architecture, cost-model, and production-roadmap docs to describe the single-model posture

## Test plan
- [x] `pnpm run verify` (lint + format + typecheck + vitest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)