### PR TITLE
Diff PyPI candidates against the previous release

### DIFF
--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -21,12 +21,13 @@ The repo now has a backend-only PyPI foundation in `server/lib/adapters/pypi/ind
 - recognizes wheel (`.whl`) and sdist (`.tar.gz`, `.tgz`) artifacts;
 - parses wheel `METADATA`, `WHEEL`, and `RECORD` evidence from ZIP archives;
 - strips the common root directory from sdists before reading `PKG-INFO`;
-- compares flattened candidate artifact files against optional previous artifacts using stable wheel/sdist namespaces instead of versioned artifact filenames;
+- compares flattened candidate artifact files against the previous PyPI release using stable wheel/sdist namespaces instead of versioned artifact filenames (callers may inject explicit `previousArtifacts`, otherwise the adapter resolves and downloads the baseline itself);
 - requires every artifact in the bundle to agree on the normalized package name and version before forming a reviewable release;
 - adds PyPI-specific deterministic findings for metadata mismatches, missing wheel `RECORD`, `.pth` startup hooks, custom `setup.py` install commands, and `.pyd` native extensions;
 - fetches PyPI project metadata from `GET /pypi/<project>/json`;
 - selects a default PyPI baseline release from `info.version`, falling back to newest non-yanked upload time;
 - extracts wheel/sdist download metadata and SHA-256 digests from non-yanked PyPI release files;
+- downloads the baseline wheel/sdist artifacts whose namespace matches a staged artifact through a credential-free `PyPiBroker`, so completed reviews show changed/unchanged files against the selected previous release;
 - restricts public PyPI artifact downloads to `https://files.pythonhosted.org`.
 
 The sandbox parser now supports safe ZIP archive parsing for wheels in addition to npm-style gzipped tar archives. ZIP downloads are read through a bounded stream before parsing; ZIP parsing then reads the central directory, accepts stored and deflated entries, rejects traversal paths and Zip64, enforces file/expanded-size caps, and keeps package contents as bounded text samples or binary metadata.
@@ -412,6 +413,34 @@ public-artifact allowlist, `subRequests: 0`). Because identity is derived from
 the sandbox-parsed metadata, the release-target match happens after parsing
 rather than before.
 
+### Baseline acquisition
+
+`pypiAdapter.acquireBaseline` resolves the previous release the candidate is
+diffed against. When the caller supplies `previousArtifacts` (the inline-bytes
+path used by `createPyPiReleaseCandidateReview`) those files are used directly.
+Otherwise the adapter fetches `GET /pypi/<project>/json` through the
+`PyPiBroker`, picks the baseline via `pickPyPiBaselineRelease` (`info.version`,
+falling back to the newest non-yanked upload time), and downloads the baseline
+artifacts.
+
+Downloads are bounded and credential-free:
+
+- `selectPyPiReleaseArtifacts` drops yanked files, and the URLs are filtered to
+  `https://files.pythonhosted.org` (`isAllowedPyPiArtifactUrl`).
+- Only baseline artifacts whose filename-derived namespace matches a staged
+  artifact namespace are fetched, so popular projects with dozens of platform
+  wheels don't trigger dozens of downloads; at most one artifact per namespace
+  is pulled.
+- `PyPiBroker.downloadPublicArtifact` runs each fetch through
+  `downloadInSandbox` with no npm token and a public-artifact allowlist pinned
+  to the single URL being fetched, so the `NpmStageGateway` forwards the
+  request uncredentialed. PyPI artifacts never receive npm credentials or
+  arbitrary egress.
+
+The downloaded wheel/sdist files are flattened through the same wheel/sdist
+namespaces as the candidate, so `createPackageDiff` reports changed/unchanged
+files across versions.
+
 ## Remaining work
 
 - Wire `preparePyPiReleaseCandidateForGate` into the scan pipeline so a
@@ -422,8 +451,6 @@ rather than before.
 - Add UI for workflow-gate reviews and GitHub/PyPI setup guidance.
 - Record the reviewed artifact SHA-256 digests in the persisted report
   payload (the resolver returns them; the persister doesn't store them yet).
-- Compare against prior PyPI release artifacts by downloading selected
-  `files.pythonhosted.org` URLs through the exact public-artifact allowlist.
 
 Until those items land, the PyPI code is a review engine foundation and
 testable backend slice, not an end-to-end publish gate.

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -432,10 +432,10 @@ Downloads are bounded and credential-free:
   wheels don't trigger dozens of downloads; at most one artifact per namespace
   is pulled.
 - `PyPiBroker.downloadPublicArtifact` runs each fetch through
-  `downloadInSandbox` with no npm token and a public-artifact allowlist pinned
-  to the single URL being fetched, so the `NpmStageGateway` forwards the
-  request uncredentialed. PyPI artifacts never receive npm credentials or
-  arbitrary egress.
+  `downloadInSandbox` only after re-validating the artifact host, with no npm
+  token and a public-artifact allowlist pinned to the single URL being fetched,
+  so the `NpmStageGateway` forwards the request uncredentialed. PyPI artifacts
+  never receive npm credentials or arbitrary egress.
 
 The downloaded wheel/sdist files are flattened through the same wheel/sdist
 namespaces as the candidate, so `createPackageDiff` reports changed/unchanged

--- a/server/lib/adapters/pypi/broker.ts
+++ b/server/lib/adapters/pypi/broker.ts
@@ -1,0 +1,62 @@
+import type { DownloadResult } from "../../sandbox";
+import type { AdapterBroker, AdapterConnectionRef, AdapterContext } from "../types";
+import type { PyPiArtifactKind, PyPiProjectMetadata } from "./index";
+
+export interface PyPiBrokerDownloadOptions {
+  maxFiles?: number;
+  maxBytesPerFile?: number;
+}
+
+export interface PyPiPublicArtifactRef {
+  url: string;
+  kind: PyPiArtifactKind;
+}
+
+export interface PyPiBroker extends AdapterBroker {
+  fetchProjectMetadata(projectName: string): Promise<PyPiProjectMetadata | null>;
+  downloadPublicArtifact(
+    artifact: PyPiPublicArtifactRef,
+    opts?: PyPiBrokerDownloadOptions,
+  ): Promise<DownloadResult>;
+}
+
+const PYPI_METADATA_REGISTRY = "https://pypi.org/pypi";
+
+// PyPI public artifacts carry no credentials, so unlike the npm broker this is a
+// plain object rather than a WorkerEntrypoint. The sandbox download path is
+// pulled in dynamically so node-env logic tests can import this module without
+// loading `cloudflare:workers`.
+export function createPyPiBroker(ctx: AdapterContext, _ref: AdapterConnectionRef): PyPiBroker {
+  return {
+    async fetchProjectMetadata(projectName: string): Promise<PyPiProjectMetadata | null> {
+      try {
+        const res = await fetch(
+          `${PYPI_METADATA_REGISTRY}/${encodeURIComponent(projectName)}/json`,
+          { headers: { accept: "application/json" } },
+        );
+        if (!res.ok) return null;
+        return (await res.json()) as PyPiProjectMetadata;
+      } catch {
+        return null;
+      }
+    },
+
+    async downloadPublicArtifact(
+      artifact: PyPiPublicArtifactRef,
+      opts?: PyPiBrokerDownloadOptions,
+    ): Promise<DownloadResult> {
+      const { downloadInSandbox } = await import("../../sandbox");
+      // No npm token is passed: the gateway sees only this single pinned URL on
+      // its public-artifact allowlist, so it forwards the request uncredentialed.
+      return downloadInSandbox(ctx.env, ctx.executionCtx, {
+        tarballUrl: artifact.url,
+        archiveFormat: artifact.kind === "wheel" ? "zip" : "tgz",
+        publicArtifactUrls: [artifact.url],
+        maxFiles: opts?.maxFiles,
+        maxBytesPerFile: opts?.maxBytesPerFile,
+      });
+    },
+
+    dispose(): void {},
+  };
+}

--- a/server/lib/adapters/pypi/broker.ts
+++ b/server/lib/adapters/pypi/broker.ts
@@ -22,6 +22,15 @@ export interface PyPiBroker extends AdapterBroker {
 
 const PYPI_METADATA_REGISTRY = "https://pypi.org/pypi";
 
+function isAllowedPublicPyPiArtifactUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" && parsed.hostname === "files.pythonhosted.org";
+  } catch {
+    return false;
+  }
+}
+
 // PyPI public artifacts carry no credentials, so unlike the npm broker this is a
 // plain object rather than a WorkerEntrypoint. The sandbox download path is
 // pulled in dynamically so node-env logic tests can import this module without
@@ -45,6 +54,9 @@ export function createPyPiBroker(ctx: AdapterContext, _ref: AdapterConnectionRef
       artifact: PyPiPublicArtifactRef,
       opts?: PyPiBrokerDownloadOptions,
     ): Promise<DownloadResult> {
+      if (!isAllowedPublicPyPiArtifactUrl(artifact.url)) {
+        throw new Error("PyPI public artifact URL is not allowed");
+      }
       const { downloadInSandbox } = await import("../../sandbox");
       // No npm token is passed: the gateway sees only this single pinned URL on
       // its public-artifact allowlist, so it forwards the request uncredentialed.

--- a/server/lib/adapters/pypi/index.ts
+++ b/server/lib/adapters/pypi/index.ts
@@ -12,13 +12,12 @@ import {
 } from "../../review";
 import type {
   AcquiredArtifact,
-  AdapterBroker,
-  AdapterConnectionRef,
   AdapterContext,
   BaselineInfo,
   PackageAdapter,
   StagedDetails,
 } from "../types";
+import { createPyPiBroker, type PyPiBroker } from "./broker";
 
 export const PYPI_RELEASE_MANIFEST_SCHEMA = "drydock.release-artifacts.v1";
 export const PYPI_RULES_VERSION = "0.1.0";
@@ -102,8 +101,6 @@ export interface PyPiAdapterDetails {
   preparedArtifacts: PyPiPreparedArtifact[];
 }
 
-export type PyPiBroker = AdapterBroker;
-
 export interface PyPiProjectMetadata {
   info?: { name?: string; version?: string };
   releases?: Record<string, PyPiReleaseFile[]>;
@@ -157,8 +154,8 @@ export const pypiAdapter: PackageAdapter<PyPiAdapterInput, PyPiBroker> = {
     return acquireStagedPyPi(input);
   },
 
-  async acquireBaseline(_ctx, input, _broker) {
-    return acquireBaselinePyPi(input);
+  async acquireBaseline(ctx, input, broker, staged) {
+    return acquireBaselinePyPi(ctx, input, broker, staged);
   },
 
   runFindings(args) {
@@ -188,12 +185,6 @@ export const pypiAdapter: PackageAdapter<PyPiAdapterInput, PyPiBroker> = {
     };
   },
 };
-
-export function createPyPiBroker(_ctx: AdapterContext, _ref: AdapterConnectionRef): PyPiBroker {
-  return {
-    dispose(): void {},
-  };
-}
 
 export function normalizePyPiProjectName(name: string): string {
   return name.toLowerCase().replace(/[-_.]+/g, "-");
@@ -333,7 +324,7 @@ export function createPyPiReleaseCandidateReview(input: {
 }): PyPiReleaseCandidateReview {
   const adapterInput = pypiAdapter.parseInput(input);
   const staged = acquireStagedPyPi(adapterInput);
-  const baseline = acquireBaselinePyPi(adapterInput);
+  const baseline = baselineFromPreviousArtifacts(adapterInput);
   const diff = createPackageDiff(baseline.artifact?.files ?? [], staged.artifact.files);
   const ruleFindings = redactFindings(
     pypiAdapter.runFindings({
@@ -389,65 +380,126 @@ function acquireStagedPyPi(input: PyPiAdapterInput): {
   };
 }
 
-function acquireBaselinePyPi(input: PyPiAdapterInput): {
-  artifact: AcquiredArtifact | null;
-  baseline: BaselineInfo;
-} {
+async function acquireBaselinePyPi(
+  ctx: AdapterContext,
+  input: PyPiAdapterInput,
+  broker: PyPiBroker,
+  staged: { artifact: AcquiredArtifact; details: StagedDetails },
+): Promise<{ artifact: AcquiredArtifact | null; baseline: BaselineInfo }> {
   if (input.previousArtifacts?.length) {
-    const preparedArtifacts = input.previousArtifacts.map(preparePyPiArtifact);
-    const manifest = packageJsonSummaryFor(input.manifest, preparedArtifacts);
-    return {
-      artifact: {
-        files: flattenPyPiArtifactFiles(preparedArtifacts),
-        manifest,
-      },
-      baseline: {
-        version: manifest.version ?? null,
-        tag: null,
-        source: "latest-published",
-        distTagVersion: null,
-        reason: "provided-previous-artifacts",
-      },
-    };
+    return baselineFromPreviousArtifacts(input);
   }
 
-  if (input.metadata) {
-    const selection = pickPyPiBaselineRelease(input.metadata, input.manifest.version);
-    return {
-      artifact: null,
-      baseline: {
-        version: selection.version,
-        tag: null,
-        source: selection.source,
-        distTagVersion: null,
-        reason: `${selection.reason}:not-downloaded`,
-      },
-    };
+  const metadata = input.metadata ?? (await broker.fetchProjectMetadata(input.manifest.package));
+  if (!metadata) return emptyPyPiBaseline("metadata-unavailable");
+
+  const selection = pickPyPiBaselineRelease(metadata, input.manifest.version);
+  if (!selection.version) {
+    return emptyPyPiBaseline(selection.reason, { source: selection.source });
   }
 
+  const stagedNamespaces = stagedArtifactNamespaces(staged.details);
+  const comparable = selectComparableBaselineArtifacts(
+    selectPyPiReleaseArtifacts(metadata, selection.version).filter((artifact) =>
+      isAllowedPyPiArtifactUrl(artifact.url),
+    ),
+    stagedNamespaces,
+  );
+  if (!comparable.length) {
+    return emptyPyPiBaseline(`${selection.reason}:no-comparable-artifacts`, {
+      version: selection.version,
+      source: selection.source,
+    });
+  }
+
+  const downloaded: PyPiArtifactInput[] = [];
+  for (const artifact of comparable) {
+    const result = await broker.downloadPublicArtifact({
+      url: artifact.url,
+      kind: artifact.kind,
+    });
+    downloaded.push({ path: artifact.filename, files: result.files });
+  }
+
+  const preparedArtifacts = downloaded.map(preparePyPiArtifact);
   return {
-    artifact: null,
+    artifact: {
+      files: flattenPyPiArtifactFiles(preparedArtifacts),
+      manifest: packageJsonSummaryFor(input.manifest, preparedArtifacts),
+    },
     baseline: {
-      version: null,
+      version: selection.version,
       tag: null,
-      source: "none",
+      source: selection.source,
       distTagVersion: null,
-      reason: "no-previous-artifacts",
+      reason: selection.reason,
     },
   };
 }
 
-export async function fetchPyPiProjectMetadata(
-  projectName: string,
-  options: { registryUrl?: string } = {},
-): Promise<PyPiProjectMetadata> {
-  if (!isValidPyPiProjectName(projectName)) throw new Error("invalid PyPI project name");
-  const registry = (options.registryUrl || "https://pypi.org/pypi").replace(/\/$/, "");
-  const res = await fetch(`${registry}/${encodeURIComponent(projectName)}/json`, {
-    headers: { accept: "application/json" },
-  });
-  if (!res.ok) throw new Error(`PyPI metadata fetch failed: ${res.status}`);
-  return (await res.json()) as PyPiProjectMetadata;
+function baselineFromPreviousArtifacts(input: PyPiAdapterInput): {
+  artifact: AcquiredArtifact | null;
+  baseline: BaselineInfo;
+} {
+  if (!input.previousArtifacts?.length) return emptyPyPiBaseline("no-previous-artifacts");
+  const preparedArtifacts = input.previousArtifacts.map(preparePyPiArtifact);
+  const manifest = packageJsonSummaryFor(input.manifest, preparedArtifacts);
+  return {
+    artifact: {
+      files: flattenPyPiArtifactFiles(preparedArtifacts),
+      manifest,
+    },
+    baseline: {
+      version: manifest.version ?? null,
+      tag: null,
+      source: "latest-published",
+      distTagVersion: null,
+      reason: "provided-previous-artifacts",
+    },
+  };
+}
+
+function emptyPyPiBaseline(
+  reason: string,
+  opts: { version?: string | null; source?: PyPiBaselineSelectionSource } = {},
+): { artifact: null; baseline: BaselineInfo } {
+  return {
+    artifact: null,
+    baseline: {
+      version: opts.version ?? null,
+      tag: null,
+      source: opts.source ?? "none",
+      distTagVersion: null,
+      reason,
+    },
+  };
+}
+
+// Download selection runs before any bytes are fetched, so it can only key off
+// the public filename. Both the staged artifact paths and the candidate
+// baseline filenames are reduced to the same filename-derived namespace, which
+// bounds downloads to the wheel/sdist shapes that are actually staged. The diff
+// itself re-derives namespaces from parsed WHEEL tags via artifactDiffNamespace.
+function stagedArtifactNamespaces(details: StagedDetails): Set<string> {
+  const d = details as PyPiAdapterDetails;
+  return new Set(
+    d.preparedArtifacts.map((artifact) => filenameArtifactNamespace(artifact.path, artifact.kind)),
+  );
+}
+
+function selectComparableBaselineArtifacts(
+  artifacts: PyPiRemoteArtifact[],
+  stagedNamespaces: Set<string>,
+): PyPiRemoteArtifact[] {
+  const seen = new Set<string>();
+  const selected: PyPiRemoteArtifact[] = [];
+  for (const artifact of artifacts) {
+    const namespace = filenameArtifactNamespace(artifact.filename, artifact.kind);
+    if (!stagedNamespaces.has(namespace) || seen.has(namespace)) continue;
+    seen.add(namespace);
+    selected.push(artifact);
+  }
+  return selected;
 }
 
 export function pickPyPiBaselineRelease(
@@ -713,7 +765,15 @@ function artifactDiffNamespace(artifact: PyPiPreparedArtifact): string {
   if (artifact.kind === "sdist") return "sdist";
   const tags = artifact.summary.wheel?.tags ?? [];
   if (tags.length) return `wheel/${tags.slice().sort().map(safeDiffPathPart).join("+")}`;
-  const filename = artifact.path.split("/").at(-1) ?? "";
+  return wheelFilenameNamespace(artifact.path);
+}
+
+function filenameArtifactNamespace(pathOrFilename: string, kind: PyPiArtifactKind): string {
+  return kind === "sdist" ? "sdist" : wheelFilenameNamespace(pathOrFilename);
+}
+
+function wheelFilenameNamespace(pathOrFilename: string): string {
+  const filename = pathOrFilename.split("/").at(-1) ?? "";
   const wheelTags = filename
     .replace(/\.whl$/i, "")
     .split("-")

--- a/test/pypi.test.mjs
+++ b/test/pypi.test.mjs
@@ -10,6 +10,7 @@ import {
   preparePyPiArtifact,
   selectPyPiReleaseArtifacts,
 } from "../server/lib/adapters/pypi/index.ts";
+import { createPackageDiff } from "../server/lib/review.ts";
 
 function file(path, textSample, extra = {}) {
   return {
@@ -20,6 +21,48 @@ function file(path, textSample, extra = {}) {
     textSample,
     ...extra,
   };
+}
+
+const adapterCtx = { env: {}, executionCtx: {}, db: {}, session: { userId: "user_1" } };
+
+// Network-free PyPI broker. Tests inject the project metadata and a map of
+// artifact-url -> parsed files so the adapter download path can be exercised
+// without touching pypi.org or the sandbox loader.
+function stubBroker({ metadata = null, downloads = {} } = {}) {
+  const calls = [];
+  return {
+    calls,
+    broker: {
+      async fetchProjectMetadata() {
+        return metadata;
+      },
+      async downloadPublicArtifact(artifact) {
+        calls.push(artifact);
+        const files = downloads[artifact.url];
+        if (!files) throw new Error(`unexpected download for ${artifact.url}`);
+        return { files, packageJson: null };
+      },
+      dispose() {},
+    },
+  };
+}
+
+function wheelArtifactFiles(version) {
+  return [
+    file(
+      `demo_package-${version}.dist-info/METADATA`,
+      `Metadata-Version: 2.3\nName: demo-package\nVersion: ${version}\n`,
+    ),
+    file(
+      `demo_package-${version}.dist-info/WHEEL`,
+      "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+      { sha256: "sha-wheel-metadata" },
+    ),
+    file(`demo_package-${version}.dist-info/RECORD`, "demo_package/__init__.py,,\n", {
+      sha256: "sha-wheel-record",
+    }),
+    file("demo_package/__init__.py", "VALUE = 1\n", { sha256: "sha-init-shared" }),
+  ];
 }
 
 describe("PyPI release manifests", () => {
@@ -344,10 +387,13 @@ describe("PyPI artifact summaries and review", () => {
         },
       ],
     });
-    const ctx = { env: {}, executionCtx: {}, db: {}, session: { userId: "user_1" } };
-    const broker = pypiAdapter.createBroker(ctx, { organizationId: "org_1" });
-    const staged = await pypiAdapter.acquireStaged(ctx, input, broker);
-    const baseline = await pypiAdapter.acquireBaseline(ctx, input, broker, staged);
+    const created = pypiAdapter.createBroker(adapterCtx, { organizationId: "org_1" });
+    expect(typeof created.fetchProjectMetadata).toBe("function");
+    expect(typeof created.downloadPublicArtifact).toBe("function");
+
+    const { broker, calls } = stubBroker({ metadata: null });
+    const staged = await pypiAdapter.acquireStaged(adapterCtx, input, broker);
+    const baseline = await pypiAdapter.acquireBaseline(adapterCtx, input, broker, staged);
     const summary = pypiAdapter.describe({
       input,
       staged: staged.artifact,
@@ -368,10 +414,13 @@ describe("PyPI artifact summaries and review", () => {
       "wheel/py3-none-any/.dist-info/WHEEL",
       "wheel/py3-none-any/.dist-info/RECORD",
     ]);
+    // No published metadata available -> no baseline download attempted.
+    expect(calls).toHaveLength(0);
+    expect(baseline.artifact).toBeNull();
     expect(baseline.baseline).toMatchObject({
       version: null,
       source: "none",
-      reason: "no-previous-artifacts",
+      reason: "metadata-unavailable",
     });
   });
 });
@@ -465,5 +514,145 @@ describe("PyPI registry metadata helpers", () => {
     expect(isAllowedPyPiArtifactUrl("https://files.pythonhosted.org/packages/demo.whl")).toBe(true);
     expect(isAllowedPyPiArtifactUrl("https://example.com/packages/demo.whl")).toBe(false);
     expect(isAllowedPyPiArtifactUrl("http://files.pythonhosted.org/packages/demo.whl")).toBe(false);
+  });
+});
+
+describe("PyPI baseline acquisition through the broker", () => {
+  const candidateManifest = (artifacts) =>
+    parsePyPiReleaseManifest({
+      schema: "drydock.release-artifacts.v1",
+      ecosystem: "pypi",
+      package: "demo-package",
+      version: "1.2.0",
+      artifacts,
+    });
+
+  test("downloads the selected previous release and namespaces baseline files for diffing", async () => {
+    const wheelUrl = "https://files.pythonhosted.org/packages/demo_package-1.1.0-py3-none-any.whl";
+    const manifest = candidateManifest([
+      { path: "dist/demo_package-1.2.0-py3-none-any.whl", sha256: "a".repeat(64) },
+    ]);
+    const input = pypiAdapter.parseInput({
+      manifest,
+      artifacts: [
+        { path: "dist/demo_package-1.2.0-py3-none-any.whl", files: wheelArtifactFiles("1.2.0") },
+      ],
+    });
+    const { broker, calls } = stubBroker({
+      metadata: {
+        info: { version: "1.1.0" },
+        releases: {
+          "1.1.0": [
+            {
+              filename: "demo_package-1.1.0-py3-none-any.whl",
+              packagetype: "bdist_wheel",
+              url: wheelUrl,
+              digests: { sha256: "c".repeat(64) },
+              upload_time_iso_8601: "2026-02-01T00:00:00.000Z",
+            },
+          ],
+        },
+      },
+      downloads: { [wheelUrl]: wheelArtifactFiles("1.1.0") },
+    });
+
+    const staged = await pypiAdapter.acquireStaged(adapterCtx, input, broker);
+    const baseline = await pypiAdapter.acquireBaseline(adapterCtx, input, broker, staged);
+
+    expect(calls).toEqual([{ url: wheelUrl, kind: "wheel" }]);
+    expect(baseline.baseline).toMatchObject({
+      version: "1.1.0",
+      source: "latest-published",
+      reason: "project-json-info-version",
+    });
+
+    const diff = createPackageDiff(baseline.artifact.files, staged.artifact.files);
+    expect(diff).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          path: "wheel/py3-none-any/demo_package/__init__.py",
+          status: "unchanged",
+        }),
+        expect.objectContaining({
+          path: "wheel/py3-none-any/.dist-info/METADATA",
+          status: "modified",
+        }),
+      ]),
+    );
+  });
+
+  test("skips yanked baseline files and only downloads staged artifact namespaces", async () => {
+    const wheelUrl = "https://files.pythonhosted.org/packages/demo_package-1.1.0-py3-none-any.whl";
+    const manifest = candidateManifest([
+      { path: "dist/demo_package-1.2.0-py3-none-any.whl", sha256: "a".repeat(64) },
+      { path: "dist/demo_package-1.2.0.tar.gz", sha256: "b".repeat(64) },
+    ]);
+    const input = pypiAdapter.parseInput({
+      manifest,
+      artifacts: [
+        { path: "dist/demo_package-1.2.0-py3-none-any.whl", files: wheelArtifactFiles("1.2.0") },
+        {
+          path: "dist/demo_package-1.2.0.tar.gz",
+          files: [
+            file(
+              "demo_package-1.2.0/PKG-INFO",
+              "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n",
+            ),
+            file("demo_package-1.2.0/demo_package/__init__.py", "VALUE = 1\n", {
+              sha256: "sha-sdist-init",
+            }),
+          ],
+        },
+      ],
+    });
+    const { broker, calls } = stubBroker({
+      metadata: {
+        info: { version: "1.1.0" },
+        releases: {
+          "1.1.0": [
+            {
+              filename: "demo_package-1.1.0-py3-none-any.whl",
+              packagetype: "bdist_wheel",
+              url: wheelUrl,
+              digests: { sha256: "c".repeat(64) },
+              upload_time_iso_8601: "2026-02-01T00:00:00.000Z",
+            },
+            {
+              filename: "demo_package-1.1.0.tar.gz",
+              packagetype: "sdist",
+              url: "https://files.pythonhosted.org/packages/demo_package-1.1.0.tar.gz",
+              digests: { sha256: "d".repeat(64) },
+              upload_time_iso_8601: "2026-02-01T00:00:00.000Z",
+              yanked: true,
+            },
+            {
+              filename: "demo_package-1.1.0-cp39-cp39-manylinux1_x86_64.whl",
+              packagetype: "bdist_wheel",
+              url: "https://files.pythonhosted.org/packages/demo_package-1.1.0-cp39-cp39-manylinux1_x86_64.whl",
+              digests: { sha256: "e".repeat(64) },
+              upload_time_iso_8601: "2026-02-01T00:00:00.000Z",
+            },
+            {
+              filename: "demo_package-1.1.0-py3-none-any.whl",
+              packagetype: "bdist_wheel",
+              url: "https://evil.example.com/demo_package-1.1.0-py3-none-any.whl",
+              digests: { sha256: "f".repeat(64) },
+              upload_time_iso_8601: "2026-02-01T00:00:00.000Z",
+            },
+          ],
+        },
+      },
+      downloads: { [wheelUrl]: wheelArtifactFiles("1.1.0") },
+    });
+
+    const staged = await pypiAdapter.acquireStaged(adapterCtx, input, broker);
+    const baseline = await pypiAdapter.acquireBaseline(adapterCtx, input, broker, staged);
+
+    // Yanked sdist, off-host wheel, and the unstaged manylinux namespace are all
+    // excluded; only the staged py3-none-any wheel is fetched.
+    expect(calls).toEqual([{ url: wheelUrl, kind: "wheel" }]);
+    expect(
+      baseline.artifact.files.every((entry) => entry.path.startsWith("wheel/py3-none-any/")),
+    ).toBe(true);
   });
 });

--- a/test/workers/pypi-broker.test.ts
+++ b/test/workers/pypi-broker.test.ts
@@ -117,6 +117,21 @@ describe("createPyPiBroker public artifact download", () => {
     ).rejects.toThrow();
     expect(loader.loads).toHaveLength(0);
   });
+
+  test("rejects foreign HTTPS artifact URLs before loading the sandbox", async () => {
+    const loader = buildLoaderMock();
+    const { ctx, gatewayProps } = buildCtxWithGateway();
+    const broker = createPyPiBroker(brokerCtx(ctx, loader.binding), { organizationId: "org_1" });
+
+    await expect(
+      broker.downloadPublicArtifact({
+        url: "https://example.com/packages/a.whl",
+        kind: "wheel",
+      }),
+    ).rejects.toThrow(/not allowed/);
+    expect(loader.loads).toHaveLength(0);
+    expect(gatewayProps).toHaveLength(0);
+  });
 });
 
 describe("createPyPiBroker project metadata", () => {

--- a/test/workers/pypi-broker.test.ts
+++ b/test/workers/pypi-broker.test.ts
@@ -1,0 +1,151 @@
+import { createExecutionContext, env } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { createPyPiBroker } from "../../server/lib/adapters/pypi/broker";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+interface LoadConfig {
+  env: Record<string, unknown>;
+}
+
+function buildLoaderMock() {
+  const loads: LoadConfig[] = [];
+  return {
+    loads,
+    binding: {
+      load: vi.fn((config: LoadConfig) => {
+        loads.push(config);
+        return {
+          getEntrypoint: () => ({
+            fetch: vi.fn(
+              async () =>
+                new Response(
+                  JSON.stringify({
+                    files: [{ path: "stub.txt", size: 1, sha256: "00", flags: [] }],
+                    packageJson: null,
+                  }),
+                  { status: 200, headers: { "content-type": "application/json" } },
+                ),
+            ),
+          }),
+        };
+      }),
+    },
+  };
+}
+
+interface GatewayProps {
+  npmToken?: string;
+  npmRegistry?: string;
+  publicArtifactUrls?: string[];
+}
+
+function buildCtxWithGateway() {
+  const gatewayProps: GatewayProps[] = [];
+  const ctx = createExecutionContext() as ExecutionContext & {
+    exports: { NpmStageGateway(options: { props: GatewayProps }): Fetcher };
+  };
+  ctx.exports = {
+    NpmStageGateway: vi.fn((options: { props: GatewayProps }) => {
+      gatewayProps.push(options.props);
+      return { fetch: vi.fn() } as unknown as Fetcher;
+    }),
+  };
+  return { ctx, gatewayProps };
+}
+
+function brokerCtx(executionCtx: ExecutionContext, loaderBinding: unknown) {
+  return {
+    env: { ...env, LOADER: loaderBinding } as Cloudflare.Env,
+    executionCtx,
+    db: {} as never,
+    session: {} as never,
+  };
+}
+
+describe("createPyPiBroker public artifact download", () => {
+  test("downloads a wheel as zip through an uncredentialed, URL-pinned gateway", async () => {
+    const wheelUrl = "https://files.pythonhosted.org/packages/demo-1.1.0-py3-none-any.whl";
+    const loader = buildLoaderMock();
+    const { ctx, gatewayProps } = buildCtxWithGateway();
+    const broker = createPyPiBroker(brokerCtx(ctx, loader.binding), { organizationId: "org_1" });
+
+    const result = await broker.downloadPublicArtifact({ url: wheelUrl, kind: "wheel" });
+
+    expect(result.files).toHaveLength(1);
+    expect(loader.loads).toHaveLength(1);
+    expect(loader.loads[0].env.ARCHIVE_FORMAT).toBe("zip");
+    // The gateway must never receive an npm token, and its public-artifact
+    // allowlist must contain exactly the single URL being fetched.
+    expect(gatewayProps).toHaveLength(1);
+    expect(gatewayProps[0].npmToken).toBeUndefined();
+    expect(gatewayProps[0].publicArtifactUrls).toEqual([wheelUrl]);
+  });
+
+  test("downloads an sdist as tgz", async () => {
+    const sdistUrl = "https://files.pythonhosted.org/packages/demo-1.1.0.tar.gz";
+    const loader = buildLoaderMock();
+    const { ctx, gatewayProps } = buildCtxWithGateway();
+    const broker = createPyPiBroker(brokerCtx(ctx, loader.binding), { organizationId: "org_1" });
+
+    await broker.downloadPublicArtifact({ url: sdistUrl, kind: "sdist" });
+
+    expect(loader.loads[0].env.ARCHIVE_FORMAT).toBe("tgz");
+    expect(gatewayProps[0].npmToken).toBeUndefined();
+    expect(gatewayProps[0].publicArtifactUrls).toEqual([sdistUrl]);
+  });
+
+  test("rejects non-https artifact URLs before loading the sandbox", async () => {
+    const loader = buildLoaderMock();
+    const { ctx } = buildCtxWithGateway();
+    const broker = createPyPiBroker(brokerCtx(ctx, loader.binding), { organizationId: "org_1" });
+
+    await expect(
+      broker.downloadPublicArtifact({
+        url: "http://files.pythonhosted.org/packages/a.whl",
+        kind: "wheel",
+      }),
+    ).rejects.toThrow();
+    expect(loader.loads).toHaveLength(0);
+  });
+});
+
+describe("createPyPiBroker project metadata", () => {
+  test("returns parsed metadata from pypi.org", async () => {
+    const fetchSpy = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input instanceof Request ? input.url : String(input);
+      expect(url).toBe("https://pypi.org/pypi/demo-package/json");
+      return Response.json({ info: { name: "demo-package", version: "1.1.0" } });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const { ctx } = buildCtxWithGateway();
+    const loader = buildLoaderMock();
+    const broker = createPyPiBroker(brokerCtx(ctx, loader.binding), { organizationId: "org_1" });
+
+    const metadata = await broker.fetchProjectMetadata("demo-package");
+    expect(metadata?.info?.version).toBe("1.1.0");
+  });
+
+  test("returns null when pypi.org responds with an error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("not found", { status: 404 })),
+    );
+
+    const { ctx } = buildCtxWithGateway();
+    const loader = buildLoaderMock();
+    const broker = createPyPiBroker(brokerCtx(ctx, loader.binding), { organizationId: "org_1" });
+
+    expect(await broker.fetchProjectMetadata("missing-package")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a credential-free `PyPiBroker` (`server/lib/adapters/pypi/broker.ts`) that fetches project metadata from `pypi.org` and downloads non-yanked wheel/sdist artifacts from `files.pythonhosted.org` through a single-URL public-artifact allowlist, so the sandbox never receives npm credentials or arbitrary egress.
- Rewrites PyPI baseline acquisition in `server/lib/adapters/pypi/index.ts` to select a previous release (from `info.version`, falling back to newest non-yanked upload), skip yanked files, and download only baseline artifacts whose filename-namespace matches a staged artifact so completed reviews show changed/unchanged files against the prior release.
- Adds node logic tests (`test/pypi.test.mjs`) for broker-driven baseline diffing and yanked/off-host/namespace bounding, plus a workerd invariant test (`test/workers/pypi-broker.test.ts`) asserting the gateway gets no npm token and an exact-URL allowlist.
- Updates `docs/pypi-workflow-gate.md` to document baseline acquisition and remove the now-completed remaining-work item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)