### PR TITLE
Derive PyPI release set from uploaded artifacts

### DIFF
--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -269,8 +269,15 @@ Remaining tasks:
   resolves the release-target mapping, persists a pending gate, and exposes
   `markGateDecided` + `postDeploymentProtectionDecision` for the future review
   pipeline to release or block the publish job.
-- Fetch GitHub Actions artifacts and the required `drydock-manifest.json`.
-- Verify artifact SHA-256 digests before review and before publish.
+- ~~Fetch GitHub Actions artifacts and the required `drydock-manifest.json`.~~
+  Implemented without a manifest file: `fetchReleaseBundleForGate` downloads the
+  run's artifact bundle and collects every wheel/sdist, and
+  `preparePyPiReleaseCandidateForGate` derives the release set (package name,
+  version, and SHA-256 digests) from the artifact bytes themselves. There is no
+  `drydock-manifest.json` contract.
+- Recompute artifact SHA-256 digests from the bundle bytes for review evidence.
+  (There is no maintainer-declared digest to verify against; the publish-side
+  digest-match check is intentionally gone — see `pypi-workflow-gate.md`.)
 - Persist workflow-gate reviews without overloading npm `stage_id`.
 - Download previous PyPI release artifacts from `files.pythonhosted.org` for comparison.
 - Add UI for PyPI setup, gate status, and review reports.
@@ -279,7 +286,7 @@ Exit criteria:
 
 - A GitHub Actions PyPI publish job waits on Drydock through a GitHub Environment gate.
 - Drydock reviews all candidate wheels/sdists and compares them to the selected previous PyPI release.
-- The publish job verifies the reviewed manifest digest and publishes with PyPI Trusted Publishing only after gate approval.
+- The publish job uploads the exact reviewed wheel/sdist bytes with PyPI Trusted Publishing only after gate approval.
 
 ## Deferred work
 

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -2,7 +2,7 @@
 
 PyPI support uses a different product shape from npm staged publishing.
 
-npm owns a pending staged tarball, so Drydock can fetch `/-/stage/<stage-id>/tarball` and leave final approval in npm. PyPI does not expose an equivalent registry-staged artifact. The PyPI path is therefore **workflow gate mode**: CI builds wheels/sdists first, uploads a manifest plus artifacts for review, and a GitHub Environment blocks the publish job until the reviewed artifact digests are approved.
+npm owns a pending staged tarball, so Drydock can fetch `/-/stage/<stage-id>/tarball` and leave final approval in npm. PyPI does not expose an equivalent registry-staged artifact. The PyPI path is therefore **workflow gate mode**: CI builds wheels/sdists first, uploads them as a `pypi-release-candidate` bundle for review, and a GitHub Environment blocks the publish job until the reviewed release is approved. There is no `drydock-manifest.json` to write — the release set is whatever wheels/sdists the bundle contains, and the package identity is derived from the artifacts themselves.
 
 Official references:
 
@@ -15,14 +15,14 @@ Official references:
 
 The repo now has a backend-only PyPI foundation in `server/lib/adapters/pypi/index.ts`:
 
-- validates `drydock.release-artifacts.v1` manifests for `ecosystem: "pypi"`;
+- derives a `drydock.release-artifacts.v1` release set from the uploaded artifacts (identity from wheel `METADATA` / sdist `PKG-INFO`, digests recomputed from the bytes) — there is no maintainer-declared manifest;
 - exposes a `PackageAdapter` implementation compatible with the pluggable scan pipeline introduced for npm;
 - normalizes PyPI project names using the PEP 503-style `[-_.]+ -> -` convention;
 - recognizes wheel (`.whl`) and sdist (`.tar.gz`, `.tgz`) artifacts;
 - parses wheel `METADATA`, `WHEEL`, and `RECORD` evidence from ZIP archives;
 - strips the common root directory from sdists before reading `PKG-INFO`;
 - compares flattened candidate artifact files against optional previous artifacts using stable wheel/sdist namespaces instead of versioned artifact filenames;
-- requires the reviewed artifact path set to exactly match the manifest artifact path set;
+- requires every artifact in the bundle to agree on the normalized package name and version before forming a reviewable release;
 - adds PyPI-specific deterministic findings for metadata mismatches, missing wheel `RECORD`, `.pth` startup hooks, custom `setup.py` install commands, and `.pyd` native extensions;
 - fetches PyPI project metadata from `GET /pypi/<project>/json`;
 - selects a default PyPI baseline release from `info.version`, falling back to newest non-yanked upload time;
@@ -31,30 +31,37 @@ The repo now has a backend-only PyPI foundation in `server/lib/adapters/pypi/ind
 
 The sandbox parser now supports safe ZIP archive parsing for wheels in addition to npm-style gzipped tar archives. ZIP downloads are read through a bounded stream before parsing; ZIP parsing then reads the central directory, accepts stored and deflated entries, rejects traversal paths and Zip64, enforces file/expanded-size caps, and keeps package contents as bounded text samples or binary metadata.
 
-## Manifest contract
+## Release set derivation
 
-The manifest is the boundary between the GitHub workflow and Drydock:
+There is no manifest file. The boundary between the GitHub workflow and Drydock
+is simply the `pypi-release-candidate` artifact bundle: CI uploads `dist/*` and
+Drydock treats every `.whl` / `.tar.gz` / `.tgz` in the bundle as the release
+set. The reviewable identity is derived internally into the same
+`drydock.release-artifacts.v1` shape the rest of the pipeline consumes:
 
-```json
-{
-  "schema": "drydock.release-artifacts.v1",
-  "ecosystem": "pypi",
-  "package": "example-package",
-  "version": "1.2.3",
-  "artifacts": [
-    {
-      "path": "dist/example_package-1.2.3-py3-none-any.whl",
-      "sha256": "..."
-    },
-    {
-      "path": "dist/example_package-1.2.3.tar.gz",
-      "sha256": "..."
-    }
-  ]
-}
-```
+- `package` / `version` come from each wheel's `METADATA` and each sdist's
+  `PKG-INFO`. Every artifact must expose a `Name`/`Version` and agree on the
+  normalized (PEP 503) name and the version, so a foreign or version-skewed file
+  in `dist/` is rejected, not silently shipped.
+- each artifact's `sha256` is recomputed server-side from the bundle bytes.
 
-The publish job must verify these digests immediately before publishing. A reviewed wheel/sdist must be the exact file uploaded to PyPI; rebuilding after the gate breaks the security boundary.
+### Trust tradeoff (deliberate)
+
+Dropping the manifest removes the maintainer's explicit "ship exactly these N
+files, at these digests" declaration. There is no externally-declared digest to
+compare against, so the publish-side digest-match check disappears. Byte
+integrity between review and publish rests on GitHub artifact immutability plus
+the publish job never rebuilding (it only downloads the reviewed artifact).
+What keeps this safe:
+
+- cross-artifact identity consistency (a foreign or version-skewed wheel cannot
+  sneak into the release set);
+- the release-target name match still applies;
+- a bundle whose artifacts cannot be identified (no `METADATA`/`PKG-INFO`
+  `Name`/`Version`) is rejected rather than guessed.
+
+A reviewed wheel/sdist must be the exact file uploaded to PyPI; rebuilding after
+the gate breaks the security boundary.
 
 ## Target workflow
 
@@ -65,15 +72,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: python -m build
-      - run: sha256sum dist/* > drydock-sha256.txt
-      - run: python scripts/write-drydock-manifest.py
       - uses: actions/upload-artifact@v4
         with:
           name: pypi-release-candidate
-          path: |
-            dist/*
-            drydock-manifest.json
-            drydock-sha256.txt
+          path: dist/*
 
   publish:
     needs: build-release-artifacts
@@ -85,11 +87,13 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: pypi-release-candidate
-      - run: sha256sum --check drydock-sha256.txt
       - uses: pypa/gh-action-pypi-publish@release/v1
 ```
 
-PyPI strongly encourages configuring a GitHub Environment for Trusted Publishers. Drydock should attach to that same environment as a GitHub custom deployment protection rule when the GitHub App work lands.
+No manifest-writing or checksum step is required — CI just builds and uploads
+`dist/*`. PyPI strongly encourages configuring a GitHub Environment for Trusted
+Publishers. Drydock attaches to that same environment as a GitHub custom
+deployment protection rule.
 
 ## GitHub App mapping
 
@@ -224,8 +228,9 @@ the link to the Drydock report.
 exactly once thanks to the `status = 'pending'` WHERE clause, so even if the
 PyPI candidate review completes more than once we will only call GitHub a
 single time. The companion `markGateErrored` records failures (e.g. inability
-to fetch the manifest, scan pipeline crash) without consuming the gate, so
-the operator can retry once the underlying issue is fixed.
+to fetch the artifact bundle, unidentifiable artifacts, scan pipeline crash)
+without consuming the gate, so the operator can retry once the underlying
+issue is fixed.
 
 ### Trust boundary (webhook)
 
@@ -337,11 +342,12 @@ a new deploy gate. The same helper guards the
 
 ### Resolving artifacts for a pending gate
 
-`server/lib/github-app-artifacts.ts` turns a pending gate into a verified
-release bundle on the trusted control-plane side, then
+`server/lib/github-app-artifacts.ts` turns a pending gate into a release bundle
+of recomputed-SHA-256 wheel/sdist bytes on the trusted control-plane side, then
 `server/lib/release-candidate-pypi.ts` hands each wheel/sdist to the
 credentials-free `downloadInSandboxInline` sandbox path so the same untrusted-
-archive parser the npm pipeline uses produces bounded `FileRecord[]` evidence.
+archive parser the npm pipeline uses produces bounded `FileRecord[]` evidence,
+and derives the release identity from that parsed metadata.
 
 What the resolver enforces, in order:
 
@@ -366,31 +372,32 @@ What the resolver enforces, in order:
    (`findZipEndOfCentralDirectory`, `inflateRawBounded`, `normalizeZipPath`).
    Traversal paths, ZIP64, oversized entries, and unsupported compression
    methods are rejected.
-4. The bundle must contain `drydock-manifest.json` at the root. It is parsed
-   with the existing `parsePyPiReleaseManifest` (PEP 503 project name, safe
-   version, ≤20 artifacts, safe artifact paths).
-5. The bundle's wheel/sdist set must exactly match the manifest's declared
-   artifact set — extra wheel/sdist files or missing declared paths fail.
-6. Each declared artifact has its SHA-256 recomputed against the bundle
-   bytes; mismatches reject before any bytes reach the sandbox. The
-   workflow's own `drydock-sha256.txt` is never trusted.
-7. The gate wrapper compares the normalized manifest package name against the
-   mapped `github_release_targets.package_name` before wheel/sdist bytes enter
-   the sandbox. A repo/environment gate for one PyPI project cannot approve a
-   manifest for another project.
+4. Every `.whl` / `.tar.gz` / `.tgz` entry becomes the release set; its SHA-256
+   is recomputed from the bundle bytes. Non-artifact files are ignored. A bundle
+   with no wheels/sdists is `bundle_empty`; more than 20 is `bundle_too_large`.
+5. Each wheel/sdist's bytes cross into the credentials-free sandbox, which
+   parses `METADATA`/`PKG-INFO` into bounded evidence.
+6. The release identity is derived from that parsed metadata: every artifact
+   must expose a `Name`/`Version` and agree on the normalized package name and
+   the version. The synthesized `drydock.release-artifacts.v1` shape (PEP 503
+   project name, safe version, ≤20 artifacts, safe artifact paths) is then
+   re-validated before scanning.
+7. The gate wrapper compares the derived normalized package name against the
+   mapped `github_release_targets.package_name`. A repo/environment gate for one
+   PyPI project cannot approve a release for another project.
 
 Typed errors returned by `WorkflowArtifactError.code`:
 
 - `bundle_unavailable` — workflow run / artifact name is unreachable.
-- `bundle_too_large` — outer ZIP exceeded the size or entry cap.
-- `manifest_missing` — `drydock-manifest.json` not present at root.
-- `manifest_invalid` — manifest JSON / schema validation failed.
-- `manifest_artifact_mismatch` — declared vs. bundled artifact sets differ.
+- `bundle_too_large` — outer ZIP exceeded the size/entry cap, or the bundle held
+  more than 20 wheel/sdist files.
+- `bundle_empty` — the bundle contained no `.whl` / `.tar.gz` / `.tgz` files.
 - `artifact_path_unsafe` — bundle entry path contained traversal segments.
-- `artifact_kind_unsupported` — bundle has a file that isn't `.whl` /
-  `.tar.gz` / `.tgz`, or the kind disagrees with the manifest entry.
-- `artifact_digest_mismatch` — recomputed SHA-256 ≠ manifest sha256.
-- `release_target_mismatch` — normalized manifest package name did not match
+- `artifact_identity_missing` — an artifact exposed no usable `Name`/`Version`
+  (or the derived identity failed validation).
+- `artifact_identity_inconsistent` — artifacts disagreed on the normalized
+  package name or the version.
+- `release_target_mismatch` — derived normalized package name did not match
   the release target mapped to the pending gate.
 
 `preparePyPiReleaseCandidateForGate(env, ctx, db, { config, organizationId,
@@ -398,10 +405,12 @@ gateId })` is the gate-aware wrapper. It looks up the gate row, swaps the App
 JWT for a fresh installation access token, and on any failure calls
 `markGateErrored` with the typed error code so the gate cannot advance to
 scanning. The GitHub installation token never enters the sandbox: the parent
-worker downloads the artifact ZIP, validates and digests it, and only the
-verified wheel/sdist bytes cross the trust boundary through
-`downloadInSandboxInline`, which constructs the `NpmStageGateway` with empty
-props (no npm token, no public-artifact allowlist, `subRequests: 0`).
+worker downloads the artifact ZIP and recomputes digests, and only the
+wheel/sdist bytes cross the trust boundary through `downloadInSandboxInline`,
+which constructs the `NpmStageGateway` with empty props (no npm token, no
+public-artifact allowlist, `subRequests: 0`). Because identity is derived from
+the sandbox-parsed metadata, the release-target match happens after parsing
+rather than before.
 
 ## Remaining work
 

--- a/server/lib/github-app-artifacts.ts
+++ b/server/lib/github-app-artifacts.ts
@@ -7,12 +7,7 @@ import {
   readUint32Le,
 } from "./tar-parser.js";
 import { getInstallationAccessToken, type GithubAppConfig } from "./github-app";
-import {
-  inferPyPiArtifactKind,
-  parsePyPiReleaseManifest,
-  type PyPiArtifactKind,
-  type PyPiReleaseManifest,
-} from "./adapters/pypi/index";
+import { inferPyPiArtifactKind, type PyPiArtifactKind } from "./adapters/pypi/index";
 
 // ── Public surface ───────────────────────────────────────────────────────────
 
@@ -31,8 +26,6 @@ export interface ResolvedReleaseFile {
 }
 
 export interface ResolvedReleaseBundle {
-  manifest: PyPiReleaseManifest;
-  manifestRaw: string;
   artifacts: ResolvedReleaseFile[];
   artifactId: number;
   artifactName: string;
@@ -42,13 +35,11 @@ export interface ResolvedReleaseBundle {
 export type WorkflowArtifactErrorCode =
   | "bundle_unavailable"
   | "bundle_too_large"
-  | "manifest_missing"
-  | "manifest_invalid"
-  | "manifest_artifact_mismatch"
+  | "bundle_empty"
   | "release_target_mismatch"
   | "artifact_path_unsafe"
-  | "artifact_kind_unsupported"
-  | "artifact_digest_mismatch";
+  | "artifact_identity_missing"
+  | "artifact_identity_inconsistent";
 
 export class WorkflowArtifactError extends Error {
   constructor(
@@ -63,13 +54,11 @@ export class WorkflowArtifactError extends Error {
 // ── Configuration ────────────────────────────────────────────────────────────
 
 const DEFAULT_ARTIFACT_NAME = "pypi-release-candidate";
-const MANIFEST_FILENAME = "drydock-manifest.json";
-const ALLOWED_SUPPORT_FILENAMES = new Set(["drydock-sha256.txt"]);
 
 const MAX_OUTER_ZIP_BYTES = 25 * 1024 * 1024;
 const MAX_OUTER_ZIP_ENTRIES = 256;
 const MAX_PER_ENTRY_BYTES = 25 * 1024 * 1024;
-const MAX_MANIFEST_BYTES = 64 * 1024;
+const MAX_RELEASE_ARTIFACTS = 20;
 const MAX_LIST_PAGES = 4;
 const MAX_DOWNLOAD_REDIRECTS = 4;
 
@@ -123,6 +112,13 @@ export function evaluateGithubArtifactEgress(requestUrl: string): GithubArtifact
  * gate-aware caller is responsible for swapping the GitHub App JWT for a fresh
  * installation token; isolating that step lets us test artifact ingestion
  * without supplying a real RSA private key.
+ *
+ * There is no `drydock-manifest.json` contract: the release set is whatever
+ * wheel/sdist files the bundle contains. Identity (`package`/`version`) is
+ * derived from the artifacts themselves downstream
+ * (`server/lib/release-candidate-pypi.ts`) once the bytes have been parsed in
+ * the sandbox. This stage only collects the artifact bytes and recomputes their
+ * SHA-256; non-artifact files in the bundle are ignored.
  */
 export async function fetchReleaseBundleWithToken(
   installationToken: string,
@@ -153,77 +149,31 @@ export async function fetchReleaseBundleWithToken(
   );
 
   const entries = await extractOuterZipEntries(zipBytes);
-  const manifestEntry = entries.find((entry) => entry.path === MANIFEST_FILENAME);
-  if (!manifestEntry) {
-    throw new WorkflowArtifactError(
-      "manifest_missing",
-      `artifact bundle did not contain ${MANIFEST_FILENAME}`,
-    );
-  }
-  if (manifestEntry.bytes.byteLength > MAX_MANIFEST_BYTES) {
-    throw new WorkflowArtifactError(
-      "manifest_invalid",
-      `${MANIFEST_FILENAME} exceeds ${MAX_MANIFEST_BYTES} bytes`,
-    );
-  }
 
-  const manifestRaw = new TextDecoder("utf-8", { fatal: false }).decode(manifestEntry.bytes);
-  const manifest = parseAndValidateManifest(manifestRaw);
-
-  // Reject anything beyond the manifest, declared artifacts, and explicit
-  // support files before digesting.
-  const declaredPaths = new Set(manifest.artifacts.map((entry) => entry.path));
+  // The release set is every wheel/sdist in the bundle. Non-artifact files
+  // (checksums, READMEs, anything else upload-artifact happened to include) are
+  // ignored — they are never scanned, so they cannot influence the review.
   const candidateArtifacts: ResolvedReleaseFile[] = [];
   for (const entry of entries) {
-    if (entry.path === MANIFEST_FILENAME) continue;
-    if (ALLOWED_SUPPORT_FILENAMES.has(entry.path)) continue;
-    if (declaredPaths.has(entry.path)) continue;
-    if (inferPyPiArtifactKind(entry.path) !== null) {
-      throw new WorkflowArtifactError(
-        "manifest_artifact_mismatch",
-        `bundle includes ${entry.path} which is not declared in ${MANIFEST_FILENAME}`,
-      );
-    }
+    const kind = inferPyPiArtifactKind(entry.path);
+    if (!kind) continue;
+    const sha256 = await sha256Hex(entry.bytes);
+    candidateArtifacts.push({ path: entry.path, bytes: entry.bytes, sha256, kind });
+  }
+  if (candidateArtifacts.length === 0) {
     throw new WorkflowArtifactError(
-      "artifact_kind_unsupported",
-      `bundle includes unsupported file ${entry.path}`,
+      "bundle_empty",
+      "artifact bundle contained no wheel or sdist files",
     );
   }
-
-  for (const declared of manifest.artifacts) {
-    const entry = entries.find((candidate) => candidate.path === declared.path);
-    if (!entry) {
-      throw new WorkflowArtifactError(
-        "manifest_artifact_mismatch",
-        `bundle is missing artifact ${declared.path} declared in ${MANIFEST_FILENAME}`,
-      );
-    }
-    const kind = inferPyPiArtifactKind(entry.path);
-    if (!kind) {
-      throw new WorkflowArtifactError(
-        "artifact_kind_unsupported",
-        `${entry.path} is not a wheel or sdist`,
-      );
-    }
-    if (kind !== declared.kind) {
-      throw new WorkflowArtifactError(
-        "artifact_kind_unsupported",
-        `${entry.path} kind ${kind} does not match manifest kind ${declared.kind}`,
-      );
-    }
-    const sha256 = await sha256Hex(entry.bytes);
-    if (sha256 !== declared.sha256.toLowerCase()) {
-      throw new WorkflowArtifactError(
-        "artifact_digest_mismatch",
-        `${entry.path} sha256 ${sha256} != manifest sha256`,
-      );
-    }
-    candidateArtifacts.push({ path: entry.path, bytes: entry.bytes, sha256, kind });
+  if (candidateArtifacts.length > MAX_RELEASE_ARTIFACTS) {
+    throw new WorkflowArtifactError(
+      "bundle_too_large",
+      `artifact bundle contains more than ${MAX_RELEASE_ARTIFACTS} wheel/sdist files`,
+    );
   }
 
   return {
-    manifest,
-    manifestRaw,
     artifacts: candidateArtifacts,
     artifactId: artifact.id,
     artifactName: artifact.name,
@@ -517,25 +467,6 @@ function containsPathTraversal(rawPath: string): boolean {
   if (rawPath.startsWith("../") || rawPath.includes("/../") || rawPath.endsWith("/..")) return true;
   if (/^[A-Za-z]:/.test(rawPath)) return true;
   return false;
-}
-
-// ── Manifest validation ──────────────────────────────────────────────────────
-
-function parseAndValidateManifest(raw: string): PyPiReleaseManifest {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    throw new WorkflowArtifactError("manifest_invalid", "drydock-manifest.json is not valid JSON");
-  }
-  try {
-    return parsePyPiReleaseManifest(parsed);
-  } catch (err) {
-    throw new WorkflowArtifactError(
-      "manifest_invalid",
-      err instanceof Error ? err.message : "manifest validation failed",
-    );
-  }
 }
 
 // ── Shared helpers ───────────────────────────────────────────────────────────

--- a/server/lib/release-candidate-pypi.ts
+++ b/server/lib/release-candidate-pypi.ts
@@ -3,9 +3,14 @@ import type { AppDb } from "../db";
 import { githubAppInstallations, githubReleaseTargets } from "../db/schema";
 import {
   normalizePyPiProjectName,
+  parsePyPiReleaseManifest,
+  preparePyPiArtifact,
+  PYPI_RELEASE_MANIFEST_SCHEMA,
   type PyPiAdapterInput,
   type PyPiArtifactInput,
   type PyPiArtifactKind,
+  type PyPiPreparedArtifact,
+  type PyPiReleaseManifest,
 } from "./adapters/pypi/index";
 import {
   fetchReleaseBundleForGate,
@@ -39,12 +44,14 @@ export interface PreparedPyPiReleaseCandidate {
  *
  * Step 1 (`fetchReleaseBundleForGate`) lives entirely in the control plane:
  * the GitHub installation token is used to list and download artifact bytes,
- * the outer ZIP is parsed with hardened limits, the manifest is validated,
- * and every wheel/sdist SHA-256 is recomputed and compared to the manifest.
+ * the outer ZIP is parsed with hardened limits, and every wheel/sdist SHA-256
+ * is recomputed from the bundle bytes.
  *
  * Step 2 hands each wheel/sdist's bytes to the credentials-free
  * `downloadInSandboxInline` path so the same untrusted-archive parser the npm
- * pipeline uses produces bounded `FileRecord[]` evidence.
+ * pipeline uses produces bounded `FileRecord[]` evidence, then derives the
+ * release identity from the parsed `METADATA`/`PKG-INFO` (see
+ * `deriveReleaseManifest`).
  */
 export async function preparePyPiReleaseCandidate(
   env: Cloudflare.Env,
@@ -65,10 +72,77 @@ async function preparePyPiReleaseCandidateFromBundle(
     const files = await parseArtifactBytes(env, ctx, artifact);
     artifacts.push({ path: artifact.path, files });
   }
+  const prepared = artifacts.map(preparePyPiArtifact);
+  const manifest = deriveReleaseManifest(bundle, prepared);
   return {
-    adapterInput: { manifest: bundle.manifest, artifacts },
+    adapterInput: { manifest, artifacts },
     bundle,
   };
+}
+
+/**
+ * Synthesize the `PyPiReleaseManifest` the rest of the pipeline consumes from
+ * the artifacts themselves. There is no maintainer-declared manifest: identity
+ * comes from each wheel's `METADATA` / sdist's `PKG-INFO`, and the SHA-256 is
+ * the digest already recomputed from the bundle bytes.
+ *
+ * Every artifact must expose a `Name`/`Version` and agree on the normalized
+ * (PEP 503) name and the version, so a foreign or version-skewed file slipped
+ * into the bundle is rejected rather than silently shipped.
+ */
+function deriveReleaseManifest(
+  bundle: ResolvedReleaseBundle,
+  prepared: PyPiPreparedArtifact[],
+): PyPiReleaseManifest {
+  let name: string | null = null;
+  let normalizedName: string | null = null;
+  let version: string | null = null;
+  for (const artifact of prepared) {
+    const { summary } = artifact;
+    if (!summary.name || !summary.version) {
+      throw new WorkflowArtifactError(
+        "artifact_identity_missing",
+        `${artifact.path} does not expose a PyPI Name/Version in its metadata`,
+      );
+    }
+    const normalized = normalizePyPiProjectName(summary.name);
+    if (name === null) {
+      name = summary.name;
+      normalizedName = normalized;
+      version = summary.version;
+      continue;
+    }
+    if (normalized !== normalizedName) {
+      throw new WorkflowArtifactError(
+        "artifact_identity_inconsistent",
+        `${artifact.path} package ${summary.name} disagrees with ${name}`,
+      );
+    }
+    if (summary.version !== version) {
+      throw new WorkflowArtifactError(
+        "artifact_identity_inconsistent",
+        `${artifact.path} version ${summary.version} disagrees with ${version}`,
+      );
+    }
+  }
+
+  // `prepared` is non-empty: the resolver throws `bundle_empty` when a bundle
+  // has no wheels/sdists, so `name`/`version` are always set here.
+  const candidate = {
+    schema: PYPI_RELEASE_MANIFEST_SCHEMA,
+    ecosystem: "pypi",
+    package: name,
+    version,
+    artifacts: bundle.artifacts.map((file) => ({ path: file.path, sha256: file.sha256 })),
+  };
+  try {
+    return parsePyPiReleaseManifest(candidate);
+  } catch (err) {
+    throw new WorkflowArtifactError(
+      "artifact_identity_missing",
+      err instanceof Error ? err.message : "derived release identity is not valid",
+    );
+  }
 }
 
 export interface PrepareForGateInput {
@@ -157,14 +231,14 @@ export async function preparePyPiReleaseCandidateForGate(
       runId: gate.runId,
       artifactName: input.artifactName,
     });
-    const manifestPackage = normalizePyPiProjectName(bundle.manifest.package);
-    if (manifestPackage !== releaseTarget.packageName) {
+    const prepared = await preparePyPiReleaseCandidateFromBundle(env, ctx, bundle);
+    const derivedPackage = normalizePyPiProjectName(prepared.adapterInput.manifest.package);
+    if (derivedPackage !== releaseTarget.packageName) {
       throw new WorkflowArtifactError(
         "release_target_mismatch",
-        `manifest package ${manifestPackage} does not match release target ${releaseTarget.packageName}`,
+        `derived package ${derivedPackage} does not match release target ${releaseTarget.packageName}`,
       );
     }
-    const prepared = await preparePyPiReleaseCandidateFromBundle(env, ctx, bundle);
     return { ...prepared, gate };
   } catch (err) {
     const reason = err instanceof WorkflowArtifactError ? err.code : "preparation_failed";

--- a/test/workers/github-app-artifacts.test.ts
+++ b/test/workers/github-app-artifacts.test.ts
@@ -150,45 +150,28 @@ function makeWheelBytes(name: string, version: string): FakeWheel {
   return { bytes: wheelBytes, path };
 }
 
+// The bundle no longer carries a `drydock-manifest.json`: the release set is
+// simply the wheel/sdist files the bundle contains.
 async function buildFixture(opts?: {
   extraEntries?: ZipEntry[];
   mutateWheel?: (bytes: Uint8Array) => Uint8Array;
-  omitManifest?: boolean;
-  manifestRaw?: string;
-  declareWheelKind?: "wheel" | "sdist";
+  includeWheel?: boolean;
 }): Promise<{
   wheel: FakeWheel;
-  manifestRaw: string;
+  wheelSha: string;
   bundleZip: Uint8Array;
 }> {
   const wheel = makeWheelBytes("demo-package", "1.2.0");
   const wheelBytes = opts?.mutateWheel ? opts.mutateWheel(wheel.bytes) : wheel.bytes;
   const wheelSha = await sha256Hex(wheelBytes);
 
-  const manifestObject = {
-    schema: "drydock.release-artifacts.v1",
-    ecosystem: "pypi",
-    package: "demo-package",
-    version: "1.2.0",
-    artifacts: [
-      {
-        path: wheel.path,
-        sha256: wheelSha,
-        // The PyPI adapter's parsePyPiReleaseManifest infers kind from the
-        // suffix; we don't include "kind" in the JSON.
-      },
-    ],
-  };
-  const manifestRaw = opts?.manifestRaw ?? JSON.stringify(manifestObject, null, 2);
-
   const entries: ZipEntry[] = [];
-  if (!opts?.omitManifest) {
-    entries.push({ path: "drydock-manifest.json", body: manifestRaw });
+  if (opts?.includeWheel !== false) {
+    entries.push({ path: wheel.path, body: wheelBytes });
   }
-  entries.push({ path: wheel.path, body: wheelBytes });
   if (opts?.extraEntries) entries.push(...opts.extraEntries);
   const bundleZip = makeZip(entries);
-  return { wheel: { bytes: wheelBytes, path: wheel.path }, manifestRaw, bundleZip };
+  return { wheel: { bytes: wheelBytes, path: wheel.path }, wheelSha, bundleZip };
 }
 
 // ── Fetch stub ───────────────────────────────────────────────────────────────
@@ -258,21 +241,78 @@ function source(): WorkflowArtifactSource {
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe("fetchReleaseBundleWithToken", () => {
-  test("returns the manifest and verified wheel bytes on the happy path", async () => {
+  test("returns the verified wheel bytes on the happy path", async () => {
     const fixture = await buildFixture();
     const calls = stubGithubFetch({ bundleZip: fixture.bundleZip });
 
     const bundle = await fetchReleaseBundleWithToken(TOKEN, source());
 
-    expect(bundle.manifest.package).toBe("demo-package");
-    expect(bundle.manifest.version).toBe("1.2.0");
     expect(bundle.artifactName).toBe(ARTIFACT_NAME);
     expect(bundle.artifactId).toBe(ARTIFACT_ID);
     expect(bundle.artifacts).toHaveLength(1);
     expect(bundle.artifacts[0]?.path).toBe(fixture.wheel.path);
     expect(bundle.artifacts[0]?.kind).toBe("wheel");
     expect(bundle.artifacts[0]?.bytes).toEqual(fixture.wheel.bytes);
+    expect(bundle.artifacts[0]?.sha256).toBe(fixture.wheelSha);
     expect(calls.every((call) => call.authorization === `Bearer ${TOKEN}`)).toBe(true);
+  });
+
+  test("collects every wheel and sdist in the bundle as the release set", async () => {
+    const sdistPath = "dist/demo_package-1.2.0.tar.gz";
+    const sdistBytes = new TextEncoder().encode("opaque sdist bytes");
+    const fixture = await buildFixture({
+      extraEntries: [{ path: sdistPath, body: sdistBytes }],
+    });
+    stubGithubFetch({ bundleZip: fixture.bundleZip });
+
+    const bundle = await fetchReleaseBundleWithToken(TOKEN, source());
+
+    const paths = bundle.artifacts.map((artifact) => artifact.path).sort();
+    expect(paths).toEqual([sdistPath, fixture.wheel.path].sort());
+    const sdist = bundle.artifacts.find((artifact) => artifact.path === sdistPath);
+    expect(sdist?.kind).toBe("sdist");
+    expect(sdist?.sha256).toBe(await sha256Hex(sdistBytes));
+  });
+
+  test("ignores non-artifact files in the bundle", async () => {
+    const fixture = await buildFixture({
+      extraEntries: [
+        { path: "drydock-sha256.txt", body: "placeholder\n" },
+        { path: "dist/demo_package-1.2.0.zip", body: "not a wheel or sdist" },
+        { path: "README.md", body: "# notes\n" },
+      ],
+    });
+    stubGithubFetch({ bundleZip: fixture.bundleZip });
+
+    const bundle = await fetchReleaseBundleWithToken(TOKEN, source());
+
+    expect(bundle.artifacts).toHaveLength(1);
+    expect(bundle.artifacts[0]?.path).toBe(fixture.wheel.path);
+  });
+
+  test("bundle_empty when the bundle has no wheel or sdist files", async () => {
+    const fixture = await buildFixture({
+      includeWheel: false,
+      extraEntries: [{ path: "drydock-sha256.txt", body: "placeholder\n" }],
+    });
+    stubGithubFetch({ bundleZip: fixture.bundleZip });
+
+    await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
+      code: "bundle_empty",
+    });
+  });
+
+  test("bundle_too_large when the bundle declares more than 20 artifacts", async () => {
+    const entries: ZipEntry[] = [];
+    for (let index = 0; index < 21; index += 1) {
+      entries.push({ path: `dist/demo_package-1.2.${index}.tar.gz`, body: `sdist ${index}` });
+    }
+    const bundleZip = makeZip(entries);
+    stubGithubFetch({ bundleZip });
+
+    await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
+      code: "bundle_too_large",
+    });
   });
 
   test("bundle_unavailable when no artifact with that name exists", async () => {
@@ -308,117 +348,9 @@ describe("fetchReleaseBundleWithToken", () => {
     });
   });
 
-  test("manifest_missing when the zip lacks drydock-manifest.json", async () => {
-    const fixture = await buildFixture({ omitManifest: true });
-    stubGithubFetch({ bundleZip: fixture.bundleZip });
-
-    await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
-      code: "manifest_missing",
-    });
-  });
-
-  test("manifest_invalid when the manifest JSON is malformed", async () => {
-    const fixture = await buildFixture({ manifestRaw: "{ not json" });
-    stubGithubFetch({ bundleZip: fixture.bundleZip });
-
-    await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
-      code: "manifest_invalid",
-    });
-  });
-
-  test("manifest_artifact_mismatch when the bundle has an extra wheel not declared in the manifest", async () => {
-    const sneaky = makeWheelBytes("evil-package", "9.9.9");
-    const fixture = await buildFixture({
-      extraEntries: [{ path: sneaky.path, body: sneaky.bytes }],
-    });
-    stubGithubFetch({ bundleZip: fixture.bundleZip });
-
-    await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
-      code: "manifest_artifact_mismatch",
-    });
-  });
-
-  test("artifact_kind_unsupported when the bundle has an undeclared dist file", async () => {
-    const fixture = await buildFixture({
-      extraEntries: [{ path: "dist/demo_package-1.2.0.zip", body: "not reviewed" }],
-    });
-    stubGithubFetch({ bundleZip: fixture.bundleZip });
-
-    await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
-      code: "artifact_kind_unsupported",
-    });
-  });
-
-  test("allows the workflow checksum support file outside the manifest", async () => {
-    const fixture = await buildFixture({
-      extraEntries: [{ path: "drydock-sha256.txt", body: "placeholder\n" }],
-    });
-    stubGithubFetch({ bundleZip: fixture.bundleZip });
-
-    const bundle = await fetchReleaseBundleWithToken(TOKEN, source());
-
-    expect(bundle.artifacts).toHaveLength(1);
-    expect(bundle.artifacts[0]?.path).toBe(fixture.wheel.path);
-  });
-
-  test("manifest_artifact_mismatch when manifest declares a path the bundle omits", async () => {
-    const realWheel = makeWheelBytes("demo-package", "1.2.0");
-    const realSha = await sha256Hex(realWheel.bytes);
-    const declaredButAbsent = "dist/demo_package-1.2.0-py3-none-any.whl";
-    const manifestRaw = JSON.stringify({
-      schema: "drydock.release-artifacts.v1",
-      ecosystem: "pypi",
-      package: "demo-package",
-      version: "1.2.0",
-      artifacts: [
-        { path: declaredButAbsent, sha256: realSha },
-        {
-          path: "dist/demo_package-1.2.0.tar.gz",
-          sha256: "b".repeat(64),
-        },
-      ],
-    });
-    const bundle = makeZip([
-      { path: "drydock-manifest.json", body: manifestRaw },
-      { path: declaredButAbsent, body: realWheel.bytes },
-    ]);
-    stubGithubFetch({ bundleZip: bundle });
-
-    await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
-      code: "manifest_artifact_mismatch",
-    });
-  });
-
-  test("artifact_digest_mismatch when a declared artifact's bytes differ from the manifest sha256", async () => {
-    const fixture = await buildFixture({
-      mutateWheel: (bytes) => {
-        // After we mutate, the manifest sha256 (computed over original bytes
-        // in `buildFixture`) won't match the bundled bytes. Build the
-        // manifest before mutation, mutate after.
-        return bytes;
-      },
-    });
-    // Replace the wheel entry with a tampered copy that does not match the
-    // recorded sha256.
-    const tamperedWheel = makeWheelBytes("demo-package", "1.2.0").bytes;
-    tamperedWheel[tamperedWheel.length - 5] ^= 0xff;
-    const tamperedBundle = makeZip([
-      { path: "drydock-manifest.json", body: fixture.manifestRaw },
-      { path: fixture.wheel.path, body: tamperedWheel },
-    ]);
-    stubGithubFetch({ bundleZip: tamperedBundle });
-
-    await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({
-      code: "artifact_digest_mismatch",
-    });
-  });
-
   test("artifact_path_unsafe when the bundle includes a traversal path", async () => {
     const sneaky = makeWheelBytes("demo-package", "1.2.0");
-    const bundle = makeZip([
-      { path: "drydock-manifest.json", body: "{}" },
-      { path: "../../etc/passwd", body: sneaky.bytes },
-    ]);
+    const bundle = makeZip([{ path: "../../etc/passwd", body: sneaky.bytes }]);
     stubGithubFetch({ bundleZip: bundle });
 
     await expect(fetchReleaseBundleWithToken(TOKEN, source())).rejects.toMatchObject({

--- a/test/workers/release-candidate-pypi.test.ts
+++ b/test/workers/release-candidate-pypi.test.ts
@@ -10,7 +10,6 @@ import {
 } from "../../server/lib/github-app";
 import { getGateForOrganization } from "../../server/lib/github-app-webhook";
 import { preparePyPiReleaseCandidateForGate } from "../../server/lib/release-candidate-pypi";
-import { WorkflowArtifactError } from "../../server/lib/github-app-artifacts";
 
 const WEBHOOK_SECRET = "webhook-secret-value-1234567890";
 
@@ -162,13 +161,33 @@ function crc32(bytes: Uint8Array): number {
   return (crc ^ 0xffffffff) >>> 0;
 }
 
-async function sha256Hex(bytes: Uint8Array): Promise<string> {
-  const digest = await crypto.subtle.digest("SHA-256", bytes as BufferSource);
-  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+type SandboxFile = {
+  path: string;
+  size: number;
+  sha256: string;
+  flags: string[];
+  textSample?: string;
+};
+
+// A `.dist-info/METADATA` record the way the sandbox surfaces it after parsing a
+// wheel; identity derivation reads Name/Version from this textSample.
+function metadataFile(name: string, version: string): SandboxFile {
+  const slug = name.replace(/-/g, "_");
+  return {
+    path: `${slug}-${version}.dist-info/METADATA`,
+    size: 64,
+    sha256: "ab".repeat(32),
+    flags: [],
+    textSample: `Metadata-Version: 2.3\nName: ${name}\nVersion: ${version}\n`,
+  };
 }
 
-function buildLoaderMock() {
+// `fileSets[i]` is what the sandbox returns for the i-th artifact it parses, in
+// bundle order. The mock clamps to the last entry so single-set callers can omit
+// extras.
+function buildLoaderMock(fileSets: SandboxFile[][]) {
   const calls: { format: string | null; bodySize: number }[] = [];
+  let index = 0;
   return {
     calls,
     binding: {
@@ -179,21 +198,12 @@ function buildLoaderMock() {
               format: request.headers.get("x-archive-format"),
               bodySize: (await request.arrayBuffer()).byteLength,
             });
-            return new Response(
-              JSON.stringify({
-                files: [
-                  {
-                    path: "stub.txt",
-                    size: 1,
-                    sha256: "00",
-                    flags: [],
-                    textSample: "x",
-                  },
-                ],
-                packageJson: null,
-              }),
-              { status: 200, headers: { "content-type": "application/json" } },
-            );
+            const files = fileSets[Math.min(index, fileSets.length - 1)] ?? [];
+            index += 1;
+            return new Response(JSON.stringify({ files, packageJson: null }), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            });
           }),
         }),
       })),
@@ -226,39 +236,14 @@ function buildConfigBindings(): Record<string, string> {
   };
 }
 
-interface ScenarioOpts {
-  digestMatches: boolean;
-  manifestPackage?: string;
-}
-
-async function buildScenario(runId: number, opts: ScenarioOpts) {
-  const wheelPath = "dist/demo_package-1.2.0-py3-none-any.whl";
-  const wheelBytes = makeZip([
-    {
-      path: "demo_package-1.2.0.dist-info/METADATA",
-      body: "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n",
-    },
-    {
-      path: "demo_package-1.2.0.dist-info/WHEEL",
-      body: "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
-    },
-    {
-      path: "demo_package-1.2.0.dist-info/RECORD",
-      body: "",
-    },
-  ]);
-  const declaredSha = opts.digestMatches ? await sha256Hex(wheelBytes) : "0".repeat(64);
-  const manifestRaw = JSON.stringify({
-    schema: "drydock.release-artifacts.v1",
-    ecosystem: "pypi",
-    package: opts.manifestPackage ?? "demo-package",
-    version: "1.2.0",
-    artifacts: [{ path: wheelPath, sha256: declaredSha }],
-  });
-  const bundleZip = makeZip([
-    { path: "drydock-manifest.json", body: manifestRaw },
-    { path: wheelPath, body: wheelBytes },
-  ]);
+// The bundle contains only the wheel/sdist files — no `drydock-manifest.json`.
+// The wheel bytes here are opaque: the sandbox is mocked, so identity comes from
+// the loader's returned METADATA rather than these bytes.
+async function buildScenario(runId: number, opts?: { artifactPaths?: string[] }) {
+  const artifactPaths = opts?.artifactPaths ?? ["dist/demo_package-1.2.0-py3-none-any.whl"];
+  const bundleZip = makeZip(
+    artifactPaths.map((path) => ({ path, body: `opaque bytes for ${path}` })),
+  );
 
   const fetchSpy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = input instanceof Request ? input : new Request(input, init);
@@ -293,20 +278,20 @@ async function buildScenario(runId: number, opts: ScenarioOpts) {
     throw new Error(`unexpected fetch in test: ${request.url}`);
   });
   vi.stubGlobal("fetch", fetchSpy);
-  return { fetchSpy, manifestRaw, wheelPath, wheelBytes };
+  return { fetchSpy, artifactPaths };
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe("preparePyPiReleaseCandidateForGate", () => {
-  test("returns a PyPiAdapterInput for a pending gate with a matching manifest", async () => {
+  test("derives the release identity from the artifacts for a matching gate", async () => {
     const seeded = await seedGateForTest({
       installationExternalId: "9100",
       repositoryId: 71001,
       runId: 7777,
     });
-    const scenario = await buildScenario(7777, { digestMatches: true });
-    const loaderMock = buildLoaderMock();
+    const scenario = await buildScenario(7777);
+    const loaderMock = buildLoaderMock([[metadataFile("demo-package", "1.2.0")]]);
     const ctx = buildCtxWithGateway();
     const bindings = buildConfigBindings();
     const config = readGithubAppConfig({
@@ -327,26 +312,31 @@ describe("preparePyPiReleaseCandidateForGate", () => {
     });
 
     expect(result.gate.id).toBe(seeded.gateId);
-    expect(result.bundle.manifest.package).toBe("demo-package");
+    expect(result.adapterInput.manifest.package).toBe("demo-package");
+    expect(result.adapterInput.manifest.version).toBe("1.2.0");
+    expect(result.adapterInput.manifest.artifacts).toHaveLength(1);
+    expect(result.adapterInput.manifest.artifacts[0].path).toBe(scenario.artifactPaths[0]);
     expect(result.adapterInput.artifacts).toHaveLength(1);
-    expect(result.adapterInput.artifacts[0].path).toBe(scenario.wheelPath);
+    expect(result.adapterInput.artifacts[0].path).toBe(scenario.artifactPaths[0]);
     expect(result.adapterInput.artifacts[0].files).toHaveLength(1);
     expect(loaderMock.calls).toHaveLength(1);
     expect(loaderMock.calls[0].format).toBe("zip");
-    expect(loaderMock.calls[0].bodySize).toBe(scenario.wheelBytes.byteLength);
 
     const refreshed = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
     expect(refreshed?.status).toBe("pending");
   });
 
-  test("marks the gate errored when the manifest digest does not match the wheel bytes", async () => {
+  test("marks the gate errored when an artifact exposes no Name/Version", async () => {
     const seeded = await seedGateForTest({
       installationExternalId: "9101",
       repositoryId: 71002,
       runId: 8888,
     });
-    await buildScenario(8888, { digestMatches: false });
-    const loaderMock = buildLoaderMock();
+    await buildScenario(8888);
+    // The sandbox returns a file with no usable PyPI metadata.
+    const loaderMock = buildLoaderMock([
+      [{ path: "demo_package/__init__.py", size: 1, sha256: "00", flags: [], textSample: "x" }],
+    ]);
     const ctx = buildCtxWithGateway();
     const bindings = buildConfigBindings();
     const config = readGithubAppConfig({
@@ -366,24 +356,62 @@ describe("preparePyPiReleaseCandidateForGate", () => {
         organizationId: seeded.organizationId,
         gateId: seeded.gateId,
       }),
-    ).rejects.toBeInstanceOf(WorkflowArtifactError);
+    ).rejects.toMatchObject({ code: "artifact_identity_missing" });
 
     const refreshed = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
     expect(refreshed?.status).toBe("pending");
-    expect(refreshed?.failureReason).toBe("artifact_digest_mismatch");
+    expect(refreshed?.failureReason).toBe("artifact_identity_missing");
   });
 
-  test("marks the gate errored when the manifest package does not match the release target", async () => {
+  test("marks the gate errored when artifacts disagree on identity", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9104",
+      repositoryId: 71005,
+      runId: 11111,
+    });
+    await buildScenario(11111, {
+      artifactPaths: ["dist/demo_package-1.2.0-py3-none-any.whl", "dist/demo_package-1.3.0.tar.gz"],
+    });
+    // The wheel and sdist disagree on version: a version-skewed file must be
+    // rejected rather than silently shipped.
+    const loaderMock = buildLoaderMock([
+      [metadataFile("demo-package", "1.2.0")],
+      [{ ...metadataFile("demo-package", "1.3.0"), path: "demo_package-1.3.0/PKG-INFO" }],
+    ]);
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const config = readGithubAppConfig({
+      ...bindings,
+      BETTER_AUTH_SECRET: bindings.BETTER_AUTH_SECRET,
+    });
+    const sandboxEnv = {
+      ...env,
+      ...bindings,
+      LOADER: loaderMock.binding as unknown as WorkerLoader,
+    } as Cloudflare.Env;
+
+    const db = createDb(env.DB);
+    await expect(
+      preparePyPiReleaseCandidateForGate(sandboxEnv, ctx, db, {
+        config,
+        organizationId: seeded.organizationId,
+        gateId: seeded.gateId,
+      }),
+    ).rejects.toMatchObject({ code: "artifact_identity_inconsistent" });
+
+    const refreshed = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(refreshed?.status).toBe("pending");
+    expect(refreshed?.failureReason).toBe("artifact_identity_inconsistent");
+  });
+
+  test("marks the gate errored when the derived package does not match the release target", async () => {
     const seeded = await seedGateForTest({
       installationExternalId: "9102",
       repositoryId: 71003,
       runId: 9999,
     });
-    await buildScenario(9999, {
-      digestMatches: true,
-      manifestPackage: "other-package",
-    });
-    const loaderMock = buildLoaderMock();
+    await buildScenario(9999);
+    const loaderMock = buildLoaderMock([[metadataFile("other-package", "1.2.0")]]);
     const ctx = buildCtxWithGateway();
     const bindings = buildConfigBindings();
     const config = readGithubAppConfig({
@@ -405,7 +433,6 @@ describe("preparePyPiReleaseCandidateForGate", () => {
       }),
     ).rejects.toMatchObject({ code: "release_target_mismatch" });
 
-    expect(loaderMock.calls).toHaveLength(0);
     const refreshed = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
     expect(refreshed?.status).toBe("pending");
     expect(refreshed?.failureReason).toBe("release_target_mismatch");
@@ -422,7 +449,7 @@ describe("preparePyPiReleaseCandidateForGate", () => {
       ...bindings,
       BETTER_AUTH_SECRET: bindings.BETTER_AUTH_SECRET,
     });
-    const loaderMock = buildLoaderMock();
+    const loaderMock = buildLoaderMock([[metadataFile("demo-package", "1.2.0")]]);
     const ctx = buildCtxWithGateway();
     const sandboxEnv = {
       ...env,


### PR DESCRIPTION
## Summary
- Erases the `drydock-manifest.json` contract from the PyPI workflow-gate path: the resolver in `github-app-artifacts.ts` now collects every `.whl`/`.tar.gz`/`.tgz` in the run's artifact bundle and recomputes each SHA-256, ignoring non-artifact files, with new `bundle_empty`/`bundle_too_large` (>20 artifacts) guards.
- The release identity (package name and version) is derived in `release-candidate-pypi.ts` from each wheel's `METADATA` / sdist's `PKG-INFO` after credentials-free sandbox parsing, then synthesized into the internal `drydock.release-artifacts.v1` shape; cross-artifact agreement and the release-target name match keep the bundle honest (`artifact_identity_missing`/`artifact_identity_inconsistent`).
- This is a deliberate trust tradeoff — without a maintainer-declared digest the publish-side digest-match check is dropped, so byte integrity now rests on GitHub artifact immutability and the publish job not rebuilding.
- Worker-runtime tests and the `docs/pypi-workflow-gate.md` + `docs/production-roadmap.md` docs are updated in the same change.

## Test plan
- [x] `pnpm run verify` (lint, format check, typecheck, logic + worker test suites) passes.
- [ ] e2e not run: the fake-registry suite is npm-only and does not exercise the PyPI/GitHub-artifact gate path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)