### PR TITLE
[codex] Add GitHub App settings flow

### DIFF
--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -184,10 +184,45 @@ The private key may be GitHub's downloaded PKCS#1 PEM or a converted PKCS#8 PEM.
 `GITHUB_APP_STATE_SECRET` is optional and falls back to `BETTER_AUTH_SECRET` for
 HMAC-signing the OAuth state.
 
+### GitHub App setup URL
+
+The "Setup URL" configured on the GitHub App (under "Identifying and authorizing
+users") must point at the Drydock callback page:
+
+```
+https://<your-drydock-host>/dashboard/settings/github-app/callback
+```
+
+The setup URL must be marked **active** and "Request user authorization (OAuth)
+during installation" must be checked so GitHub appends `code`, `installation_id`,
+`setup_action`, and `state` to the redirect. The callback page reads those four
+parameters and POSTs them to `/api/v1/github-app/install/callback`.
+
+### Front-end
+
+The install flow lives on `/dashboard/settings` (gated behind
+`import.meta.env.DEV` until the workflow-gate path is ready for users):
+
+1. The page calls `GET /api/v1/github-app/config`; when `configured === false`
+   it renders a "not configured yet — ask the operator" notice instead of the
+   install button.
+2. The "Install GitHub App" button calls `POST /api/v1/github-app/install` and
+   navigates to the returned `installUrl`.
+3. After install, GitHub redirects back to
+   `/dashboard/settings/github-app/callback`, which POSTs `state`, `code`,
+   `installationId`, and `setupAction` to
+   `POST /api/v1/github-app/install/callback`. Success refreshes the
+   installation list; typed validation codes
+   (`installation_missing`, `installation_inactive`, `installation_not_active`,
+   etc.) are surfaced inline.
+   If the Drydock session expired while the user was on GitHub, the callback
+   sends them through `/login?returnTo=...`; login only honors same-origin
+   `/dashboard...` return paths before resuming the callback.
+4. Linked installations render with `active` / `suspended` / `uninstalled`
+   status badges.
+
 ## Remaining work
 
-- Add the front-end OAuth flow (install button + callback page) that consumes
-  the existing `/install` and `/install/callback` routes.
 - Replace the free-text `repositoryFullName` field with a dropdown of repos the
   installation can see (`GET /installation/repositories`).
 - Handle `deployment_protection_rule` webhooks (uses `resolveDeploymentProtectionTarget`).

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,8 @@ const LoginPage = lazy(() => import("./pages/Auth/Login"));
 const RegisterPage = lazy(() => import("./pages/Auth/Register"));
 const DashboardPage = lazy(() => import("./pages/Dashboard"));
 const ScanDetailPage = lazy(() => import("./pages/Dashboard/ScanDetail"));
+const SettingsPage = lazy(() => import("./pages/Dashboard/Settings"));
+const GithubAppCallbackPage = lazy(() => import("./pages/Dashboard/GithubAppCallback"));
 const NotFoundPage = lazy(() => import("./pages/NotFound"));
 
 export function App() {
@@ -19,6 +21,8 @@ export function App() {
           <Route path="/register" component={RegisterPage} />
           <Route path="/dashboard" component={DashboardPage} />
           <Route path="/dashboard/scans/:id" component={ScanDetailPage} />
+          <Route path="/dashboard/settings" component={SettingsPage} />
+          <Route path="/dashboard/settings/github-app/callback" component={GithubAppCallbackPage} />
           <Route default component={NotFoundPage} />
         </Router>
       </ErrorBoundary>

--- a/src/lib/auth-return.ts
+++ b/src/lib/auth-return.ts
@@ -1,0 +1,14 @@
+const DEFAULT_AUTH_RETURN_TO = "/dashboard";
+
+export function normalizeAuthReturnTo(value: unknown, origin?: string): string {
+  if (typeof value !== "string" || !value.trim()) return DEFAULT_AUTH_RETURN_TO;
+  const baseOrigin = origin ?? window.location.origin;
+  try {
+    const parsed = new URL(value, baseOrigin);
+    if (parsed.origin !== baseOrigin) return DEFAULT_AUTH_RETURN_TO;
+    if (!parsed.pathname.startsWith("/dashboard")) return DEFAULT_AUTH_RETURN_TO;
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+  } catch {
+    return DEFAULT_AUTH_RETURN_TO;
+  }
+}

--- a/src/models/api.ts
+++ b/src/models/api.ts
@@ -5,6 +5,7 @@ export class ApiError extends Error {
     message: string,
     readonly status: number,
     readonly detail?: string,
+    readonly code?: string,
   ) {
     super(message);
     this.name = "ApiError";
@@ -24,13 +25,14 @@ export async function apiFetch<T>(input: RequestInfo | URL, init?: RequestInit):
     headers,
   });
   const data = (await res.json().catch(() => null)) as
-    | (Partial<T> & { error?: string; detail?: string; message?: string })
+    | (Partial<T> & { error?: string; detail?: string; message?: string; code?: string })
     | null;
   if (!res.ok) {
-    if (res.status === 401) throw new ApiError("Please sign in to continue.", 401);
+    const code = typeof data?.code === "string" ? data.code : undefined;
+    if (res.status === 401) throw new ApiError("Please sign in to continue.", 401, undefined, code);
     const detail = typeof data?.detail === "string" ? data.detail : undefined;
     const message = data?.message || data?.error || "request failed";
-    throw new ApiError(detail ? `${message}: ${detail}` : message, res.status, detail);
+    throw new ApiError(detail ? `${message}: ${detail}` : message, res.status, detail, code);
   }
   return data as T;
 }

--- a/src/models/github-app.ts
+++ b/src/models/github-app.ts
@@ -1,0 +1,185 @@
+import { computed, createModel, signal } from "@preact/signals";
+import { ApiError, apiFetch, apiJson, errorMessage } from "./api";
+
+export type InstallationStatus = "active" | "suspended" | "uninstalled";
+
+export interface PublicGithubAppInstallation {
+  id: string;
+  organizationId: string;
+  installationId: string;
+  accountLogin: string;
+  accountType: string;
+  targetType: string;
+  status: InstallationStatus;
+  installedAt: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GithubAppConfigState {
+  configured: boolean;
+  appSlug?: string;
+}
+
+export type GithubAppInstallStatus = "idle" | "starting" | "completing" | "loading";
+
+export type GithubAppCallbackErrorCode =
+  | "github_app_not_configured"
+  | "installation_missing"
+  | "installation_inactive"
+  | "installation_not_authorized"
+  | "invalid_input"
+  | "state_invalid"
+  | "state_org_mismatch"
+  | "state_user_mismatch"
+  | "installation_not_active"
+  | "unknown";
+
+export interface CallbackError {
+  code: GithubAppCallbackErrorCode;
+  message: string;
+}
+
+export interface CallbackQuery {
+  state: string;
+  code: string;
+  installationId: string;
+  setupAction: string;
+}
+
+export const GithubAppModel = createModel(() => {
+  const config = signal<GithubAppConfigState | null>(null);
+  const installations = signal<PublicGithubAppInstallation[]>([]);
+  const status = signal<GithubAppInstallStatus>("idle");
+  const error = signal<string | null>(null);
+  const callbackError = signal<CallbackError | null>(null);
+  const lastLinked = signal<PublicGithubAppInstallation | null>(null);
+  const configLoaded = signal(false);
+  const installationsLoaded = signal(false);
+
+  const busy = computed(() => status.value !== "idle");
+  const notConfigured = computed(() => config.value?.configured === false);
+  const loaded = computed(() => configLoaded.value && installationsLoaded.value);
+
+  return {
+    config,
+    installations,
+    status,
+    error,
+    callbackError,
+    lastLinked,
+    configLoaded,
+    installationsLoaded,
+    busy,
+    notConfigured,
+    loaded,
+
+    async loadConfig(): Promise<void> {
+      try {
+        const data = await apiFetch<GithubAppConfigState>("/api/v1/github-app/config");
+        config.value = data;
+      } catch (err) {
+        error.value = errorMessage(err);
+        config.value = { configured: false };
+      } finally {
+        configLoaded.value = true;
+      }
+    },
+
+    async loadInstallations(): Promise<void> {
+      try {
+        const data = await apiFetch<{ installations: PublicGithubAppInstallation[] }>(
+          "/api/v1/github-app/installations",
+        );
+        installations.value = data.installations;
+      } catch (err) {
+        error.value = errorMessage(err);
+        installations.value = [];
+      } finally {
+        installationsLoaded.value = true;
+      }
+    },
+
+    async startInstall(): Promise<void> {
+      status.value = "starting";
+      error.value = null;
+      try {
+        const data = await apiJson<{
+          installUrl: string;
+          state: string;
+          expiresInSeconds: number;
+        }>("/api/v1/github-app/install", {});
+        window.location.assign(data.installUrl);
+      } catch (err) {
+        if (err instanceof ApiError && err.code === "github_app_not_configured") {
+          config.value = { configured: false };
+          error.value =
+            "GitHub App is not configured yet on this Drydock instance. Ask the operator to add the GitHub App secrets.";
+        } else {
+          error.value = errorMessage(err);
+        }
+        status.value = "idle";
+      }
+    },
+
+    async completeInstall(query: CallbackQuery): Promise<PublicGithubAppInstallation | null> {
+      status.value = "completing";
+      callbackError.value = null;
+      error.value = null;
+      lastLinked.value = null;
+      try {
+        const data = await apiJson<{ installation: PublicGithubAppInstallation }>(
+          "/api/v1/github-app/install/callback",
+          query,
+        );
+        lastLinked.value = data.installation;
+        const existing = installations.peek();
+        installations.value = [
+          data.installation,
+          ...existing.filter((row) => row.id !== data.installation.id),
+        ];
+        return data.installation;
+      } catch (err) {
+        callbackError.value = mapCallbackError(err);
+        return null;
+      } finally {
+        status.value = "idle";
+      }
+    },
+
+    reset() {
+      error.value = null;
+      callbackError.value = null;
+      lastLinked.value = null;
+    },
+  };
+});
+
+function mapCallbackError(err: unknown): CallbackError {
+  if (err instanceof ApiError) {
+    if (err.code === "github_app_not_configured") {
+      return {
+        code: "github_app_not_configured",
+        message:
+          "GitHub App is not configured yet on this Drydock instance. Ask the operator to add the GitHub App secrets.",
+      };
+    }
+    if (err.code) {
+      return { code: err.code as GithubAppCallbackErrorCode, message: err.message };
+    }
+    if (err.status === 400 && /state token/i.test(err.message)) {
+      return { code: "state_invalid", message: err.message };
+    }
+    if (err.status === 403 && /organization/i.test(err.message)) {
+      return { code: "state_org_mismatch", message: err.message };
+    }
+    if (err.status === 403 && /user/i.test(err.message)) {
+      return { code: "state_user_mismatch", message: err.message };
+    }
+    if (err.status === 409) {
+      return { code: "installation_not_active", message: err.message };
+    }
+    return { code: "unknown", message: err.message };
+  }
+  return { code: "unknown", message: errorMessage(err) };
+}

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "preact/hooks";
 import { useSignal } from "@preact/signals";
 import { useLocation } from "preact-iso";
+import { normalizeAuthReturnTo } from "../../lib/auth-return";
 import { sessionModel } from "../../models/auth";
 import { errorMessage } from "../../models/api";
 import { Alert, Button, Card, Eyebrow, Field, Input, PageShell, Muted } from "../../components";
@@ -11,17 +12,18 @@ export default function LoginPage() {
   const password = useSignal("");
   const error = useSignal<string | null>(null);
   const loading = useSignal(false);
+  const returnTo = normalizeAuthReturnTo(location.query.returnTo);
 
   useEffect(() => {
     let cancelled = false;
     void sessionModel.load().then((session) => {
       if (cancelled) return;
-      if (session?.user) location.route("/dashboard", true);
+      if (session?.user) location.route(returnTo, true);
     });
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [returnTo]);
 
   const onSubmit = async (event: Event) => {
     event.preventDefault();
@@ -31,7 +33,7 @@ export default function LoginPage() {
     error.value = null;
     try {
       await sessionModel.signIn(submittedEmail, submittedPassword);
-      location.route("/dashboard", true);
+      location.route(returnTo, true);
     } catch (err) {
       error.value = errorMessage(err);
     } finally {

--- a/src/pages/Dashboard/GithubAppCallback.tsx
+++ b/src/pages/Dashboard/GithubAppCallback.tsx
@@ -1,0 +1,238 @@
+import { useEffect } from "preact/hooks";
+import { useModel, useSignal } from "@preact/signals";
+import { useLocation } from "preact-iso";
+import { sessionModel } from "../../models/auth";
+import { OrganizationModel } from "../../models/organization";
+import {
+  GithubAppModel,
+  type CallbackError,
+  type GithubAppCallbackErrorCode,
+} from "../../models/github-app";
+import {
+  Alert,
+  Card,
+  Eyebrow,
+  LinkButton,
+  LoadingState,
+  MonoDetail,
+  Muted,
+  PageShell,
+  SectionLabel,
+  UserMenu,
+} from "../../components";
+
+const SETTINGS_PATH = "/dashboard/settings";
+const SUCCESS_REDIRECT_MS = 1500;
+const GITHUB_APP_UI_ENABLED = import.meta.env.DEV;
+
+type CallbackPhase = "checking-session" | "verifying" | "success" | "error";
+
+export default function GithubAppCallbackPage() {
+  const location = useLocation();
+  const githubApp = useModel(GithubAppModel);
+  const organizations = useModel(OrganizationModel);
+  const phase = useSignal<CallbackPhase>("checking-session");
+  const queryError = useSignal<string | null>(null);
+
+  useEffect(() => {
+    if (!GITHUB_APP_UI_ENABLED) {
+      location.route(SETTINGS_PATH, true);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      const data = await sessionModel.load();
+      if (cancelled) return;
+      if (!data) {
+        // Preserve return path so the user lands back here after login.
+        const returnTo = `${SETTINGS_PATH}/github-app/callback${window.location.search}`;
+        location.route(`/login?returnTo=${encodeURIComponent(returnTo)}`, true);
+        return;
+      }
+      await organizations.load();
+      if (cancelled) return;
+
+      const parsed = parseCallbackQuery(window.location.search);
+      if (typeof parsed === "string") {
+        queryError.value = parsed;
+        phase.value = "error";
+        return;
+      }
+      phase.value = "verifying";
+      const installation = await githubApp.completeInstall(parsed);
+      if (cancelled) return;
+      if (installation) {
+        phase.value = "success";
+        window.setTimeout(() => {
+          if (cancelled) return;
+          location.route(SETTINGS_PATH, true);
+        }, SUCCESS_REDIRECT_MS);
+      } else {
+        phase.value = "error";
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const user = sessionModel.user.value;
+  const callbackError = githubApp.callbackError.value;
+  const lastLinked = githubApp.lastLinked.value;
+
+  const onSignOut = async () => {
+    await sessionModel.signOut();
+    location.route("/", true);
+  };
+
+  return (
+    <PageShell
+      headerActions={
+        user ? <UserMenu email={user.email} name={user.name} onSignOut={onSignOut} /> : undefined
+      }
+    >
+      <header class="flex flex-col gap-2 max-w-[640px]">
+        <Eyebrow>GitHub App install</Eyebrow>
+        <h1 class="text-3xl font-semibold tracking-[-0.02em] m-0">
+          {phase.value === "success"
+            ? "Installation linked"
+            : phase.value === "error"
+              ? "Installation could not be linked"
+              : "Finishing GitHub App install"}
+        </h1>
+        <Muted class="text-[14px] leading-[1.55] m-0">
+          We're confirming the install with GitHub and storing the installation against your active
+          organization.
+        </Muted>
+      </header>
+
+      {(phase.value === "checking-session" || phase.value === "verifying") && (
+        <LoadingState
+          title={
+            phase.value === "checking-session" ? "Confirming session" : "Verifying with GitHub"
+          }
+          detail={
+            phase.value === "checking-session"
+              ? "loading user"
+              : "exchanging code · linking installation"
+          }
+        />
+      )}
+
+      {phase.value === "success" && lastLinked ? (
+        <Card as="section" class="p-5 flex flex-col gap-4">
+          <SectionLabel>Linked installation</SectionLabel>
+          <div class="flex flex-col gap-2">
+            <span class="font-mono text-[16px] font-medium">{lastLinked.accountLogin}</span>
+            <MonoDetail
+              parts={[
+                <span key="installation">installation {lastLinked.installationId}</span>,
+                <span key="status">{lastLinked.status}</span>,
+                <span key="account">{lastLinked.accountType.toLowerCase()}</span>,
+              ]}
+            />
+          </div>
+          <Muted class="text-[13px] m-0">Returning you to settings…</Muted>
+          <div>
+            <LinkButton variant="secondary" size="sm" href={SETTINGS_PATH}>
+              Back to settings now
+            </LinkButton>
+          </div>
+        </Card>
+      ) : null}
+
+      {phase.value === "error" ? (
+        <Card as="section" class="p-5 flex flex-col gap-4">
+          <SectionLabel>What went wrong</SectionLabel>
+          <CallbackErrorView queryError={queryError.value} callbackError={callbackError} />
+          <div class="flex gap-2 flex-wrap">
+            <LinkButton href={SETTINGS_PATH}>Back to settings</LinkButton>
+            <LinkButton variant="ghost" href="/dashboard">
+              Go to dashboard
+            </LinkButton>
+          </div>
+        </Card>
+      ) : null}
+    </PageShell>
+  );
+}
+
+function CallbackErrorView({
+  queryError,
+  callbackError,
+}: {
+  queryError: string | null;
+  callbackError: CallbackError | null;
+}) {
+  if (queryError) {
+    return (
+      <Alert tone="critical">
+        <div class="flex flex-col gap-1.5">
+          <span>{queryError}</span>
+          <span class="font-mono text-[12px] text-ink-muted">code: invalid_callback_url</span>
+        </div>
+      </Alert>
+    );
+  }
+  if (!callbackError) {
+    return <Alert tone="critical">Installation could not be linked.</Alert>;
+  }
+  const tone = callbackError.code === "github_app_not_configured" ? "warn" : "critical";
+  return (
+    <Alert tone={tone}>
+      <div class="flex flex-col gap-1.5">
+        <span>{describeCallbackError(callbackError.code)}</span>
+        <span class="font-mono text-[12px] text-ink-muted">
+          code: {callbackError.code} · {callbackError.message}
+        </span>
+      </div>
+    </Alert>
+  );
+}
+
+function describeCallbackError(code: GithubAppCallbackErrorCode): string {
+  switch (code) {
+    case "github_app_not_configured":
+      return "GitHub App is not configured yet on this Drydock instance. Ask the operator to add the GitHub App secrets.";
+    case "installation_missing":
+      return "GitHub returned an installation id we couldn't resolve. Try installing again from the settings page.";
+    case "installation_inactive":
+      return "The installation exists but is suspended on GitHub. Re-enable it on GitHub and link it again.";
+    case "installation_not_authorized":
+      return "The signed-in GitHub user does not have access to that installation. Pick an account they own and retry.";
+    case "installation_not_active":
+      return "GitHub reported the installation isn't active yet. Approve the install on GitHub, then try again.";
+    case "invalid_input":
+      return "GitHub redirected back with missing or malformed parameters. Start the install again from settings.";
+    case "state_invalid":
+      return "The install link expired or was tampered with. Start the install again from settings.";
+    case "state_org_mismatch":
+      return "Your active organization changed during the install. Switch back to the original organization and retry.";
+    case "state_user_mismatch":
+      return "The signed-in user doesn't match the user who started the install. Sign in as that user and retry.";
+    case "unknown":
+      return "Something went wrong while linking the installation. Try again or contact the operator.";
+  }
+}
+
+function parseCallbackQuery(
+  search: string,
+): { state: string; code: string; installationId: string; setupAction: string } | string {
+  const params = new URLSearchParams(search);
+  const state = params.get("state")?.trim() ?? "";
+  const code = params.get("code")?.trim() ?? "";
+  const installationId = params.get("installation_id")?.trim() ?? "";
+  const setupAction = params.get("setup_action")?.trim() ?? "install";
+
+  if (!state)
+    return "GitHub did not return an install state token. Restart the install from settings.";
+  if (!installationId)
+    return "GitHub did not return an installation id. Restart the install from settings.";
+  if (!code) {
+    return "GitHub did not return a user authorization code. Make sure the GitHub App has 'Request user authorization (OAuth) during installation' enabled.";
+  }
+  if (setupAction === "request") {
+    return "Your install is pending an organization owner's approval. Once approved, GitHub will redirect you back here automatically.";
+  }
+  return { state, code, installationId, setupAction };
+}

--- a/src/pages/Dashboard/Settings.tsx
+++ b/src/pages/Dashboard/Settings.tsx
@@ -1,0 +1,471 @@
+import { useEffect } from "preact/hooks";
+import { useModel, useSignal } from "@preact/signals";
+import { useLocation } from "preact-iso";
+import { rememberDashboardReturnUrl } from "../../lib/query-state";
+import { sessionModel } from "../../models/auth";
+import { NpmConnectionModel } from "../../models/npm-connection";
+import { OrganizationModel } from "../../models/organization";
+import {
+  GithubAppModel,
+  type InstallationStatus,
+  type PublicGithubAppInstallation,
+} from "../../models/github-app";
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Eyebrow,
+  Field,
+  Input,
+  LinkButton,
+  LoadingState,
+  MonoDetail,
+  Muted,
+  OrgSwitcher,
+  PageShell,
+  SectionLabel,
+  UserMenu,
+  type BadgeTone,
+} from "../../components";
+
+const GITHUB_APP_UI_ENABLED = import.meta.env.DEV;
+
+export default function SettingsPage() {
+  const location = useLocation();
+  const npm = useModel(NpmConnectionModel);
+  const organizations = useModel(OrganizationModel);
+  const githubApp = useModel(GithubAppModel);
+  const sessionChecked = useSignal(false);
+
+  useEffect(() => {
+    rememberDashboardReturnUrl(location.url);
+  }, [location.url]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const data = await sessionModel.load();
+      if (cancelled) return;
+      if (!data) {
+        location.route("/login", true);
+        return;
+      }
+      sessionChecked.value = true;
+      const loaders: Promise<unknown>[] = [organizations.load(), npm.load()];
+      if (GITHUB_APP_UI_ENABLED) {
+        loaders.push(githubApp.loadConfig(), githubApp.loadInstallations());
+      }
+      await Promise.all(loaders);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const reloadActiveOrgScopedData = async () => {
+    const loaders: Promise<unknown>[] = [npm.load()];
+    if (GITHUB_APP_UI_ENABLED) loaders.push(githubApp.loadInstallations());
+    await Promise.all(loaders);
+  };
+
+  const onSwitchOrganization = async (organizationId: string) => {
+    if (organizations.activate(organizationId)) {
+      await reloadActiveOrgScopedData();
+    }
+  };
+
+  const onCreateOrganization = async (name: string) => {
+    const created = await organizations.create(name);
+    if (created) {
+      await reloadActiveOrgScopedData();
+    }
+  };
+
+  const onSignOut = async () => {
+    await sessionModel.signOut();
+    location.route("/", true);
+  };
+
+  if (!sessionChecked.value) {
+    return (
+      <PageShell>
+        <SettingsHeader />
+        <LoadingState title="Opening settings" detail="confirming session" />
+      </PageShell>
+    );
+  }
+
+  const user = sessionModel.user.value;
+  const githubAppLoaded = GITHUB_APP_UI_ENABLED ? githubApp.loaded.value : true;
+  const npmLoaded = npm.loaded.value;
+  const workspaceLoaded = githubAppLoaded && npmLoaded;
+
+  return (
+    <PageShell
+      headerActions={
+        <>
+          <OrgSwitcher
+            organizations={organizations.organizations.value}
+            activeOrganizationId={organizations.activeOrganizationId.value}
+            busy={organizations.busy.value}
+            error={organizations.error.value}
+            onActivate={onSwitchOrganization}
+            onCreate={onCreateOrganization}
+          />
+          <UserMenu email={user?.email} name={user?.name} onSignOut={onSignOut} />
+        </>
+      }
+    >
+      <SettingsHeader />
+
+      {workspaceLoaded ? (
+        <div class="flex flex-col gap-6">
+          {GITHUB_APP_UI_ENABLED ? <GithubAppSection githubApp={githubApp} /> : null}
+          <NpmConnectionSection npm={npm} />
+        </div>
+      ) : (
+        <LoadingState title="Loading settings" detail={loadingDetail(npmLoaded, githubAppLoaded)} />
+      )}
+    </PageShell>
+  );
+}
+
+function loadingDetail(npmLoaded: boolean, githubAppLoaded: boolean): string {
+  const parts: string[] = [];
+  if (!npmLoaded) parts.push("checking npm connection");
+  if (GITHUB_APP_UI_ENABLED && !githubAppLoaded) parts.push("checking GitHub App");
+  return parts.join(" · ");
+}
+
+function SettingsHeader() {
+  return (
+    <header class="flex flex-col gap-2 max-w-[640px]">
+      <Eyebrow>Organization settings</Eyebrow>
+      <h1 class="text-3xl font-semibold tracking-[-0.02em] m-0">Integrations &amp; access</h1>
+      <Muted class="text-[14px] leading-[1.55] m-0">
+        {GITHUB_APP_UI_ENABLED
+          ? "Connect npm so Drydock can fetch staged tarballs, and install the GitHub App so it can gate PyPI workflow releases for this organization."
+          : "Connect npm so Drydock can fetch staged tarballs for this organization."}
+      </Muted>
+    </header>
+  );
+}
+
+function GithubAppSection({
+  githubApp,
+}: {
+  githubApp: ReturnType<typeof useModel<typeof GithubAppModel.prototype>>;
+}) {
+  const configured = githubApp.config.value?.configured === true;
+  const appSlug = githubApp.config.value?.appSlug;
+  const installations = githubApp.installations.value;
+  const status = githubApp.status.value;
+  const error = githubApp.error.value;
+  const lastLinked = githubApp.lastLinked.value;
+  const busy = githubApp.busy.value;
+
+  const onInstall = () => {
+    void githubApp.startInstall();
+  };
+
+  return (
+    <Card as="section" class="p-0 overflow-hidden">
+      <div class="p-5 flex flex-col gap-5">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div class="flex flex-col gap-1.5 max-w-[760px]">
+            <SectionLabel>GitHub App</SectionLabel>
+            <Muted class="text-[13px] m-0">
+              Install the Drydock GitHub App on your organization so PyPI releases gated by a GitHub
+              Actions environment can be approved here. We never ask for PyPI credentials — the
+              workflow keeps its OIDC trust with PyPI and Drydock only acts as the
+              deployment-protection approver.
+            </Muted>
+            <MonoDetail
+              parts={[
+                <span key="ecosystem">pypi workflow gate</span>,
+                <span key="oidc">no pypi credentials</span>,
+                <span key="env">github environment required</span>,
+              ]}
+            />
+          </div>
+          <div class="flex flex-col items-end gap-2 shrink-0">
+            {configured ? (
+              <Badge tone="ok">configured</Badge>
+            ) : (
+              <Badge tone="info">not configured</Badge>
+            )}
+            {configured && appSlug ? (
+              <span class="font-mono text-[11px] text-ink-subtle">{appSlug}</span>
+            ) : null}
+          </div>
+        </div>
+
+        {!configured ? (
+          <Alert tone="warn">
+            GitHub App is not configured yet — ask the operator to add the GitHub App secrets (
+            <code class="font-mono text-[12px]">GITHUB_APP_ID</code>,{" "}
+            <code class="font-mono text-[12px]">GITHUB_APP_SLUG</code>,{" "}
+            <code class="font-mono text-[12px]">GITHUB_APP_PRIVATE_KEY</code>, and the OAuth client
+            + webhook secrets) on the Drydock Worker.
+          </Alert>
+        ) : null}
+
+        {error ? <Alert tone="critical">{error}</Alert> : null}
+
+        {lastLinked ? (
+          <Alert tone="ok">
+            Linked <strong>{lastLinked.accountLogin}</strong> · installation{" "}
+            <code class="font-mono text-[12px]">{lastLinked.installationId}</code>.
+          </Alert>
+        ) : null}
+
+        <div class="flex flex-wrap items-center gap-3">
+          <Button onClick={onInstall} disabled={!configured || busy}>
+            {status === "starting"
+              ? "Redirecting…"
+              : installations.length
+                ? "Install on another organization"
+                : "Install GitHub App"}
+          </Button>
+          <Muted class="text-[12px] m-0">
+            You'll be sent to GitHub to pick which account to install on, then returned here.
+          </Muted>
+        </div>
+      </div>
+
+      <div class="border-t border-border">
+        <div class="px-5 py-4 flex items-center justify-between gap-3">
+          <SectionLabel>Linked installations</SectionLabel>
+          <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
+            {installations.length} linked
+          </span>
+        </div>
+        {installations.length ? (
+          <InstallationList installations={installations} />
+        ) : (
+          <div class="px-5 pb-5">
+            <Muted class="text-[13px] m-0">No installations linked to this organization yet.</Muted>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+function InstallationList({ installations }: { installations: PublicGithubAppInstallation[] }) {
+  return (
+    <ul class="m-0 p-0 list-none border-t border-border">
+      {installations.map((installation) => (
+        <li
+          key={installation.id}
+          class="border-b border-border last:border-b-0 px-5 py-4 flex flex-wrap items-center justify-between gap-3"
+        >
+          <div class="flex flex-col gap-1.5 min-w-0">
+            <div class="flex items-center gap-2 flex-wrap">
+              <span class="font-mono text-[14px] font-medium">{installation.accountLogin}</span>
+              <Badge tone={installationStatusTone(installation.status)}>
+                {installation.status}
+              </Badge>
+              <Badge tone="neutral">{installation.accountType.toLowerCase()}</Badge>
+            </div>
+            <MonoDetail
+              parts={[
+                <span key="installation">installation {installation.installationId}</span>,
+                <span key="target">{installation.targetType.toLowerCase()}</span>,
+                <span key="linked">linked {formatDate(installation.installedAt)}</span>,
+              ]}
+            />
+          </div>
+          {installation.status !== "active" ? (
+            <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
+              {installation.status === "suspended"
+                ? "re-enable on github to use"
+                : "removed on github · re-install to reconnect"}
+            </span>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function installationStatusTone(status: InstallationStatus): BadgeTone {
+  switch (status) {
+    case "active":
+      return "ok";
+    case "suspended":
+      return "medium";
+    case "uninstalled":
+      return "critical";
+  }
+}
+
+function NpmConnectionSection({
+  npm,
+}: {
+  npm: ReturnType<typeof useModel<typeof NpmConnectionModel.prototype>>;
+}) {
+  const connection = npm.connection.value;
+  const status = npm.status.value;
+  const busy = npm.busy.value;
+  const validated = npm.validated.value;
+  const token = npm.token.value;
+  const label = npm.label.value;
+  const registry = npm.registry.value;
+  const validationStageId = npm.validationStageId.value;
+  const error = npm.error.value;
+
+  const onSave = async (event: Event) => {
+    event.preventDefault();
+    await npm.save();
+  };
+
+  return (
+    <Card as="section" class="p-5">
+      <div class="flex flex-col gap-5">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div class="flex flex-col gap-1.5 max-w-[760px]">
+            <SectionLabel>npm access</SectionLabel>
+            <Muted class="text-[13px] m-0">
+              Add an organization npm token so reviews can fetch staged packages securely. We
+              encrypt it, hide it after save, and use it only to retrieve release evidence.
+            </Muted>
+          </div>
+          {connection ? (
+            <Badge
+              tone={
+                validated ? "ok" : connection.validationStatus === "invalid" ? "critical" : "info"
+              }
+            >
+              {connection.validationStatus}
+            </Badge>
+          ) : (
+            <Badge tone="info">not connected</Badge>
+          )}
+        </div>
+
+        {connection ? (
+          <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-x-6 gap-y-2 border-y border-border py-3">
+            <CompactMetadataRow label="label" value={connection.label} />
+            <CompactMetadataRow label="registry" value={connection.registryUrl} />
+            <CompactMetadataRow label="token" value={`•••• ${connection.tokenLast4 || "stored"}`} />
+            <CompactMetadataRow
+              label="validated"
+              value={connection.validatedAt ? formatDate(connection.validatedAt) : "not yet"}
+            />
+            <CompactMetadataRow
+              label="last used"
+              value={connection.lastUsedAt ? formatDate(connection.lastUsedAt) : "never"}
+            />
+          </div>
+        ) : null}
+
+        <form
+          class="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.5fr)_auto] gap-3 items-end"
+          onSubmit={onSave}
+        >
+          <Field label="Connection name" for="npmLabel">
+            <Input
+              id="npmLabel"
+              type="text"
+              value={label}
+              onInput={(e) => (npm.label.value = (e.target as HTMLInputElement).value)}
+              disabled={busy}
+            />
+          </Field>
+          <Field label="Registry" for="npmRegistry">
+            <Input
+              id="npmRegistry"
+              type="url"
+              value={registry}
+              onInput={(e) => (npm.registry.value = (e.target as HTMLInputElement).value)}
+              disabled={busy}
+            />
+          </Field>
+          <Field label={connection ? "New npm token" : "npm token"} for="npmToken">
+            <Input
+              id="npmToken"
+              type="password"
+              value={token}
+              placeholder={connection ? "Paste a new token to rotate" : "npm_..."}
+              onInput={(e) => (npm.token.value = (e.target as HTMLInputElement).value)}
+              disabled={busy}
+              autoComplete="off"
+              spellcheck={false}
+            />
+          </Field>
+          <Button type="submit" disabled={busy || !token.trim()} class="shrink-0">
+            {status === "saving"
+              ? "Saving…"
+              : status === "validating"
+                ? "Checking…"
+                : connection
+                  ? "Rotate"
+                  : "Save"}
+          </Button>
+        </form>
+
+        <div class="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_auto] gap-3 items-end">
+          <Field label="Stage ID access check" for="validationStageId">
+            <Input
+              id="validationStageId"
+              type="text"
+              value={validationStageId}
+              placeholder="Paste a real stage ID to confirm package access"
+              onInput={(e) => (npm.validationStageId.value = (e.target as HTMLInputElement).value)}
+              disabled={busy || !connection}
+              autoComplete="off"
+              spellcheck={false}
+            />
+          </Field>
+          <Button
+            variant="secondary"
+            onClick={() => void npm.validate()}
+            disabled={busy || !connection}
+            class="shrink-0"
+          >
+            {status === "validating"
+              ? "Checking…"
+              : validationStageId.trim()
+                ? "Check stage access"
+                : "Check npm auth"}
+          </Button>
+        </div>
+
+        <Muted class="text-xs">
+          Saving runs the npm auth check automatically. Add a stage ID to prove the token can read
+          that staged release; we do not keep the release archive.
+        </Muted>
+
+        {error ? <Alert tone="critical">{error}</Alert> : null}
+
+        {connection ? (
+          <div class="flex items-center justify-between border-t border-border pt-4 gap-3">
+            <LinkButton variant="ghost" size="sm" href="/dashboard">
+              Back to dashboard
+            </LinkButton>
+            <Button variant="danger" size="sm" onClick={() => void npm.remove()} disabled={busy}>
+              {status === "deleting" ? "Removing…" : "Disconnect npm"}
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    </Card>
+  );
+}
+
+function CompactMetadataRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div class="grid grid-cols-[92px_minmax(0,1fr)] gap-3 text-[13px] min-w-0">
+      <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">{label}</span>
+      <code class="text-xs text-ink-muted break-all">{value}</code>
+    </div>
+  );
+}
+
+function formatDate(value: string | number | Date | null | undefined) {
+  if (value === null || value === undefined) return "—";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString();
+}

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -15,10 +15,8 @@ import {
   Card,
   EmptyLine,
   Eyebrow,
-  Field,
-  Input,
+  LinkButton,
   LoadingState,
-  MonoDetail,
   Muted,
   OrgSwitcher,
   PageShell,
@@ -111,6 +109,9 @@ export default function DashboardPage() {
     <PageShell
       headerActions={
         <>
+          <LinkButton variant="ghost" size="sm" href="/dashboard/settings">
+            Settings
+          </LinkButton>
           <OrgSwitcher
             organizations={organizations.organizations.value}
             activeOrganizationId={organizations.activeOrganizationId.value}
@@ -127,8 +128,8 @@ export default function DashboardPage() {
 
       {workspaceLoaded ? (
         <>
+          {!npm.connection.value ? <NpmSetupCallout /> : null}
           <RecentReviewsSection scans={scans} stagedPublishes={stagedPublishes} npm={npm} />
-          <WorkspaceSetupPanel npm={npm} />
         </>
       ) : (
         <LoadingState
@@ -324,206 +325,19 @@ function formatStartedScanLabel(scan: { packageName: string | null; version: str
   return scan.packageName || scan.version || null;
 }
 
-function WorkspaceSetupPanel({
-  npm,
-}: {
-  npm: ReturnType<typeof useModel<typeof NpmConnectionModel.prototype>>;
-}) {
-  const connection = npm.connection.value;
+function NpmSetupCallout() {
   return (
-    <section id="workspace-setup" class="scroll-mt-6">
-      <Card as="div" class="p-0 overflow-hidden">
-        <details open={!connection} class="group">
-          <summary class="list-none cursor-pointer px-5 py-4 transition-colors duration-150 ease-out hover:bg-surface-2 group-open:border-b group-open:border-border">
-            <div class="flex flex-wrap items-center justify-between gap-3">
-              <div class="flex flex-col gap-1.5 min-w-0">
-                <SectionLabel>Workspace setup</SectionLabel>
-                <Muted class="text-[13px] m-0">
-                  Manage npm access, credential checks, and workspace safety defaults.
-                </Muted>
-                <MonoDetail
-                  parts={[
-                    <span key="connection">npm {connection ? "connected" : "not connected"}</span>,
-                    <span key="evidence">redacted evidence</span>,
-                    <span key="approval">human approval</span>,
-                  ]}
-                />
-              </div>
-              <div class="flex flex-wrap items-center justify-end gap-2">
-                <Badge tone={connection ? "ok" : "info"}>
-                  {connection ? connection.validationStatus : "connect npm"}
-                </Badge>
-                <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
-                  <span class="group-open:hidden">open settings</span>
-                  <span class="hidden group-open:inline">close settings</span>
-                </span>
-              </div>
-            </div>
-          </summary>
-          <div class="p-5">
-            <NpmConnectionCard npm={npm} />
-          </div>
-        </details>
-      </Card>
-    </section>
-  );
-}
-
-function NpmConnectionCard({
-  npm,
-}: {
-  npm: ReturnType<typeof useModel<typeof NpmConnectionModel.prototype>>;
-}) {
-  const connection = npm.connection.value;
-  const status = npm.status.value;
-  const busy = npm.busy.value;
-  const validated = npm.validated.value;
-  const token = npm.token.value;
-  const label = npm.label.value;
-  const registry = npm.registry.value;
-  const validationStageId = npm.validationStageId.value;
-  const error = npm.error.value;
-
-  const onSave = async (event: Event) => {
-    event.preventDefault();
-    await npm.save();
-  };
-
-  return (
-    <div class="flex flex-col gap-5">
-      <div class="flex flex-wrap items-start justify-between gap-3">
-        <div class="flex flex-col gap-1.5">
-          <SectionLabel>npm access</SectionLabel>
-          <Muted class="text-[13px] max-w-[760px]">
-            Add an organization npm token so reviews can fetch staged packages securely. We encrypt
-            it, hide it after save, and use it only to retrieve release evidence.
-          </Muted>
-        </div>
-        {connection ? (
-          <Badge
-            tone={
-              validated ? "ok" : connection.validationStatus === "invalid" ? "critical" : "info"
-            }
-          >
-            {connection.validationStatus}
-          </Badge>
-        ) : (
-          <Badge tone="info">not connected</Badge>
-        )}
+    <Card as="section" class="p-5 flex flex-wrap items-center justify-between gap-3">
+      <div class="flex flex-col gap-1.5 min-w-0">
+        <SectionLabel>npm not connected</SectionLabel>
+        <Muted class="text-[13px] m-0">
+          Connect npm in settings so Drydock can fetch staged tarballs and run reviews.
+        </Muted>
       </div>
-
-      {connection ? (
-        <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-x-6 gap-y-2 border-y border-border py-3">
-          <CompactMetadataRow label="label" value={connection.label} />
-          <CompactMetadataRow label="registry" value={connection.registryUrl} />
-          <CompactMetadataRow label="token" value={`•••• ${connection.tokenLast4 || "stored"}`} />
-          <CompactMetadataRow
-            label="validated"
-            value={connection.validatedAt ? formatDate(connection.validatedAt) : "not yet"}
-          />
-          <CompactMetadataRow
-            label="last used"
-            value={connection.lastUsedAt ? formatDate(connection.lastUsedAt) : "never"}
-          />
-        </div>
-      ) : null}
-
-      <form
-        class="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.5fr)_auto] gap-3 items-end"
-        onSubmit={onSave}
-      >
-        <Field label="Connection name" for="npmLabel">
-          <Input
-            id="npmLabel"
-            type="text"
-            value={label}
-            onInput={(e) => (npm.label.value = (e.target as HTMLInputElement).value)}
-            disabled={busy}
-          />
-        </Field>
-        <Field label="Registry" for="npmRegistry">
-          <Input
-            id="npmRegistry"
-            type="url"
-            value={registry}
-            onInput={(e) => (npm.registry.value = (e.target as HTMLInputElement).value)}
-            disabled={busy}
-          />
-        </Field>
-        <Field label={connection ? "New npm token" : "npm token"} for="npmToken">
-          <Input
-            id="npmToken"
-            type="password"
-            value={token}
-            placeholder={connection ? "Paste a new token to rotate" : "npm_..."}
-            onInput={(e) => (npm.token.value = (e.target as HTMLInputElement).value)}
-            disabled={busy}
-            autoComplete="off"
-            spellcheck={false}
-          />
-        </Field>
-        <Button type="submit" disabled={busy || !token.trim()} class="shrink-0">
-          {status === "saving"
-            ? "Saving…"
-            : status === "validating"
-              ? "Checking…"
-              : connection
-                ? "Rotate"
-                : "Save"}
-        </Button>
-      </form>
-
-      <div class="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_auto] gap-3 items-end">
-        <Field label="Stage ID access check" for="validationStageId">
-          <Input
-            id="validationStageId"
-            type="text"
-            value={validationStageId}
-            placeholder="Paste a real stage ID to confirm package access"
-            onInput={(e) => (npm.validationStageId.value = (e.target as HTMLInputElement).value)}
-            disabled={busy || !connection}
-            autoComplete="off"
-            spellcheck={false}
-          />
-        </Field>
-        <Button
-          variant="secondary"
-          onClick={() => void npm.validate()}
-          disabled={busy || !connection}
-          class="shrink-0"
-        >
-          {status === "validating"
-            ? "Checking…"
-            : validationStageId.trim()
-              ? "Check stage access"
-              : "Check npm auth"}
-        </Button>
-      </div>
-
-      <Muted class="text-xs">
-        Saving runs the npm auth check automatically. Add a stage ID to prove the token can read
-        that staged release; we do not keep the release archive.
-      </Muted>
-
-      {error ? <Alert tone="critical">{error}</Alert> : null}
-
-      {connection ? (
-        <div class="flex justify-end border-t border-border pt-4">
-          <Button variant="danger" size="sm" onClick={() => void npm.remove()} disabled={busy}>
-            {status === "deleting" ? "Removing…" : "Disconnect npm"}
-          </Button>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function CompactMetadataRow({ label, value }: { label: string; value: string }) {
-  return (
-    <div class="grid grid-cols-[92px_minmax(0,1fr)] gap-3 text-[13px] min-w-0">
-      <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">{label}</span>
-      <code class="text-xs text-ink-muted break-all">{value}</code>
-    </div>
+      <LinkButton variant="primary" size="sm" href="/dashboard/settings">
+        Open settings
+      </LinkButton>
+    </Card>
   );
 }
 
@@ -609,12 +423,6 @@ function Th({ children }: { children: ComponentChildren }) {
 
 function Td({ children, class: className }: { children: ComponentChildren; class?: string }) {
   return <td class={`px-4 py-2.5 align-middle ${className || ""}`}>{children}</td>;
-}
-
-function formatDate(value: string | number | Date | null | undefined) {
-  if (value === null || value === undefined) return "—";
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString();
 }
 
 function pluralize(word: string, count: number) {

--- a/test/auth-return.test.ts
+++ b/test/auth-return.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { normalizeAuthReturnTo } from "../src/lib/auth-return";
+
+const ORIGIN = "https://drydock.example";
+
+describe("normalizeAuthReturnTo", () => {
+  test("preserves dashboard callback paths with query strings", () => {
+    expect(
+      normalizeAuthReturnTo(
+        "/dashboard/settings/github-app/callback?state=abc&code=def&installation_id=123",
+        ORIGIN,
+      ),
+    ).toBe("/dashboard/settings/github-app/callback?state=abc&code=def&installation_id=123");
+  });
+
+  test("allows same-origin absolute dashboard urls", () => {
+    expect(normalizeAuthReturnTo(`${ORIGIN}/dashboard?filter=all`, ORIGIN)).toBe(
+      "/dashboard?filter=all",
+    );
+  });
+
+  test("falls back for non-dashboard, cross-origin, or malformed targets", () => {
+    expect(normalizeAuthReturnTo("/login?returnTo=/dashboard", ORIGIN)).toBe("/dashboard");
+    expect(normalizeAuthReturnTo("https://attacker.example/dashboard", ORIGIN)).toBe("/dashboard");
+    expect(normalizeAuthReturnTo("http://[", ORIGIN)).toBe("/dashboard");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable", "WebWorker"],
-    "types": ["@cloudflare/workers-types"],
+    "types": ["@cloudflare/workers-types", "vite/client"],
     "jsx": "react-jsx",
     "jsxImportSource": "preact",
     "strict": true,


### PR DESCRIPTION
Adds a dedicated org settings surface for npm access and a dev-gated GitHub App install flow for PyPI workflow gating. The callback page preserves safe dashboard return paths, maps typed GitHub App errors, and links installations back to the active org. The dashboard now points disconnected npm users to settings, and the PyPI workflow docs describe the setup URL and frontend behavior. Validated with `pnpm run verify` via pre-commit.