### PR TITLE
Mark drizzle/meta as generated to skip diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+drizzle/meta/** linguist-generated=true
+drizzle/meta/** -diff


### PR DESCRIPTION
## Summary
- Adds `.gitattributes` marking `drizzle/meta/**` as `linguist-generated` (collapses on GitHub) and `-diff` (suppresses local diff output) so auto-generated Drizzle snapshot/journal files don't clutter reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)