### PR TITLE
Email maintainers when a workflow gate needs review

### DIFF
--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -522,6 +522,34 @@ and the consumer re-checks gate status, so a re-enqueue is safe.
    `approved`) and record `github_workflow_gate.reviewed` with it. Then link the
    scan to the gate via `attachScanToGate` and **leave the gate pending** — the
    review never posts to GitHub.
+8. Email the maintainer that a gate is parked pending their decision
+   (`notifyWorkflowGateReview` in `server/lib/notify.ts`). Because Drydock never
+   auto-decides, this email is the only proactive signal that a held GitHub
+   deployment is waiting on a human.
+
+### Notifying the maintainer
+
+Step 8 is the gate equivalent of the npm scan-completion email. It reuses the
+`sendNotificationEmail` primitive and goes to the organization owner
+(`getOrganizationOwnerUserId` → `getUserContact`; recipient/role resolution will
+follow the org membership model as that lands). The body carries only the
+release identity (`package@version`), the computed release risk, the repository,
+the environment, and a deep link to the review at
+`/dashboard/scans/<scanId>` — never a token, header, callback URL, or artifact
+bytes, per the observability rules in `AGENTS.md`.
+
+Delivery is best-effort and **never blocks or fails the gate**: the outcome is
+recorded as a `github_workflow_gate.notification_sent` or
+`github_workflow_gate.notification_failed` `scan_events` row (mirroring the
+`scan.notification_*` pattern), and a thrown send error is swallowed into a
+`github_workflow_gate.notification_error` operational event.
+
+The email is **send-once per gate**. Step 8 sits on the single review-ready
+transition, and a GitHub re-delivery of the same `deployment_protection_rule`
+event short-circuits earlier at the `already_reviewed` guard (a pending gate
+with a completed attached scan is never re-reviewed), so one review-ready gate
+produces exactly one email. A failed first review records no email; a later
+retry that succeeds sends the one email when it reaches review-ready.
 
 The job never auto-approves a release: approving releases the GitHub job and
 publishing happens immediately through Trusted Publishing/OIDC, which is too

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -545,11 +545,14 @@ recorded as a `github_workflow_gate.notification_sent` or
 `github_workflow_gate.notification_error` operational event.
 
 The email is **send-once per gate**. Step 8 sits on the single review-ready
-transition, and a GitHub re-delivery of the same `deployment_protection_rule`
-event short-circuits earlier at the `already_reviewed` guard (a pending gate
-with a completed attached scan is never re-reviewed), so one review-ready gate
-produces exactly one email. A failed first review records no email; a later
-retry that succeeds sends the one email when it reaches review-ready.
+transition, after the job re-confirms that the gate is still `pending` while
+linking the completed scan. If a maintainer has already decided the gate during
+the review, that compare-and-set fails and no stale "needs review" email is
+sent. A GitHub re-delivery of the same `deployment_protection_rule` event
+short-circuits earlier at the `already_reviewed` guard (a pending gate with a
+completed attached scan is never re-reviewed), so one review-ready gate produces
+exactly one email. A failed first review records no email; a later retry that
+succeeds sends the one email when it reaches review-ready.
 
 The job never auto-approves a release: approving releases the GitHub job and
 publishing happens immediately through Trusted Publishing/OIDC, which is too

--- a/server/lib/notify.ts
+++ b/server/lib/notify.ts
@@ -1,5 +1,6 @@
 import { getScan, getUserContact, recordScanEvent, type AppDb } from "../db";
 import { sendNotificationEmail } from "./email";
+import type { RiskLevel } from "./review";
 
 export interface NotifyScanCompletionInput {
   env: Cloudflare.Env;
@@ -65,6 +66,106 @@ export async function notifyScanCompletion(input: NotifyScanCompletionInput): Pr
     metadata: {
       outcome,
       channel: "email",
+      ...(result.ok ? {} : { reason: result.reason }),
+    },
+  });
+}
+
+export interface NotifyWorkflowGateReviewInput {
+  env: Cloudflare.Env;
+  db: AppDb;
+  organizationId: string;
+  ownerUserId: string;
+  gateId: string;
+  repositoryFullName: string;
+  environment: string;
+  scanId: string;
+  packageName: string | null;
+  version: string | null;
+  releaseRisk: RiskLevel;
+}
+
+/**
+ * Email the maintainer that a workflow gate has a completed review parked
+ * pending their decision. Drydock never auto-decides a gate, so this is the only
+ * proactive signal that a held GitHub deployment is waiting on a human.
+ *
+ * Send-once is owned by the caller: `executeWorkflowGateJob` only reaches the
+ * review-ready path once per gate (a re-delivered gate with a completed scan
+ * short-circuits at its `already_reviewed` guard), so a single review-ready
+ * transition produces a single email. Delivery is best-effort — the outcome is
+ * recorded as a `github_workflow_gate.notification_sent` /
+ * `notification_failed` event and never blocks or fails the gate. The body
+ * carries only release identity, risk, repo/environment, and a dashboard link;
+ * no token, header, or artifact bytes ever reach the email.
+ */
+export async function notifyWorkflowGateReview(
+  input: NotifyWorkflowGateReviewInput,
+): Promise<void> {
+  const {
+    env,
+    db,
+    organizationId,
+    ownerUserId,
+    gateId,
+    repositoryFullName,
+    environment,
+    scanId,
+    packageName,
+    version,
+    releaseRisk,
+  } = input;
+
+  const contact = await getUserContact(db, ownerUserId);
+  if (!contact?.email) {
+    await recordScanEvent(db, {
+      organizationId,
+      actorUserId: ownerUserId,
+      scanId,
+      type: "github_workflow_gate.notification_failed",
+      metadata: { gateId, channel: "email", reason: "no_contact_email" },
+    });
+    return;
+  }
+
+  const packageLabel = formatPackageLabel(packageName, version);
+  const dashboardUrl = scanUrl(env, scanId);
+  const subject = `Release gate needs your review — ${packageLabel}`;
+  const lines = [
+    `Hi ${contact.name ?? "there"},`,
+    "",
+    `A staged release is held in ${repositoryFullName} and is waiting for your decision before it can publish.`,
+    "",
+    `Package: ${packageLabel}`,
+    `Release risk: ${releaseRisk}`,
+    `Repository: ${repositoryFullName}`,
+    `Environment: ${environment}`,
+    "",
+    dashboardUrl ? `Approve or block the release: ${dashboardUrl}` : null,
+    "",
+    "The held GitHub deployment stays blocked until you approve or reject it.",
+    "",
+    "— Drydock",
+  ];
+  const text = lines.filter((line): line is string => line !== null).join("\n");
+
+  const result = await sendNotificationEmail(env, {
+    to: contact.email,
+    subject,
+    text,
+  });
+
+  await recordScanEvent(db, {
+    organizationId,
+    actorUserId: ownerUserId,
+    scanId,
+    type: result.ok
+      ? "github_workflow_gate.notification_sent"
+      : "github_workflow_gate.notification_failed",
+    metadata: {
+      gateId,
+      channel: "email",
+      releaseRisk,
       ...(result.ok ? {} : { reason: result.reason }),
     },
   });

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -21,6 +21,7 @@ import {
   WorkflowArtifactError,
   type WorkflowGateRecord,
 } from "./github-app";
+import { notifyWorkflowGateReview } from "./notify";
 import { describeOperationalError, durationMsSince, emitOperationalEvent } from "./observability";
 import { preparePyPiReleaseCandidateForGate } from "./release-candidate-pypi";
 import type { RiskLevel } from "./review";
@@ -289,6 +290,34 @@ export async function executeWorkflowGateJob(
   // drives the decision from the workbench; the recommendation above is
   // advisory.
   await attachScanToGate(db, gate.id, scanId, scanId);
+
+  // Tell the maintainer there is a gate to decide. This is the only review-ready
+  // transition for the gate (a re-delivery short-circuits above at
+  // `already_reviewed`), so it produces exactly one email. Delivery is
+  // best-effort: a failure is recorded inside the notifier and must never fail
+  // or stall the held deployment.
+  try {
+    await notifyWorkflowGateReview({
+      env,
+      db,
+      organizationId,
+      ownerUserId,
+      gateId: gate.id,
+      repositoryFullName: gate.repositoryFullName,
+      environment: gate.environment,
+      scanId,
+      packageName: result.package.name,
+      version: result.package.stagedVersion,
+      releaseRisk,
+    });
+  } catch (err) {
+    emitOperationalEvent("warn", "github_workflow_gate.notification_error", {
+      organizationId,
+      gateId,
+      scanId,
+      error: describeOperationalError(err),
+    });
+  }
 
   emitOperationalEvent("info", "github_workflow_gate.review_ready", {
     organizationId,

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -289,7 +289,19 @@ export async function executeWorkflowGateJob(
   // Keep the completed review linked and leave the gate PENDING. A maintainer
   // drives the decision from the workbench; the recommendation above is
   // advisory.
-  await attachScanToGate(db, gate.id, scanId, scanId);
+  const reviewStillPending = await attachScanToGate(db, gate.id, scanId, scanId);
+  if (!reviewStillPending) {
+    const currentGate = await getGateForOrganization(db, organizationId, gate.id);
+    emitOperationalEvent("info", "github_workflow_gate.job_skipped", {
+      organizationId,
+      gateId,
+      scanId,
+      reason: currentGate
+        ? `review_ready_lost_to_status_${currentGate.status}`
+        : "review_ready_gate_missing",
+    });
+    return;
+  }
 
   // Tell the maintainer there is a gate to decide. This is the only review-ready
   // transition for the gate (a re-delivery short-circuits above at

--- a/test/notify.test.mjs
+++ b/test/notify.test.mjs
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const dbMock = vi.hoisted(() => ({
+  getScan: vi.fn(),
+  getUserContact: vi.fn(),
+  recordScanEvent: vi.fn().mockResolvedValue(undefined),
+}));
+const emailMock = vi.hoisted(() => ({
+  sendNotificationEmail: vi.fn(),
+}));
+
+vi.mock("../server/db/index.ts", () => dbMock);
+vi.mock("../server/lib/email.ts", () => emailMock);
+
+const { notifyWorkflowGateReview } = await import("../server/lib/notify.ts");
+
+function baseInput(overrides = {}) {
+  return {
+    env: { BETTER_AUTH_URL: "https://drydock.test" },
+    db: {},
+    organizationId: "org_1",
+    ownerUserId: "user_1",
+    gateId: "gate_1",
+    repositoryFullName: "octo/example",
+    environment: "pypi",
+    scanId: "scan_1",
+    packageName: "demo-package",
+    version: "1.2.0",
+    releaseRisk: "high",
+    ...overrides,
+  };
+}
+
+describe("notifyWorkflowGateReview", () => {
+  beforeEach(() => {
+    dbMock.getUserContact.mockResolvedValue({
+      id: "user_1",
+      email: "owner@example.com",
+      name: "Olga",
+    });
+    emailMock.sendNotificationEmail.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    dbMock.getUserContact.mockReset();
+    dbMock.recordScanEvent.mockClear();
+    emailMock.sendNotificationEmail.mockReset();
+  });
+
+  test("emails the owner with release identity, risk, repo, environment and a dashboard link", async () => {
+    await notifyWorkflowGateReview(baseInput());
+
+    expect(emailMock.sendNotificationEmail).toHaveBeenCalledTimes(1);
+    const [, message] = emailMock.sendNotificationEmail.mock.calls[0];
+    expect(message.to).toBe("owner@example.com");
+    expect(message.subject).toContain("demo-package@1.2.0");
+    expect(message.text).toContain("demo-package@1.2.0");
+    expect(message.text).toContain("Release risk: high");
+    expect(message.text).toContain("Repository: octo/example");
+    expect(message.text).toContain("Environment: pypi");
+    expect(message.text).toContain("https://drydock.test/dashboard/scans/scan_1");
+
+    expect(dbMock.recordScanEvent).toHaveBeenCalledTimes(1);
+    const [, event] = dbMock.recordScanEvent.mock.calls[0];
+    expect(event).toMatchObject({
+      organizationId: "org_1",
+      actorUserId: "user_1",
+      scanId: "scan_1",
+      type: "github_workflow_gate.notification_sent",
+      metadata: { gateId: "gate_1", channel: "email", releaseRisk: "high" },
+    });
+  });
+
+  test("never leaks token, header, or callback material into the email", async () => {
+    await notifyWorkflowGateReview(baseInput());
+
+    const [, message] = emailMock.sendNotificationEmail.mock.calls[0];
+    const payload = `${message.subject}\n${message.text}`;
+    for (const secret of [
+      "ghs_",
+      "Authorization",
+      "Bearer",
+      "deployment_protection_rule",
+      "api.github.com",
+      "deployment_callback_url",
+    ]) {
+      expect(payload).not.toContain(secret);
+    }
+  });
+
+  test("records a delivery failure without throwing", async () => {
+    emailMock.sendNotificationEmail.mockResolvedValue({ ok: false, reason: "smtp down" });
+
+    await expect(notifyWorkflowGateReview(baseInput())).resolves.toBeUndefined();
+
+    const [, event] = dbMock.recordScanEvent.mock.calls[0];
+    expect(event.type).toBe("github_workflow_gate.notification_failed");
+    expect(event.metadata).toMatchObject({
+      gateId: "gate_1",
+      channel: "email",
+      reason: "smtp down",
+    });
+  });
+
+  test("skips delivery and records a failure when the owner has no email on record", async () => {
+    dbMock.getUserContact.mockResolvedValue({ id: "user_1", email: null, name: "Olga" });
+
+    await notifyWorkflowGateReview(baseInput());
+
+    expect(emailMock.sendNotificationEmail).not.toHaveBeenCalled();
+    const [, event] = dbMock.recordScanEvent.mock.calls[0];
+    expect(event.type).toBe("github_workflow_gate.notification_failed");
+    expect(event.metadata).toMatchObject({ gateId: "gate_1", reason: "no_contact_email" });
+  });
+});

--- a/test/workers/workflow-gate-job.test.ts
+++ b/test/workers/workflow-gate-job.test.ts
@@ -352,6 +352,14 @@ function buildEnv(bindings: Record<string, string>, loaderBinding: unknown): Clo
   } as Cloudflare.Env;
 }
 
+function buildEnvWithEmail(
+  bindings: Record<string, string>,
+  loaderBinding: unknown,
+  sendEmail: SendEmailBinding,
+): Cloudflare.Env {
+  return { ...buildEnv(bindings, loaderBinding), SEND_EMAIL: sendEmail } as Cloudflare.Env;
+}
+
 async function scanEventTypes(organizationId: string, gateId: string): Promise<string[]> {
   const db = createDb(env.DB);
   const rows = await db
@@ -837,5 +845,120 @@ describe("executeWorkflowGateJob", () => {
       "GitHub deployment protection decision failed (503)",
     );
     expect(retry).not.toHaveBeenCalled();
+  });
+
+  test("emails the maintainer once when a clean review leaves the gate pending", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9220",
+      repositoryId: 72021,
+      runId: 17171,
+    });
+    await buildScenario(17171, { digestMatches: true });
+    const loaderMock = buildLoaderMock();
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const send = vi.fn(async () => undefined);
+    const sandboxEnv = buildEnvWithEmail(bindings, loaderMock.binding, { send });
+    const db = createDb(env.DB);
+
+    await executeWorkflowGateJob(
+      sandboxEnv,
+      ctx,
+      { kind: "workflow_gate", organizationId: seeded.organizationId, gateId: seeded.gateId },
+      db,
+    );
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(gate?.status).toBe("pending");
+
+    const types = await scanEventTypes(seeded.organizationId, seeded.gateId);
+    expect(types).toContain("github_workflow_gate.notification_sent");
+    expect(types).not.toContain("github_workflow_gate.notification_failed");
+
+    const meta = await gateEventMetadata(
+      seeded.organizationId,
+      seeded.gateId,
+      "github_workflow_gate.notification_sent",
+    );
+    expect(meta).toMatchObject({ channel: "email", releaseRisk: "low" });
+  });
+
+  test("does not email again when the same gate is re-delivered", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9221",
+      repositoryId: 72022,
+      runId: 18181,
+    });
+    await buildScenario(18181, { digestMatches: true });
+    const loaderMock = buildLoaderMock();
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const send = vi.fn(async () => undefined);
+    const sandboxEnv = buildEnvWithEmail(bindings, loaderMock.binding, { send });
+    const db = createDb(env.DB);
+    const message = {
+      kind: "workflow_gate" as const,
+      organizationId: seeded.organizationId,
+      gateId: seeded.gateId,
+    };
+
+    await executeWorkflowGateJob(sandboxEnv, ctx, message, db);
+    expect(send).toHaveBeenCalledTimes(1);
+
+    // GitHub re-delivers the same deployment_protection_rule event: the gate is
+    // skipped at `already_reviewed`, so no second email is sent.
+    await executeWorkflowGateJob(sandboxEnv, ctx, message, db);
+    expect(send).toHaveBeenCalledTimes(1);
+
+    const sentEvents = (await scanEventTypes(seeded.organizationId, seeded.gateId)).filter(
+      (type) => type === "github_workflow_gate.notification_sent",
+    );
+    expect(sentEvents).toHaveLength(1);
+  });
+
+  test("records a notification failure without blocking the gate when delivery fails", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9222",
+      repositoryId: 72023,
+      runId: 19191,
+    });
+    const scenario = await buildScenario(19191, { digestMatches: true });
+    const loaderMock = buildLoaderMock();
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const send = vi.fn(async () => {
+      throw new Error("smtp down");
+    });
+    const sandboxEnv = buildEnvWithEmail(bindings, loaderMock.binding, { send });
+    const db = createDb(env.DB);
+
+    await executeWorkflowGateJob(
+      sandboxEnv,
+      ctx,
+      { kind: "workflow_gate", organizationId: seeded.organizationId, gateId: seeded.gateId },
+      db,
+    );
+
+    // The held deployment is unaffected: the review is still attached and the
+    // gate is still pending a human decision.
+    const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(gate?.status).toBe("pending");
+    expect(gate?.scanId).toBeTruthy();
+    expect(scenario.decisionCalls).toHaveLength(0);
+
+    const persisted = await getScan(db, gate!.scanId!, seeded.organizationId);
+    expect(persisted?.scan.status).toBe("complete");
+
+    const types = await scanEventTypes(seeded.organizationId, seeded.gateId);
+    expect(types).toContain("github_workflow_gate.notification_failed");
+    expect(types).not.toContain("github_workflow_gate.notification_sent");
+
+    const meta = await gateEventMetadata(
+      seeded.organizationId,
+      seeded.gateId,
+      "github_workflow_gate.notification_failed",
+    );
+    expect(meta?.reason).toBeTruthy();
   });
 });

--- a/test/workers/workflow-gate-job.test.ts
+++ b/test/workers/workflow-gate-job.test.ts
@@ -917,6 +917,62 @@ describe("executeWorkflowGateJob", () => {
     expect(sentEvents).toHaveLength(1);
   });
 
+  test("does not email when the gate is decided before notification", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9223",
+      repositoryId: 72024,
+      runId: 20202,
+    });
+    const scenario = await buildScenario(20202, { digestMatches: true });
+    const db = createDb(env.DB);
+    const triggerName = `reject_gate_after_reviewed_${crypto.randomUUID().replaceAll("-", "_")}`;
+    await env.DB.prepare(`
+      CREATE TRIGGER ${triggerName}
+      AFTER INSERT ON scan_events
+      WHEN NEW.type = 'github_workflow_gate.reviewed'
+      BEGIN
+        UPDATE github_workflow_gates
+        SET status = 'rejected',
+            decision = 'rejected',
+            decision_comment = 'blocked during review',
+            decided_at = 1,
+            updated_at = 1
+        WHERE id = json_extract(NEW.metadata_json, '$.gateId')
+          AND status = 'pending';
+      END
+    `).run();
+    const loaderMock = buildLoaderMock();
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const send = vi.fn(async () => undefined);
+    const sandboxEnv = buildEnvWithEmail(bindings, loaderMock.binding, { send });
+
+    try {
+      await executeWorkflowGateJob(
+        sandboxEnv,
+        ctx,
+        { kind: "workflow_gate", organizationId: seeded.organizationId, gateId: seeded.gateId },
+        db,
+      );
+    } finally {
+      await env.DB.prepare(`DROP TRIGGER IF EXISTS ${triggerName}`).run();
+    }
+
+    expect(send).not.toHaveBeenCalled();
+    expect(scenario.decisionCalls).toHaveLength(0);
+
+    const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(gate?.status).toBe("rejected");
+    expect(gate?.scanId).toBeTruthy();
+
+    const persisted = await getScan(db, gate!.scanId!, seeded.organizationId);
+    expect(persisted?.scan.status).toBe("complete");
+
+    const types = await scanEventTypes(seeded.organizationId, seeded.gateId);
+    expect(types).not.toContain("github_workflow_gate.notification_sent");
+    expect(types).not.toContain("github_workflow_gate.notification_failed");
+  });
+
   test("records a notification failure without blocking the gate when delivery fails", async () => {
     const seeded = await seedGateForTest({
       installationExternalId: "9222",


### PR DESCRIPTION
## Summary
- Adds `notifyWorkflowGateReview` (`server/lib/notify.ts`), the gate equivalent of the npm scan-completion email: it emails the org owner the release identity, computed release risk, repository, environment, and a `/dashboard/scans/<scanId>` deep link, then records a `github_workflow_gate.notification_sent` / `notification_failed` event — no token, header, callback URL, or artifact bytes ever enter the body.
- Wires it into the single review-ready transition in `executeWorkflowGateJob`, wrapped so a delivery failure becomes a `notification_error` operational event and never fails or stalls the held deployment; send-once is guaranteed because a GitHub re-delivery short-circuits earlier at the `already_reviewed` guard.
- Covers the behavior with a node unit test (content + redaction + failure paths) and worker/D1 integration tests (exactly one email, no duplicate on re-delivery, failure recorded without blocking the gate), and documents it in `docs/pypi-workflow-gate.md`.

Closes #165.

## Test plan
- [x] `pnpm run verify` (lint, format, typecheck, node + worker tests) passes