### PR TITLE
Trim dashboard explainer copy to one diff-first line

### DIFF
--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -154,8 +154,7 @@ function DashboardHeader() {
       <Eyebrow>Review workspace</Eyebrow>
       <h1 class="text-3xl font-semibold tracking-[-0.02em] m-0">Ready for the next release</h1>
       <Muted class="text-[14px] leading-[1.55] m-0">
-        Bring a staged npm publish into drydock, compare it with the live version, and leave with a
-        focused safety brief before maintainers approve.
+        Diff a staged npm publish against the live version before maintainers approve.
       </Muted>
     </header>
   );


### PR DESCRIPTION
## Summary

Trims the dashboard header explainer (`DashboardHeader`) from the two-clause elevator pitch down to a single diff-first line: "Diff a staged npm publish against the live version before maintainers approve." Reduces above-the-table chrome so returning maintainers get to the work faster, while keeping enough orientation for new users.

Went with the copy-only trim rather than a first-visit/show-once variant — the issue flags that mechanism as too much complexity for a copy change.

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)