### PR TITLE
Trim deployment-gate header copy to first line

### DIFF
--- a/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
@@ -63,9 +63,7 @@ export function GateContextPanel({
             for <code>{packageName}</code>
           </>
         ) : null}
-        . Drydock reviewed the release candidate it built — approving releases the held job and
-        publishing proceeds through PyPI Trusted Publishing (OIDC). Drydock never holds PyPI
-        credentials and never uploads the package itself.
+        .
       </p>
       {gate ? (
         <MonoDetail


### PR DESCRIPTION
## Summary
- Trim the deployment-gate context panel copy down to just the first line ("GitHub Actions is holding the publish job for `<package>`."), dropping the sentence about PyPI Trusted Publishing and credential handling.

## Test plan
- Verify the gate detail view renders the shortened sentence without the trailing PyPI/credentials text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)