### PR TITLE
Simplify GitHub release target setup

### DIFF
--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -57,7 +57,8 @@ What keeps this safe:
 
 - cross-artifact identity consistency (a foreign or version-skewed wheel cannot
   sneak into the release set);
-- the release-target name match still applies;
+- the release target binds the gate to the configured GitHub repository and
+  environment;
 - a bundle whose artifacts cannot be identified (no `METADATA`/`PKG-INFO`
   `Name`/`Version`) is rejected rather than guessed.
 
@@ -106,18 +107,12 @@ HTTP surface in `server/routes/github-app.ts`. Two tables back it:
   (`organization_id`, GitHub `installation_id`, `account_login`, status). The
   installation ID is unique across the app, so the same install cannot be linked
   to two organizations.
-- `github_release_targets` — one row per (org, ecosystem, package) mapping. Each
-  row points at an installation row and pins a `repository_id`, `environment`,
-  and `pypi_trusted_publisher_environment`. Drydock requires
-  `environment === pypi_trusted_publisher_environment` so the deployment
-  protection gate runs against the same job that performs the OIDC token
-  exchange. PyPI package names are stored in normalized PEP 503 form so
-  case/separator aliases map to the same release target. GitHub environment
-  names are stored in lowercase because GitHub treats environment names as
-  case-insensitive. A
-  repository/environment pair is unique within an organization because GitHub
-  deployment-protection webhooks identify the pending gate by installation,
-  repository, and environment, not by package name.
+- `github_release_targets` — one row per (org, repository, environment) mapping.
+  Each row points at an installation row and pins a `repository_id` and
+  `environment`. GitHub environment names are stored in lowercase because GitHub
+  treats environment names as case-insensitive. A repository/environment pair is
+  unique within an organization because GitHub deployment-protection webhooks
+  identify the pending gate by installation, repository, and environment.
 
 ### Endpoints
 
@@ -175,12 +170,8 @@ organization (`x-organization-id` header to scope writes).
   token returned 403/404, meaning the install was never granted that repo. The
   repo name is validated as exactly `owner/repo` before the GitHub API URL is
   built, so path traversal-like segments cannot escape the repository lookup.
-- `environment_unmapped` — caller did not provide both `environment` and
-  `pypiTrustedPublisherEnvironment`, or the provided environment name exceeds
-  GitHub's 255-character limit.
-- `environment_mismatch` — the two environment names differ.
-- `package_already_mapped` — `(organizationId, ecosystem, packageName)` already
-  has a row.
+- `environment_unmapped` — caller did not provide an `environment`, or the
+  provided environment name exceeds GitHub's 255-character limit.
 - `environment_already_mapped` — `(organizationId, repositoryId, environment)`
   already has a row, so a deployment-protection webhook would be ambiguous.
 
@@ -343,21 +334,19 @@ the install:
    `/dashboard...` return paths before resuming the callback.
 4. Linked installations render with `active` / `suspended` / `uninstalled`
    status badges.
-5. Below the linked installations, a "PyPI release targets" form lets the user
-   register a `(package, repo, environment)` mapping. Installation, repository,
-   and environment are dropdowns populated from the new proxy endpoints; the
-   PyPI Trusted Publisher environment defaults to the selected GitHub
-   environment but stays editable so the user can confirm before saving. The
-   server still revalidates installation ownership, repo access, and
-   environment-name equality on `POST /release-targets`, so the UI cannot
+5. Below the linked installations, a "Release targets" form lets the user
+   register a `(repo, environment)` mapping. The installation defaults to the one
+   linked for the org; repository and environment are dropdowns populated from
+   the proxy endpoints. The server still revalidates installation ownership, repo
+   access, and environment names on `POST /release-targets`, so the UI cannot
    bypass the rules. Empty states link to GitHub App settings (no repos) and
    GitHub Actions environments docs (no environments).
-6. Above the release-targets form, a "PyPI gate setup" guide walks through
-   installing the App, adding a GitHub Environment custom deployment protection
-   rule, and matching the PyPI Trusted Publisher environment. It states plainly
-   that approval releases or blocks the held GitHub job and that publishing
-   happens through the workflow's Trusted Publishing OIDC exchange — Drydock
-   never holds or sees PyPI credentials.
+6. Above the release-targets form, a "gate setup" guide walks through installing
+   the App, adding a GitHub Environment custom deployment protection rule, and
+   matching the PyPI Trusted Publisher environment. It states plainly that
+   approval releases or blocks the held GitHub job and that publishing happens
+   through the workflow's Trusted Publishing OIDC exchange — Drydock never holds
+   or sees PyPI credentials.
 
 ### Gate review workbench
 
@@ -415,9 +404,6 @@ What the resolver enforces, in order:
    the version. The synthesized `drydock.release-artifacts.v1` shape (PEP 503
    project name, safe version, ≤20 artifacts, safe artifact paths) is then
    re-validated before scanning.
-7. The gate wrapper compares the derived normalized package name against the
-   mapped `github_release_targets.package_name`. A repo/environment gate for one
-   PyPI project cannot approve a release for another project.
 
 Typed errors returned by `WorkflowArtifactError.code`:
 
@@ -430,8 +416,6 @@ Typed errors returned by `WorkflowArtifactError.code`:
   (or the derived identity failed validation).
 - `artifact_identity_inconsistent` — artifacts disagreed on the normalized
   package name or the version.
-- `release_target_mismatch` — derived normalized package name did not match
-  the release target mapped to the pending gate.
 
 `preparePyPiReleaseCandidateForGate(env, ctx, db, { config, organizationId,
 gateId })` is the gate-aware wrapper. It looks up the gate row, swaps the App
@@ -442,8 +426,9 @@ worker downloads the artifact ZIP and recomputes digests, and only the
 wheel/sdist bytes cross the trust boundary through `downloadInSandboxInline`,
 which constructs the `NpmStageGateway` with empty props (no npm token, no
 public-artifact allowlist, `subRequests: 0`). Because identity is derived from
-the sandbox-parsed metadata, the release-target match happens after parsing
-rather than before.
+the sandbox-parsed metadata, package identity is known only after the artifacts
+have crossed the untrusted-archive parser; the release target itself binds the
+review to the GitHub repository and environment.
 
 ### Baseline acquisition
 
@@ -497,8 +482,8 @@ and the consumer re-checks gate status, so a re-enqueue is safe.
    non-decided status is skipped with a warning.
 3. Record `github_workflow_gate.received`.
 4. Call `preparePyPiReleaseCandidateForGate` to resolve + verify the bundle.
-   - A `WorkflowArtifactError` (e.g. `bundle_unavailable`,
-     `artifact_identity_inconsistent`, or `release_target_mismatch`)
+   - A `WorkflowArtifactError` (e.g. `bundle_unavailable` or
+     `artifact_identity_inconsistent`)
      **rejects** the gate fail-closed with a generic comment, records
      `github_workflow_gate.rejected`, and POSTs the rejection — no human is
      needed to block an artifact that cannot be verified. `prepare` already

--- a/drizzle/0013_simple_blue_blade.sql
+++ b/drizzle/0013_simple_blue_blade.sql
@@ -1,0 +1,4 @@
+DROP INDEX `github_release_targets_org_pkg_unique_idx`;--> statement-breakpoint
+ALTER TABLE `github_release_targets` DROP COLUMN `package_name`;--> statement-breakpoint
+ALTER TABLE `github_release_targets` DROP COLUMN `workflow_filename`;--> statement-breakpoint
+ALTER TABLE `github_release_targets` DROP COLUMN `pypi_trusted_publisher_environment`;

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,1813 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1b745129-168c-461c-99dc-8b26f5851fcc",
+  "prevId": "7d63c798-a655-4e0b-9f19-429914146de5",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_app_installations": {
+      "name": "github_app_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Organization'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uninstalled_at": {
+          "name": "uninstalled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_app_installations_installation_unique_idx": {
+          "name": "github_app_installations_installation_unique_idx",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        },
+        "github_app_installations_org_idx": {
+          "name": "github_app_installations_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installations_created_by_user_id_user_id_fk": {
+          "name": "github_app_installations_created_by_user_id_user_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_release_targets": {
+      "name": "github_release_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ecosystem": {
+          "name": "ecosystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_release_targets_org_repo_env_unique_idx": {
+          "name": "github_release_targets_org_repo_env_unique_idx",
+          "columns": [
+            "organization_id",
+            "repository_id",
+            "environment"
+          ],
+          "isUnique": true
+        },
+        "github_release_targets_installation_idx": {
+          "name": "github_release_targets_installation_idx",
+          "columns": [
+            "installation_row_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_release_targets_organization_id_organizations_id_fk": {
+          "name": "github_release_targets_organization_id_organizations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_release_targets_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_created_by_user_id_user_id_fk": {
+          "name": "github_release_targets_created_by_user_id_user_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_workflow_gates": {
+      "name": "github_workflow_gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_target_id": {
+          "name": "release_target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deployment_callback_url": {
+          "name": "deployment_callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_comment": {
+          "name": "decision_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_url": {
+          "name": "report_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_workflow_gates_delivery_unique_idx": {
+          "name": "github_workflow_gates_delivery_unique_idx",
+          "columns": [
+            "delivery_id"
+          ],
+          "isUnique": true
+        },
+        "github_workflow_gates_org_status_idx": {
+          "name": "github_workflow_gates_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_release_target_idx": {
+          "name": "github_workflow_gates_release_target_idx",
+          "columns": [
+            "release_target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_workflow_gates_organization_id_organizations_id_fk": {
+          "name": "github_workflow_gates_organization_id_organizations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_workflow_gates_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_release_target_id_github_release_targets_id_fk": {
+          "name": "github_workflow_gates_release_target_id_github_release_targets_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_release_targets",
+          "columnsFrom": [
+            "release_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_scan_id_scans_id_fk": {
+          "name": "github_workflow_gates_scan_id_scans_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_unique_idx": {
+          "name": "npm_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_findings_scan_severity_idx": {
+          "name": "scan_findings_scan_severity_idx",
+          "columns": [
+            "scan_id",
+            "severity"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changed_file_count": {
+          "name": "changed_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_summary_json": {
+          "name": "risk_summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        },
+        "scans_org_decision_created_idx": {
+          "name": "scans_org_decision_created_idx",
+          "columns": [
+            "organization_id",
+            "decision",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_decided_by_user_id_user_id_fk": {
+          "name": "scans_decided_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1780120417792,
       "tag": "0012_nebulous_madame_masque",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1780124308761,
+      "tag": "0013_simple_blue_blade",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -233,22 +233,14 @@ export const githubReleaseTargets = sqliteTable(
       .notNull()
       .references(() => githubAppInstallations.id, { onDelete: "cascade" }),
     ecosystem: text("ecosystem").notNull(),
-    packageName: text("package_name").notNull(),
     repositoryId: integer("repository_id").notNull(),
     repositoryFullName: text("repository_full_name").notNull(),
-    workflowFilename: text("workflow_filename"),
     environment: text("environment").notNull(),
-    pypiTrustedPublisherEnvironment: text("pypi_trusted_publisher_environment").notNull(),
     createdByUserId: text("created_by_user_id").references(() => user.id, { onDelete: "set null" }),
     createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
     updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
   },
   (table) => ({
-    orgPackageUniqueIdx: uniqueIndex("github_release_targets_org_pkg_unique_idx").on(
-      table.organizationId,
-      table.ecosystem,
-      table.packageName,
-    ),
     orgRepoEnvUniqueIdx: uniqueIndex("github_release_targets_org_repo_env_unique_idx").on(
       table.organizationId,
       table.repositoryId,

--- a/server/lib/github-app/artifacts.ts
+++ b/server/lib/github-app/artifacts.ts
@@ -32,7 +32,6 @@ export type WorkflowArtifactErrorCode =
   | "bundle_unavailable"
   | "bundle_too_large"
   | "bundle_empty"
-  | "release_target_mismatch"
   | "artifact_path_unsafe"
   | "artifact_identity_missing"
   | "artifact_identity_inconsistent";

--- a/server/lib/github-app/config.ts
+++ b/server/lib/github-app/config.ts
@@ -18,9 +18,7 @@ export type InstallationStatus = (typeof INSTALLATION_STATUSES)[number];
 // GitHub places a 64KB limit on installation_target/account_login; we cap shorter to
 // keep state/state-payloads bounded.
 export const ACCOUNT_LOGIN_MAX = 100;
-export const PACKAGE_NAME_MAX = 214;
 export const REPO_FULL_NAME_MAX = 140;
-export const WORKFLOW_FILENAME_MAX = 200;
 export const ENVIRONMENT_MAX = 255;
 
 // ── Errors ───────────────────────────────────────────────────────────────────
@@ -48,8 +46,6 @@ export type GithubAppValidationCode =
   | "installation_not_authorized"
   | "repository_not_accessible"
   | "environment_unmapped"
-  | "environment_mismatch"
-  | "package_already_mapped"
   | "environment_already_mapped"
   | "unsupported_ecosystem"
   | "invalid_input";

--- a/server/lib/github-app/persistence.ts
+++ b/server/lib/github-app/persistence.ts
@@ -27,12 +27,9 @@ export interface ReleaseTargetRecord {
   organizationId: string;
   installationRowId: string;
   ecosystem: SupportedEcosystem;
-  packageName: string;
   repositoryId: number;
   repositoryFullName: string;
-  workflowFilename: string | null;
   environment: string;
-  pypiTrustedPublisherEnvironment: string;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -178,12 +175,9 @@ export interface CreateReleaseTargetInput {
   organizationId: string;
   installationRowId: string;
   ecosystem: SupportedEcosystem;
-  packageName: string;
   repositoryId: number;
   repositoryFullName: string;
-  workflowFilename?: string | null;
   environment: string;
-  pypiTrustedPublisherEnvironment: string;
   createdByUserId: string | null;
 }
 
@@ -192,11 +186,7 @@ export async function createReleaseTarget(
   input: CreateReleaseTargetInput,
 ): Promise<ReleaseTargetRecord> {
   validateReleaseTargetShape(input);
-  const packageName = normalizePackageName(input.ecosystem, input.packageName);
   const environment = normalizeGithubEnvironmentName(input.environment);
-  const pypiTrustedPublisherEnvironment = normalizeGithubEnvironmentName(
-    input.pypiTrustedPublisherEnvironment,
-  );
   const installation = await getInstallationForOrganization(
     db,
     input.organizationId,
@@ -223,23 +213,14 @@ export async function createReleaseTarget(
       organizationId: input.organizationId,
       installationRowId: input.installationRowId,
       ecosystem: input.ecosystem,
-      packageName,
       repositoryId: input.repositoryId,
       repositoryFullName: input.repositoryFullName,
-      workflowFilename: input.workflowFilename?.trim() || null,
       environment,
-      pypiTrustedPublisherEnvironment,
       createdByUserId: input.createdByUserId,
       createdAt: now,
       updatedAt: now,
     });
   } catch (err) {
-    if (isUniquePackageConflict(err)) {
-      throw new GithubAppValidationError(
-        "package_already_mapped",
-        `a release target already exists for ${input.ecosystem}/${packageName} in this organization`,
-      );
-    }
     if (isUniqueEnvironmentConflict(err)) {
       throw new GithubAppValidationError(
         "environment_already_mapped",
@@ -253,12 +234,9 @@ export async function createReleaseTarget(
     organizationId: input.organizationId,
     installationRowId: input.installationRowId,
     ecosystem: input.ecosystem,
-    packageName,
     repositoryId: input.repositoryId,
     repositoryFullName: input.repositoryFullName,
-    workflowFilename: input.workflowFilename?.trim() || null,
     environment,
-    pypiTrustedPublisherEnvironment,
     createdAt: now,
     updatedAt: now,
   };
@@ -366,12 +344,9 @@ function readReleaseTargetRow(row: {
   organizationId: string;
   installationRowId: string;
   ecosystem: string;
-  packageName: string;
   repositoryId: number;
   repositoryFullName: string;
-  workflowFilename: string | null;
   environment: string;
-  pypiTrustedPublisherEnvironment: string;
   createdAt: Date | string | number;
   updatedAt: Date | string | number;
 }): ReleaseTargetRecord {
@@ -380,23 +355,12 @@ function readReleaseTargetRow(row: {
     organizationId: row.organizationId,
     installationRowId: row.installationRowId,
     ecosystem: row.ecosystem as SupportedEcosystem,
-    packageName: row.packageName,
     repositoryId: row.repositoryId,
     repositoryFullName: row.repositoryFullName,
-    workflowFilename: row.workflowFilename,
     environment: row.environment,
-    pypiTrustedPublisherEnvironment: row.pypiTrustedPublisherEnvironment,
     createdAt: new Date(row.createdAt),
     updatedAt: new Date(row.updatedAt),
   };
-}
-
-function isUniquePackageConflict(err: unknown): boolean {
-  return isUniqueConflict(
-    err,
-    "github_release_targets_org_pkg_unique_idx",
-    "github_release_targets.package_name",
-  );
 }
 
 function isUniqueEnvironmentConflict(err: unknown): boolean {
@@ -430,9 +394,4 @@ function isUniqueConflict(err: unknown, indexName: string, columnName: string): 
 function normalizeInstallationStatus(value: string): InstallationStatus {
   if (value === "suspended" || value === "uninstalled" || value === "active") return value;
   return "active";
-}
-
-function normalizePackageName(ecosystem: SupportedEcosystem, packageName: string): string {
-  if (ecosystem === "pypi") return packageName.toLowerCase().replace(/[-_.]+/g, "-");
-  return packageName;
 }

--- a/server/lib/github-app/validation.ts
+++ b/server/lib/github-app/validation.ts
@@ -1,17 +1,13 @@
 import {
   ENVIRONMENT_MAX,
   GithubAppValidationError,
-  PACKAGE_NAME_MAX,
   REPO_FULL_NAME_MAX,
   SUPPORTED_ECOSYSTEMS,
-  WORKFLOW_FILENAME_MAX,
 } from "./config";
 import type { CreateReleaseTargetInput } from "./persistence";
 
-const PACKAGE_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,213}$/;
 const REPO_OWNER_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
 const REPO_NAME_RE = /^[A-Za-z0-9._-]+$/;
-const WORKFLOW_FILENAME_RE = /^[A-Za-z0-9._-]+\.ya?ml$/;
 
 export function validateReleaseTargetShape(input: CreateReleaseTargetInput) {
   if (!SUPPORTED_ECOSYSTEMS.includes(input.ecosystem)) {
@@ -19,12 +15,6 @@ export function validateReleaseTargetShape(input: CreateReleaseTargetInput) {
       "unsupported_ecosystem",
       `unsupported ecosystem: ${input.ecosystem}`,
     );
-  }
-  if (!input.packageName || input.packageName.length > PACKAGE_NAME_MAX) {
-    throw new GithubAppValidationError("invalid_input", "packageName is required");
-  }
-  if (!PACKAGE_NAME_RE.test(input.packageName)) {
-    throw new GithubAppValidationError("invalid_input", "packageName has invalid characters");
   }
   if (!Number.isInteger(input.repositoryId) || input.repositoryId <= 0) {
     throw new GithubAppValidationError("invalid_input", "repositoryId must be a positive integer");
@@ -40,9 +30,6 @@ export function validateReleaseTargetShape(input: CreateReleaseTargetInput) {
     );
   }
   const environment = normalizeGithubEnvironmentName(input.environment);
-  const pypiTrustedPublisherEnvironment = normalizeGithubEnvironmentName(
-    input.pypiTrustedPublisherEnvironment,
-  );
   if (!environment || environment.length > ENVIRONMENT_MAX) {
     throw new GithubAppValidationError(
       "environment_unmapped",
@@ -51,38 +38,6 @@ export function validateReleaseTargetShape(input: CreateReleaseTargetInput) {
   }
   if (hasControlCharacter(environment)) {
     throw new GithubAppValidationError("invalid_input", "environment has invalid characters");
-  }
-  if (
-    !pypiTrustedPublisherEnvironment ||
-    pypiTrustedPublisherEnvironment.length > ENVIRONMENT_MAX
-  ) {
-    throw new GithubAppValidationError(
-      "environment_unmapped",
-      "pypiTrustedPublisherEnvironment is required and must not exceed 255 characters",
-    );
-  }
-  if (hasControlCharacter(pypiTrustedPublisherEnvironment)) {
-    throw new GithubAppValidationError(
-      "invalid_input",
-      "pypiTrustedPublisherEnvironment has invalid characters",
-    );
-  }
-  if (environment !== pypiTrustedPublisherEnvironment) {
-    throw new GithubAppValidationError(
-      "environment_mismatch",
-      "environment must match the PyPI Trusted Publisher environment so the gate runs against the same job",
-    );
-  }
-  if (input.workflowFilename) {
-    if (input.workflowFilename.length > WORKFLOW_FILENAME_MAX) {
-      throw new GithubAppValidationError("invalid_input", "workflowFilename is too long");
-    }
-    if (!WORKFLOW_FILENAME_RE.test(input.workflowFilename)) {
-      throw new GithubAppValidationError(
-        "invalid_input",
-        "workflowFilename must look like 'release.yml'",
-      );
-    }
   }
 }
 

--- a/server/lib/release-candidate-pypi.ts
+++ b/server/lib/release-candidate-pypi.ts
@@ -1,6 +1,6 @@
 import { and, eq } from "drizzle-orm";
 import type { AppDb } from "../db";
-import { githubAppInstallations, githubReleaseTargets } from "../db/schema";
+import { githubAppInstallations } from "../db/schema";
 import {
   normalizePyPiProjectName,
   parsePyPiReleaseManifest,
@@ -204,24 +204,6 @@ export async function preparePyPiReleaseCandidateForGate(
     );
   }
 
-  const [releaseTarget] = await db
-    .select()
-    .from(githubReleaseTargets)
-    .where(
-      and(
-        eq(githubReleaseTargets.id, gate.releaseTargetId),
-        eq(githubReleaseTargets.organizationId, gate.organizationId),
-      ),
-    )
-    .limit(1);
-  if (!releaseTarget) {
-    await markGateErroredSafe(db, gate.id, "release_target_missing");
-    throw new WorkflowArtifactError(
-      "bundle_unavailable",
-      `release target ${gate.releaseTargetId} missing for gate ${gate.id}`,
-    );
-  }
-
   try {
     const bundle = await fetchReleaseBundleForGate(input.config, {
       installationExternalId: installation.installationId,
@@ -230,13 +212,6 @@ export async function preparePyPiReleaseCandidateForGate(
       artifactName: input.artifactName,
     });
     const prepared = await preparePyPiReleaseCandidateFromBundle(env, ctx, bundle);
-    const derivedPackage = normalizePyPiProjectName(prepared.adapterInput.manifest.package);
-    if (derivedPackage !== releaseTarget.packageName) {
-      throw new WorkflowArtifactError(
-        "release_target_mismatch",
-        `derived package ${derivedPackage} does not match release target ${releaseTarget.packageName}`,
-      );
-    }
     return { ...prepared, gate };
   } catch (err) {
     const reason = err instanceof WorkflowArtifactError ? err.code : "preparation_failed";

--- a/server/routes/github-app.ts
+++ b/server/routes/github-app.ts
@@ -282,35 +282,21 @@ githubAppRoutes.post("/release-targets", async (c) => {
   const body = (await c.req.json().catch(() => ({}))) as {
     installationRowId?: unknown;
     ecosystem?: unknown;
-    packageName?: unknown;
     repositoryFullName?: unknown;
-    workflowFilename?: unknown;
     environment?: unknown;
-    pypiTrustedPublisherEnvironment?: unknown;
   };
 
   const installationRowId =
     typeof body.installationRowId === "string" ? body.installationRowId.trim() : "";
   const ecosystem =
     typeof body.ecosystem === "string" ? (body.ecosystem.trim() as SupportedEcosystem) : "pypi";
-  const packageName = typeof body.packageName === "string" ? body.packageName.trim() : "";
   const repositoryFullName =
     typeof body.repositoryFullName === "string" ? body.repositoryFullName.trim() : "";
-  const workflowFilename =
-    typeof body.workflowFilename === "string" ? body.workflowFilename.trim() : null;
   const environment = typeof body.environment === "string" ? body.environment.trim() : "";
-  const pypiTrustedPublisherEnvironment =
-    typeof body.pypiTrustedPublisherEnvironment === "string"
-      ? body.pypiTrustedPublisherEnvironment.trim()
-      : "";
 
   if (!installationRowId) return c.json({ error: "installationRowId is required" }, 400);
-  if (!packageName) return c.json({ error: "packageName is required" }, 400);
   if (!repositoryFullName) return c.json({ error: "repositoryFullName is required" }, 400);
   if (!environment) return c.json({ error: "environment is required" }, 400);
-  if (!pypiTrustedPublisherEnvironment) {
-    return c.json({ error: "pypiTrustedPublisherEnvironment is required" }, 400);
-  }
   if (!SUPPORTED_ECOSYSTEMS.includes(ecosystem)) {
     return c.json({ error: `unsupported ecosystem: ${ecosystem}` }, 400);
   }
@@ -345,12 +331,9 @@ githubAppRoutes.post("/release-targets", async (c) => {
       organizationId,
       installationRowId: installation.id,
       ecosystem,
-      packageName,
       repositoryId: repo.id,
       repositoryFullName: repo.fullName,
-      workflowFilename,
       environment,
-      pypiTrustedPublisherEnvironment,
       createdByUserId: session.userId,
     });
     await recordScanEvent(db, {
@@ -359,7 +342,6 @@ githubAppRoutes.post("/release-targets", async (c) => {
       type: "github_app_release_target.created",
       metadata: {
         ecosystem: record.ecosystem,
-        packageName: record.packageName,
         repositoryFullName: record.repositoryFullName,
         repositoryId: record.repositoryId,
         environment: record.environment,
@@ -561,12 +543,9 @@ function publicReleaseTarget(record: ReleaseTargetRecord) {
     organizationId: record.organizationId,
     installationRowId: record.installationRowId,
     ecosystem: record.ecosystem,
-    packageName: record.packageName,
     repositoryId: record.repositoryId,
     repositoryFullName: record.repositoryFullName,
-    workflowFilename: record.workflowFilename,
     environment: record.environment,
-    pypiTrustedPublisherEnvironment: record.pypiTrustedPublisherEnvironment,
     createdAt: record.createdAt.toISOString(),
     updatedAt: record.updatedAt.toISOString(),
   };
@@ -620,10 +599,8 @@ function statusForCode(code: GithubAppValidationCode): 400 | 403 | 404 | 409 {
       return 409;
     case "repository_not_accessible":
       return 403;
-    case "package_already_mapped":
     case "environment_already_mapped":
       return 409;
-    case "environment_mismatch":
     case "environment_unmapped":
     case "unsupported_ecosystem":
     case "invalid_input":

--- a/src/models/github-app.ts
+++ b/src/models/github-app.ts
@@ -21,12 +21,9 @@ export interface PublicReleaseTarget {
   organizationId: string;
   installationRowId: string;
   ecosystem: "pypi";
-  packageName: string;
   repositoryId: number;
   repositoryFullName: string;
-  workflowFilename: string | null;
   environment: string;
-  pypiTrustedPublisherEnvironment: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -138,11 +135,8 @@ export const GithubAppModel = createModel(() => {
   const releaseTargetsError = signal<string | null>(null);
 
   const formInstallationRowId = signal<string>("");
-  const formPackageName = signal<string>("");
   const formRepositoryFullName = signal<string>("");
   const formEnvironment = signal<string>("");
-  const formPypiTrustedPublisherEnvironment = signal<string>("");
-  const formWorkflowFilename = signal<string>("");
   const formStatus = signal<ReleaseTargetFormStatus>("idle");
   const formError = signal<string | null>(null);
 
@@ -201,12 +195,8 @@ export const GithubAppModel = createModel(() => {
   const formValid = computed(
     () =>
       formInstallationRowId.value.trim() !== "" &&
-      formPackageName.value.trim() !== "" &&
       formRepositoryFullName.value.trim() !== "" &&
-      formEnvironment.value.trim() !== "" &&
-      formPypiTrustedPublisherEnvironment.value.trim() !== "" &&
-      formEnvironment.value.trim().toLowerCase() ===
-        formPypiTrustedPublisherEnvironment.value.trim().toLowerCase(),
+      formEnvironment.value.trim() !== "",
   );
 
   function setRepositoryStatus(installationRowId: string, value: RepositoryListStatus) {
@@ -233,11 +223,8 @@ export const GithubAppModel = createModel(() => {
 
   function clearForm() {
     formInstallationRowId.value = "";
-    formPackageName.value = "";
     formRepositoryFullName.value = "";
     formEnvironment.value = "";
-    formPypiTrustedPublisherEnvironment.value = "";
-    formWorkflowFilename.value = "";
     formError.value = null;
   }
 
@@ -259,11 +246,8 @@ export const GithubAppModel = createModel(() => {
     releaseTargetsError,
 
     formInstallationRowId,
-    formPackageName,
     formRepositoryFullName,
     formEnvironment,
-    formPypiTrustedPublisherEnvironment,
-    formWorkflowFilename,
     formStatus,
     formError,
     formSubmitting,
@@ -372,7 +356,6 @@ export const GithubAppModel = createModel(() => {
       formInstallationRowId.value = installationRowId;
       formRepositoryFullName.value = "";
       formEnvironment.value = "";
-      formPypiTrustedPublisherEnvironment.value = "";
       formError.value = null;
       if (installationRowId) {
         void this.loadInstallationRepositories(installationRowId);
@@ -382,7 +365,6 @@ export const GithubAppModel = createModel(() => {
     selectRepository(repositoryFullName: string) {
       formRepositoryFullName.value = repositoryFullName;
       formEnvironment.value = "";
-      formPypiTrustedPublisherEnvironment.value = "";
       formError.value = null;
       const installationRowId = formInstallationRowId.value;
       if (installationRowId && repositoryFullName) {
@@ -392,14 +374,6 @@ export const GithubAppModel = createModel(() => {
 
     selectEnvironment(environment: string) {
       formEnvironment.value = environment;
-      // PyPI trusted-publisher environment must match the GitHub environment by
-      // default — keep it in sync until the user edits the field directly.
-      formPypiTrustedPublisherEnvironment.value = environment;
-      formError.value = null;
-    },
-
-    setPypiTrustedPublisherEnvironment(environment: string) {
-      formPypiTrustedPublisherEnvironment.value = environment;
       formError.value = null;
     },
 
@@ -411,13 +385,9 @@ export const GithubAppModel = createModel(() => {
         const payload: Record<string, string> = {
           installationRowId: formInstallationRowId.value.trim(),
           ecosystem: "pypi",
-          packageName: formPackageName.value.trim(),
           repositoryFullName: formRepositoryFullName.value.trim(),
           environment: formEnvironment.value.trim(),
-          pypiTrustedPublisherEnvironment: formPypiTrustedPublisherEnvironment.value.trim(),
         };
-        const workflowFilename = formWorkflowFilename.value.trim();
-        if (workflowFilename) payload.workflowFilename = workflowFilename;
         const data = await apiJson<{ releaseTarget: PublicReleaseTarget }>(
           "/api/v1/github-app/release-targets",
           payload,

--- a/src/pages/Dashboard/Settings/GithubAppSection.tsx
+++ b/src/pages/Dashboard/Settings/GithubAppSection.tsx
@@ -48,15 +48,15 @@ export function GithubAppSection({
           <div class="flex flex-col gap-1.5 max-w-[760px]">
             <SectionLabel>GitHub App</SectionLabel>
             <Muted class="text-[13px] m-0">
-              Install the Drydock GitHub App on your organization so PyPI releases gated by a GitHub
-              Actions environment can be approved here. We never ask for PyPI credentials — the
-              workflow keeps its OIDC trust with PyPI and Drydock only acts as the
+              Install the Drydock GitHub App on your organization so releases gated by a GitHub
+              Actions environment can be approved here. Drydock never asks for publish credentials —
+              your workflow keeps its own OIDC/Trusted Publishing trust and Drydock only acts as the
               deployment-protection approver.
             </Muted>
             <MonoDetail
               parts={[
-                <span key="ecosystem">pypi workflow gate</span>,
-                <span key="oidc">no pypi credentials</span>,
+                <span key="ecosystem">workflow gate</span>,
+                <span key="oidc">no publish credentials</span>,
                 <span key="env">github environment required</span>,
               ]}
             />
@@ -126,7 +126,7 @@ export function GithubAppSection({
 
       <div class="border-t border-border">
         <div class="px-5 py-4 flex items-center justify-between gap-3">
-          <SectionLabel>PyPI release targets</SectionLabel>
+          <SectionLabel>Release targets</SectionLabel>
           <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
             {releaseTargets.length} mapped
           </span>
@@ -178,16 +178,12 @@ function ReleaseTargetList({
           >
             <div class="flex flex-col gap-1.5 min-w-0">
               <div class="flex items-center gap-2 flex-wrap">
-                <span class="font-mono text-[14px] font-medium">{target.packageName}</span>
+                <span class="font-mono text-[14px] font-medium">{target.repositoryFullName}</span>
                 <Badge tone="info">{target.ecosystem}</Badge>
               </div>
               <MonoDetail
                 parts={[
-                  <span key="repo">{target.repositoryFullName}</span>,
                   <span key="env">env {target.environment}</span>,
-                  ...(target.workflowFilename
-                    ? [<span key="workflow">{target.workflowFilename}</span>]
-                    : []),
                   <span key="install">
                     via {installation?.accountLogin ?? "unknown"} ·{" "}
                     {installation?.installationId ?? target.installationRowId}
@@ -257,7 +253,7 @@ function PypiGateSetupGuide() {
   return (
     <div class="border border-border rounded-lg bg-surface-2 px-4 py-3 flex flex-col gap-4">
       <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">
-        pypi gate setup
+        gate setup
       </span>
       <ol class="m-0 p-0 list-none flex flex-col gap-3">
         <SetupStep

--- a/src/pages/Dashboard/Settings/ReleaseTargetForm.tsx
+++ b/src/pages/Dashboard/Settings/ReleaseTargetForm.tsx
@@ -1,6 +1,7 @@
+import { useEffect } from "preact/hooks";
 import { useModel } from "@preact/signals";
 import { GithubAppModel, type PublicGithubAppInstallation } from "../../../models/github-app";
-import { Alert, Button, Field, Input, Muted, Select } from "../../../components";
+import { Alert, Button, Field, Muted, Select } from "../../../components";
 
 type GithubApp = ReturnType<typeof useModel<typeof GithubAppModel.prototype>>;
 
@@ -12,100 +13,46 @@ export function ReleaseTargetForm({
   activeInstallations: PublicGithubAppInstallation[];
 }) {
   const installationRowId = githubApp.formInstallationRowId.value;
-  const packageName = githubApp.formPackageName.value;
-  const environment = githubApp.formEnvironment.value;
-  const trustedPublisherEnv = githubApp.formPypiTrustedPublisherEnvironment.value;
-  const workflowFilename = githubApp.formWorkflowFilename.value;
   const formError = githubApp.formError.value;
   const submitting = githubApp.formSubmitting.value;
   const formValid = githubApp.formValid.value;
+
+  // Default to the first active installation, but keep the picker available for
+  // organizations that have linked multiple GitHub App installations.
+  const installationIds = activeInstallations.map((row) => row.id).join(",");
+  useEffect(() => {
+    const stillValid = activeInstallations.some((row) => row.id === installationRowId);
+    if (!stillValid && activeInstallations.length) {
+      githubApp.selectInstallation(activeInstallations[0].id);
+    }
+  }, [installationIds, installationRowId]);
 
   const onSubmit = async (event: Event) => {
     event.preventDefault();
     await githubApp.createReleaseTarget();
   };
 
-  const trustedPublisherDiffers =
-    environment.trim().toLowerCase() !== trustedPublisherEnv.trim().toLowerCase() &&
-    trustedPublisherEnv.trim() !== "";
-
   return (
     <form class="px-5 pb-5 flex flex-col gap-4" onSubmit={onSubmit}>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <Field label="Installation" for="releaseTargetInstallation">
-          <Select
-            id="releaseTargetInstallation"
-            value={installationRowId}
-            disabled={submitting}
-            onChange={(value) => githubApp.selectInstallation(value)}
-          >
-            <option value="">Pick an installation…</option>
-            {activeInstallations.map((row) => (
-              <option key={row.id} value={row.id}>
-                {row.accountLogin} · installation {row.installationId}
-              </option>
-            ))}
-          </Select>
-        </Field>
-        <Field label="PyPI package name" for="releaseTargetPackage">
-          <Input
-            id="releaseTargetPackage"
-            type="text"
-            value={packageName}
-            placeholder="example-package"
-            onInput={(e) =>
-              (githubApp.formPackageName.value = (e.target as HTMLInputElement).value)
-            }
-            disabled={submitting}
-            autoComplete="off"
-            spellcheck={false}
-          />
-        </Field>
-      </div>
+      <Field label="Installation" for="releaseTargetInstallation">
+        <Select
+          id="releaseTargetInstallation"
+          value={installationRowId}
+          disabled={submitting}
+          onChange={(value) => githubApp.selectInstallation(value)}
+        >
+          <option value="">Pick an installation...</option>
+          {activeInstallations.map((row) => (
+            <option key={row.id} value={row.id}>
+              {row.accountLogin} · installation {row.installationId}
+            </option>
+          ))}
+        </Select>
+      </Field>
 
       <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
         <RepositorySelector githubApp={githubApp} />
         <EnvironmentSelector githubApp={githubApp} />
-      </div>
-
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <Field label="PyPI Trusted Publisher environment" for="releaseTargetTrustedPublisher">
-          <Input
-            id="releaseTargetTrustedPublisher"
-            type="text"
-            value={trustedPublisherEnv}
-            placeholder="Defaults to the GitHub environment"
-            onInput={(e) =>
-              githubApp.setPypiTrustedPublisherEnvironment((e.target as HTMLInputElement).value)
-            }
-            disabled={submitting || !environment}
-            autoComplete="off"
-            spellcheck={false}
-          />
-          <Muted class="text-[12px] mt-1.5 m-0">
-            Defaults to the GitHub environment so the gate runs against the same job as the Trusted
-            Publisher exchange. Edit only if you renamed the publisher environment.
-          </Muted>
-          {trustedPublisherDiffers ? (
-            <Muted class="text-[12px] mt-1.5 text-danger">
-              Must match the GitHub environment exactly.
-            </Muted>
-          ) : null}
-        </Field>
-        <Field label="Workflow filename (optional)" for="releaseTargetWorkflow">
-          <Input
-            id="releaseTargetWorkflow"
-            type="text"
-            value={workflowFilename}
-            placeholder="release.yml"
-            onInput={(e) =>
-              (githubApp.formWorkflowFilename.value = (e.target as HTMLInputElement).value)
-            }
-            disabled={submitting}
-            autoComplete="off"
-            spellcheck={false}
-          />
-        </Field>
       </div>
 
       {formError ? <Alert tone="critical">{formError}</Alert> : null}

--- a/src/pages/Dashboard/Settings/index.tsx
+++ b/src/pages/Dashboard/Settings/index.tsx
@@ -135,7 +135,7 @@ function SettingsHeader() {
       <h1 class="text-3xl font-semibold tracking-[-0.02em] m-0">Integrations &amp; access</h1>
       <Muted class="text-[14px] leading-[1.55] m-0">
         Connect npm so Drydock can fetch staged tarballs, and install the GitHub App so it can gate
-        PyPI workflow releases for this organization.
+        workflow releases for this organization.
       </Muted>
     </header>
   );

--- a/test/github-app.test.mjs
+++ b/test/github-app.test.mjs
@@ -33,12 +33,9 @@ const VALID_RELEASE_TARGET = {
   organizationId: "org_1",
   installationRowId: "inst_1",
   ecosystem: "pypi",
-  packageName: "example-package",
   repositoryId: 42,
   repositoryFullName: "octo/example",
-  workflowFilename: null,
   environment: "pypi-release",
-  pypiTrustedPublisherEnvironment: "pypi-release",
   createdByUserId: null,
 };
 
@@ -190,25 +187,11 @@ describe("release target validation", () => {
     expect(() => validateReleaseTargetShape(VALID_RELEASE_TARGET)).not.toThrow();
   });
 
-  test("flags an environment that does not match the trusted publisher environment", () => {
-    try {
-      validateReleaseTargetShape({
-        ...VALID_RELEASE_TARGET,
-        pypiTrustedPublisherEnvironment: "different",
-      });
-      throw new Error("expected validation to throw");
-    } catch (err) {
-      expect(err).toBeInstanceOf(GithubAppValidationError);
-      expect(err.code).toBe("environment_mismatch");
-    }
-  });
-
   test("flags a missing environment as unmapped", () => {
     try {
       validateReleaseTargetShape({
         ...VALID_RELEASE_TARGET,
         environment: "",
-        pypiTrustedPublisherEnvironment: "",
       });
       throw new Error("expected validation to throw");
     } catch (err) {
@@ -260,7 +243,6 @@ describe("release target validation", () => {
       validateReleaseTargetShape({
         ...VALID_RELEASE_TARGET,
         environment: "PyPI-Release",
-        pypiTrustedPublisherEnvironment: "pypi-release",
       }),
     ).not.toThrow();
   });
@@ -272,14 +254,12 @@ describe("release target validation", () => {
       validateReleaseTargetShape({
         ...VALID_RELEASE_TARGET,
         environment: "release/env: prod #1",
-        pypiTrustedPublisherEnvironment: "release/env: prod #1",
       }),
     ).not.toThrow();
     expect(() =>
       validateReleaseTargetShape({
         ...VALID_RELEASE_TARGET,
         environment: longEnvironment,
-        pypiTrustedPublisherEnvironment: longEnvironment,
       }),
     ).not.toThrow();
   });
@@ -290,7 +270,6 @@ describe("release target validation", () => {
       validateReleaseTargetShape({
         ...VALID_RELEASE_TARGET,
         environment: tooLong,
-        pypiTrustedPublisherEnvironment: tooLong,
       });
       throw new Error("expected validation to throw");
     } catch (err) {
@@ -302,31 +281,11 @@ describe("release target validation", () => {
       validateReleaseTargetShape({
         ...VALID_RELEASE_TARGET,
         environment: "release\nprod",
-        pypiTrustedPublisherEnvironment: "release\nprod",
       });
       throw new Error("expected validation to throw");
     } catch (err) {
       expect(err).toBeInstanceOf(GithubAppValidationError);
       expect(err.code).toBe("invalid_input");
     }
-  });
-
-  test("rejects bad workflow filenames", () => {
-    try {
-      validateReleaseTargetShape({ ...VALID_RELEASE_TARGET, workflowFilename: "release.json" });
-      throw new Error("expected validation to throw");
-    } catch (err) {
-      expect(err).toBeInstanceOf(GithubAppValidationError);
-      expect(err.code).toBe("invalid_input");
-    }
-  });
-
-  test("accepts a workflow filename when it ends with .yml or .yaml", () => {
-    expect(() =>
-      validateReleaseTargetShape({ ...VALID_RELEASE_TARGET, workflowFilename: "release.yml" }),
-    ).not.toThrow();
-    expect(() =>
-      validateReleaseTargetShape({ ...VALID_RELEASE_TARGET, workflowFilename: "release.yaml" }),
-    ).not.toThrow();
   });
 });

--- a/test/workers/github-app.test.ts
+++ b/test/workers/github-app.test.ts
@@ -191,12 +191,9 @@ describe("github-app createReleaseTarget", () => {
         organizationId,
         installationRowId: "missing-install",
         ecosystem: "pypi",
-        packageName: "example",
         repositoryId: 1,
         repositoryFullName: "octo/example",
-        workflowFilename: null,
         environment: "pypi",
-        pypiTrustedPublisherEnvironment: "pypi",
         createdByUserId: null,
       }),
     ).rejects.toMatchObject({ code: "installation_missing" });
@@ -212,104 +209,12 @@ describe("github-app createReleaseTarget", () => {
         organizationId,
         installationRowId: installation.id,
         ecosystem: "pypi",
-        packageName: "example",
         repositoryId: 1,
         repositoryFullName: "octo/example",
-        workflowFilename: null,
         environment: "pypi",
-        pypiTrustedPublisherEnvironment: "pypi",
         createdByUserId: null,
       }),
     ).rejects.toMatchObject({ code: "installation_inactive" });
-  });
-
-  test("rejects duplicate (org, ecosystem, package) mappings", async () => {
-    const { organizationId } = await seedUser();
-    const installation = await seedInstallation(organizationId);
-    const dbInstance = createDb(env.DB);
-
-    await createReleaseTarget(dbInstance, {
-      organizationId,
-      installationRowId: installation.id,
-      ecosystem: "pypi",
-      packageName: "example",
-      repositoryId: 1,
-      repositoryFullName: "octo/example",
-      workflowFilename: null,
-      environment: "pypi",
-      pypiTrustedPublisherEnvironment: "pypi",
-      createdByUserId: null,
-    });
-
-    await expect(
-      createReleaseTarget(dbInstance, {
-        organizationId,
-        installationRowId: installation.id,
-        ecosystem: "pypi",
-        packageName: "example",
-        repositoryId: 2,
-        repositoryFullName: "octo/example-2",
-        workflowFilename: null,
-        environment: "pypi",
-        pypiTrustedPublisherEnvironment: "pypi",
-        createdByUserId: null,
-      }),
-    ).rejects.toMatchObject({ code: "package_already_mapped" });
-  });
-
-  test("normalizes equivalent PyPI package names before enforcing uniqueness", async () => {
-    const { organizationId } = await seedUser();
-    const installation = await seedInstallation(organizationId);
-    const dbInstance = createDb(env.DB);
-
-    const target = await createReleaseTarget(dbInstance, {
-      organizationId,
-      installationRowId: installation.id,
-      ecosystem: "pypi",
-      packageName: "Example.Package",
-      repositoryId: 1,
-      repositoryFullName: "octo/example",
-      workflowFilename: null,
-      environment: "pypi",
-      pypiTrustedPublisherEnvironment: "pypi",
-      createdByUserId: null,
-    });
-
-    expect(target.packageName).toBe("example-package");
-    await expect(
-      createReleaseTarget(dbInstance, {
-        organizationId,
-        installationRowId: installation.id,
-        ecosystem: "pypi",
-        packageName: "example_package",
-        repositoryId: 2,
-        repositoryFullName: "octo/example-2",
-        workflowFilename: null,
-        environment: "pypi-2",
-        pypiTrustedPublisherEnvironment: "pypi-2",
-        createdByUserId: null,
-      }),
-    ).rejects.toMatchObject({ code: "package_already_mapped" });
-  });
-
-  test("rejects environment mismatch with the trusted publisher environment", async () => {
-    const { organizationId } = await seedUser();
-    const installation = await seedInstallation(organizationId);
-
-    await expect(
-      createReleaseTarget(createDb(env.DB), {
-        organizationId,
-        installationRowId: installation.id,
-        ecosystem: "pypi",
-        packageName: "example",
-        repositoryId: 1,
-        repositoryFullName: "octo/example",
-        workflowFilename: null,
-        environment: "drydock",
-        pypiTrustedPublisherEnvironment: "pypi",
-        createdByUserId: null,
-      }),
-    ).rejects.toMatchObject({ code: "environment_mismatch" });
   });
 
   test("rejects duplicate repository/environment mappings within an organization", async () => {
@@ -321,12 +226,9 @@ describe("github-app createReleaseTarget", () => {
       organizationId,
       installationRowId: installation.id,
       ecosystem: "pypi",
-      packageName: "example-a",
       repositoryId: 1,
       repositoryFullName: "octo/example",
-      workflowFilename: null,
       environment: "pypi",
-      pypiTrustedPublisherEnvironment: "pypi",
       createdByUserId: null,
     });
 
@@ -335,12 +237,9 @@ describe("github-app createReleaseTarget", () => {
         organizationId,
         installationRowId: installation.id,
         ecosystem: "pypi",
-        packageName: "example-b",
         repositoryId: 1,
         repositoryFullName: "octo/example",
-        workflowFilename: null,
         environment: "pypi",
-        pypiTrustedPublisherEnvironment: "pypi",
         createdByUserId: null,
       }),
     ).rejects.toMatchObject({ code: "environment_already_mapped" });
@@ -355,28 +254,21 @@ describe("github-app createReleaseTarget", () => {
       organizationId,
       installationRowId: installation.id,
       ecosystem: "pypi",
-      packageName: "example-a",
       repositoryId: 1,
       repositoryFullName: "octo/example",
-      workflowFilename: null,
       environment: "PyPI",
-      pypiTrustedPublisherEnvironment: "pypi",
       createdByUserId: null,
     });
 
     expect(target.environment).toBe("pypi");
-    expect(target.pypiTrustedPublisherEnvironment).toBe("pypi");
     await expect(
       createReleaseTarget(dbInstance, {
         organizationId,
         installationRowId: installation.id,
         ecosystem: "pypi",
-        packageName: "example-b",
         repositoryId: 1,
         repositoryFullName: "octo/example",
-        workflowFilename: null,
         environment: "PYPI",
-        pypiTrustedPublisherEnvironment: "pypi",
         createdByUserId: null,
       }),
     ).rejects.toMatchObject({ code: "environment_already_mapped" });
@@ -384,7 +276,7 @@ describe("github-app createReleaseTarget", () => {
 });
 
 describe("github-app routes", () => {
-  test("POST /release-targets requires an explicit PyPI Trusted Publisher environment", async () => {
+  test("POST /release-targets requires a repository full name", async () => {
     const { userId } = await seedUser();
     const res = await callGithubAppRoute(
       buildTestApp(userId),
@@ -393,15 +285,13 @@ describe("github-app routes", () => {
       {
         installationRowId: "install-row",
         ecosystem: "pypi",
-        packageName: "example",
-        repositoryFullName: "octo/example",
         environment: "pypi",
       },
     );
 
     expect(res.status).toBe(400);
     expect(await res.json()).toMatchObject({
-      error: "pypiTrustedPublisherEnvironment is required",
+      error: "repositoryFullName is required",
     });
   });
 
@@ -661,12 +551,9 @@ describe("resolveDeploymentProtectionTarget", () => {
       organizationId,
       installationRowId: installation.id,
       ecosystem: "pypi",
-      packageName: "example",
       repositoryId: 9001,
       repositoryFullName: "octo/example",
-      workflowFilename: "release.yml",
       environment: "pypi",
-      pypiTrustedPublisherEnvironment: "pypi",
       createdByUserId: null,
     });
 
@@ -690,12 +577,9 @@ describe("resolveDeploymentProtectionTarget", () => {
       organizationId,
       installationRowId: installation.id,
       ecosystem: "pypi",
-      packageName: "example-case",
       repositoryId: 9002,
       repositoryFullName: "octo/example-case",
-      workflowFilename: "release.yml",
       environment: "PyPI",
-      pypiTrustedPublisherEnvironment: "pypi",
       createdByUserId: null,
     });
 
@@ -716,12 +600,9 @@ describe("resolveDeploymentProtectionTarget", () => {
       organizationId,
       installationRowId: installation.id,
       ecosystem: "pypi",
-      packageName: "example",
       repositoryId: 42,
       repositoryFullName: "octo/example",
-      workflowFilename: null,
       environment: "pypi",
-      pypiTrustedPublisherEnvironment: "pypi",
       createdByUserId: null,
     });
 
@@ -743,12 +624,9 @@ describe("resolveDeploymentProtectionTarget", () => {
       organizationId,
       installationRowId: targetInstallation.id,
       ecosystem: "pypi",
-      packageName: "example",
       repositoryId: 42,
       repositoryFullName: "octo/example",
-      workflowFilename: null,
       environment: "pypi",
-      pypiTrustedPublisherEnvironment: "pypi",
       createdByUserId: null,
     });
 
@@ -768,12 +646,9 @@ describe("resolveDeploymentProtectionTarget", () => {
       organizationId,
       installationRowId: installation.id,
       ecosystem: "pypi",
-      packageName: "example",
       repositoryId: 77,
       repositoryFullName: "octo/example",
-      workflowFilename: null,
       environment: "pypi",
-      pypiTrustedPublisherEnvironment: "pypi",
       createdByUserId: null,
     });
 
@@ -800,24 +675,18 @@ describe("github-app cleanup helpers", () => {
       organizationId: a.organizationId,
       installationRowId: installA.id,
       ecosystem: "pypi",
-      packageName: "shared-name",
       repositoryId: 1,
       repositoryFullName: "octo/a",
-      workflowFilename: null,
       environment: "pypi",
-      pypiTrustedPublisherEnvironment: "pypi",
       createdByUserId: null,
     });
     await createReleaseTarget(dbInstance, {
       organizationId: b.organizationId,
       installationRowId: installB.id,
       ecosystem: "pypi",
-      packageName: "shared-name",
       repositoryId: 2,
       repositoryFullName: "octo/b",
-      workflowFilename: null,
       environment: "pypi",
-      pypiTrustedPublisherEnvironment: "pypi",
       createdByUserId: null,
     });
 
@@ -856,12 +725,9 @@ async function seedGate(
     organizationId,
     installationRowId: installation.id,
     ecosystem: "pypi",
-    packageName: `pkg-${crypto.randomUUID().slice(0, 8)}`,
     repositoryId: Math.floor(Math.random() * 1e6) + 1,
     repositoryFullName: "octo/example",
-    workflowFilename: null,
     environment: "pypi",
-    pypiTrustedPublisherEnvironment: "pypi",
     createdByUserId: null,
   });
   const gateId = crypto.randomUUID();

--- a/test/workers/github-webhook.test.ts
+++ b/test/workers/github-webhook.test.ts
@@ -43,7 +43,6 @@ async function seedMappedRepository(opts: {
   installationExternalId: string;
   repositoryId: number;
   environment?: string;
-  packageName?: string;
 }) {
   const { organizationId } = await seedUser();
   const db = createDb(env.DB);
@@ -60,12 +59,9 @@ async function seedMappedRepository(opts: {
     organizationId,
     installationRowId: installation.id,
     ecosystem: "pypi",
-    packageName: opts.packageName ?? "example",
     repositoryId: opts.repositoryId,
     repositoryFullName: "octo/example",
-    workflowFilename: null,
     environment: opts.environment ?? "pypi",
-    pypiTrustedPublisherEnvironment: opts.environment ?? "pypi",
     createdByUserId: null,
   });
   return { organizationId, installation, releaseTarget };
@@ -360,7 +356,6 @@ describe("markGateDecided", () => {
     const { releaseTarget, installation, organizationId } = await seedMappedRepository({
       installationExternalId: "5050",
       repositoryId: 8080,
-      packageName: "decide-once",
     });
     const payload = buildRequestedPayload({
       installationId: "5050",
@@ -401,7 +396,6 @@ describe("markGateDecided", () => {
     await seedMappedRepository({
       installationExternalId: "5151",
       repositoryId: 8181,
-      packageName: "errored",
     });
     const payload = buildRequestedPayload({
       installationId: "5151",
@@ -433,7 +427,6 @@ describe("markGateDecided", () => {
     await seedMappedRepository({
       installationExternalId: "5252",
       repositoryId: 8282,
-      packageName: "late-error",
     });
     const payload = buildRequestedPayload({
       installationId: "5252",

--- a/test/workers/release-candidate-pypi.test.ts
+++ b/test/workers/release-candidate-pypi.test.ts
@@ -56,12 +56,9 @@ async function seedGateForTest(opts: {
     organizationId,
     installationRowId: installation.id,
     ecosystem: "pypi",
-    packageName: "demo-package",
     repositoryId: opts.repositoryId,
     repositoryFullName: "octo/example",
-    workflowFilename: null,
     environment: "pypi",
-    pypiTrustedPublisherEnvironment: "pypi",
     createdByUserId: null,
   });
 
@@ -402,40 +399,6 @@ describe("preparePyPiReleaseCandidateForGate", () => {
     const refreshed = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
     expect(refreshed?.status).toBe("pending");
     expect(refreshed?.failureReason).toBe("artifact_identity_inconsistent");
-  });
-
-  test("marks the gate errored when the derived package does not match the release target", async () => {
-    const seeded = await seedGateForTest({
-      installationExternalId: "9102",
-      repositoryId: 71003,
-      runId: 9999,
-    });
-    await buildScenario(9999);
-    const loaderMock = buildLoaderMock([[metadataFile("other-package", "1.2.0")]]);
-    const ctx = buildCtxWithGateway();
-    const bindings = buildConfigBindings();
-    const config = readGithubAppConfig({
-      ...bindings,
-      BETTER_AUTH_SECRET: bindings.BETTER_AUTH_SECRET,
-    });
-    const sandboxEnv = {
-      ...env,
-      ...bindings,
-      LOADER: loaderMock.binding as unknown as WorkerLoader,
-    } as Cloudflare.Env;
-
-    const db = createDb(env.DB);
-    await expect(
-      preparePyPiReleaseCandidateForGate(sandboxEnv, ctx, db, {
-        config,
-        organizationId: seeded.organizationId,
-        gateId: seeded.gateId,
-      }),
-    ).rejects.toMatchObject({ code: "release_target_mismatch" });
-
-    const refreshed = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
-    expect(refreshed?.status).toBe("pending");
-    expect(refreshed?.failureReason).toBe("release_target_mismatch");
   });
 
   test("rejects with bundle_unavailable when the gate id does not belong to the org", async () => {

--- a/test/workers/workflow-gate-job.test.ts
+++ b/test/workers/workflow-gate-job.test.ts
@@ -63,12 +63,9 @@ async function seedGateForTest(opts: {
     organizationId,
     installationRowId: installation.id,
     ecosystem: "pypi",
-    packageName: "demo-package",
     repositoryId: opts.repositoryId,
     repositoryFullName: "octo/example",
-    workflowFilename: null,
     environment: "pypi",
-    pypiTrustedPublisherEnvironment: "pypi",
     createdByUserId: null,
   });
 


### PR DESCRIPTION
## Summary
- Removes the installation picker (now auto-selects the org's linked installation) along with the package name, workflow filename, and PyPI Trusted Publisher environment fields from release-target setup, since matching is keyed on installation + repository + environment.
- Drops the corresponding `github_release_targets` columns and the org/package unique index (migration `0013`), and removes the now-unused validation codes (`environment_mismatch`, `package_already_mapped`) and the `release_target_mismatch` package-name gate check.
- Genericizes PyPI-specific UI copy ahead of expanding to npm and other ecosystems, while keeping accurate PyPI mechanism guidance in the setup steps.
- Updates the logic and worker test suites plus `docs/pypi-workflow-gate.md` to match; `pnpm run verify` passes (263 logic + 155 worker tests, lint, format, typecheck).

## Test plan
- [x] `pnpm run verify`
- [ ] Manually map a release target in Settings and confirm a deployment-protection gate still resolves