### PR TITLE
[codex] Add server change safety gates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,9 @@
   - `pages/` — landing, login/register, dashboard, persisted scan detail.
   - `models/` — fetch wrappers for Better Auth and scan APIs. Scan models re-use types from `server/`.
 - `drizzle/` — D1 migrations.
-- `test/` — Vitest specs for pure logic (no Worker runtime).
+- `test/` — Vitest specs. Pure logic tests live directly under `test/`; Worker-runtime route
+  and D1 tests live under `test/workers/`; Playwright + fake-registry e2e tests live under
+  `test/e2e/` and `test/e2e-fixtures/`.
 
 ## Conventions
 
@@ -31,6 +33,20 @@
 - `useState` and `useReducer` are banned (oxlint `no-restricted-imports` enforces it). Component-local state goes through `useSignal`/`useComputed` or `createModel`/`useModel`. See `docs/tooling.md` and the skills under `.claude/skills/preact-signals-*` (also surfaced through the `.agents/skills` symlink).
 - Lint with `pnpm run lint` (oxlint) and format with `pnpm run format` (oxfmt). Configs live in `.oxlintrc.json` and `.oxfmtrc.json`.
 - Before every commit, run `pnpm run verify` (lint + format check + typecheck + tests). The pre-commit hook in `.githooks/pre-commit` runs it automatically; `pnpm install` wires `core.hooksPath` for you. Don't bypass it with `--no-verify` unless you have a real reason.
+- New functionality needs tests in the same change. Use the narrowest useful layer, then add
+  broader coverage when the behavior crosses a trust boundary:
+  - `server/routes/*`, auth, organization scoping, rate limits, D1 persistence, queues, and
+    scan lifecycle behavior require Worker-route tests in `test/workers/`.
+  - Sandbox, archive parser, npm credential forwarding, redaction, and deterministic-rule
+    changes require invariant/regression tests. The sandbox must never receive token material,
+    and `NpmStageGateway` must remain the only credentialed egress path.
+  - npm registry behavior, staged-publish discovery, endpoint drift, or browser-visible scan
+    workflow changes require fake-registry e2e coverage in `test/e2e-fixtures/` and
+    `test/e2e/local-registry.spec.ts`.
+  - Deterministic detection changes require security-corpus fixtures with explicit expected
+    rule IDs, severity, and risk.
+  - Operational paths should emit structured, secret-redacted observability events through
+    `server/lib/observability.ts`; do not log raw errors, tokens, headers, or package contents.
 - Never write SQL migrations by hand; use `pnpm db:generate` to create migrations from `server/db/schema.ts`.
 - Before you start work read up on `docs/`, when you are done working update `docs/` with relevant information
 - WE NEVER USE `preact/compat`
@@ -42,6 +58,6 @@
 - `npm run typecheck` — `tsc --noEmit`.
 - `npm run lint` / `npm run lint:fix` — oxlint over `src/`, `server/`, `test/`. Use `:fix` to apply autofixes.
 - `npm run format` / `npm run format:check` — oxfmt write / check-only.
-- `npm run test` — Vitest logic suite.
+- `npm run test` — Vitest logic suite plus Worker-runtime tests.
 - `npm run verify` — runs lint, format check, typecheck, and tests in order. CI and the pre-commit hook both call this.
 - `npm run db:generate` — Drizzle migration from `server/db/schema.ts`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@
 - We use `preact`, `preact-iso`, and `signals`.
 - `useState` and `useReducer` are banned (oxlint `no-restricted-imports` enforces it). Component-local state goes through `useSignal`/`useComputed` or `createModel`/`useModel`. See `docs/tooling.md` and the skills under `.claude/skills/preact-signals-*` (also surfaced through the `.agents/skills` symlink).
 - Lint with `pnpm run lint` (oxlint) and format with `pnpm run format` (oxfmt). Configs live in `.oxlintrc.json` and `.oxfmtrc.json`.
-- Before every commit, run `pnpm run verify` (lint + format check + typecheck + tests). The pre-commit hook in `.githooks/pre-commit` runs it automatically; `pnpm install` wires `core.hooksPath` for you. Don't bypass it with `--no-verify` unless you have a real reason.
+- Before every commit, run `pnpm run verify` (lint + format check + typecheck + tests). Run `pnpm run test:e2e` as well when changes touch npm registry behavior, staged-publish discovery, scan workflow, credential forwarding, or browser-visible review flows. The pre-commit hook in `.githooks/pre-commit` runs `verify` automatically; `pnpm install` wires `core.hooksPath` for you. Don't bypass it with `--no-verify` unless you have a real reason.
 - New functionality needs tests in the same change. Use the narrowest useful layer, then add
   broader coverage when the behavior crosses a trust boundary:
   - `server/routes/*`, auth, organization scoping, rate limits, D1 persistence, queues, and
@@ -59,5 +59,8 @@
 - `npm run lint` / `npm run lint:fix` — oxlint over `src/`, `server/`, `test/`. Use `:fix` to apply autofixes.
 - `npm run format` / `npm run format:check` — oxfmt write / check-only.
 - `npm run test` — Vitest logic suite plus Worker-runtime tests.
+- `npm run e2e:fixtures` — Pack fake-registry fixture packages into `.context/e2e-registry/`.
+- `npm run e2e:dev` — Start the fake npm staging registry plus the local Worker dev server.
+- `npm run test:e2e` — Run Playwright against the fake-registry harness; required for registry, credential-forwarding, staged-publish, and scan-workflow changes.
 - `npm run verify` — runs lint, format check, typecheck, and tests in order. CI and the pre-commit hook both call this.
 - `npm run db:generate` — Drizzle migration from `server/db/schema.ts`.

--- a/docs/e2e-test-environment.md
+++ b/docs/e2e-test-environment.md
@@ -12,6 +12,11 @@ The normal end-to-end loop is local and deterministic. It uses fixture packages 
 
 The fake registry writes `.context/e2e-registry/requests.jsonl`. The browser test checks this journal so we can verify authorization headers only appear on expected npm-like endpoints.
 
+Any change to npm staged-publish endpoints, registry metadata handling,
+credential forwarding, or browser-visible scan workflow should add or update a
+fixture scenario and journal assertion in this harness. See
+[`release-safety.md`](./release-safety.md) for the broader test matrix.
+
 ## Commands
 
 ```sh

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -77,7 +77,7 @@ Exit criteria:
 - Add structured error classes and user-safe messages across all scan failures.
 - Add archive parser fuzz/regression tests and deeper archive-bomb protections.
 - Add line numbers to deterministic findings where possible.
-- Add metrics/logging for scan durations, queue retries/exhaustion, failures, AI failures, and npm failures.
+- Build dashboards/alerts from the structured operational events now emitted for scan durations, queue retries/exhaustion, failures, and AI failures; add provider-specific npm failure rollups where the current safe error codes are too coarse.
 - Add D1/R2 retention controls for persisted redacted text samples and derived artifacts.
 - Add deployment checklist and incident-response notes.
 

--- a/docs/release-safety.md
+++ b/docs/release-safety.md
@@ -1,0 +1,76 @@
+# Release safety
+
+Drydock is a security-grade service, so confidence comes from layered evidence:
+small unit checks, Worker-route tests that exercise Cloudflare/D1 behavior,
+fake-registry e2e tests, and production observability. A server change is not
+ready just because TypeScript compiles.
+
+## Required test layer by change type
+
+| Change type                                                                                  | Required coverage                                                                                                                                                                      |
+| -------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `server/routes/*`, auth, organization scoping, rate limits, D1 persistence, queue enqueueing | Worker-route tests in `test/workers/`                                                                                                                                                  |
+| Scan job lifecycle, retry classification, queue retry/exhaustion, notification dispatch      | Node tests near `test/scan-job.test.mjs` plus Worker-route coverage when HTTP behavior changes                                                                                         |
+| Sandbox, tar/zip parsing, archive limits, credential egress                                  | Invariant tests in `test/sandbox-gateway.test.mjs`, `test/workers/sandbox-gateway-runtime.test.ts`, parser regression tests, and e2e journal checks when registry behavior is involved |
+| Deterministic findings, risk, redaction, package diff behavior                               | Focused Node tests plus `test/fixtures/security-corpus/cases/*.json` fixtures with exact expected rule IDs, severities, and risk                                                       |
+| npm staged-publish API, registry metadata, fake registry behavior, browser-visible scan flow | Scenario fixtures under `test/e2e-fixtures/scenarios/` and assertions in `test/e2e/local-registry.spec.ts`                                                                             |
+| UI-only changes                                                                              | Component/page-level logic where available, `pnpm run verify`, and Playwright coverage when workflow behavior changes                                                                  |
+
+When a change spans layers, test the lowest deterministic unit and the highest
+user- or operator-visible contract. For example, a new scan route should usually
+have a Worker-route test for the HTTP/D1 contract and a scan-job or pipeline test
+for the lifecycle behavior behind it.
+
+## Non-negotiable invariants
+
+- Every non-auth `/api/*` route requires a Better Auth session.
+- Client-supplied organization IDs are only selectors; route handlers must verify
+  membership through `requireActiveOrganization`.
+- Queue messages carry scan IDs and organization IDs, not npm tokens or decrypted
+  credential material.
+- The Dynamic Worker sandbox never receives npm token material.
+- `NpmStageGateway` is the only credentialed sandbox egress path and only forwards
+  auth to allowlisted registry endpoints.
+- Package code is never executed, imported, installed, built, rendered as active
+  content, or allowed to define instructions for reviewers.
+- Archive parsing fails closed on traversal, symlinks/hardlinks, malformed
+  archives, excessive files, and excessive expanded size.
+- Deterministic findings are authoritative while AI review is disabled, and AI
+  cannot downgrade deterministic findings when it returns.
+
+## Operational observability
+
+Runtime paths should emit structured events through
+`server/lib/observability.ts`. The helper redacts sensitive key names and bearer
+tokens before calling `console`, which keeps Cloudflare logs useful without
+turning them into a credential sink.
+
+Current structured events cover:
+
+- `scan.pipeline.completed` / `scan.pipeline.failed` with adapter, duration,
+  file counts, finding count, and risk.
+- `scan.ai_review.completed` / `scan.ai_review.failed` when AI review is enabled.
+- `scan.job.completed`, `scan.job.failed`, `scan.job.retryable_failed`, and
+  `scan.job.skipped` with scan ID, organization ID, source, attempt, duration,
+  and safe error code.
+- `scan.queue.message.completed`, `scan.queue.retry_scheduled`, and
+  `scan.queue.message_failed` with attempt, delay/exhaustion, duration, and safe
+  error code.
+
+Do not log raw package text, headers, tokens, token fingerprints, ciphertext,
+nonces, cookies, or raw unexpected error messages. If an operator needs detail,
+add a safe structured code or sanitized metadata field instead.
+
+## Release checklist
+
+Before merging server-risk changes:
+
+1. Identify the touched trust boundary: auth/org, credential, sandbox, parser,
+   registry, queue, persistence, detection, or UI-only.
+2. Add or update tests in the table above.
+3. Run `pnpm run verify`.
+4. Run `pnpm run test:e2e` when registry behavior or end-to-end scan workflow
+   changed.
+5. Confirm operational events exist for new failure modes and do not include
+   sensitive material.
+6. Update the relevant docs in the same change.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -203,7 +203,7 @@ Do not expose signed report URLs until access controls, report canonicalization,
 ## Known gaps
 
 - Per-organization encrypted npm connections exist, and validation can check staged-tarball access when supplied a real stage ID; npm list/view capability checks still need confirmation before launch.
-- Queue-backed scan retry/dead-letter behavior exists in code and Wrangler config, but production queue resources and operational metrics still need deployment validation.
+- Queue-backed scan retry/dead-letter behavior exists in code and Wrangler config, and scan/queue paths now emit structured secret-redacted operational events. Production queue resources, DLQ visibility, metrics dashboards, and alerts still need deployment validation.
 - Persisted detail UI now renders core report data, but finding grouping and lifecycle timelines still need polish.
 - Tar parsing now rejects traversal paths, skips symlinks/hardlinks, handles long-name/PAX paths, caps expanded size, and fails closed when the safe file-count limit is exceeded, but it still needs deeper archive-bomb fuzzing before broad public launch.
 - Basic D1-backed rate limits exist for scans and credential operations; production should add metrics, alerts, and edge/IP-based abuse controls.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -24,6 +24,11 @@
 
 `pnpm lint` (the shorthand without `run`) can collide with workspace forwarding or shell wrappers — always use `pnpm run lint`.
 
+Server-risk changes have a stricter test matrix than the command table alone
+can express. See [`release-safety.md`](./release-safety.md) for the expected
+Worker-route, sandbox invariant, fake-registry e2e, security-corpus, and
+observability coverage by change type.
+
 ## Pre-commit hook
 
 `pnpm install` runs a `prepare` script that points `git config core.hooksPath` at `.githooks/`. The `.githooks/pre-commit` script then runs `pnpm run verify`, so every commit on this repo must pass lint + format + typecheck + tests. CI (`.github/workflows/ci.yml`) runs the same core checks and then installs Chromium and runs `pnpm run test:e2e`.

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,6 +8,7 @@ import {
 } from "./db";
 import { createAuth, getAuthSession } from "./lib/auth";
 import { allowInsecureLocalRegistry } from "./lib/npm-connection";
+import { durationMsSince, emitOperationalEvent } from "./lib/observability";
 import {
   classifyScanError,
   executeScanJob,
@@ -281,26 +282,43 @@ export default {
   },
   async queue(batch: MessageBatch<ScanQueueMessage>, env: Cloudflare.Env, ctx: ExecutionContext) {
     for (const message of batch.messages) {
+      const messageStartedAtMs = Date.now();
       try {
         await executeScanJob(env, ctx, message.body, undefined, {
           attempt: message.attempts,
           finalAttempt: message.attempts >= MAX_SCAN_JOB_ATTEMPTS,
         });
+        emitOperationalEvent("info", "scan.queue.message.completed", {
+          scanId: message.body.scanId,
+          organizationId: message.body.organizationId,
+          stageId: message.body.stageId,
+          source: message.body.source ?? "manual",
+          attempt: message.attempts,
+          durationMs: durationMsSince(messageStartedAtMs),
+        });
       } catch (err) {
         const safe = classifyScanError(err);
         if (safe.retryable && message.attempts < MAX_SCAN_JOB_ATTEMPTS) {
           message.retry({ delaySeconds: retryDelaySeconds(message.attempts) });
-          console.warn("scan queue job scheduled for retry", {
+          emitOperationalEvent("warn", "scan.queue.retry_scheduled", {
             scanId: message.body.scanId,
+            organizationId: message.body.organizationId,
+            stageId: message.body.stageId,
+            source: message.body.source ?? "manual",
             attempt: message.attempts,
             nextDelaySeconds: retryDelaySeconds(message.attempts),
+            durationMs: durationMsSince(messageStartedAtMs),
             error: safe,
           });
         } else {
-          console.error("scan queue job failed", {
+          emitOperationalEvent("error", "scan.queue.message_failed", {
             scanId: message.body.scanId,
+            organizationId: message.body.organizationId,
+            stageId: message.body.stageId,
+            source: message.body.source ?? "manual",
             attempt: message.attempts,
             exhausted: safe.retryable,
+            durationMs: durationMsSince(messageStartedAtMs),
             error: safe,
           });
           if (safe.retryable) throw err;

--- a/server/lib/observability.ts
+++ b/server/lib/observability.ts
@@ -1,0 +1,71 @@
+export type OperationalEventLevel = "info" | "warn" | "error";
+
+export type OperationalFields = Record<string, unknown>;
+
+const SENSITIVE_KEY_RE =
+  /(authorization|cookie|credential|password|secret|token|ciphertext|nonce)/i;
+const BEARER_RE = /\bBearer\s+[A-Za-z0-9._\-+/=]+/gi;
+
+export function durationMsSince(startedAtMs: number, nowMs = Date.now()) {
+  return Math.max(0, nowMs - startedAtMs);
+}
+
+export function emitOperationalEvent(
+  level: OperationalEventLevel,
+  event: string,
+  fields: OperationalFields = {},
+) {
+  const payload = sanitizeOperationalFields({ event, ...fields });
+  switch (level) {
+    case "error":
+      console.error(event, payload);
+      break;
+    case "warn":
+      console.warn(event, payload);
+      break;
+    default:
+      console.log(event, payload);
+  }
+}
+
+export function describeOperationalError(err: unknown) {
+  if (err instanceof Error) {
+    return { name: err.name };
+  }
+  if (err && typeof err === "object") {
+    const value = err as Record<string, unknown>;
+    return {
+      name: typeof value.name === "string" ? value.name : "UnknownError",
+    };
+  }
+  return { name: typeof err };
+}
+
+export function sanitizeOperationalFields(value: unknown): unknown {
+  return sanitizeValue(value, new WeakSet(), 0, null);
+}
+
+function sanitizeValue(
+  value: unknown,
+  seen: WeakSet<object>,
+  depth: number,
+  key: string | null,
+): unknown {
+  if (key && SENSITIVE_KEY_RE.test(key)) return "[redacted]";
+  if (typeof value === "string") return value.replace(BEARER_RE, "Bearer [redacted]");
+  if (value === null || typeof value !== "object") return value;
+  if (value instanceof Error) return describeOperationalError(value);
+  if (depth > 5) return "[truncated]";
+  if (seen.has(value)) return "[circular]";
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeValue(item, seen, depth + 1, null));
+  }
+
+  const output: Record<string, unknown> = {};
+  for (const [entryKey, entryValue] of Object.entries(value)) {
+    output[entryKey] = sanitizeValue(entryValue, seen, depth + 1, entryKey);
+  }
+  return output;
+}

--- a/server/lib/scan-job.ts
+++ b/server/lib/scan-job.ts
@@ -12,6 +12,7 @@ import {
 } from "../db";
 import { npmAdapter } from "./adapters/npm";
 import { notifyScanCompletion } from "./notify";
+import { describeOperationalError, durationMsSince, emitOperationalEvent } from "./observability";
 import { runScanPipeline } from "./scan-pipeline";
 import { sandboxErrorDetail } from "./sandbox";
 import type { ScanInput } from "../types";
@@ -43,12 +44,19 @@ export async function executeScanJob(
   db: AppDb = createDb(env.DB),
   options: ExecuteScanJobOptions = {},
 ) {
+  const startedAtMs = Date.now();
+  const attempt = options.attempt ?? 1;
   const session: WorkspaceSession = { userId: message.actorUserId };
   const claimed = await claimScanForRun(db, message.scanId, message.organizationId);
   if (!claimed) {
-    console.warn("scan queue job skipped: scan already terminal", {
+    emitOperationalEvent("warn", "scan.job.skipped", {
       scanId: message.scanId,
-      attempt: options.attempt ?? 1,
+      organizationId: message.organizationId,
+      stageId: message.stageId,
+      source: message.source ?? "manual",
+      attempt,
+      reason: "already_terminal",
+      durationMs: durationMsSince(startedAtMs),
     });
     return null;
   }
@@ -57,7 +65,7 @@ export async function executeScanJob(
     actorUserId: message.actorUserId,
     scanId: message.scanId,
     type: "scan.started",
-    metadata: { stageId: message.stageId, attempt: options.attempt ?? 1 },
+    metadata: { stageId: message.stageId, attempt },
   });
 
   try {
@@ -91,6 +99,16 @@ export async function executeScanJob(
       maxBytesPerFile: message.maxBytesPerFile,
       organizationId: message.organizationId,
     });
+    emitOperationalEvent("info", "scan.job.completed", {
+      scanId: message.scanId,
+      organizationId: message.organizationId,
+      stageId: message.stageId,
+      source: message.source ?? "manual",
+      attempt,
+      durationMs: durationMsSince(startedAtMs),
+      packageName: result.package?.name ?? null,
+      releaseRisk: result.risk,
+    });
     if (message.source === "auto_discovery") {
       executionCtx.waitUntil(
         notifyScanCompletion({
@@ -117,11 +135,21 @@ export async function executeScanJob(
           metadata: {
             scanId: message.scanId,
             stageId: message.stageId,
-            attempt: options.attempt ?? 1,
+            attempt,
             error: safe,
           },
         });
         await discardScanAttempt(db, message.scanId, message.organizationId);
+        emitOperationalEvent("warn", "scan.job.skipped", {
+          scanId: message.scanId,
+          organizationId: message.organizationId,
+          stageId: message.stageId,
+          source: message.source,
+          attempt,
+          reason: "staged_tarball_unavailable",
+          durationMs: durationMsSince(startedAtMs),
+          error: safe,
+        });
       } else {
         await Promise.all([
           markScanFailed(db, message.scanId, message.organizationId, safe),
@@ -130,9 +158,19 @@ export async function executeScanJob(
             actorUserId: message.actorUserId,
             scanId: message.scanId,
             type: "scan.failed",
-            metadata: { stageId: message.stageId, attempt: options.attempt ?? 1, error: safe },
+            metadata: { stageId: message.stageId, attempt, error: safe },
           }),
         ]);
+        emitOperationalEvent("error", "scan.job.failed", {
+          scanId: message.scanId,
+          organizationId: message.organizationId,
+          stageId: message.stageId,
+          source: message.source ?? "manual",
+          attempt,
+          finalAttempt: Boolean(options.finalAttempt),
+          durationMs: durationMsSince(startedAtMs),
+          error: safe,
+        });
         if (message.source === "auto_discovery") {
           executionCtx.waitUntil(
             notifyScanCompletion({
@@ -153,7 +191,16 @@ export async function executeScanJob(
         actorUserId: message.actorUserId,
         scanId: message.scanId,
         type: "scan.retryable_failed",
-        metadata: { stageId: message.stageId, attempt: options.attempt ?? 1, error: safe },
+        metadata: { stageId: message.stageId, attempt, error: safe },
+      });
+      emitOperationalEvent("warn", "scan.job.retryable_failed", {
+        scanId: message.scanId,
+        organizationId: message.organizationId,
+        stageId: message.stageId,
+        source: message.source ?? "manual",
+        attempt,
+        durationMs: durationMsSince(startedAtMs),
+        error: safe,
       });
     }
     throw err;
@@ -185,7 +232,9 @@ export function classifyScanError(err: unknown): SafeScanError {
       retryable: false,
     };
   }
-  console.error("scan job failed", err);
+  emitOperationalEvent("error", "scan.error.unclassified", {
+    error: describeOperationalError(err),
+  });
   return {
     code: "scan_failed",
     message: "The scan failed before a report could be generated.",

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -6,6 +6,7 @@ import type {
   AdapterContext,
   PackageAdapter,
 } from "./adapters/types";
+import { describeOperationalError, durationMsSince, emitOperationalEvent } from "./observability";
 import {
   annotateFindingsWithDiffStatus,
   createPackageDiff,
@@ -41,6 +42,7 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
   const adapterInput = adapter.parseInput(input);
   const connectionRef: AdapterConnectionRef = { organizationId: input.organizationId };
   const broker = adapter.createBroker(adapterCtx, connectionRef);
+  const pipelineStartedAtMs = Date.now();
 
   try {
     const staged = await adapter.acquireStaged(adapterCtx, adapterInput, broker);
@@ -203,11 +205,37 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
           releaseRisk: risk,
           artifactRisk: riskSummary.artifactRisk,
           contextRisk: riskSummary.contextRisk,
+          durationMs: durationMsSince(pipelineStartedAtMs),
         },
       });
     }
 
+    emitOperationalEvent("info", "scan.pipeline.completed", {
+      scanId,
+      organizationId: input.organizationId,
+      stageId: input.stageId,
+      adapterId: adapter.id,
+      durationMs: durationMsSince(pipelineStartedAtMs),
+      packageName: result.package.name,
+      releaseRisk: risk,
+      artifactRisk: riskSummary.artifactRisk,
+      contextRisk: riskSummary.contextRisk,
+      fileCount: result.fileCount,
+      previousFileCount: result.previousFileCount,
+      findingCount: ruleFindings.length,
+    });
+
     return result;
+  } catch (err) {
+    emitOperationalEvent("error", "scan.pipeline.failed", {
+      scanId: input.scanId ?? null,
+      organizationId: input.organizationId,
+      stageId: input.stageId,
+      adapterId: adapter.id,
+      durationMs: durationMsSince(pipelineStartedAtMs),
+      error: describeOperationalError(err),
+    });
+    throw err;
   } finally {
     await broker.dispose();
   }
@@ -246,15 +274,34 @@ async function maybeRunAiReview(args: AiReviewArgs): Promise<AiReview> {
     : false;
   if (!aiReviewEnabled) return disabled;
 
-  return runSelectiveAiReview(args.env, {
-    scanId: args.scanId,
-    files: args.redactedStagedFiles,
-    previousFiles: args.redactedPreviousFiles,
-    diff: args.fileDiff,
-    packageJsonDiff: args.manifestDiff,
-    ruleFindings: args.releaseRuleFindings,
-    previousVersionAvailable: args.previousVersionAvailable,
-  });
+  const startedAtMs = Date.now();
+  try {
+    const review = await runSelectiveAiReview(args.env, {
+      scanId: args.scanId,
+      files: args.redactedStagedFiles,
+      previousFiles: args.redactedPreviousFiles,
+      diff: args.fileDiff,
+      packageJsonDiff: args.manifestDiff,
+      ruleFindings: args.releaseRuleFindings,
+      previousVersionAvailable: args.previousVersionAvailable,
+    });
+    emitOperationalEvent("info", "scan.ai_review.completed", {
+      scanId: args.scanId,
+      organizationId: args.input.organizationId,
+      durationMs: durationMsSince(startedAtMs),
+      status: review.status,
+      model: review.model,
+    });
+    return review;
+  } catch (err) {
+    emitOperationalEvent("error", "scan.ai_review.failed", {
+      scanId: args.scanId,
+      organizationId: args.input.organizationId,
+      durationMs: durationMsSince(startedAtMs),
+      error: describeOperationalError(err),
+    });
+    throw err;
+  }
 }
 
 function stripFindingAnnotations(

--- a/server/routes/scan.ts
+++ b/server/routes/scan.ts
@@ -57,6 +57,7 @@ scanRoutes.post("/", async (c) => {
       c.executionCtx,
       { ...input, scanId, organizationId, actorUserId: session.userId },
       db,
+      { finalAttempt: true },
     );
 
     return c.json(result);

--- a/test/observability.test.mjs
+++ b/test/observability.test.mjs
@@ -1,0 +1,58 @@
+import { describe, expect, test, vi } from "vitest";
+
+const {
+  describeOperationalError,
+  durationMsSince,
+  emitOperationalEvent,
+  sanitizeOperationalFields,
+} = await import("../server/lib/observability.ts");
+
+describe("operational observability helpers", () => {
+  test("redacts token-like fields before logging", () => {
+    const sanitized = sanitizeOperationalFields({
+      scanId: "scan_1",
+      npmToken: "npm_secret_token",
+      nested: {
+        authorization: "Bearer abc123secret",
+        tokenFingerprint: "fp_should_not_log",
+      },
+      message: "upstream said Bearer abc123secret",
+    });
+
+    expect(sanitized).toEqual({
+      scanId: "scan_1",
+      npmToken: "[redacted]",
+      nested: {
+        authorization: "[redacted]",
+        tokenFingerprint: "[redacted]",
+      },
+      message: "upstream said Bearer [redacted]",
+    });
+  });
+
+  test("logs structured events with bounded duration fields", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      emitOperationalEvent("warn", "scan.queue.retry_scheduled", {
+        scanId: "scan_1",
+        durationMs: durationMsSince(100, 175),
+        token: "npm_secret_token",
+      });
+
+      expect(spy).toHaveBeenCalledWith("scan.queue.retry_scheduled", {
+        event: "scan.queue.retry_scheduled",
+        scanId: "scan_1",
+        durationMs: 75,
+        token: "[redacted]",
+      });
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("describes errors without carrying raw messages", () => {
+    expect(describeOperationalError(new Error("D1_ERROR: column not found"))).toEqual({
+      name: "Error",
+    });
+  });
+});

--- a/test/scan-job.test.mjs
+++ b/test/scan-job.test.mjs
@@ -71,6 +71,7 @@ describe("scan job retry classification", () => {
   });
 
   test("does not include raw error messages on generic failures", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const safe = classifyScanError(new Error("D1_ERROR: column not found"));
     expect(safe).toEqual({
       code: "scan_failed",
@@ -78,6 +79,11 @@ describe("scan job retry classification", () => {
       retryable: true,
     });
     expect(JSON.stringify(safe)).not.toContain("D1_ERROR");
+    expect(errorSpy).toHaveBeenCalledWith("scan.error.unclassified", {
+      event: "scan.error.unclassified",
+      error: { name: "Error" },
+    });
+    errorSpy.mockRestore();
   });
 
   test("does not retry credential and missing-stage sandbox failures", () => {
@@ -150,6 +156,9 @@ describe("executeScanJob idempotency", () => {
   };
 
   beforeEach(() => {
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
     dbMock.getNpmConnection.mockResolvedValue({
       registryUrl: "https://registry.npmjs.org",
       tokenFingerprint: "fp",
@@ -164,6 +173,7 @@ describe("executeScanJob idempotency", () => {
     pipelineMock.runScanPipeline.mockReset();
     npmConnectionMock.decryptNpmToken.mockReset();
     notifyMock.notifyScanCompletion.mockClear();
+    vi.restoreAllMocks();
   });
 
   test("returns null without running the pipeline when claim is rejected", async () => {
@@ -187,6 +197,33 @@ describe("executeScanJob idempotency", () => {
     );
     expect(started).toHaveLength(1);
     expect(pipelineMock.runScanPipeline).toHaveBeenCalledTimes(1);
+  });
+
+  test("emits a structured completion log without token material", async () => {
+    dbMock.claimScanForRun.mockResolvedValue(true);
+    pipelineMock.runScanPipeline.mockResolvedValue({
+      id: message.scanId,
+      risk: "low",
+      package: { name: "@scope/pkg" },
+    });
+
+    await executeScanJob(env, ctx, message, {}, { attempt: 1 });
+
+    expect(console.log).toHaveBeenCalledWith(
+      "scan.job.completed",
+      expect.objectContaining({
+        event: "scan.job.completed",
+        scanId: message.scanId,
+        organizationId: message.organizationId,
+        stageId: message.stageId,
+        source: "manual",
+        attempt: 1,
+        packageName: "@scope/pkg",
+        releaseRisk: "low",
+        durationMs: expect.any(Number),
+      }),
+    );
+    expect(JSON.stringify(console.log.mock.calls)).not.toContain("npm_token");
   });
 
   test("records scan.failed and marks the scan failed on a terminal error in the final attempt", async () => {

--- a/test/scan-route.test.mjs
+++ b/test/scan-route.test.mjs
@@ -1,0 +1,85 @@
+import { Hono } from "hono";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+const dbMock = vi.hoisted(() => ({
+  createDb: vi.fn(() => ({})),
+  createScanJob: vi.fn(),
+  enforceRateLimit: vi.fn(),
+  getNpmConnection: vi.fn(),
+  RateLimitError: class RateLimitError extends Error {
+    constructor(retryAfterSeconds) {
+      super("rate limit exceeded");
+      this.retryAfterSeconds = retryAfterSeconds;
+    }
+  },
+}));
+const activeOrgMock = vi.hoisted(() => ({
+  requireActiveOrganization: vi.fn(),
+}));
+const scanJobMock = vi.hoisted(() => ({
+  executeScanJob: vi.fn(),
+}));
+
+vi.mock("cloudflare:workers", () => ({
+  WorkerEntrypoint: class {},
+}));
+vi.mock("../server/db/index.ts", () => dbMock);
+vi.mock("../server/lib/active-organization.ts", () => activeOrgMock);
+vi.mock("../server/lib/scan-job.ts", () => scanJobMock);
+
+const { scanRoutes } = await import("../server/routes/scan.ts");
+
+function buildTestApp() {
+  const app = new Hono();
+  app.use("*", async (c, next) => {
+    c.set("authSession", { userId: "user_route" });
+    await next();
+  });
+  app.route("/api/v1/scan", scanRoutes);
+  return app;
+}
+
+afterEach(() => {
+  for (const fn of [
+    dbMock.createDb,
+    dbMock.createScanJob,
+    dbMock.enforceRateLimit,
+    dbMock.getNpmConnection,
+    activeOrgMock.requireActiveOrganization,
+    scanJobMock.executeScanJob,
+  ]) {
+    fn.mockReset();
+  }
+});
+
+describe("compatibility scan route", () => {
+  test("runs the synchronous scan as a final attempt because no queue retry will occur", async () => {
+    activeOrgMock.requireActiveOrganization.mockResolvedValue("org_route");
+    dbMock.getNpmConnection.mockResolvedValue({ validationStatus: "valid" });
+    dbMock.createScanJob.mockResolvedValue(undefined);
+    scanJobMock.executeScanJob.mockResolvedValue({ id: "scan_route" });
+
+    const res = await buildTestApp().fetch(
+      new Request("http://test.local/api/v1/scan", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ stageId: "stage-route-sync-000001" }),
+      }),
+      { DB: {} },
+      { waitUntil: () => undefined },
+    );
+
+    expect(res.status).toBe(200);
+    expect(scanJobMock.executeScanJob).toHaveBeenCalledWith(
+      { DB: {} },
+      expect.anything(),
+      expect.objectContaining({
+        organizationId: "org_route",
+        actorUserId: "user_route",
+        stageId: "stage-route-sync-000001",
+      }),
+      {},
+      { finalAttempt: true },
+    );
+  });
+});

--- a/test/workers/api-auth-routes.test.ts
+++ b/test/workers/api-auth-routes.test.ts
@@ -1,0 +1,58 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { describe, expect, test } from "vitest";
+import worker from "../../server/index";
+
+const STATE_CHANGING_ORIGIN = "http://example.com";
+
+interface RouteCase {
+  method: string;
+  path: string;
+  body?: unknown;
+}
+
+const protectedRoutes: RouteCase[] = [
+  { method: "GET", path: "/api/health" },
+  { method: "GET", path: "/api/v1/organizations" },
+  { method: "POST", path: "/api/v1/organizations", body: { name: "acme" } },
+  { method: "GET", path: "/api/v1/npm-connection" },
+  {
+    method: "POST",
+    path: "/api/v1/npm-connection",
+    body: { token: "npm_test_token", label: "test" },
+  },
+  { method: "DELETE", path: "/api/v1/npm-connection" },
+  { method: "POST", path: "/api/v1/npm-connection/validate", body: {} },
+  { method: "POST", path: "/api/v1/scan", body: { stageId: "stage-auth-route-000001" } },
+  { method: "GET", path: "/api/v1/scans" },
+  { method: "POST", path: "/api/v1/scans", body: { stageId: "stage-auth-route-000001" } },
+  { method: "GET", path: "/api/v1/scans/scan_auth_route" },
+  { method: "GET", path: "/api/v1/scans/scan_auth_route/versions" },
+  { method: "GET", path: "/api/v1/scans/scan_auth_route/compare?version=1.0.0" },
+  {
+    method: "POST",
+    path: "/api/v1/scans/scan_auth_route/decision",
+    body: { decision: "no_publish" },
+  },
+  { method: "POST", path: "/api/v1/staged-publishes/scan", body: {} },
+];
+
+describe("non-auth API routes", () => {
+  test.each(protectedRoutes)("$method $path rejects anonymous requests", async (route) => {
+    const ctx = createExecutionContext();
+    const headers = new Headers();
+    const init: RequestInit = { method: route.method, headers };
+    if (route.body !== undefined) {
+      headers.set("content-type", "application/json");
+      init.body = JSON.stringify(route.body);
+    }
+    if (!["GET", "HEAD", "OPTIONS"].includes(route.method)) {
+      headers.set("origin", STATE_CHANGING_ORIGIN);
+    }
+
+    const res = await worker.fetch(new Request(`http://example.com${route.path}`, init), env, ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "unauthorized" });
+  });
+});

--- a/test/workers/sandbox-gateway-runtime.test.ts
+++ b/test/workers/sandbox-gateway-runtime.test.ts
@@ -9,7 +9,11 @@ interface CapturedRequest {
   userAgent: string | null;
 }
 
-function setupGateway(props: { npmToken?: string; npmRegistry?: string }) {
+function setupGateway(props: {
+  npmToken?: string;
+  npmRegistry?: string;
+  publicArtifactUrls?: string[];
+}) {
   const captured: CapturedRequest[] = [];
   const fetchSpy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = input instanceof Request ? input : new Request(input, init);
@@ -24,7 +28,7 @@ function setupGateway(props: { npmToken?: string; npmRegistry?: string }) {
   vi.stubGlobal("fetch", fetchSpy);
 
   const ctx = createExecutionContext() as ExecutionContext & {
-    props: { npmToken?: string; npmRegistry?: string };
+    props: { npmToken?: string; npmRegistry?: string; publicArtifactUrls?: string[] };
   };
   ctx.props = props;
   const gateway = new (NpmStageGateway as unknown as new (
@@ -105,6 +109,36 @@ describe("NpmStageGateway runtime credential injection", () => {
     expect(captured).toHaveLength(1);
     expect(captured[0].authorization).toBeNull();
     expect(captured[0].userAgent).toBe("staged-publish-review/0.3");
+  });
+
+  test("allows exact public artifact URLs without forwarding npm credentials", async () => {
+    const publicUrl = "https://files.pythonhosted.org/packages/aa/bb/demo-1.0.0-py3-none-any.whl";
+    const { gateway, captured } = setupGateway({
+      npmToken: "npm_should_not_reach_public_artifact",
+      publicArtifactUrls: [publicUrl],
+    });
+
+    const res = await gateway.fetch(new Request(publicUrl));
+
+    expect(res.status).toBe(200);
+    expect(captured).toHaveLength(1);
+    expect(captured[0].authorization).toBeNull();
+  });
+
+  test("blocks non-exact public artifact URLs without forwarding npm credentials", async () => {
+    const { gateway, captured } = setupGateway({
+      npmToken: "npm_should_not_leak",
+      publicArtifactUrls: [
+        "https://files.pythonhosted.org/packages/aa/bb/demo-1.0.0-py3-none-any.whl",
+      ],
+    });
+
+    const res = await gateway.fetch(
+      new Request("https://files.pythonhosted.org/packages/aa/bb/other-1.0.0-py3-none-any.whl"),
+    );
+
+    expect(res.status).toBe(403);
+    expect(captured).toHaveLength(0);
   });
 
   test("respects custom registry origins supplied via props", async () => {

--- a/test/workers/scans-route-queue.test.ts
+++ b/test/workers/scans-route-queue.test.ts
@@ -1,0 +1,130 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { describe, expect, test, vi } from "vitest";
+import {
+  createDb,
+  ensurePersonalOrganization,
+  updateNpmConnectionValidation,
+  upsertNpmConnection,
+} from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { encryptNpmToken } from "../../server/lib/npm-connection";
+import { scansRoutes } from "../../server/routes/scans";
+import type { Bindings, Variables } from "../../server/types";
+
+interface SeededUser {
+  userId: string;
+  organizationId: string;
+}
+
+async function seedUser(): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+function buildTestApp(session: { userId: string }) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.use("*", async (c, next) => {
+    c.set("authSession", { userId: session.userId });
+    await next();
+  });
+  app.route("/api/v1/scans", scansRoutes);
+  return app;
+}
+
+async function connectValidNpmToken(owner: SeededUser, token: string) {
+  const db = createDb(env.DB);
+  const encrypted = await encryptNpmToken(env, token);
+  await upsertNpmConnection(db, {
+    organizationId: owner.organizationId,
+    registryUrl: "https://registry.npmjs.org",
+    label: "npm registry",
+    createdByUserId: owner.userId,
+    ...encrypted,
+  });
+  await updateNpmConnectionValidation(db, {
+    organizationId: owner.organizationId,
+    validationStatus: "valid",
+    validatedAt: new Date(),
+  });
+}
+
+describe("scans route queue behavior", () => {
+  test("POST /scans enqueues a token-free scan message and records the queue event", async () => {
+    const owner = await seedUser();
+    const token = "npm_route_queue_secret_0123456789";
+    await connectValidNpmToken(owner, token);
+    const queue = { send: vi.fn(async () => undefined) };
+    const app = buildTestApp(owner);
+    const ctx = createExecutionContext();
+
+    const res = await app.fetch(
+      new Request("http://test.local/api/v1/scans", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ stageId: "stage-route-queue-000001" }),
+      }),
+      { ...env, SCAN_QUEUE: queue } as unknown as Bindings,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as { scan: { id: string; stageId: string }; queued: boolean };
+    expect(body.queued).toBe(true);
+    expect(body.scan.stageId).toBe("stage-route-queue-000001");
+
+    expect(queue.send).toHaveBeenCalledTimes(1);
+    const message = queue.send.mock.calls[0]?.[0];
+    expect(message).toMatchObject({
+      scanId: body.scan.id,
+      stageId: "stage-route-queue-000001",
+      organizationId: owner.organizationId,
+      actorUserId: owner.userId,
+    });
+    expect(JSON.stringify(message)).not.toContain(token);
+    expect(JSON.stringify(message)).not.toContain("token");
+    expect(JSON.stringify(message)).not.toContain("authorization");
+
+    const db = createDb(env.DB);
+    const events = await db
+      .select()
+      .from(schema.scanEvents)
+      .where(eq(schema.scanEvents.scanId, body.scan.id));
+    expect(events.map((event) => event.type)).toContain("scan.queued");
+  });
+
+  test("POST /scans rejects client-controlled scan limits before queueing", async () => {
+    const owner = await seedUser();
+    await connectValidNpmToken(owner, "npm_route_limit_secret_0123456789");
+    const queue = { send: vi.fn(async () => undefined) };
+    const app = buildTestApp(owner);
+    const ctx = createExecutionContext();
+
+    const res = await app.fetch(
+      new Request("http://test.local/api/v1/scans", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ stageId: "stage-route-queue-000002", maxFiles: 10 }),
+      }),
+      { ...env, SCAN_QUEUE: queue } as unknown as Bindings,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(400);
+    expect(queue.send).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds documented server-change safety gates in AGENTS and docs, including required Worker-route tests, sandbox/credential invariants, fake-registry e2e expectations, security-corpus coverage, and secret-safe observability guidance.

Introduces structured secret-redacted operational events for scan pipeline, scan job, AI-review, and queue paths, and fixes the synchronous compatibility scan route to treat failures as final attempts.

Expands coverage with auth-gate route tests, token-free queue-message tests, observability tests, compatibility-route coverage, and gateway public-artifact credential-isolation tests.

Validated with `pnpm run verify` and `E2E_APP_PORT=5200 E2E_REGISTRY_PORT=5201 pnpm run test:e2e`.