### PR TITLE
Treat implicit node-gyp as release evidence when manifest enables it

### DIFF
--- a/docs/diff-baseline.md
+++ b/docs/diff-baseline.md
@@ -65,4 +65,6 @@ New scan reports persist this split as a risk breakdown in `summary_json.risk`:
 
 The `scans.risk` column now stores `releaseRisk` for new reports. Older reports without `summary_json.risk` are interpreted with the previous behavior, where `scans.risk` is the artifact risk and release/context risk is derived from persisted finding annotations.
 
+Implicit behavior introduced by manifest changes is release evidence even when the finding points at unchanged supporting files. For example, if a previous package had a root `binding.gyp` but suppressed npm's implicit `node-gyp rebuild` install hook with `gypfile=false`, and the staged package only removes that suppressor from `package.json`, the high-severity implicit node-gyp finding remains attached to `binding.gyp` for evidence but is still marked as `releaseDelta=true`. If the previous package already had the implicit hook and only unrelated metadata changes, the finding remains contextual.
+
 This avoids hiding persistent risk while keeping the staged-publish review centered on the actual release delta.

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -521,6 +521,7 @@ export function annotateFindingsWithDiffStatus<
       diffStatus,
       releaseDelta:
         isReleaseScopedFinding(finding) ||
+        isNewlyEnabledImplicitNodeGypFinding(finding, previousByPath, stagedByPath) ||
         isFindingOnReleaseDelta(
           finding,
           diffStatus,
@@ -540,6 +541,27 @@ function isReleaseScopedFinding(finding: { ruleId?: string | null }): boolean {
     finding.ruleId === DETERMINISTIC_RULE_IDS.diffCredentialFileAdded ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.diffLargeNewFile,
   );
+}
+
+function isNewlyEnabledImplicitNodeGypFinding(
+  finding: { ruleId?: string | null },
+  previousByPath: Map<string, Pick<FileRecord, "path" | "textSample" | "flags">>,
+  stagedByPath: Map<string, Pick<FileRecord, "path" | "textSample" | "flags">>,
+): boolean {
+  if (finding.ruleId !== DETERMINISTIC_RULE_IDS.installScriptImplicitNodeGyp) return false;
+
+  const stagedPackageJson = parsePackageJsonFile(stagedByPath.get("package.json"));
+  if (!hasImplicitNodeGypInstall([...stagedByPath.values()], stagedPackageJson)) return false;
+
+  const previousPackageJson = parsePackageJsonFile(previousByPath.get("package.json"));
+  return !hasImplicitNodeGypInstall([...previousByPath.values()], previousPackageJson);
+}
+
+function parsePackageJsonFile(
+  file: Pick<FileRecord, "textSample"> | undefined,
+): PackageJsonSummary | null {
+  if (!file?.textSample) return null;
+  return safeJson(file.textSample) as PackageJsonSummary | null;
 }
 
 function isFindingOnReleaseDelta(

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -386,6 +386,83 @@ describe("review", () => {
     );
   });
 
+  test("marks implicit node-gyp as release delta when package.json newly enables it", () => {
+    const previous = [
+      {
+        path: "package.json",
+        size: 70,
+        sha256: "pkg-old",
+        flags: [],
+        textSample: JSON.stringify({ name: "pkg", version: "1.0.0", gypfile: false }),
+      },
+      { path: "binding.gyp", size: 2, sha256: "gyp", flags: [], textSample: "{}" },
+    ];
+    const staged = [
+      {
+        path: "package.json",
+        size: 55,
+        sha256: "pkg-new",
+        flags: [],
+        textSample: JSON.stringify({ name: "pkg", version: "1.0.1" }),
+      },
+      { path: "binding.gyp", size: 2, sha256: "gyp", flags: [], textSample: "{}" },
+    ];
+    const diff = createPackageDiff(previous, staged);
+    const findings = deterministicFindings(staged, diff);
+    const annotated = annotateFindingsWithDiffStatus(findings, diff, {
+      previousFiles: previous,
+      stagedFiles: staged,
+    });
+
+    expect(diff.find((entry) => entry.path === "binding.gyp")?.status).toBe("unchanged");
+    expect(annotated).toContainEqual(
+      expect.objectContaining({
+        file: "binding.gyp",
+        ruleId: "install-script.implicit-node-gyp",
+        diffStatus: "unchanged",
+        releaseDelta: true,
+      }),
+    );
+    expect(computeRisk(annotated.filter((finding) => finding.releaseDelta))).toBe("high");
+  });
+
+  test("keeps pre-existing implicit node-gyp findings contextual when only package metadata changes", () => {
+    const previous = [
+      {
+        path: "package.json",
+        size: 55,
+        sha256: "pkg-old",
+        flags: [],
+        textSample: JSON.stringify({ name: "pkg", version: "1.0.0" }),
+      },
+      { path: "binding.gyp", size: 2, sha256: "gyp", flags: [], textSample: "{}" },
+    ];
+    const staged = [
+      {
+        path: "package.json",
+        size: 55,
+        sha256: "pkg-new",
+        flags: [],
+        textSample: JSON.stringify({ name: "pkg", version: "1.0.1" }),
+      },
+      { path: "binding.gyp", size: 2, sha256: "gyp", flags: [], textSample: "{}" },
+    ];
+    const diff = createPackageDiff(previous, staged);
+    const findings = deterministicFindings(staged, diff);
+    const annotated = annotateFindingsWithDiffStatus(findings, diff, {
+      previousFiles: previous,
+      stagedFiles: staged,
+    });
+
+    expect(annotated).toContainEqual(
+      expect.objectContaining({
+        ruleId: "install-script.implicit-node-gyp",
+        diffStatus: "unchanged",
+        releaseDelta: false,
+      }),
+    );
+  });
+
   test("does not flag implicit node-gyp when npm suppressors are present", () => {
     const withPreinstall = [
       {


### PR DESCRIPTION
### Motivation
- Fix a logic gap where a high-severity `install-script.implicit-node-gyp` finding attached to an unchanged `binding.gyp` could be classified as contextual even when the staged package removed a `gypfile: false` suppressor in `package.json`, thereby newly enabling npm's implicit `node-gyp rebuild` behavior.

### Description
- Add `isNewlyEnabledImplicitNodeGypFinding(...)` to detect when `install-script.implicit-node-gyp` is newly enabled by manifest changes by comparing previous vs staged `package.json` state and calling `hasImplicitNodeGypInstall`.
- Wire the helper into `annotateFindingsWithDiffStatus` so the annotation sets `releaseDelta = true` when a finding is newly enabled by manifest changes even if the evidence file path is unchanged.
- Add `parsePackageJsonFile(...)` helper to safely read JSON samples from persisted `FileRecord` entries.
- Add regression tests to `test/review.test.mjs` covering (a) newly-enabled implicit node-gyp (previous `gypfile: false` → staged removal) and (b) the non-regression case where the implicit hook pre-existed and remains contextual; update assertions to check release-risk aggregation for the newly-enabled case.
- Update `docs/diff-baseline.md` to document that manifest-introduced implicit behavior is release evidence even when supporting files are unchanged.

### Testing
- Ran the focused unit tests with `pnpm run test:node -- test/review.test.mjs` and the new tests passed.
- Ran type checking with `pnpm run typecheck` which passed with no errors.
- Ran full verification `pnpm run verify` (lint, format check, typecheck, tests) and the suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1845fe44dc832fb9a9048ff1a2316e)