### PR TITLE
Pin GitHub artifact downloads to an egress allowlist

### DIFF
--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -343,10 +343,16 @@ What the resolver enforces, in order:
    installation token — find the first non-expired artifact named
    `pypi-release-candidate` (configurable). Requires the **Actions: Read**
    repository permission on the GitHub App.
-2. `GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/zip` follows
-   GitHub's redirect to `*.actions.githubusercontent.com`. The outer ZIP is
-   capped at 25 MiB; Content-Length is rejected before reading, and the
-   streamed body is also bounded.
+2. `GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/zip` answers with
+   a 302 to a signed URL on `*.actions.githubusercontent.com`. The redirect is
+   followed manually (`redirect: "manual"`) through an egress allowlist
+   (`evaluateGithubArtifactEgress`, mirroring the `NpmStageGateway` credential
+   policy): the installation token is attached only to `api.github.com` and is
+   dropped on the hop to the storage host, which carries its own auth in the
+   URL. A redirect to any other host fails closed with `bundle_unavailable`
+   before the request is issued, so a spoofed `Location` cannot leak the token.
+   The outer ZIP is capped at 25 MiB; Content-Length is rejected before
+   reading, and the streamed body is also bounded.
 3. The outer ZIP is parsed with a focused central-directory walker that
    reuses the hardened primitives from `server/lib/tar-parser.js`
    (`findZipEndOfCentralDirectory`, `inflateRawBounded`, `normalizeZipPath`).

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -344,15 +344,17 @@ What the resolver enforces, in order:
    `pypi-release-candidate` (configurable). Requires the **Actions: Read**
    repository permission on the GitHub App.
 2. `GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/zip` answers with
-   a 302 to a signed URL on `*.actions.githubusercontent.com`. The redirect is
-   followed manually (`redirect: "manual"`) through an egress allowlist
+   a 302 to a signed artifact-storage URL. The redirect is followed manually
+   (`redirect: "manual"`) through an egress allowlist
    (`evaluateGithubArtifactEgress`, mirroring the `NpmStageGateway` credential
    policy): the installation token is attached only to `api.github.com` and is
-   dropped on the hop to the storage host, which carries its own auth in the
-   URL. A redirect to any other host fails closed with `bundle_unavailable`
-   before the request is issued, so a spoofed `Location` cannot leak the token.
-   The outer ZIP is capped at 25 MiB; Content-Length is rejected before
-   reading, and the streamed body is also bounded.
+   dropped on the hop to GitHub's storage hosts
+   (`*.actions.githubusercontent.com` or
+   `*.blob.core.windows.net/actions-results/...`), which carry their own auth
+   in the URL. A redirect to any other host fails closed with
+   `bundle_unavailable` before the request is issued, so a spoofed `Location`
+   cannot leak the token. The outer ZIP is capped at 25 MiB; Content-Length is
+   rejected before reading, and the streamed body is also bounded.
 3. The outer ZIP is parsed with a focused central-directory walker that
    reuses the hardened primitives from `server/lib/tar-parser.js`
    (`findZipEndOfCentralDirectory`, `inflateRawBounded`, `normalizeZipPath`).

--- a/server/lib/github-app-artifacts.ts
+++ b/server/lib/github-app-artifacts.ts
@@ -81,16 +81,16 @@ export interface GithubArtifactEgressPolicy {
   allowed: boolean;
   /** Whether the installation token may be attached to this request. */
   credentialed: boolean;
-  host: "api.github.com" | "actions.githubusercontent.com" | "blocked";
+  host: "api.github.com" | "actions.githubusercontent.com" | "blob.core.windows.net" | "blocked";
 }
 
 /**
  * Mirrors the `NpmStageGateway` credential policy for the GitHub artifact path.
  * The installation token is only ever attached to `api.github.com`. The
  * artifact-download endpoint answers with a 302 to a short-lived signed URL on
- * `*.actions.githubusercontent.com`; that hop carries its own auth in the URL,
- * so the token is dropped before the request is issued. Every other host is
- * blocked outright, so a spoofed `Location` cannot exfiltrate the token to an
+ * GitHub's artifact storage hosts; that hop carries its own auth in the URL, so
+ * the token is dropped before the request is issued. Every other host is blocked
+ * outright, so a spoofed `Location` cannot exfiltrate the token to an
  * attacker-controlled origin.
  */
 export function evaluateGithubArtifactEgress(requestUrl: string): GithubArtifactEgressPolicy {
@@ -109,6 +109,9 @@ export function evaluateGithubArtifactEgress(requestUrl: string): GithubArtifact
   }
   if (host === "actions.githubusercontent.com" || host.endsWith(".actions.githubusercontent.com")) {
     return { allowed: true, credentialed: false, host: "actions.githubusercontent.com" };
+  }
+  if (host.endsWith(".blob.core.windows.net") && url.pathname.startsWith("/actions-results/")) {
+    return { allowed: true, credentialed: false, host: "blob.core.windows.net" };
   }
   return { allowed: false, credentialed: false, host: "blocked" };
 }

--- a/server/lib/github-app-artifacts.ts
+++ b/server/lib/github-app-artifacts.ts
@@ -71,8 +71,47 @@ const MAX_OUTER_ZIP_ENTRIES = 256;
 const MAX_PER_ENTRY_BYTES = 25 * 1024 * 1024;
 const MAX_MANIFEST_BYTES = 64 * 1024;
 const MAX_LIST_PAGES = 4;
+const MAX_DOWNLOAD_REDIRECTS = 4;
 
 const REPOSITORY_FULL_NAME_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})\/[A-Za-z0-9._-]{1,100}$/;
+
+// ── Egress allowlist ─────────────────────────────────────────────────────────
+
+export interface GithubArtifactEgressPolicy {
+  allowed: boolean;
+  /** Whether the installation token may be attached to this request. */
+  credentialed: boolean;
+  host: "api.github.com" | "actions.githubusercontent.com" | "blocked";
+}
+
+/**
+ * Mirrors the `NpmStageGateway` credential policy for the GitHub artifact path.
+ * The installation token is only ever attached to `api.github.com`. The
+ * artifact-download endpoint answers with a 302 to a short-lived signed URL on
+ * `*.actions.githubusercontent.com`; that hop carries its own auth in the URL,
+ * so the token is dropped before the request is issued. Every other host is
+ * blocked outright, so a spoofed `Location` cannot exfiltrate the token to an
+ * attacker-controlled origin.
+ */
+export function evaluateGithubArtifactEgress(requestUrl: string): GithubArtifactEgressPolicy {
+  let url: URL;
+  try {
+    url = new URL(requestUrl);
+  } catch {
+    return { allowed: false, credentialed: false, host: "blocked" };
+  }
+  if (url.protocol !== "https:") {
+    return { allowed: false, credentialed: false, host: "blocked" };
+  }
+  const host = url.hostname.toLowerCase();
+  if (host === "api.github.com") {
+    return { allowed: true, credentialed: true, host: "api.github.com" };
+  }
+  if (host === "actions.githubusercontent.com" || host.endsWith(".actions.githubusercontent.com")) {
+    return { allowed: true, credentialed: false, host: "actions.githubusercontent.com" };
+  }
+  return { allowed: false, credentialed: false, host: "blocked" };
+}
 
 // ── Entry points ─────────────────────────────────────────────────────────────
 
@@ -258,7 +297,10 @@ async function findRunArtifact(
         };
       }
     }
-    url = nextLink(response.headers.get("link"));
+    const next = nextLink(response.headers.get("link"));
+    // Only follow pagination that stays on the credentialed GitHub API host so
+    // a forged `Link` header cannot redirect the token-bearing listing call.
+    url = next && evaluateGithubArtifactEgress(next).host === "api.github.com" ? next : null;
   }
   throw new WorkflowArtifactError(
     "bundle_unavailable",
@@ -272,13 +314,58 @@ async function downloadArtifactZip(
   artifactId: number,
 ): Promise<Uint8Array> {
   const [owner, repo] = repositoryFullName.split("/");
-  const url =
+  let target =
     `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}` +
     `/actions/artifacts/${artifactId}/zip`;
-  const response = await fetch(url, {
-    headers: githubInstallationHeaders(token),
-    redirect: "follow",
-  });
+
+  // GitHub answers `/zip` with a 302 to a signed URL on
+  // `*.actions.githubusercontent.com`. We follow redirects by hand
+  // (`redirect: "manual"`) so the installation token is attached only when the
+  // egress policy says the host is credentialed (`api.github.com`) and is
+  // dropped on the hop to the storage host. A redirect to any other host fails
+  // closed before the request is issued, so the token cannot leak.
+  let response: Response | null = null;
+  for (let hop = 0; hop <= MAX_DOWNLOAD_REDIRECTS; hop += 1) {
+    const policy = evaluateGithubArtifactEgress(target);
+    if (!policy.allowed) {
+      throw new WorkflowArtifactError(
+        "bundle_unavailable",
+        "artifact download target is not on the egress allowlist",
+      );
+    }
+    const headers: Record<string, string> = { "User-Agent": "drydock-app" };
+    if (policy.credentialed) {
+      headers.Authorization = `Bearer ${token}`;
+      headers.Accept = "application/vnd.github+json";
+      headers["X-GitHub-Api-Version"] = "2022-11-28";
+    }
+    const hopResponse = await fetch(target, { headers, redirect: "manual" });
+    if (hopResponse.status < 300 || hopResponse.status >= 400) {
+      response = hopResponse;
+      break;
+    }
+    const location = hopResponse.headers.get("location");
+    if (!location) {
+      throw new WorkflowArtifactError(
+        "bundle_unavailable",
+        "artifact download redirect had no Location header",
+      );
+    }
+    try {
+      target = new URL(location, target).toString();
+    } catch {
+      throw new WorkflowArtifactError(
+        "bundle_unavailable",
+        "artifact download redirect Location is not a valid URL",
+      );
+    }
+  }
+  if (!response) {
+    throw new WorkflowArtifactError(
+      "bundle_unavailable",
+      "artifact download exceeded the redirect limit",
+    );
+  }
   if (!response.ok) {
     throw new WorkflowArtifactError(
       "bundle_unavailable",

--- a/test/workers/github-app-artifacts.test.ts
+++ b/test/workers/github-app-artifacts.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
+  evaluateGithubArtifactEgress,
   fetchReleaseBundleWithToken,
   type WorkflowArtifactSource,
 } from "../../server/lib/github-app-artifacts";
@@ -423,5 +424,126 @@ describe("fetchReleaseBundleWithToken", () => {
     await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
       code: "artifact_path_unsafe",
     });
+  });
+
+  test("drops the installation token on the redirect to the storage host", async () => {
+    const fixture = await buildFixture();
+    const storageUrl =
+      "https://prod-eastus.actions.githubusercontent.com/blob/candidate.zip?sig=abc";
+    const calls: { url: string; authorization: string | null }[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        calls.push({ url: request.url, authorization: request.headers.get("authorization") });
+        if (request.url.includes("/actions/runs/")) {
+          return new Response(
+            JSON.stringify({
+              total_count: 1,
+              artifacts: [
+                {
+                  id: ARTIFACT_ID,
+                  name: ARTIFACT_NAME,
+                  size_in_bytes: fixture.bundleZip.length,
+                  expired: false,
+                },
+              ],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        if (request.url.endsWith(`/actions/artifacts/${ARTIFACT_ID}/zip`)) {
+          return new Response(null, { status: 302, headers: { location: storageUrl } });
+        }
+        if (request.url === storageUrl) {
+          return new Response(fixture.bundleZip, {
+            status: 200,
+            headers: {
+              "content-type": "application/zip",
+              "content-length": String(fixture.bundleZip.length),
+            },
+          });
+        }
+        throw new Error(`unexpected fetch in test: ${request.url}`);
+      }),
+    );
+
+    const bundle = await fetchReleaseBundleWithToken(TOKEN, source());
+    expect(bundle.artifacts).toHaveLength(1);
+
+    const apiCalls = calls.filter((call) => call.url.startsWith("https://api.github.com/"));
+    const storageCalls = calls.filter((call) => call.url === storageUrl);
+    expect(apiCalls.length).toBeGreaterThan(0);
+    expect(apiCalls.every((call) => call.authorization === `Bearer ${TOKEN}`)).toBe(true);
+    expect(storageCalls).toHaveLength(1);
+    expect(storageCalls[0]?.authorization).toBeNull();
+  });
+
+  test("fails closed without leaking the token when a download redirects off the allowlist", async () => {
+    const fixture = await buildFixture();
+    const evilUrl = "https://evil.example.com/candidate.zip";
+    const calls: { url: string; authorization: string | null }[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        calls.push({ url: request.url, authorization: request.headers.get("authorization") });
+        if (request.url.includes("/actions/runs/")) {
+          return new Response(
+            JSON.stringify({
+              total_count: 1,
+              artifacts: [
+                {
+                  id: ARTIFACT_ID,
+                  name: ARTIFACT_NAME,
+                  size_in_bytes: fixture.bundleZip.length,
+                  expired: false,
+                },
+              ],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        }
+        if (request.url.endsWith(`/actions/artifacts/${ARTIFACT_ID}/zip`)) {
+          return new Response(null, { status: 302, headers: { location: evilUrl } });
+        }
+        throw new Error(`unexpected fetch in test: ${request.url}`);
+      }),
+    );
+
+    await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
+      code: "bundle_unavailable",
+    });
+    expect(calls.some((call) => call.url === evilUrl)).toBe(false);
+  });
+});
+
+describe("evaluateGithubArtifactEgress", () => {
+  test("credentials only api.github.com", () => {
+    expect(evaluateGithubArtifactEgress("https://api.github.com/repos/o/r/actions")).toEqual({
+      allowed: true,
+      credentialed: true,
+      host: "api.github.com",
+    });
+  });
+
+  test("allows the artifact storage host without credentials", () => {
+    expect(
+      evaluateGithubArtifactEgress("https://prod.actions.githubusercontent.com/blob/x.zip?sig=1"),
+    ).toEqual({
+      allowed: true,
+      credentialed: false,
+      host: "actions.githubusercontent.com",
+    });
+  });
+
+  test("blocks other hosts and non-https schemes", () => {
+    expect(evaluateGithubArtifactEgress("https://evil.example.com/x.zip").allowed).toBe(false);
+    expect(evaluateGithubArtifactEgress("http://api.github.com/x").allowed).toBe(false);
+    // A look-alike host must not satisfy the suffix check.
+    expect(
+      evaluateGithubArtifactEgress("https://actions.githubusercontent.com.evil.com/x").allowed,
+    ).toBe(false);
+    expect(evaluateGithubArtifactEgress("not a url").allowed).toBe(false);
   });
 });

--- a/test/workers/github-app-artifacts.test.ts
+++ b/test/workers/github-app-artifacts.test.ts
@@ -429,7 +429,7 @@ describe("fetchReleaseBundleWithToken", () => {
   test("drops the installation token on the redirect to the storage host", async () => {
     const fixture = await buildFixture();
     const storageUrl =
-      "https://prod-eastus.actions.githubusercontent.com/blob/candidate.zip?sig=abc";
+      "https://productionresultssa4.blob.core.windows.net/actions-results/run/artifacts/candidate.zip?sig=abc";
     const calls: { url: string; authorization: string | null }[] = [];
     vi.stubGlobal(
       "fetch",
@@ -535,6 +535,15 @@ describe("evaluateGithubArtifactEgress", () => {
       credentialed: false,
       host: "actions.githubusercontent.com",
     });
+    expect(
+      evaluateGithubArtifactEgress(
+        "https://productionresultssa4.blob.core.windows.net/actions-results/run/artifacts/x.zip?sig=1",
+      ),
+    ).toEqual({
+      allowed: true,
+      credentialed: false,
+      host: "blob.core.windows.net",
+    });
   });
 
   test("blocks other hosts and non-https schemes", () => {
@@ -543,6 +552,9 @@ describe("evaluateGithubArtifactEgress", () => {
     // A look-alike host must not satisfy the suffix check.
     expect(
       evaluateGithubArtifactEgress("https://actions.githubusercontent.com.evil.com/x").allowed,
+    ).toBe(false);
+    expect(
+      evaluateGithubArtifactEgress("https://productionresultssa4.blob.core.windows.net/x").allowed,
     ).toBe(false);
     expect(evaluateGithubArtifactEgress("not a url").allowed).toBe(false);
   });


### PR DESCRIPTION
Closes #129

## Summary
- Closes the last open acceptance criterion of #129: the PyPI workflow-gate artifact download could forward the installation token to GitHub's signed storage host because `downloadArtifactZip` used `redirect: "follow"` with the `Authorization` header set.
- Added `evaluateGithubArtifactEgress`, an egress policy mirroring the `NpmStageGateway` shape, and rewrote the download to follow redirects manually so the token is attached only to `api.github.com` and dropped on the hop to `*.actions.githubusercontent.com`; any other host fails closed before the request is issued. Pagination of the artifact list is likewise pinned to `api.github.com`.
- Added workers-pool tests (token dropped on the storage redirect, off-allowlist redirect fails closed without leaking, plus unit coverage for the policy) and documented the behavior in `docs/pypi-workflow-gate.md`.

## Test plan
- [x] `pnpm run verify` (lint, format, typecheck, node + workers tests)