### PR TITLE
Add PyPI gate artifact preparation

### DIFF
--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -260,6 +260,29 @@ The private key may be GitHub's downloaded PKCS#1 PEM or a converted PKCS#8 PEM.
 `GITHUB_APP_STATE_SECRET` is optional and falls back to `BETTER_AUTH_SECRET` for
 HMAC-signing the OAuth state.
 
+### GitHub App permissions
+
+Repository permissions the App must request on the repos the org maps to a
+release target:
+
+- **Actions: Read** — list workflow run artifacts and download the
+  artifact ZIP for a pending gate.
+- **Deployments: Read & write** — receive `deployment_protection_rule`
+  webhooks and POST the deployment-protection decision callback.
+- **Metadata: Read** — mandatory for any fine-grained App; backs
+  `GET /repos/{owner}/{repo}` and the future `GET /installation/repositories`
+  repo picker.
+
+Webhook events to subscribe to:
+
+- `deployment_protection_rule` (pending-gate trigger).
+- `installation` (suspend / unsuspend / deleted, so we fail closed on
+  revoked installs).
+
+Account permissions: "Request user authorization (OAuth) during installation"
+must be on so the install callback gets a `code` to confirm the installer
+actually controls the installation. No additional OAuth scopes are required.
+
 ### GitHub App setup URL
 
 The "Setup URL" configured on the GitHub App (under "Identifying and authorizing
@@ -306,17 +329,76 @@ The install flow lives on `/dashboard/settings` (gated behind
    bypass the rules. Empty states link to GitHub App settings (no repos) and
    GitHub Actions environments docs (no environments).
 
+### Resolving artifacts for a pending gate
+
+`server/lib/github-app-artifacts.ts` turns a pending gate into a verified
+release bundle on the trusted control-plane side, then
+`server/lib/release-candidate-pypi.ts` hands each wheel/sdist to the
+credentials-free `downloadInSandboxInline` sandbox path so the same untrusted-
+archive parser the npm pipeline uses produces bounded `FileRecord[]` evidence.
+
+What the resolver enforces, in order:
+
+1. `GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts` with an
+   installation token — find the first non-expired artifact named
+   `pypi-release-candidate` (configurable). Requires the **Actions: Read**
+   repository permission on the GitHub App.
+2. `GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/zip` follows
+   GitHub's redirect to `*.actions.githubusercontent.com`. The outer ZIP is
+   capped at 25 MiB; Content-Length is rejected before reading, and the
+   streamed body is also bounded.
+3. The outer ZIP is parsed with a focused central-directory walker that
+   reuses the hardened primitives from `server/lib/tar-parser.js`
+   (`findZipEndOfCentralDirectory`, `inflateRawBounded`, `normalizeZipPath`).
+   Traversal paths, ZIP64, oversized entries, and unsupported compression
+   methods are rejected.
+4. The bundle must contain `drydock-manifest.json` at the root. It is parsed
+   with the existing `parsePyPiReleaseManifest` (PEP 503 project name, safe
+   version, ≤20 artifacts, safe artifact paths).
+5. The bundle's wheel/sdist set must exactly match the manifest's declared
+   artifact set — extra wheel/sdist files or missing declared paths fail.
+6. Each declared artifact has its SHA-256 recomputed against the bundle
+   bytes; mismatches reject before any bytes reach the sandbox. The
+   workflow's own `drydock-sha256.txt` is never trusted.
+7. The gate wrapper compares the normalized manifest package name against the
+   mapped `github_release_targets.package_name` before wheel/sdist bytes enter
+   the sandbox. A repo/environment gate for one PyPI project cannot approve a
+   manifest for another project.
+
+Typed errors returned by `WorkflowArtifactError.code`:
+
+- `bundle_unavailable` — workflow run / artifact name is unreachable.
+- `bundle_too_large` — outer ZIP exceeded the size or entry cap.
+- `manifest_missing` — `drydock-manifest.json` not present at root.
+- `manifest_invalid` — manifest JSON / schema validation failed.
+- `manifest_artifact_mismatch` — declared vs. bundled artifact sets differ.
+- `artifact_path_unsafe` — bundle entry path contained traversal segments.
+- `artifact_kind_unsupported` — bundle has a file that isn't `.whl` /
+  `.tar.gz` / `.tgz`, or the kind disagrees with the manifest entry.
+- `artifact_digest_mismatch` — recomputed SHA-256 ≠ manifest sha256.
+- `release_target_mismatch` — normalized manifest package name did not match
+  the release target mapped to the pending gate.
+
+`preparePyPiReleaseCandidateForGate(env, ctx, db, { config, organizationId,
+gateId })` is the gate-aware wrapper. It looks up the gate row, swaps the App
+JWT for a fresh installation access token, and on any failure calls
+`markGateErrored` with the typed error code so the gate cannot advance to
+scanning. The GitHub installation token never enters the sandbox: the parent
+worker downloads the artifact ZIP, validates and digests it, and only the
+verified wheel/sdist bytes cross the trust boundary through
+`downloadInSandboxInline`, which constructs the `NpmStageGateway` with empty
+props (no npm token, no public-artifact allowlist, `subRequests: 0`).
+
 ## Remaining work
 
-- Fetch GitHub Actions artifacts and `drydock-manifest.json` with installation
-  credentials, then call `markGateDecided` / `postDeploymentProtectionDecision`
-  to release or block the publish job.
-- Run the existing PyPI candidate review helper from the gate handler.
+- Wire `preparePyPiReleaseCandidateForGate` into the scan pipeline so a
+  resolved gate runs `pypiAdapter` to completion, persists the report, and
+  calls `markGateDecided` / `postDeploymentProtectionDecision`.
 - Persist workflow-gate reviews separately from npm `stageId` scans or
   generalize the scan schema around `release_candidate` records.
 - Add UI for workflow-gate reviews and GitHub/PyPI setup guidance.
-- Verify artifact digests in the gate path before scanning and record those
-  digests in the report payload.
+- Record the reviewed artifact SHA-256 digests in the persisted report
+  payload (the resolver returns them; the persister doesn't store them yet).
 - Compare against prior PyPI release artifacts by downloading selected
   `files.pythonhosted.org` URLs through the exact public-artifact allowlist.
 

--- a/server/lib/github-app-artifacts.ts
+++ b/server/lib/github-app-artifacts.ts
@@ -64,6 +64,7 @@ export class WorkflowArtifactError extends Error {
 
 const DEFAULT_ARTIFACT_NAME = "pypi-release-candidate";
 const MANIFEST_FILENAME = "drydock-manifest.json";
+const ALLOWED_SUPPORT_FILENAMES = new Set(["drydock-sha256.txt"]);
 
 const MAX_OUTER_ZIP_BYTES = 25 * 1024 * 1024;
 const MAX_OUTER_ZIP_ENTRIES = 256;
@@ -127,11 +128,13 @@ export async function fetchReleaseBundleWithToken(
   const manifestRaw = new TextDecoder("utf-8", { fatal: false }).decode(manifestEntry.bytes);
   const manifest = parseAndValidateManifest(manifestRaw);
 
-  // Reject anything beyond the manifest + recognized artifacts before digesting.
+  // Reject anything beyond the manifest, declared artifacts, and explicit
+  // support files before digesting.
   const declaredPaths = new Set(manifest.artifacts.map((entry) => entry.path));
   const candidateArtifacts: ResolvedReleaseFile[] = [];
   for (const entry of entries) {
     if (entry.path === MANIFEST_FILENAME) continue;
+    if (ALLOWED_SUPPORT_FILENAMES.has(entry.path)) continue;
     if (declaredPaths.has(entry.path)) continue;
     if (inferPyPiArtifactKind(entry.path) !== null) {
       throw new WorkflowArtifactError(
@@ -139,6 +142,10 @@ export async function fetchReleaseBundleWithToken(
         `bundle includes ${entry.path} which is not declared in ${MANIFEST_FILENAME}`,
       );
     }
+    throw new WorkflowArtifactError(
+      "artifact_kind_unsupported",
+      `bundle includes unsupported file ${entry.path}`,
+    );
   }
 
   for (const declared of manifest.artifacts) {

--- a/server/lib/github-app-artifacts.ts
+++ b/server/lib/github-app-artifacts.ts
@@ -1,0 +1,475 @@
+import {
+  findZipEndOfCentralDirectory,
+  inflateRawBounded,
+  normalizeZipPath,
+  readStreamBounded,
+  readUint16Le,
+  readUint32Le,
+} from "./tar-parser.js";
+import { getInstallationAccessToken, type GithubAppConfig } from "./github-app";
+import {
+  inferPyPiArtifactKind,
+  parsePyPiReleaseManifest,
+  type PyPiArtifactKind,
+  type PyPiReleaseManifest,
+} from "./adapters/pypi/index";
+
+// ── Public surface ───────────────────────────────────────────────────────────
+
+export interface WorkflowArtifactSource {
+  installationExternalId: string;
+  repositoryFullName: string;
+  runId: number;
+  artifactName?: string;
+}
+
+export interface ResolvedReleaseFile {
+  path: string;
+  bytes: Uint8Array;
+  sha256: string;
+  kind: PyPiArtifactKind;
+}
+
+export interface ResolvedReleaseBundle {
+  manifest: PyPiReleaseManifest;
+  manifestRaw: string;
+  artifacts: ResolvedReleaseFile[];
+  artifactId: number;
+  artifactName: string;
+  artifactSizeBytes: number;
+}
+
+export type WorkflowArtifactErrorCode =
+  | "bundle_unavailable"
+  | "bundle_too_large"
+  | "manifest_missing"
+  | "manifest_invalid"
+  | "manifest_artifact_mismatch"
+  | "release_target_mismatch"
+  | "artifact_path_unsafe"
+  | "artifact_kind_unsupported"
+  | "artifact_digest_mismatch";
+
+export class WorkflowArtifactError extends Error {
+  constructor(
+    public code: WorkflowArtifactErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "WorkflowArtifactError";
+  }
+}
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+const DEFAULT_ARTIFACT_NAME = "pypi-release-candidate";
+const MANIFEST_FILENAME = "drydock-manifest.json";
+
+const MAX_OUTER_ZIP_BYTES = 25 * 1024 * 1024;
+const MAX_OUTER_ZIP_ENTRIES = 256;
+const MAX_PER_ENTRY_BYTES = 25 * 1024 * 1024;
+const MAX_MANIFEST_BYTES = 64 * 1024;
+const MAX_LIST_PAGES = 4;
+
+const REPOSITORY_FULL_NAME_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})\/[A-Za-z0-9._-]{1,100}$/;
+
+// ── Entry points ─────────────────────────────────────────────────────────────
+
+/**
+ * Resolve a release bundle from a pre-fetched installation access token. The
+ * gate-aware caller is responsible for swapping the GitHub App JWT for a fresh
+ * installation token; isolating that step lets us test artifact ingestion
+ * without supplying a real RSA private key.
+ */
+export async function fetchReleaseBundleWithToken(
+  installationToken: string,
+  source: WorkflowArtifactSource,
+): Promise<ResolvedReleaseBundle> {
+  if (!REPOSITORY_FULL_NAME_RE.test(source.repositoryFullName)) {
+    throw new WorkflowArtifactError(
+      "bundle_unavailable",
+      `repository full name ${source.repositoryFullName} is not owner/repo`,
+    );
+  }
+  if (!Number.isInteger(source.runId) || source.runId <= 0) {
+    throw new WorkflowArtifactError("bundle_unavailable", "runId must be a positive integer");
+  }
+  const artifactName =
+    (source.artifactName ?? DEFAULT_ARTIFACT_NAME).trim() || DEFAULT_ARTIFACT_NAME;
+
+  const artifact = await findRunArtifact(
+    installationToken,
+    source.repositoryFullName,
+    source.runId,
+    artifactName,
+  );
+  const zipBytes = await downloadArtifactZip(
+    installationToken,
+    source.repositoryFullName,
+    artifact.id,
+  );
+
+  const entries = await extractOuterZipEntries(zipBytes);
+  const manifestEntry = entries.find((entry) => entry.path === MANIFEST_FILENAME);
+  if (!manifestEntry) {
+    throw new WorkflowArtifactError(
+      "manifest_missing",
+      `artifact bundle did not contain ${MANIFEST_FILENAME}`,
+    );
+  }
+  if (manifestEntry.bytes.byteLength > MAX_MANIFEST_BYTES) {
+    throw new WorkflowArtifactError(
+      "manifest_invalid",
+      `${MANIFEST_FILENAME} exceeds ${MAX_MANIFEST_BYTES} bytes`,
+    );
+  }
+
+  const manifestRaw = new TextDecoder("utf-8", { fatal: false }).decode(manifestEntry.bytes);
+  const manifest = parseAndValidateManifest(manifestRaw);
+
+  // Reject anything beyond the manifest + recognized artifacts before digesting.
+  const declaredPaths = new Set(manifest.artifacts.map((entry) => entry.path));
+  const candidateArtifacts: ResolvedReleaseFile[] = [];
+  for (const entry of entries) {
+    if (entry.path === MANIFEST_FILENAME) continue;
+    if (declaredPaths.has(entry.path)) continue;
+    if (inferPyPiArtifactKind(entry.path) !== null) {
+      throw new WorkflowArtifactError(
+        "manifest_artifact_mismatch",
+        `bundle includes ${entry.path} which is not declared in ${MANIFEST_FILENAME}`,
+      );
+    }
+  }
+
+  for (const declared of manifest.artifacts) {
+    const entry = entries.find((candidate) => candidate.path === declared.path);
+    if (!entry) {
+      throw new WorkflowArtifactError(
+        "manifest_artifact_mismatch",
+        `bundle is missing artifact ${declared.path} declared in ${MANIFEST_FILENAME}`,
+      );
+    }
+    const kind = inferPyPiArtifactKind(entry.path);
+    if (!kind) {
+      throw new WorkflowArtifactError(
+        "artifact_kind_unsupported",
+        `${entry.path} is not a wheel or sdist`,
+      );
+    }
+    if (kind !== declared.kind) {
+      throw new WorkflowArtifactError(
+        "artifact_kind_unsupported",
+        `${entry.path} kind ${kind} does not match manifest kind ${declared.kind}`,
+      );
+    }
+    const sha256 = await sha256Hex(entry.bytes);
+    if (sha256 !== declared.sha256.toLowerCase()) {
+      throw new WorkflowArtifactError(
+        "artifact_digest_mismatch",
+        `${entry.path} sha256 ${sha256} != manifest sha256`,
+      );
+    }
+    candidateArtifacts.push({ path: entry.path, bytes: entry.bytes, sha256, kind });
+  }
+
+  return {
+    manifest,
+    manifestRaw,
+    artifacts: candidateArtifacts,
+    artifactId: artifact.id,
+    artifactName: artifact.name,
+    artifactSizeBytes: zipBytes.byteLength,
+  };
+}
+
+/**
+ * Convenience wrapper that swaps the App JWT for an installation token before
+ * calling `fetchReleaseBundleWithToken`. Production callers should use this so
+ * the access token's lifetime is scoped to a single bundle resolution.
+ */
+export async function fetchReleaseBundleForGate(
+  config: GithubAppConfig,
+  source: WorkflowArtifactSource,
+): Promise<ResolvedReleaseBundle> {
+  const token = await getInstallationAccessToken(config, source.installationExternalId);
+  return fetchReleaseBundleWithToken(token, source);
+}
+
+// ── GitHub API: list + download ──────────────────────────────────────────────
+
+interface RunArtifactRef {
+  id: number;
+  name: string;
+  sizeInBytes: number | null;
+  expired: boolean;
+}
+
+async function findRunArtifact(
+  token: string,
+  repositoryFullName: string,
+  runId: number,
+  artifactName: string,
+): Promise<RunArtifactRef> {
+  const [owner, repo] = repositoryFullName.split("/");
+  let url: string | null =
+    `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}` +
+    `/actions/runs/${runId}/artifacts?per_page=100`;
+  for (let page = 0; page < MAX_LIST_PAGES && url; page += 1) {
+    const response = await fetch(url, { headers: githubInstallationHeaders(token) });
+    if (response.status === 404) {
+      throw new WorkflowArtifactError(
+        "bundle_unavailable",
+        `workflow run ${runId} not found in ${repositoryFullName}`,
+      );
+    }
+    if (!response.ok) {
+      throw new WorkflowArtifactError(
+        "bundle_unavailable",
+        `list artifacts failed (${response.status})`,
+      );
+    }
+    const data = (await response.json()) as {
+      artifacts?: Array<{
+        id?: number;
+        name?: string;
+        size_in_bytes?: number;
+        expired?: boolean;
+      }>;
+    };
+    for (const candidate of data.artifacts ?? []) {
+      if (
+        typeof candidate.id === "number" &&
+        candidate.id > 0 &&
+        candidate.name === artifactName &&
+        candidate.expired !== true
+      ) {
+        return {
+          id: candidate.id,
+          name: candidate.name,
+          sizeInBytes: typeof candidate.size_in_bytes === "number" ? candidate.size_in_bytes : null,
+          expired: false,
+        };
+      }
+    }
+    url = nextLink(response.headers.get("link"));
+  }
+  throw new WorkflowArtifactError(
+    "bundle_unavailable",
+    `no non-expired artifact named ${artifactName} on run ${runId}`,
+  );
+}
+
+async function downloadArtifactZip(
+  token: string,
+  repositoryFullName: string,
+  artifactId: number,
+): Promise<Uint8Array> {
+  const [owner, repo] = repositoryFullName.split("/");
+  const url =
+    `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}` +
+    `/actions/artifacts/${artifactId}/zip`;
+  const response = await fetch(url, {
+    headers: githubInstallationHeaders(token),
+    redirect: "follow",
+  });
+  if (!response.ok) {
+    throw new WorkflowArtifactError(
+      "bundle_unavailable",
+      `artifact download failed (${response.status})`,
+    );
+  }
+  const declared = parseContentLength(response.headers.get("content-length"));
+  if (declared !== null && declared > MAX_OUTER_ZIP_BYTES) {
+    throw new WorkflowArtifactError(
+      "bundle_too_large",
+      `artifact content-length ${declared} exceeds ${MAX_OUTER_ZIP_BYTES} bytes`,
+    );
+  }
+  try {
+    return await readStreamBounded(response.body, MAX_OUTER_ZIP_BYTES);
+  } catch (err) {
+    if (err instanceof Error && err.message === "archive too large") {
+      throw new WorkflowArtifactError(
+        "bundle_too_large",
+        `artifact body exceeds ${MAX_OUTER_ZIP_BYTES} bytes`,
+      );
+    }
+    throw err;
+  }
+}
+
+// ── Outer ZIP extraction ─────────────────────────────────────────────────────
+
+interface ExtractedEntry {
+  path: string;
+  bytes: Uint8Array;
+}
+
+async function extractOuterZipEntries(zip: Uint8Array): Promise<ExtractedEntry[]> {
+  const eocd = findZipEndOfCentralDirectory(zip);
+  if (eocd < 0) {
+    throw new WorkflowArtifactError(
+      "bundle_unavailable",
+      "artifact zip central directory not found",
+    );
+  }
+  const entryCount = readUint16Le(zip, eocd + 10);
+  const centralDirectorySize = readUint32Le(zip, eocd + 12);
+  const centralDirectoryOffset = readUint32Le(zip, eocd + 16);
+  if (
+    entryCount === 0xffff ||
+    centralDirectorySize === 0xffffffff ||
+    centralDirectoryOffset === 0xffffffff
+  ) {
+    throw new WorkflowArtifactError("bundle_unavailable", "zip64 archives are not supported");
+  }
+  if (entryCount > MAX_OUTER_ZIP_ENTRIES) {
+    throw new WorkflowArtifactError("bundle_too_large", "artifact zip contains too many entries");
+  }
+  if (centralDirectoryOffset + centralDirectorySize > zip.byteLength) {
+    throw new WorkflowArtifactError("bundle_unavailable", "truncated zip central directory");
+  }
+
+  const entries: ExtractedEntry[] = [];
+  let totalExpanded = 0;
+  let offset = centralDirectoryOffset;
+  for (let index = 0; index < entryCount; index += 1) {
+    if (offset + 46 > zip.byteLength || readUint32Le(zip, offset) !== 0x02014b50) {
+      throw new WorkflowArtifactError("bundle_unavailable", "invalid zip central directory entry");
+    }
+    const compressionMethod = readUint16Le(zip, offset + 10);
+    const compressedSize = readUint32Le(zip, offset + 20);
+    const uncompressedSize = readUint32Le(zip, offset + 24);
+    const fileNameLength = readUint16Le(zip, offset + 28);
+    const extraLength = readUint16Le(zip, offset + 30);
+    const commentLength = readUint16Le(zip, offset + 32);
+    const localHeaderOffset = readUint32Le(zip, offset + 42);
+    const fileNameStart = offset + 46;
+    const fileNameEnd = fileNameStart + fileNameLength;
+    if (fileNameEnd > zip.byteLength) {
+      throw new WorkflowArtifactError("bundle_unavailable", "truncated zip filename");
+    }
+    const rawPath = new TextDecoder("utf-8", { fatal: false }).decode(
+      zip.subarray(fileNameStart, fileNameEnd),
+    );
+    offset = fileNameEnd + extraLength + commentLength;
+
+    // Directory entries / paths that fail normalization → reject hard. Path
+    // traversal in artifact entries is `artifact_path_unsafe`. Directory
+    // markers (trailing slash) are silently skipped because GitHub's
+    // upload-artifact action always packs files only — this matches the
+    // existing readZipArchive semantics.
+    if (!rawPath || rawPath.endsWith("/")) continue;
+    if (containsPathTraversal(rawPath)) {
+      throw new WorkflowArtifactError(
+        "artifact_path_unsafe",
+        `zip entry ${rawPath} has an unsafe path`,
+      );
+    }
+    const path = normalizeZipPath(rawPath);
+    if (!path) {
+      throw new WorkflowArtifactError(
+        "artifact_path_unsafe",
+        `zip entry ${rawPath} has an unsafe path`,
+      );
+    }
+    if (uncompressedSize > MAX_PER_ENTRY_BYTES) {
+      throw new WorkflowArtifactError("bundle_too_large", `zip entry ${path} is too large`);
+    }
+    if (totalExpanded + uncompressedSize > MAX_OUTER_ZIP_BYTES) {
+      throw new WorkflowArtifactError("bundle_too_large", "zip expands beyond safety limit");
+    }
+    if (
+      localHeaderOffset + 30 > zip.byteLength ||
+      readUint32Le(zip, localHeaderOffset) !== 0x04034b50
+    ) {
+      throw new WorkflowArtifactError("bundle_unavailable", "invalid zip local header");
+    }
+    const localFileNameLength = readUint16Le(zip, localHeaderOffset + 26);
+    const localExtraLength = readUint16Le(zip, localHeaderOffset + 28);
+    const dataOffset = localHeaderOffset + 30 + localFileNameLength + localExtraLength;
+    if (dataOffset + compressedSize > zip.byteLength) {
+      throw new WorkflowArtifactError("bundle_unavailable", "truncated zip entry");
+    }
+    let body: Uint8Array;
+    if (compressionMethod === 0) {
+      body = zip.subarray(dataOffset, dataOffset + compressedSize).slice();
+    } else if (compressionMethod === 8) {
+      body = await inflateRawBounded(
+        zip.subarray(dataOffset, dataOffset + compressedSize),
+        MAX_OUTER_ZIP_BYTES,
+      );
+    } else {
+      throw new WorkflowArtifactError(
+        "bundle_unavailable",
+        `unsupported zip compression method ${compressionMethod}`,
+      );
+    }
+    if (body.byteLength !== uncompressedSize) {
+      throw new WorkflowArtifactError("bundle_unavailable", "zip entry size mismatch");
+    }
+    totalExpanded += body.byteLength;
+    entries.push({ path, bytes: body });
+  }
+  return entries;
+}
+
+function containsPathTraversal(rawPath: string): boolean {
+  if (rawPath.includes("\0") || rawPath.includes("\\")) return true;
+  if (rawPath.startsWith("/")) return true;
+  if (rawPath.startsWith("../") || rawPath.includes("/../") || rawPath.endsWith("/..")) return true;
+  if (/^[A-Za-z]:/.test(rawPath)) return true;
+  return false;
+}
+
+// ── Manifest validation ──────────────────────────────────────────────────────
+
+function parseAndValidateManifest(raw: string): PyPiReleaseManifest {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new WorkflowArtifactError("manifest_invalid", "drydock-manifest.json is not valid JSON");
+  }
+  try {
+    return parsePyPiReleaseManifest(parsed);
+  } catch (err) {
+    throw new WorkflowArtifactError(
+      "manifest_invalid",
+      err instanceof Error ? err.message : "manifest validation failed",
+    );
+  }
+}
+
+// ── Shared helpers ───────────────────────────────────────────────────────────
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes as BufferSource);
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function parseContentLength(value: string | null): number | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!/^\d+$/.test(trimmed)) return null;
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+function githubInstallationHeaders(token: string): HeadersInit {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "User-Agent": "drydock-app",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+function nextLink(linkHeader: string | null): string | null {
+  if (!linkHeader) return null;
+  for (const part of linkHeader.split(",")) {
+    const match = part.match(/<([^>]+)>;\s*rel="next"/);
+    if (match?.[1]) return match[1];
+  }
+  return null;
+}

--- a/server/lib/release-candidate-pypi.ts
+++ b/server/lib/release-candidate-pypi.ts
@@ -1,0 +1,213 @@
+import { and, eq } from "drizzle-orm";
+import type { AppDb } from "../db";
+import { githubAppInstallations, githubReleaseTargets } from "../db/schema";
+import {
+  normalizePyPiProjectName,
+  type PyPiAdapterInput,
+  type PyPiArtifactInput,
+  type PyPiArtifactKind,
+} from "./adapters/pypi/index";
+import {
+  fetchReleaseBundleForGate,
+  WorkflowArtifactError,
+  type ResolvedReleaseBundle,
+  type ResolvedReleaseFile,
+  type WorkflowArtifactSource,
+} from "./github-app-artifacts";
+import { type GithubAppConfig } from "./github-app";
+import {
+  getGateForOrganization,
+  markGateErrored,
+  type WorkflowGateRecord,
+} from "./github-app-webhook";
+import { describeOperationalError, emitOperationalEvent } from "./observability";
+import { downloadInSandboxInline, type DownloadResult } from "./sandbox";
+
+export interface PreparePyPiReleaseCandidateInput {
+  config: GithubAppConfig;
+  source: WorkflowArtifactSource;
+}
+
+export interface PreparedPyPiReleaseCandidate {
+  adapterInput: PyPiAdapterInput;
+  bundle: ResolvedReleaseBundle;
+}
+
+/**
+ * Resolve a pending PyPI workflow gate into a `PyPiAdapterInput` the existing
+ * adapter can run findings against.
+ *
+ * Step 1 (`fetchReleaseBundleForGate`) lives entirely in the control plane:
+ * the GitHub installation token is used to list and download artifact bytes,
+ * the outer ZIP is parsed with hardened limits, the manifest is validated,
+ * and every wheel/sdist SHA-256 is recomputed and compared to the manifest.
+ *
+ * Step 2 hands each wheel/sdist's bytes to the credentials-free
+ * `downloadInSandboxInline` path so the same untrusted-archive parser the npm
+ * pipeline uses produces bounded `FileRecord[]` evidence.
+ */
+export async function preparePyPiReleaseCandidate(
+  env: Cloudflare.Env,
+  ctx: ExecutionContext,
+  input: PreparePyPiReleaseCandidateInput,
+): Promise<PreparedPyPiReleaseCandidate> {
+  const bundle = await fetchReleaseBundleForGate(input.config, input.source);
+  return preparePyPiReleaseCandidateFromBundle(env, ctx, bundle);
+}
+
+async function preparePyPiReleaseCandidateFromBundle(
+  env: Cloudflare.Env,
+  ctx: ExecutionContext,
+  bundle: ResolvedReleaseBundle,
+): Promise<PreparedPyPiReleaseCandidate> {
+  const artifacts: PyPiArtifactInput[] = [];
+  for (const artifact of bundle.artifacts) {
+    const files = await parseArtifactBytes(env, ctx, artifact);
+    artifacts.push({ path: artifact.path, files });
+  }
+  return {
+    adapterInput: { manifest: bundle.manifest, artifacts },
+    bundle,
+  };
+}
+
+export interface PrepareForGateInput {
+  config: GithubAppConfig;
+  organizationId: string;
+  gateId: string;
+  artifactName?: string;
+}
+
+export interface PreparedPyPiReleaseCandidateForGate extends PreparedPyPiReleaseCandidate {
+  gate: WorkflowGateRecord;
+}
+
+/**
+ * Gate-aware wrapper. On any `WorkflowArtifactError` (or downstream sandbox
+ * parse failure) the pending gate is transitioned to `errored` with the
+ * typed code so it cannot advance to scanning.
+ */
+export async function preparePyPiReleaseCandidateForGate(
+  env: Cloudflare.Env,
+  ctx: ExecutionContext,
+  db: AppDb,
+  input: PrepareForGateInput,
+): Promise<PreparedPyPiReleaseCandidateForGate> {
+  const gate = await getGateForOrganization(db, input.organizationId, input.gateId);
+  if (!gate) {
+    throw new WorkflowArtifactError(
+      "bundle_unavailable",
+      `workflow gate ${input.gateId} not found in organization`,
+    );
+  }
+  if (gate.status !== "pending") {
+    throw new WorkflowArtifactError(
+      "bundle_unavailable",
+      `workflow gate ${gate.id} is not pending (status=${gate.status})`,
+    );
+  }
+
+  const [installation] = await db
+    .select()
+    .from(githubAppInstallations)
+    .where(
+      and(
+        eq(githubAppInstallations.id, gate.installationRowId),
+        eq(githubAppInstallations.organizationId, gate.organizationId),
+      ),
+    )
+    .limit(1);
+  if (!installation) {
+    await markGateErroredSafe(db, gate.id, "installation_missing");
+    throw new WorkflowArtifactError(
+      "bundle_unavailable",
+      `installation row ${gate.installationRowId} missing for gate ${gate.id}`,
+    );
+  }
+  if (installation.status !== "active") {
+    await markGateErroredSafe(db, gate.id, `installation_${installation.status}`);
+    throw new WorkflowArtifactError(
+      "bundle_unavailable",
+      `installation ${installation.installationId} is ${installation.status}`,
+    );
+  }
+
+  const [releaseTarget] = await db
+    .select()
+    .from(githubReleaseTargets)
+    .where(
+      and(
+        eq(githubReleaseTargets.id, gate.releaseTargetId),
+        eq(githubReleaseTargets.organizationId, gate.organizationId),
+      ),
+    )
+    .limit(1);
+  if (!releaseTarget) {
+    await markGateErroredSafe(db, gate.id, "release_target_missing");
+    throw new WorkflowArtifactError(
+      "bundle_unavailable",
+      `release target ${gate.releaseTargetId} missing for gate ${gate.id}`,
+    );
+  }
+
+  try {
+    const bundle = await fetchReleaseBundleForGate(input.config, {
+      installationExternalId: installation.installationId,
+      repositoryFullName: gate.repositoryFullName,
+      runId: gate.runId,
+      artifactName: input.artifactName,
+    });
+    const manifestPackage = normalizePyPiProjectName(bundle.manifest.package);
+    if (manifestPackage !== releaseTarget.packageName) {
+      throw new WorkflowArtifactError(
+        "release_target_mismatch",
+        `manifest package ${manifestPackage} does not match release target ${releaseTarget.packageName}`,
+      );
+    }
+    const prepared = await preparePyPiReleaseCandidateFromBundle(env, ctx, bundle);
+    return { ...prepared, gate };
+  } catch (err) {
+    const reason = err instanceof WorkflowArtifactError ? err.code : "preparation_failed";
+    await markGateErroredSafe(db, gate.id, reason);
+    emitOperationalEvent("error", "github_workflow_gate.bundle_failed", {
+      gateId: gate.id,
+      organizationId: gate.organizationId,
+      repositoryFullName: gate.repositoryFullName,
+      runId: gate.runId,
+      reason,
+      error: describeOperationalError(err),
+    });
+    throw err;
+  }
+}
+
+// ── Internals ────────────────────────────────────────────────────────────────
+
+async function parseArtifactBytes(
+  env: Cloudflare.Env,
+  ctx: ExecutionContext,
+  artifact: ResolvedReleaseFile,
+): Promise<DownloadResult["files"]> {
+  const format = inlineFormatForKind(artifact.kind);
+  const result = await downloadInSandboxInline(env, ctx, {
+    bytes: artifact.bytes,
+    format,
+  });
+  return result.files;
+}
+
+function inlineFormatForKind(kind: PyPiArtifactKind): "zip" | "tgz" {
+  return kind === "wheel" ? "zip" : "tgz";
+}
+
+async function markGateErroredSafe(db: AppDb, gateId: string, reason: string): Promise<void> {
+  try {
+    await markGateErrored(db, gateId, reason);
+  } catch (err) {
+    emitOperationalEvent("error", "github_workflow_gate.mark_errored_failed", {
+      gateId,
+      reason,
+      error: describeOperationalError(err),
+    });
+  }
+}

--- a/server/lib/sandbox.ts
+++ b/server/lib/sandbox.ts
@@ -166,6 +166,77 @@ function isSerializedSandboxDetail(message: string): boolean {
   }
 }
 
+export interface InlineDownloadOptions {
+  bytes: Uint8Array;
+  format: "tgz" | "zip";
+  maxFiles?: number;
+  maxBytesPerFile?: number;
+}
+
+/**
+ * Inline-bytes sandbox entrypoint. The control plane passes a pre-downloaded
+ * archive directly as the POST body; the sandbox parses it with the same tar/
+ * zip readers it uses for npm tarballs, but no outbound fetch is issued.
+ *
+ * This is the credentials-free counterpart of `downloadInSandbox` — the gateway
+ * is constructed with empty props so even an internally compromised sandbox
+ * could not exfiltrate an npm token (there isn't one in scope). It exists for
+ * the PyPI workflow-gate path, where GitHub installation tokens stay in the
+ * parent worker and the wheel/sdist bytes are the only thing that crosses the
+ * trust boundary.
+ */
+export async function downloadInSandboxInline(
+  env: Cloudflare.Env,
+  ctx: ExecutionContext,
+  options: InlineDownloadOptions,
+): Promise<DownloadResult> {
+  if (!options.bytes || options.bytes.byteLength === 0) {
+    throw new SandboxError(JSON.stringify({ error: "inline archive body is empty", status: 400 }));
+  }
+  if (options.bytes.byteLength > MAX_TAR_BYTES) {
+    throw new SandboxError(JSON.stringify({ error: "archive too large", status: 413 }));
+  }
+  const sandbox = env.LOADER.load({
+    compatibilityDate: "2026-05-20",
+    mainModule: "sandbox.js",
+    modules: { "sandbox.js": sandboxSource() },
+    env: {
+      NPM_REGISTRY: env.NPM_REGISTRY || "https://registry.npmjs.org",
+      ARCHIVE_FORMAT: options.format,
+      MAX_FILES: Math.min(options.maxFiles ?? MAX_FILES, MAX_FILES),
+      MAX_BYTES_PER_FILE: Math.min(
+        options.maxBytesPerFile ?? MAX_BYTES_PER_FILE,
+        MAX_BYTES_PER_FILE,
+      ),
+      MAX_TAR_BYTES,
+    },
+    globalOutbound: (
+      ctx as unknown as {
+        exports: { NpmStageGateway(options: { props: NpmStageGatewayProps }): Fetcher };
+      }
+    ).exports.NpmStageGateway({ props: {} }),
+    limits: { cpuMs: 2_000, subRequests: 0 },
+  });
+
+  const body = new ArrayBuffer(options.bytes.byteLength);
+  new Uint8Array(body).set(options.bytes);
+  const response = await sandbox.getEntrypoint().fetch(
+    new Request("https://sandbox.local/download", {
+      method: "POST",
+      body,
+      headers: {
+        "content-type": "application/octet-stream",
+        "x-archive-format": options.format,
+      },
+    }),
+  );
+
+  if (!response.ok) {
+    throw new SandboxError(await response.text());
+  }
+  return (await response.json()) as DownloadResult;
+}
+
 export async function downloadInSandbox(
   env: Cloudflare.Env,
   ctx: ExecutionContext,
@@ -243,18 +314,25 @@ const STAGE_ID_RE = new RegExp(${JSON.stringify(`^${STAGE_ID_PATTERN}$`)});
 
 export default {
   async fetch(request, env) {
-    const { stageId, tarballUrl } = await request.json();
-    if (!tarballUrl && !STAGE_ID_RE.test(stageId)) return json({ error: "invalid stageId" }, 400);
-
-    const registry = env.NPM_REGISTRY || "https://registry.npmjs.org";
-    const url = tarballUrl || registry.replace(/\\/$/, "") + "/-/stage/" + encodeURIComponent(stageId) + "/tarball";
-    const res = await fetch(url, { headers: { accept: "application/octet-stream" } });
-    if (!res.ok) return json({ error: "download failed", status: res.status }, 502);
-
+    const inlineFormat = request.headers.get("x-archive-format");
     const maxTarBytes = env.MAX_TAR_BYTES || 26214400;
-    const contentLength = Number(res.headers.get("content-length") || "0");
-    if (contentLength > maxTarBytes) return json({ error: "tarball too large", status: 413 }, 413);
-    const archiveFormat = env.ARCHIVE_FORMAT || "tgz";
+    const archiveFormat = inlineFormat || env.ARCHIVE_FORMAT || "tgz";
+    let res;
+    if (inlineFormat) {
+      if (archiveFormat !== "zip" && archiveFormat !== "tgz") return json({ error: "invalid inline archive format", status: 400 }, 400);
+      res = new Response(request.body, { status: 200, headers: { "content-type": "application/octet-stream" } });
+    } else {
+      const { stageId, tarballUrl } = await request.json();
+      if (!tarballUrl && !STAGE_ID_RE.test(stageId)) return json({ error: "invalid stageId" }, 400);
+
+      const registry = env.NPM_REGISTRY || "https://registry.npmjs.org";
+      const url = tarballUrl || registry.replace(/\\/$/, "") + "/-/stage/" + encodeURIComponent(stageId) + "/tarball";
+      res = await fetch(url, { headers: { accept: "application/octet-stream" } });
+      if (!res.ok) return json({ error: "download failed", status: res.status }, 502);
+
+      const contentLength = Number(res.headers.get("content-length") || "0");
+      if (contentLength > maxTarBytes) return json({ error: "tarball too large", status: 413 }, 413);
+    }
     if (archiveFormat === "zip") {
       let zip;
       try {

--- a/test/workers/github-app-artifacts.test.ts
+++ b/test/workers/github-app-artifacts.test.ts
@@ -337,6 +337,29 @@ describe("fetchReleaseBundleWithToken", () => {
     });
   });
 
+  test("artifact_kind_unsupported when the bundle has an undeclared dist file", async () => {
+    const fixture = await buildFixture({
+      extraEntries: [{ path: "dist/demo_package-1.2.0.zip", body: "not reviewed" }],
+    });
+    stubGithubFetch({ bundleZip: fixture.bundleZip });
+
+    await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
+      code: "artifact_kind_unsupported",
+    });
+  });
+
+  test("allows the workflow checksum support file outside the manifest", async () => {
+    const fixture = await buildFixture({
+      extraEntries: [{ path: "drydock-sha256.txt", body: "placeholder\n" }],
+    });
+    stubGithubFetch({ bundleZip: fixture.bundleZip });
+
+    const bundle = await fetchReleaseBundleWithToken(TOKEN, source());
+
+    expect(bundle.artifacts).toHaveLength(1);
+    expect(bundle.artifacts[0]?.path).toBe(fixture.wheel.path);
+  });
+
   test("manifest_artifact_mismatch when manifest declares a path the bundle omits", async () => {
     const realWheel = makeWheelBytes("demo-package", "1.2.0");
     const realSha = await sha256Hex(realWheel.bytes);

--- a/test/workers/github-app-artifacts.test.ts
+++ b/test/workers/github-app-artifacts.test.ts
@@ -1,0 +1,404 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  fetchReleaseBundleWithToken,
+  type WorkflowArtifactSource,
+} from "../../server/lib/github-app-artifacts";
+
+const TOKEN = "ghs_installation_test_token";
+const REPO = "octo/example";
+const RUN_ID = 4242;
+const ARTIFACT_ID = 99999;
+const ARTIFACT_NAME = "pypi-release-candidate";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ── Tiny store-only ZIP builder (no deflate; matches existing readZipArchive
+// expectations of compressionMethod === 0) ────────────────────────────────────
+
+interface ZipEntry {
+  path: string;
+  body: Uint8Array | string;
+}
+
+function makeZip(entries: ZipEntry[]): Uint8Array {
+  const encoder = new TextEncoder();
+  const records: Uint8Array[] = [];
+  const central: Uint8Array[] = [];
+  let offset = 0;
+  for (const entry of entries) {
+    const body = typeof entry.body === "string" ? encoder.encode(entry.body) : entry.body;
+    const nameBytes = encoder.encode(entry.path);
+    const crc = crc32(body);
+    const local = new Uint8Array(30 + nameBytes.length + body.length);
+    const localView = new DataView(local.buffer);
+    localView.setUint32(0, 0x04034b50, true);
+    localView.setUint16(4, 20, true); // version needed
+    localView.setUint16(6, 0, true); // flags
+    localView.setUint16(8, 0, true); // method = stored
+    localView.setUint16(10, 0, true); // time
+    localView.setUint16(12, 0, true); // date
+    localView.setUint32(14, crc, true);
+    localView.setUint32(18, body.length, true);
+    localView.setUint32(22, body.length, true);
+    localView.setUint16(26, nameBytes.length, true);
+    localView.setUint16(28, 0, true); // extra
+    local.set(nameBytes, 30);
+    local.set(body, 30 + nameBytes.length);
+    records.push(local);
+
+    const c = new Uint8Array(46 + nameBytes.length);
+    const cView = new DataView(c.buffer);
+    cView.setUint32(0, 0x02014b50, true);
+    cView.setUint16(4, 20, true); // version made by
+    cView.setUint16(6, 20, true); // version needed
+    cView.setUint16(8, 0, true); // flags
+    cView.setUint16(10, 0, true); // method = stored
+    cView.setUint16(12, 0, true);
+    cView.setUint16(14, 0, true);
+    cView.setUint32(16, crc, true);
+    cView.setUint32(20, body.length, true);
+    cView.setUint32(24, body.length, true);
+    cView.setUint16(28, nameBytes.length, true);
+    cView.setUint16(30, 0, true);
+    cView.setUint16(32, 0, true); // comment
+    cView.setUint16(34, 0, true); // disk
+    cView.setUint16(36, 0, true); // internal attrs
+    cView.setUint32(38, 0, true); // external attrs
+    cView.setUint32(42, offset, true);
+    c.set(nameBytes, 46);
+    central.push(c);
+    offset += local.length;
+  }
+  const centralStart = offset;
+  const centralBytes = concat(central);
+  const eocd = new Uint8Array(22);
+  const eocdView = new DataView(eocd.buffer);
+  eocdView.setUint32(0, 0x06054b50, true);
+  eocdView.setUint16(4, 0, true);
+  eocdView.setUint16(6, 0, true);
+  eocdView.setUint16(8, entries.length, true);
+  eocdView.setUint16(10, entries.length, true);
+  eocdView.setUint32(12, centralBytes.length, true);
+  eocdView.setUint32(16, centralStart, true);
+  eocdView.setUint16(20, 0, true);
+  return concat([...records, centralBytes, eocd]);
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let cursor = 0;
+  for (const part of parts) {
+    out.set(part, cursor);
+    cursor += part.length;
+  }
+  return out;
+}
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let i = 0; i < 8; i += 1) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes as BufferSource);
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+// ── Bundle fixture helpers ───────────────────────────────────────────────────
+
+interface FakeWheel {
+  bytes: Uint8Array;
+  path: string;
+}
+
+function makeWheelBytes(name: string, version: string): FakeWheel {
+  // A wheel is a ZIP. We embed minimal METADATA + RECORD entries so the PyPI
+  // adapter would later be able to parse them; this test only needs the bytes
+  // for digest verification.
+  const path = `dist/${name.replace(/-/g, "_")}-${version}-py3-none-any.whl`;
+  const wheelBytes = makeZip([
+    {
+      path: `${name.replace(/-/g, "_")}-${version}.dist-info/METADATA`,
+      body: `Metadata-Version: 2.3\nName: ${name}\nVersion: ${version}\n`,
+    },
+    {
+      path: `${name.replace(/-/g, "_")}-${version}.dist-info/WHEEL`,
+      body: "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+    },
+    {
+      path: `${name.replace(/-/g, "_")}-${version}.dist-info/RECORD`,
+      body: "",
+    },
+  ]);
+  return { bytes: wheelBytes, path };
+}
+
+async function buildFixture(opts?: {
+  extraEntries?: ZipEntry[];
+  mutateWheel?: (bytes: Uint8Array) => Uint8Array;
+  omitManifest?: boolean;
+  manifestRaw?: string;
+  declareWheelKind?: "wheel" | "sdist";
+}): Promise<{
+  wheel: FakeWheel;
+  manifestRaw: string;
+  bundleZip: Uint8Array;
+}> {
+  const wheel = makeWheelBytes("demo-package", "1.2.0");
+  const wheelBytes = opts?.mutateWheel ? opts.mutateWheel(wheel.bytes) : wheel.bytes;
+  const wheelSha = await sha256Hex(wheelBytes);
+
+  const manifestObject = {
+    schema: "drydock.release-artifacts.v1",
+    ecosystem: "pypi",
+    package: "demo-package",
+    version: "1.2.0",
+    artifacts: [
+      {
+        path: wheel.path,
+        sha256: wheelSha,
+        // The PyPI adapter's parsePyPiReleaseManifest infers kind from the
+        // suffix; we don't include "kind" in the JSON.
+      },
+    ],
+  };
+  const manifestRaw = opts?.manifestRaw ?? JSON.stringify(manifestObject, null, 2);
+
+  const entries: ZipEntry[] = [];
+  if (!opts?.omitManifest) {
+    entries.push({ path: "drydock-manifest.json", body: manifestRaw });
+  }
+  entries.push({ path: wheel.path, body: wheelBytes });
+  if (opts?.extraEntries) entries.push(...opts.extraEntries);
+  const bundleZip = makeZip(entries);
+  return { wheel: { bytes: wheelBytes, path: wheel.path }, manifestRaw, bundleZip };
+}
+
+// ── Fetch stub ───────────────────────────────────────────────────────────────
+
+interface StubOptions {
+  bundleZip: Uint8Array | null;
+  artifactsResponse?: () => Response;
+  artifactId?: number;
+  artifactName?: string;
+  contentLength?: number | null;
+}
+
+function stubGithubFetch(options: StubOptions) {
+  const calls: { url: string; authorization: string | null }[] = [];
+  const artifactsBody = JSON.stringify({
+    total_count: 1,
+    artifacts: [
+      {
+        id: options.artifactId ?? ARTIFACT_ID,
+        name: options.artifactName ?? ARTIFACT_NAME,
+        size_in_bytes: options.bundleZip?.length ?? 0,
+        expired: false,
+      },
+    ],
+  });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      calls.push({
+        url: request.url,
+        authorization: request.headers.get("authorization"),
+      });
+      if (request.url.includes("/actions/runs/")) {
+        if (options.artifactsResponse) return options.artifactsResponse();
+        return new Response(artifactsBody, {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (request.url.includes("/actions/artifacts/")) {
+        if (!options.bundleZip) {
+          return new Response("not found", { status: 404 });
+        }
+        const headers: Record<string, string> = {
+          "content-type": "application/zip",
+        };
+        if (options.contentLength !== null) {
+          headers["content-length"] = String(options.contentLength ?? options.bundleZip.length);
+        }
+        return new Response(options.bundleZip, { status: 200, headers });
+      }
+      throw new Error(`unexpected fetch in test: ${request.url}`);
+    }),
+  );
+  return calls;
+}
+
+function source(): WorkflowArtifactSource {
+  return {
+    installationExternalId: "1010",
+    repositoryFullName: REPO,
+    runId: RUN_ID,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("fetchReleaseBundleWithToken", () => {
+  test("returns the manifest and verified wheel bytes on the happy path", async () => {
+    const fixture = await buildFixture();
+    const calls = stubGithubFetch({ bundleZip: fixture.bundleZip });
+
+    const bundle = await fetchReleaseBundleWithToken(TOKEN, source());
+
+    expect(bundle.manifest.package).toBe("demo-package");
+    expect(bundle.manifest.version).toBe("1.2.0");
+    expect(bundle.artifactName).toBe(ARTIFACT_NAME);
+    expect(bundle.artifactId).toBe(ARTIFACT_ID);
+    expect(bundle.artifacts).toHaveLength(1);
+    expect(bundle.artifacts[0]?.path).toBe(fixture.wheel.path);
+    expect(bundle.artifacts[0]?.kind).toBe("wheel");
+    expect(bundle.artifacts[0]?.bytes).toEqual(fixture.wheel.bytes);
+    expect(calls.every((call) => call.authorization === `Bearer ${TOKEN}`)).toBe(true);
+  });
+
+  test("bundle_unavailable when no artifact with that name exists", async () => {
+    const fixture = await buildFixture();
+    stubGithubFetch({ bundleZip: fixture.bundleZip, artifactName: "something-else" });
+
+    await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
+      name: "WorkflowArtifactError",
+      code: "bundle_unavailable",
+    });
+  });
+
+  test("bundle_unavailable when list-artifacts returns 404", async () => {
+    stubGithubFetch({
+      bundleZip: null,
+      artifactsResponse: () => new Response("missing", { status: 404 }),
+    });
+
+    await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
+      code: "bundle_unavailable",
+    });
+  });
+
+  test("bundle_too_large when content-length exceeds the cap", async () => {
+    const fixture = await buildFixture();
+    stubGithubFetch({
+      bundleZip: fixture.bundleZip,
+      contentLength: 26 * 1024 * 1024,
+    });
+
+    await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
+      code: "bundle_too_large",
+    });
+  });
+
+  test("manifest_missing when the zip lacks drydock-manifest.json", async () => {
+    const fixture = await buildFixture({ omitManifest: true });
+    stubGithubFetch({ bundleZip: fixture.bundleZip });
+
+    await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
+      code: "manifest_missing",
+    });
+  });
+
+  test("manifest_invalid when the manifest JSON is malformed", async () => {
+    const fixture = await buildFixture({ manifestRaw: "{ not json" });
+    stubGithubFetch({ bundleZip: fixture.bundleZip });
+
+    await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
+      code: "manifest_invalid",
+    });
+  });
+
+  test("manifest_artifact_mismatch when the bundle has an extra wheel not declared in the manifest", async () => {
+    const sneaky = makeWheelBytes("evil-package", "9.9.9");
+    const fixture = await buildFixture({
+      extraEntries: [{ path: sneaky.path, body: sneaky.bytes }],
+    });
+    stubGithubFetch({ bundleZip: fixture.bundleZip });
+
+    await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
+      code: "manifest_artifact_mismatch",
+    });
+  });
+
+  test("manifest_artifact_mismatch when manifest declares a path the bundle omits", async () => {
+    const realWheel = makeWheelBytes("demo-package", "1.2.0");
+    const realSha = await sha256Hex(realWheel.bytes);
+    const declaredButAbsent = "dist/demo_package-1.2.0-py3-none-any.whl";
+    const manifestRaw = JSON.stringify({
+      schema: "drydock.release-artifacts.v1",
+      ecosystem: "pypi",
+      package: "demo-package",
+      version: "1.2.0",
+      artifacts: [
+        { path: declaredButAbsent, sha256: realSha },
+        {
+          path: "dist/demo_package-1.2.0.tar.gz",
+          sha256: "b".repeat(64),
+        },
+      ],
+    });
+    const bundle = makeZip([
+      { path: "drydock-manifest.json", body: manifestRaw },
+      { path: declaredButAbsent, body: realWheel.bytes },
+    ]);
+    stubGithubFetch({ bundleZip: bundle });
+
+    await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
+      code: "manifest_artifact_mismatch",
+    });
+  });
+
+  test("artifact_digest_mismatch when a declared artifact's bytes differ from the manifest sha256", async () => {
+    const fixture = await buildFixture({
+      mutateWheel: (bytes) => {
+        // After we mutate, the manifest sha256 (computed over original bytes
+        // in `buildFixture`) won't match the bundled bytes. Build the
+        // manifest before mutation, mutate after.
+        return bytes;
+      },
+    });
+    // Replace the wheel entry with a tampered copy that does not match the
+    // recorded sha256.
+    const tamperedWheel = makeWheelBytes("demo-package", "1.2.0").bytes;
+    tamperedWheel[tamperedWheel.length - 5] ^= 0xff;
+    const tamperedBundle = makeZip([
+      { path: "drydock-manifest.json", body: fixture.manifestRaw },
+      { path: fixture.wheel.path, body: tamperedWheel },
+    ]);
+    stubGithubFetch({ bundleZip: tamperedBundle });
+
+    await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
+      code: "artifact_digest_mismatch",
+    });
+  });
+
+  test("artifact_path_unsafe when the bundle includes a traversal path", async () => {
+    const sneaky = makeWheelBytes("demo-package", "1.2.0");
+    const bundle = makeZip([
+      { path: "drydock-manifest.json", body: "{}" },
+      { path: "../../etc/passwd", body: sneaky.bytes },
+    ]);
+    stubGithubFetch({ bundleZip: bundle });
+
+    await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
+      code: "artifact_path_unsafe",
+    });
+  });
+});

--- a/test/workers/release-candidate-pypi.test.ts
+++ b/test/workers/release-candidate-pypi.test.ts
@@ -1,0 +1,441 @@
+import { createExecutionContext, env } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { generateKeyPairSync } from "node:crypto";
+import { createDb, ensurePersonalOrganization } from "../../server/db";
+import * as schema from "../../server/db/schema";
+import {
+  createReleaseTarget,
+  readGithubAppConfig,
+  upsertInstallation,
+} from "../../server/lib/github-app";
+import { getGateForOrganization } from "../../server/lib/github-app-webhook";
+import { preparePyPiReleaseCandidateForGate } from "../../server/lib/release-candidate-pypi";
+import { WorkflowArtifactError } from "../../server/lib/github-app-artifacts";
+
+const WEBHOOK_SECRET = "webhook-secret-value-1234567890";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ── Test setup helpers ───────────────────────────────────────────────────────
+
+async function seedGateForTest(opts: {
+  installationExternalId: string;
+  repositoryId: number;
+  runId: number;
+}) {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  const installation = await upsertInstallation(db, {
+    organizationId,
+    installationId: opts.installationExternalId,
+    accountLogin: "octo",
+    accountType: "Organization",
+    targetType: "Organization",
+    status: "active",
+    createdByUserId: null,
+  });
+  const releaseTarget = await createReleaseTarget(db, {
+    organizationId,
+    installationRowId: installation.id,
+    ecosystem: "pypi",
+    packageName: "demo-package",
+    repositoryId: opts.repositoryId,
+    repositoryFullName: "octo/example",
+    workflowFilename: null,
+    environment: "pypi",
+    pypiTrustedPublisherEnvironment: "pypi",
+    createdByUserId: null,
+  });
+
+  const gateId = crypto.randomUUID();
+  await db.insert(schema.githubWorkflowGates).values({
+    id: gateId,
+    organizationId,
+    installationRowId: installation.id,
+    releaseTargetId: releaseTarget.id,
+    deliveryId: crypto.randomUUID(),
+    repositoryId: opts.repositoryId,
+    repositoryFullName: "octo/example",
+    environment: "pypi",
+    runId: opts.runId,
+    deploymentId: 909,
+    deploymentCallbackUrl: `https://api.github.com/repos/octo/example/actions/runs/${opts.runId}/deployment_protection_rule`,
+    eventAction: "requested",
+    status: "pending",
+    requestedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  });
+  return { organizationId, installation, releaseTarget, gateId };
+}
+
+// Minimal store-only ZIP builder.
+interface ZipEntry {
+  path: string;
+  body: Uint8Array | string;
+}
+
+function makeZip(entries: ZipEntry[]): Uint8Array {
+  const encoder = new TextEncoder();
+  const records: Uint8Array[] = [];
+  const central: Uint8Array[] = [];
+  let offset = 0;
+  for (const entry of entries) {
+    const body = typeof entry.body === "string" ? encoder.encode(entry.body) : entry.body;
+    const nameBytes = encoder.encode(entry.path);
+    const crc = crc32(body);
+    const local = new Uint8Array(30 + nameBytes.length + body.length);
+    const lv = new DataView(local.buffer);
+    lv.setUint32(0, 0x04034b50, true);
+    lv.setUint16(4, 20, true);
+    lv.setUint16(8, 0, true);
+    lv.setUint32(14, crc, true);
+    lv.setUint32(18, body.length, true);
+    lv.setUint32(22, body.length, true);
+    lv.setUint16(26, nameBytes.length, true);
+    local.set(nameBytes, 30);
+    local.set(body, 30 + nameBytes.length);
+    records.push(local);
+
+    const c = new Uint8Array(46 + nameBytes.length);
+    const cv = new DataView(c.buffer);
+    cv.setUint32(0, 0x02014b50, true);
+    cv.setUint16(4, 20, true);
+    cv.setUint16(6, 20, true);
+    cv.setUint16(10, 0, true);
+    cv.setUint32(16, crc, true);
+    cv.setUint32(20, body.length, true);
+    cv.setUint32(24, body.length, true);
+    cv.setUint16(28, nameBytes.length, true);
+    cv.setUint32(42, offset, true);
+    c.set(nameBytes, 46);
+    central.push(c);
+    offset += local.length;
+  }
+  const centralBytes = concat(central);
+  const eocd = new Uint8Array(22);
+  const ev = new DataView(eocd.buffer);
+  ev.setUint32(0, 0x06054b50, true);
+  ev.setUint16(8, entries.length, true);
+  ev.setUint16(10, entries.length, true);
+  ev.setUint32(12, centralBytes.length, true);
+  ev.setUint32(16, offset, true);
+  return concat([...records, centralBytes, eocd]);
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, p) => sum + p.length, 0);
+  const out = new Uint8Array(total);
+  let i = 0;
+  for (const part of parts) {
+    out.set(part, i);
+    i += part.length;
+  }
+  return out;
+}
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let i = 0; i < 8; i += 1) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes as BufferSource);
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function buildLoaderMock() {
+  const calls: { format: string | null; bodySize: number }[] = [];
+  return {
+    calls,
+    binding: {
+      load: vi.fn(() => ({
+        getEntrypoint: () => ({
+          fetch: vi.fn(async (request: Request) => {
+            calls.push({
+              format: request.headers.get("x-archive-format"),
+              bodySize: (await request.arrayBuffer()).byteLength,
+            });
+            return new Response(
+              JSON.stringify({
+                files: [
+                  {
+                    path: "stub.txt",
+                    size: 1,
+                    sha256: "00",
+                    flags: [],
+                    textSample: "x",
+                  },
+                ],
+                packageJson: null,
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            );
+          }),
+        }),
+      })),
+    },
+  };
+}
+
+function buildCtxWithGateway() {
+  const ctx = createExecutionContext() as ExecutionContext & {
+    exports: { NpmStageGateway(options: { props: unknown }): Fetcher };
+  };
+  ctx.exports = {
+    NpmStageGateway: vi.fn(() => ({ fetch: vi.fn() }) as unknown as Fetcher),
+  };
+  return ctx;
+}
+
+function buildConfigBindings(): Record<string, string> {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const privateKeyPem = privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+  return {
+    GITHUB_APP_ID: "12345",
+    GITHUB_APP_SLUG: "drydock-test",
+    GITHUB_APP_CLIENT_ID: "client-id",
+    GITHUB_APP_CLIENT_SECRET: "client-secret",
+    GITHUB_APP_PRIVATE_KEY: privateKeyPem,
+    GITHUB_APP_WEBHOOK_SECRET: WEBHOOK_SECRET,
+    GITHUB_APP_STATE_SECRET: "0123456789abcdef0123456789abcdef",
+    BETTER_AUTH_SECRET: "fallback-secret-with-enough-entropy-aaaaaaaa",
+  };
+}
+
+interface ScenarioOpts {
+  digestMatches: boolean;
+  manifestPackage?: string;
+}
+
+async function buildScenario(runId: number, opts: ScenarioOpts) {
+  const wheelPath = "dist/demo_package-1.2.0-py3-none-any.whl";
+  const wheelBytes = makeZip([
+    {
+      path: "demo_package-1.2.0.dist-info/METADATA",
+      body: "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n",
+    },
+    {
+      path: "demo_package-1.2.0.dist-info/WHEEL",
+      body: "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+    },
+    {
+      path: "demo_package-1.2.0.dist-info/RECORD",
+      body: "",
+    },
+  ]);
+  const declaredSha = opts.digestMatches ? await sha256Hex(wheelBytes) : "0".repeat(64);
+  const manifestRaw = JSON.stringify({
+    schema: "drydock.release-artifacts.v1",
+    ecosystem: "pypi",
+    package: opts.manifestPackage ?? "demo-package",
+    version: "1.2.0",
+    artifacts: [{ path: wheelPath, sha256: declaredSha }],
+  });
+  const bundleZip = makeZip([
+    { path: "drydock-manifest.json", body: manifestRaw },
+    { path: wheelPath, body: wheelBytes },
+  ]);
+
+  const fetchSpy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    if (request.url.includes("/access_tokens")) {
+      return Response.json({
+        token: "ghs_install_token",
+        expires_at: "2099-01-01T00:00:00Z",
+      });
+    }
+    if (request.url.includes(`/actions/runs/${runId}/artifacts`)) {
+      return new Response(
+        JSON.stringify({
+          total_count: 1,
+          artifacts: [
+            {
+              id: 88888,
+              name: "pypi-release-candidate",
+              size_in_bytes: bundleZip.length,
+              expired: false,
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (request.url.includes("/actions/artifacts/")) {
+      return new Response(bundleZip, {
+        status: 200,
+        headers: { "content-type": "application/zip" },
+      });
+    }
+    throw new Error(`unexpected fetch in test: ${request.url}`);
+  });
+  vi.stubGlobal("fetch", fetchSpy);
+  return { fetchSpy, manifestRaw, wheelPath, wheelBytes };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("preparePyPiReleaseCandidateForGate", () => {
+  test("returns a PyPiAdapterInput for a pending gate with a matching manifest", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9100",
+      repositoryId: 71001,
+      runId: 7777,
+    });
+    const scenario = await buildScenario(7777, { digestMatches: true });
+    const loaderMock = buildLoaderMock();
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const config = readGithubAppConfig({
+      ...bindings,
+      BETTER_AUTH_SECRET: bindings.BETTER_AUTH_SECRET,
+    });
+    const sandboxEnv = {
+      ...env,
+      ...bindings,
+      LOADER: loaderMock.binding as unknown as WorkerLoader,
+    } as Cloudflare.Env;
+
+    const db = createDb(env.DB);
+    const result = await preparePyPiReleaseCandidateForGate(sandboxEnv, ctx, db, {
+      config,
+      organizationId: seeded.organizationId,
+      gateId: seeded.gateId,
+    });
+
+    expect(result.gate.id).toBe(seeded.gateId);
+    expect(result.bundle.manifest.package).toBe("demo-package");
+    expect(result.adapterInput.artifacts).toHaveLength(1);
+    expect(result.adapterInput.artifacts[0].path).toBe(scenario.wheelPath);
+    expect(result.adapterInput.artifacts[0].files).toHaveLength(1);
+    expect(loaderMock.calls).toHaveLength(1);
+    expect(loaderMock.calls[0].format).toBe("zip");
+    expect(loaderMock.calls[0].bodySize).toBe(scenario.wheelBytes.byteLength);
+
+    const refreshed = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(refreshed?.status).toBe("pending");
+  });
+
+  test("marks the gate errored when the manifest digest does not match the wheel bytes", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9101",
+      repositoryId: 71002,
+      runId: 8888,
+    });
+    await buildScenario(8888, { digestMatches: false });
+    const loaderMock = buildLoaderMock();
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const config = readGithubAppConfig({
+      ...bindings,
+      BETTER_AUTH_SECRET: bindings.BETTER_AUTH_SECRET,
+    });
+    const sandboxEnv = {
+      ...env,
+      ...bindings,
+      LOADER: loaderMock.binding as unknown as WorkerLoader,
+    } as Cloudflare.Env;
+
+    const db = createDb(env.DB);
+    await expect(
+      preparePyPiReleaseCandidateForGate(sandboxEnv, ctx, db, {
+        config,
+        organizationId: seeded.organizationId,
+        gateId: seeded.gateId,
+      }),
+    ).rejects.toBeInstanceOf(WorkflowArtifactError);
+
+    const refreshed = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(refreshed?.status).toBe("pending");
+    expect(refreshed?.failureReason).toBe("artifact_digest_mismatch");
+  });
+
+  test("marks the gate errored when the manifest package does not match the release target", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9102",
+      repositoryId: 71003,
+      runId: 9999,
+    });
+    await buildScenario(9999, {
+      digestMatches: true,
+      manifestPackage: "other-package",
+    });
+    const loaderMock = buildLoaderMock();
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const config = readGithubAppConfig({
+      ...bindings,
+      BETTER_AUTH_SECRET: bindings.BETTER_AUTH_SECRET,
+    });
+    const sandboxEnv = {
+      ...env,
+      ...bindings,
+      LOADER: loaderMock.binding as unknown as WorkerLoader,
+    } as Cloudflare.Env;
+
+    const db = createDb(env.DB);
+    await expect(
+      preparePyPiReleaseCandidateForGate(sandboxEnv, ctx, db, {
+        config,
+        organizationId: seeded.organizationId,
+        gateId: seeded.gateId,
+      }),
+    ).rejects.toMatchObject({ code: "release_target_mismatch" });
+
+    expect(loaderMock.calls).toHaveLength(0);
+    const refreshed = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(refreshed?.status).toBe("pending");
+    expect(refreshed?.failureReason).toBe("release_target_mismatch");
+  });
+
+  test("rejects with bundle_unavailable when the gate id does not belong to the org", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9103",
+      repositoryId: 71004,
+      runId: 10000,
+    });
+    const bindings = buildConfigBindings();
+    const config = readGithubAppConfig({
+      ...bindings,
+      BETTER_AUTH_SECRET: bindings.BETTER_AUTH_SECRET,
+    });
+    const loaderMock = buildLoaderMock();
+    const ctx = buildCtxWithGateway();
+    const sandboxEnv = {
+      ...env,
+      ...bindings,
+      LOADER: loaderMock.binding as unknown as WorkerLoader,
+    } as Cloudflare.Env;
+    const db = createDb(env.DB);
+    await expect(
+      preparePyPiReleaseCandidateForGate(sandboxEnv, ctx, db, {
+        config,
+        organizationId: "other-org",
+        gateId: seeded.gateId,
+      }),
+    ).rejects.toMatchObject({ code: "bundle_unavailable" });
+  });
+});

--- a/test/workers/sandbox-inline.test.ts
+++ b/test/workers/sandbox-inline.test.ts
@@ -1,0 +1,112 @@
+import { createExecutionContext, env } from "cloudflare:test";
+import { describe, expect, test, vi } from "vitest";
+import { downloadInSandboxInline, SandboxError } from "../../server/lib/sandbox";
+
+interface LoaderRecord {
+  globalOutboundProps: unknown;
+  subRequestsLimit: number | undefined;
+  receivedHeaders: Headers | null;
+  receivedBody: Uint8Array | null;
+}
+
+function buildLoader(record: LoaderRecord) {
+  const handler = vi.fn(async (request: Request) => {
+    record.receivedHeaders = request.headers;
+    const buf = await request.arrayBuffer();
+    record.receivedBody = new Uint8Array(buf);
+    return new Response(
+      JSON.stringify({
+        files: [{ path: "hello.txt", size: 5, sha256: "abc", flags: [] }],
+        packageJson: null,
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  });
+  return {
+    load: vi.fn((options: { limits?: { subRequests?: number } }) => {
+      record.subRequestsLimit = options.limits?.subRequests;
+      return {
+        getEntrypoint: () => ({
+          fetch: (request: Request) => handler(request),
+        }),
+      };
+    }),
+  };
+}
+
+function buildCtxWithGateway(record: LoaderRecord) {
+  const ctx = createExecutionContext() as ExecutionContext & {
+    exports: {
+      NpmStageGateway(options: { props: unknown }): Fetcher;
+    };
+  };
+  ctx.exports = {
+    NpmStageGateway: vi.fn((options: { props: unknown }) => {
+      record.globalOutboundProps = options.props;
+      return { fetch: vi.fn() } as unknown as Fetcher;
+    }),
+  };
+  return ctx;
+}
+
+describe("downloadInSandboxInline", () => {
+  test("constructs the gateway with empty props so no npm credentials enter the sandbox", async () => {
+    const record: LoaderRecord = {
+      globalOutboundProps: undefined,
+      subRequestsLimit: undefined,
+      receivedHeaders: null,
+      receivedBody: null,
+    };
+    const loader = buildLoader(record);
+    const ctx = buildCtxWithGateway(record);
+    const sandboxEnv = { ...env, LOADER: loader as unknown as WorkerLoader } as Cloudflare.Env;
+
+    const archive = new TextEncoder().encode("not-really-a-zip-but-fine-for-the-stub");
+    const result = await downloadInSandboxInline(sandboxEnv, ctx, {
+      bytes: archive,
+      format: "zip",
+    });
+
+    expect(result.files).toHaveLength(1);
+    expect(record.globalOutboundProps).toEqual({});
+    expect(record.subRequestsLimit).toBe(0);
+    expect(record.receivedHeaders?.get("x-archive-format")).toBe("zip");
+    expect(record.receivedBody).toEqual(archive);
+  });
+
+  test("rejects an empty inline body", async () => {
+    const record: LoaderRecord = {
+      globalOutboundProps: undefined,
+      subRequestsLimit: undefined,
+      receivedHeaders: null,
+      receivedBody: null,
+    };
+    const ctx = buildCtxWithGateway(record);
+    const sandboxEnv = {
+      ...env,
+      LOADER: buildLoader(record) as unknown as WorkerLoader,
+    } as Cloudflare.Env;
+
+    await expect(
+      downloadInSandboxInline(sandboxEnv, ctx, { bytes: new Uint8Array(), format: "zip" }),
+    ).rejects.toBeInstanceOf(SandboxError);
+  });
+
+  test("rejects an oversized inline body before hitting the loader", async () => {
+    const record: LoaderRecord = {
+      globalOutboundProps: undefined,
+      subRequestsLimit: undefined,
+      receivedHeaders: null,
+      receivedBody: null,
+    };
+    const loader = buildLoader(record);
+    const ctx = buildCtxWithGateway(record);
+    const sandboxEnv = { ...env, LOADER: loader as unknown as WorkerLoader } as Cloudflare.Env;
+    const oversized = new Uint8Array(25 * 1024 * 1024 + 1);
+
+    await expect(
+      downloadInSandboxInline(sandboxEnv, ctx, { bytes: oversized, format: "tgz" }),
+    ).rejects.toBeInstanceOf(SandboxError);
+    expect(loader.load).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Adds backend support for resolving PyPI workflow-gate artifacts from GitHub Actions, validating the release manifest, digesting declared wheels and sdists, and parsing them through a credentials-free inline sandbox path. Updates the sandbox to accept inline tgz/zip bytes without outbound access and fail closed on undeclared or unsupported bundle files while allowing the documented checksum support file. Documents the required GitHub App permissions, artifact resolution flow, typed errors, and remaining integration work. Validation: pnpm run verify.