### PR TITLE
Improve comparison loading UX

### DIFF
--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -343,8 +343,7 @@ export const ScanDetailModel = createModel((id: string) => {
 
     async loadVersions(): Promise<void> {
       const current = this.detail.peek();
-      if (!current || current.scan.status !== "complete") return;
-      if (!current.scan.packageName) return;
+      if (!current?.scan.packageName) return;
       const id = this.scanId.peek();
       this.compareError.value = null;
       try {

--- a/src/pages/Dashboard/ScanDetail.tsx
+++ b/src/pages/Dashboard/ScanDetail.tsx
@@ -120,9 +120,8 @@ export default function ScanDetailPage() {
     };
   }, [id]);
 
-  // Fetch version metadata as soon as the scan is complete with a package name.
+  // Fetch version metadata as soon as we have a package name (don't wait for complete).
   useSignalEffect(() => {
-    if (model.status.value !== "complete") return;
     if (!model.detail.value?.scan.packageName) return;
     if (model.versions.value) return;
     void model.loadVersions();
@@ -621,11 +620,11 @@ function DiffWorkbench({
   const isBinaryPrev = Boolean(previousMeta?.flags?.includes("binary"));
 
   if (needsPrevious && !compareReady && entry.status !== "unchanged") {
-    return <LoadingLine>Loading previous version metadata</LoadingLine>;
+    return <LoadingLine size="inline">Loading comparison</LoadingLine>;
   }
 
   if (needsPrevious && previousMeta && !isBinaryPrev && !previousContent) {
-    return <LoadingLine size="inline">Loading file</LoadingLine>;
+    return <LoadingLine size="inline">Loading file content</LoadingLine>;
   }
 
   if (!staged && !previousContent && !previousMeta) {


### PR DESCRIPTION
## Summary
- Replace unclear "Loading previous version metadata" text with simpler "Loading comparison" indicator using inline size for consistency
- Load compare-versions earlier when package name becomes available, rather than waiting for scan to complete - this makes the version picker ready sooner

## Test plan
- [ ] Open a scan detail page and verify loading states show "Loading comparison" and "Loading file content"
- [ ] Verify versions load as soon as package name is available (during pending/running status)

Slack thread: https://resynapse.slack.com/archives/C0B6T44D9K3/p1779985065636539

https://claude.ai/code/session_01V1gZEypHZZKKbTjv7LgSuh

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1gZEypHZZKKbTjv7LgSuh)_