### PR TITLE
Gate credential work behind rate limits

### DIFF
--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -53,6 +53,7 @@ Recommended customer guidance:
 
 Implementation requirements:
 
+- Enforce credential-route and compare-route rate limits before starting token encryption, decryption, fingerprinting, registry fetches, or token last-used writes. Do not place protected credential work in the same `Promise.all` as `enforceRateLimit()`, because rejected rate-limit checks do not cancel sibling promises.
 - Store token material encrypted at rest.
 - Show only a label/fingerprint/last-used timestamp after storage.
 - Validate credentials before use.

--- a/server/routes/npm-connection.ts
+++ b/server/routes/npm-connection.ts
@@ -55,14 +55,12 @@ npmConnectionRoutes.post("/", async (c) => {
     const db = createDb(c.env.DB);
     const session = c.get("authSession");
     const organizationId = await requireActiveOrganization(c, db);
-    const [, encrypted] = await Promise.all([
-      enforceRateLimit(db, {
-        key: `npm-connection:save:${organizationId}`,
-        limit: 20,
-        windowMs: 60 * 60 * 1000,
-      }),
-      encryptNpmToken(c.env, token),
-    ]);
+    await enforceRateLimit(db, {
+      key: `npm-connection:save:${organizationId}`,
+      limit: 20,
+      windowMs: 60 * 60 * 1000,
+    });
+    const encrypted = await encryptNpmToken(c.env, token);
     const [connection] = await Promise.all([
       upsertNpmConnection(db, {
         organizationId,

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -224,14 +224,12 @@ scansRoutes.get("/:id/versions", async (c) => {
 
   let connection: Awaited<ReturnType<typeof getOrganizationNpmToken>> = null;
   try {
-    [, connection] = await Promise.all([
-      enforceRateLimit(db, {
-        key: `compare-versions:${session.userId}`,
-        limit: 60,
-        windowMs: 60 * 1000,
-      }),
-      getOrganizationNpmToken(db, c.env, organizationId).catch(() => null),
-    ]);
+    await enforceRateLimit(db, {
+      key: `compare-versions:${session.userId}`,
+      limit: 60,
+      windowMs: 60 * 1000,
+    });
+    connection = await getOrganizationNpmToken(db, c.env, organizationId).catch(() => null);
   } catch (err) {
     if (err instanceof RateLimitError) {
       return c.json(
@@ -341,14 +339,12 @@ scansRoutes.get("/:id/compare", async (c) => {
 
   let connection: Awaited<ReturnType<typeof getOrganizationNpmToken>> = null;
   try {
-    [, connection] = await Promise.all([
-      enforceRateLimit(db, {
-        key: `compare-fetch:${session.userId}`,
-        limit: 30,
-        windowMs: 60 * 1000,
-      }),
-      getOrganizationNpmToken(db, c.env, ctx.organizationId).catch(() => null),
-    ]);
+    await enforceRateLimit(db, {
+      key: `compare-fetch:${session.userId}`,
+      limit: 30,
+      windowMs: 60 * 1000,
+    });
+    connection = await getOrganizationNpmToken(db, c.env, ctx.organizationId).catch(() => null);
   } catch (err) {
     if (err instanceof RateLimitError) {
       return c.json(
@@ -437,14 +433,12 @@ scansRoutes.get("/:id/compare/file", async (c) => {
 
   let connection: Awaited<ReturnType<typeof getOrganizationNpmToken>> = null;
   try {
-    [, connection] = await Promise.all([
-      enforceRateLimit(db, {
-        key: `compare-file:${session.userId}`,
-        limit: 240,
-        windowMs: 60 * 1000,
-      }),
-      getOrganizationNpmToken(db, c.env, ctx.organizationId).catch(() => null),
-    ]);
+    await enforceRateLimit(db, {
+      key: `compare-file:${session.userId}`,
+      limit: 240,
+      windowMs: 60 * 1000,
+    });
+    connection = await getOrganizationNpmToken(db, c.env, ctx.organizationId).catch(() => null);
   } catch (err) {
     if (err instanceof RateLimitError) {
       return c.json(

--- a/test/workers/cross-org-npm-connection.test.ts
+++ b/test/workers/cross-org-npm-connection.test.ts
@@ -27,6 +27,18 @@ async function seedUser(): Promise<SeededUser> {
   return { userId, organizationId };
 }
 
+async function seedRateLimit(keyPrefix: string, count: number, windowMs: number) {
+  const db = createDb(env.DB);
+  const nowMs = Date.now();
+  const bucket = Math.floor(nowMs / windowMs);
+  await db.insert(schema.rateLimits).values({
+    key: `${keyPrefix}:${bucket}`,
+    count,
+    expiresAt: new Date((bucket + 1) * windowMs),
+    updatedAt: new Date(nowMs),
+  });
+}
+
 function buildTestApp(session: { userId: string }) {
   const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
   app.use("*", async (c, next) => {
@@ -106,6 +118,19 @@ describe("npm-connection routes enforce organization boundaries", () => {
     expect(intruderConnection?.label).toBe("intruder registry");
     expect(intruderConnection?.tokenLast4).toBe(INTRUDER_TOKEN.slice(-4));
     expect(ownerConnection?.tokenCiphertext).not.toBe(intruderConnection?.tokenCiphertext);
+  });
+
+  test("POST /npm-connection enforces the save rate limit before storing credentials", async () => {
+    const owner = await seedUser();
+    await seedRateLimit(`npm-connection:save:${owner.organizationId}`, 20, 60 * 60 * 1000);
+
+    const res = await call(buildTestApp(owner), "POST", "/api/v1/npm-connection", {
+      token: OWNER_TOKEN,
+      label: "blocked registry",
+    });
+
+    expect(res.status).toBe(429);
+    expect(await getNpmConnection(createDb(env.DB), owner.organizationId)).toBeNull();
   });
 
   test("POST /npm-connection accepts custom registries for organization connections", async () => {

--- a/test/workers/scans-route-queue.test.ts
+++ b/test/workers/scans-route-queue.test.ts
@@ -34,6 +34,39 @@ async function seedUser(): Promise<SeededUser> {
   return { userId, organizationId };
 }
 
+async function seedRateLimit(keyPrefix: string, count: number, windowMs: number) {
+  const db = createDb(env.DB);
+  const nowMs = Date.now();
+  const bucket = Math.floor(nowMs / windowMs);
+  await db.insert(schema.rateLimits).values({
+    key: `${keyPrefix}:${bucket}`,
+    count,
+    expiresAt: new Date((bucket + 1) * windowMs),
+    updatedAt: new Date(nowMs),
+  });
+}
+
+async function seedCompletedPackageScan(owner: SeededUser) {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const scanId = `scan_${crypto.randomUUID()}`;
+  await db.insert(schema.scans).values({
+    id: scanId,
+    stageId: "stage-route-versions-000001",
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+    packageName: "@drydock/test-package",
+    stagedVersion: "2.0.0",
+    previousVersion: "1.0.0",
+    risk: "low",
+    status: "complete",
+    source: "manual",
+    createdAt: now,
+    updatedAt: now,
+  });
+  return scanId;
+}
+
 function buildTestApp(session: { userId: string }) {
   const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
   app.use("*", async (c, next) => {
@@ -42,6 +75,23 @@ function buildTestApp(session: { userId: string }) {
   });
   app.route("/api/v1/scans", scansRoutes);
   return app;
+}
+
+async function call(
+  app: Hono<{ Bindings: Bindings; Variables: Variables }>,
+  method: string,
+  path: string,
+  body?: unknown,
+) {
+  const ctx = createExecutionContext();
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+    init.headers = { "content-type": "application/json" };
+  }
+  const res = await app.fetch(new Request(`http://test.local${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
 }
 
 async function connectValidNpmToken(owner: SeededUser, token: string) {
@@ -104,6 +154,23 @@ describe("scans route queue behavior", () => {
       .from(schema.scanEvents)
       .where(eq(schema.scanEvents.scanId, body.scan.id));
     expect(events.map((event) => event.type)).toContain("scan.queued");
+  });
+
+  test("GET /scans/:id/versions enforces rate limit before marking npm token used", async () => {
+    const owner = await seedUser();
+    await connectValidNpmToken(owner, "npm_versions_secret_0123456789");
+    const scanId = await seedCompletedPackageScan(owner);
+    await seedRateLimit(`compare-versions:${owner.userId}`, 60, 60 * 1000);
+
+    const res = await call(buildTestApp(owner), "GET", `/api/v1/scans/${scanId}/versions`);
+
+    expect(res.status).toBe(429);
+    const [connection] = await createDb(env.DB)
+      .select({ lastUsedAt: schema.npmConnections.lastUsedAt })
+      .from(schema.npmConnections)
+      .where(eq(schema.npmConnections.organizationId, owner.organizationId))
+      .limit(1);
+    expect(connection?.lastUsedAt).toBeNull();
   });
 
   test("POST /scans rejects client-controlled scan limits before queueing", async () => {


### PR DESCRIPTION
### Motivation

- A recent change ran `enforceRateLimit()` in the same `Promise.all` as credential crypto/decrypt work, allowing expensive encryption/decryption and D1 writes to run for requests that should be blocked by rate limits.

### Description

- Sequence credential work for the npm-connection save route by awaiting `enforceRateLimit()` before calling `encryptNpmToken()`.
- Sequence compare-related credential lookups by awaiting `enforceRateLimit()` before calling `getOrganizationNpmToken()` in the `versions`, `compare`, and `compare/file` routes.
- Add Worker-route regression tests that seed D1 rate-limit buckets and assert over-limit requests return `429` and do not perform credential storage or mark tokens as used (`test/workers/cross-org-npm-connection.test.ts` and `test/workers/scans-route-queue.test.ts`).
- Document the invariant in `docs/security-model.md` that credential operations must not be started in the same `Promise.all` as `enforceRateLimit()`.

### Testing

- Ran the focused worker tests with `vitest` for the modified suites (`test/workers/cross-org-npm-connection.test.ts` and `test/workers/scans-route-queue.test.ts`), and both test files passed.
- Ran the full repository verification via `pnpm run verify` (lint, format-check, typecheck, and tests), and the verification completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18493b869c832fbbb87bcc621435d0)