### PR TITLE
Add opt-in TOTP two-factor authentication

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"22c3ab82-b165-4075-ad5f-5c05de65bede","pid":8496,"procStart":"Fri May 29 14:32:13 2026","acquiredAt":1780070882907}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"22c3ab82-b165-4075-ad5f-5c05de65bede","pid":8496,"procStart":"Fri May 29 14:32:13 2026","acquiredAt":1780070882907}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ packages/experiments/build/
 .dev.vars
 .gstack/
 .context/
+.claude/scheduled_tasks.lock

--- a/docs/two-factor-auth.md
+++ b/docs/two-factor-auth.md
@@ -67,7 +67,7 @@ All under the Better Auth base path `/api/auth` and handled by `auth.handler`:
 - `two_factor` table — one row per enrolled user:
   - `id` (text, PK)
   - `secret` (text) — symmetrically encrypted by Better Auth, never the raw base32
-  - `backup_codes` (text) — hashed
+  - `backup_codes` (text) — symmetrically encrypted by Better Auth
   - `verified` (integer, boolean mode) — `true` after the first successful TOTP verification;
     the plugin requires this column
   - `user_id` (text, FK → `user.id`, `ON DELETE CASCADE`)

--- a/docs/two-factor-auth.md
+++ b/docs/two-factor-auth.md
@@ -25,7 +25,9 @@ account. Backup codes use the plugin default: 10 single-use codes.
    (`POST /api/auth/two-factor/verify-totp`), which finalizes enrollment and flips
    `user.twoFactorEnabled` to `true`.
 3. The backup codes are shown once behind an "I've saved these codes" confirmation, with a
-   download-to-`.txt` option.
+   download-to-`.txt` option. The setup dialog cannot be dismissed from this step until that
+   confirmation is checked, because 2FA is already enabled and these recovery codes are not shown
+   again.
 
 ### Sign-in challenge
 

--- a/docs/two-factor-auth.md
+++ b/docs/two-factor-auth.md
@@ -16,7 +16,7 @@ account. Backup codes use the plugin default: 10 single-use codes.
 
 ### Enrollment (Settings → Security)
 
-`src/pages/Dashboard/TwoFactorSection.tsx` drives a dialog:
+`src/pages/Dashboard/Settings/TwoFactorSection.tsx` drives a dialog:
 
 1. Confirm the current password (`POST /api/auth/two-factor/enable`). The response carries the
    `totpURI` and the freshly generated `backupCodes`.
@@ -72,7 +72,7 @@ All under the Better Auth base path `/api/auth` and handled by `auth.handler`:
     the plugin requires this column
   - `user_id` (text, FK → `user.id`, `ON DELETE CASCADE`)
 
-Migrations are generated with `pnpm db:generate` (see `drizzle/0012_late_mattie_franklin.sql`),
+Migrations are generated with `pnpm db:generate` (see `drizzle/0015_nebulous_patch.sql`),
 never hand-written.
 
 ## Rate limiting

--- a/docs/two-factor-auth.md
+++ b/docs/two-factor-auth.md
@@ -1,0 +1,97 @@
+# Two-factor authentication
+
+Drydock supports opt-in two-factor authentication (2FA) using TOTP (time-based one-time
+passwords from an authenticator app) plus single-use backup recovery codes. It is built on
+Better Auth's first-party [`two-factor`](https://www.better-auth.com/docs/plugins/2fa) plugin,
+registered in `server/lib/auth.ts`:
+
+```ts
+plugins: [twoFactor({ issuer: "Drydock" })];
+```
+
+The `issuer` (and `appName: "Drydock"`) is the label authenticator apps display next to the
+account. Backup codes use the plugin default: 10 single-use codes.
+
+## User flows
+
+### Enrollment (Settings → Security)
+
+`src/pages/Dashboard/TwoFactorSection.tsx` drives a dialog:
+
+1. Confirm the current password (`POST /api/auth/two-factor/enable`). The response carries the
+   `totpURI` and the freshly generated `backupCodes`.
+2. The UI renders the `totpURI` as a QR code (PNG data-URL via `qrcode`) plus the raw base32
+   secret as copyable text for manual entry. The user scans it and submits a 6-digit code
+   (`POST /api/auth/two-factor/verify-totp`), which finalizes enrollment and flips
+   `user.twoFactorEnabled` to `true`.
+3. The backup codes are shown once behind an "I've saved these codes" confirmation, with a
+   download-to-`.txt` option.
+
+### Sign-in challenge
+
+When an enrolled user signs in, `POST /api/auth/sign-in/email` returns
+`{ twoFactorRedirect: true }` instead of an authenticated session. `src/pages/Auth/Login.tsx`
+swaps to a "Verify it's you" step that accepts either:
+
+- a TOTP code → `POST /api/auth/two-factor/verify-totp`, or
+- a backup recovery code → `POST /api/auth/two-factor/verify-backup-code`.
+
+Only after the second factor succeeds is a full session cookie set. The client model logic lives
+in `src/models/auth.ts` (`signIn` returns `{ twoFactorRequired }`; `completeTwoFactorSignIn`)
+and `src/models/two-factor.ts`.
+
+### Management
+
+Enrolled users can regenerate backup codes
+(`POST /api/auth/two-factor/generate-backup-codes`, password-gated) or disable 2FA
+(`POST /api/auth/two-factor/disable`, password-gated) from Settings → Security.
+
+## Endpoints
+
+All under the Better Auth base path `/api/auth` and handled by `auth.handler`:
+
+| Endpoint                                          | Purpose                                             | Auth required          |
+| ------------------------------------------------- | --------------------------------------------------- | ---------------------- |
+| `POST /api/auth/two-factor/enable`                | Begin enrollment; returns `totpURI` + `backupCodes` | Session + password     |
+| `POST /api/auth/two-factor/verify-totp`           | Confirm enrollment / pass sign-in challenge         | Session or pending 2FA |
+| `POST /api/auth/two-factor/verify-backup-code`    | Pass sign-in challenge with a recovery code         | Pending 2FA            |
+| `POST /api/auth/two-factor/disable`               | Turn off 2FA                                        | Session + password     |
+| `POST /api/auth/two-factor/generate-backup-codes` | Issue a fresh set of recovery codes                 | Session + password     |
+
+## Data model
+
+`server/db/schema.ts`:
+
+- `user.two_factor_enabled` (`integer`, boolean mode, nullable) — set `true` once TOTP enrollment
+  is verified.
+- `two_factor` table — one row per enrolled user:
+  - `id` (text, PK)
+  - `secret` (text) — symmetrically encrypted by Better Auth, never the raw base32
+  - `backup_codes` (text) — hashed
+  - `verified` (integer, boolean mode) — `true` after the first successful TOTP verification;
+    the plugin requires this column
+  - `user_id` (text, FK → `user.id`, `ON DELETE CASCADE`)
+
+Migrations are generated with `pnpm db:generate` (see `drizzle/0012_late_mattie_franklin.sql`),
+never hand-written.
+
+## Rate limiting
+
+The verify endpoints are brute-force targets, so `authIpLimit()` in `server/index.ts` adds a
+dedicated bucket for everything under `/api/auth/two-factor`:
+
+```
+{ bucket: "two-factor", max: 10, windowMs: 15 * 60 * 1000 }
+```
+
+10 requests per IP per 15-minute window; the 11th returns `429`. The existing origin/CSRF check
+already covers these POSTs.
+
+## Tests
+
+- `test/workers/two-factor-routes.test.ts` — drives the real Better Auth handler via
+  `worker.fetch`: enroll → verify TOTP → assert `twoFactorEnabled`, sign-in challenge
+  (`twoFactorRedirect`), backup-code sign-in, disable, and the rate-limit bucket. (The full TOTP
+  flow runs several scrypt hashes, so the test sets a 30s timeout.)
+- `test/e2e/two-factor.spec.ts` — Playwright flow: register → enable 2FA in Settings (reads the
+  secret, computes a TOTP with `otpauth`) → sign out → sign in through the challenge step.

--- a/docs/two-factor-auth.md
+++ b/docs/two-factor-auth.md
@@ -14,7 +14,7 @@ account. Backup codes use the plugin default: 10 single-use codes.
 
 ## User flows
 
-### Enrollment (Settings → Security)
+### Enrollment (Settings → General)
 
 `src/pages/Dashboard/Settings/TwoFactorSection.tsx` drives a dialog:
 
@@ -44,7 +44,7 @@ and `src/models/two-factor.ts`.
 
 Enrolled users can regenerate backup codes
 (`POST /api/auth/two-factor/generate-backup-codes`, password-gated) or disable 2FA
-(`POST /api/auth/two-factor/disable`, password-gated) from Settings → Security.
+(`POST /api/auth/two-factor/disable`, password-gated) from Settings → General.
 
 ## Endpoints
 
@@ -72,7 +72,7 @@ All under the Better Auth base path `/api/auth` and handled by `auth.handler`:
     the plugin requires this column
   - `user_id` (text, FK → `user.id`, `ON DELETE CASCADE`)
 
-Migrations are generated with `pnpm db:generate` (see `drizzle/0015_nebulous_patch.sql`),
+Migrations are generated with `pnpm db:generate` (see `drizzle/0016_lovely_madrox.sql`),
 never hand-written.
 
 ## Rate limiting

--- a/drizzle/0016_lovely_madrox.sql
+++ b/drizzle/0016_lovely_madrox.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `two_factor` (
+	`id` text PRIMARY KEY NOT NULL,
+	`secret` text NOT NULL,
+	`backup_codes` text NOT NULL,
+	`verified` integer,
+	`user_id` text NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+ALTER TABLE `user` ADD `two_factor_enabled` integer;

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,2127 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d174cbd6-bbfd-4216-9e59-85dcb351d96b",
+  "prevId": "d36879bb-8265-463b-a818-3461538d2098",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_app_installations": {
+      "name": "github_app_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Organization'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uninstalled_at": {
+          "name": "uninstalled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_app_installations_installation_unique_idx": {
+          "name": "github_app_installations_installation_unique_idx",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        },
+        "github_app_installations_org_idx": {
+          "name": "github_app_installations_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installations_created_by_user_id_user_id_fk": {
+          "name": "github_app_installations_created_by_user_id_user_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_release_targets": {
+      "name": "github_release_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ecosystem": {
+          "name": "ecosystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_release_targets_org_repo_env_unique_idx": {
+          "name": "github_release_targets_org_repo_env_unique_idx",
+          "columns": [
+            "organization_id",
+            "repository_id",
+            "environment"
+          ],
+          "isUnique": true
+        },
+        "github_release_targets_installation_idx": {
+          "name": "github_release_targets_installation_idx",
+          "columns": [
+            "installation_row_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_release_targets_organization_id_organizations_id_fk": {
+          "name": "github_release_targets_organization_id_organizations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_release_targets_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_created_by_user_id_user_id_fk": {
+          "name": "github_release_targets_created_by_user_id_user_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_workflow_gates": {
+      "name": "github_workflow_gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_target_id": {
+          "name": "release_target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deployment_callback_url": {
+          "name": "deployment_callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_comment": {
+          "name": "decision_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_url": {
+          "name": "report_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_workflow_gates_delivery_unique_idx": {
+          "name": "github_workflow_gates_delivery_unique_idx",
+          "columns": [
+            "delivery_id"
+          ],
+          "isUnique": true
+        },
+        "github_workflow_gates_org_status_idx": {
+          "name": "github_workflow_gates_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_release_target_idx": {
+          "name": "github_workflow_gates_release_target_idx",
+          "columns": [
+            "release_target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_workflow_gates_organization_id_organizations_id_fk": {
+          "name": "github_workflow_gates_organization_id_organizations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_workflow_gates_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_release_target_id_github_release_targets_id_fk": {
+          "name": "github_workflow_gates_release_target_id_github_release_targets_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_release_targets",
+          "columnsFrom": [
+            "release_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_scan_id_scans_id_fk": {
+          "name": "github_workflow_gates_scan_id_scans_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_unique_idx": {
+          "name": "npm_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_invitations": {
+      "name": "organization_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_invitations_token_hash_unique_idx": {
+          "name": "organization_invitations_token_hash_unique_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "organization_invitations_org_status_idx": {
+          "name": "organization_invitations_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "organization_invitations_org_email_idx": {
+          "name": "organization_invitations_org_email_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_invitations_organization_id_organizations_id_fk": {
+          "name": "organization_invitations_organization_id_organizations_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_invited_by_user_id_user_id_fk": {
+          "name": "organization_invitations_invited_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_accepted_by_user_id_user_id_fk": {
+          "name": "organization_invitations_accepted_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_notification_recipients": {
+      "name": "organization_notification_recipients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_notification_recipients_org_email_unique_idx": {
+          "name": "organization_notification_recipients_org_email_unique_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_notification_recipients_organization_id_organizations_id_fk": {
+          "name": "organization_notification_recipients_organization_id_organizations_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_notification_recipients_created_by_user_id_user_id_fk": {
+          "name": "organization_notification_recipients_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_findings_scan_severity_idx": {
+          "name": "scan_findings_scan_severity_idx",
+          "columns": [
+            "scan_id",
+            "severity"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changed_file_count": {
+          "name": "changed_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_summary_json": {
+          "name": "risk_summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        },
+        "scans_org_decision_created_idx": {
+          "name": "scans_org_decision_created_idx",
+          "columns": [
+            "organization_id",
+            "decision",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_decided_by_user_id_user_id_fk": {
+          "name": "scans_decided_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "two_factor": {
+      "name": "two_factor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1780333664282,
       "tag": "0015_slippery_xavin",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1780377399680,
+      "tag": "0016_lovely_madrox",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "hono": "^4.12.15",
     "preact": "^10.29.2",
     "preact-iso": "^2.12.0",
+    "qrcode": "^1.5.4",
     "shiki": "^4.1.0",
     "workers-ai-provider": "^3.1.14",
     "zod": "^4.4.3"
@@ -51,7 +52,9 @@
     "@preact/preset-vite": "^2.10.5",
     "@tailwindcss/vite": "^4.3.0",
     "@types/diff": "^5.2.3",
+    "@types/qrcode": "^1.5.6",
     "drizzle-kit": "^0.31.10",
+    "otpauth": "^9.5.1",
     "oxfmt": "^0.51.0",
     "oxlint": "^1.66.0",
     "tailwindcss": "^4.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 6.0.191(zod@4.4.3)
       better-auth:
         specifier: ^1.6.11
-        version: 1.6.11(@cloudflare/workers-types@4.20260520.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260520.1)(@opentelemetry/api@1.9.1)(kysely@0.28.17))(vitest@4.1.7(@opentelemetry/api@1.9.1)(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)))
+        version: 1.6.11(@cloudflare/workers-types@4.20260520.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260520.1)(@opentelemetry/api@1.9.1)(kysely@0.28.17))(vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)))
       diff:
         specifier: ^5.2.0
         version: 5.2.2
@@ -32,6 +32,9 @@ importers:
       preact-iso:
         specifier: ^2.12.0
         version: 2.12.0(preact-render-to-string@6.7.0(preact@10.29.2))(preact@10.29.2)
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       shiki:
         specifier: ^4.1.0
         version: 4.1.0
@@ -44,10 +47,10 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: ^1.33.2
-        version: 1.37.2(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))(workerd@1.20260518.1)(wrangler@4.93.0(@cloudflare/workers-types@4.20260520.1))
+        version: 1.37.2(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))(workerd@1.20260518.1)(wrangler@4.93.0(@cloudflare/workers-types@4.20260520.1))
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.16.7
-        version: 0.16.7(@cloudflare/workers-types@4.20260520.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.7(@opentelemetry/api@1.9.1)(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)))
+        version: 0.16.7(@cloudflare/workers-types@4.20260520.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)))
       '@cloudflare/workers-types':
         specifier: ^4.20260520.0
         version: 4.20260520.1
@@ -59,16 +62,22 @@ importers:
         version: 0.2.0
       '@preact/preset-vite':
         specifier: ^2.10.5
-        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
+        version: 2.10.5(@babel/core@7.29.0)(preact@10.29.2)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
       '@tailwindcss/vite':
         specifier: ^4.3.0
-        version: 4.3.0(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
+        version: 4.3.0(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
       '@types/diff':
         specifier: ^5.2.3
         version: 5.2.3
+      '@types/qrcode':
+        specifier: ^1.5.6
+        version: 1.5.6
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
+      otpauth:
+        specifier: ^9.5.1
+        version: 9.5.1
       oxfmt:
         specifier: ^0.51.0
         version: 0.51.0
@@ -83,10 +92,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.10
-        version: 8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
+        version: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@opentelemetry/api@1.9.1)(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
       wrangler:
         specifier: ^4.85.0
         version: 4.93.0(@cloudflare/workers-types@4.20260520.1)
@@ -1722,6 +1731,12 @@ packages:
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+
+  '@types/qrcode@1.5.6':
+    resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -1766,6 +1781,14 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -1865,6 +1888,10 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
   caniuse-lite@1.0.30001793:
     resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
 
@@ -1883,6 +1910,16 @@ packages:
 
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
@@ -1910,6 +1947,10 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
@@ -1927,6 +1968,9 @@ packages:
   diff@5.2.2:
     resolution: {integrity: sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==}
     engines: {node: '>=0.3.1'}
+
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -2040,6 +2084,9 @@ packages:
   electron-to-chromium@1.5.360:
     resolution: {integrity: sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==}
 
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
   enhanced-resolve@5.21.5:
     resolution: {integrity: sha512-mLCNbrQli11K1ySUmuNt4ZUB3OpGIDq4q2vTBTf5cL2lpsRjI9QKqSD0ndjW8FyvcW/Jj46gMe9syyHAsvMa/A==}
     engines: {node: '>=10.13.0'}
@@ -2101,6 +2148,10 @@ packages:
       picomatch:
         optional: true
 
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2114,6 +2165,10 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
@@ -2137,6 +2192,10 @@ packages:
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
@@ -2246,6 +2305,10 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2306,6 +2369,9 @@ packages:
   oniguruma-to-es@4.3.6:
     resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
 
+  otpauth@9.5.1:
+    resolution: {integrity: sha512-fJmDAHc8wImfqqqOXIlBvT1dEKrZK0Cmb2VEgScpNTolCz0PHh6ExUZGv4sLtOsWNaHCQlD+rRqaPgnoxFoZjQ==}
+
   oxfmt@0.51.0:
     resolution: {integrity: sha512-l/AoAnaEOV7Q5/Z9kHOMDehVJnCgYN7wRoooWCTUMBMi16BJhLZqd9cmCnwcVFfVlzkt53zK2KLPFNp8vSsoDg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2325,6 +2391,22 @@ packages:
     peerDependenciesMeta:
       oxlint-tsgolint:
         optional: true
+
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -2353,6 +2435,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
+
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2374,6 +2460,11 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
 
@@ -2382,6 +2473,13 @@ packages:
 
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -2402,6 +2500,9 @@ packages:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   set-cookie-parser@3.1.0:
     resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
@@ -2448,8 +2549,16 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   supports-color@10.2.2:
     resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
@@ -2496,6 +2605,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   undici@7.24.8:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
@@ -2620,6 +2732,9 @@ packages:
       jsdom:
         optional: true
 
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -2646,6 +2761,10 @@ packages:
       '@cloudflare/workers-types':
         optional: true
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
     engines: {node: '>=10.0.0'}
@@ -2658,8 +2777,19 @@ packages:
       utf-8-validate:
         optional: true
 
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
 
   youch-core@0.3.3:
     resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
@@ -2892,12 +3022,12 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260518.1
 
-  '@cloudflare/vite-plugin@1.37.2(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))(workerd@1.20260518.1)(wrangler@4.93.0(@cloudflare/workers-types@4.20260520.1))':
+  '@cloudflare/vite-plugin@1.37.2(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))(workerd@1.20260518.1)(wrangler@4.93.0(@cloudflare/workers-types@4.20260520.1))':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260518.1)
       miniflare: 4.20260518.0
       unenv: 2.0.0-rc.24
-      vite: 8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
+      vite: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
       wrangler: 4.93.0(@cloudflare/workers-types@4.20260520.1)
       ws: 8.18.0
     transitivePeerDependencies:
@@ -2905,14 +3035,14 @@ snapshots:
       - utf-8-validate
       - workerd
 
-  '@cloudflare/vitest-pool-workers@0.16.7(@cloudflare/workers-types@4.20260520.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.7(@opentelemetry/api@1.9.1)(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)))':
+  '@cloudflare/vitest-pool-workers@0.16.7(@cloudflare/workers-types@4.20260520.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)))':
     dependencies:
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
       cjs-module-lexer: 1.4.3
       esbuild: 0.27.3
       miniflare: 4.20260518.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
       wrangler: 4.93.0(@cloudflare/workers-types@4.20260520.1)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -3538,19 +3668,19 @@ snapshots:
 
   '@preact/eslint-plugin-signals@0.2.0': {}
 
-  '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@10.29.2)(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))':
+  '@preact/preset-vite@2.10.5(@babel/core@7.29.0)(preact@10.29.2)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
-      '@prefresh/vite': 2.4.12(preact@10.29.2)(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
+      '@prefresh/vite': 2.4.12(preact@10.29.2)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
       '@rollup/pluginutils': 5.3.0
       babel-plugin-transform-hook-names: 1.0.2(@babel/core@7.29.0)
       debug: 4.4.3
       magic-string: 0.30.21
       picocolors: 1.1.1
-      vite: 8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
-      vite-prerender-plugin: 0.5.13(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
+      vite: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
+      vite-prerender-plugin: 0.5.13(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
       zimmerframe: 1.1.4
     transitivePeerDependencies:
       - preact
@@ -3572,7 +3702,7 @@ snapshots:
 
   '@prefresh/utils@1.2.1': {}
 
-  '@prefresh/vite@2.4.12(preact@10.29.2)(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))':
+  '@prefresh/vite@2.4.12(preact@10.29.2)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))':
     dependencies:
       '@babel/core': 7.29.0
       '@prefresh/babel-plugin': 0.5.3
@@ -3580,7 +3710,7 @@ snapshots:
       '@prefresh/utils': 1.2.1
       '@rollup/pluginutils': 4.2.1
       preact: 10.29.2
-      vite: 8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
+      vite: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -3753,12 +3883,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
 
-  '@tailwindcss/vite@4.3.0(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))':
+  '@tailwindcss/vite@4.3.0(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))':
     dependencies:
       '@tailwindcss/node': 4.3.0
       '@tailwindcss/oxide': 4.3.0
       tailwindcss: 4.3.0
-      vite: 8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
+      vite: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
 
   '@tybys/wasm-util@0.10.2':
     dependencies:
@@ -3784,6 +3914,14 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/node@25.9.1':
+    dependencies:
+      undici-types: 7.24.6
+
+  '@types/qrcode@1.5.6':
+    dependencies:
+      '@types/node': 25.9.1
+
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.1': {}
@@ -3799,13 +3937,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.7(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))':
+  '@vitest/mocker@4.1.7(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))':
     dependencies:
       '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
+      vite: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
 
   '@vitest/pretty-format@4.1.7':
     dependencies:
@@ -3839,6 +3977,12 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       zod: 4.4.3
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
   assertion-error@2.0.1: {}
 
   babel-plugin-transform-hook-names@1.0.2(@babel/core@7.29.0):
@@ -3847,7 +3991,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.31: {}
 
-  better-auth@1.6.11(@cloudflare/workers-types@4.20260520.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260520.1)(@opentelemetry/api@1.9.1)(kysely@0.28.17))(vitest@4.1.7(@opentelemetry/api@1.9.1)(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))):
+  better-auth@1.6.11(@cloudflare/workers-types@4.20260520.1)(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260520.1)(@opentelemetry/api@1.9.1)(kysely@0.28.17))(vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))):
     dependencies:
       '@better-auth/core': 1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260520.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.11(@better-auth/core@1.6.11(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@cloudflare/workers-types@4.20260520.1)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.3.0))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260520.1)(@opentelemetry/api@1.9.1)(kysely@0.28.17))
@@ -3869,7 +4013,7 @@ snapshots:
     optionalDependencies:
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260520.1)(@opentelemetry/api@1.9.1)(kysely@0.28.17)
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -3897,6 +4041,8 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  camelcase@5.3.1: {}
+
   caniuse-lite@1.0.30001793: {}
 
   ccount@2.0.1: {}
@@ -3908,6 +4054,18 @@ snapshots:
   character-entities-legacy@3.0.0: {}
 
   cjs-module-lexer@1.4.3: {}
+
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
 
   comma-separated-tokens@2.0.3: {}
 
@@ -3929,6 +4087,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize@1.2.0: {}
+
   defu@6.1.7: {}
 
   dequal@2.0.3: {}
@@ -3940,6 +4100,8 @@ snapshots:
       dequal: 2.0.3
 
   diff@5.2.2: {}
+
+  dijkstrajs@1.0.3: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -3973,6 +4135,8 @@ snapshots:
       kysely: 0.28.17
 
   electron-to-chromium@1.5.360: {}
+
+  emoji-regex@8.0.0: {}
 
   enhanced-resolve@5.21.5:
     dependencies:
@@ -4113,6 +4277,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
   fsevents@2.3.2:
     optional: true
 
@@ -4120,6 +4289,8 @@ snapshots:
     optional: true
 
   gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
 
   get-tsconfig@4.14.0:
     dependencies:
@@ -4150,6 +4321,8 @@ snapshots:
   hono@4.12.21: {}
 
   html-void-elements@3.0.0: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   jiti@2.7.0: {}
 
@@ -4217,6 +4390,10 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
 
   lru-cache@5.1.1:
     dependencies:
@@ -4294,6 +4471,10 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  otpauth@9.5.1:
+    dependencies:
+      '@noble/hashes': 2.2.0
+
   oxfmt@0.51.0:
     dependencies:
       tinypool: 2.1.0
@@ -4340,6 +4521,18 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.66.0
       '@oxlint/binding-win32-x64-msvc': 1.66.0
 
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
+  p-try@2.2.0: {}
+
+  path-exists@4.0.0: {}
+
   path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
@@ -4357,6 +4550,8 @@ snapshots:
       playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
+
+  pngjs@5.0.0: {}
 
   postcss@8.5.15:
     dependencies:
@@ -4377,6 +4572,12 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
+
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
@@ -4386,6 +4587,10 @@ snapshots:
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
+
+  require-directory@2.1.1: {}
+
+  require-main-filename@2.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -4415,6 +4620,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.8.0: {}
+
+  set-blocking@2.0.0: {}
 
   set-cookie-parser@3.1.0: {}
 
@@ -4485,10 +4692,20 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   supports-color@10.2.2: {}
 
@@ -4521,6 +4738,8 @@ snapshots:
       fsevents: 2.3.3
 
   typescript@5.9.3: {}
+
+  undici-types@7.24.6: {}
 
   undici@7.24.8: {}
 
@@ -4567,7 +4786,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-prerender-plugin@0.5.13(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)):
+  vite-prerender-plugin@0.5.13(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)):
     dependencies:
       kolorist: 1.8.0
       magic-string: 0.30.21
@@ -4575,9 +4794,9 @@ snapshots:
       simple-code-frame: 1.3.0
       source-map: 0.7.6
       stack-trace: 1.0.0
-      vite: 8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
+      vite: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
 
-  vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3):
+  vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -4585,15 +4804,16 @@ snapshots:
       rolldown: 1.0.1
       tinyglobby: 0.2.16
     optionalDependencies:
+      '@types/node': 25.9.1
       esbuild: 0.28.0
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.22.3
 
-  vitest@4.1.7(@opentelemetry/api@1.9.1)(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)):
+  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)):
     dependencies:
       '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
+      '@vitest/mocker': 4.1.7(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
       '@vitest/pretty-format': 4.1.7
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
@@ -4610,12 +4830,15 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.13(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
+      vite: 8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
+      '@types/node': 25.9.1
     transitivePeerDependencies:
       - msw
+
+  which-module@2.0.1: {}
 
   why-is-node-running@2.3.0:
     dependencies:
@@ -4652,9 +4875,36 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
   ws@8.18.0: {}
 
+  y18n@4.0.3: {}
+
   yallist@3.1.1: {}
+
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
 
   youch-core@0.3.3:
     dependencies:

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -6,6 +6,7 @@ export const user = sqliteTable("user", {
   email: text("email").notNull().unique(),
   emailVerified: integer("email_verified", { mode: "boolean" }).notNull().default(false),
   image: text("image"),
+  twoFactorEnabled: integer("two_factor_enabled", { mode: "boolean" }),
   createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
   updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
 });
@@ -387,4 +388,14 @@ export const verification = sqliteTable("verification", {
   expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
   createdAt: integer("created_at", { mode: "timestamp_ms" }),
   updatedAt: integer("updated_at", { mode: "timestamp_ms" }),
+});
+
+export const twoFactor = sqliteTable("two_factor", {
+  id: text("id").primaryKey(),
+  secret: text("secret").notNull(),
+  backupCodes: text("backup_codes").notNull(),
+  verified: integer("verified", { mode: "boolean" }),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -160,6 +160,9 @@ app.all("/api/auth/*", (c) => {
 });
 
 function authIpLimit(path: string): { bucket: string; max: number; windowMs: number } | null {
+  if (path.startsWith("/api/auth/two-factor")) {
+    return { bucket: "two-factor", max: 10, windowMs: 15 * 60 * 1000 };
+  }
   if (path.startsWith("/api/auth/sign-in")) {
     return { bucket: "sign-in", max: 10, windowMs: 15 * 60 * 1000 };
   }

--- a/server/lib/auth.ts
+++ b/server/lib/auth.ts
@@ -1,5 +1,6 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
+import { twoFactor } from "better-auth/plugins";
 import { createDb } from "../db";
 import * as schema from "../db/schema";
 import { sendAccountVerificationEmail } from "./account-email";
@@ -24,6 +25,7 @@ export function createAuth(env: Cloudflare.Env) {
   // always binds SEND_EMAIL, so verification is always enforced there.
   const emailVerificationEnabled = Boolean(env.SEND_EMAIL);
   return betterAuth({
+    appName: "Drydock",
     secret: env.BETTER_AUTH_SECRET,
     baseURL: env.BETTER_AUTH_URL,
     basePath: "/api/auth",
@@ -50,6 +52,7 @@ export function createAuth(env: Cloudflare.Env) {
       minPasswordLength: 12,
       maxPasswordLength: 256,
     },
+    plugins: [twoFactor({ issuer: "Drydock" })],
     advanced: {
       cookiePrefix: "spr",
       ipAddress: {

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -5,6 +5,7 @@ export interface SessionUser {
   id: string;
   name?: string;
   email?: string;
+  twoFactorEnabled?: boolean;
 }
 
 export interface AuthSession {
@@ -62,13 +63,33 @@ export const SessionModel = createModel(() => {
       }
     },
 
-    async signIn(email: string, password: string, returnTo?: string): Promise<void> {
-      await authPost("/api/auth/sign-in/email", {
+    async signIn(
+      email: string,
+      password: string,
+      returnTo?: string,
+    ): Promise<{ twoFactorRequired: boolean }> {
+      const data = await authPost("/api/auth/sign-in/email", {
         email,
         password,
         rememberMe: true,
         callbackURL: verificationCallbackPath(returnTo),
       });
+      if (
+        data &&
+        typeof data === "object" &&
+        (data as { twoFactorRedirect?: unknown }).twoFactorRedirect
+      ) {
+        return { twoFactorRequired: true };
+      }
+      await this.load();
+      return { twoFactorRequired: false };
+    },
+
+    async completeTwoFactorSignIn(code: string, options: { backup?: boolean } = {}): Promise<void> {
+      const path = options.backup
+        ? "/api/auth/two-factor/verify-backup-code"
+        : "/api/auth/two-factor/verify-totp";
+      await authPost(path, { code });
       await this.load();
     },
 
@@ -106,7 +127,7 @@ async function fetchSession(): Promise<AuthSession | null> {
   return (await res.json()) as AuthSession | null;
 }
 
-async function authPost(path: string, body: unknown) {
+export async function authPost(path: string, body: unknown): Promise<unknown> {
   const res = await fetch(path, {
     method: "POST",
     credentials: "same-origin",
@@ -125,4 +146,5 @@ async function authPost(path: string, body: unknown) {
       res.status,
     );
   }
+  return data;
 }

--- a/src/models/two-factor.ts
+++ b/src/models/two-factor.ts
@@ -1,0 +1,116 @@
+import QRCode from "qrcode";
+import { createModel, signal } from "@preact/signals";
+import { errorMessage } from "./api";
+import { authPost, sessionModel } from "./auth";
+
+interface EnableResponse {
+  totpURI?: string;
+  backupCodes?: string[];
+}
+
+interface BackupCodesResponse {
+  backupCodes?: string[];
+}
+
+function parseSecret(totpURI: string): string | null {
+  try {
+    return new URL(totpURI).searchParams.get("secret");
+  } catch {
+    return null;
+  }
+}
+
+export const TwoFactorModel = createModel(() => {
+  const busy = signal(false);
+  const error = signal<string | null>(null);
+  const totpURI = signal<string | null>(null);
+  const secret = signal<string | null>(null);
+  const qrDataUrl = signal<string | null>(null);
+  const backupCodes = signal<string[] | null>(null);
+
+  return {
+    busy,
+    error,
+    totpURI,
+    secret,
+    qrDataUrl,
+    backupCodes,
+
+    reset() {
+      this.busy.value = false;
+      this.error.value = null;
+      this.totpURI.value = null;
+      this.secret.value = null;
+      this.qrDataUrl.value = null;
+      this.backupCodes.value = null;
+    },
+
+    async beginEnroll(password: string): Promise<boolean> {
+      this.busy.value = true;
+      this.error.value = null;
+      try {
+        const data = (await authPost("/api/auth/two-factor/enable", {
+          password,
+        })) as EnableResponse;
+        if (!data.totpURI) throw new Error("Could not start two-factor setup.");
+        this.totpURI.value = data.totpURI;
+        this.secret.value = parseSecret(data.totpURI);
+        this.backupCodes.value = data.backupCodes ?? null;
+        this.qrDataUrl.value = await QRCode.toDataURL(data.totpURI, { margin: 1, width: 200 });
+        return true;
+      } catch (err) {
+        this.error.value = errorMessage(err);
+        return false;
+      } finally {
+        this.busy.value = false;
+      }
+    },
+
+    async confirmEnroll(code: string): Promise<boolean> {
+      this.busy.value = true;
+      this.error.value = null;
+      try {
+        await authPost("/api/auth/two-factor/verify-totp", { code });
+        await sessionModel.load();
+        return true;
+      } catch (err) {
+        this.error.value = errorMessage(err);
+        return false;
+      } finally {
+        this.busy.value = false;
+      }
+    },
+
+    async disable(password: string): Promise<boolean> {
+      this.busy.value = true;
+      this.error.value = null;
+      try {
+        await authPost("/api/auth/two-factor/disable", { password });
+        await sessionModel.load();
+        return true;
+      } catch (err) {
+        this.error.value = errorMessage(err);
+        return false;
+      } finally {
+        this.busy.value = false;
+      }
+    },
+
+    async regenerateBackupCodes(password: string): Promise<boolean> {
+      this.busy.value = true;
+      this.error.value = null;
+      try {
+        const data = (await authPost("/api/auth/two-factor/generate-backup-codes", {
+          password,
+        })) as BackupCodesResponse;
+        this.backupCodes.value = data.backupCodes ?? null;
+        return true;
+      } catch (err) {
+        this.error.value = errorMessage(err);
+        return false;
+      } finally {
+        this.busy.value = false;
+      }
+    },
+  };
+});

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -10,6 +10,9 @@ export default function LoginPage() {
   const location = useLocation();
   const email = useSignal("");
   const password = useSignal("");
+  const code = useSignal("");
+  const useBackup = useSignal(false);
+  const step = useSignal<"credentials" | "twoFactor">("credentials");
   const error = useSignal<string | null>(null);
   const loading = useSignal(false);
   const needsVerificationFor = useSignal<string | null>(null);
@@ -37,7 +40,15 @@ export default function LoginPage() {
     loading.value = true;
     error.value = null;
     try {
-      await sessionModel.signIn(submittedEmail, submittedPassword, returnTo);
+      const { twoFactorRequired } = await sessionModel.signIn(
+        submittedEmail,
+        submittedPassword,
+        returnTo,
+      );
+      if (twoFactorRequired) {
+        step.value = "twoFactor";
+        return;
+      }
       location.route(returnTo, true);
     } catch (err) {
       // The server re-sends a verification link on an unverified sign-in, so
@@ -69,6 +80,22 @@ export default function LoginPage() {
     }
   };
 
+  const onVerify = async (event: Event) => {
+    event.preventDefault();
+    const submittedCode = code.value.trim();
+    const backup = useBackup.value;
+    loading.value = true;
+    error.value = null;
+    try {
+      await sessionModel.completeTwoFactorSignIn(submittedCode, { backup });
+      location.route(returnTo, true);
+    } catch (err) {
+      error.value = errorMessage(err);
+    } finally {
+      loading.value = false;
+    }
+  };
+
   if (needsVerificationFor.value) {
     return (
       <PageShell width="narrow">
@@ -95,6 +122,59 @@ export default function LoginPage() {
               Back to sign in
             </a>
           </p>
+        </Card>
+      </PageShell>
+    );
+  }
+
+  if (step.value === "twoFactor") {
+    return (
+      <PageShell width="narrow">
+        <Card class="flex flex-col gap-4">
+          <Eyebrow>Two-factor authentication</Eyebrow>
+          <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">Verify it's you</h1>
+          <Muted class="text-[13px] m-0">
+            {useBackup.value
+              ? "Enter one of your saved backup recovery codes."
+              : "Enter the 6-digit code from your authenticator app."}
+          </Muted>
+
+          <form class="flex flex-col gap-4 mt-2" onSubmit={onVerify}>
+            <Field
+              label={useBackup.value ? "Backup code" : "Authentication code"}
+              for="twofactor-code"
+            >
+              <Input
+                id="twofactor-code"
+                type="text"
+                value={code}
+                inputmode={useBackup.value ? "text" : "numeric"}
+                autocomplete="one-time-code"
+                autoFocus
+                required
+                onInput={(e) => (code.value = (e.target as HTMLInputElement).value)}
+              />
+            </Field>
+
+            {error.value ? <Alert tone="critical">{error.value}</Alert> : null}
+
+            <Button type="submit" disabled={loading.value}>
+              {loading.value ? "Verifying…" : "Verify"}
+            </Button>
+          </form>
+
+          <Button
+            variant="ghost"
+            size="sm"
+            class="self-start"
+            onClick={() => {
+              useBackup.value = !useBackup.value;
+              code.value = "";
+              error.value = null;
+            }}
+          >
+            {useBackup.value ? "Use an authenticator code instead" : "Use a backup code instead"}
+          </Button>
         </Card>
       </PageShell>
     );

--- a/src/pages/Dashboard/Settings/TwoFactorSection.tsx
+++ b/src/pages/Dashboard/Settings/TwoFactorSection.tsx
@@ -67,6 +67,13 @@ export function TwoFactorSection() {
     dialog.value = mode;
   };
 
+  const onDialogClose = () => {
+    if (dialog.value === "enroll" && enrollStep.value === "backup" && !savedConfirmed.value) {
+      return;
+    }
+    close();
+  };
+
   const onBeginEnroll = async (event: Event) => {
     event.preventDefault();
     const pw = password.value;
@@ -268,7 +275,7 @@ export function TwoFactorSection() {
 
       <Dialog
         open={dialog.value !== "none"}
-        onClose={close}
+        onClose={onDialogClose}
         title={dialogTitle}
         description={dialogDescription}
       >

--- a/src/pages/Dashboard/Settings/TwoFactorSection.tsx
+++ b/src/pages/Dashboard/Settings/TwoFactorSection.tsx
@@ -1,0 +1,279 @@
+import { useModel, useSignal } from "@preact/signals";
+import { sessionModel } from "../../../models/auth";
+import { TwoFactorModel } from "../../../models/two-factor";
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Dialog,
+  Field,
+  Input,
+  LinkButton,
+  MonoDetail,
+  Muted,
+  SectionLabel,
+} from "../../../components";
+
+type DialogMode = "none" | "enroll" | "regenerate" | "disable";
+type EnrollStep = "password" | "verify" | "backup";
+
+function BackupCodes({ codes }: { codes: string[] }) {
+  const downloadHref = `data:text/plain;charset=utf-8,${encodeURIComponent(codes.join("\n"))}`;
+  return (
+    <div class="flex flex-col gap-3">
+      <div class="grid grid-cols-2 gap-1.5 rounded-md border border-border bg-surface-2 p-3 font-mono text-[13px]">
+        {codes.map((value) => (
+          <span key={value}>{value}</span>
+        ))}
+      </div>
+      <LinkButton
+        variant="secondary"
+        size="sm"
+        class="self-start"
+        href={downloadHref}
+        download="drydock-backup-codes.txt"
+      >
+        Download codes
+      </LinkButton>
+    </div>
+  );
+}
+
+export function TwoFactorSection() {
+  const tf = useModel(TwoFactorModel);
+  const dialog = useSignal<DialogMode>("none");
+  const enrollStep = useSignal<EnrollStep>("password");
+  const password = useSignal("");
+  const code = useSignal("");
+  const savedConfirmed = useSignal(false);
+
+  const enabled = sessionModel.user.value?.twoFactorEnabled === true;
+  const busy = tf.busy.value;
+  const error = tf.error.value;
+  const codes = tf.backupCodes.value;
+
+  const close = () => {
+    dialog.value = "none";
+    enrollStep.value = "password";
+    password.value = "";
+    code.value = "";
+    savedConfirmed.value = false;
+    tf.reset();
+  };
+
+  const open = (mode: Exclude<DialogMode, "none">) => {
+    close();
+    dialog.value = mode;
+  };
+
+  const onBeginEnroll = async (event: Event) => {
+    event.preventDefault();
+    const pw = password.value;
+    if (await tf.beginEnroll(pw)) enrollStep.value = "verify";
+  };
+
+  const onConfirmEnroll = async (event: Event) => {
+    event.preventDefault();
+    const value = code.value.trim();
+    if (await tf.confirmEnroll(value)) enrollStep.value = "backup";
+  };
+
+  const onRegenerate = async (event: Event) => {
+    event.preventDefault();
+    const pw = password.value;
+    await tf.regenerateBackupCodes(pw);
+  };
+
+  const onDisable = async (event: Event) => {
+    event.preventDefault();
+    const pw = password.value;
+    if (await tf.disable(pw)) close();
+  };
+
+  let dialogTitle = "";
+  let dialogDescription: string | undefined;
+  let dialogBody = null;
+
+  if (dialog.value === "enroll" && enrollStep.value === "password") {
+    dialogTitle = "Enable two-factor";
+    dialogDescription = "Confirm your password to begin setup.";
+    dialogBody = (
+      <form class="flex flex-col gap-4" onSubmit={onBeginEnroll}>
+        <Field label="Current password" for="tf-enroll-password">
+          <Input
+            id="tf-enroll-password"
+            type="password"
+            value={password}
+            autocomplete="current-password"
+            required
+            onInput={(e) => (password.value = (e.target as HTMLInputElement).value)}
+          />
+        </Field>
+        {error ? <Alert tone="critical">{error}</Alert> : null}
+        <Button type="submit" class="self-end" disabled={busy}>
+          {busy ? "Starting…" : "Continue"}
+        </Button>
+      </form>
+    );
+  } else if (dialog.value === "enroll" && enrollStep.value === "verify") {
+    dialogTitle = "Scan the QR code";
+    dialogDescription = "Scan with your authenticator app, then enter the 6-digit code to confirm.";
+    dialogBody = (
+      <form class="flex flex-col gap-4" onSubmit={onConfirmEnroll}>
+        {tf.qrDataUrl.value ? (
+          <img
+            src={tf.qrDataUrl.value}
+            alt="Two-factor QR code"
+            width={200}
+            height={200}
+            class="self-center rounded-md border border-border bg-white p-2"
+          />
+        ) : null}
+        {tf.secret.value ? (
+          <div class="flex flex-col gap-1">
+            <Muted class="text-[12px] m-0">Can't scan? Enter this key manually:</Muted>
+            <code class="font-mono text-[12px] text-ink break-all rounded-md border border-border bg-surface-2 px-2 py-1.5">
+              {tf.secret.value}
+            </code>
+          </div>
+        ) : null}
+        <Field label="Authentication code" for="tf-verify-code">
+          <Input
+            id="tf-verify-code"
+            type="text"
+            value={code}
+            inputmode="numeric"
+            autocomplete="one-time-code"
+            required
+            onInput={(e) => (code.value = (e.target as HTMLInputElement).value)}
+          />
+        </Field>
+        {error ? <Alert tone="critical">{error}</Alert> : null}
+        <Button type="submit" class="self-end" disabled={busy}>
+          {busy ? "Verifying…" : "Verify & enable"}
+        </Button>
+      </form>
+    );
+  } else if (dialog.value === "enroll" && enrollStep.value === "backup") {
+    dialogTitle = "Save your backup codes";
+    dialogDescription =
+      "Each code works once. Store them somewhere safe — you won't see them again.";
+    dialogBody = (
+      <div class="flex flex-col gap-4">
+        {codes ? <BackupCodes codes={codes} /> : null}
+        <label class="flex items-center gap-2 text-[13px] text-ink-muted">
+          <input
+            type="checkbox"
+            checked={savedConfirmed.value}
+            onInput={(e) => (savedConfirmed.value = (e.target as HTMLInputElement).checked)}
+          />
+          I've saved these codes
+        </label>
+        <Button class="self-end" disabled={!savedConfirmed.value} onClick={close}>
+          Done
+        </Button>
+      </div>
+    );
+  } else if (dialog.value === "regenerate") {
+    dialogTitle = "Regenerate backup codes";
+    dialogDescription = codes
+      ? undefined
+      : "Confirm your password to generate a fresh set. Your old codes stop working.";
+    dialogBody = codes ? (
+      <div class="flex flex-col gap-4">
+        <BackupCodes codes={codes} />
+        <Button class="self-end" onClick={close}>
+          Done
+        </Button>
+      </div>
+    ) : (
+      <form class="flex flex-col gap-4" onSubmit={onRegenerate}>
+        <Field label="Current password" for="tf-regen-password">
+          <Input
+            id="tf-regen-password"
+            type="password"
+            value={password}
+            autocomplete="current-password"
+            required
+            onInput={(e) => (password.value = (e.target as HTMLInputElement).value)}
+          />
+        </Field>
+        {error ? <Alert tone="critical">{error}</Alert> : null}
+        <Button type="submit" class="self-end" disabled={busy}>
+          {busy ? "Generating…" : "Regenerate"}
+        </Button>
+      </form>
+    );
+  } else if (dialog.value === "disable") {
+    dialogTitle = "Disable two-factor";
+    dialogDescription = "Confirm your password. Your account will be protected by password only.";
+    dialogBody = (
+      <form class="flex flex-col gap-4" onSubmit={onDisable}>
+        <Field label="Current password" for="tf-disable-password">
+          <Input
+            id="tf-disable-password"
+            type="password"
+            value={password}
+            autocomplete="current-password"
+            required
+            onInput={(e) => (password.value = (e.target as HTMLInputElement).value)}
+          />
+        </Field>
+        {error ? <Alert tone="critical">{error}</Alert> : null}
+        <Button type="submit" variant="danger" class="self-end" disabled={busy}>
+          {busy ? "Disabling…" : "Disable two-factor"}
+        </Button>
+      </form>
+    );
+  }
+
+  return (
+    <Card as="section" class="p-0 overflow-hidden">
+      <div class="p-5 flex flex-col gap-5">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div class="flex flex-col gap-1.5 max-w-[760px]">
+            <SectionLabel>Two-factor authentication</SectionLabel>
+            <Muted class="text-[13px] m-0">
+              Protect your account with a time-based code from an authenticator app. Once enabled,
+              you'll enter a code each time you sign in.
+            </Muted>
+            <MonoDetail
+              parts={[
+                <span key="totp">totp authenticator</span>,
+                <span key="backup">10 backup codes</span>,
+              ]}
+            />
+          </div>
+          <div class="shrink-0">
+            {enabled ? <Badge tone="ok">enabled</Badge> : <Badge tone="neutral">not enabled</Badge>}
+          </div>
+        </div>
+
+        {enabled ? (
+          <div class="flex flex-wrap gap-2">
+            <Button variant="secondary" onClick={() => open("regenerate")}>
+              Regenerate backup codes
+            </Button>
+            <Button variant="danger" onClick={() => open("disable")}>
+              Disable two-factor
+            </Button>
+          </div>
+        ) : (
+          <div>
+            <Button onClick={() => open("enroll")}>Enable two-factor</Button>
+          </div>
+        )}
+      </div>
+
+      <Dialog
+        open={dialog.value !== "none"}
+        onClose={close}
+        title={dialogTitle}
+        description={dialogDescription}
+      >
+        {dialogBody}
+      </Dialog>
+    </Card>
+  );
+}

--- a/src/pages/Dashboard/Settings/index.tsx
+++ b/src/pages/Dashboard/Settings/index.tsx
@@ -28,6 +28,7 @@ import { NotificationRecipientsSection } from "./NotificationRecipientsSection";
 import { NpmConnectionSection } from "./NpmConnectionSection";
 import { OrganizationMembersSection } from "./OrganizationMembersSection";
 import { SettingsNav, isSettingsTab, type SettingsTab } from "./SettingsNav";
+import { TwoFactorSection } from "./TwoFactorSection";
 
 export default function SettingsPage() {
   const location = useLocation();
@@ -140,11 +141,14 @@ export default function SettingsPage() {
 
           <div class="min-w-0 flex flex-col gap-6">
             {tab === "general" ? (
-              <GeneralSection
-                organizations={organizations}
-                currentUserRole={activeRole(organizations)}
-                onDeleted={reloadActiveOrgScopedData}
-              />
+              <>
+                <GeneralSection
+                  organizations={organizations}
+                  currentUserRole={activeRole(organizations)}
+                  onDeleted={reloadActiveOrgScopedData}
+                />
+                <TwoFactorSection />
+              </>
             ) : null}
             {tab === "members" ? (
               <OrganizationMembersSection

--- a/test/e2e/two-factor.spec.ts
+++ b/test/e2e/two-factor.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test, type Page } from "@playwright/test";
+import * as OTPAuth from "otpauth";
+
+const PASSWORD = "correct horse battery staple";
+
+function totpFromSecret(secret: string): string {
+  const totp = new OTPAuth.TOTP({ secret: OTPAuth.Secret.fromBase32(secret) });
+  return totp.generate();
+}
+
+async function register(page: Page): Promise<string> {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const email = `2fa-${unique}@example.test`;
+  await page.goto("/register");
+  await page.getByLabel("Name").fill("2FA Tester");
+  await page.getByLabel("Email").fill(email);
+  await page.getByLabel("Password").fill(PASSWORD);
+  await page.getByRole("button", { name: "Create account" }).click();
+  await page.waitForURL(/\/dashboard$/, { timeout: 30_000 });
+  return email;
+}
+
+test("enrolls in TOTP 2FA and signs in through the challenge", async ({ browser, baseURL }) => {
+  const context = await browser.newContext({ baseURL });
+  const page = await context.newPage();
+  try {
+    const email = await register(page);
+
+    // Enroll from Settings → Security.
+    await page.goto("/dashboard/settings");
+    await page.getByRole("button", { name: "Enable two-factor" }).click();
+
+    const dialog = page.getByRole("dialog");
+    await dialog.getByLabel("Current password").fill(PASSWORD);
+    await dialog.getByRole("button", { name: "Continue" }).click();
+
+    // The manual-entry key is the base32 TOTP secret.
+    const secret = (await dialog.locator("code").first().innerText()).trim();
+    expect(secret.length).toBeGreaterThan(0);
+
+    await dialog.getByLabel("Authentication code").fill(totpFromSecret(secret));
+    await dialog.getByRole("button", { name: "Verify & enable" }).click();
+
+    // Backup codes are revealed; confirm and close.
+    await expect(dialog.getByText("Save your backup codes")).toBeVisible();
+    await dialog.getByLabel("I've saved these codes").check();
+    await dialog.getByRole("button", { name: "Done" }).click();
+
+    await expect(page.getByText("enabled", { exact: true })).toBeVisible();
+
+    // Sign out via the account menu.
+    await page.getByRole("button", { name: /Account menu/ }).click();
+    await page.getByRole("menuitem", { name: "Sign out" }).click();
+    await page.waitForURL(/\/$/, { timeout: 30_000 });
+
+    // Sign in again — credentials alone should land on the 2FA challenge.
+    await page.goto("/login");
+    await page.getByLabel("Email").fill(email);
+    await page.getByLabel("Password").fill(PASSWORD);
+    await page.getByRole("button", { name: "Sign in" }).click();
+
+    await expect(page.getByRole("heading", { name: "Verify it's you" })).toBeVisible({
+      timeout: 30_000,
+    });
+
+    await page.getByLabel("Authentication code").fill(totpFromSecret(secret));
+    await page.getByRole("button", { name: "Verify" }).click();
+
+    await page.waitForURL(/\/dashboard$/, { timeout: 30_000 });
+    await expect(page.getByRole("heading", { name: "Ready for the next release" })).toBeVisible({
+      timeout: 30_000,
+    });
+  } finally {
+    await context.close();
+  }
+});

--- a/test/e2e/two-factor.spec.ts
+++ b/test/e2e/two-factor.spec.ts
@@ -43,6 +43,8 @@ test("enrolls in TOTP 2FA and signs in through the challenge", async ({ browser,
 
     // Backup codes are revealed; confirm and close.
     await expect(dialog.getByText("Save your backup codes")).toBeVisible();
+    await page.keyboard.press("Escape");
+    await expect(dialog.getByText("Save your backup codes")).toBeVisible();
     await dialog.getByLabel("I've saved these codes").check();
     await dialog.getByRole("button", { name: "Done" }).click();
 

--- a/test/workers/two-factor-routes.test.ts
+++ b/test/workers/two-factor-routes.test.ts
@@ -1,0 +1,146 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { describe, expect, test } from "vitest";
+import * as OTPAuth from "otpauth";
+import worker from "../../server/index";
+
+const ORIGIN = "http://example.com";
+const PASSWORD = "correct horse battery staple";
+
+type Jar = Map<string, string>;
+
+function mergeSetCookies(jar: Jar, res: Response) {
+  const cookies = res.headers.getSetCookie?.() ?? [];
+  for (const raw of cookies) {
+    const [pair] = raw.split(";");
+    const idx = pair.indexOf("=");
+    if (idx === -1) continue;
+    jar.set(pair.slice(0, idx).trim(), pair.slice(idx + 1).trim());
+  }
+}
+
+function cookieHeader(jar: Jar): string {
+  return [...jar.entries()].map(([k, v]) => `${k}=${v}`).join("; ");
+}
+
+interface CallOptions {
+  body?: unknown;
+  jar?: Jar;
+  ip?: string;
+}
+
+async function call(method: string, path: string, opts: CallOptions = {}) {
+  const ctx = createExecutionContext();
+  const headers = new Headers();
+  if (opts.body !== undefined) headers.set("content-type", "application/json");
+  if (!["GET", "HEAD", "OPTIONS"].includes(method)) headers.set("origin", ORIGIN);
+  if (opts.jar && opts.jar.size) headers.set("cookie", cookieHeader(opts.jar));
+  if (opts.ip) headers.set("cf-connecting-ip", opts.ip);
+  const init: RequestInit = { method, headers };
+  if (opts.body !== undefined) init.body = JSON.stringify(opts.body);
+  const res = await worker.fetch(new Request(`${ORIGIN}${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  if (opts.jar) mergeSetCookies(opts.jar, res);
+  const text = await res.text();
+  let json: unknown = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = null;
+  }
+  return { res, json: json as Record<string, unknown> | null, text };
+}
+
+function totpFor(totpURI: string): string {
+  const parsed = OTPAuth.URI.parse(totpURI) as OTPAuth.TOTP;
+  return parsed.generate();
+}
+
+async function signUp(jar: Jar, email: string) {
+  const { res } = await call("POST", "/api/auth/sign-up/email", {
+    body: { name: "2FA Tester", email, password: PASSWORD },
+    jar,
+  });
+  expect(res.status).toBe(200);
+}
+
+describe("two-factor routes", () => {
+  test(
+    "full TOTP enrollment, sign-in challenge, backup code, and disable",
+    { timeout: 30_000 },
+    async () => {
+      const email = `tf-${crypto.randomUUID()}@example.test`;
+      const jar: Jar = new Map();
+      await signUp(jar, email);
+
+      // Enable: returns the otpauth URI and backup codes.
+      const enable = await call("POST", "/api/auth/two-factor/enable", {
+        body: { password: PASSWORD },
+        jar,
+      });
+      expect(enable.res.status).toBe(200);
+      const totpURI = enable.json?.totpURI as string;
+      const backupCodes = enable.json?.backupCodes as string[];
+      expect(typeof totpURI).toBe("string");
+      expect(Array.isArray(backupCodes)).toBe(true);
+      expect(backupCodes.length).toBeGreaterThan(0);
+
+      // Confirm enrollment with a freshly generated TOTP code.
+      const verify = await call("POST", "/api/auth/two-factor/verify-totp", {
+        body: { code: totpFor(totpURI) },
+        jar,
+      });
+      expect(verify.res.status).toBe(200);
+
+      // Session now reports two-factor enabled.
+      const session = await call("GET", "/api/auth/get-session", { jar });
+      expect((session.json?.user as { twoFactorEnabled?: boolean })?.twoFactorEnabled).toBe(true);
+
+      // Sign out, then sign in again — should be redirected to the 2FA challenge.
+      await call("POST", "/api/auth/sign-out", { jar });
+      const freshJar: Jar = new Map();
+      const signIn = await call("POST", "/api/auth/sign-in/email", {
+        body: { email, password: PASSWORD },
+        jar: freshJar,
+      });
+      expect(signIn.res.status).toBe(200);
+      expect(signIn.json?.twoFactorRedirect).toBe(true);
+
+      // No authenticated session until the second factor is provided.
+      const pending = await call("GET", "/api/auth/get-session", { jar: freshJar });
+      expect(pending.json?.user).toBeFalsy();
+
+      // Complete sign-in with a backup code.
+      const backup = await call("POST", "/api/auth/two-factor/verify-backup-code", {
+        body: { code: backupCodes[0] },
+        jar: freshJar,
+      });
+      expect(backup.res.status).toBe(200);
+      const authed = await call("GET", "/api/auth/get-session", { jar: freshJar });
+      expect((authed.json?.user as { email?: string })?.email).toBe(email);
+
+      // Disable two-factor.
+      const disable = await call("POST", "/api/auth/two-factor/disable", {
+        body: { password: PASSWORD },
+        jar: freshJar,
+      });
+      expect(disable.res.status).toBe(200);
+      const after = await call("GET", "/api/auth/get-session", { jar: freshJar });
+      expect((after.json?.user as { twoFactorEnabled?: boolean })?.twoFactorEnabled).toBeFalsy();
+    },
+  );
+
+  test("rate limits two-factor verification attempts per IP", async () => {
+    const ip = `203.0.113.${Math.floor(Math.random() * 250) + 1}`;
+    const statuses: number[] = [];
+    for (let i = 0; i < 12; i++) {
+      const { res } = await call("POST", "/api/auth/two-factor/verify-totp", {
+        body: { code: "000000" },
+        ip,
+      });
+      statuses.push(res.status);
+    }
+    // The limit is 10 per window; the 11th request (index 10) is rejected.
+    expect(statuses.slice(0, 10).every((s) => s !== 429)).toBe(true);
+    expect(statuses[10]).toBe(429);
+  });
+});


### PR DESCRIPTION
## Summary
- Enables Better Auth's `two-factor` plugin (TOTP authenticator + 10 single-use backup recovery codes) as opt-in 2FA, configured in `server/lib/auth.ts` with a `two_factor` table and a nullable `user.two_factor_enabled` column (migration `0012_late_mattie_franklin.sql`).
- Adds enrollment/management UI in Settings → Security (`TwoFactorSection.tsx`: QR code + copyable secret, backup-code reveal/download, regenerate, disable) and a sign-in challenge step in `Login.tsx`, backed by new client models (`signIn` 2FA detection, `completeTwoFactorSignIn`, `TwoFactorModel`).
- Protects the verify endpoints with a dedicated `/api/auth/two-factor` rate-limit bucket (10 req / 15 min) in `server/index.ts`, and adds `qrcode` plus dev-only `@types/qrcode`/`otpauth`.
- Covers the flow with a worker-route test (enroll → verify → challenge → backup-code → disable + rate limit) and a Playwright e2e test, plus `docs/two-factor-auth.md`.

## Test plan
- [x] `pnpm run verify` (lint, format, typecheck, 230 logic + 127 worker tests) passes
- [x] `pnpm exec playwright test two-factor.spec.ts` passes (register → enroll → sign-out → sign-in challenge)
- [ ] Manual: enroll with a real authenticator app, sign in via TOTP and a backup code, regenerate codes, disable

🤖 Generated with [Claude Code](https://claude.com/claude-code)