### PR TITLE
Handle deployment_protection_rule webhooks for PyPI gates (#115)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - `server/` — Hono Worker. `index.ts` mounts routes under `/api/*`. The worker is the deploy target (`main` in `wrangler.jsonc`).
   - `routes/scan.ts` — `POST /api/v1/scan { stageId }`. Runs the full pipeline.
   - `routes/scans.ts` — `GET /api/v1/scans` (list), `GET /api/v1/scans/:id` (persisted detail).
+  - `routes/github-webhooks.ts` — `POST /webhooks/github`. Public, signed by the GitHub App webhook secret; bypasses Better Auth. Persists `deployment_protection_rule` deliveries into `github_workflow_gates` and updates installation status on lifecycle events. See `docs/pypi-workflow-gate.md`.
   - `lib/sandbox.ts` — Dynamic Worker that downloads + parses a tarball; `NpmStageGateway` is the only egress allowed (staged tarball, published tarball, registry metadata).
   - `lib/review.ts` — Deterministic findings, package diff, package.json diff, risk computation. Shared types are imported by both server and UI.
   - `lib/ai-review.ts` — Workers AI JSON-mode reviewer. Currently **disabled in the pipeline**; kept on disk for a planned paid-tier re-introduction. Do not wire it back into `scan-pipeline.ts` without a feature decision.

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -264,7 +264,11 @@ Implemented foundation:
 Remaining tasks:
 
 - Add GitHub App installation, repository, workflow, and environment mapping.
-- Handle GitHub `deployment_protection_rule` webhooks for the PyPI environment.
+- ~~Handle GitHub `deployment_protection_rule` webhooks for the PyPI
+  environment.~~ Implemented: `POST /webhooks/github` verifies the App secret,
+  resolves the release-target mapping, persists a pending gate, and exposes
+  `markGateDecided` + `postDeploymentProtectionDecision` for the future review
+  pipeline to release or block the publish job.
 - Fetch GitHub Actions artifacts and the required `drydock-manifest.json`.
 - Verify artifact SHA-256 digests before review and before publish.
 - Persist workflow-gate reviews without overloading npm `stage_id`.

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -153,13 +153,74 @@ organization (`x-organization-id` header to scope writes).
 ### Webhook resolution
 
 `resolveDeploymentProtectionTarget(db, { installationId, repositoryId,
-environment })` is the lookup helper a future `deployment_protection_rule`
-webhook will call to find the owning organization and release target. It
-returns `null` for unknown installs, suspended installs, and unmapped
-environments — the caller decides whether that becomes an HTTP 404 or a silent
-skip. The environment is normalized the same way as stored release targets, and
-the database enforces one target per organization/repository/environment so this
+environment })` is the lookup helper the `deployment_protection_rule` webhook
+calls to find the owning organization and release target. It returns `null`
+for unknown installs, suspended installs, and unmapped environments — the
+caller decides whether that becomes an HTTP 404 or a silent skip. The
+environment is normalized the same way as stored release targets, and the
+database enforces one target per organization/repository/environment so this
 lookup is deterministic.
+
+## Deployment-protection webhook
+
+The webhook endpoint is `POST /webhooks/github`. It is mounted outside the
+Better Auth middleware so GitHub can deliver to it directly; the trust
+boundary is the GitHub App webhook secret. Configure the GitHub App to send
+deliveries to `https://<drydock-host>/webhooks/github` with the same secret
+that is stored in `GITHUB_APP_WEBHOOK_SECRET`.
+
+What the handler does on each delivery:
+
+1. Read `X-GitHub-Event`, `X-GitHub-Delivery`, and `X-Hub-Signature-256`.
+   Missing required headers, missing/invalid signatures, or empty bodies all
+   return 4xx — we fail closed so unsigned or malformed requests cannot bypass
+   the gate.
+2. HMAC-SHA256 verify the signature against the raw body in constant time.
+3. Parse the payload. The handler accepts two event types:
+   - `deployment_protection_rule` (action `requested`) — resolves the
+     `(installationId, repositoryId, environment)` triple against the
+     release-target table, then inserts a `github_workflow_gates` row in
+     `pending` state. Insertion is keyed on `delivery_id`, so GitHub
+     retries with the same delivery are idempotent.
+   - `installation` (actions `suspend` / `unsuspend` / `deleted`) — updates
+     the installation row's status so subsequent webhook deliveries fail
+     closed if GitHub later revokes access.
+4. Audit the resolved gate via `scan_events`
+   (`github_workflow_gate.requested`).
+
+Deliveries that resolve to no release target are ack'd with HTTP 200 + an
+`ignored` body. GitHub considers that a successful delivery, so the webhook
+log stays clean even when other GitHub Apps the org installs send events to
+the same URL.
+
+### Posting the decision back to GitHub
+
+`postDeploymentProtectionDecision` reads the stored
+`deployment_callback_url`, swaps the App JWT for an installation access token,
+and POSTs `{ state, environment_name, comment }`. The callback URL is
+re-validated before the request — only `https://api.github.com/repos/<owner>/
+<repo>/actions/runs/<run_id>/deployment_protection_rule` URLs are accepted, so
+a spoofed `deployment_callback_url` in the original webhook cannot redirect
+the approval to an attacker-controlled host. The comment is truncated to 140
+characters and is what GitHub renders in the Actions run log, so it carries
+the link to the Drydock report.
+
+`markGateDecided` is the only transition out of `pending`: it succeeds
+exactly once thanks to the `status = 'pending'` WHERE clause, so even if the
+PyPI candidate review completes more than once we will only call GitHub a
+single time. The companion `markGateErrored` records failures (e.g. inability
+to fetch the manifest, scan pipeline crash) without consuming the gate, so
+the operator can retry once the underlying issue is fixed.
+
+### Trust boundary (webhook)
+
+- Signatures are required. There is no "trust the header" fallback.
+- Callback URLs are pinned to `api.github.com` and the deployment-protection
+  path; spoofed URLs are rejected even when the signature is valid.
+- The decision API uses a fresh installation access token; no long-lived
+  PyPI credential ever touches Drydock.
+- `markGateDecided` is a CAS on the pending status, so a race between
+  webhook retries and the review pipeline cannot double-approve.
 
 ### Trust boundary
 
@@ -190,9 +251,9 @@ HMAC-signing the OAuth state.
   the existing `/install` and `/install/callback` routes.
 - Replace the free-text `repositoryFullName` field with a dropdown of repos the
   installation can see (`GET /installation/repositories`).
-- Handle `deployment_protection_rule` webhooks (uses `resolveDeploymentProtectionTarget`).
 - Fetch GitHub Actions artifacts and `drydock-manifest.json` with installation
-  credentials.
+  credentials, then call `markGateDecided` / `postDeploymentProtectionDecision`
+  to release or block the publish job.
 - Run the existing PyPI candidate review helper from the gate handler.
 - Persist workflow-gate reviews separately from npm `stageId` scans or
   generalize the scan schema around `release_candidate` records.

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -174,7 +174,9 @@ What the handler does on each delivery:
 1. Read `X-GitHub-Event`, `X-GitHub-Delivery`, and `X-Hub-Signature-256`.
    Missing required headers, missing/invalid signatures, or empty bodies all
    return 4xx — we fail closed so unsigned or malformed requests cannot bypass
-   the gate.
+   the gate. Bodies are capped before materialization: oversized
+   `Content-Length` values are rejected immediately, and chunked/undeclared
+   bodies are read through a hard streaming byte limit.
 2. HMAC-SHA256 verify the signature against the raw body in constant time.
 3. Parse the payload. The handler accepts two event types:
    - `deployment_protection_rule` (action `requested`) — resolves the

--- a/drizzle/0011_sad_ezekiel_stane.sql
+++ b/drizzle/0011_sad_ezekiel_stane.sql
@@ -1,0 +1,32 @@
+CREATE TABLE `github_workflow_gates` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`installation_row_id` text NOT NULL,
+	`release_target_id` text NOT NULL,
+	`delivery_id` text NOT NULL,
+	`repository_id` integer NOT NULL,
+	`repository_full_name` text NOT NULL,
+	`environment` text NOT NULL,
+	`run_id` integer NOT NULL,
+	`deployment_id` integer,
+	`deployment_callback_url` text NOT NULL,
+	`event_action` text NOT NULL,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`decision` text,
+	`decision_comment` text,
+	`report_url` text,
+	`scan_id` text,
+	`failure_reason` text,
+	`requested_at` integer NOT NULL,
+	`decided_at` integer,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`installation_row_id`) REFERENCES `github_app_installations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`release_target_id`) REFERENCES `github_release_targets`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`scan_id`) REFERENCES `scans`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `github_workflow_gates_delivery_unique_idx` ON `github_workflow_gates` (`delivery_id`);--> statement-breakpoint
+CREATE INDEX `github_workflow_gates_org_status_idx` ON `github_workflow_gates` (`organization_id`,`status`);--> statement-breakpoint
+CREATE INDEX `github_workflow_gates_release_target_idx` ON `github_workflow_gates` (`release_target_id`);

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,1834 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "cf6f889e-4390-46e5-bceb-1b33f18a7d89",
+  "prevId": "e3a27384-e88d-4e81-8b70-0658d8a325ab",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_app_installations": {
+      "name": "github_app_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Organization'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uninstalled_at": {
+          "name": "uninstalled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_app_installations_installation_unique_idx": {
+          "name": "github_app_installations_installation_unique_idx",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        },
+        "github_app_installations_org_idx": {
+          "name": "github_app_installations_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installations_created_by_user_id_user_id_fk": {
+          "name": "github_app_installations_created_by_user_id_user_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_release_targets": {
+      "name": "github_release_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ecosystem": {
+          "name": "ecosystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workflow_filename": {
+          "name": "workflow_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pypi_trusted_publisher_environment": {
+          "name": "pypi_trusted_publisher_environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_release_targets_org_pkg_unique_idx": {
+          "name": "github_release_targets_org_pkg_unique_idx",
+          "columns": [
+            "organization_id",
+            "ecosystem",
+            "package_name"
+          ],
+          "isUnique": true
+        },
+        "github_release_targets_org_repo_env_unique_idx": {
+          "name": "github_release_targets_org_repo_env_unique_idx",
+          "columns": [
+            "organization_id",
+            "repository_id",
+            "environment"
+          ],
+          "isUnique": true
+        },
+        "github_release_targets_installation_idx": {
+          "name": "github_release_targets_installation_idx",
+          "columns": [
+            "installation_row_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_release_targets_organization_id_organizations_id_fk": {
+          "name": "github_release_targets_organization_id_organizations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_release_targets_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_created_by_user_id_user_id_fk": {
+          "name": "github_release_targets_created_by_user_id_user_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_workflow_gates": {
+      "name": "github_workflow_gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_target_id": {
+          "name": "release_target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deployment_callback_url": {
+          "name": "deployment_callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_comment": {
+          "name": "decision_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_url": {
+          "name": "report_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_workflow_gates_delivery_unique_idx": {
+          "name": "github_workflow_gates_delivery_unique_idx",
+          "columns": [
+            "delivery_id"
+          ],
+          "isUnique": true
+        },
+        "github_workflow_gates_org_status_idx": {
+          "name": "github_workflow_gates_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_release_target_idx": {
+          "name": "github_workflow_gates_release_target_idx",
+          "columns": [
+            "release_target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_workflow_gates_organization_id_organizations_id_fk": {
+          "name": "github_workflow_gates_organization_id_organizations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_workflow_gates_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_release_target_id_github_release_targets_id_fk": {
+          "name": "github_workflow_gates_release_target_id_github_release_targets_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_release_targets",
+          "columnsFrom": [
+            "release_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_scan_id_scans_id_fk": {
+          "name": "github_workflow_gates_scan_id_scans_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_unique_idx": {
+          "name": "npm_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changed_file_count": {
+          "name": "changed_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_summary_json": {
+          "name": "risk_summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        },
+        "scans_org_decision_created_idx": {
+          "name": "scans_org_decision_created_idx",
+          "columns": [
+            "organization_id",
+            "decision",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_decided_by_user_id_user_id_fk": {
+          "name": "scans_decided_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1779984081781,
       "tag": "0010_low_doctor_faustus",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1779984604056,
+      "tag": "0011_sad_ezekiel_stane",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -252,6 +252,50 @@ export const githubReleaseTargets = sqliteTable(
   }),
 );
 
+export const githubWorkflowGates = sqliteTable(
+  "github_workflow_gates",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    installationRowId: text("installation_row_id")
+      .notNull()
+      .references(() => githubAppInstallations.id, { onDelete: "cascade" }),
+    releaseTargetId: text("release_target_id")
+      .notNull()
+      .references(() => githubReleaseTargets.id, { onDelete: "cascade" }),
+    deliveryId: text("delivery_id").notNull(),
+    repositoryId: integer("repository_id").notNull(),
+    repositoryFullName: text("repository_full_name").notNull(),
+    environment: text("environment").notNull(),
+    runId: integer("run_id").notNull(),
+    deploymentId: integer("deployment_id"),
+    deploymentCallbackUrl: text("deployment_callback_url").notNull(),
+    eventAction: text("event_action").notNull(),
+    status: text("status").notNull().default("pending"),
+    decision: text("decision"),
+    decisionComment: text("decision_comment"),
+    reportUrl: text("report_url"),
+    scanId: text("scan_id").references(() => scans.id, { onDelete: "set null" }),
+    failureReason: text("failure_reason"),
+    requestedAt: integer("requested_at", { mode: "timestamp_ms" }).notNull(),
+    decidedAt: integer("decided_at", { mode: "timestamp_ms" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+  },
+  (table) => ({
+    deliveryUniqueIdx: uniqueIndex("github_workflow_gates_delivery_unique_idx").on(
+      table.deliveryId,
+    ),
+    orgStatusIdx: index("github_workflow_gates_org_status_idx").on(
+      table.organizationId,
+      table.status,
+    ),
+    releaseTargetIdx: index("github_workflow_gates_release_target_idx").on(table.releaseTargetId),
+  }),
+);
+
 export const session = sqliteTable("session", {
   id: text("id").primaryKey(),
   expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),

--- a/server/index.ts
+++ b/server/index.ts
@@ -25,6 +25,7 @@ import {
   StagedPublishesFetchError,
 } from "./lib/staged-publishes-discovery";
 import { githubAppRoutes } from "./routes/github-app";
+import { githubWebhookRoutes } from "./routes/github-webhooks";
 import { npmConnectionRoutes } from "./routes/npm-connection";
 import { organizationsRoutes } from "./routes/organizations";
 import { scanRoutes } from "./routes/scan";
@@ -73,6 +74,12 @@ app.use("*", async (c, next) => {
   if (c.res.status < 200 || c.res.status > 599) return;
   applySecurityHeaders(c);
 });
+
+// GitHub App webhooks are signed by GitHub itself, not Better Auth, and arrive
+// without an Origin/Referer header. They must be mounted before the auth and
+// CSRF middleware below — the signature verification inside the handler is the
+// trust boundary.
+app.route("/webhooks", githubWebhookRoutes);
 
 app.use("/api/*", async (c, next) => {
   try {
@@ -188,6 +195,7 @@ app.get("/api", (c) =>
         "GET /api/v1/organizations; POST /api/v1/organizations; PATCH /api/v1/organizations/:id",
       githubApp:
         "GET /api/v1/github-app/config; POST /api/v1/github-app/install; POST /api/v1/github-app/install/callback; GET /api/v1/github-app/installations; GET/POST /api/v1/github-app/release-targets; DELETE /api/v1/github-app/release-targets/:id",
+      githubWebhooks: "POST /webhooks/github (signed by GitHub App webhook secret)",
       health: "GET /api/health",
     },
     auth: "Better Auth is required for every non-auth API endpoint.",

--- a/server/lib/github-app-webhook.ts
+++ b/server/lib/github-app-webhook.ts
@@ -1,0 +1,579 @@
+import { and, eq } from "drizzle-orm";
+import type { AppDb } from "../db";
+import { githubWorkflowGates } from "../db/schema";
+import {
+  fetchInstallationMetadata,
+  getInstallationAccessToken,
+  markInstallationStatus,
+  resolveDeploymentProtectionTarget,
+  type GithubAppConfig,
+  type InstallationRecord,
+  type ReleaseTargetRecord,
+} from "./github-app";
+
+// ── Signature verification ───────────────────────────────────────────────────
+
+const SIGNATURE_PREFIX = "sha256=";
+
+/**
+ * Constant-time verification of GitHub's HMAC-SHA256 webhook signature. GitHub
+ * sends the signature as `sha256=<hex>` in the `X-Hub-Signature-256` header and
+ * computes it over the raw request body. We must compare the bytes — not the
+ * string — to avoid timing leaks, and we MUST reject any request that does not
+ * carry a valid signature header. Anything else would let an attacker bypass
+ * the gate by replaying a forged payload.
+ */
+export async function verifyGithubWebhookSignature(
+  secret: string,
+  signatureHeader: string | null,
+  rawBody: string,
+): Promise<boolean> {
+  if (!signatureHeader || !signatureHeader.startsWith(SIGNATURE_PREFIX)) return false;
+  const provided = hexDecode(signatureHeader.slice(SIGNATURE_PREFIX.length));
+  if (!provided) return false;
+  const expected = await hmacSha256(secret, rawBody);
+  return timingSafeEqual(expected, provided);
+}
+
+// ── Event parsing ────────────────────────────────────────────────────────────
+
+export type WebhookParseError =
+  | "invalid_json"
+  | "unsupported_event"
+  | "unsupported_action"
+  | "missing_installation"
+  | "missing_repository"
+  | "missing_environment"
+  | "missing_run"
+  | "missing_callback_url"
+  | "invalid_callback_url";
+
+export interface ParsedDeploymentProtectionEvent {
+  kind: "deployment_protection_rule";
+  action: "requested";
+  installationId: string;
+  repositoryId: number;
+  repositoryFullName: string;
+  environment: string;
+  runId: number;
+  deploymentId: number | null;
+  deploymentCallbackUrl: string;
+}
+
+export interface ParsedInstallationLifecycleEvent {
+  kind: "installation";
+  action: "suspend" | "unsuspend" | "deleted";
+  installationId: string;
+}
+
+export type ParsedGithubEvent = ParsedDeploymentProtectionEvent | ParsedInstallationLifecycleEvent;
+
+/**
+ * Parse a raw webhook body for the events we care about. Returns a discriminated
+ * union the caller can switch on, or a parse-error string the caller can audit.
+ * Unknown event types fall through as `unsupported_event` so the route can ack
+ * (HTTP 200) without doing anything, which is what GitHub expects.
+ */
+export function parseGithubWebhookEvent(
+  eventName: string,
+  rawBody: string,
+): ParsedGithubEvent | { error: WebhookParseError } {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return { error: "invalid_json" };
+  }
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return { error: "invalid_json" };
+  }
+
+  if (eventName === "deployment_protection_rule") {
+    return parseDeploymentProtectionEvent(payload as Record<string, unknown>);
+  }
+  if (eventName === "installation") {
+    return parseInstallationLifecycleEvent(payload as Record<string, unknown>);
+  }
+  return { error: "unsupported_event" };
+}
+
+function parseDeploymentProtectionEvent(
+  body: Record<string, unknown>,
+): ParsedDeploymentProtectionEvent | { error: WebhookParseError } {
+  const action = typeof body.action === "string" ? body.action : "";
+  if (action !== "requested") return { error: "unsupported_action" };
+
+  const installation = isObject(body.installation) ? body.installation : null;
+  const installationId = extractIdAsString(installation?.id);
+  if (!installationId) return { error: "missing_installation" };
+
+  const repository = isObject(body.repository) ? body.repository : null;
+  const repositoryId = extractIdAsNumber(repository?.id);
+  const repositoryFullName = typeof repository?.full_name === "string" ? repository.full_name : "";
+  if (!repositoryId || !repositoryFullName) return { error: "missing_repository" };
+
+  const environment = typeof body.environment === "string" ? body.environment.trim() : "";
+  if (!environment) return { error: "missing_environment" };
+
+  const callbackUrl =
+    typeof body.deployment_callback_url === "string" ? body.deployment_callback_url.trim() : "";
+  if (!callbackUrl) return { error: "missing_callback_url" };
+  if (!isAllowedCallbackUrl(callbackUrl)) return { error: "invalid_callback_url" };
+
+  const runId = extractRunIdFromCallback(callbackUrl);
+  if (!runId) return { error: "missing_run" };
+
+  const deployment = isObject(body.deployment) ? body.deployment : null;
+  const deploymentId = extractIdAsNumber(deployment?.id);
+
+  return {
+    kind: "deployment_protection_rule",
+    action,
+    installationId,
+    repositoryId,
+    repositoryFullName,
+    environment,
+    runId,
+    deploymentId,
+    deploymentCallbackUrl: callbackUrl,
+  };
+}
+
+function parseInstallationLifecycleEvent(
+  body: Record<string, unknown>,
+): ParsedInstallationLifecycleEvent | { error: WebhookParseError } {
+  const action = typeof body.action === "string" ? body.action : "";
+  if (action !== "suspend" && action !== "unsuspend" && action !== "deleted") {
+    return { error: "unsupported_action" };
+  }
+  const installation = isObject(body.installation) ? body.installation : null;
+  const installationId = extractIdAsString(installation?.id);
+  if (!installationId) return { error: "missing_installation" };
+  return { kind: "installation", action, installationId };
+}
+
+// Only allow callback URLs that look like the real GitHub Actions deployment
+// protection callback path; otherwise a spoofed payload could trick us into
+// posting an approval to an attacker-controlled host.
+const CALLBACK_PATH_RE =
+  /^\/repos\/[^/]+\/[^/]+\/actions\/runs\/(\d+)\/deployment_protection_rule\/?$/;
+
+function isAllowedCallbackUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "https:") return false;
+  if (parsed.host !== "api.github.com") return false;
+  return CALLBACK_PATH_RE.test(parsed.pathname);
+}
+
+function extractRunIdFromCallback(url: string): number | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return null;
+  }
+  const match = parsed.pathname.match(CALLBACK_PATH_RE);
+  if (!match) return null;
+  const numeric = Number.parseInt(match[1], 10);
+  return Number.isInteger(numeric) && numeric > 0 ? numeric : null;
+}
+
+function extractIdAsString(value: unknown): string {
+  if (typeof value === "number" && Number.isFinite(value) && Math.floor(value) === value) {
+    return String(value);
+  }
+  if (typeof value === "string" && /^\d+$/.test(value)) return value;
+  return "";
+}
+
+function extractIdAsNumber(value: unknown): number {
+  if (typeof value === "number" && Number.isInteger(value) && value > 0) return value;
+  if (typeof value === "string" && /^\d+$/.test(value)) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : 0;
+  }
+  return 0;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+// ── Persistence ──────────────────────────────────────────────────────────────
+
+export type WorkflowGateStatus = "pending" | "approved" | "rejected" | "errored";
+
+export interface WorkflowGateRecord {
+  id: string;
+  organizationId: string;
+  installationRowId: string;
+  releaseTargetId: string;
+  deliveryId: string;
+  repositoryId: number;
+  repositoryFullName: string;
+  environment: string;
+  runId: number;
+  deploymentId: number | null;
+  deploymentCallbackUrl: string;
+  eventAction: string;
+  status: WorkflowGateStatus;
+  decision: "approved" | "rejected" | null;
+  decisionComment: string | null;
+  reportUrl: string | null;
+  scanId: string | null;
+  failureReason: string | null;
+  requestedAt: Date;
+  decidedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface RecordGateRequestInput {
+  deliveryId: string;
+  installation: InstallationRecord;
+  releaseTarget: ReleaseTargetRecord;
+  event: ParsedDeploymentProtectionEvent;
+}
+
+/**
+ * Persist a pending gate after a `deployment_protection_rule.requested`
+ * webhook. Returns the existing row if the same `X-GitHub-Delivery` ID has
+ * already been recorded, so retries from GitHub are idempotent.
+ */
+export async function recordGateRequest(
+  db: AppDb,
+  input: RecordGateRequestInput,
+): Promise<{ gate: WorkflowGateRecord; created: boolean }> {
+  const existing = await getGateByDeliveryId(db, input.deliveryId);
+  if (existing) return { gate: existing, created: false };
+
+  const now = new Date();
+  const id = crypto.randomUUID();
+  await db.insert(githubWorkflowGates).values({
+    id,
+    organizationId: input.installation.organizationId,
+    installationRowId: input.installation.id,
+    releaseTargetId: input.releaseTarget.id,
+    deliveryId: input.deliveryId,
+    repositoryId: input.event.repositoryId,
+    repositoryFullName: input.event.repositoryFullName,
+    environment: input.event.environment.toLowerCase(),
+    runId: input.event.runId,
+    deploymentId: input.event.deploymentId,
+    deploymentCallbackUrl: input.event.deploymentCallbackUrl,
+    eventAction: input.event.action,
+    status: "pending",
+    requestedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const fresh = await getGateByDeliveryId(db, input.deliveryId);
+  if (!fresh) throw new Error("workflow gate row vanished immediately after insert");
+  return { gate: fresh, created: true };
+}
+
+export async function getGateByDeliveryId(
+  db: AppDb,
+  deliveryId: string,
+): Promise<WorkflowGateRecord | null> {
+  const [row] = await db
+    .select()
+    .from(githubWorkflowGates)
+    .where(eq(githubWorkflowGates.deliveryId, deliveryId))
+    .limit(1);
+  return row ? readGateRow(row) : null;
+}
+
+export async function getGateForOrganization(
+  db: AppDb,
+  organizationId: string,
+  gateId: string,
+): Promise<WorkflowGateRecord | null> {
+  const [row] = await db
+    .select()
+    .from(githubWorkflowGates)
+    .where(
+      and(
+        eq(githubWorkflowGates.id, gateId),
+        eq(githubWorkflowGates.organizationId, organizationId),
+      ),
+    )
+    .limit(1);
+  return row ? readGateRow(row) : null;
+}
+
+export async function attachScanToGate(db: AppDb, gateId: string, scanId: string): Promise<void> {
+  const now = new Date();
+  await db
+    .update(githubWorkflowGates)
+    .set({ scanId, updatedAt: now })
+    .where(and(eq(githubWorkflowGates.id, gateId), eq(githubWorkflowGates.status, "pending")));
+}
+
+interface DecideGateInput {
+  gateId: string;
+  decision: "approved" | "rejected";
+  comment: string;
+  reportUrl?: string | null;
+}
+
+/**
+ * Atomically transition a pending gate to `approved` or `rejected`. Returns
+ * null if the gate was already decided (or never existed), so the caller can
+ * skip re-posting to GitHub.
+ */
+export async function markGateDecided(
+  db: AppDb,
+  input: DecideGateInput,
+): Promise<WorkflowGateRecord | null> {
+  const now = new Date();
+  const updated = await db
+    .update(githubWorkflowGates)
+    .set({
+      status: input.decision,
+      decision: input.decision,
+      decisionComment: input.comment,
+      reportUrl: input.reportUrl ?? null,
+      decidedAt: now,
+      updatedAt: now,
+    })
+    .where(and(eq(githubWorkflowGates.id, input.gateId), eq(githubWorkflowGates.status, "pending")))
+    .returning({ id: githubWorkflowGates.id });
+  if (updated.length === 0) return null;
+  const [row] = await db
+    .select()
+    .from(githubWorkflowGates)
+    .where(eq(githubWorkflowGates.id, input.gateId))
+    .limit(1);
+  return row ? readGateRow(row) : null;
+}
+
+export async function markGateErrored(
+  db: AppDb,
+  gateId: string,
+  reason: string,
+): Promise<WorkflowGateRecord | null> {
+  const now = new Date();
+  const updated = await db
+    .update(githubWorkflowGates)
+    .set({ failureReason: reason.slice(0, 500), updatedAt: now })
+    .where(and(eq(githubWorkflowGates.id, gateId), eq(githubWorkflowGates.status, "pending")))
+    .returning({ id: githubWorkflowGates.id });
+  if (updated.length === 0) return null;
+  const [row] = await db
+    .select()
+    .from(githubWorkflowGates)
+    .where(eq(githubWorkflowGates.id, gateId))
+    .limit(1);
+  return row ? readGateRow(row) : null;
+}
+
+function readGateRow(row: {
+  id: string;
+  organizationId: string;
+  installationRowId: string;
+  releaseTargetId: string;
+  deliveryId: string;
+  repositoryId: number;
+  repositoryFullName: string;
+  environment: string;
+  runId: number;
+  deploymentId: number | null;
+  deploymentCallbackUrl: string;
+  eventAction: string;
+  status: string;
+  decision: string | null;
+  decisionComment: string | null;
+  reportUrl: string | null;
+  scanId: string | null;
+  failureReason: string | null;
+  requestedAt: Date | string | number;
+  decidedAt: Date | string | number | null;
+  createdAt: Date | string | number;
+  updatedAt: Date | string | number;
+}): WorkflowGateRecord {
+  return {
+    id: row.id,
+    organizationId: row.organizationId,
+    installationRowId: row.installationRowId,
+    releaseTargetId: row.releaseTargetId,
+    deliveryId: row.deliveryId,
+    repositoryId: row.repositoryId,
+    repositoryFullName: row.repositoryFullName,
+    environment: row.environment,
+    runId: row.runId,
+    deploymentId: row.deploymentId,
+    deploymentCallbackUrl: row.deploymentCallbackUrl,
+    eventAction: row.eventAction,
+    status: normalizeGateStatus(row.status),
+    decision: normalizeGateDecision(row.decision),
+    decisionComment: row.decisionComment,
+    reportUrl: row.reportUrl,
+    scanId: row.scanId,
+    failureReason: row.failureReason,
+    requestedAt: new Date(row.requestedAt),
+    decidedAt: row.decidedAt ? new Date(row.decidedAt) : null,
+    createdAt: new Date(row.createdAt),
+    updatedAt: new Date(row.updatedAt),
+  };
+}
+
+function normalizeGateStatus(value: string): WorkflowGateStatus {
+  if (value === "approved" || value === "rejected" || value === "errored") return value;
+  return "pending";
+}
+
+function normalizeGateDecision(value: string | null): "approved" | "rejected" | null {
+  if (value === "approved" || value === "rejected") return value;
+  return null;
+}
+
+// ── Webhook dispatcher ───────────────────────────────────────────────────────
+
+export type WebhookOutcome =
+  | { kind: "gate_pending"; gate: WorkflowGateRecord; created: boolean }
+  | { kind: "installation_updated"; installationId: string; action: string }
+  | { kind: "ignored"; reason: string };
+
+export interface DispatchDeps {
+  deliveryId: string;
+}
+
+/**
+ * Apply a verified webhook event to the database. Lookup misses (unknown
+ * installation / unmapped environment) intentionally return `ignored` rather
+ * than 4xx so GitHub considers the delivery successful — replaying a 404 over
+ * and over for an unmapped environment would clutter the audit log without
+ * any safety win. Malformed payloads, by contrast, are surfaced by the caller
+ * with HTTP 400 because they are a signal of either misconfiguration or
+ * tampering.
+ */
+export async function applyGithubWebhookEvent(
+  db: AppDb,
+  event: ParsedGithubEvent,
+  deps: DispatchDeps,
+): Promise<WebhookOutcome> {
+  if (event.kind === "deployment_protection_rule") {
+    const resolved = await resolveDeploymentProtectionTarget(db, {
+      installationId: event.installationId,
+      repositoryId: event.repositoryId,
+      environment: event.environment,
+    });
+    if (!resolved) {
+      return {
+        kind: "ignored",
+        reason: "no release target mapped for this installation/repository/environment",
+      };
+    }
+    const { gate, created } = await recordGateRequest(db, {
+      deliveryId: deps.deliveryId,
+      installation: resolved.installation,
+      releaseTarget: resolved.releaseTarget,
+      event,
+    });
+    return { kind: "gate_pending", gate, created };
+  }
+
+  if (event.kind === "installation") {
+    const status =
+      event.action === "suspend"
+        ? "suspended"
+        : event.action === "unsuspend"
+          ? "active"
+          : "uninstalled";
+    await markInstallationStatus(db, event.installationId, status);
+    return {
+      kind: "installation_updated",
+      installationId: event.installationId,
+      action: event.action,
+    };
+  }
+
+  return { kind: "ignored", reason: "unhandled event kind" };
+}
+
+// ── Deployment protection callback ───────────────────────────────────────────
+
+export interface DeploymentProtectionDecisionInput {
+  config: GithubAppConfig;
+  installationExternalId: string;
+  callbackUrl: string;
+  environment: string;
+  state: "approved" | "rejected";
+  comment: string;
+}
+
+/**
+ * POST the deployment-protection decision callback to GitHub using a fresh
+ * installation access token. The comment is what GitHub renders in the
+ * Actions run log, so we lean on it to link back to the Drydock report.
+ */
+export async function postDeploymentProtectionDecision(
+  input: DeploymentProtectionDecisionInput,
+): Promise<void> {
+  if (!isAllowedCallbackUrl(input.callbackUrl)) {
+    throw new Error("refusing to POST decision to a non-GitHub callback URL");
+  }
+  const token = await getInstallationAccessToken(input.config, input.installationExternalId);
+  const comment = input.comment.slice(0, 140);
+  const response = await fetch(input.callbackUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/vnd.github+json",
+      "Content-Type": "application/json",
+      "User-Agent": "drydock-app",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    body: JSON.stringify({
+      state: input.state,
+      environment_name: input.environment,
+      comment,
+    }),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(
+      `GitHub deployment protection decision failed (${response.status}): ${text.slice(0, 200)}`,
+    );
+  }
+}
+
+// Re-export for convenience in callers that want a one-shot freshness check.
+export { fetchInstallationMetadata };
+
+// ── Crypto helpers ───────────────────────────────────────────────────────────
+
+async function hmacSha256(secret: string, message: string): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(message));
+  return new Uint8Array(signature);
+}
+
+function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) diff |= a[i] ^ b[i];
+  return diff === 0;
+}
+
+function hexDecode(value: string): Uint8Array | null {
+  if (value.length === 0 || value.length % 2 !== 0) return null;
+  if (!/^[0-9a-fA-F]+$/.test(value)) return null;
+  const out = new Uint8Array(value.length / 2);
+  for (let i = 0; i < out.length; i += 1) {
+    out[i] = Number.parseInt(value.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}

--- a/server/routes/github-webhooks.ts
+++ b/server/routes/github-webhooks.ts
@@ -1,0 +1,171 @@
+import { Hono } from "hono";
+import { createDb, enforceRateLimit, RateLimitError, recordScanEvent } from "../db";
+import {
+  GithubAppConfigError,
+  isGithubAppConfigured,
+  readGithubAppConfig,
+} from "../lib/github-app";
+import {
+  applyGithubWebhookEvent,
+  parseGithubWebhookEvent,
+  verifyGithubWebhookSignature,
+  type WebhookOutcome,
+} from "../lib/github-app-webhook";
+import { emitOperationalEvent } from "../lib/observability";
+import type { Bindings, Variables } from "../types";
+
+export const githubWebhookRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+// Bound how much body we'll read from a webhook delivery before failing closed.
+// GitHub deliveries are well under 256KB; anything bigger is either misconfigured
+// or hostile, so we don't want to spend Worker CPU on it.
+const MAX_WEBHOOK_BODY_BYTES = 1024 * 1024;
+
+githubWebhookRoutes.post("/github", async (c) => {
+  if (!isGithubAppConfigured(c.env)) {
+    emitOperationalEvent("warn", "github_webhook.config_missing", {});
+    return c.json({ error: "github app not configured" }, 503);
+  }
+
+  let config;
+  try {
+    config = readGithubAppConfig(c.env);
+  } catch (err) {
+    if (err instanceof GithubAppConfigError) {
+      emitOperationalEvent("error", "github_webhook.config_error", { message: err.message });
+      return c.json({ error: "github app not configured" }, 503);
+    }
+    throw err;
+  }
+
+  const eventName = c.req.header("x-github-event")?.trim() ?? "";
+  const deliveryId = c.req.header("x-github-delivery")?.trim() ?? "";
+  const signature = c.req.header("x-hub-signature-256")?.trim() ?? null;
+
+  if (!eventName || !deliveryId) {
+    emitOperationalEvent("warn", "github_webhook.missing_headers", {
+      hasEvent: Boolean(eventName),
+      hasDelivery: Boolean(deliveryId),
+    });
+    return c.json({ error: "missing github webhook headers" }, 400);
+  }
+
+  const buffer = await c.req.raw.arrayBuffer();
+  if (buffer.byteLength === 0) {
+    emitOperationalEvent("warn", "github_webhook.empty_body", { deliveryId, eventName });
+    return c.json({ error: "empty webhook body" }, 400);
+  }
+  if (buffer.byteLength > MAX_WEBHOOK_BODY_BYTES) {
+    emitOperationalEvent("warn", "github_webhook.body_too_large", {
+      deliveryId,
+      eventName,
+      bytes: buffer.byteLength,
+    });
+    return c.json({ error: "webhook body too large" }, 413);
+  }
+  const rawBody = new TextDecoder().decode(buffer);
+
+  const signatureValid = await verifyGithubWebhookSignature(
+    config.webhookSecret,
+    signature,
+    rawBody,
+  );
+  if (!signatureValid) {
+    emitOperationalEvent("warn", "github_webhook.signature_invalid", {
+      deliveryId,
+      eventName,
+      hasSignature: Boolean(signature),
+    });
+    return c.json({ error: "invalid signature" }, 401);
+  }
+
+  const db = createDb(c.env.DB);
+  try {
+    await enforceRateLimit(db, {
+      key: `github-webhook:${deliveryId.slice(0, 8)}`,
+      limit: 60,
+      windowMs: 60 * 1000,
+    });
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      return c.json(
+        { error: "webhook rate limit exceeded", retryAfterSeconds: err.retryAfterSeconds },
+        429,
+        { "retry-after": String(err.retryAfterSeconds) },
+      );
+    }
+    throw err;
+  }
+
+  const parsed = parseGithubWebhookEvent(eventName, rawBody);
+  if ("error" in parsed) {
+    if (parsed.error === "unsupported_event" || parsed.error === "unsupported_action") {
+      emitOperationalEvent("info", "github_webhook.ignored", {
+        deliveryId,
+        eventName,
+        reason: parsed.error,
+      });
+      return c.json({ ok: true, ignored: parsed.error });
+    }
+    // Malformed deployment_protection_rule payloads are auditable failures —
+    // we don't want to silently accept them.
+    emitOperationalEvent("error", "github_webhook.invalid_payload", {
+      deliveryId,
+      eventName,
+      reason: parsed.error,
+    });
+    return c.json({ error: `invalid webhook payload: ${parsed.error}` }, 400);
+  }
+
+  try {
+    const outcome = await applyGithubWebhookEvent(db, parsed, { deliveryId });
+    await recordOutcomeAudit(db, deliveryId, eventName, outcome);
+    return c.json({ ok: true, ...summarizeOutcome(outcome) });
+  } catch (err) {
+    emitOperationalEvent("error", "github_webhook.apply_failed", {
+      deliveryId,
+      eventName,
+      message: err instanceof Error ? err.message : String(err),
+    });
+    // We failed closed: GitHub will retry, and the audit event above records
+    // what we saw before the failure.
+    return c.json({ error: "failed to apply webhook" }, 500);
+  }
+});
+
+async function recordOutcomeAudit(
+  db: ReturnType<typeof createDb>,
+  deliveryId: string,
+  eventName: string,
+  outcome: WebhookOutcome,
+): Promise<void> {
+  if (outcome.kind === "gate_pending") {
+    await recordScanEvent(db, {
+      organizationId: outcome.gate.organizationId,
+      type: "github_workflow_gate.requested",
+      metadata: {
+        deliveryId,
+        eventName,
+        gateId: outcome.gate.id,
+        repositoryFullName: outcome.gate.repositoryFullName,
+        environment: outcome.gate.environment,
+        runId: outcome.gate.runId,
+        created: outcome.created,
+      },
+    });
+  }
+}
+
+function summarizeOutcome(outcome: WebhookOutcome) {
+  if (outcome.kind === "gate_pending") {
+    return {
+      result: "gate_pending",
+      gateId: outcome.gate.id,
+      created: outcome.created,
+    };
+  }
+  if (outcome.kind === "installation_updated") {
+    return { result: "installation_updated", action: outcome.action };
+  }
+  return { result: "ignored", reason: outcome.reason };
+}

--- a/server/routes/github-webhooks.ts
+++ b/server/routes/github-webhooks.ts
@@ -50,18 +50,36 @@ githubWebhookRoutes.post("/github", async (c) => {
     return c.json({ error: "missing github webhook headers" }, 400);
   }
 
-  const buffer = await c.req.raw.arrayBuffer();
-  if (buffer.byteLength === 0) {
-    emitOperationalEvent("warn", "github_webhook.empty_body", { deliveryId, eventName });
-    return c.json({ error: "empty webhook body" }, 400);
+  const declaredBodyBytes = parseContentLength(c.req.header("content-length"));
+  if (declaredBodyBytes === "invalid") {
+    emitOperationalEvent("warn", "github_webhook.invalid_content_length", {
+      deliveryId,
+      eventName,
+    });
+    return c.json({ error: "invalid content-length" }, 400);
   }
-  if (buffer.byteLength > MAX_WEBHOOK_BODY_BYTES) {
+  if (declaredBodyBytes !== null && declaredBodyBytes > MAX_WEBHOOK_BODY_BYTES) {
     emitOperationalEvent("warn", "github_webhook.body_too_large", {
       deliveryId,
       eventName,
-      bytes: buffer.byteLength,
+      bytes: declaredBodyBytes,
     });
     return c.json({ error: "webhook body too large" }, 413);
+  }
+
+  const body = await readLimitedWebhookBody(c.req.raw, MAX_WEBHOOK_BODY_BYTES);
+  if (body.tooLarge) {
+    emitOperationalEvent("warn", "github_webhook.body_too_large", {
+      deliveryId,
+      eventName,
+      bytes: body.bytes,
+    });
+    return c.json({ error: "webhook body too large" }, 413);
+  }
+  const buffer = body.buffer;
+  if (buffer.byteLength === 0) {
+    emitOperationalEvent("warn", "github_webhook.empty_body", { deliveryId, eventName });
+    return c.json({ error: "empty webhook body" }, 400);
   }
   const rawBody = new TextDecoder().decode(buffer);
 
@@ -168,4 +186,46 @@ function summarizeOutcome(outcome: WebhookOutcome) {
     return { result: "installation_updated", action: outcome.action };
   }
   return { result: "ignored", reason: outcome.reason };
+}
+
+function parseContentLength(value: string | null | undefined): number | "invalid" | null {
+  if (value == null) return null;
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return "invalid";
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(parsed) ? parsed : "invalid";
+}
+
+async function readLimitedWebhookBody(
+  request: Request,
+  maxBytes: number,
+): Promise<{ buffer: Uint8Array; bytes: number; tooLarge: boolean }> {
+  if (!request.body) return { buffer: new Uint8Array(), bytes: 0, tooLarge: false };
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        return { buffer: new Uint8Array(), bytes: total, tooLarge: true };
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const buffer = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    buffer.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return { buffer, bytes: total, tooLarge: false };
 }

--- a/test/github-app-webhook.test.mjs
+++ b/test/github-app-webhook.test.mjs
@@ -1,0 +1,188 @@
+import { describe, expect, test } from "vitest";
+import {
+  parseGithubWebhookEvent,
+  verifyGithubWebhookSignature,
+} from "../server/lib/github-app-webhook.ts";
+
+const WEBHOOK_SECRET = "webhook-secret-value-1234567890";
+
+async function signBody(body) {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(WEBHOOK_SECRET),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = new Uint8Array(
+    await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body)),
+  );
+  return "sha256=" + [...signature].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function buildRequestedPayload(overrides = {}) {
+  return {
+    action: "requested",
+    environment: "pypi",
+    deployment_callback_url:
+      "https://api.github.com/repos/octo/example/actions/runs/77/deployment_protection_rule",
+    deployment: { id: 9009 },
+    installation: { id: 555 },
+    repository: { id: 9001, full_name: "octo/example" },
+    ...overrides,
+  };
+}
+
+describe("verifyGithubWebhookSignature", () => {
+  test("accepts a signature produced with the matching secret", async () => {
+    const body = JSON.stringify({ hello: "world" });
+    const signature = await signBody(body);
+    expect(await verifyGithubWebhookSignature(WEBHOOK_SECRET, signature, body)).toBe(true);
+  });
+
+  test("rejects a missing or unexpectedly-formatted signature header", async () => {
+    const body = JSON.stringify({ hello: "world" });
+    expect(await verifyGithubWebhookSignature(WEBHOOK_SECRET, null, body)).toBe(false);
+    expect(await verifyGithubWebhookSignature(WEBHOOK_SECRET, "", body)).toBe(false);
+    expect(await verifyGithubWebhookSignature(WEBHOOK_SECRET, "sha1=abc", body)).toBe(false);
+    expect(await verifyGithubWebhookSignature(WEBHOOK_SECRET, "sha256=zz", body)).toBe(false);
+  });
+
+  test("rejects a signature signed with a different secret", async () => {
+    const body = JSON.stringify({ hello: "world" });
+    const otherSecret = "another-secret-value-1234567890";
+    const key = await crypto.subtle.importKey(
+      "raw",
+      new TextEncoder().encode(otherSecret),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["sign"],
+    );
+    const signature = new Uint8Array(
+      await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body)),
+    );
+    const header =
+      "sha256=" + [...signature].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+    expect(await verifyGithubWebhookSignature(WEBHOOK_SECRET, header, body)).toBe(false);
+  });
+
+  test("rejects a signature whose body has been tampered with", async () => {
+    const body = JSON.stringify({ hello: "world" });
+    const signature = await signBody(body);
+    expect(await verifyGithubWebhookSignature(WEBHOOK_SECRET, signature, body + " ")).toBe(false);
+  });
+});
+
+describe("parseGithubWebhookEvent (deployment_protection_rule)", () => {
+  test("parses a well-formed requested payload", () => {
+    const parsed = parseGithubWebhookEvent(
+      "deployment_protection_rule",
+      JSON.stringify(buildRequestedPayload()),
+    );
+    expect(parsed).toEqual({
+      kind: "deployment_protection_rule",
+      action: "requested",
+      installationId: "555",
+      repositoryId: 9001,
+      repositoryFullName: "octo/example",
+      environment: "pypi",
+      runId: 77,
+      deploymentId: 9009,
+      deploymentCallbackUrl:
+        "https://api.github.com/repos/octo/example/actions/runs/77/deployment_protection_rule",
+    });
+  });
+
+  test("returns unsupported_action for actions other than requested", () => {
+    const parsed = parseGithubWebhookEvent(
+      "deployment_protection_rule",
+      JSON.stringify(buildRequestedPayload({ action: "completed" })),
+    );
+    expect(parsed).toEqual({ error: "unsupported_action" });
+  });
+
+  test("rejects callback URLs that point outside api.github.com", () => {
+    const parsed = parseGithubWebhookEvent(
+      "deployment_protection_rule",
+      JSON.stringify(
+        buildRequestedPayload({
+          deployment_callback_url:
+            "https://evil.example.com/repos/octo/example/actions/runs/77/deployment_protection_rule",
+        }),
+      ),
+    );
+    expect(parsed).toEqual({ error: "invalid_callback_url" });
+  });
+
+  test("rejects callback URLs that do not follow the deployment-protection path", () => {
+    const parsed = parseGithubWebhookEvent(
+      "deployment_protection_rule",
+      JSON.stringify(
+        buildRequestedPayload({
+          deployment_callback_url: "https://api.github.com/repos/octo/example/issues/1",
+        }),
+      ),
+    );
+    expect(parsed).toEqual({ error: "invalid_callback_url" });
+  });
+
+  test("requires installation, repository, environment, and callback url", () => {
+    const cases = [
+      { override: { installation: null }, error: "missing_installation" },
+      { override: { repository: null }, error: "missing_repository" },
+      { override: { environment: "" }, error: "missing_environment" },
+      { override: { deployment_callback_url: "" }, error: "missing_callback_url" },
+    ];
+    for (const { override, error } of cases) {
+      const parsed = parseGithubWebhookEvent(
+        "deployment_protection_rule",
+        JSON.stringify(buildRequestedPayload(override)),
+      );
+      expect(parsed).toEqual({ error });
+    }
+  });
+
+  test("returns invalid_json for unparseable bodies", () => {
+    const parsed = parseGithubWebhookEvent("deployment_protection_rule", "not json");
+    expect(parsed).toEqual({ error: "invalid_json" });
+  });
+});
+
+describe("parseGithubWebhookEvent (installation)", () => {
+  test("parses suspend, unsuspend, and deleted actions", () => {
+    for (const action of ["suspend", "unsuspend", "deleted"]) {
+      const parsed = parseGithubWebhookEvent(
+        "installation",
+        JSON.stringify({ action, installation: { id: 555 } }),
+      );
+      expect(parsed).toEqual({
+        kind: "installation",
+        action,
+        installationId: "555",
+      });
+    }
+  });
+
+  test("rejects unknown installation actions", () => {
+    const parsed = parseGithubWebhookEvent(
+      "installation",
+      JSON.stringify({ action: "created", installation: { id: 555 } }),
+    );
+    expect(parsed).toEqual({ error: "unsupported_action" });
+  });
+
+  test("requires installation id", () => {
+    const parsed = parseGithubWebhookEvent(
+      "installation",
+      JSON.stringify({ action: "suspend", installation: {} }),
+    );
+    expect(parsed).toEqual({ error: "missing_installation" });
+  });
+});
+
+describe("parseGithubWebhookEvent (other events)", () => {
+  test("returns unsupported_event for events outside our handler set", () => {
+    const parsed = parseGithubWebhookEvent("push", JSON.stringify({ ref: "main" }));
+    expect(parsed).toEqual({ error: "unsupported_event" });
+  });
+});

--- a/test/workers/github-webhook.test.ts
+++ b/test/workers/github-webhook.test.ts
@@ -93,6 +93,7 @@ interface SendArgs {
   body: unknown;
   deliveryId?: string;
   signOverride?: string | null;
+  headers?: Record<string, string>;
 }
 
 async function sendWebhook(args: SendArgs) {
@@ -107,6 +108,7 @@ async function sendWebhook(args: SendArgs) {
     "content-type": "application/json",
     "x-github-event": args.eventName,
     "x-github-delivery": deliveryId,
+    ...args.headers,
   };
   if (signature) headers["x-hub-signature-256"] = signature;
 
@@ -268,6 +270,23 @@ describe("POST /webhooks/github", () => {
     );
     await waitOnExecutionContext(ctx);
     expect(res.status).toBe(400);
+  });
+
+  test("returns 413 before reading when content-length exceeds the webhook cap", async () => {
+    const { res } = await sendWebhook({
+      eventName: "deployment_protection_rule",
+      body: { action: "requested" },
+      headers: { "content-length": String(1024 * 1024 + 1) },
+    });
+    expect(res.status).toBe(413);
+  });
+
+  test("returns 413 when a streamed body crosses the webhook cap", async () => {
+    const { res } = await sendWebhook({
+      eventName: "deployment_protection_rule",
+      body: { action: "requested", padding: "x".repeat(1024 * 1024) },
+    });
+    expect(res.status).toBe(413);
   });
 
   test("returns 503 when GitHub App is not configured", async () => {

--- a/test/workers/github-webhook.test.ts
+++ b/test/workers/github-webhook.test.ts
@@ -1,0 +1,529 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { createDb, ensurePersonalOrganization } from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { eq } from "drizzle-orm";
+import { createReleaseTarget, upsertInstallation } from "../../server/lib/github-app";
+import {
+  getGateByDeliveryId,
+  getGateForOrganization,
+  markGateDecided,
+  markGateErrored,
+} from "../../server/lib/github-app-webhook";
+import { githubWebhookRoutes } from "../../server/routes/github-webhooks";
+import type { Bindings, Variables } from "../../server/types";
+
+const WEBHOOK_SECRET = "webhook-secret-value-1234567890";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+async function seedUser() {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+async function seedMappedRepository(opts: {
+  installationExternalId: string;
+  repositoryId: number;
+  environment?: string;
+  packageName?: string;
+}) {
+  const { organizationId } = await seedUser();
+  const db = createDb(env.DB);
+  const installation = await upsertInstallation(db, {
+    organizationId,
+    installationId: opts.installationExternalId,
+    accountLogin: "octo",
+    accountType: "Organization",
+    targetType: "Organization",
+    status: "active",
+    createdByUserId: null,
+  });
+  const releaseTarget = await createReleaseTarget(db, {
+    organizationId,
+    installationRowId: installation.id,
+    ecosystem: "pypi",
+    packageName: opts.packageName ?? "example",
+    repositoryId: opts.repositoryId,
+    repositoryFullName: "octo/example",
+    workflowFilename: null,
+    environment: opts.environment ?? "pypi",
+    pypiTrustedPublisherEnvironment: opts.environment ?? "pypi",
+    createdByUserId: null,
+  });
+  return { organizationId, installation, releaseTarget };
+}
+
+function buildApp() {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.route("/webhooks", githubWebhookRoutes);
+  return app;
+}
+
+async function hmacHex(secret: string, body: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const sig = new Uint8Array(await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(body)));
+  return [...sig].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+interface SendArgs {
+  eventName: string;
+  body: unknown;
+  deliveryId?: string;
+  signOverride?: string | null;
+}
+
+async function sendWebhook(args: SendArgs) {
+  const rawBody = typeof args.body === "string" ? args.body : JSON.stringify(args.body);
+  const deliveryId = args.deliveryId ?? crypto.randomUUID();
+  const signature =
+    args.signOverride !== undefined
+      ? args.signOverride
+      : `sha256=${await hmacHex(WEBHOOK_SECRET, rawBody)}`;
+
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "x-github-event": args.eventName,
+    "x-github-delivery": deliveryId,
+  };
+  if (signature) headers["x-hub-signature-256"] = signature;
+
+  const ctx = createExecutionContext();
+  const routeEnv: Bindings = {
+    ...env,
+    GITHUB_APP_ID: "12345",
+    GITHUB_APP_SLUG: "drydock-test",
+    GITHUB_APP_CLIENT_ID: "client-id",
+    GITHUB_APP_CLIENT_SECRET: "client-secret",
+    GITHUB_APP_PRIVATE_KEY: "----- placeholder -----",
+    GITHUB_APP_WEBHOOK_SECRET: WEBHOOK_SECRET,
+    GITHUB_APP_STATE_SECRET: "0123456789abcdef0123456789abcdef",
+    BETTER_AUTH_SECRET: "fallback-secret-with-enough-entropy-aaaaaaaa",
+  };
+  const app = buildApp();
+  const res = await app.fetch(
+    new Request("http://test.local/webhooks/github", {
+      method: "POST",
+      headers,
+      body: rawBody,
+    }),
+    routeEnv,
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return { res, deliveryId };
+}
+
+function buildRequestedPayload(opts: {
+  installationId: string;
+  repositoryId: number;
+  environment?: string;
+  runId?: number;
+}) {
+  const runId = opts.runId ?? 77;
+  return {
+    action: "requested",
+    environment: opts.environment ?? "pypi",
+    deployment_callback_url: `https://api.github.com/repos/octo/example/actions/runs/${runId}/deployment_protection_rule`,
+    deployment: { id: 909 },
+    installation: { id: Number(opts.installationId) },
+    repository: { id: opts.repositoryId, full_name: "octo/example" },
+  };
+}
+
+describe("POST /webhooks/github", () => {
+  test("creates a pending gate when the mapping resolves", async () => {
+    const { organizationId, installation, releaseTarget } = await seedMappedRepository({
+      installationExternalId: "1010",
+      repositoryId: 4242,
+    });
+    const payload = buildRequestedPayload({
+      installationId: "1010",
+      repositoryId: 4242,
+    });
+
+    const { res, deliveryId } = await sendWebhook({
+      eventName: "deployment_protection_rule",
+      body: payload,
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { result: string; gateId: string; created: boolean };
+    expect(body.result).toBe("gate_pending");
+    expect(body.created).toBe(true);
+
+    const gate = await getGateByDeliveryId(createDb(env.DB), deliveryId);
+    expect(gate).not.toBeNull();
+    expect(gate?.organizationId).toBe(organizationId);
+    expect(gate?.installationRowId).toBe(installation.id);
+    expect(gate?.releaseTargetId).toBe(releaseTarget.id);
+    expect(gate?.runId).toBe(77);
+    expect(gate?.status).toBe("pending");
+    expect(gate?.deploymentCallbackUrl).toBe(payload.deployment_callback_url);
+
+    const events = await createDb(env.DB)
+      .select()
+      .from(schema.scanEvents)
+      .where(eq(schema.scanEvents.organizationId, organizationId));
+    expect(events.some((event) => event.type === "github_workflow_gate.requested")).toBe(true);
+  });
+
+  test("is idempotent for the same X-GitHub-Delivery id", async () => {
+    await seedMappedRepository({ installationExternalId: "2020", repositoryId: 5151 });
+    const payload = buildRequestedPayload({
+      installationId: "2020",
+      repositoryId: 5151,
+    });
+    const deliveryId = crypto.randomUUID();
+    const first = await sendWebhook({
+      eventName: "deployment_protection_rule",
+      body: payload,
+      deliveryId,
+    });
+    const second = await sendWebhook({
+      eventName: "deployment_protection_rule",
+      body: payload,
+      deliveryId,
+    });
+    expect(first.res.status).toBe(200);
+    expect(second.res.status).toBe(200);
+    const firstBody = (await first.res.json()) as { created: boolean };
+    const secondBody = (await second.res.json()) as { created: boolean };
+    expect(firstBody.created).toBe(true);
+    expect(secondBody.created).toBe(false);
+  });
+
+  test("returns 401 when the signature does not match the body", async () => {
+    const { res } = await sendWebhook({
+      eventName: "deployment_protection_rule",
+      body: { action: "requested" },
+      signOverride: "sha256=00",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("returns 401 when the signature header is missing", async () => {
+    const { res } = await sendWebhook({
+      eventName: "deployment_protection_rule",
+      body: { action: "requested" },
+      signOverride: null,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("returns 400 for malformed deployment_protection_rule payloads", async () => {
+    const { res } = await sendWebhook({
+      eventName: "deployment_protection_rule",
+      body: { action: "requested", environment: "pypi" },
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toMatch(/invalid webhook payload/);
+  });
+
+  test("returns 400 when required headers are missing", async () => {
+    const ctx = createExecutionContext();
+    const app = buildApp();
+    const routeEnv: Bindings = {
+      ...env,
+      GITHUB_APP_ID: "12345",
+      GITHUB_APP_SLUG: "drydock-test",
+      GITHUB_APP_CLIENT_ID: "client-id",
+      GITHUB_APP_CLIENT_SECRET: "client-secret",
+      GITHUB_APP_PRIVATE_KEY: "----- placeholder -----",
+      GITHUB_APP_WEBHOOK_SECRET: WEBHOOK_SECRET,
+      GITHUB_APP_STATE_SECRET: "0123456789abcdef0123456789abcdef",
+      BETTER_AUTH_SECRET: "fallback-secret-with-enough-entropy-aaaaaaaa",
+    };
+    const res = await app.fetch(
+      new Request("http://test.local/webhooks/github", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      }),
+      routeEnv,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(400);
+  });
+
+  test("returns 503 when GitHub App is not configured", async () => {
+    const ctx = createExecutionContext();
+    const app = buildApp();
+    const res = await app.fetch(
+      new Request("http://test.local/webhooks/github", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-github-event": "deployment_protection_rule",
+          "x-github-delivery": "abc",
+          "x-hub-signature-256": "sha256=00",
+        },
+        body: "{}",
+      }),
+      env,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(503);
+  });
+
+  test("acks unsupported events without touching the database", async () => {
+    const { res } = await sendWebhook({
+      eventName: "push",
+      body: { ref: "main" },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ignored: string };
+    expect(body.ignored).toBe("unsupported_event");
+  });
+
+  test("returns 'ignored' when the installation/environment is not mapped", async () => {
+    const payload = buildRequestedPayload({
+      installationId: "404404",
+      repositoryId: 6262,
+    });
+    const { res } = await sendWebhook({
+      eventName: "deployment_protection_rule",
+      body: payload,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { result: string };
+    expect(body.result).toBe("ignored");
+  });
+
+  test("installation suspend events move the installation into suspended state", async () => {
+    const { organizationId } = await seedMappedRepository({
+      installationExternalId: "3030",
+      repositoryId: 7070,
+    });
+    const { res } = await sendWebhook({
+      eventName: "installation",
+      body: { action: "suspend", installation: { id: 3030 } },
+    });
+    expect(res.status).toBe(200);
+    const [row] = await createDb(env.DB)
+      .select()
+      .from(schema.githubAppInstallations)
+      .where(eq(schema.githubAppInstallations.installationId, "3030"));
+    expect(row?.status).toBe("suspended");
+    // status change is reflected in the org's installations
+    expect(row?.organizationId).toBe(organizationId);
+  });
+});
+
+describe("markGateDecided", () => {
+  test("transitions a pending gate exactly once", async () => {
+    const { releaseTarget, installation, organizationId } = await seedMappedRepository({
+      installationExternalId: "5050",
+      repositoryId: 8080,
+      packageName: "decide-once",
+    });
+    const payload = buildRequestedPayload({
+      installationId: "5050",
+      repositoryId: 8080,
+    });
+    const { deliveryId } = await sendWebhook({
+      eventName: "deployment_protection_rule",
+      body: payload,
+    });
+    const db = createDb(env.DB);
+    const gate = await getGateByDeliveryId(db, deliveryId);
+    expect(gate).not.toBeNull();
+
+    const first = await markGateDecided(db, {
+      gateId: gate!.id,
+      decision: "approved",
+      comment: "Drydock review passed (release-target=" + releaseTarget.id + ")",
+      reportUrl: "https://drydock.local/scans/abc",
+    });
+    expect(first?.status).toBe("approved");
+    expect(first?.decision).toBe("approved");
+    expect(first?.decisionComment).toMatch(/Drydock/);
+    expect(first?.reportUrl).toBe("https://drydock.local/scans/abc");
+
+    const second = await markGateDecided(db, {
+      gateId: gate!.id,
+      decision: "rejected",
+      comment: "should not overwrite",
+    });
+    expect(second).toBeNull();
+
+    const fetched = await getGateForOrganization(db, organizationId, gate!.id);
+    expect(fetched?.status).toBe("approved");
+    expect(fetched?.installationRowId).toBe(installation.id);
+  });
+
+  test("markGateErrored records the failure reason without consuming the gate", async () => {
+    await seedMappedRepository({
+      installationExternalId: "5151",
+      repositoryId: 8181,
+      packageName: "errored",
+    });
+    const payload = buildRequestedPayload({
+      installationId: "5151",
+      repositoryId: 8181,
+    });
+    const { deliveryId } = await sendWebhook({
+      eventName: "deployment_protection_rule",
+      body: payload,
+    });
+    const db = createDb(env.DB);
+    const gate = await getGateByDeliveryId(db, deliveryId);
+    expect(gate).not.toBeNull();
+
+    const reason = "x".repeat(800);
+    const updated = await markGateErrored(db, gate!.id, reason);
+    expect(updated?.status).toBe("pending");
+    expect(updated?.failureReason?.length).toBe(500);
+
+    const decided = await markGateDecided(db, {
+      gateId: gate!.id,
+      decision: "rejected",
+      comment: "Drydock review failed",
+    });
+    expect(decided?.status).toBe("rejected");
+    expect(decided?.failureReason?.length).toBe(500);
+  });
+
+  test("markGateErrored does not overwrite a decided gate", async () => {
+    await seedMappedRepository({
+      installationExternalId: "5252",
+      repositoryId: 8282,
+      packageName: "late-error",
+    });
+    const payload = buildRequestedPayload({
+      installationId: "5252",
+      repositoryId: 8282,
+    });
+    const { deliveryId } = await sendWebhook({
+      eventName: "deployment_protection_rule",
+      body: payload,
+    });
+    const db = createDb(env.DB);
+    const gate = await getGateByDeliveryId(db, deliveryId);
+    expect(gate).not.toBeNull();
+
+    const decided = await markGateDecided(db, {
+      gateId: gate!.id,
+      decision: "approved",
+      comment: "Drydock review passed",
+    });
+    expect(decided?.status).toBe("approved");
+
+    const errored = await markGateErrored(db, gate!.id, "late failure");
+    expect(errored).toBeNull();
+
+    const fetched = await getGateByDeliveryId(db, deliveryId);
+    expect(fetched?.status).toBe("approved");
+    expect(fetched?.failureReason).toBeNull();
+  });
+});
+
+describe("postDeploymentProtectionDecision integration via mock fetch", () => {
+  test("rejects when the stored callback URL is no longer github-controlled", async () => {
+    const { postDeploymentProtectionDecision } =
+      await import("../../server/lib/github-app-webhook");
+    const { readGithubAppConfig } = await import("../../server/lib/github-app");
+    const config = readGithubAppConfig({
+      GITHUB_APP_ID: "12345",
+      GITHUB_APP_SLUG: "drydock-test",
+      GITHUB_APP_CLIENT_ID: "client-id",
+      GITHUB_APP_CLIENT_SECRET: "client-secret",
+      GITHUB_APP_PRIVATE_KEY: "----- placeholder -----",
+      GITHUB_APP_WEBHOOK_SECRET: WEBHOOK_SECRET,
+      GITHUB_APP_STATE_SECRET: "0123456789abcdef0123456789abcdef",
+      BETTER_AUTH_SECRET: "fallback-secret-with-enough-entropy-aaaaaaaa",
+    });
+    await expect(
+      postDeploymentProtectionDecision({
+        config,
+        installationExternalId: "1010",
+        callbackUrl:
+          "https://evil.example.com/repos/octo/example/actions/runs/77/deployment_protection_rule",
+        environment: "pypi",
+        state: "approved",
+        comment: "noop",
+      }),
+    ).rejects.toThrow(/non-GitHub callback/);
+  });
+
+  test("posts to the callback URL with installation token + structured body", async () => {
+    const { postDeploymentProtectionDecision } =
+      await import("../../server/lib/github-app-webhook");
+    const tokenFetch = vi.fn(async () =>
+      Response.json({ token: "ghs_install_token", expires_at: "2099-01-01T00:00:00Z" }),
+    );
+    const callbackFetch = vi.fn(async () => new Response(null, { status: 204 }));
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes("/access_tokens")) return tokenFetch(input, init);
+      return callbackFetch(input, init);
+    }) as unknown as typeof fetch;
+
+    const { generateKeyPairSync } = await import("node:crypto");
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+    const privateKeyPem = privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+
+    const { readGithubAppConfig } = await import("../../server/lib/github-app");
+    const config = readGithubAppConfig({
+      GITHUB_APP_ID: "12345",
+      GITHUB_APP_SLUG: "drydock-test",
+      GITHUB_APP_CLIENT_ID: "client-id",
+      GITHUB_APP_CLIENT_SECRET: "client-secret",
+      GITHUB_APP_PRIVATE_KEY: privateKeyPem,
+      GITHUB_APP_WEBHOOK_SECRET: WEBHOOK_SECRET,
+      GITHUB_APP_STATE_SECRET: "0123456789abcdef0123456789abcdef",
+      BETTER_AUTH_SECRET: "fallback-secret-with-enough-entropy-aaaaaaaa",
+    });
+
+    await postDeploymentProtectionDecision({
+      config,
+      installationExternalId: "1010",
+      callbackUrl:
+        "https://api.github.com/repos/octo/example/actions/runs/77/deployment_protection_rule",
+      environment: "pypi",
+      state: "approved",
+      comment: "Drydock review passed",
+    });
+
+    expect(callbackFetch).toHaveBeenCalledOnce();
+    const [callbackUrl, callbackInit] = callbackFetch.mock.calls[0];
+    expect(callbackUrl).toBe(
+      "https://api.github.com/repos/octo/example/actions/runs/77/deployment_protection_rule",
+    );
+    expect(callbackInit?.method).toBe("POST");
+    expect((callbackInit?.headers as Record<string, string>)?.Authorization).toBe(
+      "Bearer ghs_install_token",
+    );
+    const body = JSON.parse(callbackInit?.body as string);
+    expect(body).toEqual({
+      state: "approved",
+      environment_name: "pypi",
+      comment: "Drydock review passed",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #115. Adds the `POST /webhooks/github` endpoint that GitHub deployment-protection deliveries land on, plus the persistence and decision-callback primitives the PyPI candidate review will use to release or block the publish job.

- `server/lib/github-app-webhook.ts` — constant-time HMAC-SHA256 signature verification, typed payload parser for `deployment_protection_rule.requested` and `installation.{suspend,unsuspend,deleted}`, callback-URL pinning to `https://api.github.com/repos/<owner>/<repo>/actions/runs/<run_id>/deployment_protection_rule`, gate persistence helpers (`recordGateRequest`, `markGateDecided` CAS, `markGateErrored`, `attachScanToGate`), and `postDeploymentProtectionDecision` that swaps the App JWT for an installation token and POSTs `{ state, environment_name, comment }`.
- `server/routes/github-webhooks.ts` + `server/index.ts` — public POST route mounted before Better Auth; fails closed on missing/invalid signature, missing headers, oversize bodies, unconfigured app, or malformed payload; emits `github_workflow_gate.requested` audit events.
- New `github_workflow_gates` table (drizzle migration `0011`) keyed on `delivery_id` so GitHub retries are idempotent.
- Tests: pure-logic suite for signature/parse + worker-runtime suite for the full route, gate persistence, idempotency, callback-host enforcement, and decision-callback shape.
- Docs: `docs/pypi-workflow-gate.md` gains the webhook + decision sections, roadmap marks the webhook task done, AGENTS layout updated.

Trust boundary is preserved: no PyPI credentials or OIDC tokens touch Drydock; the App webhook secret is the only auth surface; the callback URL is re-validated before posting so a spoofed payload can't redirect the approval; `markGateDecided` is a status-CAS so the gate is decided at most once.

## Test plan

- [x] `pnpm exec oxlint server src test`
- [x] `pnpm exec oxfmt --check`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` (225 node tests + 96 worker tests, all green)
- [ ] End-to-end against a real GitHub App once provisioned: deliver a `deployment_protection_rule` event, observe a pending gate row, call `markGateDecided` + `postDeploymentProtectionDecision`, confirm the Actions run unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)