### PR TITLE
Gate GitHub App UI by per-org allowlist

### DIFF
--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -299,8 +299,14 @@ parameters and POSTs them to `/api/v1/github-app/install/callback`.
 
 ### Front-end
 
-The install flow lives on `/dashboard/settings` (gated behind
-`import.meta.env.DEV` until the workflow-gate path is ready for users):
+The install flow lives on `/dashboard/settings`, gated by
+`isGithubAppUiEnabled` in `src/lib/github-app-ui.ts` until the workflow-gate
+path is ready for users. It is enabled in dev (`import.meta.env.DEV`) and, in
+production, only for the organizations listed in `GITHUB_APP_UI_ALLOWLIST` —
+the per-org escape hatch for production testing before GA. The gate is
+evaluated against the active organization, so it can be flipped per org without
+a new deploy gate. The same helper guards the
+`/dashboard/settings/github-app/callback` page:
 
 1. The page calls `GET /api/v1/github-app/config`; when `configured === false`
    it renders a "not configured yet — ask the operator" notice instead of the

--- a/src/lib/github-app-ui.ts
+++ b/src/lib/github-app-ui.ts
@@ -1,0 +1,11 @@
+// The GitHub App settings UI (PyPI workflow-gate flow) is not generally
+// available yet, so it is hidden in production. These organizations are
+// allowlisted to exercise the flow on production before GA.
+export const GITHUB_APP_UI_ALLOWLIST: ReadonlySet<string> = new Set([
+  "personal:vMEkEjmZLH960ddSJzfT6N8Jxw2jTuHQ",
+]);
+
+export function isGithubAppUiEnabled(organizationId: string | null | undefined): boolean {
+  if (import.meta.env.DEV) return true;
+  return organizationId != null && GITHUB_APP_UI_ALLOWLIST.has(organizationId);
+}

--- a/src/pages/Dashboard/GithubAppCallback.tsx
+++ b/src/pages/Dashboard/GithubAppCallback.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from "preact/hooks";
 import { useModel, useSignal } from "@preact/signals";
 import { useLocation } from "preact-iso";
+import { isGithubAppUiEnabled } from "../../lib/github-app-ui";
 import { sessionModel } from "../../models/auth";
+import { activeOrganizationId } from "../../models/active-organization";
 import { OrganizationModel } from "../../models/organization";
 import {
   GithubAppModel,
@@ -23,7 +25,6 @@ import {
 
 const SETTINGS_PATH = "/dashboard/settings";
 const SUCCESS_REDIRECT_MS = 1500;
-const GITHUB_APP_UI_ENABLED = import.meta.env.DEV;
 
 type CallbackPhase = "checking-session" | "verifying" | "success" | "error";
 
@@ -35,7 +36,7 @@ export default function GithubAppCallbackPage() {
   const queryError = useSignal<string | null>(null);
 
   useEffect(() => {
-    if (!GITHUB_APP_UI_ENABLED) {
+    if (!isGithubAppUiEnabled(activeOrganizationId.peek())) {
       location.route(SETTINGS_PATH, true);
       return;
     }

--- a/src/pages/Dashboard/GithubAppCallback.tsx
+++ b/src/pages/Dashboard/GithubAppCallback.tsx
@@ -3,7 +3,6 @@ import { useModel, useSignal } from "@preact/signals";
 import { useLocation } from "preact-iso";
 import { isGithubAppUiEnabled } from "../../lib/github-app-ui";
 import { sessionModel } from "../../models/auth";
-import { activeOrganizationId } from "../../models/active-organization";
 import { OrganizationModel } from "../../models/organization";
 import {
   GithubAppModel,
@@ -36,10 +35,6 @@ export default function GithubAppCallbackPage() {
   const queryError = useSignal<string | null>(null);
 
   useEffect(() => {
-    if (!isGithubAppUiEnabled(activeOrganizationId.peek())) {
-      location.route(SETTINGS_PATH, true);
-      return;
-    }
     let cancelled = false;
     void (async () => {
       const data = await sessionModel.load();
@@ -52,6 +47,10 @@ export default function GithubAppCallbackPage() {
       }
       await organizations.load();
       if (cancelled) return;
+      if (!isGithubAppUiEnabled(organizations.activeOrganizationId.peek())) {
+        location.route(SETTINGS_PATH, true);
+        return;
+      }
 
       const parsed = parseCallbackQuery(window.location.search);
       if (typeof parsed === "string") {

--- a/src/pages/Dashboard/Settings.tsx
+++ b/src/pages/Dashboard/Settings.tsx
@@ -2,6 +2,7 @@ import type { ComponentChildren } from "preact";
 import { useEffect } from "preact/hooks";
 import { useModel, useSignal } from "@preact/signals";
 import { useLocation } from "preact-iso";
+import { isGithubAppUiEnabled } from "../../lib/github-app-ui";
 import { rememberDashboardReturnUrl } from "../../lib/query-state";
 import { sessionModel } from "../../models/auth";
 import { NpmConnectionModel } from "../../models/npm-connection";
@@ -31,8 +32,6 @@ import {
   type BadgeTone,
 } from "../../components";
 
-const GITHUB_APP_UI_ENABLED = import.meta.env.DEV;
-
 export default function SettingsPage() {
   const location = useLocation();
   const npm = useModel(NpmConnectionModel);
@@ -54,15 +53,15 @@ export default function SettingsPage() {
         return;
       }
       sessionChecked.value = true;
-      const loaders: Promise<unknown>[] = [organizations.load(), npm.load()];
-      if (GITHUB_APP_UI_ENABLED) {
-        loaders.push(
+      await Promise.all([organizations.load(), npm.load()]);
+      if (cancelled) return;
+      if (isGithubAppUiEnabled(organizations.activeOrganizationId.peek())) {
+        await Promise.all([
           githubApp.loadConfig(),
           githubApp.loadInstallations(),
           githubApp.loadReleaseTargets(),
-        );
+        ]);
       }
-      await Promise.all(loaders);
     })();
     return () => {
       cancelled = true;
@@ -71,8 +70,9 @@ export default function SettingsPage() {
 
   const reloadActiveOrgScopedData = async () => {
     const loaders: Promise<unknown>[] = [npm.load()];
-    if (GITHUB_APP_UI_ENABLED) {
+    if (isGithubAppUiEnabled(organizations.activeOrganizationId.peek())) {
       githubApp.clearForm();
+      if (!githubApp.configLoaded.peek()) loaders.push(githubApp.loadConfig());
       loaders.push(githubApp.loadInstallations(), githubApp.loadReleaseTargets());
     }
     await Promise.all(loaders);
@@ -96,17 +96,19 @@ export default function SettingsPage() {
     location.route("/", true);
   };
 
+  const githubAppUiEnabled = isGithubAppUiEnabled(organizations.activeOrganizationId.value);
+
   if (!sessionChecked.value) {
     return (
       <PageShell>
-        <SettingsHeader />
+        <SettingsHeader githubAppUiEnabled={githubAppUiEnabled} />
         <LoadingState title="Opening settings" detail="confirming session" />
       </PageShell>
     );
   }
 
   const user = sessionModel.user.value;
-  const githubAppLoaded = GITHUB_APP_UI_ENABLED ? githubApp.loaded.value : true;
+  const githubAppLoaded = githubAppUiEnabled ? githubApp.loaded.value : true;
   const npmLoaded = npm.loaded.value;
   const workspaceLoaded = githubAppLoaded && npmLoaded;
 
@@ -126,34 +128,41 @@ export default function SettingsPage() {
         </>
       }
     >
-      <SettingsHeader />
+      <SettingsHeader githubAppUiEnabled={githubAppUiEnabled} />
 
       {workspaceLoaded ? (
         <div class="flex flex-col gap-6">
-          {GITHUB_APP_UI_ENABLED ? <GithubAppSection githubApp={githubApp} /> : null}
+          {githubAppUiEnabled ? <GithubAppSection githubApp={githubApp} /> : null}
           <NpmConnectionSection npm={npm} />
         </div>
       ) : (
-        <LoadingState title="Loading settings" detail={loadingDetail(npmLoaded, githubAppLoaded)} />
+        <LoadingState
+          title="Loading settings"
+          detail={loadingDetail(npmLoaded, githubAppLoaded, githubAppUiEnabled)}
+        />
       )}
     </PageShell>
   );
 }
 
-function loadingDetail(npmLoaded: boolean, githubAppLoaded: boolean): string {
+function loadingDetail(
+  npmLoaded: boolean,
+  githubAppLoaded: boolean,
+  githubAppUiEnabled: boolean,
+): string {
   const parts: string[] = [];
   if (!npmLoaded) parts.push("checking npm connection");
-  if (GITHUB_APP_UI_ENABLED && !githubAppLoaded) parts.push("checking GitHub App");
+  if (githubAppUiEnabled && !githubAppLoaded) parts.push("checking GitHub App");
   return parts.join(" · ");
 }
 
-function SettingsHeader() {
+function SettingsHeader({ githubAppUiEnabled }: { githubAppUiEnabled: boolean }) {
   return (
     <header class="flex flex-col gap-2 max-w-[640px]">
       <Eyebrow>Organization settings</Eyebrow>
       <h1 class="text-3xl font-semibold tracking-[-0.02em] m-0">Integrations &amp; access</h1>
       <Muted class="text-[14px] leading-[1.55] m-0">
-        {GITHUB_APP_UI_ENABLED
+        {githubAppUiEnabled
           ? "Connect npm so Drydock can fetch staged tarballs, and install the GitHub App so it can gate PyPI workflow releases for this organization."
           : "Connect npm so Drydock can fetch staged tarballs for this organization."}
       </Muted>

--- a/test/github-app-ui.test.ts
+++ b/test/github-app-ui.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "vitest";
+import { GITHUB_APP_UI_ALLOWLIST, isGithubAppUiEnabled } from "../src/lib/github-app-ui";
+
+describe("GitHub App UI allowlist", () => {
+  test("includes only the organizations approved for production testing", () => {
+    expect([...GITHUB_APP_UI_ALLOWLIST]).toEqual(["personal:vMEkEjmZLH960ddSJzfT6N8Jxw2jTuHQ"]);
+  });
+
+  test("allowlisted organization can use the GitHub App UI", () => {
+    expect(isGithubAppUiEnabled("personal:vMEkEjmZLH960ddSJzfT6N8Jxw2jTuHQ")).toBe(true);
+  });
+
+  test("a non-allowlisted organization is not in the allowlist", () => {
+    expect(GITHUB_APP_UI_ALLOWLIST.has("personal:someone-else")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces the build-time `import.meta.env.DEV` gate on the GitHub App settings UI with `isGithubAppUiEnabled`, a new helper (`src/lib/github-app-ui.ts`) that checks the active organization against a `GITHUB_APP_UI_ALLOWLIST`.
- The Settings page and the install callback page now evaluate the gate per-org, so the GitHub App / PyPI workflow-gate flow can be enabled for specific organizations in production for pre-GA testing while staying hidden for everyone else.
- GitHub data now loads after the active organization resolves (so the org-scoped requests carry the right org), and switching into an allowlisted org backfills config if needed.
- Adds a unit test pinning the allowlist contents and the enablement check, plus updates `docs/pypi-workflow-gate.md`.

## Test plan
- [ ] `pnpm run verify` (lint, format, typecheck, tests) — passing locally
- [ ] On production, confirm the GitHub App section appears for the allowlisted org and stays hidden for others