### PR TITLE
[codex] Add GitHub App release target mapping

### DIFF
--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -130,6 +130,16 @@ organization (`x-organization-id` header to scope writes).
   authorization (OAuth) during installation" so the setup callback includes
   this `code`; the installation ID alone is treated as untrusted.
 - `GET /installations` — lists every installation linked to the active org.
+- `GET /installations/:installationRowId/repositories` — proxies
+  `GET /installation/repositories` via the installation token so the UI can
+  surface a dropdown of repos the install can see, without holding GitHub App
+  credentials. Returns `{ id, fullName, defaultBranch }`.
+- `GET /installations/:installationRowId/repositories/:owner/:repo/environments`
+  — proxies `GET /repos/:owner/:repo/environments` via the installation token
+  so the UI can surface a dropdown of GitHub Environments configured on the
+  selected repo. Returns `{ name }[]`. Both routes call
+  `ensureInstallationOwnedBy` first, so foreign installation IDs return
+  `installation_missing` before any GitHub call is made.
 - `GET /release-targets`, `POST /release-targets`,
   `DELETE /release-targets/:id` — CRUD over the mapping.
 
@@ -283,11 +293,18 @@ The install flow lives on `/dashboard/settings` (gated behind
    `/dashboard...` return paths before resuming the callback.
 4. Linked installations render with `active` / `suspended` / `uninstalled`
    status badges.
+5. Below the linked installations, a "PyPI release targets" form lets the user
+   register a `(package, repo, environment)` mapping. Installation, repository,
+   and environment are dropdowns populated from the new proxy endpoints; the
+   PyPI Trusted Publisher environment defaults to the selected GitHub
+   environment but stays editable so the user can confirm before saving. The
+   server still revalidates installation ownership, repo access, and
+   environment-name equality on `POST /release-targets`, so the UI cannot
+   bypass the rules. Empty states link to GitHub App settings (no repos) and
+   GitHub Actions environments docs (no environments).
 
 ## Remaining work
 
-- Replace the free-text `repositoryFullName` field with a dropdown of repos the
-  installation can see (`GET /installation/repositories`).
 - Fetch GitHub Actions artifacts and `drydock-manifest.json` with installation
   credentials, then call `markGateDecided` / `postDeploymentProtectionDecision`
   to release or block the publish job.

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -134,13 +134,14 @@ organization (`x-organization-id` header to scope writes).
   `GET /installation/repositories` via the installation token so the UI can
   surface a dropdown of repos the install can see, without holding GitHub App
   credentials. It follows GitHub pagination until exhausted. Returns
-  `{ id, fullName, defaultBranch }`.
+  `{ repositories: [{ id, fullName, defaultBranch }] }`.
 - `GET /installations/:installationRowId/repositories/:owner/:repo/environments`
   — proxies `GET /repos/:owner/:repo/environments` via the installation token
   so the UI can surface a dropdown of GitHub Environments configured on the
-  selected repo. Returns `{ name }[]`. Both routes call
+  selected repo. Returns `{ environments: [{ name }] }`. Both routes call
   `ensureInstallationOwnedBy` first, so foreign installation IDs return
-  `installation_missing` before any GitHub call is made.
+  `installation_missing` before any GitHub call is made, and both are
+  rate-limited before minting an installation token or calling GitHub.
 - `GET /release-targets`, `POST /release-targets`,
   `DELETE /release-targets/:id` — CRUD over the mapping.
 

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -133,7 +133,8 @@ organization (`x-organization-id` header to scope writes).
 - `GET /installations/:installationRowId/repositories` — proxies
   `GET /installation/repositories` via the installation token so the UI can
   surface a dropdown of repos the install can see, without holding GitHub App
-  credentials. Returns `{ id, fullName, defaultBranch }`.
+  credentials. It follows GitHub pagination until exhausted. Returns
+  `{ id, fullName, defaultBranch }`.
 - `GET /installations/:installationRowId/repositories/:owner/:repo/environments`
   — proxies `GET /repos/:owner/:repo/environments` via the installation token
   so the UI can surface a dropdown of GitHub Environments configured on the

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -153,7 +153,8 @@ organization (`x-organization-id` header to scope writes).
   repo name is validated as exactly `owner/repo` before the GitHub API URL is
   built, so path traversal-like segments cannot escape the repository lookup.
 - `environment_unmapped` — caller did not provide both `environment` and
-  `pypiTrustedPublisherEnvironment`.
+  `pypiTrustedPublisherEnvironment`, or the provided environment name exceeds
+  GitHub's 255-character limit.
 - `environment_mismatch` — the two environment names differ.
 - `package_already_mapped` — `(organizationId, ecosystem, packageName)` already
   has a row.

--- a/server/lib/github-app.ts
+++ b/server/lib/github-app.ts
@@ -416,6 +416,95 @@ export async function fetchRepository(
   return { id: data.id, fullName: data.full_name, defaultBranch: data.default_branch };
 }
 
+export async function listInstallationRepositories(
+  config: GithubAppConfig,
+  installationId: string,
+): Promise<GithubRepositoryRef[]> {
+  const token = await getInstallationAccessToken(config, installationId);
+  const repositories: GithubRepositoryRef[] = [];
+  let url = "https://api.github.com/installation/repositories?per_page=100";
+
+  for (let page = 0; page < 10 && url; page += 1) {
+    const response = await fetch(url, { headers: githubInstallationHeaders(token) });
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new GithubAppValidationError(
+        "repository_not_accessible",
+        `installation repositories lookup failed (${response.status}): ${text.slice(0, 200)}`,
+      );
+    }
+    const data = (await response.json()) as {
+      repositories?: {
+        id?: number;
+        full_name?: string;
+        default_branch?: string;
+      }[];
+    };
+    for (const repo of data.repositories ?? []) {
+      if (typeof repo.id !== "number" || typeof repo.full_name !== "string") continue;
+      repositories.push({
+        id: repo.id,
+        fullName: repo.full_name,
+        defaultBranch: typeof repo.default_branch === "string" ? repo.default_branch : undefined,
+      });
+    }
+    url = nextLink(response.headers.get("link"));
+  }
+
+  repositories.sort((a, b) => a.fullName.localeCompare(b.fullName));
+  return repositories;
+}
+
+export interface GithubEnvironmentRef {
+  name: string;
+}
+
+export async function listRepositoryEnvironments(
+  config: GithubAppConfig,
+  installationId: string,
+  fullName: string,
+): Promise<GithubEnvironmentRef[]> {
+  const repository = parseRepositoryFullName(fullName);
+  if (!repository) {
+    throw new GithubAppValidationError(
+      "invalid_input",
+      "repositoryFullName must be in owner/repo form",
+    );
+  }
+  const token = await getInstallationAccessToken(config, installationId);
+  const repositoryPath = `${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.name)}`;
+  const environments: GithubEnvironmentRef[] = [];
+  let url = `https://api.github.com/repos/${repositoryPath}/environments?per_page=100`;
+
+  for (let page = 0; page < 10 && url; page += 1) {
+    const response = await fetch(url, { headers: githubInstallationHeaders(token) });
+    if (response.status === 404) {
+      throw new GithubAppValidationError(
+        "repository_not_accessible",
+        `repository ${fullName} is not accessible to installation ${installationId}`,
+      );
+    }
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      throw new GithubAppValidationError(
+        "repository_not_accessible",
+        `environments lookup for ${fullName} failed (${response.status}): ${text.slice(0, 200)}`,
+      );
+    }
+    const data = (await response.json()) as {
+      environments?: { name?: string }[];
+    };
+    for (const environment of data.environments ?? []) {
+      if (typeof environment.name === "string" && environment.name) {
+        environments.push({ name: environment.name });
+      }
+    }
+    url = nextLink(response.headers.get("link"));
+  }
+
+  return environments;
+}
+
 // ── DB-backed service ────────────────────────────────────────────────────────
 
 export interface InstallationRecord {

--- a/server/lib/github-app.ts
+++ b/server/lib/github-app.ts
@@ -424,7 +424,15 @@ export async function listInstallationRepositories(
   const repositories: GithubRepositoryRef[] = [];
   let url = "https://api.github.com/installation/repositories?per_page=100";
 
-  for (let page = 0; page < 10 && url; page += 1) {
+  const seenUrls = new Set<string>();
+  while (url) {
+    if (seenUrls.has(url)) {
+      throw new GithubAppValidationError(
+        "repository_not_accessible",
+        "installation repositories lookup returned a repeated pagination link",
+      );
+    }
+    seenUrls.add(url);
     const response = await fetch(url, { headers: githubInstallationHeaders(token) });
     if (!response.ok) {
       const text = await response.text().catch(() => "");

--- a/server/lib/github-app.ts
+++ b/server/lib/github-app.ts
@@ -25,7 +25,7 @@ const ACCOUNT_LOGIN_MAX = 100;
 const PACKAGE_NAME_MAX = 214;
 const REPO_FULL_NAME_MAX = 140;
 const WORKFLOW_FILENAME_MAX = 200;
-const ENVIRONMENT_MAX = 80;
+const ENVIRONMENT_MAX = 255;
 
 // ── Errors ───────────────────────────────────────────────────────────────────
 
@@ -836,7 +836,6 @@ export async function resolveDeploymentProtectionTarget(
 const PACKAGE_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,213}$/;
 const REPO_OWNER_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
 const REPO_NAME_RE = /^[A-Za-z0-9._-]+$/;
-const ENVIRONMENT_RE = /^[A-Za-z0-9][A-Za-z0-9 ._-]{0,79}$/;
 const WORKFLOW_FILENAME_RE = /^[A-Za-z0-9._-]+\.ya?ml$/;
 
 export function validateReleaseTargetShape(input: CreateReleaseTargetInput) {
@@ -870,9 +869,12 @@ export function validateReleaseTargetShape(input: CreateReleaseTargetInput) {
     input.pypiTrustedPublisherEnvironment,
   );
   if (!environment || environment.length > ENVIRONMENT_MAX) {
-    throw new GithubAppValidationError("environment_unmapped", "environment is required");
+    throw new GithubAppValidationError(
+      "environment_unmapped",
+      "environment is required and must not exceed 255 characters",
+    );
   }
-  if (!ENVIRONMENT_RE.test(environment)) {
+  if (hasControlCharacter(environment)) {
     throw new GithubAppValidationError("invalid_input", "environment has invalid characters");
   }
   if (
@@ -881,10 +883,10 @@ export function validateReleaseTargetShape(input: CreateReleaseTargetInput) {
   ) {
     throw new GithubAppValidationError(
       "environment_unmapped",
-      "pypiTrustedPublisherEnvironment is required",
+      "pypiTrustedPublisherEnvironment is required and must not exceed 255 characters",
     );
   }
-  if (!ENVIRONMENT_RE.test(pypiTrustedPublisherEnvironment)) {
+  if (hasControlCharacter(pypiTrustedPublisherEnvironment)) {
     throw new GithubAppValidationError(
       "invalid_input",
       "pypiTrustedPublisherEnvironment has invalid characters",
@@ -1015,6 +1017,14 @@ function normalizePackageName(ecosystem: SupportedEcosystem, packageName: string
 
 function normalizeGithubEnvironmentName(environment: string): string {
   return environment.trim().toLowerCase();
+}
+
+function hasControlCharacter(value: string): boolean {
+  for (const char of value) {
+    const code = char.charCodeAt(0);
+    if (code <= 31 || code === 127) return true;
+  }
+  return false;
 }
 
 function parseRepositoryFullName(fullName: string): { owner: string; name: string } | null {

--- a/server/routes/github-app.ts
+++ b/server/routes/github-app.ts
@@ -1,6 +1,7 @@
 import { Hono, type Context } from "hono";
 import { RateLimitError, createDb, enforceRateLimit, recordScanEvent } from "../db";
 import { requireActiveOrganization } from "../lib/active-organization";
+import { rateLimitResponse } from "../lib/http";
 import {
   GithubAppConfigError,
   GithubAppValidationError,
@@ -31,6 +32,9 @@ import type { Bindings, Variables } from "../types";
 type RouteContext = Context<{ Bindings: Bindings; Variables: Variables }>;
 
 export const githubAppRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+const GITHUB_APP_PROXY_LIMIT = 60;
+const GITHUB_APP_PROXY_WINDOW_MS = 60 * 1000;
 
 githubAppRoutes.get("/config", (c) => {
   const configured = isGithubAppConfigured(c.env);
@@ -173,6 +177,18 @@ githubAppRoutes.get("/installations/:installationRowId/repositories", async (c) 
   const installationRowId = c.req.param("installationRowId");
   try {
     const installation = await ensureInstallationOwnedBy(db, organizationId, installationRowId);
+    try {
+      await enforceRateLimit(db, {
+        key: `github-app:repositories:${organizationId}:${installation.id}`,
+        limit: GITHUB_APP_PROXY_LIMIT,
+        windowMs: GITHUB_APP_PROXY_WINDOW_MS,
+      });
+    } catch (err) {
+      if (err instanceof RateLimitError) {
+        return rateLimitResponse(c, "GitHub repository lookup rate limit exceeded", err);
+      }
+      throw err;
+    }
     const repositories = await listInstallationRepositories(config, installation.installationId);
     return c.json({
       repositories: repositories.map((repo) => ({
@@ -205,6 +221,18 @@ githubAppRoutes.get(
     }
     try {
       const installation = await ensureInstallationOwnedBy(db, organizationId, installationRowId);
+      try {
+        await enforceRateLimit(db, {
+          key: `github-app:environments:${organizationId}:${installation.id}:${owner}/${repo}`,
+          limit: GITHUB_APP_PROXY_LIMIT,
+          windowMs: GITHUB_APP_PROXY_WINDOW_MS,
+        });
+      } catch (err) {
+        if (err instanceof RateLimitError) {
+          return rateLimitResponse(c, "GitHub environment lookup rate limit exceeded", err);
+        }
+        throw err;
+      }
       const environments = await listRepositoryEnvironments(
         config,
         installation.installationId,

--- a/server/routes/github-app.ts
+++ b/server/routes/github-app.ts
@@ -16,8 +16,10 @@ import {
   fetchInstallationMetadata,
   fetchRepository,
   isGithubAppConfigured,
+  listInstallationRepositories,
   listInstallationsForOrganization,
   listReleaseTargetsForOrganization,
+  listRepositoryEnvironments,
   readGithubAppConfig,
   signOAuthState,
   upsertInstallation,
@@ -158,6 +160,64 @@ githubAppRoutes.get("/installations", async (c) => {
   const installations = await listInstallationsForOrganization(db, organizationId);
   return c.json({ installations: installations.map(publicInstallation) });
 });
+
+githubAppRoutes.get("/installations/:installationRowId/repositories", async (c) => {
+  let config: GithubAppConfig;
+  try {
+    config = readGithubAppConfig(c.env);
+  } catch (err) {
+    return configErrorResponse(c, err);
+  }
+  const db = createDb(c.env.DB);
+  const organizationId = await requireActiveOrganization(c, db);
+  const installationRowId = c.req.param("installationRowId");
+  try {
+    const installation = await ensureInstallationOwnedBy(db, organizationId, installationRowId);
+    const repositories = await listInstallationRepositories(config, installation.installationId);
+    return c.json({
+      repositories: repositories.map((repo) => ({
+        id: repo.id,
+        fullName: repo.fullName,
+        defaultBranch: repo.defaultBranch ?? null,
+      })),
+    });
+  } catch (err) {
+    return validationErrorResponse(c, err);
+  }
+});
+
+githubAppRoutes.get(
+  "/installations/:installationRowId/repositories/:owner/:repo/environments",
+  async (c) => {
+    let config: GithubAppConfig;
+    try {
+      config = readGithubAppConfig(c.env);
+    } catch (err) {
+      return configErrorResponse(c, err);
+    }
+    const db = createDb(c.env.DB);
+    const organizationId = await requireActiveOrganization(c, db);
+    const installationRowId = c.req.param("installationRowId");
+    const owner = c.req.param("owner");
+    const repo = c.req.param("repo");
+    if (!owner || !repo) {
+      return c.json({ error: "owner and repo are required" }, 400);
+    }
+    try {
+      const installation = await ensureInstallationOwnedBy(db, organizationId, installationRowId);
+      const environments = await listRepositoryEnvironments(
+        config,
+        installation.installationId,
+        `${owner}/${repo}`,
+      );
+      return c.json({
+        environments: environments.map((environment) => ({ name: environment.name })),
+      });
+    } catch (err) {
+      return validationErrorResponse(c, err);
+    }
+  },
+);
 
 githubAppRoutes.get("/release-targets", async (c) => {
   const db = createDb(c.env.DB);

--- a/src/models/github-app.ts
+++ b/src/models/github-app.ts
@@ -16,6 +16,31 @@ export interface PublicGithubAppInstallation {
   updatedAt: string;
 }
 
+export interface PublicReleaseTarget {
+  id: string;
+  organizationId: string;
+  installationRowId: string;
+  ecosystem: "pypi";
+  packageName: string;
+  repositoryId: number;
+  repositoryFullName: string;
+  workflowFilename: string | null;
+  environment: string;
+  pypiTrustedPublisherEnvironment: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface InstallationRepository {
+  id: number;
+  fullName: string;
+  defaultBranch: string | null;
+}
+
+export interface RepositoryEnvironment {
+  name: string;
+}
+
 export interface GithubAppConfigState {
   configured: boolean;
   appSlug?: string;
@@ -47,6 +72,10 @@ export interface CallbackQuery {
   setupAction: string;
 }
 
+export type ReleaseTargetFormStatus = "idle" | "submitting";
+export type RepositoryListStatus = "idle" | "loading" | "error";
+export type EnvironmentListStatus = "idle" | "loading" | "error";
+
 export const GithubAppModel = createModel(() => {
   const config = signal<GithubAppConfigState | null>(null);
   const installations = signal<PublicGithubAppInstallation[]>([]);
@@ -57,9 +86,113 @@ export const GithubAppModel = createModel(() => {
   const configLoaded = signal(false);
   const installationsLoaded = signal(false);
 
+  const releaseTargets = signal<PublicReleaseTarget[]>([]);
+  const releaseTargetsLoaded = signal(false);
+  const releaseTargetsError = signal<string | null>(null);
+
+  const formInstallationRowId = signal<string>("");
+  const formPackageName = signal<string>("");
+  const formRepositoryFullName = signal<string>("");
+  const formEnvironment = signal<string>("");
+  const formPypiTrustedPublisherEnvironment = signal<string>("");
+  const formWorkflowFilename = signal<string>("");
+  const formStatus = signal<ReleaseTargetFormStatus>("idle");
+  const formError = signal<string | null>(null);
+
+  const repositoryCache = signal<Record<string, InstallationRepository[]>>({});
+  const repositoryStatus = signal<Record<string, RepositoryListStatus>>({});
+  const repositoryErrors = signal<Record<string, string>>({});
+
+  const environmentCache = signal<Record<string, RepositoryEnvironment[]>>({});
+  const environmentStatus = signal<Record<string, EnvironmentListStatus>>({});
+  const environmentErrors = signal<Record<string, string>>({});
+
   const busy = computed(() => status.value !== "idle");
   const notConfigured = computed(() => config.value?.configured === false);
-  const loaded = computed(() => configLoaded.value && installationsLoaded.value);
+  const loaded = computed(
+    () => configLoaded.value && installationsLoaded.value && releaseTargetsLoaded.value,
+  );
+  const formSubmitting = computed(() => formStatus.value === "submitting");
+
+  const activeRepositories = computed<InstallationRepository[]>(() => {
+    const id = formInstallationRowId.value;
+    const cache = repositoryCache.value;
+    return id ? (cache[id] ?? []) : [];
+  });
+  const activeRepositoryStatus = computed<RepositoryListStatus>(() => {
+    const id = formInstallationRowId.value;
+    const statusMap = repositoryStatus.value;
+    return id ? (statusMap[id] ?? "idle") : "idle";
+  });
+  const activeRepositoryError = computed<string | null>(() => {
+    const id = formInstallationRowId.value;
+    const errors = repositoryErrors.value;
+    return id ? (errors[id] ?? null) : null;
+  });
+
+  const environmentCacheKey = computed<string>(() => {
+    const installationId = formInstallationRowId.value;
+    const repo = formRepositoryFullName.value;
+    return installationId && repo ? `${installationId}::${repo}` : "";
+  });
+  const activeEnvironments = computed<RepositoryEnvironment[]>(() => {
+    const key = environmentCacheKey.value;
+    const cache = environmentCache.value;
+    return key ? (cache[key] ?? []) : [];
+  });
+  const activeEnvironmentStatus = computed<EnvironmentListStatus>(() => {
+    const key = environmentCacheKey.value;
+    const statusMap = environmentStatus.value;
+    return key ? (statusMap[key] ?? "idle") : "idle";
+  });
+  const activeEnvironmentError = computed<string | null>(() => {
+    const key = environmentCacheKey.value;
+    const errors = environmentErrors.value;
+    return key ? (errors[key] ?? null) : null;
+  });
+
+  const formValid = computed(
+    () =>
+      formInstallationRowId.value.trim() !== "" &&
+      formPackageName.value.trim() !== "" &&
+      formRepositoryFullName.value.trim() !== "" &&
+      formEnvironment.value.trim() !== "" &&
+      formPypiTrustedPublisherEnvironment.value.trim() !== "" &&
+      formEnvironment.value.trim().toLowerCase() ===
+        formPypiTrustedPublisherEnvironment.value.trim().toLowerCase(),
+  );
+
+  function setRepositoryStatus(installationRowId: string, value: RepositoryListStatus) {
+    repositoryStatus.value = { ...repositoryStatus.peek(), [installationRowId]: value };
+  }
+
+  function setRepositoryError(installationRowId: string, message: string | null) {
+    const next = { ...repositoryErrors.peek() };
+    if (message) next[installationRowId] = message;
+    else delete next[installationRowId];
+    repositoryErrors.value = next;
+  }
+
+  function setEnvironmentStatus(key: string, value: EnvironmentListStatus) {
+    environmentStatus.value = { ...environmentStatus.peek(), [key]: value };
+  }
+
+  function setEnvironmentError(key: string, message: string | null) {
+    const next = { ...environmentErrors.peek() };
+    if (message) next[key] = message;
+    else delete next[key];
+    environmentErrors.value = next;
+  }
+
+  function clearForm() {
+    formInstallationRowId.value = "";
+    formPackageName.value = "";
+    formRepositoryFullName.value = "";
+    formEnvironment.value = "";
+    formPypiTrustedPublisherEnvironment.value = "";
+    formWorkflowFilename.value = "";
+    formError.value = null;
+  }
 
   return {
     config,
@@ -73,6 +206,28 @@ export const GithubAppModel = createModel(() => {
     busy,
     notConfigured,
     loaded,
+
+    releaseTargets,
+    releaseTargetsLoaded,
+    releaseTargetsError,
+
+    formInstallationRowId,
+    formPackageName,
+    formRepositoryFullName,
+    formEnvironment,
+    formPypiTrustedPublisherEnvironment,
+    formWorkflowFilename,
+    formStatus,
+    formError,
+    formSubmitting,
+    formValid,
+
+    activeRepositories,
+    activeRepositoryStatus,
+    activeRepositoryError,
+    activeEnvironments,
+    activeEnvironmentStatus,
+    activeEnvironmentError,
 
     async loadConfig(): Promise<void> {
       try {
@@ -99,6 +254,157 @@ export const GithubAppModel = createModel(() => {
         installationsLoaded.value = true;
       }
     },
+
+    async loadReleaseTargets(): Promise<void> {
+      try {
+        const data = await apiFetch<{ releaseTargets: PublicReleaseTarget[] }>(
+          "/api/v1/github-app/release-targets",
+        );
+        releaseTargets.value = data.releaseTargets;
+        releaseTargetsError.value = null;
+      } catch (err) {
+        releaseTargetsError.value = errorMessage(err);
+        releaseTargets.value = [];
+      } finally {
+        releaseTargetsLoaded.value = true;
+      }
+    },
+
+    async loadInstallationRepositories(
+      installationRowId: string,
+      { force = false }: { force?: boolean } = {},
+    ): Promise<void> {
+      if (!installationRowId) return;
+      if (!force && repositoryCache.peek()[installationRowId]) return;
+      setRepositoryStatus(installationRowId, "loading");
+      setRepositoryError(installationRowId, null);
+      try {
+        const data = await apiFetch<{ repositories: InstallationRepository[] }>(
+          `/api/v1/github-app/installations/${encodeURIComponent(installationRowId)}/repositories`,
+        );
+        repositoryCache.value = {
+          ...repositoryCache.peek(),
+          [installationRowId]: data.repositories,
+        };
+        setRepositoryStatus(installationRowId, "idle");
+      } catch (err) {
+        setRepositoryError(installationRowId, errorMessage(err));
+        setRepositoryStatus(installationRowId, "error");
+      }
+    },
+
+    async loadRepositoryEnvironments(
+      installationRowId: string,
+      repositoryFullName: string,
+      { force = false }: { force?: boolean } = {},
+    ): Promise<void> {
+      if (!installationRowId || !repositoryFullName) return;
+      const key = `${installationRowId}::${repositoryFullName}`;
+      if (!force && environmentCache.peek()[key]) return;
+      setEnvironmentStatus(key, "loading");
+      setEnvironmentError(key, null);
+      const [owner, repo] = repositoryFullName.split("/", 2);
+      if (!owner || !repo) {
+        setEnvironmentError(key, "repository must be in owner/repo form");
+        setEnvironmentStatus(key, "error");
+        return;
+      }
+      try {
+        const data = await apiFetch<{ environments: RepositoryEnvironment[] }>(
+          `/api/v1/github-app/installations/${encodeURIComponent(installationRowId)}/repositories/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/environments`,
+        );
+        environmentCache.value = { ...environmentCache.peek(), [key]: data.environments };
+        setEnvironmentStatus(key, "idle");
+      } catch (err) {
+        setEnvironmentError(key, errorMessage(err));
+        setEnvironmentStatus(key, "error");
+      }
+    },
+
+    selectInstallation(installationRowId: string) {
+      formInstallationRowId.value = installationRowId;
+      formRepositoryFullName.value = "";
+      formEnvironment.value = "";
+      formPypiTrustedPublisherEnvironment.value = "";
+      formError.value = null;
+      if (installationRowId) {
+        void this.loadInstallationRepositories(installationRowId);
+      }
+    },
+
+    selectRepository(repositoryFullName: string) {
+      formRepositoryFullName.value = repositoryFullName;
+      formEnvironment.value = "";
+      formPypiTrustedPublisherEnvironment.value = "";
+      formError.value = null;
+      const installationRowId = formInstallationRowId.value;
+      if (installationRowId && repositoryFullName) {
+        void this.loadRepositoryEnvironments(installationRowId, repositoryFullName);
+      }
+    },
+
+    selectEnvironment(environment: string) {
+      formEnvironment.value = environment;
+      // PyPI trusted-publisher environment must match the GitHub environment by
+      // default — keep it in sync until the user edits the field directly.
+      formPypiTrustedPublisherEnvironment.value = environment;
+      formError.value = null;
+    },
+
+    setPypiTrustedPublisherEnvironment(environment: string) {
+      formPypiTrustedPublisherEnvironment.value = environment;
+      formError.value = null;
+    },
+
+    async createReleaseTarget(): Promise<PublicReleaseTarget | null> {
+      if (formSubmitting.value) return null;
+      formStatus.value = "submitting";
+      formError.value = null;
+      try {
+        const payload: Record<string, string> = {
+          installationRowId: formInstallationRowId.value.trim(),
+          ecosystem: "pypi",
+          packageName: formPackageName.value.trim(),
+          repositoryFullName: formRepositoryFullName.value.trim(),
+          environment: formEnvironment.value.trim(),
+          pypiTrustedPublisherEnvironment: formPypiTrustedPublisherEnvironment.value.trim(),
+        };
+        const workflowFilename = formWorkflowFilename.value.trim();
+        if (workflowFilename) payload.workflowFilename = workflowFilename;
+        const data = await apiJson<{ releaseTarget: PublicReleaseTarget }>(
+          "/api/v1/github-app/release-targets",
+          payload,
+        );
+        const next = [
+          data.releaseTarget,
+          ...releaseTargets.peek().filter((row) => row.id !== data.releaseTarget.id),
+        ];
+        releaseTargets.value = next;
+        clearForm();
+        return data.releaseTarget;
+      } catch (err) {
+        formError.value = errorMessage(err);
+        return null;
+      } finally {
+        formStatus.value = "idle";
+      }
+    },
+
+    async deleteReleaseTarget(id: string): Promise<boolean> {
+      try {
+        await apiFetch<{ ok: true }>(
+          `/api/v1/github-app/release-targets/${encodeURIComponent(id)}`,
+          { method: "DELETE" },
+        );
+        releaseTargets.value = releaseTargets.peek().filter((row) => row.id !== id);
+        return true;
+      } catch (err) {
+        releaseTargetsError.value = errorMessage(err);
+        return false;
+      }
+    },
+
+    clearForm,
 
     async startInstall(): Promise<void> {
       status.value = "starting";

--- a/src/pages/Dashboard/Settings.tsx
+++ b/src/pages/Dashboard/Settings.tsx
@@ -1,3 +1,4 @@
+import type { ComponentChildren } from "preact";
 import { useEffect } from "preact/hooks";
 import { useModel, useSignal } from "@preact/signals";
 import { useLocation } from "preact-iso";
@@ -9,6 +10,7 @@ import {
   GithubAppModel,
   type InstallationStatus,
   type PublicGithubAppInstallation,
+  type PublicReleaseTarget,
 } from "../../models/github-app";
 import {
   Alert,
@@ -54,7 +56,11 @@ export default function SettingsPage() {
       sessionChecked.value = true;
       const loaders: Promise<unknown>[] = [organizations.load(), npm.load()];
       if (GITHUB_APP_UI_ENABLED) {
-        loaders.push(githubApp.loadConfig(), githubApp.loadInstallations());
+        loaders.push(
+          githubApp.loadConfig(),
+          githubApp.loadInstallations(),
+          githubApp.loadReleaseTargets(),
+        );
       }
       await Promise.all(loaders);
     })();
@@ -65,7 +71,10 @@ export default function SettingsPage() {
 
   const reloadActiveOrgScopedData = async () => {
     const loaders: Promise<unknown>[] = [npm.load()];
-    if (GITHUB_APP_UI_ENABLED) loaders.push(githubApp.loadInstallations());
+    if (GITHUB_APP_UI_ENABLED) {
+      githubApp.clearForm();
+      loaders.push(githubApp.loadInstallations(), githubApp.loadReleaseTargets());
+    }
     await Promise.all(loaders);
   };
 
@@ -159,11 +168,16 @@ function GithubAppSection({
 }) {
   const configured = githubApp.config.value?.configured === true;
   const appSlug = githubApp.config.value?.appSlug;
-  const installations = githubApp.installations.value;
+  const installations: PublicGithubAppInstallation[] = githubApp.installations.value;
   const status = githubApp.status.value;
   const error = githubApp.error.value;
   const lastLinked = githubApp.lastLinked.value;
   const busy = githubApp.busy.value;
+  const releaseTargets: PublicReleaseTarget[] = githubApp.releaseTargets.value;
+  const releaseTargetsError = githubApp.releaseTargetsError.value;
+  const activeInstallations = installations.filter(
+    (row: PublicGithubAppInstallation) => row.status === "active",
+  );
 
   const onInstall = () => {
     void githubApp.startInstall();
@@ -249,7 +263,330 @@ function GithubAppSection({
           </div>
         )}
       </div>
+
+      <div class="border-t border-border">
+        <div class="px-5 py-4 flex items-center justify-between gap-3">
+          <SectionLabel>PyPI release targets</SectionLabel>
+          <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
+            {releaseTargets.length} mapped
+          </span>
+        </div>
+        {activeInstallations.length ? (
+          <ReleaseTargetForm githubApp={githubApp} activeInstallations={activeInstallations} />
+        ) : (
+          <div class="px-5 pb-5">
+            <Muted class="text-[13px] m-0">
+              Install the GitHub App on an organization with the repo you want to gate before
+              mapping a release target.
+            </Muted>
+          </div>
+        )}
+        {releaseTargetsError ? (
+          <div class="px-5 pb-5">
+            <Alert tone="critical">{releaseTargetsError}</Alert>
+          </div>
+        ) : null}
+        {releaseTargets.length ? (
+          <ReleaseTargetList
+            releaseTargets={releaseTargets}
+            installations={installations}
+            onDelete={(id) => void githubApp.deleteReleaseTarget(id)}
+          />
+        ) : null}
+      </div>
     </Card>
+  );
+}
+
+function ReleaseTargetForm({
+  githubApp,
+  activeInstallations,
+}: {
+  githubApp: ReturnType<typeof useModel<typeof GithubAppModel.prototype>>;
+  activeInstallations: PublicGithubAppInstallation[];
+}) {
+  const installationRowId = githubApp.formInstallationRowId.value;
+  const packageName = githubApp.formPackageName.value;
+  const repositoryFullName = githubApp.formRepositoryFullName.value;
+  const environment = githubApp.formEnvironment.value;
+  const trustedPublisherEnv = githubApp.formPypiTrustedPublisherEnvironment.value;
+  const workflowFilename = githubApp.formWorkflowFilename.value;
+  const formError = githubApp.formError.value;
+  const submitting = githubApp.formSubmitting.value;
+  const formValid = githubApp.formValid.value;
+
+  const repositories = githubApp.activeRepositories.value;
+  const repositoryStatus = githubApp.activeRepositoryStatus.value;
+  const repositoryError = githubApp.activeRepositoryError.value;
+  const environments = githubApp.activeEnvironments.value;
+  const environmentStatus = githubApp.activeEnvironmentStatus.value;
+  const environmentError = githubApp.activeEnvironmentError.value;
+
+  const onSubmit = async (event: Event) => {
+    event.preventDefault();
+    await githubApp.createReleaseTarget();
+  };
+
+  const trustedPublisherDiffers =
+    environment.trim().toLowerCase() !== trustedPublisherEnv.trim().toLowerCase() &&
+    trustedPublisherEnv.trim() !== "";
+
+  return (
+    <form class="px-5 pb-5 flex flex-col gap-4" onSubmit={onSubmit}>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <Field label="Installation" for="releaseTargetInstallation">
+          <Select
+            id="releaseTargetInstallation"
+            value={installationRowId}
+            disabled={submitting}
+            onChange={(value) => githubApp.selectInstallation(value)}
+          >
+            <option value="">Pick an installation…</option>
+            {activeInstallations.map((row) => (
+              <option key={row.id} value={row.id}>
+                {row.accountLogin} · installation {row.installationId}
+              </option>
+            ))}
+          </Select>
+        </Field>
+        <Field label="PyPI package name" for="releaseTargetPackage">
+          <Input
+            id="releaseTargetPackage"
+            type="text"
+            value={packageName}
+            placeholder="example-package"
+            onInput={(e) =>
+              (githubApp.formPackageName.value = (e.target as HTMLInputElement).value)
+            }
+            disabled={submitting}
+            autoComplete="off"
+            spellcheck={false}
+          />
+        </Field>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <Field label="Repository" for="releaseTargetRepo">
+          <Select
+            id="releaseTargetRepo"
+            value={repositoryFullName}
+            disabled={submitting || !installationRowId || repositoryStatus === "loading"}
+            onChange={(value) => githubApp.selectRepository(value)}
+          >
+            <option value="">
+              {!installationRowId
+                ? "Pick an installation first…"
+                : repositoryStatus === "loading"
+                  ? "Loading repositories…"
+                  : repositories.length
+                    ? "Pick a repository…"
+                    : "No repositories visible"}
+            </option>
+            {repositories.map((repo: { id: number; fullName: string }) => (
+              <option key={repo.id} value={repo.fullName}>
+                {repo.fullName}
+              </option>
+            ))}
+          </Select>
+          {repositoryError ? (
+            <Muted class="text-[12px] mt-1.5 text-danger">{repositoryError}</Muted>
+          ) : null}
+          {installationRowId &&
+          !repositoryError &&
+          repositoryStatus === "idle" &&
+          !repositories.length ? (
+            <Muted class="text-[12px] mt-1.5">
+              This installation has no accessible repositories. Grant the GitHub App access to a
+              repository in{" "}
+              <a
+                class="underline"
+                href="https://github.com/settings/installations"
+                target="_blank"
+                rel="noreferrer"
+              >
+                GitHub App settings
+              </a>{" "}
+              and refresh.
+            </Muted>
+          ) : null}
+        </Field>
+        <Field label="GitHub environment" for="releaseTargetEnv">
+          <Select
+            id="releaseTargetEnv"
+            value={environment}
+            disabled={submitting || !repositoryFullName || environmentStatus === "loading"}
+            onChange={(value) => githubApp.selectEnvironment(value)}
+          >
+            <option value="">
+              {!repositoryFullName
+                ? "Pick a repository first…"
+                : environmentStatus === "loading"
+                  ? "Loading environments…"
+                  : environments.length
+                    ? "Pick an environment…"
+                    : "No environments configured"}
+            </option>
+            {environments.map((env: { name: string }) => (
+              <option key={env.name} value={env.name}>
+                {env.name}
+              </option>
+            ))}
+          </Select>
+          {environmentError ? (
+            <Muted class="text-[12px] mt-1.5 text-danger">{environmentError}</Muted>
+          ) : null}
+          {repositoryFullName &&
+          !environmentError &&
+          environmentStatus === "idle" &&
+          !environments.length ? (
+            <Muted class="text-[12px] mt-1.5">
+              No environments on this repo yet. Create one in{" "}
+              <a
+                class="underline"
+                href="https://docs.github.com/en/actions/deployment/targeting-different-environments/managing-environments-for-deployment"
+                target="_blank"
+                rel="noreferrer"
+              >
+                GitHub Actions environments
+              </a>
+              , then refresh.
+            </Muted>
+          ) : null}
+        </Field>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <Field label="PyPI Trusted Publisher environment" for="releaseTargetTrustedPublisher">
+          <Input
+            id="releaseTargetTrustedPublisher"
+            type="text"
+            value={trustedPublisherEnv}
+            placeholder="Defaults to the GitHub environment"
+            onInput={(e) =>
+              githubApp.setPypiTrustedPublisherEnvironment((e.target as HTMLInputElement).value)
+            }
+            disabled={submitting || !environment}
+            autoComplete="off"
+            spellcheck={false}
+          />
+          <Muted class="text-[12px] mt-1.5 m-0">
+            Defaults to the GitHub environment so the gate runs against the same job as the Trusted
+            Publisher exchange. Edit only if you renamed the publisher environment.
+          </Muted>
+          {trustedPublisherDiffers ? (
+            <Muted class="text-[12px] mt-1.5 text-danger">
+              Must match the GitHub environment exactly.
+            </Muted>
+          ) : null}
+        </Field>
+        <Field label="Workflow filename (optional)" for="releaseTargetWorkflow">
+          <Input
+            id="releaseTargetWorkflow"
+            type="text"
+            value={workflowFilename}
+            placeholder="release.yml"
+            onInput={(e) =>
+              (githubApp.formWorkflowFilename.value = (e.target as HTMLInputElement).value)
+            }
+            disabled={submitting}
+            autoComplete="off"
+            spellcheck={false}
+          />
+        </Field>
+      </div>
+
+      {formError ? <Alert tone="critical">{formError}</Alert> : null}
+
+      <div class="flex items-center gap-3">
+        <Button type="submit" disabled={submitting || !formValid}>
+          {submitting ? "Mapping…" : "Map release target"}
+        </Button>
+        <Muted class="text-[12px] m-0">
+          Drydock revalidates installation, repo access, and environment names before saving.
+        </Muted>
+      </div>
+    </form>
+  );
+}
+
+function ReleaseTargetList({
+  releaseTargets,
+  installations,
+  onDelete,
+}: {
+  releaseTargets: PublicReleaseTarget[];
+  installations: PublicGithubAppInstallation[];
+  onDelete: (id: string) => void;
+}) {
+  return (
+    <ul class="m-0 p-0 list-none border-t border-border">
+      {releaseTargets.map((target) => {
+        const installation = installations.find((row) => row.id === target.installationRowId);
+        return (
+          <li
+            key={target.id}
+            class="border-b border-border last:border-b-0 px-5 py-4 flex flex-wrap items-center justify-between gap-3"
+          >
+            <div class="flex flex-col gap-1.5 min-w-0">
+              <div class="flex items-center gap-2 flex-wrap">
+                <span class="font-mono text-[14px] font-medium">{target.packageName}</span>
+                <Badge tone="info">{target.ecosystem}</Badge>
+              </div>
+              <MonoDetail
+                parts={[
+                  <span key="repo">{target.repositoryFullName}</span>,
+                  <span key="env">env {target.environment}</span>,
+                  ...(target.workflowFilename
+                    ? [<span key="workflow">{target.workflowFilename}</span>]
+                    : []),
+                  <span key="install">
+                    via {installation?.accountLogin ?? "unknown"} ·{" "}
+                    {installation?.installationId ?? target.installationRowId}
+                  </span>,
+                ]}
+              />
+            </div>
+            <Button variant="danger" size="sm" onClick={() => onDelete(target.id)} class="shrink-0">
+              Remove
+            </Button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function Select({
+  id,
+  value,
+  disabled,
+  onChange,
+  children,
+}: {
+  id?: string;
+  value: string;
+  disabled?: boolean;
+  onChange: (value: string) => void;
+  children: ComponentChildren;
+}) {
+  return (
+    <div class="relative inline-block w-full">
+      <select
+        id={id}
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange((event.currentTarget as HTMLSelectElement).value)}
+        class="appearance-none w-full bg-bg border border-border rounded-md text-[13px] text-ink pl-3 pr-9 py-2 outline-none transition-[border-color,box-shadow] duration-150 ease-out focus:border-accent focus:shadow-[0_0_0_3px_var(--color-accent-soft)] disabled:opacity-60 disabled:cursor-not-allowed"
+      >
+        {children}
+      </select>
+      <span
+        aria-hidden="true"
+        class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[10px] text-ink-muted"
+      >
+        ▾
+      </span>
+    </div>
   );
 }
 

--- a/test/github-app.test.mjs
+++ b/test/github-app.test.mjs
@@ -265,6 +265,52 @@ describe("release target validation", () => {
     ).not.toThrow();
   });
 
+  test("accepts GitHub environment names with punctuation up to 255 characters", () => {
+    const longEnvironment = "release/" + "a".repeat(247);
+    expect(longEnvironment).toHaveLength(255);
+    expect(() =>
+      validateReleaseTargetShape({
+        ...VALID_RELEASE_TARGET,
+        environment: "release/env: prod #1",
+        pypiTrustedPublisherEnvironment: "release/env: prod #1",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      validateReleaseTargetShape({
+        ...VALID_RELEASE_TARGET,
+        environment: longEnvironment,
+        pypiTrustedPublisherEnvironment: longEnvironment,
+      }),
+    ).not.toThrow();
+  });
+
+  test("rejects overlong and control-character environment names", () => {
+    try {
+      const tooLong = "a".repeat(256);
+      validateReleaseTargetShape({
+        ...VALID_RELEASE_TARGET,
+        environment: tooLong,
+        pypiTrustedPublisherEnvironment: tooLong,
+      });
+      throw new Error("expected validation to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(GithubAppValidationError);
+      expect(err.code).toBe("environment_unmapped");
+    }
+
+    try {
+      validateReleaseTargetShape({
+        ...VALID_RELEASE_TARGET,
+        environment: "release\nprod",
+        pypiTrustedPublisherEnvironment: "release\nprod",
+      });
+      throw new Error("expected validation to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(GithubAppValidationError);
+      expect(err.code).toBe("invalid_input");
+    }
+  });
+
   test("rejects bad workflow filenames", () => {
     try {
       validateReleaseTargetShape({ ...VALID_RELEASE_TARGET, workflowFilename: "release.json" });

--- a/test/workers/github-app.test.ts
+++ b/test/workers/github-app.test.ts
@@ -18,6 +18,8 @@ import { githubAppRoutes } from "../../server/routes/github-app";
 import type { Bindings, Variables } from "../../server/types";
 
 const originalFetch = globalThis.fetch;
+const GITHUB_APP_PROXY_LIMIT = 60;
+const GITHUB_APP_PROXY_WINDOW_MS = 60 * 1000;
 
 let testPrivateKeyPem: string | null = null;
 async function getTestPrivateKeyPem(): Promise<string> {
@@ -70,6 +72,19 @@ async function seedInstallation(
     targetType: "Organization",
     status: overrides.status ?? "active",
     createdByUserId: null,
+  });
+}
+
+async function seedRateLimit(key: string, count: number, windowMs: number) {
+  const db = createDb(env.DB);
+  const nowMs = Date.now();
+  const bucket = Math.floor(nowMs / windowMs);
+  const now = new Date(nowMs);
+  await db.insert(schema.rateLimits).values({
+    key: `${key}:${bucket}`,
+    count,
+    expiresAt: new Date((bucket + 1) * windowMs),
+    updatedAt: now,
   });
 }
 
@@ -499,6 +514,29 @@ describe("github-app routes", () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
+  test("GET /installations/:id/repositories rate limits GitHub proxy calls", async () => {
+    const { userId, organizationId } = await seedUser();
+    const installation = await seedInstallation(organizationId);
+    await seedRateLimit(
+      `github-app:repositories:${organizationId}:${installation.id}`,
+      GITHUB_APP_PROXY_LIMIT,
+      GITHUB_APP_PROXY_WINDOW_MS,
+    );
+    globalThis.fetch = vi.fn();
+
+    const res = await callGithubAppRoute(
+      buildTestApp(userId),
+      "GET",
+      `/api/v1/github-app/installations/${installation.id}/repositories`,
+    );
+
+    expect(res.status).toBe(429);
+    expect(await res.json()).toMatchObject({
+      error: "GitHub repository lookup rate limit exceeded",
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
   test("GET /installations/:id/repositories/:owner/:repo/environments proxies the install token", async () => {
     const { userId, organizationId } = await seedUser();
     const installation = await seedInstallation(organizationId);
@@ -545,6 +583,29 @@ describe("github-app routes", () => {
 
     expect(res.status).toBe(403);
     expect(await res.json()).toMatchObject({ code: "repository_not_accessible" });
+  });
+
+  test("GET /installations/:id/repositories/:owner/:repo/environments rate limits GitHub proxy calls", async () => {
+    const { userId, organizationId } = await seedUser();
+    const installation = await seedInstallation(organizationId);
+    await seedRateLimit(
+      `github-app:environments:${organizationId}:${installation.id}:octo/alpha`,
+      GITHUB_APP_PROXY_LIMIT,
+      GITHUB_APP_PROXY_WINDOW_MS,
+    );
+    globalThis.fetch = vi.fn();
+
+    const res = await callGithubAppRoute(
+      buildTestApp(userId),
+      "GET",
+      `/api/v1/github-app/installations/${installation.id}/repositories/octo/alpha/environments`,
+    );
+
+    expect(res.status).toBe(429);
+    expect(await res.json()).toMatchObject({
+      error: "GitHub environment lookup rate limit exceeded",
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
   test("POST /install/callback refuses installation ids the GitHub user cannot access", async () => {

--- a/test/workers/github-app.test.ts
+++ b/test/workers/github-app.test.ts
@@ -19,6 +19,28 @@ import type { Bindings, Variables } from "../../server/types";
 
 const originalFetch = globalThis.fetch;
 
+let testPrivateKeyPem: string | null = null;
+async function getTestPrivateKeyPem(): Promise<string> {
+  if (testPrivateKeyPem) return testPrivateKeyPem;
+  const keyPair = (await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const pkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+  let binary = "";
+  for (const byte of new Uint8Array(pkcs8)) binary += String.fromCharCode(byte);
+  const base64 = btoa(binary);
+  const lines = base64.match(/.{1,64}/g)?.join("\n") ?? base64;
+  testPrivateKeyPem = `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----`;
+  return testPrivateKeyPem;
+}
+
 async function seedUser(): Promise<{ userId: string; organizationId: string }> {
   const db = createDb(env.DB);
   const now = new Date();
@@ -79,7 +101,7 @@ async function callGithubAppRoute(
     GITHUB_APP_SLUG: "drydock-test",
     GITHUB_APP_CLIENT_ID: "client-id",
     GITHUB_APP_CLIENT_SECRET: "client-secret",
-    GITHUB_APP_PRIVATE_KEY: "----- placeholder -----",
+    GITHUB_APP_PRIVATE_KEY: await getTestPrivateKeyPem(),
     GITHUB_APP_WEBHOOK_SECRET: "webhook-secret-value-1234567890",
     GITHUB_APP_STATE_SECRET: "0123456789abcdef0123456789abcdef",
     BETTER_AUTH_SECRET: "fallback-secret-with-enough-entropy-aaaaaaaa",
@@ -383,6 +405,101 @@ describe("github-app routes", () => {
 
     expect(res.status).toBe(400);
     expect(await res.json()).toMatchObject({ error: "code is required" });
+  });
+
+  test("GET /installations/:id/repositories proxies the install token to GitHub", async () => {
+    const { userId, organizationId } = await seedUser();
+    const installation = await seedInstallation(organizationId);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ token: "install-token" }))
+      .mockResolvedValueOnce(
+        Response.json({
+          repositories: [
+            { id: 11, full_name: "octo/alpha", default_branch: "main" },
+            { id: 22, full_name: "octo/beta" },
+          ],
+        }),
+      );
+
+    const res = await callGithubAppRoute(
+      buildTestApp(userId),
+      "GET",
+      `/api/v1/github-app/installations/${installation.id}/repositories`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      repositories: [
+        { id: 11, fullName: "octo/alpha", defaultBranch: "main" },
+        { id: 22, fullName: "octo/beta", defaultBranch: null },
+      ],
+    });
+  });
+
+  test("GET /installations/:id/repositories rejects installs the org does not own", async () => {
+    const { userId } = await seedUser();
+    const other = await seedUser();
+    const installation = await seedInstallation(other.organizationId);
+    globalThis.fetch = vi.fn();
+
+    const res = await callGithubAppRoute(
+      buildTestApp(userId),
+      "GET",
+      `/api/v1/github-app/installations/${installation.id}/repositories`,
+    );
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ code: "installation_missing" });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test("GET /installations/:id/repositories/:owner/:repo/environments proxies the install token", async () => {
+    const { userId, organizationId } = await seedUser();
+    const installation = await seedInstallation(organizationId);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ token: "install-token" }))
+      .mockResolvedValueOnce(
+        Response.json({
+          environments: [{ name: "pypi" }, { name: "staging" }],
+        }),
+      );
+
+    const res = await callGithubAppRoute(
+      buildTestApp(userId),
+      "GET",
+      `/api/v1/github-app/installations/${installation.id}/repositories/octo/alpha/environments`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      environments: [{ name: "pypi" }, { name: "staging" }],
+    });
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(2);
+    expect(String(calls[1][0])).toBe(
+      "https://api.github.com/repos/octo/alpha/environments?per_page=100",
+    );
+  });
+
+  test("GET /installations/:id/repositories/:owner/:repo/environments returns 403 when repo is unreachable", async () => {
+    const { userId, organizationId } = await seedUser();
+    const installation = await seedInstallation(organizationId);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ token: "install-token" }))
+      .mockResolvedValueOnce(new Response("not found", { status: 404 }));
+
+    const res = await callGithubAppRoute(
+      buildTestApp(userId),
+      "GET",
+      `/api/v1/github-app/installations/${installation.id}/repositories/octo/gone/environments`,
+    );
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toMatchObject({ code: "repository_not_accessible" });
   });
 
   test("POST /install/callback refuses installation ids the GitHub user cannot access", async () => {

--- a/test/workers/github-app.test.ts
+++ b/test/workers/github-app.test.ts
@@ -437,6 +437,51 @@ describe("github-app routes", () => {
     });
   });
 
+  test("GET /installations/:id/repositories follows GitHub pagination until exhausted", async () => {
+    const { userId, organizationId } = await seedUser();
+    const installation = await seedInstallation(organizationId);
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json({ token: "install-token" }))
+      .mockResolvedValueOnce(
+        Response.json(
+          {
+            repositories: [{ id: 22, full_name: "octo/beta" }],
+          },
+          {
+            headers: {
+              link: '<https://api.github.com/installation/repositories?per_page=100&page=2>; rel="next"',
+            },
+          },
+        ),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          repositories: [{ id: 11, full_name: "octo/alpha", default_branch: "main" }],
+        }),
+      );
+
+    const res = await callGithubAppRoute(
+      buildTestApp(userId),
+      "GET",
+      `/api/v1/github-app/installations/${installation.id}/repositories`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      repositories: [
+        { id: 11, fullName: "octo/alpha", defaultBranch: "main" },
+        { id: 22, fullName: "octo/beta", defaultBranch: null },
+      ],
+    });
+
+    const calls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls).toHaveLength(3);
+    expect(String(calls[2][0])).toBe(
+      "https://api.github.com/installation/repositories?per_page=100&page=2",
+    );
+  });
+
   test("GET /installations/:id/repositories rejects installs the org does not own", async () => {
     const { userId } = await seedUser();
     const other = await seedUser();


### PR DESCRIPTION
Adds GitHub App proxy endpoints for installation repositories and repository environments, then wires the settings UI to map PyPI release targets from those dropdowns. Extends the client model to load, create, and delete release targets while keeping the Trusted Publisher environment aligned with the selected GitHub environment. Relaxes release-target environment validation to accept GitHub-valid names up to 255 characters while still rejecting blank or control-character values. Updates workflow-gate documentation and covers the new route and validation behavior with Vitest and Worker tests.