### PR TITLE
Add human-driven PyPI workflow gate review UI

### DIFF
--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -496,7 +496,10 @@ and the consumer re-checks gate status, so a re-enqueue is safe.
 2. Load the gate. A gate that is already `approved`/`rejected` triggers a
    **redelivery** of the stored decision to GitHub (idempotent re-POST) instead
    of re-running the review; callback failures rethrow so the queue retries. A
-   non-pending, non-decided status is skipped with a warning.
+   pending gate with an attached completed review is skipped because it is
+   waiting for a human decision; a pending gate with an attached failed review
+   is retried and relinked to the new scan if the retry succeeds. A non-pending,
+   non-decided status is skipped with a warning.
 3. Record `github_workflow_gate.received`.
 4. Call `preparePyPiReleaseCandidateForGate` to resolve + verify the bundle.
    - A `WorkflowArtifactError` (e.g. `bundle_unavailable`,
@@ -515,7 +518,8 @@ and the consumer re-checks gate status, so a re-enqueue is safe.
    `stageId: "workflow-gate:<gateId>"`) and run `runScanPipeline` with the
    `pypiAdapter` over the verified manifest + artifacts. A pipeline throw marks
    the scan failed, links that failed scan to the gate so the workbench can
-   resolve gate context, records `review_failed`, and leaves the gate pending.
+   resolve gate context, records `review_failed`, and leaves the gate pending;
+   a later retry can replace that link with a completed scan.
 7. Compute an **advisory** recommendation from the release risk
    (`recommendationForReleaseRisk`: `high`/`critical` → `rejected`, otherwise
    `approved`) and record `github_workflow_gate.reviewed` with it. Then link the

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -510,13 +510,13 @@ and the consumer re-checks gate status, so a re-enqueue is safe.
 6. Create a scan job (`source: "workflow_gate"`, synthetic
    `stageId: "workflow-gate:<gateId>"`) and run `runScanPipeline` with the
    `pypiAdapter` over the verified manifest + artifacts. A pipeline throw marks
-   the scan failed, records `review_failed`, and leaves the gate pending.
+   the scan failed, links that failed scan to the gate so the workbench can
+   resolve gate context, records `review_failed`, and leaves the gate pending.
 7. Compute an **advisory** recommendation from the release risk
    (`recommendationForReleaseRisk`: `high`/`critical` → `rejected`, otherwise
    `approved`) and record `github_workflow_gate.reviewed` with it. Then link the
    scan to the gate via `attachScanToGate` and **leave the gate pending** — the
-   review never posts to GitHub. Attaching last means a transient pipeline
-   failure leaves `scanId` unset so a retry re-runs the review.
+   review never posts to GitHub.
 
 The job never auto-approves a release: approving releases the GitHub job and
 publishing happens immediately through Trusted Publishing/OIDC, which is too

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -149,6 +149,20 @@ organization (`x-organization-id` header to scope writes).
   rate-limited before minting an installation token or calling GitHub.
 - `GET /release-targets`, `POST /release-targets`,
   `DELETE /release-targets/:id` — CRUD over the mapping.
+- `GET /workflow-gates/by-scan/:scanId` — resolves the gate a persisted review
+  belongs to so the scan workbench can render gate status and the decision
+  controls. Returns the public gate shape (no `deployment_callback_url`); 404
+  when the scan is not a gate review or belongs to another org.
+- `POST /workflow-gates/:gateId/decision` — records a maintainer's
+  `{ decision: "approved" | "rejected", comment? }` and releases/blocks the held
+  GitHub job. `markGateDecided` is the single CAS out of `pending`, so a
+  double-submit (or a race with the fail-closed artifact reject) returns 409.
+  Delivery to GitHub is scheduled immediately after the CAS, before best-effort
+  scan/audit mirroring, and is handed to the gate job (over `SCAN_QUEUE`, with
+  inline fallback) so the decided gate posts its stored decision. The decision is
+  also mirrored onto the underlying scan as `publish` for approved gates or
+  `no_publish` for rejected gates when that write succeeds. Rate-limited to
+  60/min per org.
 
 `POST /release-targets` enforces every validation listed in issue #114:
 
@@ -226,12 +240,13 @@ characters and is what GitHub renders in the Actions run log, so it carries
 the link to the Drydock report.
 
 `markGateDecided` is the only transition out of `pending`: it succeeds
-exactly once thanks to the `status = 'pending'` WHERE clause, so even if the
-PyPI candidate review completes more than once we will only call GitHub a
-single time. The companion `markGateErrored` records failures (e.g. inability
-to fetch the artifact bundle, unidentifiable artifacts, scan pipeline crash)
-without consuming the gate, so the operator can retry once the underlying
-issue is fixed.
+exactly once thanks to the `status = 'pending'` WHERE clause. Its callers are
+the maintainer decision route, the fail-closed artifact reject, and (never the
+review itself) — so a double-submit, or a race between a human decision and the
+fail-closed reject, only calls GitHub a single time. The companion
+`markGateErrored` records failures (e.g. inability to fetch the artifact bundle,
+unidentifiable artifacts, scan pipeline crash) without consuming the gate, so
+the operator can retry once the underlying issue is fixed.
 
 ### Trust boundary (webhook)
 
@@ -340,6 +355,24 @@ a new deploy gate. The same helper guards the
    environment-name equality on `POST /release-targets`, so the UI cannot
    bypass the rules. Empty states link to GitHub App settings (no repos) and
    GitHub Actions environments docs (no environments).
+6. Above the release-targets form, a "PyPI gate setup" guide walks through
+   installing the App, adding a GitHub Environment custom deployment protection
+   rule, and matching the PyPI Trusted Publisher environment. It states plainly
+   that approval releases or blocks the held GitHub job and that publishing
+   happens through the workflow's Trusted Publishing OIDC exchange — Drydock
+   never holds or sees PyPI credentials.
+
+### Gate review workbench
+
+A gate review is an ordinary persisted scan, so it opens in the same diff-first
+workbench at `/dashboard/scans/<scanId>`. When the scan's `source` is
+`workflow_gate`, the page calls `GET /workflow-gates/by-scan/:scanId` and, for a
+gate still `pending`, renders approve/reject controls wired to
+`POST /workflow-gates/:gateId/decision`. The release recommendation copy is
+gate-targeted (it talks about releasing/blocking the held GitHub job rather than
+publishing to npm) but the deterministic findings, package diff, and risk
+surface are identical to npm reviews. A decided gate shows its stored decision
+and comment instead of the controls.
 
 ### Resolving artifacts for a pending gate
 
@@ -462,34 +495,39 @@ and the consumer re-checks gate status, so a re-enqueue is safe.
    non-pending, non-decided status is skipped with a warning.
 3. Record `github_workflow_gate.received`.
 4. Call `preparePyPiReleaseCandidateForGate` to resolve + verify the bundle.
-   - A `WorkflowArtifactError` (incl. a tampered `artifact_digest_mismatch`)
-     **rejects** the gate with a generic comment, records
-     `github_workflow_gate.rejected`, and POSTs the rejection. `prepare`
-     already recorded the typed `failureReason` and kept the gate pending, so
-     the `markGateDecided` CAS still fires.
+   - A `WorkflowArtifactError` (e.g. `bundle_unavailable`,
+     `artifact_identity_inconsistent`, or `release_target_mismatch`)
+     **rejects** the gate fail-closed with a generic comment, records
+     `github_workflow_gate.rejected`, and POSTs the rejection — no human is
+     needed to block an artifact that cannot be verified. `prepare` already
+     recorded the typed `failureReason` and kept the gate pending, so the
+     `markGateDecided` CAS still fires.
    - Any other error (sandbox/review failure) leaves the gate **pending**,
      records `github_workflow_gate.review_failed`, and returns without POSTing —
-     we never auto-approve on error, and the operator can retry.
+     the operator can retry.
 5. Resolve the organization owner (so the persisted scan has an owner). A
    missing owner records `review_failed` and leaves the gate pending.
 6. Create a scan job (`source: "workflow_gate"`, synthetic
-   `stageId: "workflow-gate:<gateId>"`), link it to the gate via
-   `attachScanToGate`, and run `runScanPipeline` with the `pypiAdapter` over the
-   verified manifest + artifacts. A pipeline throw marks the scan failed,
-   records `review_failed`, and leaves the gate pending.
-7. Map the release risk to a decision: `high`/`critical` → **rejected**,
-   otherwise **approved**. Record `github_workflow_gate.reviewed`.
-8. `markGateDecided` (CAS on `pending`) stores the decision, comment, and report
-   URL (`<BETTER_AUTH_URL>/dashboard/scans/<scanId>`); a `null` return means a
-   concurrent delivery already decided the gate, so we stop. Otherwise
-   `postDeploymentProtectionDecision` POSTs the approve/reject callback and we
-   record `github_workflow_gate.approved` / `.rejected` plus
-   `github_workflow_gate.decided`.
+   `stageId: "workflow-gate:<gateId>"`) and run `runScanPipeline` with the
+   `pypiAdapter` over the verified manifest + artifacts. A pipeline throw marks
+   the scan failed, records `review_failed`, and leaves the gate pending.
+7. Compute an **advisory** recommendation from the release risk
+   (`recommendationForReleaseRisk`: `high`/`critical` → `rejected`, otherwise
+   `approved`) and record `github_workflow_gate.reviewed` with it. Then link the
+   scan to the gate via `attachScanToGate` and **leave the gate pending** — the
+   review never posts to GitHub. Attaching last means a transient pipeline
+   failure leaves `scanId` unset so a retry re-runs the review.
 
-Because `markGateDecided` is the single CAS out of `pending`, a fresh-decision
-POST failure rethrows so the queue retries; the retry then falls into the
-already-decided redelivery path (step 2) rather than re-running the review or
-double-deciding.
+The job never auto-approves a release: approving releases the GitHub job and
+publishing happens immediately through Trusted Publishing/OIDC, which is too
+late to reverse. A maintainer drives the actual decision from the scan
+workbench via `POST /workflow-gates/:gateId/decision`; the recommendation
+recorded in step 7 is advisory only. Once decided, the gate job's redelivery
+path (step 2) is what POSTs the stored decision to GitHub. The decision route
+schedules that redelivery immediately after `markGateDecided`, before scan
+decision mirroring or audit events, so post-CAS bookkeeping cannot strand the
+held GitHub job behind a future 409; callback failure rethrows so the queue
+retries rather than re-running the review or double-deciding.
 
 The persisted review is an ordinary `scans` row scoped to the org with
 `source: "workflow_gate"`, reachable at `/dashboard/scans/<scanId>` — no
@@ -498,9 +536,10 @@ schema change was needed.
 
 ## Remaining work
 
-- Add UI for workflow-gate reviews and GitHub/PyPI setup guidance.
 - Record the reviewed artifact SHA-256 digests in the persisted report
   payload (the resolver returns them; the persister doesn't store them yet).
 
-Until those items land, the PyPI code is a review engine foundation and
-testable backend slice, not an end-to-end publish gate.
+The end-to-end path now works: a maintainer can configure a gate from settings,
+the webhook holds the publish job, the review surfaces in the workbench, and the
+approve/reject decision releases or blocks the job. The digest-persistence item
+above is an audit-trail enrichment, not a gap in the gate.

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -515,11 +515,13 @@ and the consumer re-checks gate status, so a re-enqueue is safe.
 5. Resolve the organization owner (so the persisted scan has an owner). A
    missing owner records `review_failed` and leaves the gate pending.
 6. Create a scan job (`source: "workflow_gate"`, synthetic
-   `stageId: "workflow-gate:<gateId>"`) and run `runScanPipeline` with the
-   `pypiAdapter` over the verified manifest + artifacts. A pipeline throw marks
-   the scan failed, links that failed scan to the gate so the workbench can
-   resolve gate context, records `review_failed`, and leaves the gate pending;
-   a later retry can replace that link with a completed scan.
+   `stageId: "workflow-gate:<gateId>"`), claim the gate's `scanId` with a CAS
+   against the scan link the worker observed, and run `runScanPipeline` with the
+   `pypiAdapter` over the verified manifest + artifacts. If another delivery
+   already claimed the gate, the worker deletes its just-created pending scan
+   and exits. A pipeline throw marks the linked scan failed, records
+   `review_failed`, and leaves the gate pending; a later retry can replace that
+   failed link with a completed scan.
 7. Compute an **advisory** recommendation from the release risk
    (`recommendationForReleaseRisk`: `high`/`critical` → `rejected`, otherwise
    `approved`) and record `github_workflow_gate.reviewed` with it. Then link the

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -157,6 +157,8 @@ organization (`x-organization-id` header to scope writes).
   `{ decision: "approved" | "rejected", comment? }` and releases/blocks the held
   GitHub job. `markGateDecided` is the single CAS out of `pending`, so a
   double-submit (or a race with the fail-closed artifact reject) returns 409.
+  Approval requires the gate to be linked to a completed `workflow_gate` scan;
+  rejection is allowed without one so maintainers can still fail closed.
   Delivery to GitHub is scheduled immediately after the CAS, before best-effort
   scan/audit mirroring, and is handed to the gate job (over `SCAN_QUEUE`, with
   inline fallback) so the decided gate posts its stored decision. The decision is
@@ -372,7 +374,9 @@ gate still `pending`, renders approve/reject controls wired to
 gate-targeted (it talks about releasing/blocking the held GitHub job rather than
 publishing to npm) but the deterministic findings, package diff, and risk
 surface are identical to npm reviews. A decided gate shows its stored decision
-and comment instead of the controls.
+and comment instead of the controls. Failed review scans also resolve their
+linked gate so the workbench can show the held GitHub job context instead of a
+detached failure.
 
 ### Resolving artifacts for a pending gate
 

--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -313,6 +313,7 @@ export interface ListScansResult {
   scans: Array<{
     id: string;
     stageId: string;
+    source: string;
     organizationId: string | null;
     ownerUserId: string | null;
     packageName: string | null;
@@ -370,6 +371,7 @@ export async function listScans(
     .select({
       id: scans.id,
       stageId: scans.stageId,
+      source: scans.source,
       organizationId: scans.organizationId,
       ownerUserId: scans.ownerUserId,
       packageName: scans.packageName,
@@ -408,6 +410,7 @@ export async function listScans(
     scans: page.map((row) => ({
       id: row.id,
       stageId: row.stageId,
+      source: row.source,
       organizationId: row.organizationId,
       ownerUserId: row.ownerUserId,
       packageName: row.packageName,

--- a/server/index.ts
+++ b/server/index.ts
@@ -200,7 +200,7 @@ app.get("/api", (c) =>
       organizations:
         "GET /api/v1/organizations; POST /api/v1/organizations; PATCH /api/v1/organizations/:id",
       githubApp:
-        "GET /api/v1/github-app/config; POST /api/v1/github-app/install; POST /api/v1/github-app/install/callback; GET /api/v1/github-app/installations; GET/POST /api/v1/github-app/release-targets; DELETE /api/v1/github-app/release-targets/:id",
+        "GET /api/v1/github-app/config; POST /api/v1/github-app/install; POST /api/v1/github-app/install/callback; GET /api/v1/github-app/installations; GET/POST /api/v1/github-app/release-targets; DELETE /api/v1/github-app/release-targets/:id; GET /api/v1/github-app/workflow-gates/by-scan/:scanId; POST /api/v1/github-app/workflow-gates/:gateId/decision",
       githubWebhooks: "POST /webhooks/github (signed by GitHub App webhook secret)",
       health: "GET /api/health",
     },

--- a/server/lib/github-app/webhook-gates.ts
+++ b/server/lib/github-app/webhook-gates.ts
@@ -105,6 +105,24 @@ export async function getGateForOrganization(
   return row ? readGateRow(row) : null;
 }
 
+export async function getGateByScanId(
+  db: AppDb,
+  organizationId: string,
+  scanId: string,
+): Promise<WorkflowGateRecord | null> {
+  const [row] = await db
+    .select()
+    .from(githubWorkflowGates)
+    .where(
+      and(
+        eq(githubWorkflowGates.scanId, scanId),
+        eq(githubWorkflowGates.organizationId, organizationId),
+      ),
+    )
+    .limit(1);
+  return row ? readGateRow(row) : null;
+}
+
 export async function attachScanToGate(db: AppDb, gateId: string, scanId: string): Promise<void> {
   const now = new Date();
   await db

--- a/server/lib/github-app/webhook-gates.ts
+++ b/server/lib/github-app/webhook-gates.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import type { AppDb } from "../../db";
 import { githubWorkflowGates } from "../../db/schema";
 import type { InstallationRecord, ReleaseTargetRecord } from "./persistence";
@@ -123,12 +123,30 @@ export async function getGateByScanId(
   return row ? readGateRow(row) : null;
 }
 
-export async function attachScanToGate(db: AppDb, gateId: string, scanId: string): Promise<void> {
+export async function attachScanToGate(
+  db: AppDb,
+  gateId: string,
+  scanId: string,
+  expectedPreviousScanId?: string | null,
+): Promise<boolean> {
   const now = new Date();
-  await db
+  const conditions = [
+    eq(githubWorkflowGates.id, gateId),
+    eq(githubWorkflowGates.status, "pending"),
+  ];
+  if (expectedPreviousScanId !== undefined) {
+    conditions.push(
+      expectedPreviousScanId === null
+        ? isNull(githubWorkflowGates.scanId)
+        : eq(githubWorkflowGates.scanId, expectedPreviousScanId),
+    );
+  }
+  const updated = await db
     .update(githubWorkflowGates)
     .set({ scanId, updatedAt: now })
-    .where(and(eq(githubWorkflowGates.id, gateId), eq(githubWorkflowGates.status, "pending")));
+    .where(and(...conditions))
+    .returning({ id: githubWorkflowGates.id });
+  return updated.length > 0;
 }
 
 interface DecideGateInput {

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -217,6 +217,10 @@ export async function executeWorkflowGateJob(
   } catch (err) {
     const safe = classifyScanError(err);
     await markScanFailed(db, scanId, organizationId, safe);
+    // The scan is already visible to the organization. Keep the gate linked so
+    // the workbench can resolve gate context for the failed review instead of
+    // leaving a detached workflow-gate scan behind.
+    await attachScanToGate(db, gate.id, scanId);
     await recordScanEvent(db, {
       organizationId,
       actorUserId: ownerUserId,
@@ -255,8 +259,7 @@ export async function executeWorkflowGateJob(
 
   // Link the gate to its completed review and leave it PENDING. A maintainer
   // drives the decision from the workbench; the recommendation above is
-  // advisory. Attaching last means a transient pipeline failure leaves
-  // gate.scanId unset so a retry re-runs the review.
+  // advisory.
   await attachScanToGate(db, gate.id, scanId);
 
   emitOperationalEvent("info", "github_workflow_gate.review_ready", {

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -26,33 +26,41 @@ import type { RiskLevel } from "./review";
 import { runScanPipeline } from "./scan-pipeline";
 import { classifyScanError, type WorkflowGateQueueMessage } from "./scan-job";
 
-// A release whose changed (release-delta) findings reach these levels must not
-// auto-publish; everything below is approved. The threshold is intentionally a
-// product decision held in one place so it is easy to tune.
+// A release whose changed (release-delta) findings reach these levels is
+// recommended for rejection in the workbench; everything below is recommended
+// for approval. This is advisory only — a human drives the actual decision.
+// The threshold is a product decision held in one place so it is easy to tune.
 const BLOCKING_RISKS: ReadonlySet<RiskLevel> = new Set<RiskLevel>(["high", "critical"]);
 
-function decisionForReleaseRisk(releaseRisk: RiskLevel): "approved" | "rejected" {
+export function recommendationForReleaseRisk(releaseRisk: RiskLevel): "approved" | "rejected" {
   return BLOCKING_RISKS.has(releaseRisk) ? "rejected" : "approved";
 }
 
 /**
- * Review a resolved PyPI workflow gate end to end and tell GitHub whether the
- * deployment may proceed.
+ * Review a resolved PyPI workflow gate end to end and leave it pending for a
+ * human decision.
  *
  * Trust boundary: the installation token never enters the sandbox. Artifact
  * bytes are fetched + SHA-256-verified in the control plane (`prepare…`), then
  * the credentials-free sandbox parser turns them into evidence the existing
  * deterministic rules run against via `runScanPipeline`.
  *
+ * Decision model: a maintainer drives the gate from the workbench. A successful
+ * review records a `reviewed` event carrying an advisory recommendation and
+ * leaves the gate PENDING — Drydock never auto-approves, because approving
+ * releases the GitHub job and publishing happens immediately via Trusted
+ * Publishing/OIDC (too late to reverse).
+ *
  * Failure handling matches the gate contract:
- *  - Artifact-level problems (`WorkflowArtifactError`, including a tampered
- *    manifest digest) → the deployment is REJECTED with a generic comment.
+ *  - Artifact-level problems (`WorkflowArtifactError`, e.g. an unverifiable
+ *    bundle, inconsistent artifact identity, or a release-target mismatch) →
+ *    the deployment is REJECTED with a generic comment (fail-closed; no human
+ *    in the loop is needed to block).
  *  - Review/processing errors → the deployment is left PENDING (never
  *    auto-approved on error); the failure is recorded and surfaced.
- *  - The GitHub callback is delivered idempotently: `markGateDecided` is a CAS
- *    on the pending row, and an already-decided gate re-delivers its stored
- *    decision so a transient callback failure can be retried without re-running
- *    the review.
+ *  - Re-enqueues are idempotent: a gate that already has a scan attached is not
+ *    re-reviewed, and an already-decided gate re-delivers its stored decision so
+ *    a transient callback failure can be retried without re-running the review.
  */
 export async function executeWorkflowGateJob(
   env: Cloudflare.Env,
@@ -100,6 +108,18 @@ export async function executeWorkflowGateJob(
       organizationId,
       gateId,
       reason: `status_${gate.status}`,
+    });
+    return;
+  }
+
+  // A prior delivery already reviewed this gate and attached its scan; it is
+  // waiting on a human decision. Re-enqueues (GitHub redelivery, queue retry)
+  // must not re-run the pipeline.
+  if (gate.scanId) {
+    emitOperationalEvent("info", "github_workflow_gate.job_skipped", {
+      organizationId,
+      gateId,
+      reason: "already_reviewed",
     });
     return;
   }
@@ -180,7 +200,6 @@ export async function executeWorkflowGateJob(
     ownerUserId,
     source: "workflow_gate",
   });
-  await attachScanToGate(db, gate.id, scanId);
 
   let result;
   try {
@@ -216,8 +235,7 @@ export async function executeWorkflowGateJob(
   }
 
   const releaseRisk = result.riskSummary.releaseRisk;
-  const decision = decisionForReleaseRisk(releaseRisk);
-  const reportUrl = buildReportUrl(env, scanId);
+  const recommendation = recommendationForReleaseRisk(releaseRisk);
 
   await recordScanEvent(db, {
     organizationId,
@@ -226,7 +244,7 @@ export async function executeWorkflowGateJob(
     type: "github_workflow_gate.reviewed",
     metadata: {
       gateId: gate.id,
-      decision,
+      recommendation,
       releaseRisk,
       artifactRisk: result.risk,
       contextRisk: result.riskSummary.contextRisk,
@@ -235,34 +253,18 @@ export async function executeWorkflowGateJob(
     },
   });
 
-  const comment = buildDecisionComment(decision, result.package.name, releaseRisk, reportUrl);
-  const decided = await markGateDecided(db, { gateId: gate.id, decision, comment, reportUrl });
-  if (!decided) {
-    // Another delivery decided this gate first; it owns the callback.
-    emitOperationalEvent("info", "github_workflow_gate.decision_skipped", {
-      organizationId,
-      gateId,
-      reason: "already_decided",
-    });
-    return;
-  }
+  // Link the gate to its completed review and leave it PENDING. A maintainer
+  // drives the decision from the workbench; the recommendation above is
+  // advisory. Attaching last means a transient pipeline failure leaves
+  // gate.scanId unset so a retry re-runs the review.
+  await attachScanToGate(db, gate.id, scanId);
 
-  await deliverGateDecision(config, db, decided);
-
-  await recordScanEvent(db, {
-    organizationId,
-    actorUserId: ownerUserId,
-    scanId,
-    type:
-      decision === "approved" ? "github_workflow_gate.approved" : "github_workflow_gate.rejected",
-    metadata: { gateId: gate.id, releaseRisk, reportUrl },
-  });
-  emitOperationalEvent("info", "github_workflow_gate.decided", {
+  emitOperationalEvent("info", "github_workflow_gate.review_ready", {
     organizationId,
     gateId,
     scanId,
-    decision,
     releaseRisk,
+    recommendation,
     durationMs: durationMsSince(startedAtMs),
   });
 }
@@ -364,20 +366,21 @@ async function getInstallationExternalId(
   return row?.installationId ?? null;
 }
 
-function buildReportUrl(env: Cloudflare.Env, scanId: string): string | null {
+export function buildReportUrl(env: Cloudflare.Env, scanId: string | null): string | null {
   const base = env.BETTER_AUTH_URL?.trim();
-  if (!base) return null;
+  if (!base || !scanId) return null;
   return `${base.replace(/\/$/, "")}/dashboard/scans/${scanId}`;
 }
 
-function buildDecisionComment(
+/**
+ * The comment GitHub renders in the Actions run log when a maintainer decides a
+ * gate from the workbench. Trimmed to 140 chars by the callback POST.
+ */
+export function buildHumanDecisionComment(
   decision: "approved" | "rejected",
-  packageName: string | null,
-  releaseRisk: RiskLevel,
   reportUrl: string | null,
 ): string {
-  const subject = packageName ? `${packageName}` : "this release";
   const verb = decision === "approved" ? "approved" : "blocked";
-  const head = `Drydock ${verb} ${subject} (release risk: ${releaseRisk}).`;
+  const head = `A Drydock maintainer ${verb} this release.`;
   return reportUrl ? `${head} Review: ${reportUrl}` : head;
 }

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -7,7 +7,7 @@ import {
   recordScanEvent,
   type AppDb,
 } from "../db";
-import { githubAppInstallations } from "../db/schema";
+import { githubAppInstallations, scans } from "../db/schema";
 import { pypiAdapter } from "./adapters/pypi/index";
 import {
   attachScanToGate,
@@ -58,9 +58,10 @@ export function recommendationForReleaseRisk(releaseRisk: RiskLevel): "approved"
  *    in the loop is needed to block).
  *  - Review/processing errors → the deployment is left PENDING (never
  *    auto-approved on error); the failure is recorded and surfaced.
- *  - Re-enqueues are idempotent: a gate that already has a scan attached is not
- *    re-reviewed, and an already-decided gate re-delivers its stored decision so
- *    a transient callback failure can be retried without re-running the review.
+ *  - Re-enqueues are idempotent: a gate with a completed review attached is not
+ *    re-reviewed, a failed attached review can be retried, and an
+ *    already-decided gate re-delivers its stored decision so a transient
+ *    callback failure can be retried without re-running the review.
  */
 export async function executeWorkflowGateJob(
   env: Cloudflare.Env,
@@ -112,16 +113,35 @@ export async function executeWorkflowGateJob(
     return;
   }
 
-  // A prior delivery already reviewed this gate and attached its scan; it is
-  // waiting on a human decision. Re-enqueues (GitHub redelivery, queue retry)
-  // must not re-run the pipeline.
   if (gate.scanId) {
-    emitOperationalEvent("info", "github_workflow_gate.job_skipped", {
+    const attachedScan = await getAttachedGateScan(db, organizationId, gate.scanId);
+    if (attachedScan?.status === "complete") {
+      // A prior delivery already reviewed this gate and attached its completed
+      // scan; it is waiting on a human decision. Re-enqueues must not re-run the
+      // pipeline.
+      emitOperationalEvent("info", "github_workflow_gate.job_skipped", {
+        organizationId,
+        gateId,
+        scanId: gate.scanId,
+        reason: "already_reviewed",
+      });
+      return;
+    }
+    if (attachedScan?.status === "pending" || attachedScan?.status === "running") {
+      emitOperationalEvent("info", "github_workflow_gate.job_skipped", {
+        organizationId,
+        gateId,
+        scanId: gate.scanId,
+        reason: `scan_${attachedScan.status}`,
+      });
+      return;
+    }
+    emitOperationalEvent("info", "github_workflow_gate.review_retrying", {
       organizationId,
       gateId,
-      reason: "already_reviewed",
+      scanId: gate.scanId,
+      priorStatus: attachedScan?.status ?? "missing",
     });
-    return;
   }
 
   await recordScanEvent(db, {
@@ -296,6 +316,20 @@ async function rejectGateForArtifactError(
     type: "github_workflow_gate.rejected",
     metadata: { gateId: gate.id, reason: error.code },
   });
+}
+
+async function getAttachedGateScan(
+  db: AppDb,
+  organizationId: string,
+  scanId: string,
+): Promise<{ status: string; source: string } | null> {
+  const [row] = await db
+    .select({ status: scans.status, source: scans.source })
+    .from(scans)
+    .where(and(eq(scans.id, scanId), eq(scans.organizationId, organizationId)))
+    .limit(1);
+  if (!row || row.source !== "workflow_gate") return null;
+  return row;
 }
 
 /**

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -2,6 +2,7 @@ import { and, eq } from "drizzle-orm";
 import {
   createDb,
   createScanJob,
+  deletePendingScanJob,
   getOrganizationOwnerUserId,
   markScanFailed,
   recordScanEvent,
@@ -220,6 +221,17 @@ export async function executeWorkflowGateJob(
     ownerUserId,
     source: "workflow_gate",
   });
+  const claimedGate = await attachScanToGate(db, gate.id, scanId, gate.scanId);
+  if (!claimedGate) {
+    await deletePendingScanJob(db, scanId, organizationId);
+    emitOperationalEvent("info", "github_workflow_gate.job_skipped", {
+      organizationId,
+      gateId,
+      scanId,
+      reason: "scan_claim_lost",
+    });
+    return;
+  }
 
   let result;
   try {
@@ -237,10 +249,6 @@ export async function executeWorkflowGateJob(
   } catch (err) {
     const safe = classifyScanError(err);
     await markScanFailed(db, scanId, organizationId, safe);
-    // The scan is already visible to the organization. Keep the gate linked so
-    // the workbench can resolve gate context for the failed review instead of
-    // leaving a detached workflow-gate scan behind.
-    await attachScanToGate(db, gate.id, scanId);
     await recordScanEvent(db, {
       organizationId,
       actorUserId: ownerUserId,
@@ -277,10 +285,10 @@ export async function executeWorkflowGateJob(
     },
   });
 
-  // Link the gate to its completed review and leave it PENDING. A maintainer
+  // Keep the completed review linked and leave the gate PENDING. A maintainer
   // drives the decision from the workbench; the recommendation above is
   // advisory.
-  await attachScanToGate(db, gate.id, scanId);
+  await attachScanToGate(db, gate.id, scanId, scanId);
 
   emitOperationalEvent("info", "github_workflow_gate.review_ready", {
     organizationId,

--- a/server/routes/github-app.ts
+++ b/server/routes/github-app.ts
@@ -3,6 +3,7 @@ import {
   RateLimitError,
   createDb,
   enforceRateLimit,
+  getScan,
   recordScanDecision,
   recordScanEvent,
 } from "../db";
@@ -439,6 +440,15 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
   const gateId = c.req.param("gateId");
   const existing = await getGateForOrganization(db, organizationId, gateId);
   if (!existing) return c.json({ error: "not found" }, 404);
+  if (decision === "approved") {
+    if (!existing.scanId) {
+      return c.json({ error: "approval requires a completed workflow-gate review" }, 409);
+    }
+    const scan = await getScan(db, existing.scanId, organizationId);
+    if (!scan || scan.scan.source !== "workflow_gate" || scan.scan.status !== "complete") {
+      return c.json({ error: "approval requires a completed workflow-gate review" }, 409);
+    }
+  }
 
   const reportUrl = buildReportUrl(c.env, existing.scanId);
   const decided = await markGateDecided(db, {

--- a/server/routes/github-app.ts
+++ b/server/routes/github-app.ts
@@ -1,7 +1,19 @@
 import { Hono, type Context } from "hono";
-import { RateLimitError, createDb, enforceRateLimit, recordScanEvent } from "../db";
+import {
+  RateLimitError,
+  createDb,
+  enforceRateLimit,
+  recordScanDecision,
+  recordScanEvent,
+} from "../db";
 import { requireActiveOrganization } from "../lib/active-organization";
 import { rateLimitResponse } from "../lib/http";
+import { describeOperationalError, emitOperationalEvent } from "../lib/observability";
+import {
+  buildHumanDecisionComment,
+  buildReportUrl,
+  executeWorkflowGateJob,
+} from "../lib/workflow-gate-job";
 import {
   GithubAppConfigError,
   GithubAppValidationError,
@@ -11,16 +23,20 @@ import {
   type InstallationRecord,
   type ReleaseTargetRecord,
   type SupportedEcosystem,
+  type WorkflowGateRecord,
   buildInstallUrl,
   createReleaseTarget,
   deleteReleaseTarget,
   fetchInstallationMetadata,
   fetchRepository,
+  getGateByScanId,
+  getGateForOrganization,
   isGithubAppConfigured,
   listInstallationRepositories,
   listInstallationsForOrganization,
   listReleaseTargetsForOrganization,
   listRepositoryEnvironments,
+  markGateDecided,
   readGithubAppConfig,
   signOAuthState,
   upsertInstallation,
@@ -370,6 +386,128 @@ githubAppRoutes.delete("/release-targets/:id", async (c) => {
   return c.json({ ok: true });
 });
 
+const GATE_DECISIONS = ["approved", "rejected"] as const;
+type GateDecision = (typeof GATE_DECISIONS)[number];
+const GATE_DECISION_SET = new Set<GateDecision>(GATE_DECISIONS);
+const GATE_DECISION_COMMENT_MAX = 500;
+
+githubAppRoutes.get("/workflow-gates/by-scan/:scanId", async (c) => {
+  const db = createDb(c.env.DB);
+  const organizationId = await requireActiveOrganization(c, db);
+  const scanId = c.req.param("scanId");
+  const gate = await getGateByScanId(db, organizationId, scanId);
+  if (!gate) return c.json({ error: "not found" }, 404);
+  return c.json({ gate: publicWorkflowGate(gate) });
+});
+
+// Record a maintainer's decision and release/block the GitHub Actions job.
+// The CAS in `markGateDecided` is the single transition out of `pending`, so a
+// double-submit (or a race with the fail-closed artifact reject) returns 409.
+// Posting the decision to GitHub is delegated to the gate job, which sees the
+// now-decided gate and delivers its stored decision — either over the queue or
+// inline when no queue is bound.
+githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
+  const body = (await c.req.json().catch(() => ({}))) as Partial<{
+    decision: string;
+    comment: string;
+  }>;
+  if (!GATE_DECISION_SET.has(body.decision as GateDecision)) {
+    return c.json({ error: "decision must be 'approved' or 'rejected'" }, 400);
+  }
+  const decision = body.decision as GateDecision;
+  const comment = typeof body.comment === "string" ? body.comment.trim() : "";
+  if (comment.length > GATE_DECISION_COMMENT_MAX) {
+    return c.json({ error: `comment must be <= ${GATE_DECISION_COMMENT_MAX} characters` }, 400);
+  }
+
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const organizationId = await requireActiveOrganization(c, db);
+  try {
+    await enforceRateLimit(db, {
+      key: `github-app:gate-decision:${organizationId}`,
+      limit: 60,
+      windowMs: 60 * 1000,
+    });
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      return rateLimitResponse(c, "gate decision rate limit exceeded", err);
+    }
+    throw err;
+  }
+
+  const gateId = c.req.param("gateId");
+  const existing = await getGateForOrganization(db, organizationId, gateId);
+  if (!existing) return c.json({ error: "not found" }, 404);
+
+  const reportUrl = buildReportUrl(c.env, existing.scanId);
+  const decided = await markGateDecided(db, {
+    gateId,
+    decision,
+    comment: comment || buildHumanDecisionComment(decision, reportUrl),
+    reportUrl,
+  });
+  if (!decided) {
+    return c.json({ error: "gate has already been decided" }, 409);
+  }
+
+  // Schedule delivery immediately after the CAS. Everything below is
+  // bookkeeping; if it throws, the durable gate decision still has a path to
+  // GitHub instead of getting stuck behind a future 409.
+  const message = { kind: "workflow_gate" as const, organizationId, gateId };
+  c.executionCtx.waitUntil(deliverGateDecisionJob(c, db, message));
+
+  // Mirror the decision onto the underlying scan so the workbench audit trail
+  // and decision filters stay consistent (approved → publish, rejected →
+  // no_publish). Best effort: only applies once the review scan is complete.
+  try {
+    if (decided.scanId) {
+      await recordScanDecision(db, {
+        scanId: decided.scanId,
+        organizationId,
+        actorUserId: session.userId,
+        decision: decision === "approved" ? "publish" : "no_publish",
+        reason: comment || null,
+      });
+    }
+
+    await recordScanEvent(db, {
+      organizationId,
+      actorUserId: session.userId,
+      scanId: decided.scanId,
+      type:
+        decision === "approved" ? "github_workflow_gate.approved" : "github_workflow_gate.rejected",
+      metadata: { gateId, decidedBy: "human", reportUrl },
+    });
+  } catch (err) {
+    emitOperationalEvent("warn", "github_workflow_gate.decision_bookkeeping_failed", {
+      organizationId,
+      gateId,
+      decision,
+      error: describeOperationalError(err),
+    });
+  }
+
+  return c.json({ gate: publicWorkflowGate(decided) });
+});
+
+async function deliverGateDecisionJob(
+  c: RouteContext,
+  db: ReturnType<typeof createDb>,
+  message: { kind: "workflow_gate"; organizationId: string; gateId: string },
+) {
+  if (c.env.SCAN_QUEUE) {
+    try {
+      await c.env.SCAN_QUEUE.send(message);
+      return;
+    } catch {
+      // Fall back to an inline redelivery attempt so a transient queue-send
+      // failure after markGateDecided does not leave the GitHub job held.
+    }
+  }
+  await executeWorkflowGateJob(c.env, c.executionCtx, message, db);
+}
+
 async function ensureInstallationOwnedBy(
   db: ReturnType<typeof createDb>,
   organizationId: string,
@@ -419,6 +557,29 @@ function publicReleaseTarget(record: ReleaseTargetRecord) {
     workflowFilename: record.workflowFilename,
     environment: record.environment,
     pypiTrustedPublisherEnvironment: record.pypiTrustedPublisherEnvironment,
+    createdAt: record.createdAt.toISOString(),
+    updatedAt: record.updatedAt.toISOString(),
+  };
+}
+
+// Excludes the deployment callback URL (and other GitHub-internal identifiers)
+// so the credentialed egress target is never exposed to the browser.
+function publicWorkflowGate(record: WorkflowGateRecord) {
+  return {
+    id: record.id,
+    organizationId: record.organizationId,
+    releaseTargetId: record.releaseTargetId,
+    repositoryFullName: record.repositoryFullName,
+    environment: record.environment,
+    runId: record.runId,
+    status: record.status,
+    decision: record.decision,
+    decisionComment: record.decisionComment,
+    reportUrl: record.reportUrl,
+    scanId: record.scanId,
+    failureReason: record.failureReason,
+    requestedAt: record.requestedAt.toISOString(),
+    decidedAt: record.decidedAt ? record.decidedAt.toISOString() : null,
     createdAt: record.createdAt.toISOString(),
     updatedAt: record.updatedAt.toISOString(),
   };

--- a/src/models/github-app.ts
+++ b/src/models/github-app.ts
@@ -31,6 +31,53 @@ export interface PublicReleaseTarget {
   updatedAt: string;
 }
 
+export type WorkflowGateStatus = "pending" | "approved" | "rejected" | "errored";
+export type WorkflowGateDecision = "approved" | "rejected";
+
+export interface PublicWorkflowGate {
+  id: string;
+  organizationId: string;
+  releaseTargetId: string;
+  repositoryFullName: string;
+  environment: string;
+  runId: number;
+  status: WorkflowGateStatus;
+  decision: WorkflowGateDecision | null;
+  decisionComment: string | null;
+  reportUrl: string | null;
+  scanId: string | null;
+  failureReason: string | null;
+  requestedAt: string;
+  decidedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// Returns null when no gate is mapped to the scan (404) so callers can treat a
+// plain manual/auto-discovery scan and a not-yet-loaded gate the same way.
+export async function getWorkflowGateByScan(scanId: string): Promise<PublicWorkflowGate | null> {
+  try {
+    const data = await apiFetch<{ gate: PublicWorkflowGate }>(
+      `/api/v1/github-app/workflow-gates/by-scan/${encodeURIComponent(scanId)}`,
+    );
+    return data.gate;
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) return null;
+    throw err;
+  }
+}
+
+export function decideWorkflowGate(
+  gateId: string,
+  decision: WorkflowGateDecision,
+  comment: string | null,
+): Promise<{ gate: PublicWorkflowGate }> {
+  return apiJson<{ gate: PublicWorkflowGate }>(
+    `/api/v1/github-app/workflow-gates/${encodeURIComponent(gateId)}/decision`,
+    comment ? { decision, comment } : { decision },
+  );
+}
+
 export interface InstallationRepository {
   id: number;
   fullName: string;

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -6,6 +6,12 @@ import type {
   PackageJsonSummary,
 } from "../../server/lib/review";
 import { apiFetch, apiJson, errorMessage } from "./api";
+import {
+  decideWorkflowGate,
+  getWorkflowGateByScan,
+  type PublicWorkflowGate,
+  type WorkflowGateDecision,
+} from "./github-app";
 
 export interface ScanVersionsResponse {
   packageName: string | null;
@@ -42,6 +48,7 @@ export interface ScanRiskSummary {
 export interface ScanListItem {
   id: string;
   stageId: string;
+  source?: string | null;
   organizationId?: string | null;
   ownerUserId?: string | null;
   packageName: string | null;
@@ -245,7 +252,12 @@ export const ScanDetailModel = createModel((id: string) => {
   const compareError = signal<string | null>(null);
   const decisionStatus = signal<DecisionStatus>("idle");
   const decisionError = signal<string | null>(null);
+  const gate = signal<PublicWorkflowGate | null>(null);
+  const gateLoaded = signal(false);
+  const gateDecisionStatus = signal<DecisionStatus>("idle");
+  const gateDecisionError = signal<string | null>(null);
 
+  const isWorkflowGate = computed(() => detail.value?.scan.source === "workflow_gate");
   const status = computed(() => detail.value?.scan.status ?? null);
   const isPolling = computed(() => status.value === "pending" || status.value === "running");
   const isDefaultComparison = computed(() => {
@@ -323,6 +335,11 @@ export const ScanDetailModel = createModel((id: string) => {
     compareError,
     decisionStatus,
     decisionError,
+    gate,
+    gateLoaded,
+    gateDecisionStatus,
+    gateDecisionError,
+    isWorkflowGate,
     status,
     isPolling,
     isDefaultComparison,
@@ -378,6 +395,41 @@ export const ScanDetailModel = createModel((id: string) => {
       } catch (err) {
         this.decisionError.value = errorMessage(err);
         this.decisionStatus.value = "error";
+      }
+    },
+
+    async loadGate(): Promise<void> {
+      const current = this.detail.peek();
+      if (current && current.scan.source !== "workflow_gate") {
+        this.gateLoaded.value = true;
+        return;
+      }
+      const id = this.scanId.peek();
+      try {
+        const gate = await getWorkflowGateByScan(id);
+        this.gate.value = gate;
+        this.gateLoaded.value = gate !== null;
+      } catch (err) {
+        this.gateDecisionError.value = errorMessage(err);
+        this.gateLoaded.value = false;
+      }
+    },
+
+    async decideGate(decision: WorkflowGateDecision, comment: string | null): Promise<void> {
+      const current = this.gate.peek();
+      if (!current) return;
+      this.gateDecisionStatus.value = "saving";
+      this.gateDecisionError.value = null;
+      try {
+        const { gate: updated } = await decideWorkflowGate(current.id, decision, comment);
+        this.gate.value = updated;
+        this.gateDecisionStatus.value = "idle";
+        // The decision also writes the scan's publish/no_publish decision and an
+        // audit event server-side; refresh so the workbench reflects both.
+        await this.load();
+      } catch (err) {
+        this.gateDecisionError.value = errorMessage(err);
+        this.gateDecisionStatus.value = "error";
       }
     },
 

--- a/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
@@ -95,6 +95,7 @@ export function GateDecisionDialog({
   packageName,
   status,
   error,
+  canApprove,
   onSubmit,
 }: {
   open: boolean;
@@ -103,6 +104,7 @@ export function GateDecisionDialog({
   packageName: string | null;
   status: DecisionStatus;
   error: string | null;
+  canApprove: boolean;
   onSubmit: (decision: WorkflowGateDecision, comment: string | null) => void | Promise<void>;
 }) {
   const commentDraft = useSignal("");
@@ -165,14 +167,21 @@ export function GateDecisionDialog({
         </Muted>
       ) : (
         <div class="flex flex-wrap gap-2">
-          <Button onClick={() => submit("approved")} disabled={saving}>
-            {saving ? "Submitting…" : "Approve & release"}
-          </Button>
+          {canApprove ? (
+            <Button onClick={() => submit("approved")} disabled={saving}>
+              {saving ? "Submitting…" : "Approve & release"}
+            </Button>
+          ) : null}
           <Button variant="danger" onClick={() => submit("rejected")} disabled={saving}>
             {saving ? "Submitting…" : "Reject & block"}
           </Button>
         </div>
       )}
+      {!decided && !canApprove ? (
+        <Muted class="m-0 text-[13px]">
+          Approval requires a completed review. Rejecting blocks the held GitHub job.
+        </Muted>
+      ) : null}
       {error ? <Alert tone="critical">{error}</Alert> : null}
     </Dialog>
   );

--- a/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
@@ -1,0 +1,179 @@
+import { useEffect } from "preact/hooks";
+import { useSignal } from "@preact/signals";
+import type { DecisionStatus } from "../../../models/scan";
+import type { PublicWorkflowGate, WorkflowGateDecision } from "../../../models/github-app";
+import {
+  Alert,
+  Badge,
+  Button,
+  Dialog,
+  Field,
+  Input,
+  LoadingLine,
+  MonoDetail,
+  Muted,
+  SectionLabel,
+} from "../../../components";
+
+export function gateStatusTone(status: PublicWorkflowGate["status"]) {
+  switch (status) {
+    case "approved":
+      return "ok" as const;
+    case "rejected":
+    case "errored":
+      return "critical" as const;
+    default:
+      return "medium" as const;
+  }
+}
+
+export function gateStatusLabel(status: PublicWorkflowGate["status"]): string {
+  switch (status) {
+    case "approved":
+      return "approved · job released";
+    case "rejected":
+      return "rejected · job blocked";
+    case "errored":
+      return "review errored";
+    default:
+      return "awaiting decision";
+  }
+}
+
+export function GateContextPanel({
+  gate,
+  packageName,
+}: {
+  gate: PublicWorkflowGate | null;
+  packageName: string | null;
+}) {
+  return (
+    <section class="flex flex-col gap-3 border border-border rounded-lg p-4">
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <SectionLabel>Deployment gate</SectionLabel>
+        {gate ? (
+          <Badge tone={gateStatusTone(gate.status)}>{gateStatusLabel(gate.status)}</Badge>
+        ) : null}
+      </div>
+      <p class="m-0 max-w-[760px] text-[14px] leading-[1.55] text-ink-muted">
+        GitHub Actions is holding the publish job
+        {packageName ? (
+          <>
+            {" "}
+            for <code>{packageName}</code>
+          </>
+        ) : null}
+        . Drydock reviewed the release candidate it built — approving releases the held job and
+        publishing proceeds through PyPI Trusted Publishing (OIDC). Drydock never holds PyPI
+        credentials and never uploads the package itself.
+      </p>
+      {gate ? (
+        <MonoDetail
+          parts={[
+            <span key="repo">{gate.repositoryFullName}</span>,
+            <span key="env">env {gate.environment}</span>,
+            <span key="run">run #{gate.runId}</span>,
+          ]}
+        />
+      ) : (
+        <LoadingLine size="inline">Loading gate context</LoadingLine>
+      )}
+      {gate?.failureReason ? (
+        <Alert tone="critical">
+          Drydock blocked this release automatically — the published artifacts could not be verified
+          against the reviewed manifest ({gate.failureReason}).
+        </Alert>
+      ) : null}
+    </section>
+  );
+}
+
+export function GateDecisionDialog({
+  open,
+  onClose,
+  gate,
+  packageName,
+  status,
+  error,
+  onSubmit,
+}: {
+  open: boolean;
+  onClose: () => void;
+  gate: PublicWorkflowGate;
+  packageName: string | null;
+  status: DecisionStatus;
+  error: string | null;
+  onSubmit: (decision: WorkflowGateDecision, comment: string | null) => void | Promise<void>;
+}) {
+  const commentDraft = useSignal("");
+  const saving = status === "saving";
+  const decided = gate.status === "approved" || gate.status === "rejected";
+
+  useEffect(() => {
+    if (open) commentDraft.value = "";
+  }, [open]);
+
+  const submit = (next: WorkflowGateDecision) => {
+    if (saving || decided) return;
+    const trimmed = commentDraft.value.trim();
+    void onSubmit(next, trimmed.length ? trimmed : null);
+  };
+
+  const handleClose = () => {
+    if (saving) return;
+    onClose();
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      title="Release decision"
+      description="Approve to release the held GitHub Actions job — publishing then proceeds through PyPI Trusted Publishing (OIDC). Reject to block the job. Drydock never holds PyPI credentials or uploads the package."
+    >
+      <div class="flex flex-col gap-2 border border-border rounded-md p-3">
+        <MonoDetail
+          parts={[
+            packageName ? <span key="pkg">{packageName}</span> : null,
+            <span key="repo">{gate.repositoryFullName}</span>,
+            <span key="env">env {gate.environment}</span>,
+            <span key="run">run #{gate.runId}</span>,
+          ]}
+        />
+        {decided ? (
+          <Badge tone={gateStatusTone(gate.status)}>{gateStatusLabel(gate.status)}</Badge>
+        ) : null}
+      </div>
+
+      <Field label="Comment (optional · shown in the GitHub run log)" for="gateComment">
+        <Input
+          id="gateComment"
+          type="text"
+          value={commentDraft.value}
+          placeholder="e.g. reviewed changed files, no risk signals"
+          onInput={(e) => (commentDraft.value = (e.target as HTMLInputElement).value)}
+          disabled={saving || decided}
+          maxLength={500}
+          autoComplete="off"
+          spellcheck={false}
+        />
+      </Field>
+
+      {decided ? (
+        <Muted class="m-0 text-[13px]">
+          This gate has already been decided. The decision is final — GitHub has been notified.
+        </Muted>
+      ) : (
+        <div class="flex flex-wrap gap-2">
+          <Button onClick={() => submit("approved")} disabled={saving}>
+            {saving ? "Submitting…" : "Approve & release"}
+          </Button>
+          <Button variant="danger" onClick={() => submit("rejected")} disabled={saving}>
+            {saving ? "Submitting…" : "Reject & block"}
+          </Button>
+        </div>
+      )}
+      {error ? <Alert tone="critical">{error}</Alert> : null}
+    </Dialog>
+  );
+}

--- a/src/pages/Dashboard/ScanDetail/ReleaseRecommendation.tsx
+++ b/src/pages/Dashboard/ScanDetail/ReleaseRecommendation.tsx
@@ -14,6 +14,7 @@ export function ReleaseRecommendation({
   diffCount,
   findingsWithDiffStatus,
   usePersistedRiskSummary,
+  isWorkflowGate,
 }: {
   detail: PersistedScanDetail;
   summary: PersistedSummary;
@@ -21,6 +22,7 @@ export function ReleaseRecommendation({
   diffCount: number;
   findingsWithDiffStatus: FindingWithDiffStatus[];
   usePersistedRiskSummary: boolean;
+  isWorkflowGate: boolean;
 }) {
   if (detail.scan.status !== "complete") return null;
 
@@ -37,7 +39,12 @@ export function ReleaseRecommendation({
       ? detail.riskSummary.releaseFindingCount
       : changedFindings.length;
   const aiFindings: AiFinding[] = ai?.kind === "complete" ? ai.findings : [];
-  const recommendation = getReleaseRecommendation(artifactRisk, releaseRisk, releaseFindingCount);
+  const recommendation = getReleaseRecommendation(
+    artifactRisk,
+    releaseRisk,
+    releaseFindingCount,
+    isWorkflowGate ? "gate" : "npm",
+  );
   const evidence = buildRecommendationEvidence(
     detail,
     summary,

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -234,10 +234,14 @@ export default function ScanDetailPage() {
     }
   };
 
-  // npm scans become decidable once complete; gate scans only while the gate is
-  // still pending (the decision is a one-way release/block of the GitHub job).
+  const gateReviewComplete = detail?.scan.status === "complete";
+  const gateReviewFailed = detail?.scan.status === "failed";
+
+  // npm scans become decidable once complete; gate scans are decidable while
+  // pending after the review either completes or fails. Failed reviews can only
+  // be rejected because approval releases the held GitHub job.
   const onDecideClick = isWorkflowGate
-    ? gate?.status === "pending"
+    ? gate?.status === "pending" && (gateReviewComplete || gateReviewFailed)
       ? () => (gateDialogOpen.value = true)
       : undefined
     : detail?.scan.status === "complete"
@@ -380,6 +384,7 @@ export default function ScanDetailPage() {
           packageName={detail.scan.packageName}
           status={model.gateDecisionStatus.value}
           error={model.gateDecisionError.value}
+          canApprove={detail.scan.status === "complete"}
           onSubmit={handleGateDecision}
         />
       ) : null}

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -5,6 +5,7 @@ import { getDashboardReturnUrl, useQuerySignal } from "../../../lib/query-state"
 import { formatDateTime } from "../../../lib/format";
 import { sessionModel } from "../../../models/auth";
 import { ScanDetailModel, type PersistedScanDetail, type ScanDecision } from "../../../models/scan";
+import type { WorkflowGateDecision } from "../../../models/github-app";
 import { displayedAiResult, type AiReview } from "../../../../server/lib/ai-review-types";
 import {
   annotateFindingsWithDiffStatus as annotateReviewFindingsWithDiffStatus,
@@ -30,6 +31,7 @@ import {
   severityTone,
 } from "../../../components";
 import { DecisionDialog } from "./DecisionDialog";
+import { GateContextPanel, GateDecisionDialog } from "./GateDecisionDialog";
 import { DiffWorkbench } from "./DiffWorkbench";
 import { RiskSignalsSection } from "./FindingsSection";
 import { ReleaseRecommendation } from "./ReleaseRecommendation";
@@ -45,6 +47,7 @@ export default function ScanDetailPage() {
   const fileFilter = useSignal("");
   const changedFilesOnly = useSignal(true);
   const decisionDialogOpen = useSignal(false);
+  const gateDialogOpen = useSignal(false);
 
   // Two-way bind filter state to query params. The text filter is debounced
   // because it fires on every keystroke; the rest write through immediately.
@@ -92,6 +95,20 @@ export default function ScanDetailPage() {
     if (!model.detail.value?.scan.packageName) return;
     if (model.versions.value) return;
     void model.loadVersions();
+  });
+
+  // Load the workflow gate once the review completes — the gate only points at
+  // this scan after the pipeline succeeds (attach-last), so waiting for
+  // "complete" guarantees the by-scan lookup resolves.
+  useSignalEffect(() => {
+    if (!model.isWorkflowGate.value) return;
+    if (model.status.value !== "complete") return;
+    if (model.gateLoaded.value) return;
+    void model.loadGate();
+    const retryTimer = window.setInterval(() => {
+      if (!model.gateLoaded.peek()) void model.loadGate();
+    }, 2500);
+    return () => window.clearInterval(retryTimer);
   });
 
   const summary = useComputed(() => asPersistedSummary(model.detail.value?.scan.summaryJson));
@@ -200,6 +217,9 @@ export default function ScanDetailPage() {
   const hasRuleFindings = Boolean(detail?.findings.length);
   const workbenchGridClass = "grid grid-cols-1 lg:grid-cols-[300px_minmax(0,1fr)] gap-4";
 
+  const isWorkflowGate = model.isWorkflowGate.value;
+  const gate = model.gate.value;
+
   const handleDecisionSubmit = async (decision: ScanDecision, reason: string | null) => {
     await model.setDecision(decision, reason);
     if (model.decisionStatus.peek() === "idle") {
@@ -207,16 +227,31 @@ export default function ScanDetailPage() {
     }
   };
 
+  const handleGateDecision = async (decision: WorkflowGateDecision, comment: string | null) => {
+    await model.decideGate(decision, comment);
+    if (model.gateDecisionStatus.peek() === "idle") {
+      gateDialogOpen.value = false;
+    }
+  };
+
+  // npm scans become decidable once complete; gate scans only while the gate is
+  // still pending (the decision is a one-way release/block of the GitHub job).
+  const onDecideClick = isWorkflowGate
+    ? gate?.status === "pending"
+      ? () => (gateDialogOpen.value = true)
+      : undefined
+    : detail?.scan.status === "complete"
+      ? () => (decisionDialogOpen.value = true)
+      : undefined;
+
   return (
     <PageShell>
-      <ScanDetailHeader
-        detail={detail}
-        onDecideClick={
-          detail?.scan.status === "complete" ? () => (decisionDialogOpen.value = true) : undefined
-        }
-      />
+      <ScanDetailHeader detail={detail} onDecideClick={onDecideClick} />
 
       {error ? <Alert tone="critical">{error}</Alert> : null}
+      {isWorkflowGate && detail ? (
+        <GateContextPanel gate={gate} packageName={detail.scan.packageName} />
+      ) : null}
       {detail?.scan.status === "failed" ? (
         <ScanFailureAlert errorJson={detail.scan.errorJson} />
       ) : null}
@@ -235,6 +270,7 @@ export default function ScanDetailPage() {
               diffCount={diffEntries.value.filter((entry) => entry.status !== "unchanged").length}
               findingsWithDiffStatus={findingsWithDiffStatus.value}
               usePersistedRiskSummary={model.isDefaultComparison.value || !compare}
+              isWorkflowGate={isWorkflowGate}
             />
 
             {detail.scan.packageName ? (
@@ -323,7 +359,7 @@ export default function ScanDetailPage() {
         ) : null
       ) : null}
 
-      {detail && detail.scan.status === "complete" ? (
+      {detail && detail.scan.status === "complete" && !isWorkflowGate ? (
         <DecisionDialog
           open={decisionDialogOpen.value}
           onClose={() => (decisionDialogOpen.value = false)}
@@ -333,6 +369,18 @@ export default function ScanDetailPage() {
           status={model.decisionStatus.value}
           error={model.decisionError.value}
           onSubmit={handleDecisionSubmit}
+        />
+      ) : null}
+
+      {detail && isWorkflowGate && gate ? (
+        <GateDecisionDialog
+          open={gateDialogOpen.value}
+          onClose={() => (gateDialogOpen.value = false)}
+          gate={gate}
+          packageName={detail.scan.packageName}
+          status={model.gateDecisionStatus.value}
+          error={model.gateDecisionError.value}
+          onSubmit={handleGateDecision}
         />
       ) : null}
     </PageShell>
@@ -378,7 +426,7 @@ function ScanDetailHeader({
           <LoadingLine size="inline">Loading saved review</LoadingLine>
         )}
       </div>
-      {onDecideClick ? (
+      {decision || onDecideClick ? (
         <div class="flex flex-wrap items-start gap-3">
           {decision ? (
             <div class="flex flex-col items-end gap-1">
@@ -392,9 +440,11 @@ function ScanDetailHeader({
               ) : null}
             </div>
           ) : null}
-          <Button variant={decision ? "secondary" : "primary"} onClick={onDecideClick}>
-            {decision ? "Update decision" : "Decide"}
-          </Button>
+          {onDecideClick ? (
+            <Button variant={decision ? "secondary" : "primary"} onClick={onDecideClick}>
+              {decision ? "Update decision" : "Decide"}
+            </Button>
+          ) : null}
         </div>
       ) : null}
     </header>

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -97,12 +97,12 @@ export default function ScanDetailPage() {
     void model.loadVersions();
   });
 
-  // Load the workflow gate once the review completes — the gate only points at
-  // this scan after the pipeline succeeds (attach-last), so waiting for
-  // "complete" guarantees the by-scan lookup resolves.
+  // Load the workflow gate once the review reaches a terminal state. Completed
+  // and failed scans may both be linked to the pending gate so the workbench can
+  // show the held GitHub job context.
   useSignalEffect(() => {
     if (!model.isWorkflowGate.value) return;
-    if (model.status.value !== "complete") return;
+    if (model.status.value !== "complete" && model.status.value !== "failed") return;
     if (model.gateLoaded.value) return;
     void model.loadGate();
     const retryTimer = window.setInterval(() => {

--- a/src/pages/Dashboard/Settings/GithubAppSection.tsx
+++ b/src/pages/Dashboard/Settings/GithubAppSection.tsx
@@ -1,3 +1,4 @@
+import type { ComponentChildren } from "preact";
 import { useModel } from "@preact/signals";
 import { formatTimestamp } from "../../../lib/format";
 import {
@@ -103,6 +104,8 @@ export function GithubAppSection({
             You'll be sent to GitHub to pick which account to install on, then returned here.
           </Muted>
         </div>
+
+        <PypiGateSetupGuide />
       </div>
 
       <div class="border-t border-border">
@@ -248,4 +251,89 @@ function installationStatusTone(status: InstallationStatus): BadgeTone {
     case "uninstalled":
       return "critical";
   }
+}
+
+function PypiGateSetupGuide() {
+  return (
+    <div class="border border-border rounded-lg bg-surface-2 px-4 py-3 flex flex-col gap-4">
+      <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">
+        pypi gate setup
+      </span>
+      <ol class="m-0 p-0 list-none flex flex-col gap-3">
+        <SetupStep
+          index="01"
+          title="Install the GitHub App"
+          detail="Install Drydock on the GitHub organization that owns the release repository, using the button below. This lets Drydock read the held deployment and post the approve/reject decision back to GitHub."
+        />
+        <SetupStep
+          index="02"
+          title="Add a deployment protection rule"
+          detail={
+            <>
+              In the repository, open (or create) the GitHub Actions environment your publish job
+              deploys to, then enable Drydock as a custom deployment protection rule so the publish
+              job pauses for review. See{" "}
+              <a
+                class="underline"
+                href="https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-custom-deployment-protection-rules"
+                target="_blank"
+                rel="noreferrer"
+              >
+                custom deployment protection rules
+              </a>
+              .
+            </>
+          }
+        />
+        <SetupStep
+          index="03"
+          title="Match the PyPI Trusted Publisher environment"
+          detail={
+            <>
+              On PyPI, configure a Trusted Publisher for the same repository and workflow, and set
+              its environment name to match the GitHub environment exactly. The workflow keeps its
+              own OIDC trust with PyPI. See{" "}
+              <a
+                class="underline"
+                href="https://docs.pypi.org/trusted-publishers/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                PyPI Trusted Publishers
+              </a>
+              .
+            </>
+          }
+        />
+      </ol>
+      <Muted as="p" class="text-[12px] leading-[1.55] m-0">
+        Drydock reviews the release candidate and your approval releases or blocks the held GitHub
+        job. Publishing happens through the workflow's Trusted Publishing OIDC exchange{" "}
+        <span class="font-mono text-ink-subtle">→</span> Drydock never holds or sees PyPI
+        credentials.
+      </Muted>
+    </div>
+  );
+}
+
+function SetupStep({
+  index,
+  title,
+  detail,
+}: {
+  index: string;
+  title: string;
+  detail: ComponentChildren;
+}) {
+  return (
+    <li class="grid grid-cols-[28px_minmax(0,1fr)] gap-3 items-baseline min-w-0">
+      <span class="font-mono text-[11px] text-ink-subtle tabular-nums">{index}</span>
+      <div class="flex flex-col gap-1 min-w-0">
+        <span class="text-[13px] font-medium text-ink">{title}</span>
+        <Muted as="p" class="text-[12px] leading-[1.55] m-0">
+          {detail}
+        </Muted>
+      </div>
+    </li>
+  );
 }

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -360,12 +360,12 @@ function ScanTable({ scans }: { scans: ScanListItem[] }) {
           {scans.map((scan) => (
             <tr key={scan.id} class="border-b border-border last:border-b-0 hover:bg-surface-2">
               <Td>
-                <a
-                  href={`/dashboard/scans/${encodeURIComponent(scan.id)}`}
-                  class="min-w-[180px] inline-block"
-                >
-                  {scan.packageName || scan.stageId}
-                </a>
+                <span class="flex items-center gap-2 min-w-[180px]">
+                  <a href={`/dashboard/scans/${encodeURIComponent(scan.id)}`}>
+                    {scan.packageName || scan.stageId}
+                  </a>
+                  {scan.source === "workflow_gate" ? <Badge tone="neutral">gate</Badge> : null}
+                </span>
               </Td>
               <Td class="font-mono text-xs text-ink-muted whitespace-nowrap">
                 {scan.previousVersion || "—"} → {scan.stagedVersion || "—"}

--- a/src/pages/Dashboard/recommendation.ts
+++ b/src/pages/Dashboard/recommendation.ts
@@ -6,23 +6,33 @@ export interface ReleaseRecommendationCopy {
   copy: string;
 }
 
+// `target` only shapes the trailing call-to-action copy: an npm scan ends in a
+// maintainer publishing with 2FA, while a workflow gate ends in the maintainer
+// releasing or blocking the held GitHub job (publishing then happens via PyPI
+// Trusted Publishing). Labels and tones are identical either way.
 export function getReleaseRecommendation(
   artifactRisk: string,
   releaseRisk: string,
   releaseFindingCount: number,
+  target: "npm" | "gate" = "npm",
 ): ReleaseRecommendationCopy {
+  const isGate = target === "gate";
   if (releaseRisk === "critical" || releaseRisk === "high") {
     return {
       label: "block manual approval",
       tone: releaseRisk === "critical" ? "critical" : "high",
-      copy: "Do not approve this staged publish until the highlighted release evidence has been reviewed and resolved outside this tool.",
+      copy: isGate
+        ? "Reject this gate until the highlighted release evidence has been reviewed and resolved."
+        : "Do not approve this staged publish until the highlighted release evidence has been reviewed and resolved outside this tool.",
     };
   }
   if (releaseRisk === "medium") {
     return {
       label: "review carefully",
       tone: "medium",
-      copy: "Pause before approving and inspect the highest-impact findings, manifest changes, and changed files below.",
+      copy: isGate
+        ? "Pause before releasing the job and inspect the highest-impact findings, manifest changes, and changed files below."
+        : "Pause before approving and inspect the highest-impact findings, manifest changes, and changed files below.",
     };
   }
   if (
@@ -38,6 +48,8 @@ export function getReleaseRecommendation(
   return {
     label: "likely safe",
     tone: "ok",
-    copy: "No blocking deterministic signals were found; approval still remains a maintainer action in npm.",
+    copy: isGate
+      ? "No blocking deterministic signals were found; your decision below releases or blocks the held GitHub job."
+      : "No blocking deterministic signals were found; approval still remains a maintainer action in npm.",
   };
 }

--- a/test/workers/github-app.test.ts
+++ b/test/workers/github-app.test.ts
@@ -1,7 +1,13 @@
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
 import { Hono } from "hono";
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { createDb, createScanJob, ensurePersonalOrganization } from "../../server/db";
+import {
+  createDb,
+  createScanJob,
+  ensurePersonalOrganization,
+  markScanFailed,
+  persistScan,
+} from "../../server/db";
 import * as schema from "../../server/db/schema";
 import {
   GithubAppValidationError,
@@ -893,6 +899,30 @@ async function seedGate(
   return { gateId, scanId, installation, releaseTarget, runId };
 }
 
+async function completeWorkflowGateScan(input: {
+  organizationId: string;
+  ownerUserId: string;
+  gateId: string;
+  scanId: string;
+}) {
+  await persistScan(createDb(env.DB), {
+    id: input.scanId,
+    stageId: `workflow-gate:${input.gateId}`,
+    organizationId: input.organizationId,
+    ownerUserId: input.ownerUserId,
+    packageJson: { name: "pkg", version: "1.0.0" },
+    previousPackageJson: null,
+    risk: "low",
+    status: "complete",
+    summary: { diff: [] },
+    ai: null,
+    files: [],
+    previousFiles: [],
+    diff: [],
+    findings: [],
+  });
+}
+
 describe("github-app workflow-gate decision route", () => {
   test("rejects a decision that is not approved/rejected", async () => {
     const { userId, organizationId } = await seedUser();
@@ -946,9 +976,61 @@ describe("github-app workflow-gate decision route", () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
-  test("decides a pending gate once, posts to GitHub, and 409s a double-submit", async () => {
+  test("rejects approval when the gate has no completed review scan", async () => {
     const { userId, organizationId } = await seedUser();
     const { gateId } = await seedGate(organizationId);
+    globalThis.fetch = vi.fn();
+
+    const res = await callGithubAppRoute(
+      buildTestApp(userId),
+      "POST",
+      `/api/v1/github-app/workflow-gates/${gateId}/decision`,
+      { decision: "approved" },
+    );
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({
+      error: "approval requires a completed workflow-gate review",
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test("rejects approval when the linked review scan failed", async () => {
+    const { userId, organizationId } = await seedUser();
+    const { gateId, scanId } = await seedGate(organizationId, {
+      attachScan: { ownerUserId: userId },
+    });
+    await markScanFailed(createDb(env.DB), scanId!, organizationId, {
+      code: "review_failed",
+      message: "review failed",
+    });
+    globalThis.fetch = vi.fn();
+
+    const res = await callGithubAppRoute(
+      buildTestApp(userId),
+      "POST",
+      `/api/v1/github-app/workflow-gates/${gateId}/decision`,
+      { decision: "approved" },
+    );
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({
+      error: "approval requires a completed workflow-gate review",
+    });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test("decides a pending gate once, posts to GitHub, and 409s a double-submit", async () => {
+    const { userId, organizationId } = await seedUser();
+    const { gateId, scanId } = await seedGate(organizationId, {
+      attachScan: { ownerUserId: userId },
+    });
+    await completeWorkflowGateScan({
+      organizationId,
+      ownerUserId: userId,
+      gateId,
+      scanId: scanId!,
+    });
     const decisionCalls: { state: string }[] = [];
     globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const request = input instanceof Request ? input : new Request(input, init);

--- a/test/workers/github-app.test.ts
+++ b/test/workers/github-app.test.ts
@@ -1,12 +1,13 @@
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
 import { Hono } from "hono";
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { createDb, ensurePersonalOrganization } from "../../server/db";
+import { createDb, createScanJob, ensurePersonalOrganization } from "../../server/db";
 import * as schema from "../../server/db/schema";
 import {
   GithubAppValidationError,
   createReleaseTarget,
   deleteReleaseTarget,
+  getGateForOrganization,
   getInstallationByExternalId,
   listInstallationsForOrganization,
   listReleaseTargetsForOrganization,
@@ -827,5 +828,212 @@ describe("github-app cleanup helpers", () => {
 
     const aListAfter = await listReleaseTargetsForOrganization(dbInstance, a.organizationId);
     expect(aListAfter).toHaveLength(0);
+  });
+});
+
+// Seeds a pending gate (installation + release target + gate row). Pass
+// `attachScan` with the org owner's user id to also create a real `scans` row
+// and link it via the gate's `scanId` FK — required for the by-scan lookups.
+async function seedGate(
+  organizationId: string,
+  overrides: {
+    status?: "pending" | "approved" | "rejected" | "errored";
+    decision?: "approved" | "rejected" | null;
+    attachScan?: { ownerUserId: string };
+  } = {},
+) {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const installation = await seedInstallation(organizationId);
+  const runId = Math.floor(Math.random() * 1e6) + 1;
+  const releaseTarget = await createReleaseTarget(db, {
+    organizationId,
+    installationRowId: installation.id,
+    ecosystem: "pypi",
+    packageName: `pkg-${crypto.randomUUID().slice(0, 8)}`,
+    repositoryId: Math.floor(Math.random() * 1e6) + 1,
+    repositoryFullName: "octo/example",
+    workflowFilename: null,
+    environment: "pypi",
+    pypiTrustedPublisherEnvironment: "pypi",
+    createdByUserId: null,
+  });
+  const gateId = crypto.randomUUID();
+  let scanId: string | null = null;
+  if (overrides.attachScan) {
+    scanId = `scan_${crypto.randomUUID()}`;
+    await createScanJob(db, {
+      id: scanId,
+      stageId: `workflow-gate:${gateId}`,
+      organizationId,
+      ownerUserId: overrides.attachScan.ownerUserId,
+      source: "workflow_gate",
+    });
+  }
+  await db.insert(schema.githubWorkflowGates).values({
+    id: gateId,
+    organizationId,
+    installationRowId: installation.id,
+    releaseTargetId: releaseTarget.id,
+    deliveryId: crypto.randomUUID(),
+    repositoryId: releaseTarget.repositoryId,
+    repositoryFullName: "octo/example",
+    environment: "pypi",
+    runId,
+    deploymentId: 909,
+    deploymentCallbackUrl: `https://api.github.com/repos/octo/example/actions/runs/${runId}/deployment_protection_rule`,
+    eventAction: "requested",
+    status: overrides.status ?? "pending",
+    decision: overrides.decision ?? null,
+    scanId,
+    requestedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  });
+  return { gateId, scanId, installation, releaseTarget, runId };
+}
+
+describe("github-app workflow-gate decision route", () => {
+  test("rejects a decision that is not approved/rejected", async () => {
+    const { userId, organizationId } = await seedUser();
+    const { gateId } = await seedGate(organizationId);
+
+    const res = await callGithubAppRoute(
+      buildTestApp(userId),
+      "POST",
+      `/api/v1/github-app/workflow-gates/${gateId}/decision`,
+      { decision: "maybe" },
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: "decision must be 'approved' or 'rejected'",
+    });
+  });
+
+  test("rejects a comment that exceeds the length limit", async () => {
+    const { userId, organizationId } = await seedUser();
+    const { gateId } = await seedGate(organizationId);
+
+    const res = await callGithubAppRoute(
+      buildTestApp(userId),
+      "POST",
+      `/api/v1/github-app/workflow-gates/${gateId}/decision`,
+      { decision: "approved", comment: "x".repeat(501) },
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: "comment must be <= 500 characters",
+    });
+  });
+
+  test("returns 404 for a gate the organization does not own", async () => {
+    const caller = await seedUser();
+    const other = await seedUser();
+    const { gateId } = await seedGate(other.organizationId);
+    globalThis.fetch = vi.fn();
+
+    const res = await callGithubAppRoute(
+      buildTestApp(caller.userId),
+      "POST",
+      `/api/v1/github-app/workflow-gates/${gateId}/decision`,
+      { decision: "approved" },
+    );
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ error: "not found" });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  test("decides a pending gate once, posts to GitHub, and 409s a double-submit", async () => {
+    const { userId, organizationId } = await seedUser();
+    const { gateId } = await seedGate(organizationId);
+    const decisionCalls: { state: string }[] = [];
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      if (request.url.includes("/access_tokens")) {
+        return Response.json({ token: "ghs_install_token", expires_at: "2099-01-01T00:00:00Z" });
+      }
+      if (request.url.endsWith("/deployment_protection_rule")) {
+        decisionCalls.push((await request.json()) as { state: string });
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`unexpected fetch in decision test: ${request.url}`);
+    });
+
+    const first = await callGithubAppRoute(
+      buildTestApp(userId),
+      "POST",
+      `/api/v1/github-app/workflow-gates/${gateId}/decision`,
+      { decision: "approved", comment: "ship it" },
+    );
+    expect(first.status).toBe(200);
+    expect(await first.json()).toMatchObject({
+      gate: { status: "approved", decision: "approved" },
+    });
+
+    const stored = await getGateForOrganization(createDb(env.DB), organizationId, gateId);
+    expect(stored?.status).toBe("approved");
+    expect(decisionCalls).toHaveLength(1);
+    expect(decisionCalls[0].state).toBe("approved");
+
+    const second = await callGithubAppRoute(
+      buildTestApp(userId),
+      "POST",
+      `/api/v1/github-app/workflow-gates/${gateId}/decision`,
+      { decision: "rejected" },
+    );
+    expect(second.status).toBe(409);
+    expect(await second.json()).toMatchObject({ error: "gate has already been decided" });
+    // The CAS lost the second transition, so no extra callback is posted.
+    expect(decisionCalls).toHaveLength(1);
+  });
+});
+
+describe("github-app workflow-gate by-scan route", () => {
+  test("returns 404 when no gate references the scan", async () => {
+    const { userId } = await seedUser();
+    const res = await callGithubAppRoute(
+      buildTestApp(userId),
+      "GET",
+      `/api/v1/github-app/workflow-gates/by-scan/scan_${crypto.randomUUID()}`,
+    );
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ error: "not found" });
+  });
+
+  test("returns the gate for its scan without exposing the deployment callback URL", async () => {
+    const { userId, organizationId } = await seedUser();
+    const { gateId, scanId } = await seedGate(organizationId, {
+      attachScan: { ownerUserId: userId },
+    });
+
+    const res = await callGithubAppRoute(
+      buildTestApp(userId),
+      "GET",
+      `/api/v1/github-app/workflow-gates/by-scan/${scanId}`,
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { gate: Record<string, unknown> };
+    expect(body.gate.id).toBe(gateId);
+    expect(body.gate.scanId).toBe(scanId);
+    expect(body.gate).not.toHaveProperty("deploymentCallbackUrl");
+  });
+
+  test("does not leak gates across organizations", async () => {
+    const caller = await seedUser();
+    const other = await seedUser();
+    const { scanId } = await seedGate(other.organizationId, {
+      attachScan: { ownerUserId: other.userId },
+    });
+
+    const res = await callGithubAppRoute(
+      buildTestApp(caller.userId),
+      "GET",
+      `/api/v1/github-app/workflow-gates/by-scan/${scanId}`,
+    );
+    expect(res.status).toBe(404);
   });
 });

--- a/test/workers/workflow-gate-job.test.ts
+++ b/test/workers/workflow-gate-job.test.ts
@@ -554,6 +554,46 @@ describe("executeWorkflowGateJob", () => {
     expect(types).not.toContain("github_workflow_gate.rejected");
   });
 
+  test("links a failed pipeline scan back to the pending gate", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9208",
+      repositoryId: 72009,
+      runId: 14141,
+    });
+    const scenario = await buildScenario(14141, { digestMatches: true });
+    const loaderMock = buildLoaderMock();
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const sandboxEnv = {
+      ...buildEnv(bindings, loaderMock.binding),
+      FLAGS: {
+        getBooleanValue: vi.fn(async () => {
+          throw new Error("flag service unavailable");
+        }),
+      },
+    } as Cloudflare.Env;
+    const db = createDb(env.DB);
+
+    await executeWorkflowGateJob(
+      sandboxEnv,
+      ctx,
+      { kind: "workflow_gate", organizationId: seeded.organizationId, gateId: seeded.gateId },
+      db,
+    );
+
+    const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(gate?.status).toBe("pending");
+    expect(gate?.scanId).toBeTruthy();
+    expect(scenario.decisionCalls).toHaveLength(0);
+
+    const persisted = await getScan(db, gate!.scanId!, seeded.organizationId);
+    expect(persisted?.scan.status).toBe("failed");
+    expect(persisted?.scan.source).toBe("workflow_gate");
+
+    const types = await scanEventTypes(seeded.organizationId, seeded.gateId);
+    expect(types).toContain("github_workflow_gate.review_failed");
+  });
+
   test("does not re-review a pending gate that already has a scan attached", async () => {
     const seeded = await seedGateForTest({
       installationExternalId: "9207",

--- a/test/workers/workflow-gate-job.test.ts
+++ b/test/workers/workflow-gate-job.test.ts
@@ -7,9 +7,13 @@ import { eq } from "drizzle-orm";
 import {
   createReleaseTarget,
   getGateForOrganization,
+  markGateDecided,
   upsertInstallation,
 } from "../../server/lib/github-app";
-import { executeWorkflowGateJob } from "../../server/lib/workflow-gate-job";
+import {
+  executeWorkflowGateJob,
+  recommendationForReleaseRisk,
+} from "../../server/lib/workflow-gate-job";
 import worker from "../../server/index";
 
 const WEBHOOK_SECRET = "webhook-secret-value-1234567890";
@@ -361,10 +365,36 @@ async function scanEventTypes(organizationId: string, gateId: string): Promise<s
     .map((row) => row.type);
 }
 
+async function gateEventMetadata(
+  organizationId: string,
+  gateId: string,
+  type: string,
+): Promise<Record<string, unknown> | undefined> {
+  const db = createDb(env.DB);
+  const rows = await db
+    .select({ type: schema.scanEvents.type, metadataJson: schema.scanEvents.metadataJson })
+    .from(schema.scanEvents)
+    .where(eq(schema.scanEvents.organizationId, organizationId));
+  const match = rows.find((row) => {
+    const meta = row.metadataJson as { gateId?: string } | null;
+    return row.type === type && meta?.gateId === gateId;
+  });
+  return match?.metadataJson as Record<string, unknown> | undefined;
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
+describe("recommendationForReleaseRisk", () => {
+  test("recommends rejection only for high and critical release risk", () => {
+    expect(recommendationForReleaseRisk("high")).toBe("rejected");
+    expect(recommendationForReleaseRisk("critical")).toBe("rejected");
+    expect(recommendationForReleaseRisk("low")).toBe("approved");
+    expect(recommendationForReleaseRisk("medium")).toBe("approved");
+  });
+});
+
 describe("executeWorkflowGateJob", () => {
-  test("approves a clean candidate, persists the scan, and posts an approval", async () => {
+  test("reviews a clean candidate and leaves the gate pending with an approve recommendation", async () => {
     const seeded = await seedGateForTest({
       installationExternalId: "9200",
       repositoryId: 72001,
@@ -384,24 +414,30 @@ describe("executeWorkflowGateJob", () => {
       db,
     );
 
+    // Drydock never auto-approves: a clean review leaves the gate pending for a
+    // human and posts no decision to GitHub.
     const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
-    expect(gate?.status).toBe("approved");
-    expect(gate?.decision).toBe("approved");
+    expect(gate?.status).toBe("pending");
+    expect(gate?.decision).toBeNull();
     expect(gate?.scanId).toBeTruthy();
-    expect(gate?.reportUrl).toBe(`${REPORT_BASE_URL}/dashboard/scans/${gate?.scanId}`);
-
-    expect(scenario.decisionCalls).toHaveLength(1);
-    expect(scenario.decisionCalls[0].state).toBe("approved");
-    expect(scenario.decisionCalls[0].environment_name).toBe("pypi");
+    expect(scenario.decisionCalls).toHaveLength(0);
 
     const persisted = await getScan(db, gate!.scanId!, seeded.organizationId);
     expect(persisted?.scan.status).toBe("complete");
     expect(persisted?.scan.source).toBe("workflow_gate");
 
+    const reviewed = await gateEventMetadata(
+      seeded.organizationId,
+      seeded.gateId,
+      "github_workflow_gate.reviewed",
+    );
+    expect(reviewed?.recommendation).toBe("approved");
+
     const types = await scanEventTypes(seeded.organizationId, seeded.gateId);
     expect(types).toContain("github_workflow_gate.received");
     expect(types).toContain("github_workflow_gate.reviewed");
-    expect(types).toContain("github_workflow_gate.approved");
+    expect(types).not.toContain("github_workflow_gate.approved");
+    expect(types).not.toContain("github_workflow_gate.rejected");
   });
 
   test("rejects the deployment when an artifact path is unsafe", async () => {
@@ -439,7 +475,7 @@ describe("executeWorkflowGateJob", () => {
     expect(types).toContain("github_workflow_gate.rejected");
   });
 
-  test("rejects candidate-specific PyPI findings via release risk", async () => {
+  test("leaves a high-risk candidate pending with a reject recommendation", async () => {
     const seeded = await seedGateForTest({
       installationExternalId: "9206",
       repositoryId: 72007,
@@ -459,11 +495,20 @@ describe("executeWorkflowGateJob", () => {
       db,
     );
 
+    // High release risk only drives the workbench recommendation; the deployment
+    // stays pending until a human blocks it, so no decision is posted.
     const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
-    expect(gate?.status).toBe("rejected");
-    expect(gate?.decision).toBe("rejected");
-    expect(scenario.decisionCalls).toHaveLength(1);
-    expect(scenario.decisionCalls[0].state).toBe("rejected");
+    expect(gate?.status).toBe("pending");
+    expect(gate?.decision).toBeNull();
+    expect(gate?.scanId).toBeTruthy();
+    expect(scenario.decisionCalls).toHaveLength(0);
+
+    const reviewed = await gateEventMetadata(
+      seeded.organizationId,
+      seeded.gateId,
+      "github_workflow_gate.reviewed",
+    );
+    expect(reviewed?.recommendation).toBe("rejected");
 
     const persisted = await getScan(db, gate!.scanId!, seeded.organizationId);
     expect(persisted?.scan.riskSummaryJson).toMatchObject({
@@ -509,6 +554,40 @@ describe("executeWorkflowGateJob", () => {
     expect(types).not.toContain("github_workflow_gate.rejected");
   });
 
+  test("does not re-review a pending gate that already has a scan attached", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9207",
+      repositoryId: 72008,
+      runId: 13131,
+    });
+    const scenario = await buildScenario(13131, { digestMatches: true });
+    const loaderMock = buildLoaderMock();
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const sandboxEnv = buildEnv(bindings, loaderMock.binding);
+    const db = createDb(env.DB);
+    const message = {
+      kind: "workflow_gate" as const,
+      organizationId: seeded.organizationId,
+      gateId: seeded.gateId,
+    };
+
+    await executeWorkflowGateJob(sandboxEnv, ctx, message, db);
+    const loaderCallsAfterFirst = loaderMock.calls.length;
+    const gateAfterFirst = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(gateAfterFirst?.status).toBe("pending");
+    expect(gateAfterFirst?.scanId).toBeTruthy();
+
+    // Re-enqueue while the gate is still pending its human decision: the gate
+    // keeps its scan and the artifacts are not re-parsed.
+    await executeWorkflowGateJob(sandboxEnv, ctx, message, db);
+    expect(loaderMock.calls.length).toBe(loaderCallsAfterFirst);
+    expect(scenario.decisionCalls).toHaveLength(0);
+
+    const gateAfterSecond = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(gateAfterSecond?.scanId).toBe(gateAfterFirst?.scanId);
+  });
+
   test("re-delivers the decision for an already-decided gate without re-running the review", async () => {
     const seeded = await seedGateForTest({
       installationExternalId: "9203",
@@ -529,14 +608,24 @@ describe("executeWorkflowGateJob", () => {
 
     await executeWorkflowGateJob(sandboxEnv, ctx, message, db);
     const loaderCallsAfterFirst = loaderMock.calls.length;
-    expect(scenario.decisionCalls).toHaveLength(1);
+    // The review leaves the gate pending — no decision is posted yet.
+    expect(scenario.decisionCalls).toHaveLength(0);
+
+    // A maintainer approves the gate from the workbench.
+    const decided = await markGateDecided(db, {
+      gateId: seeded.gateId,
+      decision: "approved",
+      comment: "ship it",
+      reportUrl: null,
+    });
+    expect(decided).toBeTruthy();
 
     await executeWorkflowGateJob(sandboxEnv, ctx, message, db);
 
-    // Second delivery must re-post the stored decision but not re-parse artifacts.
+    // The re-enqueue must re-post the stored decision but not re-parse artifacts.
     expect(loaderMock.calls.length).toBe(loaderCallsAfterFirst);
-    expect(scenario.decisionCalls).toHaveLength(2);
-    expect(scenario.decisionCalls[1].state).toBe("approved");
+    expect(scenario.decisionCalls).toHaveLength(1);
+    expect(scenario.decisionCalls[0].state).toBe("approved");
   });
 
   test("retries a failed redelivery for an already-decided gate", async () => {
@@ -559,7 +648,14 @@ describe("executeWorkflowGateJob", () => {
 
     await executeWorkflowGateJob(sandboxEnv, ctx, message, db);
     const loaderCallsAfterFirst = loaderMock.calls.length;
-    expect(scenario.decisionCalls).toHaveLength(1);
+    expect(scenario.decisionCalls).toHaveLength(0);
+
+    await markGateDecided(db, {
+      gateId: seeded.gateId,
+      decision: "approved",
+      comment: "ship it",
+      reportUrl: null,
+    });
 
     const redeliveryFetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const request = input instanceof Request ? input : new Request(input, init);
@@ -603,7 +699,14 @@ describe("executeWorkflowGateJob", () => {
     };
 
     await executeWorkflowGateJob(sandboxEnv, ctx, body, db);
-    expect(scenario.decisionCalls).toHaveLength(1);
+    expect(scenario.decisionCalls).toHaveLength(0);
+
+    await markGateDecided(db, {
+      gateId: seeded.gateId,
+      decision: "approved",
+      comment: "ship it",
+      reportUrl: null,
+    });
 
     vi.stubGlobal(
       "fetch",

--- a/test/workers/workflow-gate-job.test.ts
+++ b/test/workers/workflow-gate-job.test.ts
@@ -554,7 +554,7 @@ describe("executeWorkflowGateJob", () => {
     expect(types).not.toContain("github_workflow_gate.rejected");
   });
 
-  test("links a failed pipeline scan back to the pending gate", async () => {
+  test("links a failed pipeline scan back to the pending gate and allows retry", async () => {
     const seeded = await seedGateForTest({
       installationExternalId: "9208",
       repositoryId: 72009,
@@ -592,6 +592,26 @@ describe("executeWorkflowGateJob", () => {
 
     const types = await scanEventTypes(seeded.organizationId, seeded.gateId);
     expect(types).toContain("github_workflow_gate.review_failed");
+
+    const retryEnv = buildEnv(bindings, loaderMock.binding);
+    const loaderCallsAfterFailure = loaderMock.calls.length;
+    await executeWorkflowGateJob(
+      retryEnv,
+      ctx,
+      { kind: "workflow_gate", organizationId: seeded.organizationId, gateId: seeded.gateId },
+      db,
+    );
+
+    const retriedGate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(retriedGate?.status).toBe("pending");
+    expect(retriedGate?.scanId).toBeTruthy();
+    expect(retriedGate?.scanId).not.toBe(gate?.scanId);
+    expect(loaderMock.calls.length).toBeGreaterThan(loaderCallsAfterFailure);
+    expect(scenario.decisionCalls).toHaveLength(0);
+
+    const retriedScan = await getScan(db, retriedGate!.scanId!, seeded.organizationId);
+    expect(retriedScan?.scan.status).toBe("complete");
+    expect(retriedScan?.scan.source).toBe("workflow_gate");
   });
 
   test("does not re-review a pending gate that already has a scan attached", async () => {

--- a/test/workers/workflow-gate-job.test.ts
+++ b/test/workers/workflow-gate-job.test.ts
@@ -1,11 +1,12 @@
 import { createExecutionContext, env } from "cloudflare:test";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { generateKeyPairSync } from "node:crypto";
-import { createDb, ensurePersonalOrganization, getScan } from "../../server/db";
+import { createDb, createScanJob, ensurePersonalOrganization, getScan } from "../../server/db";
 import * as schema from "../../server/db/schema";
 import { eq } from "drizzle-orm";
 import {
   createReleaseTarget,
+  attachScanToGate,
   getGateForOrganization,
   markGateDecided,
   upsertInstallation,
@@ -390,6 +391,48 @@ describe("recommendationForReleaseRisk", () => {
     expect(recommendationForReleaseRisk("critical")).toBe("rejected");
     expect(recommendationForReleaseRisk("low")).toBe("approved");
     expect(recommendationForReleaseRisk("medium")).toBe("approved");
+  });
+});
+
+describe("workflow gate scan attachment", () => {
+  test("claims a pending gate only when the observed scan link still matches", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9210",
+      repositoryId: 72011,
+      runId: 16161,
+    });
+    const db = createDb(env.DB);
+    const firstScanId = crypto.randomUUID();
+    const secondScanId = crypto.randomUUID();
+    for (const scanId of [firstScanId, secondScanId]) {
+      await createScanJob(db, {
+        id: scanId,
+        stageId: `workflow-gate:${seeded.gateId}`,
+        organizationId: seeded.organizationId,
+        ownerUserId: seeded.userId,
+        source: "workflow_gate",
+      });
+    }
+
+    await expect(attachScanToGate(db, seeded.gateId, firstScanId, null)).resolves.toBe(true);
+    await expect(attachScanToGate(db, seeded.gateId, secondScanId, null)).resolves.toBe(false);
+
+    const gateAfterLostClaim = await getGateForOrganization(
+      db,
+      seeded.organizationId,
+      seeded.gateId,
+    );
+    expect(gateAfterLostClaim?.scanId).toBe(firstScanId);
+    await expect(attachScanToGate(db, seeded.gateId, secondScanId, firstScanId)).resolves.toBe(
+      true,
+    );
+
+    const gateAfterRetryClaim = await getGateForOrganization(
+      db,
+      seeded.organizationId,
+      seeded.gateId,
+    );
+    expect(gateAfterRetryClaim?.scanId).toBe(secondScanId);
   });
 });
 


### PR DESCRIPTION
## Summary
Builds the PyPI gate review UI for issue #120: a gate review records an advisory recommendation and leaves the gate **pending**, and a maintainer approves/rejects it from the existing diff-first scan workbench, which releases or blocks the held GitHub Actions job (publishing still happens via PyPI Trusted Publishing/OIDC — Drydock never holds PyPI credentials, and only unverifiable artifacts reject fail-closed). Adds `POST /workflow-gates/:gateId/decision` (CAS-once decision, scan-decision mirroring, GitHub callback delivered through the gate job) and `GET /workflow-gates/by-scan/:scanId`, plus a "gate" badge on gate reviews in the scan list, gate-targeted recommendation copy, and a PyPI gate setup guide in settings. Ships route + workflow-gate-job tests and refreshes `docs/pypi-workflow-gate.md` to the human-driven model (dropping the removed digest-mismatch contract).

## Test plan
- [ ] `pnpm run verify` (lint, format, typecheck, node + worker tests) passes
- [ ] `pnpm run test:e2e` passes (npm review browser flow unaffected — gate fetch is gated on `source === "workflow_gate"`)
- [ ] Manually configure a gate from settings, confirm the workbench shows approve/reject controls while pending and the stored decision once decided

🤖 Generated with [Claude Code](https://claude.com/claude-code)