### PR TITLE
Run PyPI workflow gate reviews via the scan queue

### DIFF
--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -419,9 +419,9 @@ and the consumer re-checks gate status, so a re-enqueue is safe.
 1. Read the GitHub App config. A `GithubAppConfigError` leaves the gate pending
    and returns without retrying (a misconfigured app won't fix itself on retry).
 2. Load the gate. A gate that is already `approved`/`rejected` triggers a
-   best-effort **redelivery** of the stored decision to GitHub (idempotent
-   re-POST) instead of re-running the review; a non-pending, non-decided status
-   is skipped with a warning.
+   **redelivery** of the stored decision to GitHub (idempotent re-POST) instead
+   of re-running the review; callback failures rethrow so the queue retries. A
+   non-pending, non-decided status is skipped with a warning.
 3. Record `github_workflow_gate.received`.
 4. Call `preparePyPiReleaseCandidateForGate` to resolve + verify the bundle.
    - A `WorkflowArtifactError` (incl. a tampered `artifact_digest_mismatch`)

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -403,13 +403,63 @@ verified wheel/sdist bytes cross the trust boundary through
 `downloadInSandboxInline`, which constructs the `NpmStageGateway` with empty
 props (no npm token, no public-artifact allowlist, `subRequests: 0`).
 
+### Running the gate review (queue consumer)
+
+The webhook does not run the review inline. When a `deployment_protection_rule`
+delivery resolves to a pending gate, `POST /webhooks/github` enqueues a
+`{ kind: "workflow_gate", organizationId, gateId }` message onto `SCAN_QUEUE`
+(the same queue npm scans use). The Worker's `queue` handler routes that
+message to `executeWorkflowGateJob` in `server/lib/workflow-gate-job.ts`; the
+existing `ScanQueueMessage` path is unchanged. `SCAN_QUEUE` is optional in
+tests/local, so the enqueue is guarded — GitHub retries any non-2xx delivery
+and the consumer re-checks gate status, so a re-enqueue is safe.
+
+`executeWorkflowGateJob` runs the full pipeline for one gate:
+
+1. Read the GitHub App config. A `GithubAppConfigError` leaves the gate pending
+   and returns without retrying (a misconfigured app won't fix itself on retry).
+2. Load the gate. A gate that is already `approved`/`rejected` triggers a
+   best-effort **redelivery** of the stored decision to GitHub (idempotent
+   re-POST) instead of re-running the review; a non-pending, non-decided status
+   is skipped with a warning.
+3. Record `github_workflow_gate.received`.
+4. Call `preparePyPiReleaseCandidateForGate` to resolve + verify the bundle.
+   - A `WorkflowArtifactError` (incl. a tampered `artifact_digest_mismatch`)
+     **rejects** the gate with a generic comment, records
+     `github_workflow_gate.rejected`, and POSTs the rejection. `prepare`
+     already recorded the typed `failureReason` and kept the gate pending, so
+     the `markGateDecided` CAS still fires.
+   - Any other error (sandbox/review failure) leaves the gate **pending**,
+     records `github_workflow_gate.review_failed`, and returns without POSTing —
+     we never auto-approve on error, and the operator can retry.
+5. Resolve the organization owner (so the persisted scan has an owner). A
+   missing owner records `review_failed` and leaves the gate pending.
+6. Create a scan job (`source: "workflow_gate"`, synthetic
+   `stageId: "workflow-gate:<gateId>"`), link it to the gate via
+   `attachScanToGate`, and run `runScanPipeline` with the `pypiAdapter` over the
+   verified manifest + artifacts. A pipeline throw marks the scan failed,
+   records `review_failed`, and leaves the gate pending.
+7. Map the release risk to a decision: `high`/`critical` → **rejected**,
+   otherwise **approved**. Record `github_workflow_gate.reviewed`.
+8. `markGateDecided` (CAS on `pending`) stores the decision, comment, and report
+   URL (`<BETTER_AUTH_URL>/dashboard/scans/<scanId>`); a `null` return means a
+   concurrent delivery already decided the gate, so we stop. Otherwise
+   `postDeploymentProtectionDecision` POSTs the approve/reject callback and we
+   record `github_workflow_gate.approved` / `.rejected` plus
+   `github_workflow_gate.decided`.
+
+Because `markGateDecided` is the single CAS out of `pending`, a fresh-decision
+POST failure rethrows so the queue retries; the retry then falls into the
+already-decided redelivery path (step 2) rather than re-running the review or
+double-deciding.
+
+The persisted review is an ordinary `scans` row scoped to the org with
+`source: "workflow_gate"`, reachable at `/dashboard/scans/<scanId>` — no
+separate review table. The gate row already links scan ↔ release target, so no
+schema change was needed.
+
 ## Remaining work
 
-- Wire `preparePyPiReleaseCandidateForGate` into the scan pipeline so a
-  resolved gate runs `pypiAdapter` to completion, persists the report, and
-  calls `markGateDecided` / `postDeploymentProtectionDecision`.
-- Persist workflow-gate reviews separately from npm `stageId` scans or
-  generalize the scan schema around `release_candidate` records.
 - Add UI for workflow-gate reviews and GitHub/PyPI setup guidance.
 - Record the reviewed artifact SHA-256 digests in the persisted report
   payload (the resolver returns them; the persister doesn't store them yet).

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -67,7 +67,7 @@ export interface CreateScanJobInput {
   source?: ScanSource;
 }
 
-export const SCAN_SOURCES = ["manual", "auto_discovery"] as const;
+export const SCAN_SOURCES = ["manual", "auto_discovery", "workflow_gate"] as const;
 export type ScanSource = (typeof SCAN_SOURCES)[number];
 
 export interface AuditEventInput {

--- a/server/env.d.ts
+++ b/server/env.d.ts
@@ -6,7 +6,7 @@ declare global {
       LOADER: WorkerLoader;
       DB: D1Database;
       COMPARE_CACHE?: KVNamespace;
-      SCAN_QUEUE?: Queue<import("./lib/scan-job").ScanQueueMessage>;
+      SCAN_QUEUE?: Queue<import("./lib/scan-job").QueueMessage>;
       NPM_REGISTRY: string;
       ALLOW_INSECURE_LOCAL_REGISTRY?: string;
       NPM_CONNECTIONS_ENCRYPTION_KEY?: string;

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,14 +10,20 @@ import { createAuth, getAuthSession } from "./lib/auth";
 import { errorMessage } from "./lib/errors";
 import { rateLimitResponse } from "./lib/http";
 import { allowInsecureLocalRegistry } from "./lib/npm-connection";
-import { durationMsSince, emitOperationalEvent } from "./lib/observability";
+import {
+  describeOperationalError,
+  durationMsSince,
+  emitOperationalEvent,
+} from "./lib/observability";
 import {
   classifyScanError,
   executeScanJob,
+  isWorkflowGateMessage,
   MAX_SCAN_JOB_ATTEMPTS,
   retryDelaySeconds,
-  type ScanQueueMessage,
+  type QueueMessage,
 } from "./lib/scan-job";
+import { executeWorkflowGateJob } from "./lib/workflow-gate-job";
 import {
   discoverAndQueueStagedPublishes,
   ensureUsableNpmConnection,
@@ -290,9 +296,42 @@ export default {
   async scheduled(_event: ScheduledController, env: Cloudflare.Env, ctx: ExecutionContext) {
     await runStagedPublishesDiscoveryCron(env, ctx);
   },
-  async queue(batch: MessageBatch<ScanQueueMessage>, env: Cloudflare.Env, ctx: ExecutionContext) {
+  async queue(batch: MessageBatch<QueueMessage>, env: Cloudflare.Env, ctx: ExecutionContext) {
     for (const message of batch.messages) {
       const messageStartedAtMs = Date.now();
+      if (isWorkflowGateMessage(message.body)) {
+        const gateMessage = message.body;
+        try {
+          await executeWorkflowGateJob(env, ctx, gateMessage);
+          emitOperationalEvent("info", "workflow_gate.queue.message.completed", {
+            organizationId: gateMessage.organizationId,
+            gateId: gateMessage.gateId,
+            attempt: message.attempts,
+            durationMs: durationMsSince(messageStartedAtMs),
+          });
+        } catch (err) {
+          if (message.attempts < MAX_SCAN_JOB_ATTEMPTS) {
+            message.retry({ delaySeconds: retryDelaySeconds(message.attempts) });
+            emitOperationalEvent("warn", "workflow_gate.queue.retry_scheduled", {
+              organizationId: gateMessage.organizationId,
+              gateId: gateMessage.gateId,
+              attempt: message.attempts,
+              nextDelaySeconds: retryDelaySeconds(message.attempts),
+              durationMs: durationMsSince(messageStartedAtMs),
+              error: describeOperationalError(err),
+            });
+          } else {
+            emitOperationalEvent("error", "workflow_gate.queue.message_failed", {
+              organizationId: gateMessage.organizationId,
+              gateId: gateMessage.gateId,
+              attempt: message.attempts,
+              durationMs: durationMsSince(messageStartedAtMs),
+              error: describeOperationalError(err),
+            });
+          }
+        }
+        continue;
+      }
       try {
         await executeScanJob(env, ctx, message.body, undefined, {
           attempt: message.attempts,

--- a/server/index.ts
+++ b/server/index.ts
@@ -328,6 +328,7 @@ export default {
               durationMs: durationMsSince(messageStartedAtMs),
               error: describeOperationalError(err),
             });
+            throw err;
           }
         }
         continue;

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -573,6 +573,7 @@ export function annotateFindingsWithDiffStatus<
 function isReleaseScopedFinding(finding: { ruleId?: string | null }): boolean {
   return Boolean(
     finding.ruleId?.startsWith("stage.") ||
+    finding.ruleId?.startsWith("pypi.") ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.dependencyUnusualSpec ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.dependencyOptionalAdded ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.diffCredentialFileAdded ||

--- a/server/lib/scan-job.ts
+++ b/server/lib/scan-job.ts
@@ -25,6 +25,24 @@ export interface ScanQueueMessage extends ScanInput {
   source?: ScanSource;
 }
 
+/**
+ * A resolved PyPI workflow gate to review. The gate row already holds the
+ * installation, release target, run, and callback URL, so the message only
+ * needs to point at it. `kind` discriminates this from the npm scan messages
+ * that flow over the same queue.
+ */
+export interface WorkflowGateQueueMessage {
+  kind: "workflow_gate";
+  organizationId: string;
+  gateId: string;
+}
+
+export type QueueMessage = ScanQueueMessage | WorkflowGateQueueMessage;
+
+export function isWorkflowGateMessage(message: QueueMessage): message is WorkflowGateQueueMessage {
+  return "kind" in message && message.kind === "workflow_gate";
+}
+
 export const MAX_SCAN_JOB_ATTEMPTS = 3;
 
 export interface SafeScanError {

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -23,6 +23,9 @@ import type { ScanInput, ScanResult } from "../types";
 export interface ScanPipelineOptions extends ScanInput {
   scanId?: string;
   organizationId: string;
+  // Adapters parse their own input shape off this object (e.g. the PyPI adapter
+  // reads `manifest`/`artifacts`), so allow extra keys to flow through untyped.
+  [key: string]: unknown;
 }
 
 export interface ScanPipelineContext {

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -292,9 +292,9 @@ async function rejectGateForArtifactError(
 }
 
 /**
- * Best-effort re-delivery of a gate that a previous delivery already decided.
- * Swallows callback errors so an already-decided gate cannot trap the queue in
- * a retry loop — the decision is durable in the row regardless.
+ * Re-delivery of a gate that a previous delivery already decided. Callback
+ * errors are rethrown so the queue can retry until GitHub receives the durable
+ * decision.
  */
 async function redeliverGateDecision(
   config: GithubAppConfig,
@@ -314,6 +314,7 @@ async function redeliverGateDecision(
       gateId: gate.id,
       error: describeOperationalError(err),
     });
+    throw err;
   }
 }
 

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -1,0 +1,380 @@
+import { and, eq } from "drizzle-orm";
+import {
+  createDb,
+  createScanJob,
+  getOrganizationOwnerUserId,
+  markScanFailed,
+  recordScanEvent,
+  type AppDb,
+} from "../db";
+import { githubAppInstallations } from "../db/schema";
+import { pypiAdapter } from "./adapters/pypi/index";
+import { WorkflowArtifactError } from "./github-app-artifacts";
+import { GithubAppConfigError, readGithubAppConfig, type GithubAppConfig } from "./github-app";
+import {
+  attachScanToGate,
+  getGateForOrganization,
+  markGateDecided,
+  postDeploymentProtectionDecision,
+  type WorkflowGateRecord,
+} from "./github-app-webhook";
+import { describeOperationalError, durationMsSince, emitOperationalEvent } from "./observability";
+import { preparePyPiReleaseCandidateForGate } from "./release-candidate-pypi";
+import type { RiskLevel } from "./review";
+import { runScanPipeline } from "./scan-pipeline";
+import { classifyScanError, type WorkflowGateQueueMessage } from "./scan-job";
+
+// A release whose changed (release-delta) findings reach these levels must not
+// auto-publish; everything below is approved. The threshold is intentionally a
+// product decision held in one place so it is easy to tune.
+const BLOCKING_RISKS: ReadonlySet<RiskLevel> = new Set<RiskLevel>(["high", "critical"]);
+
+function decisionForReleaseRisk(releaseRisk: RiskLevel): "approved" | "rejected" {
+  return BLOCKING_RISKS.has(releaseRisk) ? "rejected" : "approved";
+}
+
+/**
+ * Review a resolved PyPI workflow gate end to end and tell GitHub whether the
+ * deployment may proceed.
+ *
+ * Trust boundary: the installation token never enters the sandbox. Artifact
+ * bytes are fetched + SHA-256-verified in the control plane (`prepare…`), then
+ * the credentials-free sandbox parser turns them into evidence the existing
+ * deterministic rules run against via `runScanPipeline`.
+ *
+ * Failure handling matches the gate contract:
+ *  - Artifact-level problems (`WorkflowArtifactError`, including a tampered
+ *    manifest digest) → the deployment is REJECTED with a generic comment.
+ *  - Review/processing errors → the deployment is left PENDING (never
+ *    auto-approved on error); the failure is recorded and surfaced.
+ *  - The GitHub callback is delivered idempotently: `markGateDecided` is a CAS
+ *    on the pending row, and an already-decided gate re-delivers its stored
+ *    decision so a transient callback failure can be retried without re-running
+ *    the review.
+ */
+export async function executeWorkflowGateJob(
+  env: Cloudflare.Env,
+  executionCtx: ExecutionContext,
+  message: WorkflowGateQueueMessage,
+  db: AppDb = createDb(env.DB),
+): Promise<void> {
+  const startedAtMs = Date.now();
+  const { organizationId, gateId } = message;
+
+  let config: GithubAppConfig;
+  try {
+    config = readGithubAppConfig(env);
+  } catch (err) {
+    // Without app credentials we can neither fetch artifacts nor post the
+    // callback. Leave the gate pending and surface the misconfiguration; there
+    // is nothing a retry can fix.
+    emitOperationalEvent("error", "github_workflow_gate.config_error", {
+      organizationId,
+      gateId,
+      message: err instanceof GithubAppConfigError ? err.message : describeOperationalError(err),
+    });
+    return;
+  }
+
+  const gate = await getGateForOrganization(db, organizationId, gateId);
+  if (!gate) {
+    emitOperationalEvent("warn", "github_workflow_gate.job_skipped", {
+      organizationId,
+      gateId,
+      reason: "gate_not_found",
+    });
+    return;
+  }
+
+  // A prior delivery already decided this gate. Re-deliver the stored decision
+  // to GitHub (best effort) in case that delivery's callback POST failed, then
+  // ack — we never re-run the review for a decided gate.
+  if (gate.status === "approved" || gate.status === "rejected") {
+    await redeliverGateDecision(config, db, gate);
+    return;
+  }
+  if (gate.status !== "pending") {
+    emitOperationalEvent("warn", "github_workflow_gate.job_skipped", {
+      organizationId,
+      gateId,
+      reason: `status_${gate.status}`,
+    });
+    return;
+  }
+
+  await recordScanEvent(db, {
+    organizationId,
+    scanId: gate.scanId,
+    type: "github_workflow_gate.received",
+    metadata: {
+      gateId: gate.id,
+      repositoryFullName: gate.repositoryFullName,
+      environment: gate.environment,
+      runId: gate.runId,
+    },
+  });
+
+  let prepared;
+  try {
+    prepared = await preparePyPiReleaseCandidateForGate(env, executionCtx, db, {
+      config,
+      organizationId,
+      gateId,
+    });
+  } catch (err) {
+    if (err instanceof WorkflowArtifactError) {
+      // The published artifacts could not be verified against the reviewed
+      // manifest (missing bundle, tampered digest, package mismatch, …). Block
+      // the deployment with a generic comment; the typed reason is already
+      // stored on the gate by `preparePyPiReleaseCandidateForGate`.
+      await rejectGateForArtifactError(env, db, config, gate, err);
+      emitOperationalEvent("warn", "github_workflow_gate.rejected_artifact_error", {
+        organizationId,
+        gateId,
+        reason: err.code,
+        durationMs: durationMsSince(startedAtMs),
+      });
+      return;
+    }
+    // A review/processing error (e.g. the sandbox parser). Leave the deployment
+    // pending so GitHub waits for a human; record the failure for the dashboard.
+    const safe = classifyScanError(err);
+    await recordScanEvent(db, {
+      organizationId,
+      scanId: gate.scanId,
+      type: "github_workflow_gate.review_failed",
+      metadata: { gateId: gate.id, error: safe },
+    });
+    emitOperationalEvent("error", "github_workflow_gate.review_failed", {
+      organizationId,
+      gateId,
+      durationMs: durationMsSince(startedAtMs),
+      error: safe,
+    });
+    return;
+  }
+
+  const ownerUserId = await getOrganizationOwnerUserId(db, organizationId);
+  if (!ownerUserId) {
+    await recordScanEvent(db, {
+      organizationId,
+      type: "github_workflow_gate.review_failed",
+      metadata: { gateId: gate.id, error: { code: "organization_owner_missing" } },
+    });
+    emitOperationalEvent("error", "github_workflow_gate.review_failed", {
+      organizationId,
+      gateId,
+      reason: "organization_owner_missing",
+    });
+    return;
+  }
+
+  const scanId = crypto.randomUUID();
+  const stageId = `workflow-gate:${gate.id}`;
+  await createScanJob(db, {
+    id: scanId,
+    stageId,
+    organizationId,
+    ownerUserId,
+    source: "workflow_gate",
+  });
+  await attachScanToGate(db, gate.id, scanId);
+
+  let result;
+  try {
+    result = await runScanPipeline(
+      { env, executionCtx, db, session: { userId: ownerUserId } },
+      pypiAdapter,
+      {
+        scanId,
+        stageId,
+        organizationId,
+        manifest: prepared.adapterInput.manifest,
+        artifacts: prepared.adapterInput.artifacts,
+      },
+    );
+  } catch (err) {
+    const safe = classifyScanError(err);
+    await markScanFailed(db, scanId, organizationId, safe);
+    await recordScanEvent(db, {
+      organizationId,
+      actorUserId: ownerUserId,
+      scanId,
+      type: "github_workflow_gate.review_failed",
+      metadata: { gateId: gate.id, error: safe },
+    });
+    emitOperationalEvent("error", "github_workflow_gate.review_failed", {
+      organizationId,
+      gateId,
+      scanId,
+      durationMs: durationMsSince(startedAtMs),
+      error: safe,
+    });
+    return;
+  }
+
+  const releaseRisk = result.riskSummary.releaseRisk;
+  const decision = decisionForReleaseRisk(releaseRisk);
+  const reportUrl = buildReportUrl(env, scanId);
+
+  await recordScanEvent(db, {
+    organizationId,
+    actorUserId: ownerUserId,
+    scanId,
+    type: "github_workflow_gate.reviewed",
+    metadata: {
+      gateId: gate.id,
+      decision,
+      releaseRisk,
+      artifactRisk: result.risk,
+      contextRisk: result.riskSummary.contextRisk,
+      packageName: result.package.name,
+      stagedVersion: result.package.stagedVersion,
+    },
+  });
+
+  const comment = buildDecisionComment(decision, result.package.name, releaseRisk, reportUrl);
+  const decided = await markGateDecided(db, { gateId: gate.id, decision, comment, reportUrl });
+  if (!decided) {
+    // Another delivery decided this gate first; it owns the callback.
+    emitOperationalEvent("info", "github_workflow_gate.decision_skipped", {
+      organizationId,
+      gateId,
+      reason: "already_decided",
+    });
+    return;
+  }
+
+  await deliverGateDecision(config, db, decided);
+
+  await recordScanEvent(db, {
+    organizationId,
+    actorUserId: ownerUserId,
+    scanId,
+    type:
+      decision === "approved" ? "github_workflow_gate.approved" : "github_workflow_gate.rejected",
+    metadata: { gateId: gate.id, releaseRisk, reportUrl },
+  });
+  emitOperationalEvent("info", "github_workflow_gate.decided", {
+    organizationId,
+    gateId,
+    scanId,
+    decision,
+    releaseRisk,
+    durationMs: durationMsSince(startedAtMs),
+  });
+}
+
+// ── Internals ────────────────────────────────────────────────────────────────
+
+async function rejectGateForArtifactError(
+  env: Cloudflare.Env,
+  db: AppDb,
+  config: GithubAppConfig,
+  gate: WorkflowGateRecord,
+  error: WorkflowArtifactError,
+): Promise<void> {
+  const comment =
+    "Drydock blocked this release: the published artifacts could not be verified against the reviewed manifest.";
+  const decided = await markGateDecided(db, {
+    gateId: gate.id,
+    decision: "rejected",
+    comment,
+    reportUrl: null,
+  });
+  if (!decided) return;
+  await deliverGateDecision(config, db, decided);
+  await recordScanEvent(db, {
+    organizationId: gate.organizationId,
+    type: "github_workflow_gate.rejected",
+    metadata: { gateId: gate.id, reason: error.code },
+  });
+}
+
+/**
+ * Best-effort re-delivery of a gate that a previous delivery already decided.
+ * Swallows callback errors so an already-decided gate cannot trap the queue in
+ * a retry loop — the decision is durable in the row regardless.
+ */
+async function redeliverGateDecision(
+  config: GithubAppConfig,
+  db: AppDb,
+  gate: WorkflowGateRecord,
+): Promise<void> {
+  try {
+    await deliverGateDecision(config, db, gate);
+    emitOperationalEvent("info", "github_workflow_gate.decision_redelivered", {
+      organizationId: gate.organizationId,
+      gateId: gate.id,
+      decision: gate.decision,
+    });
+  } catch (err) {
+    emitOperationalEvent("warn", "github_workflow_gate.redelivery_failed", {
+      organizationId: gate.organizationId,
+      gateId: gate.id,
+      error: describeOperationalError(err),
+    });
+  }
+}
+
+async function deliverGateDecision(
+  config: GithubAppConfig,
+  db: AppDb,
+  gate: WorkflowGateRecord,
+): Promise<void> {
+  if (gate.decision !== "approved" && gate.decision !== "rejected") {
+    throw new Error(`gate ${gate.id} has no decision to deliver`);
+  }
+  const installationExternalId = await getInstallationExternalId(
+    db,
+    gate.installationRowId,
+    gate.organizationId,
+  );
+  if (!installationExternalId) {
+    throw new Error(`installation row ${gate.installationRowId} missing for gate ${gate.id}`);
+  }
+  await postDeploymentProtectionDecision({
+    config,
+    installationExternalId,
+    callbackUrl: gate.deploymentCallbackUrl,
+    environment: gate.environment,
+    state: gate.decision,
+    comment: gate.decisionComment ?? "",
+  });
+}
+
+async function getInstallationExternalId(
+  db: AppDb,
+  installationRowId: string,
+  organizationId: string,
+): Promise<string | null> {
+  const [row] = await db
+    .select({ installationId: githubAppInstallations.installationId })
+    .from(githubAppInstallations)
+    .where(
+      and(
+        eq(githubAppInstallations.id, installationRowId),
+        eq(githubAppInstallations.organizationId, organizationId),
+      ),
+    )
+    .limit(1);
+  return row?.installationId ?? null;
+}
+
+function buildReportUrl(env: Cloudflare.Env, scanId: string): string | null {
+  const base = env.BETTER_AUTH_URL?.trim();
+  if (!base) return null;
+  return `${base.replace(/\/$/, "")}/dashboard/scans/${scanId}`;
+}
+
+function buildDecisionComment(
+  decision: "approved" | "rejected",
+  packageName: string | null,
+  releaseRisk: RiskLevel,
+  reportUrl: string | null,
+): string {
+  const subject = packageName ? `${packageName}` : "this release";
+  const verb = decision === "approved" ? "approved" : "blocked";
+  const head = `Drydock ${verb} ${subject} (release risk: ${releaseRisk}).`;
+  return reportUrl ? `${head} Review: ${reportUrl}` : head;
+}

--- a/server/routes/github-webhooks.ts
+++ b/server/routes/github-webhooks.ts
@@ -138,6 +138,17 @@ githubWebhookRoutes.post("/github", async (c) => {
   try {
     const outcome = await applyGithubWebhookEvent(db, parsed, { deliveryId });
     await recordOutcomeAudit(db, deliveryId, eventName, outcome);
+    // Hand a pending gate to the queue consumer that runs the PyPI review and
+    // posts the deployment decision. Guarded because the binding is optional in
+    // tests/local; GitHub retries a non-2xx delivery and the consumer is
+    // idempotent (it re-checks the gate status), so a re-enqueue is safe.
+    if (outcome.kind === "gate_pending" && c.env.SCAN_QUEUE) {
+      await c.env.SCAN_QUEUE.send({
+        kind: "workflow_gate",
+        organizationId: outcome.gate.organizationId,
+        gateId: outcome.gate.id,
+      });
+    }
     return c.json({ ok: true, ...summarizeOutcome(outcome) });
   } catch (err) {
     emitOperationalEvent("error", "github_webhook.apply_failed", {

--- a/test/workers/workflow-gate-job.test.ts
+++ b/test/workers/workflow-gate-job.test.ts
@@ -483,4 +483,49 @@ describe("executeWorkflowGateJob", () => {
     expect(scenario.decisionCalls).toHaveLength(2);
     expect(scenario.decisionCalls[1].state).toBe("approved");
   });
+
+  test("retries a failed redelivery for an already-decided gate", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9204",
+      repositoryId: 72005,
+      runId: 11111,
+    });
+    const scenario = await buildScenario(11111, { digestMatches: true });
+    const loaderMock = buildLoaderMock();
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const sandboxEnv = buildEnv(bindings, loaderMock.binding);
+    const db = createDb(env.DB);
+    const message = {
+      kind: "workflow_gate" as const,
+      organizationId: seeded.organizationId,
+      gateId: seeded.gateId,
+    };
+
+    await executeWorkflowGateJob(sandboxEnv, ctx, message, db);
+    const loaderCallsAfterFirst = loaderMock.calls.length;
+    expect(scenario.decisionCalls).toHaveLength(1);
+
+    const redeliveryFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      if (request.url.includes("/access_tokens")) {
+        return Response.json({
+          token: "ghs_install_token",
+          expires_at: "2099-01-01T00:00:00Z",
+        });
+      }
+      if (request.url.endsWith("/deployment_protection_rule")) {
+        return new Response("try again", { status: 503 });
+      }
+      throw new Error(`unexpected fetch in redelivery test: ${request.url}`);
+    });
+    vi.stubGlobal("fetch", redeliveryFetch);
+
+    await expect(executeWorkflowGateJob(sandboxEnv, ctx, message, db)).rejects.toThrow(
+      "GitHub deployment protection decision failed (503)",
+    );
+
+    expect(loaderMock.calls.length).toBe(loaderCallsAfterFirst);
+    expect(redeliveryFetch).toHaveBeenCalledTimes(2);
+  });
 });

--- a/test/workers/workflow-gate-job.test.ts
+++ b/test/workers/workflow-gate-job.test.ts
@@ -1,0 +1,486 @@
+import { createExecutionContext, env } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { generateKeyPairSync } from "node:crypto";
+import { createDb, ensurePersonalOrganization, getScan } from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { eq } from "drizzle-orm";
+import { createReleaseTarget, upsertInstallation } from "../../server/lib/github-app";
+import { getGateForOrganization } from "../../server/lib/github-app-webhook";
+import { executeWorkflowGateJob } from "../../server/lib/workflow-gate-job";
+
+const WEBHOOK_SECRET = "webhook-secret-value-1234567890";
+const REPORT_BASE_URL = "https://drydock.test";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.unstubAllGlobals();
+});
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ── Test setup helpers ───────────────────────────────────────────────────────
+
+async function seedGateForTest(opts: {
+  installationExternalId: string;
+  repositoryId: number;
+  runId: number;
+}) {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  const installation = await upsertInstallation(db, {
+    organizationId,
+    installationId: opts.installationExternalId,
+    accountLogin: "octo",
+    accountType: "Organization",
+    targetType: "Organization",
+    status: "active",
+    createdByUserId: null,
+  });
+  const releaseTarget = await createReleaseTarget(db, {
+    organizationId,
+    installationRowId: installation.id,
+    ecosystem: "pypi",
+    packageName: "demo-package",
+    repositoryId: opts.repositoryId,
+    repositoryFullName: "octo/example",
+    workflowFilename: null,
+    environment: "pypi",
+    pypiTrustedPublisherEnvironment: "pypi",
+    createdByUserId: null,
+  });
+
+  const gateId = crypto.randomUUID();
+  await db.insert(schema.githubWorkflowGates).values({
+    id: gateId,
+    organizationId,
+    installationRowId: installation.id,
+    releaseTargetId: releaseTarget.id,
+    deliveryId: crypto.randomUUID(),
+    repositoryId: opts.repositoryId,
+    repositoryFullName: "octo/example",
+    environment: "pypi",
+    runId: opts.runId,
+    deploymentId: 909,
+    deploymentCallbackUrl: `https://api.github.com/repos/octo/example/actions/runs/${opts.runId}/deployment_protection_rule`,
+    eventAction: "requested",
+    status: "pending",
+    requestedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  });
+  return { organizationId, userId, installation, releaseTarget, gateId };
+}
+
+interface ZipEntry {
+  path: string;
+  body: Uint8Array | string;
+}
+
+function makeZip(entries: ZipEntry[]): Uint8Array {
+  const encoder = new TextEncoder();
+  const records: Uint8Array[] = [];
+  const central: Uint8Array[] = [];
+  let offset = 0;
+  for (const entry of entries) {
+    const body = typeof entry.body === "string" ? encoder.encode(entry.body) : entry.body;
+    const nameBytes = encoder.encode(entry.path);
+    const crc = crc32(body);
+    const local = new Uint8Array(30 + nameBytes.length + body.length);
+    const lv = new DataView(local.buffer);
+    lv.setUint32(0, 0x04034b50, true);
+    lv.setUint16(4, 20, true);
+    lv.setUint16(8, 0, true);
+    lv.setUint32(14, crc, true);
+    lv.setUint32(18, body.length, true);
+    lv.setUint32(22, body.length, true);
+    lv.setUint16(26, nameBytes.length, true);
+    local.set(nameBytes, 30);
+    local.set(body, 30 + nameBytes.length);
+    records.push(local);
+
+    const c = new Uint8Array(46 + nameBytes.length);
+    const cv = new DataView(c.buffer);
+    cv.setUint32(0, 0x02014b50, true);
+    cv.setUint16(4, 20, true);
+    cv.setUint16(6, 20, true);
+    cv.setUint16(10, 0, true);
+    cv.setUint32(16, crc, true);
+    cv.setUint32(20, body.length, true);
+    cv.setUint32(24, body.length, true);
+    cv.setUint16(28, nameBytes.length, true);
+    cv.setUint32(42, offset, true);
+    c.set(nameBytes, 46);
+    central.push(c);
+    offset += local.length;
+  }
+  const centralBytes = concat(central);
+  const eocd = new Uint8Array(22);
+  const ev = new DataView(eocd.buffer);
+  ev.setUint32(0, 0x06054b50, true);
+  ev.setUint16(8, entries.length, true);
+  ev.setUint16(10, entries.length, true);
+  ev.setUint32(12, centralBytes.length, true);
+  ev.setUint32(16, offset, true);
+  return concat([...records, centralBytes, eocd]);
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, p) => sum + p.length, 0);
+  const out = new Uint8Array(total);
+  let i = 0;
+  for (const part of parts) {
+    out.set(part, i);
+    i += part.length;
+  }
+  return out;
+}
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let i = 0; i < 8; i += 1) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes as BufferSource);
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+interface LoaderMockOptions {
+  fail?: boolean;
+}
+
+function buildLoaderMock(opts: LoaderMockOptions = {}) {
+  const calls: { format: string | null; bodySize: number }[] = [];
+  return {
+    calls,
+    binding: {
+      load: vi.fn(() => ({
+        getEntrypoint: () => ({
+          fetch: vi.fn(async (request: Request) => {
+            calls.push({
+              format: request.headers.get("x-archive-format"),
+              bodySize: (await request.arrayBuffer()).byteLength,
+            });
+            if (opts.fail) {
+              return new Response(JSON.stringify({ error: "archive invalid", status: 422 }), {
+                status: 422,
+                headers: { "content-type": "application/json" },
+              });
+            }
+            return new Response(
+              JSON.stringify({
+                files: [
+                  {
+                    path: "demo_package-1.2.0.dist-info/METADATA",
+                    size: 40,
+                    sha256: "00",
+                    flags: [],
+                    textSample: "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n",
+                  },
+                  {
+                    path: "demo_package-1.2.0.dist-info/RECORD",
+                    size: 1,
+                    sha256: "01",
+                    flags: [],
+                    textSample: "",
+                  },
+                ],
+                packageJson: null,
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            );
+          }),
+        }),
+      })),
+    },
+  };
+}
+
+function buildCtxWithGateway() {
+  const ctx = createExecutionContext() as ExecutionContext & {
+    exports: { NpmStageGateway(options: { props: unknown }): Fetcher };
+  };
+  ctx.exports = {
+    NpmStageGateway: vi.fn(() => ({ fetch: vi.fn() }) as unknown as Fetcher),
+  };
+  return ctx;
+}
+
+function buildConfigBindings(): Record<string, string> {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const privateKeyPem = privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+  return {
+    GITHUB_APP_ID: "12345",
+    GITHUB_APP_SLUG: "drydock-test",
+    GITHUB_APP_CLIENT_ID: "client-id",
+    GITHUB_APP_CLIENT_SECRET: "client-secret",
+    GITHUB_APP_PRIVATE_KEY: privateKeyPem,
+    GITHUB_APP_WEBHOOK_SECRET: WEBHOOK_SECRET,
+    GITHUB_APP_STATE_SECRET: "0123456789abcdef0123456789abcdef",
+    BETTER_AUTH_SECRET: "fallback-secret-with-enough-entropy-aaaaaaaa",
+  };
+}
+
+interface DecisionCall {
+  state: string;
+  environment_name: string;
+  comment: string;
+}
+
+interface ScenarioOpts {
+  digestMatches: boolean;
+}
+
+async function buildScenario(runId: number, opts: ScenarioOpts) {
+  const wheelPath = "dist/demo_package-1.2.0-py3-none-any.whl";
+  const wheelBytes = makeZip([
+    {
+      path: "demo_package-1.2.0.dist-info/METADATA",
+      body: "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n",
+    },
+    {
+      path: "demo_package-1.2.0.dist-info/WHEEL",
+      body: "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+    },
+    {
+      path: "demo_package-1.2.0.dist-info/RECORD",
+      body: "",
+    },
+  ]);
+  const declaredSha = opts.digestMatches ? await sha256Hex(wheelBytes) : "0".repeat(64);
+  const manifestRaw = JSON.stringify({
+    schema: "drydock.release-artifacts.v1",
+    ecosystem: "pypi",
+    package: "demo-package",
+    version: "1.2.0",
+    artifacts: [{ path: wheelPath, sha256: declaredSha }],
+  });
+  const bundleZip = makeZip([
+    { path: "drydock-manifest.json", body: manifestRaw },
+    { path: wheelPath, body: wheelBytes },
+  ]);
+
+  const decisionCalls: DecisionCall[] = [];
+  const fetchSpy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    if (request.url.endsWith("/deployment_protection_rule")) {
+      decisionCalls.push((await request.json()) as DecisionCall);
+      return new Response(null, { status: 204 });
+    }
+    if (request.url.includes("/access_tokens")) {
+      return Response.json({
+        token: "ghs_install_token",
+        expires_at: "2099-01-01T00:00:00Z",
+      });
+    }
+    if (request.url.includes(`/actions/runs/${runId}/artifacts`)) {
+      return new Response(
+        JSON.stringify({
+          total_count: 1,
+          artifacts: [
+            {
+              id: 88888,
+              name: "pypi-release-candidate",
+              size_in_bytes: bundleZip.length,
+              expired: false,
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+    if (request.url.includes("/actions/artifacts/")) {
+      return new Response(bundleZip, {
+        status: 200,
+        headers: { "content-type": "application/zip" },
+      });
+    }
+    throw new Error(`unexpected fetch in test: ${request.url}`);
+  });
+  vi.stubGlobal("fetch", fetchSpy);
+  return { fetchSpy, decisionCalls, wheelPath };
+}
+
+function buildEnv(bindings: Record<string, string>, loaderBinding: unknown): Cloudflare.Env {
+  return {
+    ...env,
+    ...bindings,
+    BETTER_AUTH_URL: REPORT_BASE_URL,
+    LOADER: loaderBinding as WorkerLoader,
+  } as Cloudflare.Env;
+}
+
+async function scanEventTypes(organizationId: string, gateId: string): Promise<string[]> {
+  const db = createDb(env.DB);
+  const rows = await db
+    .select({ type: schema.scanEvents.type, metadataJson: schema.scanEvents.metadataJson })
+    .from(schema.scanEvents)
+    .where(eq(schema.scanEvents.organizationId, organizationId));
+  return rows
+    .filter((row) => {
+      const meta = row.metadataJson as { gateId?: string } | null;
+      return meta?.gateId === gateId;
+    })
+    .map((row) => row.type);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("executeWorkflowGateJob", () => {
+  test("approves a clean candidate, persists the scan, and posts an approval", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9200",
+      repositoryId: 72001,
+      runId: 7777,
+    });
+    const scenario = await buildScenario(7777, { digestMatches: true });
+    const loaderMock = buildLoaderMock();
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const sandboxEnv = buildEnv(bindings, loaderMock.binding);
+    const db = createDb(env.DB);
+
+    await executeWorkflowGateJob(
+      sandboxEnv,
+      ctx,
+      { kind: "workflow_gate", organizationId: seeded.organizationId, gateId: seeded.gateId },
+      db,
+    );
+
+    const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(gate?.status).toBe("approved");
+    expect(gate?.decision).toBe("approved");
+    expect(gate?.scanId).toBeTruthy();
+    expect(gate?.reportUrl).toBe(`${REPORT_BASE_URL}/dashboard/scans/${gate?.scanId}`);
+
+    expect(scenario.decisionCalls).toHaveLength(1);
+    expect(scenario.decisionCalls[0].state).toBe("approved");
+    expect(scenario.decisionCalls[0].environment_name).toBe("pypi");
+
+    const persisted = await getScan(db, gate!.scanId!, seeded.organizationId);
+    expect(persisted?.scan.status).toBe("complete");
+    expect(persisted?.scan.source).toBe("workflow_gate");
+
+    const types = await scanEventTypes(seeded.organizationId, seeded.gateId);
+    expect(types).toContain("github_workflow_gate.received");
+    expect(types).toContain("github_workflow_gate.reviewed");
+    expect(types).toContain("github_workflow_gate.approved");
+  });
+
+  test("rejects the deployment when the manifest digest is tampered", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9201",
+      repositoryId: 72002,
+      runId: 8888,
+    });
+    const scenario = await buildScenario(8888, { digestMatches: false });
+    const loaderMock = buildLoaderMock();
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const sandboxEnv = buildEnv(bindings, loaderMock.binding);
+    const db = createDb(env.DB);
+
+    await executeWorkflowGateJob(
+      sandboxEnv,
+      ctx,
+      { kind: "workflow_gate", organizationId: seeded.organizationId, gateId: seeded.gateId },
+      db,
+    );
+
+    const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(gate?.status).toBe("rejected");
+    expect(gate?.failureReason).toBe("artifact_digest_mismatch");
+    expect(gate?.scanId).toBeNull();
+
+    expect(scenario.decisionCalls).toHaveLength(1);
+    expect(scenario.decisionCalls[0].state).toBe("rejected");
+
+    // The sandbox parser must never run for an artifact that fails verification.
+    expect(loaderMock.calls).toHaveLength(0);
+
+    const types = await scanEventTypes(seeded.organizationId, seeded.gateId);
+    expect(types).toContain("github_workflow_gate.rejected");
+  });
+
+  test("leaves the deployment pending and visible when the review errors", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9202",
+      repositoryId: 72003,
+      runId: 9999,
+    });
+    const scenario = await buildScenario(9999, { digestMatches: true });
+    const loaderMock = buildLoaderMock({ fail: true });
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const sandboxEnv = buildEnv(bindings, loaderMock.binding);
+    const db = createDb(env.DB);
+
+    await executeWorkflowGateJob(
+      sandboxEnv,
+      ctx,
+      { kind: "workflow_gate", organizationId: seeded.organizationId, gateId: seeded.gateId },
+      db,
+    );
+
+    const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(gate?.status).toBe("pending");
+    expect(gate?.failureReason).toBe("preparation_failed");
+
+    // No decision must be posted to GitHub on a review error.
+    expect(scenario.decisionCalls).toHaveLength(0);
+
+    const types = await scanEventTypes(seeded.organizationId, seeded.gateId);
+    expect(types).toContain("github_workflow_gate.received");
+    expect(types).toContain("github_workflow_gate.review_failed");
+    expect(types).not.toContain("github_workflow_gate.approved");
+    expect(types).not.toContain("github_workflow_gate.rejected");
+  });
+
+  test("re-delivers the decision for an already-decided gate without re-running the review", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9203",
+      repositoryId: 72004,
+      runId: 10101,
+    });
+    const scenario = await buildScenario(10101, { digestMatches: true });
+    const loaderMock = buildLoaderMock();
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const sandboxEnv = buildEnv(bindings, loaderMock.binding);
+    const db = createDb(env.DB);
+    const message = {
+      kind: "workflow_gate" as const,
+      organizationId: seeded.organizationId,
+      gateId: seeded.gateId,
+    };
+
+    await executeWorkflowGateJob(sandboxEnv, ctx, message, db);
+    const loaderCallsAfterFirst = loaderMock.calls.length;
+    expect(scenario.decisionCalls).toHaveLength(1);
+
+    await executeWorkflowGateJob(sandboxEnv, ctx, message, db);
+
+    // Second delivery must re-post the stored decision but not re-parse artifacts.
+    expect(loaderMock.calls.length).toBe(loaderCallsAfterFirst);
+    expect(scenario.decisionCalls).toHaveLength(2);
+    expect(scenario.decisionCalls[1].state).toBe("approved");
+  });
+});

--- a/test/workers/workflow-gate-job.test.ts
+++ b/test/workers/workflow-gate-job.test.ts
@@ -7,6 +7,7 @@ import { eq } from "drizzle-orm";
 import { createReleaseTarget, upsertInstallation } from "../../server/lib/github-app";
 import { getGateForOrganization } from "../../server/lib/github-app-webhook";
 import { executeWorkflowGateJob } from "../../server/lib/workflow-gate-job";
+import worker from "../../server/index";
 
 const WEBHOOK_SECRET = "webhook-secret-value-1234567890";
 const REPORT_BASE_URL = "https://drydock.test";
@@ -165,10 +166,12 @@ async function sha256Hex(bytes: Uint8Array): Promise<string> {
 
 interface LoaderMockOptions {
   fail?: boolean;
+  metadataName?: string;
 }
 
 function buildLoaderMock(opts: LoaderMockOptions = {}) {
   const calls: { format: string | null; bodySize: number }[] = [];
+  const metadataName = opts.metadataName ?? "demo-package";
   return {
     calls,
     binding: {
@@ -193,7 +196,7 @@ function buildLoaderMock(opts: LoaderMockOptions = {}) {
                     size: 40,
                     sha256: "00",
                     flags: [],
-                    textSample: "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n",
+                    textSample: `Metadata-Version: 2.3\nName: ${metadataName}\nVersion: 1.2.0\n`,
                   },
                   {
                     path: "demo_package-1.2.0.dist-info/RECORD",
@@ -420,6 +423,42 @@ describe("executeWorkflowGateJob", () => {
     expect(types).toContain("github_workflow_gate.rejected");
   });
 
+  test("rejects candidate-specific PyPI critical findings via release risk", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9206",
+      repositoryId: 72007,
+      runId: 12121,
+    });
+    const scenario = await buildScenario(12121, { digestMatches: true });
+    const loaderMock = buildLoaderMock({ metadataName: "different-package" });
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const sandboxEnv = buildEnv(bindings, loaderMock.binding);
+    const db = createDb(env.DB);
+
+    await executeWorkflowGateJob(
+      sandboxEnv,
+      ctx,
+      { kind: "workflow_gate", organizationId: seeded.organizationId, gateId: seeded.gateId },
+      db,
+    );
+
+    const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(gate?.status).toBe("rejected");
+    expect(gate?.decision).toBe("rejected");
+    expect(scenario.decisionCalls).toHaveLength(1);
+    expect(scenario.decisionCalls[0].state).toBe("rejected");
+
+    const persisted = await getScan(db, gate!.scanId!, seeded.organizationId);
+    expect(persisted?.scan.riskSummaryJson).toMatchObject({
+      artifactRisk: "critical",
+      releaseRisk: "critical",
+    });
+    expect(persisted?.findings).toContainEqual(
+      expect.objectContaining({ ruleId: "pypi.metadata-mismatch", severity: "critical" }),
+    );
+  });
+
   test("leaves the deployment pending and visible when the review errors", async () => {
     const seeded = await seedGateForTest({
       installationExternalId: "9202",
@@ -527,5 +566,54 @@ describe("executeWorkflowGateJob", () => {
 
     expect(loaderMock.calls.length).toBe(loaderCallsAfterFirst);
     expect(redeliveryFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test("throws final workflow-gate queue callback failure so the message can reach the DLQ", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9205",
+      repositoryId: 72006,
+      runId: 11112,
+    });
+    const scenario = await buildScenario(11112, { digestMatches: true });
+    const loaderMock = buildLoaderMock();
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const sandboxEnv = buildEnv(bindings, loaderMock.binding);
+    const db = createDb(env.DB);
+    const body = {
+      kind: "workflow_gate" as const,
+      organizationId: seeded.organizationId,
+      gateId: seeded.gateId,
+    };
+
+    await executeWorkflowGateJob(sandboxEnv, ctx, body, db);
+    expect(scenario.decisionCalls).toHaveLength(1);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = input instanceof Request ? input : new Request(input, init);
+        if (request.url.includes("/access_tokens")) {
+          return Response.json({
+            token: "ghs_install_token",
+            expires_at: "2099-01-01T00:00:00Z",
+          });
+        }
+        if (request.url.endsWith("/deployment_protection_rule")) {
+          return new Response("still failing", { status: 503 });
+        }
+        throw new Error(`unexpected fetch in queue final-attempt test: ${request.url}`);
+      }),
+    );
+
+    const retry = vi.fn();
+    const batch = {
+      messages: [{ body, attempts: 3, retry }],
+    } as unknown as MessageBatch<import("../../server/lib/scan-job").QueueMessage>;
+
+    await expect(worker.queue(batch, sandboxEnv, ctx)).rejects.toThrow(
+      "GitHub deployment protection decision failed (503)",
+    );
+    expect(retry).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Adds a queue consumer (`executeWorkflowGateJob`) that turns a pending `deployment_protection_rule` gate into a decision: it resolves and SHA-256-verifies the release artifacts, runs the `pypiAdapter` through `runScanPipeline`, persists the result as a `workflow_gate` scan, and POSTs the approve/reject callback back to GitHub.
- Failure handling follows the gate contract — artifact-verification errors reject the gate, review/processing errors leave it pending (never auto-approve), and a queue message that exhausts its retries is rethrown so it reaches the dead-letter queue.
- The GitHub webhook now enqueues pending gates onto `SCAN_QUEUE` (guarded, since the binding is optional), and `pypi.*` findings are annotated as release-delta so candidate-specific findings (e.g. a metadata mismatch) can drive a rejection.
- Includes Worker-runtime tests covering approve/reject/pending/redelivery/DLQ paths plus updated `docs/pypi-workflow-gate.md`.

## Test plan
- [ ] `pnpm run verify` (lint + format + typecheck + unit/Worker tests)
- [ ] `pnpm run test:e2e`

🤖 Generated with [Claude Code](https://claude.com/claude-code)