### PR TITLE
Add npm token scope guidance to settings

### DIFF
--- a/src/pages/Dashboard/Settings.tsx
+++ b/src/pages/Dashboard/Settings.tsx
@@ -698,6 +698,8 @@ function NpmConnectionSection({
           </div>
         ) : null}
 
+        <NpmTokenScopeGuide />
+
         <form
           class="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.5fr)_auto] gap-3 items-end"
           onSubmit={onSave}
@@ -789,6 +791,44 @@ function NpmConnectionSection({
         ) : null}
       </div>
     </Card>
+  );
+}
+
+function NpmTokenScopeGuide() {
+  return (
+    <div class="border border-border rounded-lg bg-surface-2 px-4 py-3 flex flex-col gap-3">
+      <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">
+        recommended token scope
+      </span>
+      <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 m-0">
+        <ScopeRow term="token type" detail="Granular access token" />
+        <ScopeRow term="permission" detail="Read-only" />
+        <ScopeRow term="packages" detail="Only the packages you stage" />
+        <ScopeRow term="expiration" detail="Short, with planned rotation" />
+      </dl>
+      <Muted as="p" class="text-[12px] leading-[1.55] m-0">
+        Drydock only reads staged release evidence — it never publishes and the token never reaches
+        the sandbox, so read-only access to those packages is enough. Create one in{" "}
+        <a
+          class="underline"
+          href="https://docs.npmjs.com/creating-and-viewing-access-tokens/"
+          target="_blank"
+          rel="noreferrer"
+        >
+          npm access token settings
+        </a>
+        .
+      </Muted>
+    </div>
+  );
+}
+
+function ScopeRow({ term, detail }: { term: string; detail: string }) {
+  return (
+    <div class="grid grid-cols-[88px_minmax(0,1fr)] gap-3 items-baseline text-[13px] min-w-0">
+      <dt class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">{term}</dt>
+      <dd class="m-0 text-ink-muted break-words">{detail}</dd>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- Adds a **Recommended token scope** panel to the npm connection card in Settings, rendered directly above the token form.
- It states the least-privilege setup maintainers should provision — a read-only granular access token scoped only to the packages they stage, with short expiration — plus one line on why read-only is sufficient (Drydock only reads staged evidence, never publishes, and the token never reaches the sandbox) and a link to npm's token settings.
- Built entirely from existing primitives and design tokens, so it stays on-spec with `DESIGN.md` (no SVG icons, no new colors).

## Test plan
- [ ] `pnpm run verify` passes (typecheck, lint, format all clean locally; ran by the pre-commit hook).
- [ ] Open **Settings → npm access** and confirm the scope panel renders correctly in light and dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)