### PR TITLE
Persist artifact risk as primary scan risk (prevent downgrading by contextual findings)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -106,7 +106,7 @@ Current high-level flow:
    - package.json (manifest) diff;
    - adapter findings via `adapter.runFindings` — for npm: deterministic findings, package.json diff findings, and staged-metadata-mismatch findings;
    - release/context annotations for the deterministic findings, using package-to-package diff status and changed-line checks where text samples are available;
-   - a risk breakdown where `releaseRisk` is the primary saved scan risk, while `artifactRisk` and `contextRisk` keep full-artifact safety context visible;
+   - a risk breakdown where `artifactRisk` is the primary saved scan risk, while `releaseRisk` and `contextRisk` keep package-to-package release context visible;
    - redacted package/file records.
 10. The pipeline persists the scan, records audit events, and returns/report renders the result. (AI review is gated by the Cloudflare Flagship `ai-review` flag — see "Workers AI" below.)
 
@@ -223,7 +223,7 @@ Implemented foundation:
 
 - newly completed scans store report metadata inside `summary_json.report`;
 - `digest` is SHA-256 over stable canonical report JSON built from redacted scan evidence, including the deterministic rules version and release/context finding annotations so digests change when the ruleset or visible risk interpretation changes;
-- newly completed scans store `summary_json.risk` with release, artifact, and context risk; `scans.risk` stores the primary release risk for new reports, while old reports without the breakdown are treated as legacy artifact-risk rows;
+- newly completed scans store `summary_json.risk` with release, artifact, and context risk; `scans.risk` stores the primary artifact risk for new reports, while `summary_json.risk.releaseRisk` carries the package-to-package release verdict;
 - each deterministic finding carries `ruleId` and `ruleVersion` (see `DETERMINISTIC_RULES_VERSION` in `server/lib/review.ts`), persisted on `scan_findings.rule_id` / `rule_version`;
 - persisted scan detail renders report version, digest, rules version, package diff, and safety posture (AI review is disabled — see the Workers AI section).
 

--- a/docs/diff-baseline.md
+++ b/docs/diff-baseline.md
@@ -59,10 +59,10 @@ However, report payloads, report presentation, and AI payload construction shoul
 
 New scan reports persist this split as a risk breakdown in `summary_json.risk`:
 
-- `releaseRisk` is the primary scan risk and is computed from findings annotated as part of the package-to-package delta, plus any complete AI review result when AI review is enabled;
-- `artifactRisk` is computed from the full staged artifact findings, plus any complete AI review result when AI review is enabled, and remains visible as package context;
+- `releaseRisk` is computed from findings annotated as part of the package-to-package delta, plus any complete AI review result when AI review is enabled, and is the focused release-delta verdict;
+- `artifactRisk` is computed from the full staged artifact findings, plus any complete AI review result when AI review is enabled, and is the primary scan risk stored in `scans.risk` so deterministic evidence cannot be hidden by context classification;
 - `contextRisk` covers findings that were not part of the release delta.
 
-The `scans.risk` column now stores `releaseRisk` for new reports. Older reports without `summary_json.risk` are interpreted with the previous behavior, where `scans.risk` is the artifact risk and release/context risk is derived from persisted finding annotations.
+The `scans.risk` column stores `artifactRisk` for new reports. Older reports without `summary_json.risk` are interpreted the same way, and release/context risk is derived from persisted finding annotations.
 
-This avoids hiding persistent risk while keeping the staged-publish review centered on the actual release delta.
+This keeps the staged-publish review centered on the actual release delta without allowing contextual high-risk deterministic evidence to downgrade the primary scan verdict.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -79,7 +79,7 @@ Persist by default:
 - package.json summary and diff;
 - deterministic findings;
 - AI findings (paused — persisted as `null` while AI review is disabled);
-- risk summary split into release, artifact, and context risk so unchanged package hazards do not dominate the package-to-package release verdict;
+- risk summary split into release, artifact, and context risk so `scans.risk` reflects the full artifact while unchanged hazards remain separated from the package-to-package release verdict;
 - safety posture;
 - audit events;
 - future canonical report JSON.

--- a/server/lib/scan-job.ts
+++ b/server/lib/scan-job.ts
@@ -107,7 +107,8 @@ export async function executeScanJob(
       attempt,
       durationMs: durationMsSince(startedAtMs),
       packageName: result.package?.name ?? null,
-      releaseRisk: result.risk,
+      releaseRisk: result.riskSummary.releaseRisk,
+      artifactRisk: result.risk,
     });
     if (message.source === "auto_discovery") {
       executionCtx.waitUntil(

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -99,7 +99,7 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
       fileDiff,
     });
     const riskSummary = computeScanRiskBreakdown(annotatedFindings, aiFindings);
-    const risk = riskSummary.releaseRisk;
+    const risk = riskSummary.artifactRisk;
 
     const safety: ScanResult["safety"] = {
       tokenExposedToSandbox: false,
@@ -202,8 +202,8 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
           stagedTag: result.package.stagedTag,
           baseline: baseline.baseline,
           risk,
-          releaseRisk: risk,
-          artifactRisk: riskSummary.artifactRisk,
+          releaseRisk: riskSummary.releaseRisk,
+          artifactRisk: risk,
           contextRisk: riskSummary.contextRisk,
           durationMs: durationMsSince(pipelineStartedAtMs),
         },
@@ -217,8 +217,8 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
       adapterId: adapter.id,
       durationMs: durationMsSince(pipelineStartedAtMs),
       packageName: result.package.name,
-      releaseRisk: risk,
-      artifactRisk: riskSummary.artifactRisk,
+      releaseRisk: riskSummary.releaseRisk,
+      artifactRisk: risk,
       contextRisk: riskSummary.contextRisk,
       fileCount: result.fileCount,
       previousFileCount: result.previousFileCount,

--- a/test/e2e/local-registry.spec.ts
+++ b/test/e2e/local-registry.spec.ts
@@ -17,6 +17,7 @@ interface RegistryScenario {
   packageName: string;
   expected: {
     releaseRisk?: string;
+    artifactRisk?: string;
     packageName?: string | null;
     stagedVersion?: string;
     previousVersion?: string | null;
@@ -237,7 +238,10 @@ function isNavigationContextError(err: unknown) {
 function assertScanMatchesScenario(result: any, scenario: RegistryScenario) {
   const expected = scenario.expected;
   expect(result.stageId, scenario.name).toBe(scenario.stageId);
-  expect(result.risk, scenario.name).toBe(expected.releaseRisk);
+  expect(result.risk, scenario.name).toBe(expected.artifactRisk ?? expected.releaseRisk);
+  expect(result.riskSummary?.artifactRisk, scenario.name).toBe(
+    expected.artifactRisk ?? expected.releaseRisk,
+  );
   expect(result.riskSummary?.releaseRisk, scenario.name).toBe(expected.releaseRisk);
   expect(result.package?.name, scenario.name).toBe(
     "packageName" in expected ? expected.packageName : scenario.packageName,

--- a/test/scan-job.test.mjs
+++ b/test/scan-job.test.mjs
@@ -165,7 +165,12 @@ describe("executeScanJob idempotency", () => {
       validationStatus: "valid",
     });
     npmConnectionMock.decryptNpmToken.mockResolvedValue("npm_token");
-    pipelineMock.runScanPipeline.mockResolvedValue({ id: message.scanId });
+    pipelineMock.runScanPipeline.mockResolvedValue({
+      id: message.scanId,
+      risk: "low",
+      riskSummary: { releaseRisk: "low" },
+      package: { name: null },
+    });
   });
 
   afterEach(() => {
@@ -203,7 +208,8 @@ describe("executeScanJob idempotency", () => {
     dbMock.claimScanForRun.mockResolvedValue(true);
     pipelineMock.runScanPipeline.mockResolvedValue({
       id: message.scanId,
-      risk: "low",
+      risk: "high",
+      riskSummary: { releaseRisk: "low" },
       package: { name: "@scope/pkg" },
     });
 
@@ -220,6 +226,7 @@ describe("executeScanJob idempotency", () => {
         attempt: 1,
         packageName: "@scope/pkg",
         releaseRisk: "low",
+        artifactRisk: "high",
         durationMs: expect.any(Number),
       }),
     );

--- a/test/scan-pipeline.test.mjs
+++ b/test/scan-pipeline.test.mjs
@@ -563,7 +563,7 @@ describe("scan pipeline baseline selection", () => {
     expect(contextDigest).not.toBe(releaseDigest);
   });
 
-  test("persists release risk from the package-to-package delta while keeping artifact context", async () => {
+  test("persists artifact risk as the primary scan risk while keeping release context", async () => {
     stagedMock.fetchStagedPublishDetails.mockResolvedValue({
       id: "stage-context123",
       packageName: "pkg",
@@ -633,7 +633,7 @@ describe("scan pipeline baseline selection", () => {
 
     const persistedInput = dbMock.persistScan.mock.calls[0]?.[1];
 
-    expect(result.risk).toBe("low");
+    expect(result.risk).toBe("high");
     expect(result.riskSummary).toMatchObject({
       artifactRisk: "high",
       releaseRisk: "low",
@@ -649,7 +649,7 @@ describe("scan pipeline baseline selection", () => {
       }),
     );
     expect(persistedInput).toMatchObject({
-      risk: "low",
+      risk: "high",
       summary: {
         risk: {
           artifactRisk: "high",

--- a/test/workers/cross-org-routes.test.ts
+++ b/test/workers/cross-org-routes.test.ts
@@ -269,7 +269,7 @@ describe("scans routes enforce organization boundaries", () => {
       organizationId: owner.organizationId,
       ownerUserId: owner.userId,
       packageJson: { name: "@org/list-risk-summary", version: "1.2.3" },
-      risk: "low",
+      risk: "high",
       status: "complete",
       summary: {
         diff: [{ path: "src/server.ts", status: "modified" }],


### PR DESCRIPTION
### Motivation
- The pipeline previously stored `releaseRisk` as the primary `scans.risk`, which allowed high/critical deterministic findings classified as contextual to be hidden from the primary scan verdict.
- This could mislead API/UI consumers or automation that trusts `scan.risk` while the artifact still contains high-risk evidence.

### Description
- Change the primary persisted and returned scan `risk` to use the full-artifact risk (`riskSummary.artifactRisk`) instead of the release-delta-only risk in `server/lib/scan-pipeline.ts` by setting `const risk = riskSummary.artifactRisk` and propagating the fields accordingly.
- Emit both `artifactRisk` and `releaseRisk` separately in pipeline operational metadata and audit events so the release-delta verdict remains available (`server/lib/scan-pipeline.ts` and `server/lib/scan-job.ts`).
- Update scan-job logging to reference `result.riskSummary.releaseRisk` for `releaseRisk` and `result.risk` for `artifactRisk` to keep observability explicit (`server/lib/scan-job.ts`).
- Update tests and expectations to match the new contract, including `test/scan-pipeline.test.mjs`, `test/scan-job.test.mjs`, `test/workers/cross-org-routes.test.ts`, and `test/e2e/local-registry.spec.ts` where the primary `risk` is now the artifact risk.
- Update documentation to reflect that `scans.risk` stores the artifact risk and `summary_json.risk.releaseRisk` carries the package-to-package release verdict (`docs/diff-baseline.md`, `docs/architecture.md`, `docs/security-model.md`).

### Testing
- Ran unit and worker tests with `pnpm exec vitest run --config vitest.config.ts test/scan-pipeline.test.mjs test/scan-job.test.mjs` and `pnpm exec vitest run --config vitest.workers.config.ts test/workers/cross-org-routes.test.ts`, which passed after updating expectations.
- Ran project-wide verification with `pnpm run verify` (lint, format check, typecheck, tests) and it completed successfully.
- Attempted `pnpm run test:e2e`, but Playwright browser binaries are not installed in this environment (missing `chromium_headless_shell`), so full e2e UI runs were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18493a6770832fb41c4fff9ea6f136)