### PR TITLE
Add /docs route for staged publishing and review gating

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -5,7 +5,7 @@ The visual system is defined in [`DESIGN.md`](../DESIGN.md). This file documents
 ## Stack
 
 - **Tailwind CSS v4** via `@tailwindcss/vite` (registered in `vite.config.ts`).
-- **Preact prerendering** via `@preact/preset-vite` for the public landing and auth pages. The client hydration gate in `src/index.tsx` must match both slashless paths and Cloudflare's canonical folder-index URLs (`/login/`, `/register/`) for generated `*/index.html` pages.
+- **Preact prerendering** via `@preact/preset-vite` for the public landing, auth, and docs pages. The client hydration gate in `src/index.tsx` must match both slashless paths and Cloudflare's canonical folder-index URLs (`/login/`, `/register/`, `/docs/`) for generated `*/index.html` pages.
 - **Design tokens** declared in `src/style.css` with `@theme` — colors, fonts, shadows. Light is the default; dark mode is overridden inside `@media (prefers-color-scheme: dark) { @theme { … } }`. Every Tailwind utility that references a token (`bg-bg`, `text-ink`, `border-border`, `bg-accent`, `bg-danger-soft`, etc.) flips automatically with the system theme.
 - **No CSS-in-JS.** No external utility libraries.
 

--- a/src/components/PageShell.tsx
+++ b/src/components/PageShell.tsx
@@ -15,18 +15,14 @@ export function PageShell({
 }: {
   class?: string;
   children: ComponentChildren;
-  width?: "narrow" | "wide";
+  width?: "narrow" | "doc" | "wide";
   brand?: boolean;
   headerActions?: ComponentChildren;
 }) {
+  const maxWidth =
+    width === "narrow" ? "max-w-[640px]" : width === "doc" ? "max-w-[880px]" : "max-w-[1160px]";
   return (
-    <main
-      class={cn(
-        "mx-auto w-full px-6 pt-6 pb-24 flex flex-col gap-6",
-        width === "narrow" ? "max-w-[640px]" : "max-w-[1160px]",
-        className,
-      )}
-    >
+    <main class={cn("mx-auto w-full px-6 pt-6 pb-24 flex flex-col gap-6", maxWidth, className)}>
       {brand ? (
         <div class="flex flex-wrap items-center justify-between gap-3">
           <BrandMark href="/" size="sm" />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,7 +37,10 @@ export function isPrerenderedRoute(pathname: string) {
     pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
 
   return (
-    canonicalPathname === "/" || canonicalPathname === "/login" || canonicalPathname === "/register"
+    canonicalPathname === "/" ||
+    canonicalPathname === "/login" ||
+    canonicalPathname === "/register" ||
+    canonicalPathname === "/docs"
   );
 }
 
@@ -53,5 +56,17 @@ if (typeof window !== "undefined") {
 }
 
 export async function prerender(data: Record<string, unknown>) {
-  return await ssr(<App {...data} />);
+  const result = await ssr(<App {...data} />);
+
+  // The prerender crawler follows every rendered <a href> as a route to prerender.
+  // Keep it to the statically prerendered set so conditional links (e.g. the docs
+  // page's authenticated "Open settings" link) don't generate stray HTML.
+  const links = new Set<string>();
+  for (const href of result.links ?? []) {
+    if (isPrerenderedRoute(new URL(href, "http://localhost").pathname)) {
+      links.add(href);
+    }
+  }
+
+  return { ...result, links };
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import { ErrorBoundary, LocationProvider, Route, Router, lazy, prerender as ssr 
 import "./style.css";
 
 const LandingPage = lazy(() => import("./pages/Landing"));
+const DocsPage = lazy(() => import("./pages/Docs"));
 const LoginPage = lazy(() => import("./pages/Auth/Login"));
 const RegisterPage = lazy(() => import("./pages/Auth/Register"));
 const DashboardPage = lazy(() => import("./pages/Dashboard"));
@@ -17,6 +18,7 @@ export function App() {
       <ErrorBoundary onError={(error) => console.error(error)}>
         <Router>
           <Route path="/" component={LandingPage} />
+          <Route path="/docs" component={DocsPage} />
           <Route path="/login" component={LoginPage} />
           <Route path="/register" component={RegisterPage} />
           <Route path="/dashboard" component={DashboardPage} />

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -60,8 +60,9 @@ export default function DocsPage() {
               the same screen.
             </li>
             <li>
-              From here, paste a <Code>stageId</Code> on the dashboard to scan a release on demand,
-              or let the 15-minute auto-discovery cron pick up new staged publishes automatically.
+              From here, hit <Code>Check npm</Code> on the dashboard to discover open staged
+              publishes on demand, or let the 15-minute auto-discovery cron pick them up
+              automatically.
             </li>
           </ol>
           <div class="flex flex-wrap gap-2 pt-1">
@@ -75,9 +76,10 @@ export default function DocsPage() {
           <h3 class="text-base font-medium tracking-[-0.005em] m-0">The review lifecycle</h3>
           <ol class="list-decimal pl-5 m-0 flex flex-col gap-1.5 text-[13px] text-ink-muted leading-[1.55] marker:text-ink-subtle marker:font-mono">
             <li>
-              A maintainer (or our auto-discovery cron) submits a <Code>stageId</Code> to{" "}
-              <Code>POST /api/v1/scans</Code>. The scan is queued and the UI starts polling its
-              status.
+              A new staged publish is discovered — the 15-minute auto-discovery cron sweeps the
+              org's open stages, or a maintainer clicks <Code>Check npm</Code> on the dashboard. The
+              worker queues a scan for any <Code>stageId</Code> it hasn't seen before and the UI
+              starts polling its status.
             </li>
             <li>
               The worker resolves the active organization's npm connection. The plaintext token

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -1,5 +1,5 @@
 import type { ComponentChildren } from "preact";
-import { Alert, Badge, Card, Eyebrow, LinkButton, PageShell, SectionLabel } from "../../components";
+import { Alert, Badge, Eyebrow, LinkButton, PageShell, SectionLabel } from "../../components";
 
 export default function DocsPage() {
   return (
@@ -123,27 +123,6 @@ export default function DocsPage() {
               registry.
             </Prose>
           </Subsection>
-
-          <TrustBoundary
-            items={[
-              <>
-                The npm token only attaches to allowed registry endpoints (staged tarball, staged
-                details, registry metadata). The gateway is the single chokepoint.
-              </>,
-              <>
-                The sandbox sees package bytes, not credentials. It cannot reach the internet except
-                through the gateway, and the gateway refuses to attach auth on arbitrary origins.
-              </>,
-              <>
-                Reports persist redacted evidence: file paths, bounded text samples, deterministic
-                finding records. Raw tarballs are not retained.
-              </>,
-              <>
-                Deterministic findings are authoritative. Nothing downstream — including any future
-                AI commentary — can downgrade them.
-              </>,
-            ]}
-          />
         </section>
 
         <section id="workflow-gating" class="flex flex-col gap-8 scroll-mt-6">
@@ -292,30 +271,6 @@ export default function DocsPage() {
               ]}
             />
           </Subsection>
-
-          <TrustBoundary
-            items={[
-              <>
-                Drydock never holds a PyPI credential or an OIDC token. The publish job exchanges
-                its own OIDC identity with PyPI directly.
-              </>,
-              <>
-                The release-target mapping is unique per{" "}
-                <Code>(organization, repository, environment)</Code> so a webhook can never
-                ambiguously resolve to two organizations.
-              </>,
-              <>
-                Every artifact in the bundle must agree on the normalized package name and version,
-                so a foreign or version-skewed wheel can't slip into the release set. A bundle whose
-                artifacts can't be identified is rejected, not guessed.
-              </>,
-              <>
-                Installation lifecycle events (<Code>suspend</Code>, <Code>unsuspend</Code>,{" "}
-                <Code>deleted</Code>) update the installation row, so later deliveries on a revoked
-                install fail closed automatically.
-              </>,
-            ]}
-          />
         </section>
 
         <section class="flex flex-col gap-4 border-t border-border pt-10">
@@ -362,21 +317,6 @@ function Steps({ items }: { items: ComponentChildren[] }) {
         </li>
       ))}
     </ol>
-  );
-}
-
-function TrustBoundary({ items }: { items: ComponentChildren[] }) {
-  return (
-    <Card class="p-5 flex flex-col gap-3">
-      <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">
-        Trust boundary
-      </span>
-      <ul class="list-disc pl-5 m-0 flex flex-col gap-2 text-[13px] text-ink-muted leading-[1.55] marker:text-ink-subtle">
-        {items.map((item, index) => (
-          <li key={index}>{item}</li>
-        ))}
-      </ul>
-    </Card>
   );
 }
 

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -44,6 +44,33 @@ export default function DocsPage() {
           </p>
         </header>
 
+        <Card class="p-5 flex flex-col gap-3">
+          <h3 class="text-base font-medium tracking-[-0.005em] m-0">Set it up</h3>
+          <ol class="list-decimal pl-5 m-0 flex flex-col gap-1.5 text-[13px] text-ink-muted leading-[1.55] marker:text-ink-subtle marker:font-mono">
+            <li>
+              Sign in and switch the org picker to the organization that publishes the package.
+            </li>
+            <li>
+              Open <Code>Organization settings → npm access</Code> and paste an automation or
+              granular npm token that can read the org's packages and list staged publishes.
+            </li>
+            <li>
+              Save — Drydock encrypts the token, hashes a fingerprint, and runs the registry auth
+              check. Add a real <Code>stageId</Code> if you want to prove staged-tarball access on
+              the same screen.
+            </li>
+            <li>
+              From here, paste a <Code>stageId</Code> on the dashboard to scan a release on demand,
+              or let the 15-minute auto-discovery cron pick up new staged publishes automatically.
+            </li>
+          </ol>
+          <div class="flex flex-wrap gap-2 pt-1">
+            <LinkButton href="/dashboard/settings" size="sm">
+              Open Organization settings
+            </LinkButton>
+          </div>
+        </Card>
+
         <Card class="p-5 flex flex-col gap-2">
           <h3 class="text-base font-medium tracking-[-0.005em] m-0">The review lifecycle</h3>
           <ol class="list-decimal pl-5 m-0 flex flex-col gap-1.5 text-[13px] text-ink-muted leading-[1.55] marker:text-ink-subtle marker:font-mono">
@@ -126,6 +153,41 @@ export default function DocsPage() {
             PyPI Trusted Publishing via OIDC — does the publish.
           </p>
         </header>
+
+        <Card class="p-5 flex flex-col gap-3">
+          <h3 class="text-base font-medium tracking-[-0.005em] m-0">Set it up</h3>
+          <ol class="list-decimal pl-5 m-0 flex flex-col gap-1.5 text-[13px] text-ink-muted leading-[1.55] marker:text-ink-subtle marker:font-mono">
+            <li>
+              Sign in and switch the org picker to the organization that owns the PyPI project.
+            </li>
+            <li>
+              Open <Code>Organization settings → GitHub App</Code> and install the Drydock GitHub
+              App on the GitHub account that hosts your repository. You'll be redirected to GitHub
+              to pick the account and grant access to the repo, then back to Drydock.
+            </li>
+            <li>
+              In the repository, create a GitHub Environment (e.g. <Code>pypi</Code>) and configure
+              it as a PyPI Trusted Publisher. Drydock attaches its deployment-protection rule to
+              that same environment.
+            </li>
+            <li>
+              Map the repository + environment + PyPI package on the same settings page so the
+              webhook can resolve a delivery to your organization. The mapping is unique per{" "}
+              <Code>(organization, repository, environment)</Code>.
+            </li>
+            <li>
+              Add the build and publish workflow below. The build job writes{" "}
+              <Code>drydock-manifest.json</Code>; the publish job runs in{" "}
+              <Code>environment: pypi</Code> and is blocked until Drydock posts an approval back to
+              GitHub.
+            </li>
+          </ol>
+          <div class="flex flex-wrap gap-2 pt-1">
+            <LinkButton href="/dashboard/settings" size="sm">
+              Open Organization settings
+            </LinkButton>
+          </div>
+        </Card>
 
         <Card class="p-5 flex flex-col gap-3">
           <h3 class="text-base font-medium tracking-[-0.005em] m-0">

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -159,10 +159,10 @@ export default function DocsPage() {
             PyPI Trusted Publishing via OIDC — does the publish.
           </p>
           <Alert tone="info">
-            This is the design we're building toward. The review engine and the GitHub
-            deployment-protection webhook already exist, but connecting a GitHub App and gating a
-            real publish end-to-end is still rolling out. The steps below describe the intended
-            setup.
+            The full gate runs in production today: Drydock fetches the release candidate, reviews
+            it, and posts the approve-or-block decision back to GitHub. It is still early access —
+            connecting the GitHub App is limited to allowlisted organizations while the setup and
+            review UI are finished. The steps below describe the flow.
           </Alert>
         </header>
 

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -136,15 +136,17 @@ export default function DocsPage() {
             <Prose>
               PyPI does not expose a staged tarball. The publish job itself becomes the boundary: CI
               builds the wheels and sdists, uploads them as a release candidate, and a GitHub
-              Environment with a Drydock-owned deployment protection rule blocks the publish job
-              until the reviewed release candidate is approved. The same maintainer-controlled
-              credential — PyPI Trusted Publishing via OIDC — does the publish.
+              Environment with a Drydock-owned deployment protection rule holds the publish job.
+              Drydock reviews the candidate and records a recommendation, but never approves on its
+              own — a maintainer approves or rejects from the review workbench, and only then is the
+              held job released or blocked. The publish runs on the workflow's own PyPI Trusted
+              Publishing credential via OIDC; Drydock never holds it.
             </Prose>
             <Alert tone="info">
               The full gate runs in production today: Drydock fetches the release candidate, reviews
-              it, and posts the approve-or-block decision back to GitHub. It is still early access —
-              connecting the GitHub App is limited to allowlisted organizations while the setup and
-              review UI are finished. The steps below describe the flow.
+              it, and surfaces an approve/reject decision in the workbench — a maintainer makes the
+              call, and Drydock relays it to GitHub. It is still early access: connecting the GitHub
+              App is limited to allowlisted organizations. The steps below describe the flow.
             </Alert>
           </div>
 
@@ -172,8 +174,8 @@ export default function DocsPage() {
                 <>
                   Add the build and publish workflow below. The build job uploads the wheels and
                   sdists as a <Code>pypi-release-candidate</Code> bundle; the publish job runs in{" "}
-                  <Code>environment: pypi</Code> and is blocked until Drydock posts an approval back
-                  to GitHub.
+                  <Code>environment: pypi</Code> and stays blocked until a maintainer approves the
+                  review in Drydock.
                 </>,
               ]}
             />
@@ -229,8 +231,9 @@ export default function DocsPage() {
               No manifest or checksum step is required — CI just builds and uploads{" "}
               <Code>dist/*</Code>. The <Code>environment: pypi</Code> line is the gate: configure
               the same environment in PyPI Trusted Publishers and attach Drydock as a custom
-              deployment protection rule on it. The publish job is blocked until Drydock posts a
-              decision back, then publishes the downloaded bundle with whatever tool you prefer.
+              deployment protection rule on it. The publish job stays blocked until a maintainer
+              approves the review in Drydock, then publishes the downloaded bundle with whatever
+              tool you prefer.
             </Prose>
           </Subsection>
 
@@ -245,17 +248,26 @@ export default function DocsPage() {
                 </>,
                 <>
                   The handler resolves the <Code>(installationId, repositoryId, environment)</Code>{" "}
-                  triple against the organization's release-target table. Deliveries that don't
-                  match a mapped target are acknowledged but ignored.
+                  triple against the organization's release-target table and persists a{" "}
+                  <Code>pending</Code> <Code>github_workflow_gates</Code> row keyed on the GitHub
+                  delivery ID, so retries are idempotent. Deliveries that don't match a mapped
+                  target are acknowledged but ignored.
                 </>,
                 <>
-                  Matched deliveries persist a <Code>github_workflow_gates</Code> row keyed on the
-                  GitHub delivery ID, so retries are idempotent. Drydock then derives the release
-                  set from the uploaded bundle, recomputing each artifact's sha256, and runs the
-                  scan pipeline against it.
+                  Drydock derives the release set from the uploaded bundle, recomputes each
+                  artifact's sha256, runs the scan pipeline, and records an advisory recommendation.
+                  The review never posts to GitHub — it leaves the gate <Code>pending</Code> and
+                  hands off to a human.
                 </>,
                 <>
-                  The decision is posted back to GitHub at{" "}
+                  A maintainer opens the review in the diff-first workbench at{" "}
+                  <Code>/dashboard/scans/:id</Code> and approves or rejects. Only that decision is
+                  posted back to GitHub, releasing or blocking the held publish job. A bundle whose
+                  artifacts can't be verified is auto-rejected fail-closed — no human is needed to
+                  block something Drydock can't identify.
+                </>,
+                <>
+                  The decision callback hits{" "}
                   <Code>
                     POST
                     /repos/&lt;owner&gt;/&lt;repo&gt;/actions/runs/&lt;run_id&gt;/deployment_protection_rule
@@ -265,8 +277,9 @@ export default function DocsPage() {
                   the webhook payload is rejected even when the signature is valid.
                 </>,
                 <>
-                  The transition out of <Code>pending</Code> is a single conditional update, so even
-                  if the review pipeline runs more than once Drydock calls GitHub exactly once.
+                  The transition out of <Code>pending</Code> is a single compare-and-set, so a
+                  double-submit or a race between a human decision and the fail-closed reject calls
+                  GitHub exactly once.
                 </>,
               ]}
             />

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -1,257 +1,238 @@
+import type { ComponentChildren } from "preact";
 import { Alert, Badge, Card, Eyebrow, LinkButton, PageShell, SectionLabel } from "../../components";
 
 export default function DocsPage() {
   return (
     <PageShell
-      class="gap-16"
+      width="doc"
       headerActions={
         <LinkButton href="/" variant="ghost" size="sm">
           Home
         </LinkButton>
       }
     >
-      <section class="py-8 md:py-12 border-y border-border flex flex-col gap-5">
-        <Eyebrow tone="accent">Documentation</Eyebrow>
-        <h1 class="text-4xl md:text-5xl font-semibold tracking-[-0.03em] leading-[1.05] max-w-[760px] m-0">
-          How Drydock guards a publish.
-        </h1>
-        <p class="text-[17px] text-ink-muted max-w-[620px] leading-[1.6] m-0">
-          Drydock reviews what a release ships before it goes public, and never holds your publish
-          credential. How it hooks in depends on the registry: npm hands Drydock a staged tarball to
-          inspect; PyPI has no staged artifact, so a GitHub Actions gate holds the publish until the
-          build is reviewed.
-        </p>
-        <nav class="flex flex-wrap gap-3 mt-2 font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
-          <a class="text-accent hover:text-accent-hover" href="#staged-publishing">
-            → Staged publishing (npm)
-          </a>
-          <a class="text-accent hover:text-accent-hover" href="#action-gating">
-            → Workflow gating (PyPI)
-          </a>
-        </nav>
-      </section>
-
-      <article id="staged-publishing" class="flex flex-col gap-6 max-w-[880px]">
-        <header class="flex flex-col gap-3">
-          <SectionLabel>Staged publishing — npm</SectionLabel>
-          <h2 class="text-2xl font-semibold tracking-[-0.015em] m-0">
-            The registry holds the candidate; the maintainer holds the keys.
-          </h2>
-          <p class="text-[14px] text-ink-muted leading-[1.6] m-0">
-            npm exposes a staged-publish primitive: a maintainer runs{" "}
-            <Code>npm publish --stage</Code> and the registry parks the candidate tarball behind a{" "}
-            <Code>stageId</Code> until the same maintainer confirms the publish with 2FA. Drydock
-            reviews what is inside that staged tarball before that confirmation runs.
+      <div class="flex flex-col gap-14">
+        <header class="border-t border-border pt-8 flex flex-col gap-5">
+          <Eyebrow tone="accent">Documentation</Eyebrow>
+          <h1 class="text-4xl md:text-5xl font-semibold tracking-[-0.03em] leading-[1.05] max-w-[760px] m-0">
+            How Drydock guards a publish.
+          </h1>
+          <p class="text-[17px] text-ink-muted max-w-[620px] leading-[1.6] m-0">
+            Drydock reviews what a release ships before it goes public, and never holds your publish
+            credential. How it hooks in depends on the registry: npm hands Drydock a staged tarball
+            to inspect; PyPI has no staged artifact, so a GitHub Actions gate holds the publish
+            until the build is reviewed.
           </p>
+          <nav class="flex flex-wrap gap-x-5 gap-y-2 mt-1 font-mono text-[11px] uppercase tracking-[0.1em]">
+            <a class="text-accent hover:text-accent-hover" href="#staged-publishing">
+              → Staged publishing (npm)
+            </a>
+            <a class="text-accent hover:text-accent-hover" href="#workflow-gating">
+              → Workflow gating (PyPI)
+            </a>
+          </nav>
         </header>
 
-        <Card class="p-5 flex flex-col gap-3">
-          <h3 class="text-base font-medium tracking-[-0.005em] m-0">Set it up</h3>
-          <ol class="list-decimal pl-5 m-0 flex flex-col gap-1.5 text-[13px] text-ink-muted leading-[1.55] marker:text-ink-subtle marker:font-mono">
-            <li>
-              Sign in and switch the org picker to the organization that publishes the package.
-            </li>
-            <li>
-              Open <Code>Organization settings → npm access</Code> and paste an automation or
-              granular npm token that can read the org's packages and list staged publishes.
-            </li>
-            <li>
-              Save — Drydock encrypts the token, hashes a fingerprint, and runs the registry auth
-              check. Add a real <Code>stageId</Code> if you want to prove staged-tarball access on
-              the same screen.
-            </li>
-            <li>
-              From here, hit <Code>Check npm</Code> on the dashboard to discover open staged
-              publishes on demand, or let the 15-minute auto-discovery cron pick them up
-              automatically.
-            </li>
-          </ol>
-          <div class="flex flex-wrap gap-2 pt-1">
-            <LinkButton href="/dashboard/settings" size="sm">
-              Open Organization settings
-            </LinkButton>
+        <section id="staged-publishing" class="flex flex-col gap-8 scroll-mt-6">
+          <div class="flex flex-col gap-3">
+            <SectionLabel>Staged publishing — npm</SectionLabel>
+            <h2 class="text-2xl font-semibold tracking-[-0.015em] m-0 max-w-[680px]">
+              The registry holds the candidate; the maintainer holds the keys.
+            </h2>
+            <Prose>
+              npm exposes a staged-publish primitive: a maintainer runs{" "}
+              <Code>npm publish --stage</Code> and the registry parks the candidate tarball behind a{" "}
+              <Code>stageId</Code> until the same maintainer confirms the publish with 2FA. Drydock
+              reviews what is inside that staged tarball before that confirmation runs.
+            </Prose>
           </div>
-        </Card>
 
-        <Card class="p-5 flex flex-col gap-2">
-          <h3 class="text-base font-medium tracking-[-0.005em] m-0">The review lifecycle</h3>
-          <ol class="list-decimal pl-5 m-0 flex flex-col gap-1.5 text-[13px] text-ink-muted leading-[1.55] marker:text-ink-subtle marker:font-mono">
-            <li>
-              A new staged publish is discovered (see Auto-discovery below). The worker queues a
-              scan for any <Code>stageId</Code> it hasn't seen before, and the UI starts polling
-              that scan's status.
-            </li>
-            <li>
-              The worker resolves the active organization's npm connection. The token is stored
-              encrypted with AES-256-GCM in D1 and is decrypted only at the moment the npm adapter
-              needs to authenticate a registry request.
-            </li>
-            <li>
-              A short-lived sandbox Worker downloads the staged tarball from{" "}
-              <Code>/-/stage/&lt;stageId&gt;/tarball</Code> through a credentialed outbound gateway
-              — the sandbox itself never receives the token.
-            </li>
-            <li>
-              The sandbox unpacks the archive into bounded file metadata and text samples and hands
-              them back to the parent worker. Package contents are evidence, never instructions.
-            </li>
-            <li>
-              The parent worker resolves a tag-aware baseline version, computes the
-              package-to-package diff, runs deterministic findings against the changed files, and
-              persists a redacted report.
-            </li>
-            <li>
-              The maintainer reads the report at <Code>/dashboard/scans/:id</Code>. Approval happens
-              in npm with normal 2FA — Drydock never publishes on their behalf.
-            </li>
-          </ol>
-        </Card>
+          <Subsection title="Set it up">
+            <Steps
+              items={[
+                <>
+                  Sign in and switch the org picker to the organization that publishes the package.
+                </>,
+                <>
+                  Open <Code>Organization settings → npm access</Code> and paste an automation or
+                  granular npm token that can read the org's packages and list staged publishes.
+                </>,
+                <>
+                  Save — Drydock encrypts the token, hashes a fingerprint, and runs the registry
+                  auth check. Add a real <Code>stageId</Code> if you want to prove staged-tarball
+                  access on the same screen.
+                </>,
+                <>
+                  From here, hit <Code>Check npm</Code> on the dashboard to discover open staged
+                  publishes on demand, or let the 15-minute auto-discovery cron pick them up
+                  automatically.
+                </>,
+              ]}
+            />
+            <div class="flex flex-wrap gap-2 pt-1">
+              <LinkButton href="/dashboard/settings" size="sm">
+                Open Organization settings
+              </LinkButton>
+            </div>
+          </Subsection>
 
-        <Card class="p-5 flex flex-col gap-2">
-          <h3 class="text-base font-medium tracking-[-0.005em] m-0">Auto-discovery</h3>
-          <p class="m-0 text-[13px] text-ink-muted leading-[1.55]">
-            A <Code>*/15 * * * *</Code> cron sweeps every validated npm connection, lists the
-            organization's open staged publishes via <Code>GET /-/stage</Code>, and queues a scan
-            for any new <Code>stageId</Code>. Stages that already completed in another organization
-            are skipped, so the same tarball is never fetched twice. When an auto-discovered scan
-            finishes, the connection's creator receives an email linking to the report. Tokens
-            marked <Code>invalid</Code> are skipped without contacting the registry.
-          </p>
-        </Card>
+          <Subsection title="Review lifecycle">
+            <Steps
+              items={[
+                <>
+                  A new staged publish is discovered (see Auto-discovery below). The worker queues a
+                  scan for any <Code>stageId</Code> it hasn't seen before, and the UI starts polling
+                  that scan's status.
+                </>,
+                <>
+                  The worker resolves the active organization's npm connection. The token is stored
+                  encrypted with AES-256-GCM in D1 and is decrypted only at the moment the npm
+                  adapter needs to authenticate a registry request.
+                </>,
+                <>
+                  A short-lived sandbox Worker downloads the staged tarball from{" "}
+                  <Code>/-/stage/&lt;stageId&gt;/tarball</Code> through a credentialed outbound
+                  gateway — the sandbox itself never receives the token.
+                </>,
+                <>
+                  The sandbox unpacks the archive into bounded file metadata and text samples and
+                  hands them back to the parent worker. Package contents are evidence, never
+                  instructions.
+                </>,
+                <>
+                  The parent worker resolves a tag-aware baseline version, computes the
+                  package-to-package diff, runs deterministic findings against the changed files,
+                  and persists a redacted report.
+                </>,
+                <>
+                  The maintainer reads the report at <Code>/dashboard/scans/:id</Code>. Approval
+                  happens in npm with normal 2FA — Drydock never publishes on their behalf.
+                </>,
+              ]}
+            />
+          </Subsection>
 
-        <Card class="p-5 flex flex-col gap-2">
-          <h3 class="text-base font-medium tracking-[-0.005em] m-0">Trust boundary</h3>
-          <ul class="list-disc pl-5 m-0 flex flex-col gap-1.5 text-[13px] text-ink-muted leading-[1.55] marker:text-ink-subtle">
-            <li>
-              The npm token only attaches to allowed registry endpoints (staged tarball, staged
-              details, registry metadata). The gateway is the single chokepoint.
-            </li>
-            <li>
-              The sandbox sees package bytes, not credentials. It cannot reach the internet except
-              through the gateway, and the gateway refuses to attach auth on arbitrary origins.
-            </li>
-            <li>
-              Reports persist redacted evidence: file paths, bounded text samples, deterministic
-              finding records. Raw tarballs are not retained.
-            </li>
-            <li>
-              Deterministic findings are authoritative. Nothing downstream — including any future AI
-              commentary — can downgrade them.
-            </li>
-          </ul>
-        </Card>
-      </article>
+          <Subsection title="Auto-discovery">
+            <Prose>
+              A <Code>*/15 * * * *</Code> cron sweeps every validated npm connection, lists the
+              organization's open staged publishes via <Code>GET /-/stage</Code>, and queues a scan
+              for any new <Code>stageId</Code>. Stages that already completed in another
+              organization are skipped, so the same tarball is never fetched twice. When an
+              auto-discovered scan finishes, the connection's creator receives an email linking to
+              the report. Tokens marked <Code>invalid</Code> are skipped without contacting the
+              registry.
+            </Prose>
+          </Subsection>
 
-      <article id="action-gating" class="flex flex-col gap-6 max-w-[880px]">
-        <header class="flex flex-col gap-3">
-          <SectionLabel>
-            Action-based review gating — PyPI &amp; GitHub Actions{" "}
-            <Badge tone="info">Preview</Badge>
-          </SectionLabel>
-          <h2 class="text-2xl font-semibold tracking-[-0.015em] m-0">
-            When the registry can't hold the candidate, the workflow does.
-          </h2>
-          <p class="text-[14px] text-ink-muted leading-[1.6] m-0">
-            PyPI does not expose a staged tarball. The publish job itself becomes the boundary: CI
-            builds the wheel and sdist, uploads them as a release candidate, and a GitHub
-            Environment with a Drydock-owned deployment protection rule blocks the publish job until
-            the reviewed artifact digests are approved. The same maintainer-controlled credential —
-            PyPI Trusted Publishing via OIDC — does the publish.
-          </p>
-          <Alert tone="info">
-            The full gate runs in production today: Drydock fetches the release candidate, reviews
-            it, and posts the approve-or-block decision back to GitHub. It is still early access —
-            connecting the GitHub App is limited to allowlisted organizations while the setup and
-            review UI are finished. The steps below describe the flow.
-          </Alert>
-        </header>
+          <TrustBoundary
+            items={[
+              <>
+                The npm token only attaches to allowed registry endpoints (staged tarball, staged
+                details, registry metadata). The gateway is the single chokepoint.
+              </>,
+              <>
+                The sandbox sees package bytes, not credentials. It cannot reach the internet except
+                through the gateway, and the gateway refuses to attach auth on arbitrary origins.
+              </>,
+              <>
+                Reports persist redacted evidence: file paths, bounded text samples, deterministic
+                finding records. Raw tarballs are not retained.
+              </>,
+              <>
+                Deterministic findings are authoritative. Nothing downstream — including any future
+                AI commentary — can downgrade them.
+              </>,
+            ]}
+          />
+        </section>
 
-        <Card class="p-5 flex flex-col gap-3">
-          <h3 class="text-base font-medium tracking-[-0.005em] m-0">Set it up</h3>
-          <ol class="list-decimal pl-5 m-0 flex flex-col gap-1.5 text-[13px] text-ink-muted leading-[1.55] marker:text-ink-subtle marker:font-mono">
-            <li>
-              Sign in and switch the org picker to the organization that owns the PyPI project.
-            </li>
-            <li>
-              Open <Code>Organization settings → GitHub App</Code> and install the Drydock GitHub
-              App on the GitHub account that hosts your repository. You'll be redirected to GitHub
-              to pick the account and grant access to the repo, then back to Drydock.
-            </li>
-            <li>
-              In the repository, create a GitHub Environment (e.g. <Code>pypi</Code>) and configure
-              it as a PyPI Trusted Publisher. Drydock attaches its deployment-protection rule to
-              that same environment.
-            </li>
-            <li>
-              Map the repository + environment + PyPI package on the same settings page so the
-              webhook can resolve a delivery to your organization. The mapping is unique per{" "}
-              <Code>(organization, repository, environment)</Code>.
-            </li>
-            <li>
-              Add the build and publish workflow below. The build job writes{" "}
-              <Code>drydock-manifest.json</Code>; the publish job runs in{" "}
-              <Code>environment: pypi</Code> and is blocked until Drydock posts an approval back to
-              GitHub.
-            </li>
-          </ol>
-          <div class="flex flex-wrap gap-2 pt-1">
-            <LinkButton href="/dashboard/settings" size="sm">
-              Open Organization settings
-            </LinkButton>
+        <section id="workflow-gating" class="flex flex-col gap-8 scroll-mt-6">
+          <div class="flex flex-col gap-3">
+            <SectionLabel>
+              Workflow gating — PyPI &amp; GitHub Actions <Badge tone="info">Preview</Badge>
+            </SectionLabel>
+            <h2 class="text-2xl font-semibold tracking-[-0.015em] m-0 max-w-[680px]">
+              When the registry can't hold the candidate, the workflow does.
+            </h2>
+            <Prose>
+              PyPI does not expose a staged tarball. The publish job itself becomes the boundary: CI
+              builds the wheels and sdists, uploads them as a release candidate, and a GitHub
+              Environment with a Drydock-owned deployment protection rule blocks the publish job
+              until the reviewed release candidate is approved. The same maintainer-controlled
+              credential — PyPI Trusted Publishing via OIDC — does the publish.
+            </Prose>
+            <Alert tone="info">
+              The full gate runs in production today: Drydock fetches the release candidate, reviews
+              it, and posts the approve-or-block decision back to GitHub. It is still early access —
+              connecting the GitHub App is limited to allowlisted organizations while the setup and
+              review UI are finished. The steps below describe the flow.
+            </Alert>
           </div>
-        </Card>
 
-        <Card class="p-5 flex flex-col gap-3">
-          <h3 class="text-base font-medium tracking-[-0.005em] m-0">
-            The release-candidate manifest
-          </h3>
-          <p class="m-0 text-[13px] text-ink-muted leading-[1.55]">
-            The build job writes a <Code>drydock-manifest.json</Code> next to the artifacts. The
-            manifest names every file that must reach PyPI and pins its sha256:
-          </p>
-          <CodeBlock>
-            {`{
-  "schema": "drydock.release-artifacts.v1",
-  "ecosystem": "pypi",
-  "package": "example-package",
-  "version": "1.2.3",
-  "artifacts": [
-    {
-      "path": "dist/example_package-1.2.3-py3-none-any.whl",
-      "sha256": "…"
-    },
-    {
-      "path": "dist/example_package-1.2.3.tar.gz",
-      "sha256": "…"
-    }
-  ]
-}`}
-          </CodeBlock>
-          <p class="m-0 text-[13px] text-ink-muted leading-[1.55]">
-            The publish job re-verifies these digests immediately before invoking{" "}
-            <Code>pypa/gh-action-pypi-publish</Code>. Rebuilding after the gate is rejected — the
-            reviewed bytes must be the published bytes.
-          </p>
-        </Card>
+          <Subsection title="Set it up">
+            <Steps
+              items={[
+                <>
+                  Sign in and switch the org picker to the organization that owns the PyPI project.
+                </>,
+                <>
+                  Open <Code>Organization settings → GitHub App</Code> and install the Drydock
+                  GitHub App on the GitHub account that hosts your repository. You'll be redirected
+                  to GitHub to pick the account and grant access to the repo, then back to Drydock.
+                </>,
+                <>
+                  In the repository, create a GitHub Environment (e.g. <Code>pypi</Code>) and
+                  configure it as a PyPI Trusted Publisher. Drydock attaches its
+                  deployment-protection rule to that same environment.
+                </>,
+                <>
+                  Map the repository + environment + PyPI package on the same settings page so the
+                  webhook can resolve a delivery to your organization. The mapping is unique per{" "}
+                  <Code>(organization, repository, environment)</Code>.
+                </>,
+                <>
+                  Add the build and publish workflow below. The build job uploads the wheels and
+                  sdists as a <Code>pypi-release-candidate</Code> bundle; the publish job runs in{" "}
+                  <Code>environment: pypi</Code> and is blocked until Drydock posts an approval back
+                  to GitHub.
+                </>,
+              ]}
+            />
+            <div class="flex flex-wrap gap-2 pt-1">
+              <LinkButton href="/dashboard/settings" size="sm">
+                Open Organization settings
+              </LinkButton>
+            </div>
+          </Subsection>
 
-        <Card class="p-5 flex flex-col gap-3">
-          <h3 class="text-base font-medium tracking-[-0.005em] m-0">The workflow shape</h3>
-          <CodeBlock>
-            {`jobs:
+          <Subsection title="Release-candidate bundle">
+            <Prose>
+              There is no manifest to write. The boundary between your workflow and Drydock is the
+              uploaded <Code>pypi-release-candidate</Code> bundle: CI builds and uploads{" "}
+              <Code>dist/*</Code>, and Drydock treats every <Code>.whl</Code>, <Code>.tar.gz</Code>,
+              and <Code>.tgz</Code> in it as the release set.
+            </Prose>
+            <Prose>
+              The release identity is derived from the artifacts themselves — package name and
+              version from each wheel's <Code>METADATA</Code> and each sdist's <Code>PKG-INFO</Code>
+              , with every sha256 recomputed server-side from the uploaded bytes. The reviewed wheel
+              or sdist must be the exact file published: the publish job only downloads the reviewed
+              bundle and never rebuilds, so the reviewed bytes are the published bytes.
+            </Prose>
+          </Subsection>
+
+          <Subsection title="Workflow shape">
+            <CodeBlock name=".github/workflows/release.yml">
+              {`jobs:
   build-release-artifacts:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: python -m build
-      - run: sha256sum dist/* > drydock-sha256.txt
-      - run: python scripts/write-drydock-manifest.py
       - uses: actions/upload-artifact@v4
         with:
           name: pypi-release-candidate
-          path: |
-            dist/*
-            drydock-manifest.json
-            drydock-sha256.txt
+          path: dist/*
 
   publish:
     needs: build-release-artifacts
@@ -263,86 +244,139 @@ export default function DocsPage() {
       - uses: actions/download-artifact@v4
         with:
           name: pypi-release-candidate
-      - run: sha256sum --check drydock-sha256.txt
-      - uses: pypa/gh-action-pypi-publish@release/v1`}
-          </CodeBlock>
-          <p class="m-0 text-[13px] text-ink-muted leading-[1.55]">
-            The <Code>environment: pypi</Code> line is the gate. Configure the same environment in
-            PyPI Trusted Publishers and attach Drydock as a custom deployment protection rule on it.
-            The publish job is blocked until Drydock posts a decision back.
-          </p>
-        </Card>
+      # publish the downloaded dist/* to PyPI via Trusted Publishing (OIDC)`}
+            </CodeBlock>
+            <Prose>
+              No manifest or checksum step is required — CI just builds and uploads{" "}
+              <Code>dist/*</Code>. The <Code>environment: pypi</Code> line is the gate: configure
+              the same environment in PyPI Trusted Publishers and attach Drydock as a custom
+              deployment protection rule on it. The publish job is blocked until Drydock posts a
+              decision back, then publishes the downloaded bundle with whatever tool you prefer.
+            </Prose>
+          </Subsection>
 
-        <Card class="p-5 flex flex-col gap-2">
-          <h3 class="text-base font-medium tracking-[-0.005em] m-0">Decision flow</h3>
-          <ol class="list-decimal pl-5 m-0 flex flex-col gap-1.5 text-[13px] text-ink-muted leading-[1.55] marker:text-ink-subtle marker:font-mono">
-            <li>
-              GitHub fires a signed <Code>deployment_protection_rule</Code> webhook to{" "}
-              <Code>POST /webhooks/github</Code>. The handler HMAC-verifies the signature against
-              the raw body in constant time — unsigned or malformed requests are rejected.
-            </li>
-            <li>
-              The handler resolves the <Code>(installationId, repositoryId, environment)</Code>{" "}
-              triple against the organization's release-target table. Deliveries that don't match a
-              mapped target are acknowledged but ignored.
-            </li>
-            <li>
-              Matched deliveries persist a <Code>github_workflow_gates</Code> row keyed on the
-              GitHub delivery ID, so retries are idempotent. The scan pipeline runs against the
-              uploaded artifacts and the digests pinned in the manifest.
-            </li>
-            <li>
-              The decision is posted back to GitHub at{" "}
-              <Code>
-                POST
-                /repos/&lt;owner&gt;/&lt;repo&gt;/actions/runs/&lt;run_id&gt;/deployment_protection_rule
-              </Code>{" "}
-              with a fresh installation access token. The callback URL is pinned to{" "}
-              <Code>api.github.com</Code> and the deployment-protection path — a spoofed URL in the
-              webhook payload is rejected even when the signature is valid.
-            </li>
-            <li>
-              The transition out of <Code>pending</Code> is a single conditional update, so even if
-              the review pipeline runs more than once Drydock calls GitHub exactly once.
-            </li>
-          </ol>
-        </Card>
+          <Subsection title="Decision flow">
+            <Steps
+              items={[
+                <>
+                  GitHub fires a signed <Code>deployment_protection_rule</Code> webhook to{" "}
+                  <Code>POST /webhooks/github</Code>. The handler HMAC-verifies the signature
+                  against the raw body in constant time — unsigned or malformed requests are
+                  rejected.
+                </>,
+                <>
+                  The handler resolves the <Code>(installationId, repositoryId, environment)</Code>{" "}
+                  triple against the organization's release-target table. Deliveries that don't
+                  match a mapped target are acknowledged but ignored.
+                </>,
+                <>
+                  Matched deliveries persist a <Code>github_workflow_gates</Code> row keyed on the
+                  GitHub delivery ID, so retries are idempotent. Drydock then derives the release
+                  set from the uploaded bundle, recomputing each artifact's sha256, and runs the
+                  scan pipeline against it.
+                </>,
+                <>
+                  The decision is posted back to GitHub at{" "}
+                  <Code>
+                    POST
+                    /repos/&lt;owner&gt;/&lt;repo&gt;/actions/runs/&lt;run_id&gt;/deployment_protection_rule
+                  </Code>{" "}
+                  with a fresh installation access token. The callback URL is pinned to{" "}
+                  <Code>api.github.com</Code> and the deployment-protection path — a spoofed URL in
+                  the webhook payload is rejected even when the signature is valid.
+                </>,
+                <>
+                  The transition out of <Code>pending</Code> is a single conditional update, so even
+                  if the review pipeline runs more than once Drydock calls GitHub exactly once.
+                </>,
+              ]}
+            />
+          </Subsection>
 
-        <Card class="p-5 flex flex-col gap-2">
-          <h3 class="text-base font-medium tracking-[-0.005em] m-0">Trust boundary</h3>
-          <ul class="list-disc pl-5 m-0 flex flex-col gap-1.5 text-[13px] text-ink-muted leading-[1.55] marker:text-ink-subtle">
-            <li>
-              Drydock never holds a PyPI credential or an OIDC token. The publish job exchanges its
-              own OIDC identity with PyPI directly.
-            </li>
-            <li>
-              The release-target mapping is unique per{" "}
-              <Code>(organization, repository, environment)</Code> so a webhook can never
-              ambiguously resolve to two organizations.
-            </li>
-            <li>
-              The reviewed artifact path set must exactly match the manifest path set. Adding a file
-              post-review breaks the gate.
-            </li>
-            <li>
-              Installation lifecycle events (<Code>suspend</Code>, <Code>unsuspend</Code>,{" "}
-              <Code>deleted</Code>) update the installation row, so later deliveries on a revoked
-              install fail closed automatically.
-            </li>
-          </ul>
-        </Card>
-      </article>
+          <TrustBoundary
+            items={[
+              <>
+                Drydock never holds a PyPI credential or an OIDC token. The publish job exchanges
+                its own OIDC identity with PyPI directly.
+              </>,
+              <>
+                The release-target mapping is unique per{" "}
+                <Code>(organization, repository, environment)</Code> so a webhook can never
+                ambiguously resolve to two organizations.
+              </>,
+              <>
+                Every artifact in the bundle must agree on the normalized package name and version,
+                so a foreign or version-skewed wheel can't slip into the release set. A bundle whose
+                artifacts can't be identified is rejected, not guessed.
+              </>,
+              <>
+                Installation lifecycle events (<Code>suspend</Code>, <Code>unsuspend</Code>,{" "}
+                <Code>deleted</Code>) update the installation row, so later deliveries on a revoked
+                install fail closed automatically.
+              </>,
+            ]}
+          />
+        </section>
 
-      <section class="flex flex-col gap-4">
-        <SectionLabel>Set up an organization</SectionLabel>
-        <div class="flex flex-wrap gap-3">
-          <LinkButton href="/register">Create account</LinkButton>
-          <LinkButton href="/login" variant="secondary">
-            Sign in
-          </LinkButton>
-        </div>
-      </section>
+        <section class="flex flex-col gap-4 border-t border-border pt-10">
+          <SectionLabel>Set up an organization</SectionLabel>
+          <div class="flex flex-wrap gap-3">
+            <LinkButton href="/register">Create account</LinkButton>
+            <LinkButton href="/login" variant="secondary">
+              Sign in
+            </LinkButton>
+          </div>
+        </section>
+      </div>
     </PageShell>
+  );
+}
+
+function Subsection({ title, children }: { title: string; children: ComponentChildren }) {
+  return (
+    <div class="flex flex-col gap-3.5">
+      <h3 class="text-base font-medium tracking-[-0.005em] text-ink m-0">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function Prose({ children }: { children: ComponentChildren }) {
+  return <p class="m-0 max-w-[680px] text-[14px] text-ink-muted leading-[1.65]">{children}</p>;
+}
+
+function Steps({ items }: { items: ComponentChildren[] }) {
+  return (
+    <ol class="list-none p-0 m-0 flex flex-col">
+      {items.map((item, index) => (
+        <li key={index} class="grid grid-cols-[2rem_minmax(0,1fr)] gap-x-3">
+          <div class="flex flex-col items-center">
+            <span class="font-mono text-[11px] font-medium text-ink-subtle tabular-nums leading-none pt-px">
+              {String(index + 1).padStart(2, "0")}
+            </span>
+            {index < items.length - 1 ? (
+              <span class="w-px flex-1 bg-border mt-2" aria-hidden />
+            ) : null}
+          </div>
+          <div class="pb-5 last:pb-0 text-[13px] text-ink-muted leading-[1.6] min-w-0">{item}</div>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function TrustBoundary({ items }: { items: ComponentChildren[] }) {
+  return (
+    <Card class="p-5 flex flex-col gap-3">
+      <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">
+        Trust boundary
+      </span>
+      <ul class="list-disc pl-5 m-0 flex flex-col gap-2 text-[13px] text-ink-muted leading-[1.55] marker:text-ink-subtle">
+        {items.map((item, index) => (
+          <li key={index}>{item}</li>
+        ))}
+      </ul>
+    </Card>
   );
 }
 
@@ -352,10 +386,17 @@ function Code({ children }: { children: string }) {
   );
 }
 
-function CodeBlock({ children }: { children: string }) {
+function CodeBlock({ name, children }: { name?: string; children: string }) {
   return (
-    <pre class="m-0 p-4 rounded bg-surface-2 border border-border overflow-x-auto font-mono text-[12px] leading-[1.55] text-ink">
-      <code>{children}</code>
-    </pre>
+    <div class="rounded-md border border-border overflow-hidden bg-surface-2">
+      {name ? (
+        <div class="px-4 py-2 border-b border-border font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">
+          {name}
+        </div>
+      ) : null}
+      <pre class="m-0 p-4 overflow-x-auto font-mono text-[12px] leading-[1.55] text-ink">
+        <code>{children}</code>
+      </pre>
+    </div>
   );
 }

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -1,4 +1,4 @@
-import { Card, Eyebrow, LinkButton, PageShell, SectionLabel } from "../../components";
+import { Alert, Badge, Card, Eyebrow, LinkButton, PageShell, SectionLabel } from "../../components";
 
 export default function DocsPage() {
   return (
@@ -16,16 +16,17 @@ export default function DocsPage() {
           How Drydock guards a publish.
         </h1>
         <p class="text-[17px] text-ink-muted max-w-[620px] leading-[1.6] m-0">
-          Two release shapes exist in the wild: registries that own a staged artifact before
-          publish, and registries that don't. Drydock reviews each one with the primitive that fits
-          it, and never holds a publish credential.
+          Drydock reviews what a release ships before it goes public, and never holds your publish
+          credential. How it hooks in depends on the registry: npm hands Drydock a staged tarball to
+          inspect; PyPI has no staged artifact, so a GitHub Actions gate holds the publish until the
+          build is reviewed.
         </p>
         <nav class="flex flex-wrap gap-3 mt-2 font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
           <a class="text-accent hover:text-accent-hover" href="#staged-publishing">
-            → Staged publishing
+            → Staged publishing (npm)
           </a>
           <a class="text-accent hover:text-accent-hover" href="#action-gating">
-            → Action-based review gating
+            → Workflow gating (PyPI)
           </a>
         </nav>
       </section>
@@ -76,14 +77,14 @@ export default function DocsPage() {
           <h3 class="text-base font-medium tracking-[-0.005em] m-0">The review lifecycle</h3>
           <ol class="list-decimal pl-5 m-0 flex flex-col gap-1.5 text-[13px] text-ink-muted leading-[1.55] marker:text-ink-subtle marker:font-mono">
             <li>
-              A new staged publish is discovered — the 15-minute auto-discovery cron sweeps the
-              org's open stages, or a maintainer clicks <Code>Check npm</Code> on the dashboard. The
-              worker queues a scan for any <Code>stageId</Code> it hasn't seen before and the UI
-              starts polling its status.
+              A new staged publish is discovered (see Auto-discovery below). The worker queues a
+              scan for any <Code>stageId</Code> it hasn't seen before, and the UI starts polling
+              that scan's status.
             </li>
             <li>
-              The worker resolves the active organization's npm connection. The plaintext token
-              stays in D1 until the npm adapter broker needs it.
+              The worker resolves the active organization's npm connection. The token is stored
+              encrypted with AES-256-GCM in D1 and is decrypted only at the moment the npm adapter
+              needs to authenticate a registry request.
             </li>
             <li>
               A short-lived sandbox Worker downloads the staged tarball from{" "}
@@ -143,7 +144,10 @@ export default function DocsPage() {
 
       <article id="action-gating" class="flex flex-col gap-6 max-w-[880px]">
         <header class="flex flex-col gap-3">
-          <SectionLabel>Action-based review gating — PyPI &amp; GitHub Actions</SectionLabel>
+          <SectionLabel>
+            Action-based review gating — PyPI &amp; GitHub Actions{" "}
+            <Badge tone="info">Preview</Badge>
+          </SectionLabel>
           <h2 class="text-2xl font-semibold tracking-[-0.015em] m-0">
             When the registry can't hold the candidate, the workflow does.
           </h2>
@@ -154,6 +158,12 @@ export default function DocsPage() {
             the reviewed artifact digests are approved. The same maintainer-controlled credential —
             PyPI Trusted Publishing via OIDC — does the publish.
           </p>
+          <Alert tone="info">
+            This is the design we're building toward. The review engine and the GitHub
+            deployment-protection webhook already exist, but connecting a GitHub App and gating a
+            real publish end-to-end is still rolling out. The steps below describe the intended
+            setup.
+          </Alert>
         </header>
 
         <Card class="p-5 flex flex-col gap-3">

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -1,0 +1,287 @@
+import { Card, Eyebrow, LinkButton, PageShell, SectionLabel } from "../../components";
+
+export default function DocsPage() {
+  return (
+    <PageShell
+      class="gap-16"
+      headerActions={
+        <LinkButton href="/" variant="ghost" size="sm">
+          Home
+        </LinkButton>
+      }
+    >
+      <section class="py-8 md:py-12 border-y border-border flex flex-col gap-5">
+        <Eyebrow tone="accent">Documentation</Eyebrow>
+        <h1 class="text-4xl md:text-5xl font-semibold tracking-[-0.03em] leading-[1.05] max-w-[760px] m-0">
+          How Drydock guards a publish.
+        </h1>
+        <p class="text-[17px] text-ink-muted max-w-[620px] leading-[1.6] m-0">
+          Two release shapes exist in the wild: registries that own a staged artifact before
+          publish, and registries that don't. Drydock reviews each one with the primitive that fits
+          it, and never holds a publish credential.
+        </p>
+        <nav class="flex flex-wrap gap-3 mt-2 font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
+          <a class="text-accent hover:text-accent-hover" href="#staged-publishing">
+            → Staged publishing
+          </a>
+          <a class="text-accent hover:text-accent-hover" href="#action-gating">
+            → Action-based review gating
+          </a>
+        </nav>
+      </section>
+
+      <article id="staged-publishing" class="flex flex-col gap-6 max-w-[880px]">
+        <header class="flex flex-col gap-3">
+          <SectionLabel>Staged publishing — npm</SectionLabel>
+          <h2 class="text-2xl font-semibold tracking-[-0.015em] m-0">
+            The registry holds the candidate; the maintainer holds the keys.
+          </h2>
+          <p class="text-[14px] text-ink-muted leading-[1.6] m-0">
+            npm exposes a staged-publish primitive: a maintainer runs{" "}
+            <Code>npm publish --stage</Code> and the registry parks the candidate tarball behind a{" "}
+            <Code>stageId</Code> until the same maintainer confirms the publish with 2FA. Drydock
+            reviews what is inside that staged tarball before that confirmation runs.
+          </p>
+        </header>
+
+        <Card class="p-5 flex flex-col gap-2">
+          <h3 class="text-base font-medium tracking-[-0.005em] m-0">The review lifecycle</h3>
+          <ol class="list-decimal pl-5 m-0 flex flex-col gap-1.5 text-[13px] text-ink-muted leading-[1.55] marker:text-ink-subtle marker:font-mono">
+            <li>
+              A maintainer (or our auto-discovery cron) submits a <Code>stageId</Code> to{" "}
+              <Code>POST /api/v1/scans</Code>. The scan is queued and the UI starts polling its
+              status.
+            </li>
+            <li>
+              The worker resolves the active organization's npm connection. The plaintext token
+              stays in D1 until the npm adapter broker needs it.
+            </li>
+            <li>
+              A short-lived sandbox Worker downloads the staged tarball from{" "}
+              <Code>/-/stage/&lt;stageId&gt;/tarball</Code> through a credentialed outbound gateway
+              — the sandbox itself never receives the token.
+            </li>
+            <li>
+              The sandbox unpacks the archive into bounded file metadata and text samples and hands
+              them back to the parent worker. Package contents are evidence, never instructions.
+            </li>
+            <li>
+              The parent worker resolves a tag-aware baseline version, computes the
+              package-to-package diff, runs deterministic findings against the changed files, and
+              persists a redacted report.
+            </li>
+            <li>
+              The maintainer reads the report at <Code>/dashboard/scans/:id</Code>. Approval happens
+              in npm with normal 2FA — Drydock never publishes on their behalf.
+            </li>
+          </ol>
+        </Card>
+
+        <Card class="p-5 flex flex-col gap-2">
+          <h3 class="text-base font-medium tracking-[-0.005em] m-0">Auto-discovery</h3>
+          <p class="m-0 text-[13px] text-ink-muted leading-[1.55]">
+            A <Code>*/15 * * * *</Code> cron sweeps every validated npm connection, lists the
+            organization's open staged publishes via <Code>GET /-/stage</Code>, and queues a scan
+            for any new <Code>stageId</Code>. Stages that already completed in another organization
+            are skipped, so the same tarball is never fetched twice. When an auto-discovered scan
+            finishes, the connection's creator receives an email linking to the report. Tokens
+            marked <Code>invalid</Code> are skipped without contacting the registry.
+          </p>
+        </Card>
+
+        <Card class="p-5 flex flex-col gap-2">
+          <h3 class="text-base font-medium tracking-[-0.005em] m-0">Trust boundary</h3>
+          <ul class="list-disc pl-5 m-0 flex flex-col gap-1.5 text-[13px] text-ink-muted leading-[1.55] marker:text-ink-subtle">
+            <li>
+              The npm token only attaches to allowed registry endpoints (staged tarball, staged
+              details, registry metadata). The gateway is the single chokepoint.
+            </li>
+            <li>
+              The sandbox sees package bytes, not credentials. It cannot reach the internet except
+              through the gateway, and the gateway refuses to attach auth on arbitrary origins.
+            </li>
+            <li>
+              Reports persist redacted evidence: file paths, bounded text samples, deterministic
+              finding records. Raw tarballs are not retained.
+            </li>
+            <li>
+              Deterministic findings are authoritative. Nothing downstream — including any future AI
+              commentary — can downgrade them.
+            </li>
+          </ul>
+        </Card>
+      </article>
+
+      <article id="action-gating" class="flex flex-col gap-6 max-w-[880px]">
+        <header class="flex flex-col gap-3">
+          <SectionLabel>Action-based review gating — PyPI &amp; GitHub Actions</SectionLabel>
+          <h2 class="text-2xl font-semibold tracking-[-0.015em] m-0">
+            When the registry can't hold the candidate, the workflow does.
+          </h2>
+          <p class="text-[14px] text-ink-muted leading-[1.6] m-0">
+            PyPI does not expose a staged tarball. The publish job itself becomes the boundary: CI
+            builds the wheel and sdist, uploads them as a release candidate, and a GitHub
+            Environment with a Drydock-owned deployment protection rule blocks the publish job until
+            the reviewed artifact digests are approved. The same maintainer-controlled credential —
+            PyPI Trusted Publishing via OIDC — does the publish.
+          </p>
+        </header>
+
+        <Card class="p-5 flex flex-col gap-3">
+          <h3 class="text-base font-medium tracking-[-0.005em] m-0">
+            The release-candidate manifest
+          </h3>
+          <p class="m-0 text-[13px] text-ink-muted leading-[1.55]">
+            The build job writes a <Code>drydock-manifest.json</Code> next to the artifacts. The
+            manifest names every file that must reach PyPI and pins its sha256:
+          </p>
+          <CodeBlock>
+            {`{
+  "schema": "drydock.release-artifacts.v1",
+  "ecosystem": "pypi",
+  "package": "example-package",
+  "version": "1.2.3",
+  "artifacts": [
+    {
+      "path": "dist/example_package-1.2.3-py3-none-any.whl",
+      "sha256": "…"
+    },
+    {
+      "path": "dist/example_package-1.2.3.tar.gz",
+      "sha256": "…"
+    }
+  ]
+}`}
+          </CodeBlock>
+          <p class="m-0 text-[13px] text-ink-muted leading-[1.55]">
+            The publish job re-verifies these digests immediately before invoking{" "}
+            <Code>pypa/gh-action-pypi-publish</Code>. Rebuilding after the gate is rejected — the
+            reviewed bytes must be the published bytes.
+          </p>
+        </Card>
+
+        <Card class="p-5 flex flex-col gap-3">
+          <h3 class="text-base font-medium tracking-[-0.005em] m-0">The workflow shape</h3>
+          <CodeBlock>
+            {`jobs:
+  build-release-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: python -m build
+      - run: sha256sum dist/* > drydock-sha256.txt
+      - run: python scripts/write-drydock-manifest.py
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pypi-release-candidate
+          path: |
+            dist/*
+            drydock-manifest.json
+            drydock-sha256.txt
+
+  publish:
+    needs: build-release-artifacts
+    environment: pypi
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: pypi-release-candidate
+      - run: sha256sum --check drydock-sha256.txt
+      - uses: pypa/gh-action-pypi-publish@release/v1`}
+          </CodeBlock>
+          <p class="m-0 text-[13px] text-ink-muted leading-[1.55]">
+            The <Code>environment: pypi</Code> line is the gate. Configure the same environment in
+            PyPI Trusted Publishers and attach Drydock as a custom deployment protection rule on it.
+            The publish job is blocked until Drydock posts a decision back.
+          </p>
+        </Card>
+
+        <Card class="p-5 flex flex-col gap-2">
+          <h3 class="text-base font-medium tracking-[-0.005em] m-0">Decision flow</h3>
+          <ol class="list-decimal pl-5 m-0 flex flex-col gap-1.5 text-[13px] text-ink-muted leading-[1.55] marker:text-ink-subtle marker:font-mono">
+            <li>
+              GitHub fires a signed <Code>deployment_protection_rule</Code> webhook to{" "}
+              <Code>POST /webhooks/github</Code>. The handler HMAC-verifies the signature against
+              the raw body in constant time — unsigned or malformed requests are rejected.
+            </li>
+            <li>
+              The handler resolves the <Code>(installationId, repositoryId, environment)</Code>{" "}
+              triple against the organization's release-target table. Deliveries that don't match a
+              mapped target are acknowledged but ignored.
+            </li>
+            <li>
+              Matched deliveries persist a <Code>github_workflow_gates</Code> row keyed on the
+              GitHub delivery ID, so retries are idempotent. The scan pipeline runs against the
+              uploaded artifacts and the digests pinned in the manifest.
+            </li>
+            <li>
+              The decision is posted back to GitHub at{" "}
+              <Code>
+                POST
+                /repos/&lt;owner&gt;/&lt;repo&gt;/actions/runs/&lt;run_id&gt;/deployment_protection_rule
+              </Code>{" "}
+              with a fresh installation access token. The callback URL is pinned to{" "}
+              <Code>api.github.com</Code> and the deployment-protection path — a spoofed URL in the
+              webhook payload is rejected even when the signature is valid.
+            </li>
+            <li>
+              The transition out of <Code>pending</Code> is a single conditional update, so even if
+              the review pipeline runs more than once Drydock calls GitHub exactly once.
+            </li>
+          </ol>
+        </Card>
+
+        <Card class="p-5 flex flex-col gap-2">
+          <h3 class="text-base font-medium tracking-[-0.005em] m-0">Trust boundary</h3>
+          <ul class="list-disc pl-5 m-0 flex flex-col gap-1.5 text-[13px] text-ink-muted leading-[1.55] marker:text-ink-subtle">
+            <li>
+              Drydock never holds a PyPI credential or an OIDC token. The publish job exchanges its
+              own OIDC identity with PyPI directly.
+            </li>
+            <li>
+              The release-target mapping is unique per{" "}
+              <Code>(organization, repository, environment)</Code> so a webhook can never
+              ambiguously resolve to two organizations.
+            </li>
+            <li>
+              The reviewed artifact path set must exactly match the manifest path set. Adding a file
+              post-review breaks the gate.
+            </li>
+            <li>
+              Installation lifecycle events (<Code>suspend</Code>, <Code>unsuspend</Code>,{" "}
+              <Code>deleted</Code>) update the installation row, so later deliveries on a revoked
+              install fail closed automatically.
+            </li>
+          </ul>
+        </Card>
+      </article>
+
+      <section class="flex flex-col gap-4">
+        <SectionLabel>Set up an organization</SectionLabel>
+        <div class="flex flex-wrap gap-3">
+          <LinkButton href="/register">Create account</LinkButton>
+          <LinkButton href="/login" variant="secondary">
+            Sign in
+          </LinkButton>
+        </div>
+      </section>
+    </PageShell>
+  );
+}
+
+function Code({ children }: { children: string }) {
+  return (
+    <code class="font-mono text-[12px] text-ink bg-surface-2 px-1 py-0.5 rounded">{children}</code>
+  );
+}
+
+function CodeBlock({ children }: { children: string }) {
+  return (
+    <pre class="m-0 p-4 rounded bg-surface-2 border border-border overflow-x-auto font-mono text-[12px] leading-[1.55] text-ink">
+      <code>{children}</code>
+    </pre>
+  );
+}

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -30,7 +30,14 @@ export default function LandingPage() {
   }, []);
 
   return (
-    <PageShell class="gap-12">
+    <PageShell
+      class="gap-12"
+      headerActions={
+        <LinkButton href="/docs" variant="ghost" size="sm">
+          Docs
+        </LinkButton>
+      }
+    >
       <section class="py-8 md:py-12 border-y border-border flex flex-col gap-5">
         <Eyebrow tone="accent">Release confidence for npm maintainers</Eyebrow>
         <h1 class="text-4xl md:text-5xl font-semibold tracking-[-0.03em] leading-[1.05] max-w-[760px] m-0">

--- a/test/prerender-routes.test.ts
+++ b/test/prerender-routes.test.ts
@@ -8,11 +8,12 @@ describe("isPrerenderedRoute", () => {
     expect(isPrerenderedRoute("/login/")).toBe(true);
     expect(isPrerenderedRoute("/register")).toBe(true);
     expect(isPrerenderedRoute("/register/")).toBe(true);
+    expect(isPrerenderedRoute("/docs")).toBe(true);
+    expect(isPrerenderedRoute("/docs/")).toBe(true);
   });
 
   it("does not hydrate pages that are not prerendered by the build", () => {
     expect(isPrerenderedRoute("/dashboard")).toBe(false);
-    expect(isPrerenderedRoute("/docs")).toBe(false);
     expect(isPrerenderedRoute("/docs/intro")).toBe(false);
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig(({ mode }) => {
         prerender: {
           enabled: true,
           renderTarget: "#app",
-          additionalPrerenderRoutes: ["/login", "/register"],
+          additionalPrerenderRoutes: ["/login", "/register", "/docs"],
           previewMiddlewareEnabled: true,
           previewMiddlewareFallback: "/404",
         },


### PR DESCRIPTION
## Summary
- New `/docs` page documenting how Drydock reviews npm staged publishes and how the GitHub deployment-protection-rule gate works for ecosystems (like PyPI) that don't expose a staged artifact.
- Page is built on the existing design primitives (`PageShell`, `Card`, `Eyebrow`, `SectionLabel`, `LinkButton`) and includes the manifest schema, the target Actions workflow shape, and the webhook decision flow.
- Linked from the landing page header via a ghost `Docs` button so it is discoverable in any auth state.

## Test plan
- [x] `pnpm run verify` (lint, format, typecheck, 235 + 99 tests)
- [ ] Open `/docs` in dev, confirm hero, two anchored sections render, and the Home / Docs header links navigate correctly
- [ ] Check light + dark color scheme look correct on the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)