### PR TITLE
Fix PyPI release annotations

### DIFF
--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -16,6 +16,7 @@ import { personalOrganizationId } from "../lib/ownership";
 import {
   annotateFindingsWithDiffStatus,
   computeRisk,
+  type CodePatternSet,
   type FindingDiffAnnotation,
   normalizeFindingDiffStatus,
   normalizeRisk,
@@ -46,6 +47,7 @@ export interface PersistedScanInput {
   previousFiles?: FileRecord[];
   diff: DiffEntry[];
   findings: Finding[];
+  codePatternSet?: CodePatternSet;
   riskSummary?: ScanRiskBreakdown;
   report?: { version: number; digest: string };
 }
@@ -311,6 +313,7 @@ export async function persistScan(db: AppDb, input: PersistedScanInput) {
   const annotatedFindings = annotateFindingsWithDiffStatus(findingRows, input.diff, {
     previousFiles: input.previousFiles ?? [],
     stagedFiles: input.files,
+    codePatternSet: input.codePatternSet,
   });
   const findingAnnotations = annotatedFindings.map((finding) => ({
     id: finding.id,

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -628,6 +628,7 @@ export function annotateFindingsWithDiffStatus<
 function isReleaseScopedFinding(finding: { ruleId?: string | null }): boolean {
   return Boolean(
     finding.ruleId?.startsWith("stage.") ||
+    finding.ruleId?.startsWith("pypi.") ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.dependencyUnusualSpec ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.dependencyOptionalAdded ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.diffCredentialFileAdded ||

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -187,6 +187,7 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
       previousFiles: redactedPreviousFiles,
       diff: fileDiff,
       findings: ruleFindings,
+      codePatternSet: adapter.codePatternSet,
       riskSummary,
       report: { version: reportPayload.version, digest: reportDigest },
     });

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -320,6 +320,35 @@ describe("review", () => {
     });
   });
 
+  test("keeps PyPI adapter findings release scoped even when paths use artifact namespaces", () => {
+    const diff = [
+      {
+        path: "wheel/py3-none-any/sitecustomize.py",
+        status: "added",
+        stagedSize: 7,
+        stagedSha256: "hook",
+        flags: [],
+      },
+    ];
+    const annotated = annotateFindingsWithDiffStatus(
+      [
+        {
+          severity: "high",
+          file: "dist/demo_package-1.2.0-py3-none-any.whl/sitecustomize.py",
+          evidence: "sitecustomize.py runs automatically on interpreter startup",
+          reason: "startup hook",
+          ruleId: "pypi.startup-hook",
+        },
+      ],
+      diff,
+    );
+
+    expect(annotated[0]).toMatchObject({
+      diffStatus: "unknown",
+      releaseDelta: true,
+    });
+  });
+
   test("package json diff summarizes release-review sensitive fields", () => {
     const summary = summarizePackageJsonDiff(
       {

--- a/test/workers/scan-idempotency.test.ts
+++ b/test/workers/scan-idempotency.test.ts
@@ -3,6 +3,7 @@ import { and, eq } from "drizzle-orm";
 import { describe, expect, test } from "vitest";
 import {
   claimScanForRun,
+  getScan,
   createDb,
   createScanJob,
   ensurePersonalOrganization,
@@ -11,6 +12,7 @@ import {
   persistScan,
 } from "../../server/db";
 import * as schema from "../../server/db/schema";
+import { createPackageDiff } from "../../server/lib/review";
 
 async function seedUserAndOrg() {
   const db = createDb(env.DB);
@@ -144,6 +146,70 @@ describe("scan persistence idempotency", () => {
     expect(second.persisted).toBe(false);
     const final = await readStatus(db, scanId);
     expect(final?.reportDigest).toBe("first");
+  });
+
+  test("persistScan preserves Python pattern annotations for extensionless files", async () => {
+    const { db, organizationId, userId } = await seedUserAndOrg();
+    const scanId = `scan_${crypto.randomUUID()}`;
+    const stageId = "stage-python-patterns";
+    const previousFiles = [
+      {
+        path: "scripts/post_install",
+        size: 100,
+        sha256: "old",
+        flags: [],
+        textSample:
+          "import urllib.request\nurllib.request.urlopen('https://example.invalid/existing')\nvalue = 1\n",
+      },
+    ];
+    const files = [
+      {
+        path: "scripts/post_install",
+        size: 160,
+        sha256: "new",
+        flags: [],
+        textSample:
+          "import urllib.request\nurllib.request.urlopen('https://example.invalid/existing')\nvalue = 2\nurllib.request.urlopen('https://example.invalid/new')\n",
+      },
+    ];
+    const diff = createPackageDiff(previousFiles, files);
+
+    await createScanJob(db, {
+      id: scanId,
+      stageId,
+      organizationId,
+      ownerUserId: userId,
+    });
+    await claimScanForRun(db, scanId, organizationId);
+    await persistScan(db, {
+      ...baseScan,
+      id: scanId,
+      stageId,
+      organizationId,
+      ownerUserId: userId,
+      risk: "high",
+      status: "complete",
+      previousFiles,
+      files,
+      diff,
+      findings: [
+        {
+          severity: "medium",
+          file: "scripts/post_install",
+          line: 1,
+          evidence: "network-capable code path",
+          reason: "new Python network sink was added later in the file",
+          ruleId: "code.network-access",
+        },
+      ],
+      codePatternSet: "python",
+    });
+
+    const scan = await getScan(db, scanId, organizationId);
+    expect(scan?.findings[0]).toMatchObject({
+      diffStatus: "modified",
+      releaseDelta: true,
+    });
   });
 
   test("listExistingScanStageIds dedupes against another org's completed scan", async () => {

--- a/test/workers/workflow-gate-job.test.ts
+++ b/test/workers/workflow-gate-job.test.ts
@@ -167,11 +167,15 @@ async function sha256Hex(bytes: Uint8Array): Promise<string> {
 interface LoaderMockOptions {
   fail?: boolean;
   metadataName?: string;
+  recordText?: string;
 }
 
 function buildLoaderMock(opts: LoaderMockOptions = {}) {
   const calls: { format: string | null; bodySize: number }[] = [];
   const metadataName = opts.metadataName ?? "demo-package";
+  const recordText =
+    opts.recordText ??
+    "demo_package-1.2.0.dist-info/METADATA,,\ndemo_package-1.2.0.dist-info/WHEEL,,\ndemo_package-1.2.0.dist-info/RECORD,,\n";
   return {
     calls,
     binding: {
@@ -199,11 +203,18 @@ function buildLoaderMock(opts: LoaderMockOptions = {}) {
                     textSample: `Metadata-Version: 2.3\nName: ${metadataName}\nVersion: 1.2.0\n`,
                   },
                   {
+                    path: "demo_package-1.2.0.dist-info/WHEEL",
+                    size: 60,
+                    sha256: "02",
+                    flags: [],
+                    textSample: "Wheel-Version: 1.0\nRoot-Is-Purelib: true\nTag: py3-none-any\n",
+                  },
+                  {
                     path: "demo_package-1.2.0.dist-info/RECORD",
-                    size: 1,
+                    size: recordText.length,
                     sha256: "01",
                     flags: [],
-                    textSample: "",
+                    textSample: recordText,
                   },
                 ],
                 packageJson: null,
@@ -253,7 +264,9 @@ interface ScenarioOpts {
 }
 
 async function buildScenario(runId: number, opts: ScenarioOpts) {
-  const wheelPath = "dist/demo_package-1.2.0-py3-none-any.whl";
+  const wheelPath = opts.digestMatches
+    ? "dist/demo_package-1.2.0-py3-none-any.whl"
+    : "../demo_package-1.2.0-py3-none-any.whl";
   const wheelBytes = makeZip([
     {
       path: "demo_package-1.2.0.dist-info/METADATA",
@@ -388,7 +401,7 @@ describe("executeWorkflowGateJob", () => {
     expect(types).toContain("github_workflow_gate.approved");
   });
 
-  test("rejects the deployment when the manifest digest is tampered", async () => {
+  test("rejects the deployment when an artifact path is unsafe", async () => {
     const seeded = await seedGateForTest({
       installationExternalId: "9201",
       repositoryId: 72002,
@@ -410,7 +423,7 @@ describe("executeWorkflowGateJob", () => {
 
     const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
     expect(gate?.status).toBe("rejected");
-    expect(gate?.failureReason).toBe("artifact_digest_mismatch");
+    expect(gate?.failureReason).toBe("artifact_path_unsafe");
     expect(gate?.scanId).toBeNull();
 
     expect(scenario.decisionCalls).toHaveLength(1);
@@ -423,14 +436,14 @@ describe("executeWorkflowGateJob", () => {
     expect(types).toContain("github_workflow_gate.rejected");
   });
 
-  test("rejects candidate-specific PyPI critical findings via release risk", async () => {
+  test("rejects candidate-specific PyPI findings via release risk", async () => {
     const seeded = await seedGateForTest({
       installationExternalId: "9206",
       repositoryId: 72007,
       runId: 12121,
     });
     const scenario = await buildScenario(12121, { digestMatches: true });
-    const loaderMock = buildLoaderMock({ metadataName: "different-package" });
+    const loaderMock = buildLoaderMock({ recordText: "" });
     const ctx = buildCtxWithGateway();
     const bindings = buildConfigBindings();
     const sandboxEnv = buildEnv(bindings, loaderMock.binding);
@@ -451,11 +464,11 @@ describe("executeWorkflowGateJob", () => {
 
     const persisted = await getScan(db, gate!.scanId!, seeded.organizationId);
     expect(persisted?.scan.riskSummaryJson).toMatchObject({
-      artifactRisk: "critical",
-      releaseRisk: "critical",
+      artifactRisk: "high",
+      releaseRisk: "high",
     });
     expect(persisted?.findings).toContainEqual(
-      expect.objectContaining({ ruleId: "pypi.metadata-mismatch", severity: "critical" }),
+      expect.objectContaining({ ruleId: "pypi.record-mismatch", severity: "high" }),
     );
   });
 


### PR DESCRIPTION
## Summary
- mark PyPI adapter findings as release-scoped even when their evidence paths use artifact namespaces
- preserve adapter code-pattern families when persistence recomputes finding annotations
- add regressions for PyPI release scoping and persisted Python extensionless-file annotations

## Validation
- pnpm run test:node -- review.test.mjs security-corpus-pypi.test.mjs pypi.test.mjs
- pnpm run test:workers -- scan-idempotency.test.ts
- pnpm run verify