### PR TITLE
Move scan report artifacts from D1 to R2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
   - `lib/review.ts` — Deterministic findings, package diff, package.json diff, risk computation. Shared types are imported by both server and UI.
   - `lib/ai-review.ts` — Workers AI JSON-mode reviewer. Currently **disabled in the pipeline**; kept on disk for a planned paid-tier re-introduction. Do not wire it back into `scan-pipeline.ts` without a feature decision.
   - `lib/registry.ts` — npm metadata fetch + previous-version selection.
+  - `lib/scan-artifacts.ts` — R2 bundle storage primitives (key format, build/write/read, digest verification). No D1 imports — callers persist the returned key/digest/size. `lib/artifact-backfill.ts` runs the `ARTIFACT_BACKFILL`-gated catch-up sweep. See `docs/r2-artifacts.md`.
   - `lib/auth.ts` — Better Auth instance (D1 + Drizzle). Auth is required for every non-auth `/api/*` endpoint.
   - `db/` — Drizzle schema + persistence helpers (scans, scan_files, scan_findings, better-auth tables).
   - `env.d.ts` — `Cloudflare.Env` bindings. Regenerate with `npm run cf-typegen` if `wrangler.jsonc` changes.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -141,6 +141,7 @@ D1 stores canonical application state:
 - Better Auth users/sessions/accounts;
 - organizations and organization members;
 - scan rows, lifecycle status, timestamps, structured errors, and report digest metadata;
+- R2 artifact references (`artifact_storage_version`, `artifact_key`, `artifact_digest`, `artifact_size`) for scans whose derived evidence has been written to R2;
 - scan file manifests;
 - findings;
 - audit events;
@@ -154,13 +155,21 @@ Dashboard list rendering (`GET /api/v1/scans`) reads only compact metadata. `per
 
 ### R2
 
-R2 is the target store for durable derived artifacts:
+R2 (`ARTIFACTS` binding) stores durable derived artifacts. The first rollout
+bundles each scan's heavy derived evidence into one digest-verified object —
+`reports/{org}/{scan}/v{version}.json` — holding:
 
 - canonical report JSON;
-- redacted package manifests;
+- redacted summary/diff snapshot (`summary_json`);
 - changed-file safe text samples;
-- generated diff JSON;
 - future signed-report payloads.
+
+Completed scans dual-write the bundle to R2 alongside D1; `getScan` shadow-reads
+it (preferring R2, falling back to D1 on any miss/mismatch); an
+`ARTIFACT_BACKFILL`-gated sweep backfills old scans. No D1 data is deleted yet —
+compaction is a deferred follow-up. Full design, key format, digest verification,
+and rollback path: [`r2-artifacts.md`](./r2-artifacts.md). `server/lib/scan-artifacts.ts`
+holds the storage primitives and is intentionally free of D1 imports.
 
 Raw tarballs should not be retained by default in SaaS. If needed later, make raw retention an explicit organization setting with a short TTL, access logging, and clear warnings.
 

--- a/docs/cost-model.md
+++ b/docs/cost-model.md
@@ -45,6 +45,7 @@ Workers AI is ~90% of the variable cost at every scale above the smallest tier.
 - **Workers Paid plan**: $5/mo base, 10M requests + 30M CPU-ms included, then $0.30/M req and $0.02/M CPU-ms.
 - **D1**: 50M writes + 25B reads/mo included on the paid plan, $1/M writes and $0.001/1k reads beyond. Storage $0.75/GB-mo.
 - **KV**: $0.50/M reads, $5/M writes, $0.50/GB-mo storage. ~5 MB per cached `package@version` entry.
+- **R2**: $0.015/GB-mo storage, $4.50/M Class A (writes) and $0.36/M Class B (reads) operations, no egress fee. One scan-artifact bundle write + read-back per scan, plus one read per detail view.
 - **Queues**: $0.40/M operations.
 - **Workers AI (current default Kimi K2.5)**: $0.60/M input + $0.10/M cached input + $3.00/M output tokens on the current Cloudflare pricing page. Kimi K2.6 is more expensive at $0.95/M input + $0.16/M cached input + $4.00/M output. Confirm against current Cloudflare AI pricing before sizing margins.
 - **Dynamic Workers / Worker Loader**: treated as regular Worker billing; Cloudflare hasn't published a separate model at the time of writing.
@@ -52,7 +53,7 @@ Workers AI is ~90% of the variable cost at every scale above the smallest tier.
 ## Where the money goes
 
 - **Workers AI**: dominant at scale. Biggest levers: (a) choose the correct tag-aware comparison baseline so changed files reflect the release channel under review; (b) start AI review with a compact package manifest instead of full changed-file samples; (c) let the model request only targeted redacted file/diff/search evidence through app-owned tools; (d) keep the system prompt cache-friendly via `AI_CACHE_AFFINITY`; (e) pick the cheapest model that still produces useful structured output. See [`diff-baseline.md`](./diff-baseline.md).
-- **D1 storage growth**: ~500 KB–2 MB per scan retained. At 50k scans/mo that's 25–100 GB/mo accumulating. Add a retention/GC policy before this becomes a line item.
+- **D1 storage growth**: ~500 KB–2 MB per scan retained. At 50k scans/mo that's 25–100 GB/mo accumulating. The heavy derived evidence (canonical report, redacted file samples, diff/summary snapshot) now dual-writes to one R2 bundle per scan at $0.015/GB-mo storage — far cheaper than D1's $0.75/GB-mo — so the long-term plan is to compact those columns out of D1 once backfill + shadow-read have soaked. See [`r2-artifacts.md`](./r2-artifacts.md). Until compaction, both stores hold the payload, so this is a deferred saving, not a realized one. Add a retention/GC policy that deletes both D1 metadata and the R2 object before this becomes a line item.
 - **KV storage**: trivial. The added `COMPARE_CACHE` is essentially free across any realistic catalog of cached versions; it primarily saves sandbox CPU and tarball egress.
 - **Sandbox compute**: bounded per scan (2 Dynamic Workers, ~3s CPU each). The KV cache means alternate-version diffs in the detail page no longer linearly multiply this cost.
 

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -41,24 +41,25 @@ Open validation question:
 
 ## Phase 6 — R2 derived artifacts
 
-Status: not started. R2 is not required for private beta if D1 deletion/retention for current redacted samples is implemented, but it becomes important for larger reports, exports, and future signing.
+Status: first rollout shipped (dual-write + shadow-read + backfill). D1 compaction is the remaining step and is deliberately deferred. See [`r2-artifacts.md`](./r2-artifacts.md) for the full design, key format, bundle schema, and rollback path.
 
 Goals:
 
 - Move larger report artifacts out of D1.
 - Preserve useful evidence without default raw tarball retention.
 
-Tasks:
+Done in this rollout:
 
-- Add R2 binding and production bucket provisioning docs.
-- Store derived/redacted artifacts:
-  - canonical report JSON;
-  - manifest JSON;
-  - redacted changed-file samples;
-  - diff JSON.
-- Store R2 object references in D1.
-- Add retention cleanup strategy and deletion workflow that removes both D1 metadata and R2 objects.
-- Document object key format, access rules, and expected object sizes.
+- R2 binding (`ARTIFACTS`) and production bucket provisioning docs.
+- One digest-verified bundle object per scan holding the canonical report JSON, the redacted summary/diff snapshot, and redacted changed-file samples.
+- D1 carries the R2 reference columns (`artifact_storage_version`, `artifact_key`, `artifact_digest`, `artifact_size`); a row is only marked artifact-backed after read-back digest verification.
+- Shadow-read: `getScan` prefers the R2 bundle and falls back to D1 on a missing object, digest mismatch, or any read error (dropping the binding is the rollback toggle).
+- Resumable, idempotent backfill of old completed scans, gated behind `ARTIFACT_BACKFILL` and off by default.
+
+Deferred (separate explicit step):
+
+- D1 compaction — no existing scan data is deleted in the first rollout. Compaction happens only after a backfill + shadow-read soak.
+- Retention cleanup / deletion workflow that removes both D1 metadata and R2 objects.
 
 Default policy:
 
@@ -68,7 +69,7 @@ Default policy:
 
 Exit criteria:
 
-- D1 remains metadata-focused.
+- D1 remains metadata-focused. (Met for new columns; full compaction pending.)
 - Report artifacts are retrievable for persisted scans.
 - Artifact storage follows the documented safe default.
 

--- a/docs/r2-artifacts.md
+++ b/docs/r2-artifacts.md
@@ -108,7 +108,10 @@ authoritative in D1 until compaction, so finding-annotation logic is unchanged.
 
 `runArtifactBackfillSweep` (in the Worker `scheduled` handler, after the
 staged-publish discovery cron) writes one batch of old completed scans that have
-no `artifact_storage_version` yet, oldest first. It is **gated behind
+no `artifact_storage_version` yet, oldest first. Candidates must have
+`completed_at` at least one hour in the past so the catch-up sweep does not race
+the live pipeline's same-key dual-write for a freshly completed scan. It is
+**gated behind
 `ARTIFACT_BACKFILL`** and off by default. Backfill is naturally idempotent: a
 successful write sets `artifact_storage_version`, removing the scan from the next
 sweep's candidate set, so repeated runs converge without double-writing. The
@@ -117,7 +120,8 @@ sweep logs `scan.artifact.backfill_failed` per failure and a
 never breaks the discovery cron.
 
 `listScanArtifactBackfillCandidates` selects `status = "complete"` scans where
-`artifact_storage_version IS NULL` and `organization_id IS NOT NULL`. The
+`artifact_storage_version IS NULL`, `organization_id IS NOT NULL`, and
+`completed_at` is older than the one-hour cutoff. The
 `scans_artifact_backfill_idx` index (`status, artifact_storage_version,
 created_at`) backs the candidate query.
 

--- a/docs/r2-artifacts.md
+++ b/docs/r2-artifacts.md
@@ -1,0 +1,154 @@
+# R2 Scan Artifacts
+
+This note records how scan report artifacts move from D1 to R2. It covers the
+object key format, the bundle schema, digest verification, the dual-write /
+shadow-read / backfill phases, the rollback path, and bucket provisioning.
+
+Source: `server/lib/scan-artifacts.ts` (storage primitives, no D1 imports),
+`server/lib/canonical-json.ts` (`stableJson` + `sha256Hex`),
+`server/lib/scan-pipeline.ts` (dual-write), `server/db/index.ts`
+(`markScanArtifactBacked`, `listScanArtifactBackfillCandidates`, shadow-read in
+`getScan`), and `server/lib/artifact-backfill.ts` (sweep).
+
+## Why
+
+D1 stays the authoritative metadata and index store, but the heavy derived
+evidence — the canonical report JSON, the redacted summary/diff snapshot, and the
+redacted changed-file text samples — grows with package size and is awkward to
+keep in row storage. That payload moves into a single digest-verified R2 object
+per scan. D1 keeps a small reference (key, digest, size, storage version) so
+retention, rollback, and integrity checks stay simple.
+
+This is the first rollout from drydock issue #99. **D1 compaction is deliberately
+deferred**: no existing scan data is deleted here. Old rows keep their
+`text_sample` columns; the R2 bundle shadows them. Compaction is a separate
+explicit step after a backfill + shadow-read soak.
+
+## Object key format
+
+```
+reports/{organizationId}/{scanId}/v{storageVersion}.json
+```
+
+`SCAN_ARTIFACT_STORAGE_VERSION` is currently `1`. Keying by storage version lets a
+future schema bump write `v2.json` alongside `v1.json` without a destructive
+rewrite, and keeps retention/rollback per-version. One object per scan; we do not
+write per-artifact objects.
+
+## Bundle schema
+
+A bundle (`ScanArtifactBundle`) is JSON with:
+
+- `storageVersion` — matches the key suffix.
+- `scanId`, `organizationId` — also mirrored into the object's `customMetadata`.
+- `origin` — `"pipeline"` (written live by a completed scan) or `"backfill"`
+  (written by the catch-up sweep for scans that predate R2).
+- `report` — `{ version, digest, payload }`.
+  - For `pipeline` bundles `payload` is the canonical report object and its
+    `sha256Hex(stableJson(payload))` must equal `report.digest` (which equals
+    `scans.report_digest`). This is re-verified on write.
+  - For `backfill` bundles `payload` is `null`: the original canonical report
+    predates R2 and cannot be rebuilt from D1, so the bundle is verified by its
+    byte digest only.
+- `summary` — snapshot of `scans.summary_json` (diff, packageJsonDiff, risk,
+  baseline, safety).
+- `fileSamples` — array of `{ path, textSample }`, only for files that carry a
+  non-empty redacted text sample. Files without a sample are fully
+  reconstructable from their D1 metadata row and are skipped.
+
+`fileSamples` carries only redacted derived evidence. Raw tarballs and
+unredacted file contents are never stored, consistent with the security model.
+
+## Digest verification
+
+Two independent digests guard the data:
+
+1. **Byte digest** — `sha256Hex(JSON.stringify(bundle))`, persisted as
+   `scans.artifact_digest`. On write, the object is immediately re-read and its
+   recomputed digest must match before the row is marked artifact-backed. On
+   read, when `artifact_digest` is present, a mismatch rejects the read.
+2. **Report digest** — for `pipeline` bundles only,
+   `sha256Hex(stableJson(report.payload))` is re-derived on write and must equal
+   `report.digest` / `scans.report_digest`. This proves the canonical report
+   bytes in R2 match the digest D1 already committed.
+
+`stableJson` sorts object keys and drops `undefined` so the same logical value
+always hashes identically regardless of property order. It is shared by the scan
+pipeline and the artifact store to avoid digest drift.
+
+Verification failures raise `ScanArtifactError` with one of:
+`artifact_readback_missing`, `artifact_digest_mismatch`, `report_digest_mismatch`,
+`artifact_malformed`.
+
+## Phases
+
+### Dual-write (live scans)
+
+After a scan is persisted, `writeScanArtifactForCompletedScan` builds a
+`pipeline` bundle, writes + verifies it, and calls `markScanArtifactBacked` to
+set the four `artifact_*` columns. It is **best effort**: if `ARTIFACTS` is
+unbound or any write/verification step fails, the error is logged
+(`scan.artifact.write_failed`) and swallowed. D1 already holds the authoritative
+copy, so the scan simply stays D1-only and shadow-read falls back automatically.
+Success logs `scan.artifact.written`.
+
+### Shadow-read
+
+`getScan` accepts `{ artifacts?: R2Bucket }`. When a scan is artifact-backed and
+the binding is present, `hydrateScanFileSamples` reads and verifies the bundle
+and overrides each file's `textSample` from it. On a missing object, digest
+mismatch, or any read error it logs `scan.artifact.read_fallback` and returns the
+D1 file rows unchanged. Routes pass `c.env.ARTIFACTS` into `getScan`,
+`recordScanDecision`, and the compare-context read.
+
+Only `textSample` is hydrated from R2 in this rollout. `summary_json.diff` stays
+authoritative in D1 until compaction, so finding-annotation logic is unchanged.
+
+### Backfill
+
+`runArtifactBackfillSweep` (in the Worker `scheduled` handler, after the
+staged-publish discovery cron) writes one batch of old completed scans that have
+no `artifact_storage_version` yet, oldest first. It is **gated behind
+`ARTIFACT_BACKFILL`** and off by default. Backfill is naturally idempotent: a
+successful write sets `artifact_storage_version`, removing the scan from the next
+sweep's candidate set, so repeated runs converge without double-writing. The
+sweep logs `scan.artifact.backfill_failed` per failure and a
+`scan.artifact.backfill_sweep` summary, and a top-level failure is caught so it
+never breaks the discovery cron.
+
+`listScanArtifactBackfillCandidates` selects `status = "complete"` scans where
+`artifact_storage_version IS NULL` and `organization_id IS NOT NULL`. The
+`scans_artifact_backfill_idx` index (`status, artifact_storage_version,
+created_at`) backs the candidate query.
+
+## Rollback
+
+Reads flip back to D1 without touching R2:
+
+- **Unbind `ARTIFACTS`** (or remove the env passing): `getScan` stops shadow-
+  reading and serves D1 rows; dual-write becomes a no-op; the backfill sweep
+  returns early.
+- **Set `ARTIFACT_BACKFILL` off** (its default): the sweep stops enrolling new
+  scans while leaving everything already written intact.
+
+Because no D1 data is deleted in this rollout, both toggles are safe and
+non-destructive. R2 objects can be left in place or cleaned up separately.
+
+## Bucket provisioning
+
+`wrangler.jsonc` binds `ARTIFACTS` to `staged-publish-review-artifacts`;
+`wrangler.test.jsonc` binds it to `staged-publish-review-artifacts-test` (miniflare
+simulates it locally). The binding is optional in `server/env.d.ts` so dev, tests,
+and the worker degrade gracefully to D1-only when it is absent.
+
+Create the production bucket before enabling reads:
+
+```
+npx wrangler r2 bucket create staged-publish-review-artifacts
+```
+
+Roll out in order: deploy with dual-write (binding present), let new scans
+populate R2 and confirm `scan.artifact.written` events, then enable
+`ARTIFACT_BACKFILL` to drain old scans, watch `scan.artifact.backfill_sweep`
+converge to zero work and `scan.artifact.read_fallback` stay quiet, and only then
+plan D1 compaction as a separate change.

--- a/drizzle/0012_reflective_patriot.sql
+++ b/drizzle/0012_reflective_patriot.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `scans` ADD `artifact_storage_version` integer;--> statement-breakpoint
+ALTER TABLE `scans` ADD `artifact_key` text;--> statement-breakpoint
+ALTER TABLE `scans` ADD `artifact_digest` text;--> statement-breakpoint
+ALTER TABLE `scans` ADD `artifact_size` integer;--> statement-breakpoint
+CREATE INDEX `scans_artifact_backfill_idx` ON `scans` (`status`,`artifact_storage_version`,`created_at`);

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1871 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "18507cf5-325a-4f46-bc56-a5b2c035ba05",
+  "prevId": "cf6f889e-4390-46e5-bceb-1b33f18a7d89",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_app_installations": {
+      "name": "github_app_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Organization'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uninstalled_at": {
+          "name": "uninstalled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_app_installations_installation_unique_idx": {
+          "name": "github_app_installations_installation_unique_idx",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        },
+        "github_app_installations_org_idx": {
+          "name": "github_app_installations_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installations_created_by_user_id_user_id_fk": {
+          "name": "github_app_installations_created_by_user_id_user_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_release_targets": {
+      "name": "github_release_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ecosystem": {
+          "name": "ecosystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workflow_filename": {
+          "name": "workflow_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pypi_trusted_publisher_environment": {
+          "name": "pypi_trusted_publisher_environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_release_targets_org_pkg_unique_idx": {
+          "name": "github_release_targets_org_pkg_unique_idx",
+          "columns": [
+            "organization_id",
+            "ecosystem",
+            "package_name"
+          ],
+          "isUnique": true
+        },
+        "github_release_targets_org_repo_env_unique_idx": {
+          "name": "github_release_targets_org_repo_env_unique_idx",
+          "columns": [
+            "organization_id",
+            "repository_id",
+            "environment"
+          ],
+          "isUnique": true
+        },
+        "github_release_targets_installation_idx": {
+          "name": "github_release_targets_installation_idx",
+          "columns": [
+            "installation_row_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_release_targets_organization_id_organizations_id_fk": {
+          "name": "github_release_targets_organization_id_organizations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_release_targets_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_created_by_user_id_user_id_fk": {
+          "name": "github_release_targets_created_by_user_id_user_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_workflow_gates": {
+      "name": "github_workflow_gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_target_id": {
+          "name": "release_target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deployment_callback_url": {
+          "name": "deployment_callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_comment": {
+          "name": "decision_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_url": {
+          "name": "report_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_workflow_gates_delivery_unique_idx": {
+          "name": "github_workflow_gates_delivery_unique_idx",
+          "columns": [
+            "delivery_id"
+          ],
+          "isUnique": true
+        },
+        "github_workflow_gates_org_status_idx": {
+          "name": "github_workflow_gates_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_release_target_idx": {
+          "name": "github_workflow_gates_release_target_idx",
+          "columns": [
+            "release_target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_workflow_gates_organization_id_organizations_id_fk": {
+          "name": "github_workflow_gates_organization_id_organizations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_workflow_gates_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_release_target_id_github_release_targets_id_fk": {
+          "name": "github_workflow_gates_release_target_id_github_release_targets_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_release_targets",
+          "columnsFrom": [
+            "release_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_scan_id_scans_id_fk": {
+          "name": "github_workflow_gates_scan_id_scans_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_unique_idx": {
+          "name": "npm_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changed_file_count": {
+          "name": "changed_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_summary_json": {
+          "name": "risk_summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_storage_version": {
+          "name": "artifact_storage_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_key": {
+          "name": "artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_digest": {
+          "name": "artifact_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_size": {
+          "name": "artifact_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        },
+        "scans_org_decision_created_idx": {
+          "name": "scans_org_decision_created_idx",
+          "columns": [
+            "organization_id",
+            "decision",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scans_artifact_backfill_idx": {
+          "name": "scans_artifact_backfill_idx",
+          "columns": [
+            "status",
+            "artifact_storage_version",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_decided_by_user_id_user_id_fk": {
+          "name": "scans_decided_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1779984604056,
       "tag": "0011_sad_ezekiel_stane",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1780114691738,
+      "tag": "0012_reflective_patriot",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -307,14 +307,19 @@ export interface ScanArtifactBackfillCandidate {
   files: Array<{ path: string; textSample: string | null }>;
 }
 
+export const SCAN_ARTIFACT_BACKFILL_MIN_COMPLETED_AGE_MS = 60 * 60 * 1000;
+
 /**
- * Completed scans that have not yet been written to R2, oldest first. Backfill
- * is naturally idempotent: a successful write sets `artifact_storage_version`,
- * which removes the scan from this candidate set on the next sweep.
+ * Older completed scans that have not yet been written to R2, oldest first.
+ * The completed-at age gate keeps the catch-up sweep away from scans whose live
+ * pipeline dual-write may still be in flight. Backfill is naturally idempotent:
+ * a successful write sets `artifact_storage_version`, which removes the scan
+ * from this candidate set on the next sweep.
  */
 export async function listScanArtifactBackfillCandidates(
   db: AppDb,
   limit: number,
+  completedBefore = new Date(Date.now() - SCAN_ARTIFACT_BACKFILL_MIN_COMPLETED_AGE_MS),
 ): Promise<ScanArtifactBackfillCandidate[]> {
   const scanRows = await db
     .select({
@@ -330,6 +335,8 @@ export async function listScanArtifactBackfillCandidates(
         eq(scans.status, "complete"),
         isNull(scans.artifactStorageVersion),
         isNotNull(scans.organizationId),
+        isNotNull(scans.completedAt),
+        lt(scans.completedAt, completedBefore),
       ),
     )
     .orderBy(asc(scans.createdAt), asc(scans.id))

--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, isNull, lt, or } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNotNull, isNull, lt, or } from "drizzle-orm";
 import {
   annotateFindingsWithDiffStatus,
   type CodePatternSet,
@@ -11,7 +11,9 @@ import {
   normalizeRisk,
   type PackageJsonSummary,
 } from "../lib/review";
+import { emitOperationalEvent } from "../lib/observability";
 import { normalizeScanRiskBreakdown, type ScanRiskBreakdown } from "../lib/risk";
+import { readScanArtifact, ScanArtifactError, scanArtifactSampleMap } from "../lib/scan-artifacts";
 import type { AppDb } from "./client";
 import { recordScanEvent, redactScanEventForClient } from "./events";
 import { scanEvents, scanFiles, scanFindings, scans } from "./schema";
@@ -274,6 +276,90 @@ export async function persistScan(db: AppDb, input: PersistedScanInput) {
   return { persisted: true as const };
 }
 
+export interface MarkScanArtifactBackedInput {
+  scanId: string;
+  organizationId: string;
+  storageVersion: number;
+  key: string;
+  digest: string;
+  size: number;
+}
+
+export async function markScanArtifactBacked(db: AppDb, input: MarkScanArtifactBackedInput) {
+  await db
+    .update(scans)
+    .set({
+      artifactStorageVersion: input.storageVersion,
+      artifactKey: input.key,
+      artifactDigest: input.digest,
+      artifactSize: input.size,
+      updatedAt: new Date(),
+    })
+    .where(and(eq(scans.id, input.scanId), eq(scans.organizationId, input.organizationId)));
+}
+
+export interface ScanArtifactBackfillCandidate {
+  id: string;
+  organizationId: string;
+  reportVersion: number | null;
+  reportDigest: string | null;
+  summaryJson: unknown;
+  files: Array<{ path: string; textSample: string | null }>;
+}
+
+/**
+ * Completed scans that have not yet been written to R2, oldest first. Backfill
+ * is naturally idempotent: a successful write sets `artifact_storage_version`,
+ * which removes the scan from this candidate set on the next sweep.
+ */
+export async function listScanArtifactBackfillCandidates(
+  db: AppDb,
+  limit: number,
+): Promise<ScanArtifactBackfillCandidate[]> {
+  const scanRows = await db
+    .select({
+      id: scans.id,
+      organizationId: scans.organizationId,
+      reportVersion: scans.reportVersion,
+      reportDigest: scans.reportDigest,
+      summaryJson: scans.summaryJson,
+    })
+    .from(scans)
+    .where(
+      and(
+        eq(scans.status, "complete"),
+        isNull(scans.artifactStorageVersion),
+        isNotNull(scans.organizationId),
+      ),
+    )
+    .orderBy(asc(scans.createdAt), asc(scans.id))
+    .limit(Math.max(1, Math.floor(limit)));
+
+  if (!scanRows.length) return [];
+
+  const ids = scanRows.map((row) => row.id);
+  const fileRows = await db
+    .select({ scanId: scanFiles.scanId, path: scanFiles.path, textSample: scanFiles.textSample })
+    .from(scanFiles)
+    .where(inArray(scanFiles.scanId, ids));
+
+  const filesByScan = new Map<string, Array<{ path: string; textSample: string | null }>>();
+  for (const file of fileRows) {
+    const list = filesByScan.get(file.scanId) ?? [];
+    list.push({ path: file.path, textSample: file.textSample });
+    filesByScan.set(file.scanId, list);
+  }
+
+  return scanRows.map((row) => ({
+    id: row.id,
+    organizationId: row.organizationId as string,
+    reportVersion: row.reportVersion,
+    reportDigest: row.reportDigest,
+    summaryJson: row.summaryJson,
+    files: filesByScan.get(row.id) ?? [],
+  }));
+}
+
 function withFindingAnnotations(
   summary: unknown,
   annotations: Array<{ id: string; diffStatus: string; releaseDelta: boolean }>,
@@ -525,7 +611,11 @@ export interface RecordScanDecisionInput {
   reason?: string | null;
 }
 
-export async function recordScanDecision(db: AppDb, input: RecordScanDecisionInput) {
+export async function recordScanDecision(
+  db: AppDb,
+  input: RecordScanDecisionInput,
+  options: GetScanOptions = {},
+) {
   const now = new Date();
   const reason = input.reason?.trim() ? input.reason.trim() : null;
   const updated = await db
@@ -556,11 +646,66 @@ export async function recordScanDecision(db: AppDb, input: RecordScanDecisionInp
     metadata: { decision: input.decision, reason },
   });
 
-  return getScan(db, input.scanId, input.organizationId);
+  return getScan(db, input.scanId, input.organizationId, options);
 }
 
-export async function getScan(db: AppDb, id: string, organizationId: string) {
-  const [scanRows, files, findings, events] = await Promise.all([
+export interface GetScanOptions {
+  artifacts?: R2Bucket;
+}
+
+/**
+ * Shadow-read: when a scan is artifact-backed and an R2 binding is available,
+ * hydrate redacted file text samples from the verified bundle, preferring R2 and
+ * falling back to the D1 rows on a missing object, digest mismatch, or any read
+ * error. The fallback is what keeps reads correct before D1 compaction and what
+ * makes "flip reads back to D1" the rollback path (drop the binding).
+ */
+async function hydrateScanFileSamples<T extends { path: string; textSample: string | null }>(
+  scan: {
+    id: string;
+    organizationId: string | null;
+    artifactStorageVersion: number | null;
+    artifactKey: string | null;
+    artifactDigest: string | null;
+  },
+  files: T[],
+  bucket: R2Bucket | undefined,
+): Promise<T[]> {
+  if (!bucket || scan.artifactStorageVersion == null || !scan.artifactKey) return files;
+  try {
+    const bundle = await readScanArtifact(bucket, {
+      key: scan.artifactKey,
+      expectedDigest: scan.artifactDigest,
+    });
+    if (!bundle) {
+      emitOperationalEvent("warn", "scan.artifact.read_fallback", {
+        scanId: scan.id,
+        organizationId: scan.organizationId,
+        reason: "artifact_missing",
+      });
+      return files;
+    }
+    const sampleMap = scanArtifactSampleMap(bundle);
+    return files.map((file) =>
+      sampleMap.has(file.path) ? { ...file, textSample: sampleMap.get(file.path) ?? null } : file,
+    );
+  } catch (err) {
+    emitOperationalEvent("warn", "scan.artifact.read_fallback", {
+      scanId: scan.id,
+      organizationId: scan.organizationId,
+      reason: err instanceof ScanArtifactError ? err.code : "read_error",
+    });
+    return files;
+  }
+}
+
+export async function getScan(
+  db: AppDb,
+  id: string,
+  organizationId: string,
+  options: GetScanOptions = {},
+) {
+  const [scanRows, fileRows, findings, events] = await Promise.all([
     db
       .select()
       .from(scans)
@@ -576,6 +721,7 @@ export async function getScan(db: AppDb, id: string, organizationId: string) {
   ]);
   const scan = scanRows[0];
   if (!scan) return null;
+  const files = await hydrateScanFileSamples(scan, fileRows, options.artifacts);
   const diff = diffForFindingAnnotations(scan.summaryJson, files);
   const annotatedFindings = annotateFindingsWithDiffStatus(findings, diff, {
     persistedAnnotations: readFindingAnnotations(scan.summaryJson),

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -78,6 +78,10 @@ export const scans = sqliteTable(
     riskSummaryJson: text("risk_summary_json", { mode: "json" }),
     reportVersion: integer("report_version"),
     reportDigest: text("report_digest"),
+    artifactStorageVersion: integer("artifact_storage_version"),
+    artifactKey: text("artifact_key"),
+    artifactDigest: text("artifact_digest"),
+    artifactSize: integer("artifact_size"),
     startedAt: integer("started_at", { mode: "timestamp_ms" }),
     completedAt: integer("completed_at", { mode: "timestamp_ms" }),
     createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
@@ -91,6 +95,11 @@ export const scans = sqliteTable(
     orgDecisionCreatedIdx: index("scans_org_decision_created_idx").on(
       table.organizationId,
       table.decision,
+      table.createdAt,
+    ),
+    artifactBackfillIdx: index("scans_artifact_backfill_idx").on(
+      table.status,
+      table.artifactStorageVersion,
       table.createdAt,
     ),
   }),

--- a/server/env.d.ts
+++ b/server/env.d.ts
@@ -6,6 +6,8 @@ declare global {
       LOADER: WorkerLoader;
       DB: D1Database;
       COMPARE_CACHE?: KVNamespace;
+      ARTIFACTS?: R2Bucket;
+      ARTIFACT_BACKFILL?: string;
       SCAN_QUEUE?: Queue<import("./lib/scan-job").QueueMessage>;
       NPM_REGISTRY: string;
       ALLOW_INSECURE_LOCAL_REGISTRY?: string;

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,7 @@ import {
 import { createAuth, getAuthSession } from "./lib/auth";
 import { errorMessage } from "./lib/errors";
 import { rateLimitResponse } from "./lib/http";
+import { runArtifactBackfillSweep } from "./lib/artifact-backfill";
 import { allowInsecureLocalRegistry } from "./lib/npm-connection";
 import {
   describeOperationalError,
@@ -295,6 +296,13 @@ export default {
   fetch: app.fetch,
   async scheduled(_event: ScheduledController, env: Cloudflare.Env, ctx: ExecutionContext) {
     await runStagedPublishesDiscoveryCron(env, ctx);
+    try {
+      await runArtifactBackfillSweep(env, createDb(env.DB));
+    } catch (err) {
+      emitOperationalEvent("error", "scan.artifact.backfill_sweep_failed", {
+        error: describeOperationalError(err),
+      });
+    }
   },
   async queue(batch: MessageBatch<QueueMessage>, env: Cloudflare.Env, ctx: ExecutionContext) {
     for (const message of batch.messages) {

--- a/server/lib/artifact-backfill.ts
+++ b/server/lib/artifact-backfill.ts
@@ -1,0 +1,106 @@
+import {
+  listScanArtifactBackfillCandidates,
+  markScanArtifactBacked,
+  type AppDb,
+  type ScanArtifactBackfillCandidate,
+} from "../db";
+import {
+  buildBackfillArtifactBundle,
+  scanArtifactFileSamples,
+  ScanArtifactError,
+  writeScanArtifact,
+} from "./scan-artifacts";
+import { describeOperationalError, emitOperationalEvent } from "./observability";
+
+export const DEFAULT_ARTIFACT_BACKFILL_BATCH = 25;
+
+const ENABLED_VALUES = new Set(["1", "true", "on", "yes"]);
+
+/**
+ * Backfill is the migration's resumable catch-up phase and stays off until an
+ * operator opts in. Flipping `ARTIFACT_BACKFILL` back off (or unbinding
+ * `ARTIFACTS`) is the rollback toggle: the sweep returns early and never touches
+ * R2 or D1.
+ */
+export function artifactBackfillEnabled(env: Cloudflare.Env): boolean {
+  const flag = env.ARTIFACT_BACKFILL;
+  return typeof flag === "string" && ENABLED_VALUES.has(flag.trim().toLowerCase());
+}
+
+export interface ArtifactBackfillSweepOptions {
+  batchSize?: number;
+}
+
+export interface ArtifactBackfillSweepResult {
+  considered: number;
+  written: number;
+  failed: number;
+}
+
+/**
+ * Write one batch of un-backfilled completed scans to R2. Idempotent: a
+ * successful write marks the row artifact-backed, removing it from the next
+ * sweep's candidate set, so repeated runs converge without double-writing.
+ * Backfill bundles carry `report.payload = null` (the original canonical report
+ * predates R2 and cannot be rebuilt), so they are verified by byte digest only.
+ */
+export async function runArtifactBackfillSweep(
+  env: Cloudflare.Env,
+  db: AppDb,
+  options: ArtifactBackfillSweepOptions = {},
+): Promise<ArtifactBackfillSweepResult> {
+  const result: ArtifactBackfillSweepResult = { considered: 0, written: 0, failed: 0 };
+  const bucket = env.ARTIFACTS;
+  if (!bucket || !artifactBackfillEnabled(env)) return result;
+
+  const batchSize = options.batchSize ?? DEFAULT_ARTIFACT_BACKFILL_BATCH;
+  const candidates = await listScanArtifactBackfillCandidates(db, batchSize);
+  result.considered = candidates.length;
+  if (!candidates.length) return result;
+
+  for (const candidate of candidates) {
+    try {
+      await backfillScanArtifact(bucket, db, candidate);
+      result.written += 1;
+    } catch (err) {
+      result.failed += 1;
+      emitOperationalEvent("error", "scan.artifact.backfill_failed", {
+        scanId: candidate.id,
+        organizationId: candidate.organizationId,
+        code: err instanceof ScanArtifactError ? err.code : undefined,
+        error: describeOperationalError(err),
+      });
+    }
+  }
+
+  emitOperationalEvent("info", "scan.artifact.backfill_sweep", {
+    considered: result.considered,
+    written: result.written,
+    failed: result.failed,
+  });
+  return result;
+}
+
+async function backfillScanArtifact(
+  bucket: R2Bucket,
+  db: AppDb,
+  candidate: ScanArtifactBackfillCandidate,
+): Promise<void> {
+  const bundle = buildBackfillArtifactBundle({
+    scanId: candidate.id,
+    organizationId: candidate.organizationId,
+    reportVersion: candidate.reportVersion,
+    reportDigest: candidate.reportDigest,
+    summary: candidate.summaryJson,
+    fileSamples: scanArtifactFileSamples(candidate.files),
+  });
+  const written = await writeScanArtifact(bucket, bundle);
+  await markScanArtifactBacked(db, {
+    scanId: candidate.id,
+    organizationId: candidate.organizationId,
+    storageVersion: written.storageVersion,
+    key: written.key,
+    digest: written.digest,
+    size: written.size,
+  });
+}

--- a/server/lib/canonical-json.ts
+++ b/server/lib/canonical-json.ts
@@ -1,0 +1,19 @@
+/**
+ * Deterministic JSON serialization used for content digests. Keys are sorted and
+ * `undefined` values dropped so the same logical value always hashes identically,
+ * regardless of property insertion order. Shared by the scan pipeline (report
+ * digest) and the R2 artifact store (bundle integrity + report digest re-check).
+ */
+export function stableJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, item]) => item !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b));
+  return `{${entries.map(([key, item]) => `${JSON.stringify(key)}:${stableJson(item)}`).join(",")}}`;
+}
+
+export async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+}

--- a/server/lib/scan-artifacts.ts
+++ b/server/lib/scan-artifacts.ts
@@ -1,0 +1,239 @@
+import { sha256Hex, stableJson } from "./canonical-json";
+
+/**
+ * R2-backed scan artifact storage.
+ *
+ * D1 stays the authoritative metadata/index store; the heavy derived evidence
+ * (canonical report JSON, redacted diff, redacted staged file text samples) is
+ * bundled into a single digest-verified R2 object per scan. The bundle is keyed
+ * by organization + scan + storage version so retention and rollback stay simple.
+ *
+ * This module is intentionally free of D1/Drizzle imports: callers pass plain
+ * data in and persist the returned key/digest/size metadata themselves. See
+ * `docs/r2-artifacts.md`.
+ */
+
+export const SCAN_ARTIFACT_STORAGE_VERSION = 1;
+
+export type ScanArtifactOrigin = "pipeline" | "backfill";
+
+export interface ScanArtifactFileSample {
+  path: string;
+  textSample: string;
+}
+
+export interface ScanArtifactBundle {
+  storageVersion: number;
+  scanId: string;
+  organizationId: string;
+  origin: ScanArtifactOrigin;
+  report: {
+    version: number | null;
+    digest: string | null;
+    /**
+     * Canonical report payload. Present for pipeline-origin bundles, where it is
+     * reproducible and its digest must equal `report.digest`. `null` for
+     * backfilled scans whose original payload predates R2 and cannot be rebuilt
+     * from D1 — those bundles are verified by their byte digest only.
+     */
+    payload: unknown | null;
+  };
+  /** Snapshot of `scans.summary_json` (diff, packageJsonDiff, risk, baseline, safety). */
+  summary: unknown;
+  fileSamples: ScanArtifactFileSample[];
+}
+
+export type ScanArtifactErrorCode =
+  | "artifact_readback_missing"
+  | "artifact_digest_mismatch"
+  | "report_digest_mismatch"
+  | "artifact_malformed";
+
+export class ScanArtifactError extends Error {
+  constructor(
+    public code: ScanArtifactErrorCode,
+    public key: string,
+  ) {
+    super(`${code}: ${key}`);
+    this.name = "ScanArtifactError";
+  }
+}
+
+export function scanArtifactKey(
+  organizationId: string,
+  scanId: string,
+  storageVersion: number = SCAN_ARTIFACT_STORAGE_VERSION,
+): string {
+  return `reports/${organizationId}/${scanId}/v${storageVersion}.json`;
+}
+
+/**
+ * Project a set of file records down to the path + redacted text sample pairs
+ * that are worth persisting. Files without a text sample carry no heavy payload
+ * and are reconstructable from their D1 metadata row, so they are skipped.
+ */
+export function scanArtifactFileSamples(
+  files: Array<{ path: string; textSample?: string | null }>,
+): ScanArtifactFileSample[] {
+  const samples: ScanArtifactFileSample[] = [];
+  for (const file of files) {
+    if (typeof file.textSample === "string" && file.textSample.length > 0) {
+      samples.push({ path: file.path, textSample: file.textSample });
+    }
+  }
+  return samples;
+}
+
+export interface BuildPipelineArtifactBundleInput {
+  scanId: string;
+  organizationId: string;
+  reportVersion: number | null;
+  reportDigest: string | null;
+  reportPayload: unknown;
+  summary: unknown;
+  fileSamples: ScanArtifactFileSample[];
+}
+
+export function buildPipelineArtifactBundle(
+  input: BuildPipelineArtifactBundleInput,
+): ScanArtifactBundle {
+  return {
+    storageVersion: SCAN_ARTIFACT_STORAGE_VERSION,
+    scanId: input.scanId,
+    organizationId: input.organizationId,
+    origin: "pipeline",
+    report: {
+      version: input.reportVersion,
+      digest: input.reportDigest,
+      payload: input.reportPayload,
+    },
+    summary: input.summary,
+    fileSamples: input.fileSamples,
+  };
+}
+
+export interface BuildBackfillArtifactBundleInput {
+  scanId: string;
+  organizationId: string;
+  reportVersion: number | null;
+  reportDigest: string | null;
+  summary: unknown;
+  fileSamples: ScanArtifactFileSample[];
+}
+
+export function buildBackfillArtifactBundle(
+  input: BuildBackfillArtifactBundleInput,
+): ScanArtifactBundle {
+  return {
+    storageVersion: SCAN_ARTIFACT_STORAGE_VERSION,
+    scanId: input.scanId,
+    organizationId: input.organizationId,
+    origin: "backfill",
+    report: {
+      version: input.reportVersion,
+      digest: input.reportDigest,
+      payload: null,
+    },
+    summary: input.summary,
+    fileSamples: input.fileSamples,
+  };
+}
+
+export interface WriteScanArtifactResult {
+  key: string;
+  storageVersion: number;
+  digest: string;
+  size: number;
+}
+
+/**
+ * Write the bundle to R2 and verify it before the caller marks the scan
+ * artifact-backed. Verification re-reads the object (durability), recomputes the
+ * byte digest (integrity), and — for pipeline bundles — re-derives the canonical
+ * report digest so it provably matches the digest persisted in D1.
+ */
+export async function writeScanArtifact(
+  bucket: R2Bucket,
+  bundle: ScanArtifactBundle,
+): Promise<WriteScanArtifactResult> {
+  const key = scanArtifactKey(bundle.organizationId, bundle.scanId, bundle.storageVersion);
+  const serialized = JSON.stringify(bundle);
+  const bytes = new TextEncoder().encode(serialized);
+  const digest = await sha256Hex(serialized);
+
+  await bucket.put(key, bytes, {
+    httpMetadata: { contentType: "application/json" },
+    customMetadata: {
+      scanId: bundle.scanId,
+      organizationId: bundle.organizationId,
+      storageVersion: String(bundle.storageVersion),
+      origin: bundle.origin,
+      digest,
+    },
+  });
+
+  const readback = await bucket.get(key);
+  if (!readback) throw new ScanArtifactError("artifact_readback_missing", key);
+  const readbackDigest = await sha256Hex(await readback.text());
+  if (readbackDigest !== digest) throw new ScanArtifactError("artifact_digest_mismatch", key);
+
+  if (bundle.origin === "pipeline" && bundle.report.payload != null && bundle.report.digest) {
+    const reportDigest = await sha256Hex(stableJson(bundle.report.payload));
+    if (reportDigest !== bundle.report.digest) {
+      throw new ScanArtifactError("report_digest_mismatch", key);
+    }
+  }
+
+  return { key, storageVersion: bundle.storageVersion, digest, size: bytes.byteLength };
+}
+
+export interface ReadScanArtifactRef {
+  key: string;
+  /** `scans.artifact_digest`; when present the read is rejected on mismatch. */
+  expectedDigest: string | null;
+}
+
+/**
+ * Read and verify a bundle. Returns `null` when the object is absent (caller
+ * should fall back to D1). Throws `ScanArtifactError` on digest mismatch or a
+ * malformed payload so the caller can log the integrity failure and fall back.
+ */
+export async function readScanArtifact(
+  bucket: R2Bucket,
+  ref: ReadScanArtifactRef,
+): Promise<ScanArtifactBundle | null> {
+  const object = await bucket.get(ref.key);
+  if (!object) return null;
+  const text = await object.text();
+  if (ref.expectedDigest) {
+    const digest = await sha256Hex(text);
+    if (digest !== ref.expectedDigest)
+      throw new ScanArtifactError("artifact_digest_mismatch", ref.key);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new ScanArtifactError("artifact_malformed", ref.key);
+  }
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    Array.isArray(parsed) ||
+    !Array.isArray((parsed as ScanArtifactBundle).fileSamples)
+  ) {
+    throw new ScanArtifactError("artifact_malformed", ref.key);
+  }
+  return parsed as ScanArtifactBundle;
+}
+
+/** Map of file path → redacted text sample for hydrating D1 file rows on read. */
+export function scanArtifactSampleMap(bundle: ScanArtifactBundle): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const sample of bundle.fileSamples) {
+    if (sample && typeof sample.path === "string" && typeof sample.textSample === "string") {
+      map.set(sample.path, sample.textSample);
+    }
+  }
+  return map;
+}

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -1,5 +1,18 @@
-import { persistScan, recordScanEvent, type AppDb, type WorkspaceSession } from "../db";
+import {
+  markScanArtifactBacked,
+  persistScan,
+  recordScanEvent,
+  type AppDb,
+  type WorkspaceSession,
+} from "../db";
 import { runSelectiveAiReview, type AiReview } from "./ai-review";
+import { sha256Hex, stableJson } from "./canonical-json";
+import {
+  buildPipelineArtifactBundle,
+  ScanArtifactError,
+  scanArtifactFileSamples,
+  writeScanArtifact,
+} from "./scan-artifacts";
 import type {
   AdapterBroker,
   AdapterConnectionRef,
@@ -161,6 +174,22 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
     };
     const reportDigest = await sha256Hex(stableJson(reportPayload));
 
+    const summaryJson = {
+      report: {
+        version: reportPayload.version,
+        digest: reportDigest,
+        digestAlgorithm: "sha256",
+        generatedAt: new Date().toISOString(),
+        rulesVersion: reportPayload.rulesVersion,
+      },
+      packageJsonDiff: manifestDiff,
+      diff: fileDiff,
+      risk: riskSummary,
+      stagedPublish: redactedDetails,
+      baseline: baseline.baseline,
+      safety: result.safety,
+    };
+
     const persisted = await persistScan(db, {
       id: scanId,
       stageId: input.stageId,
@@ -170,21 +199,7 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
       previousPackageJson: redactedPreviousManifest,
       risk,
       status: "complete",
-      summary: {
-        report: {
-          version: reportPayload.version,
-          digest: reportDigest,
-          digestAlgorithm: "sha256",
-          generatedAt: new Date().toISOString(),
-          rulesVersion: reportPayload.rulesVersion,
-        },
-        packageJsonDiff: manifestDiff,
-        diff: fileDiff,
-        risk: riskSummary,
-        stagedPublish: redactedDetails,
-        baseline: baseline.baseline,
-        safety: result.safety,
-      },
+      summary: summaryJson,
       ai: aiFindings,
       files: redactedStagedFiles,
       previousFiles: redactedPreviousFiles,
@@ -196,6 +211,17 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
     });
 
     if (persisted.persisted) {
+      await writeScanArtifactForCompletedScan({
+        env,
+        db,
+        scanId,
+        organizationId: input.organizationId,
+        reportVersion: reportPayload.version,
+        reportDigest,
+        reportPayload,
+        summary: summaryJson,
+        files: redactedStagedFiles,
+      });
       await recordScanEvent(db, {
         organizationId: input.organizationId,
         actorUserId: session.userId,
@@ -324,16 +350,59 @@ function stripFindingAnnotations(
   }));
 }
 
-async function sha256Hex(value: string) {
-  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
-  return [...new Uint8Array(digest)].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+interface WriteScanArtifactArgs {
+  env: Cloudflare.Env;
+  db: AppDb;
+  scanId: string;
+  organizationId: string;
+  reportVersion: number;
+  reportDigest: string;
+  reportPayload: unknown;
+  summary: unknown;
+  files: Array<{ path: string; textSample?: string | null }>;
 }
 
-function stableJson(value: unknown): string {
-  if (value === null || typeof value !== "object") return JSON.stringify(value);
-  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
-  const entries = Object.entries(value as Record<string, unknown>)
-    .filter(([, item]) => item !== undefined)
-    .sort(([a], [b]) => a.localeCompare(b));
-  return `{${entries.map(([key, item]) => `${JSON.stringify(key)}:${stableJson(item)}`).join(",")}}`;
+/**
+ * Dual-write the completed scan's derived evidence to R2 alongside D1. Best
+ * effort: D1 already holds the authoritative copy, so a missing binding or any
+ * R2/verification failure is logged and swallowed — the scan stays D1-only and
+ * shadow-read falls back automatically. The row is only marked artifact-backed
+ * after the bundle is digest-verified.
+ */
+async function writeScanArtifactForCompletedScan(args: WriteScanArtifactArgs): Promise<void> {
+  const bucket = args.env.ARTIFACTS;
+  if (!bucket) return;
+  try {
+    const bundle = buildPipelineArtifactBundle({
+      scanId: args.scanId,
+      organizationId: args.organizationId,
+      reportVersion: args.reportVersion,
+      reportDigest: args.reportDigest,
+      reportPayload: args.reportPayload,
+      summary: args.summary,
+      fileSamples: scanArtifactFileSamples(args.files),
+    });
+    const written = await writeScanArtifact(bucket, bundle);
+    await markScanArtifactBacked(args.db, {
+      scanId: args.scanId,
+      organizationId: args.organizationId,
+      storageVersion: written.storageVersion,
+      key: written.key,
+      digest: written.digest,
+      size: written.size,
+    });
+    emitOperationalEvent("info", "scan.artifact.written", {
+      scanId: args.scanId,
+      organizationId: args.organizationId,
+      storageVersion: written.storageVersion,
+      size: written.size,
+    });
+  } catch (err) {
+    emitOperationalEvent("error", "scan.artifact.write_failed", {
+      scanId: args.scanId,
+      organizationId: args.organizationId,
+      code: err instanceof ScanArtifactError ? err.code : undefined,
+      error: describeOperationalError(err),
+    });
+  }
 }

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -164,16 +164,22 @@ scansRoutes.post("/:id/decision", async (c) => {
   const session = c.get("authSession");
   const organizationId = await requireActiveOrganization(c, db);
 
-  const updated = await recordScanDecision(db, {
-    scanId: c.req.param("id"),
-    organizationId,
-    actorUserId: session.userId,
-    decision: body.decision as ScanDecision,
-    reason,
-  });
+  const updated = await recordScanDecision(
+    db,
+    {
+      scanId: c.req.param("id"),
+      organizationId,
+      actorUserId: session.userId,
+      decision: body.decision as ScanDecision,
+      reason,
+    },
+    { artifacts: c.env.ARTIFACTS },
+  );
 
   if (!updated) {
-    const existing = await getScan(db, c.req.param("id"), organizationId);
+    const existing = await getScan(db, c.req.param("id"), organizationId, {
+      artifacts: c.env.ARTIFACTS,
+    });
     if (!existing) return c.json({ error: "not found" }, 404);
     return c.json({ error: "decision can only be set on completed scans" }, 409);
   }
@@ -185,7 +191,9 @@ scansRoutes.get("/:id", async (c) => {
   const db = createDb(c.env.DB);
   const session = c.get("authSession");
   const organizationId = await requireActiveOrganization(c, db);
-  const scan = await getScan(db, c.req.param("id"), organizationId);
+  const scan = await getScan(db, c.req.param("id"), organizationId, {
+    artifacts: c.env.ARTIFACTS,
+  });
   if (!scan) return c.json({ error: "not found" }, 404);
   if (c.req.query("poll") !== "1") {
     await recordScanEvent(db, {
@@ -307,7 +315,7 @@ async function resolveCompareContext(
   const db = createDb(c.env.DB);
   const session = c.get("authSession");
   const organizationId = await requireActiveOrganization(c, db);
-  const scan = await getScan(db, scanId, organizationId);
+  const scan = await getScan(db, scanId, organizationId, { artifacts: c.env.ARTIFACTS });
   if (!scan) return { error: c.json({ error: "not found" }, 404) } as const;
   if (!scan.scan.packageName)
     return { error: c.json({ error: "scan has no package name" }, 400) } as const;

--- a/test/workers/scan-artifacts-r2.test.ts
+++ b/test/workers/scan-artifacts-r2.test.ts
@@ -1,0 +1,335 @@
+import { env } from "cloudflare:test";
+import { eq } from "drizzle-orm";
+import { describe, expect, test } from "vitest";
+import {
+  createDb,
+  createScanJob,
+  ensurePersonalOrganization,
+  getScan,
+  markScanArtifactBacked,
+  persistScan,
+} from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { sha256Hex, stableJson } from "../../server/lib/canonical-json";
+import {
+  artifactBackfillEnabled,
+  runArtifactBackfillSweep,
+} from "../../server/lib/artifact-backfill";
+import {
+  buildPipelineArtifactBundle,
+  readScanArtifact,
+  SCAN_ARTIFACT_STORAGE_VERSION,
+  scanArtifactKey,
+  writeScanArtifact,
+} from "../../server/lib/scan-artifacts";
+
+interface SeededUser {
+  userId: string;
+  organizationId: string;
+}
+
+async function seedUser(): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+async function seedCompletedScan(
+  owner: SeededUser,
+  overrides: { textSample?: string } = {},
+): Promise<string> {
+  const db = createDb(env.DB);
+  const scanId = `scan_${crypto.randomUUID()}`;
+  const stageId = `stage-${scanId.slice(-12)}`;
+  await createScanJob(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+  });
+  await persistScan(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+    packageJson: { name: "@org/pkg", version: "1.0.0" },
+    risk: "low",
+    status: "complete",
+    summary: { diff: [{ path: "index.js", status: "modified" }] },
+    ai: null,
+    files: [
+      {
+        path: "index.js",
+        size: 12,
+        sha256: "abc",
+        flags: [],
+        textSample: overrides.textSample ?? "D1-SAMPLE",
+      },
+    ],
+    diff: [{ path: "index.js", status: "modified", flags: [] }],
+    findings: [],
+    report: { version: 1, digest: "report-digest" },
+  });
+  return scanId;
+}
+
+/** Env shim exposing only the bindings the backfill sweep reads. */
+function backfillEnv(enabled: boolean): Cloudflare.Env {
+  return {
+    ARTIFACTS: env.ARTIFACTS,
+    ARTIFACT_BACKFILL: enabled ? "1" : undefined,
+  } as unknown as Cloudflare.Env;
+}
+
+describe("R2 scan artifact dual-write", () => {
+  test("writes a digest-verified pipeline bundle and marks the row artifact-backed", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const db = createDb(env.DB);
+    const reportPayload = { version: 1, findings: [], summary: "ok" };
+    const reportDigest = await sha256Hex(stableJson(reportPayload));
+
+    const bundle = buildPipelineArtifactBundle({
+      scanId,
+      organizationId: owner.organizationId,
+      reportVersion: 1,
+      reportDigest,
+      reportPayload,
+      summary: { diff: [{ path: "index.js", status: "modified" }] },
+      fileSamples: [{ path: "index.js", textSample: "R2-SAMPLE" }],
+    });
+    const written = await writeScanArtifact(env.ARTIFACTS, bundle);
+    await markScanArtifactBacked(db, {
+      scanId,
+      organizationId: owner.organizationId,
+      storageVersion: written.storageVersion,
+      key: written.key,
+      digest: written.digest,
+      size: written.size,
+    });
+
+    expect(written.key).toBe(scanArtifactKey(owner.organizationId, scanId));
+    const [row] = await db
+      .select({
+        artifactStorageVersion: schema.scans.artifactStorageVersion,
+        artifactKey: schema.scans.artifactKey,
+        artifactDigest: schema.scans.artifactDigest,
+        artifactSize: schema.scans.artifactSize,
+      })
+      .from(schema.scans)
+      .where(eq(schema.scans.id, scanId))
+      .limit(1);
+    expect(row?.artifactStorageVersion).toBe(SCAN_ARTIFACT_STORAGE_VERSION);
+    expect(row?.artifactKey).toBe(written.key);
+    expect(row?.artifactDigest).toBe(written.digest);
+    expect(row?.artifactSize).toBe(written.size);
+
+    const object = await env.ARTIFACTS.get(written.key);
+    expect(object).not.toBeNull();
+    expect(await sha256Hex(await object!.text())).toBe(written.digest);
+  });
+
+  test("rejects a pipeline bundle whose report digest does not match the payload", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const bundle = buildPipelineArtifactBundle({
+      scanId,
+      organizationId: owner.organizationId,
+      reportVersion: 1,
+      reportDigest: "deadbeef",
+      reportPayload: { version: 1, findings: [] },
+      summary: {},
+      fileSamples: [],
+    });
+    await expect(writeScanArtifact(env.ARTIFACTS, bundle)).rejects.toMatchObject({
+      code: "report_digest_mismatch",
+    });
+  });
+});
+
+describe("R2 scan artifact shadow-read", () => {
+  test("getScan hydrates file samples from R2 and falls back to D1 without a bucket", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner, { textSample: "D1-SAMPLE" });
+    const db = createDb(env.DB);
+    const reportPayload = { version: 1 };
+    const reportDigest = await sha256Hex(stableJson(reportPayload));
+    const written = await writeScanArtifact(
+      env.ARTIFACTS,
+      buildPipelineArtifactBundle({
+        scanId,
+        organizationId: owner.organizationId,
+        reportVersion: 1,
+        reportDigest,
+        reportPayload,
+        summary: {},
+        fileSamples: [{ path: "index.js", textSample: "R2-SAMPLE" }],
+      }),
+    );
+    await markScanArtifactBacked(db, {
+      scanId,
+      organizationId: owner.organizationId,
+      storageVersion: written.storageVersion,
+      key: written.key,
+      digest: written.digest,
+      size: written.size,
+    });
+
+    const withR2 = await getScan(db, scanId, owner.organizationId, { artifacts: env.ARTIFACTS });
+    expect(withR2?.files.find((f) => f.path === "index.js")?.textSample).toBe("R2-SAMPLE");
+
+    const withoutR2 = await getScan(db, scanId, owner.organizationId);
+    expect(withoutR2?.files.find((f) => f.path === "index.js")?.textSample).toBe("D1-SAMPLE");
+
+    // Detail is otherwise identical between the two reads.
+    expect(withR2?.scan.id).toBe(withoutR2?.scan.id);
+    expect(withR2?.findings.length).toBe(withoutR2?.findings.length);
+    expect(withR2?.riskSummary).toEqual(withoutR2?.riskSummary);
+  });
+
+  test("falls back to D1 on a digest mismatch", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner, { textSample: "D1-SAMPLE" });
+    const db = createDb(env.DB);
+    const reportPayload = { version: 1 };
+    const written = await writeScanArtifact(
+      env.ARTIFACTS,
+      buildPipelineArtifactBundle({
+        scanId,
+        organizationId: owner.organizationId,
+        reportVersion: 1,
+        reportDigest: await sha256Hex(stableJson(reportPayload)),
+        reportPayload,
+        summary: {},
+        fileSamples: [{ path: "index.js", textSample: "R2-SAMPLE" }],
+      }),
+    );
+    // Persist a digest that no longer matches the stored object.
+    await markScanArtifactBacked(db, {
+      scanId,
+      organizationId: owner.organizationId,
+      storageVersion: written.storageVersion,
+      key: written.key,
+      digest: "0".repeat(64),
+      size: written.size,
+    });
+
+    const scan = await getScan(db, scanId, owner.organizationId, { artifacts: env.ARTIFACTS });
+    expect(scan?.files.find((f) => f.path === "index.js")?.textSample).toBe("D1-SAMPLE");
+  });
+
+  test("falls back to D1 when the R2 object is missing", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner, { textSample: "D1-SAMPLE" });
+    const db = createDb(env.DB);
+    const reportPayload = { version: 1 };
+    const written = await writeScanArtifact(
+      env.ARTIFACTS,
+      buildPipelineArtifactBundle({
+        scanId,
+        organizationId: owner.organizationId,
+        reportVersion: 1,
+        reportDigest: await sha256Hex(stableJson(reportPayload)),
+        reportPayload,
+        summary: {},
+        fileSamples: [{ path: "index.js", textSample: "R2-SAMPLE" }],
+      }),
+    );
+    await markScanArtifactBacked(db, {
+      scanId,
+      organizationId: owner.organizationId,
+      storageVersion: written.storageVersion,
+      key: written.key,
+      digest: written.digest,
+      size: written.size,
+    });
+    await env.ARTIFACTS.delete(written.key);
+
+    const scan = await getScan(db, scanId, owner.organizationId, { artifacts: env.ARTIFACTS });
+    expect(scan?.files.find((f) => f.path === "index.js")?.textSample).toBe("D1-SAMPLE");
+  });
+});
+
+describe("R2 scan artifact backfill", () => {
+  test("artifactBackfillEnabled reads the flag", () => {
+    expect(artifactBackfillEnabled(backfillEnv(true))).toBe(true);
+    expect(artifactBackfillEnabled(backfillEnv(false))).toBe(false);
+    expect(artifactBackfillEnabled({ ARTIFACT_BACKFILL: "ON" } as unknown as Cloudflare.Env)).toBe(
+      true,
+    );
+    expect(artifactBackfillEnabled({ ARTIFACT_BACKFILL: "0" } as unknown as Cloudflare.Env)).toBe(
+      false,
+    );
+  });
+
+  test("does nothing while disabled", async () => {
+    const owner = await seedUser();
+    await seedCompletedScan(owner);
+    const db = createDb(env.DB);
+    const result = await runArtifactBackfillSweep(backfillEnv(false), db);
+    expect(result).toEqual({ considered: 0, written: 0, failed: 0 });
+  });
+
+  test("backfills completed scans in idempotent batches", async () => {
+    const db = createDb(env.DB);
+    // Drain any candidates left behind by earlier tests so the batch counts
+    // below reflect only the three scans this test seeds.
+    while (
+      (await runArtifactBackfillSweep(backfillEnv(true), db, { batchSize: 100 })).written > 0
+    ) {
+      // keep sweeping until convergence
+    }
+
+    const owner = await seedUser();
+    const scanIds = [
+      await seedCompletedScan(owner),
+      await seedCompletedScan(owner),
+      await seedCompletedScan(owner),
+    ];
+
+    // First batch of two leaves one candidate behind.
+    const first = await runArtifactBackfillSweep(backfillEnv(true), db, { batchSize: 2 });
+    expect(first.considered).toBe(2);
+    expect(first.written).toBe(2);
+    expect(first.failed).toBe(0);
+
+    // Second batch sweeps the remaining one; a third converges to no work.
+    const second = await runArtifactBackfillSweep(backfillEnv(true), db, { batchSize: 2 });
+    expect(second.written).toBe(1);
+    const third = await runArtifactBackfillSweep(backfillEnv(true), db, { batchSize: 2 });
+    expect(third.considered).toBe(0);
+    expect(third.written).toBe(0);
+
+    for (const scanId of scanIds) {
+      const [row] = await db
+        .select({
+          artifactStorageVersion: schema.scans.artifactStorageVersion,
+          artifactKey: schema.scans.artifactKey,
+          artifactDigest: schema.scans.artifactDigest,
+        })
+        .from(schema.scans)
+        .where(eq(schema.scans.id, scanId))
+        .limit(1);
+      expect(row?.artifactStorageVersion).toBe(SCAN_ARTIFACT_STORAGE_VERSION);
+      expect(row?.artifactKey).toBe(scanArtifactKey(owner.organizationId, scanId));
+
+      const bundle = await readScanArtifact(env.ARTIFACTS, {
+        key: row!.artifactKey!,
+        expectedDigest: row!.artifactDigest,
+      });
+      expect(bundle?.origin).toBe("backfill");
+      expect(bundle?.report.payload).toBeNull();
+      expect(bundle?.fileSamples).toEqual([{ path: "index.js", textSample: "D1-SAMPLE" }]);
+    }
+  });
+});

--- a/test/workers/scan-artifacts-r2.test.ts
+++ b/test/workers/scan-artifacts-r2.test.ts
@@ -8,6 +8,7 @@ import {
   getScan,
   markScanArtifactBacked,
   persistScan,
+  SCAN_ARTIFACT_BACKFILL_MIN_COMPLETED_AGE_MS,
 } from "../../server/db";
 import * as schema from "../../server/db/schema";
 import { sha256Hex, stableJson } from "../../server/lib/canonical-json";
@@ -81,6 +82,16 @@ async function seedCompletedScan(
     report: { version: 1, digest: "report-digest" },
   });
   return scanId;
+}
+
+async function ageScanForBackfill(scanId: string): Promise<void> {
+  const db = createDb(env.DB);
+  await db
+    .update(schema.scans)
+    .set({
+      completedAt: new Date(Date.now() - SCAN_ARTIFACT_BACKFILL_MIN_COMPLETED_AGE_MS - 60_000),
+    })
+    .where(eq(schema.scans.id, scanId));
 }
 
 /** Env shim exposing only the bindings the backfill sweep reads. */
@@ -280,6 +291,22 @@ describe("R2 scan artifact backfill", () => {
     expect(result).toEqual({ considered: 0, written: 0, failed: 0 });
   });
 
+  test("skips freshly completed scans so live dual-write can finish", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const db = createDb(env.DB);
+
+    const result = await runArtifactBackfillSweep(backfillEnv(true), db, { batchSize: 100 });
+    expect(result.considered).toBe(0);
+
+    const [row] = await db
+      .select({ artifactStorageVersion: schema.scans.artifactStorageVersion })
+      .from(schema.scans)
+      .where(eq(schema.scans.id, scanId))
+      .limit(1);
+    expect(row?.artifactStorageVersion).toBeNull();
+  });
+
   test("backfills completed scans in idempotent batches", async () => {
     const db = createDb(env.DB);
     // Drain any candidates left behind by earlier tests so the batch counts
@@ -296,6 +323,7 @@ describe("R2 scan artifact backfill", () => {
       await seedCompletedScan(owner),
       await seedCompletedScan(owner),
     ];
+    for (const scanId of scanIds) await ageScanForBackfill(scanId);
 
     // First batch of two leaves one candidate behind.
     const first = await runArtifactBackfillSweep(backfillEnv(true), db, { batchSize: 2 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -44,6 +44,12 @@
 			"id": "b47f398d73b4446fbb4a7be3c4f1081a"
 		}
 	],
+	"r2_buckets": [
+		{
+			"binding": "ARTIFACTS",
+			"bucket_name": "staged-publish-review-artifacts"
+		}
+	],
 	"queues": {
 		"producers": [
 			{

--- a/wrangler.test.jsonc
+++ b/wrangler.test.jsonc
@@ -19,4 +19,10 @@
       "migrations_dir": "drizzle",
     },
   ],
+  "r2_buckets": [
+    {
+      "binding": "ARTIFACTS",
+      "bucket_name": "staged-publish-review-artifacts-test",
+    },
+  ],
 }


### PR DESCRIPTION
## Summary
- Dual-write each completed scan's derived evidence (canonical report JSON, redacted summary/diff snapshot, redacted file text samples) into one digest-verified R2 bundle per scan (`reports/{org}/{scan}/v{n}.json`), with D1 keeping only the key/digest/size/version reference columns.
- `getScan` shadow-reads from R2 (preferring it, falling back to D1 on any missing object, digest mismatch, or read error), and an `ARTIFACT_BACKFILL`-gated, idempotent `scheduled` sweep backfills old completed scans.
- This is the first rollout of drydock #99: no existing D1 data is deleted, so dropping the `ARTIFACTS` binding or the flag is a non-destructive rollback; D1 compaction is a deferred follow-up.
- Adds Worker tests covering write/verify/mark, report-digest rejection, shadow-read hydration, digest-mismatch + missing-object fallback, and idempotent batched backfill; plus `docs/r2-artifacts.md` and roadmap/cost/architecture/AGENTS updates.

## Test plan
- [x] `pnpm run verify` (lint, format, typecheck, 260 logic + 150 Worker tests)
- [x] `pnpm run test:e2e` (10 Playwright fake-registry tests; dev server now carries the `ARTIFACTS` binding so dual-write + shadow-read run through the browser flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)