### PR TITLE
Gate AiReview consumers on status via displayedAiResult helper

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -166,6 +166,8 @@ Workers AI review is currently **disabled in the scan pipeline**. The reviewer m
 
 Scans persist `scan.aiJson = null` while AI review is disabled, and the UI omits the reviewer-notes section entirely. Risk is computed exclusively from deterministic findings.
 
+All `AiReview` consumers must route the persisted record through `displayedAiResult()` (`server/lib/ai-review-types.ts`). The fallback shape used when the assistant did not complete carries `risk: "low"` and `releaseAssessment: "not_assessed"` — reading those fields raw would silently surface "we couldn't review this" as "low risk / nothing unusual." The helper narrows to a `{ kind: "complete" }` discriminated union or a `{ kind: "unavailable" }` view that intentionally omits `risk` and `releaseAssessment`, so neither the UI nor the risk computation can accidentally read fallback values as evidence.
+
 When AI review returns it will continue to:
 
 - start from deterministic findings, package.json/package.json diff, and changed-file metadata rather than a bulk dump of every changed file;

--- a/server/lib/ai-review-types.ts
+++ b/server/lib/ai-review-types.ts
@@ -10,15 +10,16 @@ export interface AiFinding {
 
 export type AiReviewStatus = "complete" | "invalid" | "unavailable";
 
+export type AiReleaseAssessment =
+  | "nothing_unusual"
+  | "review_recommended"
+  | "suspicious"
+  | "blocked";
+
 export interface AiReview {
   status: AiReviewStatus;
   risk: RiskLevel;
-  releaseAssessment:
-    | "nothing_unusual"
-    | "review_recommended"
-    | "suspicious"
-    | "blocked"
-    | "not_assessed";
+  releaseAssessment: AiReleaseAssessment | "not_assessed";
   summary: string;
   findings: AiFinding[];
   requiresManualReview: boolean;
@@ -33,4 +34,47 @@ export interface SelectiveAiReviewOptions {
   packageJsonDiff: PackageJsonDiff;
   ruleFindings: Finding[];
   previousVersionAvailable: boolean;
+}
+
+export type DisplayedAiResult =
+  | {
+      kind: "complete";
+      model: string | null;
+      summary: string;
+      risk: RiskLevel;
+      releaseAssessment: AiReleaseAssessment;
+      findings: AiFinding[];
+      requiresManualReview: boolean;
+    }
+  | {
+      kind: "unavailable";
+      model: string | null;
+      summary: string;
+      status: Exclude<AiReviewStatus, "complete">;
+    };
+
+// Single safe accessor for AiReview consumers. The fallback shape returned when
+// the assistant did not complete (`status` "invalid" or "unavailable") carries
+// `risk: "low"` and `releaseAssessment: "not_assessed"` — reading those raw
+// would surface "we couldn't review this" as "low risk / nothing unusual."
+// Always route AiReview through this helper before rendering or computing risk.
+export function displayedAiResult(review: AiReview | null | undefined): DisplayedAiResult | null {
+  if (!review) return null;
+  if (review.status === "complete" && review.releaseAssessment !== "not_assessed") {
+    return {
+      kind: "complete",
+      model: review.model,
+      summary: review.summary,
+      risk: review.risk,
+      releaseAssessment: review.releaseAssessment,
+      findings: review.findings,
+      requiresManualReview: review.requiresManualReview,
+    };
+  }
+  return {
+    kind: "unavailable",
+    model: review.model,
+    summary: review.summary,
+    status: review.status === "complete" ? "invalid" : review.status,
+  };
 }

--- a/server/lib/ai-review.ts
+++ b/server/lib/ai-review.ts
@@ -11,10 +11,13 @@ import type { AiReview, AiReviewStatus, SelectiveAiReviewOptions } from "./ai-re
 
 export type {
   AiFinding,
+  AiReleaseAssessment,
   AiReview,
   AiReviewStatus,
+  DisplayedAiResult,
   SelectiveAiReviewOptions,
 } from "./ai-review-types";
+export { displayedAiResult } from "./ai-review-types";
 
 // Single reviewer model. See docs/cost-model.md.
 export const AI_MODEL = "@cf/moonshotai/kimi-k2.5";

--- a/server/lib/risk.ts
+++ b/server/lib/risk.ts
@@ -1,4 +1,5 @@
 import type { AiReview } from "./ai-review";
+import { displayedAiResult } from "./ai-review";
 import { combineRisk, computeRisk, normalizeRisk, type Finding, type RiskLevel } from "./review";
 
 export interface ScanRiskBreakdown {
@@ -15,13 +16,16 @@ type RiskFinding = Finding & {
   releaseDelta?: boolean | null;
 };
 
-export function computeScanRisk(ruleFindings: Finding[], aiFindings: AiReview): RiskLevel {
-  const aiReviewCompleted = aiFindings.status === "complete";
-  const aiHasEvidence = aiFindings.findings.length > 0 || aiFindings.requiresManualReview;
+export function computeScanRisk(ruleFindings: Finding[], aiReview: AiReview): RiskLevel {
+  const ai = displayedAiResult(aiReview);
+  if (ai?.kind !== "complete") {
+    return computeRisk(ruleFindings);
+  }
+  const aiHasEvidence = ai.findings.length > 0 || ai.requiresManualReview;
   return combineRisk(
     computeRisk(ruleFindings),
-    aiReviewCompleted && aiHasEvidence ? aiFindings.risk : "low",
-    aiReviewCompleted && aiFindings.requiresManualReview ? "medium" : "low",
+    aiHasEvidence ? ai.risk : "low",
+    ai.requiresManualReview ? "medium" : "low",
   );
 }
 

--- a/server/lib/risk.ts
+++ b/server/lib/risk.ts
@@ -1,5 +1,5 @@
-import type { AiReview } from "./ai-review";
-import { displayedAiResult } from "./ai-review";
+import type { AiReview } from "./ai-review-types";
+import { displayedAiResult } from "./ai-review-types";
 import { combineRisk, computeRisk, normalizeRisk, type Finding, type RiskLevel } from "./review";
 
 export interface ScanRiskBreakdown {

--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -11,8 +11,8 @@ import {
   type PersistedScanDetail,
   type ScanDecision,
 } from "../../models/scan";
-import type { AiFinding, AiReview, DisplayedAiResult } from "../../../server/lib/ai-review";
-import { displayedAiResult } from "../../../server/lib/ai-review";
+import type { AiFinding, AiReview, DisplayedAiResult } from "../../../server/lib/ai-review-types";
+import { displayedAiResult } from "../../../server/lib/ai-review-types";
 import {
   annotateFindingsWithDiffStatus as annotateReviewFindingsWithDiffStatus,
   createPackageDiff,

--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -11,7 +11,8 @@ import {
   type PersistedScanDetail,
   type ScanDecision,
 } from "../../models/scan";
-import type { AiFinding, AiReview } from "../../../server/lib/ai-review";
+import type { AiFinding, AiReview, DisplayedAiResult } from "../../../server/lib/ai-review";
+import { displayedAiResult } from "../../../server/lib/ai-review";
 import {
   annotateFindingsWithDiffStatus as annotateReviewFindingsWithDiffStatus,
   createPackageDiff,
@@ -128,7 +129,7 @@ export default function ScanDetailPage() {
   });
 
   const summary = useComputed(() => asPersistedSummary(model.detail.value?.scan.summaryJson));
-  const ai = useComputed(() => asAiReview(model.detail.value?.scan.aiJson));
+  const ai = useComputed(() => displayedAiResult(asAiReview(model.detail.value?.scan.aiJson)));
 
   const diffEntries = useComputed<DiffEntry[]>(() => {
     const detail = model.detail.value;
@@ -265,7 +266,6 @@ export default function ScanDetailPage() {
               detail={detail}
               summary={summary.value}
               ai={ai.value}
-              aiFindings={ai.value?.findings ?? []}
               diffCount={diffEntries.value.filter((entry) => entry.status !== "unchanged").length}
               findingsWithDiffStatus={findingsWithDiffStatus.value}
               usePersistedRiskSummary={model.isDefaultComparison.value || !compare}
@@ -377,15 +377,13 @@ function ReleaseRecommendation({
   detail,
   summary,
   ai,
-  aiFindings,
   diffCount,
   findingsWithDiffStatus,
   usePersistedRiskSummary,
 }: {
   detail: PersistedScanDetail;
   summary: PersistedSummary;
-  ai: AiReview | null;
-  aiFindings: AiFinding[];
+  ai: DisplayedAiResult | null;
   diffCount: number;
   findingsWithDiffStatus: FindingWithDiffStatus[];
   usePersistedRiskSummary: boolean;
@@ -404,14 +402,14 @@ function ReleaseRecommendation({
     usePersistedRiskSummary && detail.riskSummary
       ? detail.riskSummary.releaseFindingCount
       : changedFindings.length;
-  const aiComplete = ai?.status === "complete";
+  const aiFindings: AiFinding[] = ai?.kind === "complete" ? ai.findings : [];
   const recommendation = getReleaseRecommendation(artifactRisk, releaseRisk, releaseFindingCount);
   const evidence = buildRecommendationEvidence(
     detail,
     summary,
     diffCount,
     changedFindings,
-    aiComplete ? aiFindings : [],
+    aiFindings,
   );
   const severityCounts = countSeverities([...detail.findings, ...aiFindings]);
   const findingTotal = Object.values(severityCounts).reduce((sum, count) => sum + (count ?? 0), 0);
@@ -425,12 +423,12 @@ function ReleaseRecommendation({
           <Badge tone="neutral">artifact {artifactRisk}</Badge>
         ) : null}
         {ai?.model != null &&
-          (aiComplete ? (
+          (ai.kind === "complete" ? (
             <>
-              <Badge tone={ai!.requiresManualReview ? "medium" : "ok"}>
-                {ai!.requiresManualReview ? "manual review" : "no extra review"}
+              <Badge tone={ai.requiresManualReview ? "medium" : "ok"}>
+                {ai.requiresManualReview ? "manual review" : "no extra review"}
               </Badge>
-              <Badge tone="neutral">{ai!.releaseAssessment.replaceAll("_", " ")}</Badge>
+              <Badge tone="neutral">{ai.releaseAssessment.replaceAll("_", " ")}</Badge>
             </>
           ) : (
             <Badge tone="neutral">assistant unavailable</Badge>
@@ -1003,7 +1001,7 @@ function PersistedReportSections({
   ai,
 }: {
   summary: PersistedSummary;
-  ai: AiReview | null;
+  ai: DisplayedAiResult | null;
 }) {
   return (
     <section class="grid grid-cols-1 lg:grid-cols-2 gap-x-8 gap-y-6">
@@ -1015,41 +1013,35 @@ function PersistedReportSections({
         )}
       </ReportSection>
 
-      {ai?.model != null && (
+      {ai != null && ai.model != null && (
         <ReportSection title="Reviewer notes" class="lg:col-span-2">
-          {ai ? (
-            ai!.status === "complete" ? (
-              <>
-                <div class="flex flex-wrap gap-2">
-                  <Badge tone={severityTone(ai!.risk)}>{ai!.risk}</Badge>
-                  <Badge tone={ai!.requiresManualReview ? "medium" : "ok"}>
-                    {ai!.requiresManualReview ? "manual review" : "no extra review"}
-                  </Badge>
-                  <Badge tone="neutral">
-                    {ai!.releaseAssessment?.replaceAll("_", " ") || "assessment stored"}
-                  </Badge>
-                </div>
-                {ai!.summary ? (
-                  <p class="m-0 text-[13px] leading-[1.6] text-ink-muted">{ai!.summary}</p>
-                ) : null}
-                {ai!.findings?.length ? (
-                  <AiFindingList findings={ai!.findings} />
-                ) : (
-                  <EmptyLine>No assistant findings.</EmptyLine>
-                )}
-              </>
-            ) : (
-              <>
-                <div class="flex flex-wrap gap-2">
-                  <Badge tone="neutral">assistant unavailable</Badge>
-                </div>
-                {ai!.summary ? (
-                  <p class="m-0 text-[13px] leading-[1.6] text-ink-muted">{ai!.summary}</p>
-                ) : null}
-              </>
-            )
+          {ai.kind === "complete" ? (
+            <>
+              <div class="flex flex-wrap gap-2">
+                <Badge tone={severityTone(ai.risk)}>{ai.risk}</Badge>
+                <Badge tone={ai.requiresManualReview ? "medium" : "ok"}>
+                  {ai.requiresManualReview ? "manual review" : "no extra review"}
+                </Badge>
+                <Badge tone="neutral">{ai.releaseAssessment.replaceAll("_", " ")}</Badge>
+              </div>
+              {ai.summary ? (
+                <p class="m-0 text-[13px] leading-[1.6] text-ink-muted">{ai.summary}</p>
+              ) : null}
+              {ai.findings.length ? (
+                <AiFindingList findings={ai.findings} />
+              ) : (
+                <EmptyLine>No assistant findings.</EmptyLine>
+              )}
+            </>
           ) : (
-            <EmptyLine>No reviewer notes were saved for this review.</EmptyLine>
+            <>
+              <div class="flex flex-wrap gap-2">
+                <Badge tone="neutral">assistant unavailable</Badge>
+              </div>
+              {ai.summary ? (
+                <p class="m-0 text-[13px] leading-[1.6] text-ink-muted">{ai.summary}</p>
+              ) : null}
+            </>
           )}
         </ReportSection>
       )}

--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
-import { AI_MODEL, analyzeWithAi, runSelectiveAiReview } from "../server/lib/ai-review.ts";
+import {
+  AI_MODEL,
+  analyzeWithAi,
+  displayedAiResult,
+  runSelectiveAiReview,
+} from "../server/lib/ai-review.ts";
 import { computeScanRisk } from "../server/lib/risk.ts";
 
 const EMPTY_PACKAGE_JSON_DIFF = {
@@ -244,5 +249,105 @@ describe.skip("ai review normalization", () => {
     );
     expect(calls).toEqual([AI_MODEL]);
     expect(review.model).toBe(AI_MODEL);
+  });
+});
+
+describe("displayedAiResult", () => {
+  test("returns null when no review is provided", () => {
+    expect(displayedAiResult(null)).toBeNull();
+    expect(displayedAiResult(undefined)).toBeNull();
+  });
+
+  test("invalid status produces an unavailable result that hides fallback risk/assessment", () => {
+    const result = displayedAiResult({
+      status: "invalid",
+      risk: "low",
+      releaseAssessment: "not_assessed",
+      summary: "Assistant returned non-JSON output.",
+      findings: [],
+      requiresManualReview: false,
+      model: "test-model",
+    });
+    expect(result).toEqual({
+      kind: "unavailable",
+      status: "invalid",
+      model: "test-model",
+      summary: "Assistant returned non-JSON output.",
+    });
+    expect(result).not.toHaveProperty("risk");
+    expect(result).not.toHaveProperty("releaseAssessment");
+  });
+
+  test("unavailable status produces an unavailable result", () => {
+    const result = displayedAiResult({
+      status: "unavailable",
+      risk: "low",
+      releaseAssessment: "not_assessed",
+      summary: "AI review is disabled.",
+      findings: [],
+      requiresManualReview: false,
+      model: null,
+    });
+    expect(result).toEqual({
+      kind: "unavailable",
+      status: "unavailable",
+      model: null,
+      summary: "AI review is disabled.",
+    });
+  });
+
+  test("complete review exposes risk/assessment", () => {
+    const result = displayedAiResult({
+      status: "complete",
+      risk: "medium",
+      releaseAssessment: "review_recommended",
+      summary: "Network behavior needs review.",
+      findings: [
+        {
+          severity: "medium",
+          file: "package/index.js",
+          evidence: "fetch('https://example.com')",
+          reason: "outbound network call",
+          recommendation: "review manually",
+        },
+      ],
+      requiresManualReview: true,
+      model: "test-model",
+    });
+    expect(result).toEqual({
+      kind: "complete",
+      model: "test-model",
+      summary: "Network behavior needs review.",
+      risk: "medium",
+      releaseAssessment: "review_recommended",
+      findings: [
+        {
+          severity: "medium",
+          file: "package/index.js",
+          evidence: "fetch('https://example.com')",
+          reason: "outbound network call",
+          recommendation: "review manually",
+        },
+      ],
+      requiresManualReview: true,
+    });
+  });
+
+  test("complete review with not_assessed assessment is treated as unavailable (defensive)", () => {
+    const result = displayedAiResult({
+      status: "complete",
+      risk: "low",
+      releaseAssessment: "not_assessed",
+      summary: "Stored without an assessment.",
+      findings: [],
+      requiresManualReview: false,
+      model: "test-model",
+    });
+    expect(result).toEqual({
+      kind: "unavailable",
+      status: "invalid",
+      model: "test-model",
+      summary: "Stored without an assessment.",
+    });
   });
 });


### PR DESCRIPTION
## Summary

- `fallbackReview` returns `risk: "low"` / `releaseAssessment: "not_assessed"` when the assistant didn't complete, so any consumer reading those raw would silently render "we couldn't review this" as "low risk / nothing unusual" — a fail-open. (#108)
- Added `displayedAiResult()` in `server/lib/ai-review-types.ts`: narrows `AiReview` into a discriminated union (`{ kind: "complete", risk, releaseAssessment, ... }` or `{ kind: "unavailable", status, summary, model }`) where the unavailable branch intentionally omits `risk` and `releaseAssessment` so they can't be read on a non-complete review.
- Routed `computeScanRisk` (server/lib/risk.ts) and the `ReleaseRecommendation` / `PersistedReportSections` UI in `src/pages/Dashboard/ScanDetail.tsx` through the helper, replacing scattered manual status checks and removing the non-null `ai!` assertions.
- Added tests covering null/invalid/unavailable/complete branches and the defensive `complete + not_assessed` case; updated `docs/architecture.md` with the helper rule.

## Test plan

- [x] `pnpm run verify` (lint, format, typecheck, 142+42 vitest)
- [ ] Re-run the Reviewer-notes section locally with a forced `status: "invalid"` payload to confirm the "assistant unavailable" branch renders

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)