### PR TITLE
Add guided setup for npm staged publishing and PyPI release gate

### DIFF
--- a/docs/guided-setup.md
+++ b/docs/guided-setup.md
@@ -42,7 +42,7 @@ The generated config is surfaced through the `CodeBlock` component
    `stage` job gets `id-token: write`, runs behind the `npm` GitHub Environment,
    disables the package-manager cache (in **both** jobs), verifies the tarball
    identity, and runs `npm stage publish`. No `NPM_TOKEN`. Pack output is isolated
-   under `.drydock-npm-pack`; the generated workflow records the tarball(s)
+   under `drydock-npm-pack`; the generated workflow records the tarball(s)
    selected from `npm pack --json` by package name, so root `.tgz` files and
    monorepo pack outputs with multiple tarballs cannot accidentally stage the
    wrong package. The UI accepts a comma-separated package allowlist for

--- a/docs/guided-setup.md
+++ b/docs/guided-setup.md
@@ -41,12 +41,17 @@ The generated config is surfaced through the `CodeBlock` component
    generates a tag-triggered workflow. The build job has no credentials; only the
    `stage` job gets `id-token: write`, runs behind the `npm` GitHub Environment,
    disables the package-manager cache (in **both** jobs), verifies the tarball
-   identity, and runs `npm stage publish`. No `NPM_TOKEN`.
+   identity, and runs `npm stage publish`. No `NPM_TOKEN`. Pack output is isolated
+   under `.drydock-npm-pack`; the generated workflow records the tarball(s)
+   selected from `npm pack --json` by package name, so root `.tgz` files and
+   monorepo pack outputs with multiple tarballs cannot accidentally stage the
+   wrong package. The UI accepts a comma-separated package allowlist for
+   monorepos that intentionally stage several workspaces in one release flow.
 3. **Configure the npm package as stage-only** (manual) — `npmTrustCommand()`
-   generates `npm trust github … --allow-stage-publish --no-allow-publish`, so
-   OIDC can stage but never publish directly. Checklist covers requiring 2FA and
-   disallowing token publishes. GitHub YAML alone does not enable trusted
-   publishing — the `npm trust` config is required.
+   generates one `npm trust github … --allow-stage-publish --no-allow-publish`
+   command per selected package, so OIDC can stage but never publish directly.
+   Checklist covers requiring 2FA and disallowing token publishes. GitHub YAML
+   alone does not enable trusted publishing — the `npm trust` config is required.
 4. **Verify** — runs staged-publish discovery (`stagedPublishes.discover()`) and
    reports whether a staged publish was found.
 
@@ -65,7 +70,9 @@ Mirrors `drydock-ci-example` and `docs/pypi-workflow-gate.md`.
    add Drydock as a custom deployment protection rule, and point a PyPI Trusted
    Publisher at the same environment name. The shared environment name is what
    ties the gate to the OIDC exchange.
-4. **Map the release target** — reuses `Settings/ReleaseTargetForm`.
+4. **Map the release target** — reuses `Settings/ReleaseTargetForm`. Existing
+   mappings must be selected explicitly for this setup flow; merely having an
+   unrelated release target in the organization does not mark the step complete.
 5. **Test the gate** (manual) — push a `v*` tag; the held deployment surfaces on
    the dashboard.
 

--- a/docs/guided-setup.md
+++ b/docs/guided-setup.md
@@ -1,0 +1,85 @@
+# Guided setup
+
+The guided setup at `/dashboard/setup` walks an organization through standing up
+a publishing flow Drydock can review. It does **not** introduce new backend
+endpoints — it orchestrates the existing npm-connection, GitHub App, release
+target, and staged-publish-discovery models and generates best-practice config.
+
+Entry points:
+
+- Dashboard header → **Set up**.
+- The dashboard "npm not connected" callout → **Set up staged publishing**
+  (`/dashboard/setup?flow=npm`).
+
+The page is authed (session check → `/login` redirect) and is **not**
+prerendered (`isPrerenderedRoute` only covers `/`, `/login`, `/register`,
+`/docs`).
+
+## Shape
+
+`src/pages/Dashboard/Setup/`:
+
+- `index.tsx` — wizard shell. Session check, loads org-scoped models, ecosystem
+  chooser, and the `?flow=npm|pypi` query binding (`useQuerySignal`).
+- `NpmFlow.tsx` / `PypiFlow.tsx` — the two flows, rendered as a vertical stack of
+  `StepCard`s. Each step lights up `done` from backing model state rather than
+  acting as a step machine; steps Drydock can't observe carry a neutral `manual`
+  badge.
+- `StepCard.tsx` — shared step shell + `Checklist` helper.
+- `workflow-templates.ts` — pure generators for the copy-paste artifacts. No repo
+  mutation happens here; these only produce text.
+
+The generated config is surfaced through the `CodeBlock` component
+(copy-to-clipboard, mono, surface-2 fill — DESIGN.md compliant).
+
+## npm flow (staged publishing via trusted publishing)
+
+1. **Connect npm for discovery** — a read-only granular token so Drydock can list
+   staged publishes (`/-/stage`). The token never reaches the sandbox and is
+   never used to publish. Status is driven by `npm.validated`.
+2. **Add the staged-publish workflow** (manual) — `npmStagedPublishWorkflow()`
+   generates a tag-triggered workflow. The build job has no credentials; only the
+   `stage` job gets `id-token: write`, runs behind the `npm` GitHub Environment,
+   disables the package-manager cache (in **both** jobs), verifies the tarball
+   identity, and runs `npm stage publish`. No `NPM_TOKEN`.
+3. **Configure the npm package as stage-only** (manual) — `npmTrustCommand()`
+   generates `npm trust github … --allow-stage-publish --no-allow-publish`, so
+   OIDC can stage but never publish directly. Checklist covers requiring 2FA and
+   disallowing token publishes. GitHub YAML alone does not enable trusted
+   publishing — the `npm trust` config is required.
+4. **Verify** — runs staged-publish discovery (`stagedPublishes.discover()`) and
+   reports whether a staged publish was found.
+
+## PyPI flow (GitHub Actions release gate)
+
+Mirrors `drydock-ci-example` and `docs/pypi-workflow-gate.md`.
+
+1. **Install the GitHub App** — `githubApp.startInstall()`. Status from active
+   installations.
+2. **Add the PyPI release workflow** (manual) — `pypiReleaseWorkflow()` generates
+   a plain tag-triggered workflow: build uploads `pypi-release-candidate`, the
+   `publish` job blocks on the GitHub Environment, downloads the reviewed artifact
+   (never rebuilds), and publishes via Trusted Publishing. There is no
+   `workflow_dispatch` target picker — it publishes to PyPI on a `v*` tag.
+3. **Configure the GitHub environment gate** (manual) — create the environment,
+   add Drydock as a custom deployment protection rule, and point a PyPI Trusted
+   Publisher at the same environment name. The shared environment name is what
+   ties the gate to the OIDC exchange.
+4. **Map the release target** — reuses `Settings/ReleaseTargetForm`.
+5. **Test the gate** (manual) — push a `v*` tag; the held deployment surfaces on
+   the dashboard.
+
+## Automation boundary
+
+Drydock **generates + guides + reuses existing automation** (npm-connection,
+release-target registration). It deliberately does **not** auto-create GitHub
+Environments or deployment protection rules — that would require an
+`Environments: write` App permission and force every existing installation to
+re-consent. Those remain manual steps with linked instructions.
+
+## Tests
+
+`test/setup-workflow-templates.test.ts` pins the security-critical invariants of
+the generators (single `id-token: write`, `npm stage publish`, no `NPM_TOKEN`,
+cache disabled on the publish path, stage-only trust, single build/checkout in
+the PyPI workflow, no `workflow_dispatch`).

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,4 +1,5 @@
 import { useSignal } from "@preact/signals";
+import { cn } from "./cn";
 
 /**
  * Mono code block with a copy-to-clipboard control. Used by the guided setup to
@@ -8,6 +9,7 @@ import { useSignal } from "@preact/signals";
  */
 export function CodeBlock({ code, label }: { code: string; label?: string }) {
   const copied = useSignal(false);
+  const literalLabel = label?.startsWith(".") || label?.includes("/");
 
   const onCopy = async () => {
     try {
@@ -23,7 +25,12 @@ export function CodeBlock({ code, label }: { code: string; label?: string }) {
   return (
     <div class="border border-border rounded-lg overflow-hidden bg-surface-2">
       <div class="flex items-center justify-between gap-3 px-3 py-2 border-b border-border">
-        <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">
+        <span
+          class={cn(
+            "font-mono text-[10px] text-ink-subtle",
+            literalLabel ? "tracking-normal break-all" : "uppercase tracking-[0.1em]",
+          )}
+        >
           {label ?? "snippet"}
         </span>
         <button

--- a/src/components/CodeBlock.tsx
+++ b/src/components/CodeBlock.tsx
@@ -1,0 +1,42 @@
+import { useSignal } from "@preact/signals";
+
+/**
+ * Mono code block with a copy-to-clipboard control. Used by the guided setup to
+ * surface generated workflow YAML and CLI commands. Follows DESIGN.md: mono
+ * body, surface-2 fill, no spinner — the copied affordance is a `✓` glyph that
+ * clears itself shortly after.
+ */
+export function CodeBlock({ code, label }: { code: string; label?: string }) {
+  const copied = useSignal(false);
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(code);
+      copied.value = true;
+      window.setTimeout(() => (copied.value = false), 1500);
+    } catch {
+      // Clipboard unavailable (insecure context / denied) — the code is still
+      // selectable, so silently leave the affordance untouched.
+    }
+  };
+
+  return (
+    <div class="border border-border rounded-lg overflow-hidden bg-surface-2">
+      <div class="flex items-center justify-between gap-3 px-3 py-2 border-b border-border">
+        <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">
+          {label ?? "snippet"}
+        </span>
+        <button
+          type="button"
+          onClick={() => void onCopy()}
+          class="font-mono text-[11px] text-ink-muted hover:text-ink transition-colors duration-150 ease-out cursor-pointer"
+        >
+          {copied.value ? "copied ✓" : "copy"}
+        </button>
+      </div>
+      <pre class="m-0 px-3 py-3 overflow-x-auto">
+        <code class="font-mono text-[12px] leading-[1.55] whitespace-pre text-ink">{code}</code>
+      </pre>
+    </div>
+  );
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,6 +9,7 @@ export type { Severity, Status, BadgeTone } from "./Badge";
 export { Alert } from "./Alert";
 export type { AlertTone } from "./Alert";
 export { Dialog } from "./Dialog";
+export { CodeBlock } from "./CodeBlock";
 export { Card, SummaryCard } from "./Card";
 export type { SummaryCardTone, SummaryCardValue } from "./Card";
 export { PageShell } from "./PageShell";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ const RegisterPage = lazy(() => import("./pages/Auth/Register"));
 const DashboardPage = lazy(() => import("./pages/Dashboard"));
 const ScanDetailPage = lazy(() => import("./pages/Dashboard/ScanDetail"));
 const SettingsPage = lazy(() => import("./pages/Dashboard/Settings"));
+const SetupPage = lazy(() => import("./pages/Dashboard/Setup"));
 const GithubAppCallbackPage = lazy(() => import("./pages/Dashboard/GithubAppCallback"));
 const NotFoundPage = lazy(() => import("./pages/NotFound"));
 
@@ -24,6 +25,7 @@ export function App() {
           <Route path="/dashboard" component={DashboardPage} />
           <Route path="/dashboard/scans/:id" component={ScanDetailPage} />
           <Route path="/dashboard/settings" component={SettingsPage} />
+          <Route path="/dashboard/setup" component={SetupPage} />
           <Route path="/dashboard/settings/github-app/callback" component={GithubAppCallbackPage} />
           <Route default component={NotFoundPage} />
         </Router>

--- a/src/pages/Dashboard/Settings/ReleaseTargetForm.tsx
+++ b/src/pages/Dashboard/Settings/ReleaseTargetForm.tsx
@@ -1,6 +1,10 @@
 import { useEffect } from "preact/hooks";
 import { useModel } from "@preact/signals";
-import { GithubAppModel, type PublicGithubAppInstallation } from "../../../models/github-app";
+import {
+  GithubAppModel,
+  type PublicGithubAppInstallation,
+  type PublicReleaseTarget,
+} from "../../../models/github-app";
 import { Alert, Button, Field, Muted, Select } from "../../../components";
 
 type GithubApp = ReturnType<typeof useModel<typeof GithubAppModel.prototype>>;
@@ -8,9 +12,11 @@ type GithubApp = ReturnType<typeof useModel<typeof GithubAppModel.prototype>>;
 export function ReleaseTargetForm({
   githubApp,
   activeInstallations,
+  onCreated,
 }: {
   githubApp: GithubApp;
   activeInstallations: PublicGithubAppInstallation[];
+  onCreated?: (target: PublicReleaseTarget) => void;
 }) {
   const installationRowId = githubApp.formInstallationRowId.value;
   const formError = githubApp.formError.value;
@@ -29,7 +35,8 @@ export function ReleaseTargetForm({
 
   const onSubmit = async (event: Event) => {
     event.preventDefault();
-    await githubApp.createReleaseTarget();
+    const created = await githubApp.createReleaseTarget();
+    if (created) onCreated?.(created);
   };
 
   return (

--- a/src/pages/Dashboard/Setup/NpmFlow.tsx
+++ b/src/pages/Dashboard/Setup/NpmFlow.tsx
@@ -52,14 +52,14 @@ export function NpmFlow({ npm, stagedPublishes }: { npm: Npm; stagedPublishes: S
         index="02"
         title="Add the staged-publish workflow"
         status="manual"
-        summary="A tag-triggered GitHub Actions workflow that stages the tarball through npm trusted publishing (OIDC). No NPM_TOKEN — only the gated stage job can mint the OIDC token."
+        summary="A tag-triggered GitHub Actions workflow that stages the selected package tarball(s) through npm trusted publishing (OIDC). No NPM_TOKEN — only the gated stage job can mint the OIDC token."
       >
-        <Field label="Published package name" for="npmFlowPackage">
+        <Field label="Published package name(s)" for="npmFlowPackage">
           <Input
             id="npmFlowPackage"
             type="text"
             value={packageName.value}
-            placeholder="@scope/pkg"
+            placeholder="@scope/pkg or @scope/a, @scope/b"
             onInput={(e) => (packageName.value = (e.target as HTMLInputElement).value)}
             autoComplete="off"
             spellcheck={false}
@@ -75,15 +75,17 @@ export function NpmFlow({ npm, stagedPublishes }: { npm: Npm; stagedPublishes: S
           Pushing a <code class="font-mono text-ink-subtle">v*</code> tag builds the tarball with no
           credentials, then the <code class="font-mono text-ink-subtle">stage</code> job (gated by
           the <code class="font-mono text-ink-subtle">{setupDefaults.npmEnvironment}</code>{" "}
-          environment) stages it. For supply-chain hardening, pin each action to a commit SHA.
+          environment) stages it. In monorepos, enter multiple package names separated by commas;
+          the workflow stages only the tarballs whose package identities match that list. For
+          supply-chain hardening, pin each action to a commit SHA.
         </Muted>
       </StepCard>
 
       <StepCard
         index="03"
-        title="Configure the npm package as stage-only"
+        title="Configure npm package trust as stage-only"
         status="manual"
-        summary="On npm, trust this repo + workflow for staged publishing only, and lock the package down so OIDC can stage but can never bypass review to publish."
+        summary="On npm, trust this repo + workflow for staged publishing only, and lock each package down so OIDC can stage but can never bypass review to publish."
       >
         <Field label="Repository (owner/repo)" for="npmFlowRepo">
           <Input
@@ -100,7 +102,7 @@ export function NpmFlow({ npm, stagedPublishes }: { npm: Npm; stagedPublishes: S
         <Checklist
           items={[
             <>
-              Trusted publisher is <strong>stage-only</strong> —{" "}
+              Each trusted publisher is <strong>stage-only</strong> —{" "}
               <code class="font-mono text-ink-subtle">--allow-stage-publish</code> with{" "}
               <code class="font-mono text-ink-subtle">--no-allow-publish</code> — so OIDC can stage
               but never publish directly.

--- a/src/pages/Dashboard/Setup/NpmFlow.tsx
+++ b/src/pages/Dashboard/Setup/NpmFlow.tsx
@@ -1,0 +1,284 @@
+import { useComputed, useModel, useSignal } from "@preact/signals";
+import type { NpmConnectionModel } from "../../../models/npm-connection";
+import type { StagedPublishesModel } from "../../../models/staged-publishes";
+import { Alert, Badge, Button, Field, Input, Muted, CodeBlock } from "../../../components";
+import { Checklist, StepCard } from "./StepCard";
+import { npmStagedPublishWorkflow, npmTrustCommand, setupDefaults } from "./workflow-templates";
+
+type Npm = ReturnType<typeof useModel<typeof NpmConnectionModel.prototype>>;
+type StagedPublishes = ReturnType<typeof useModel<typeof StagedPublishesModel.prototype>>;
+
+export function NpmFlow({ npm, stagedPublishes }: { npm: Npm; stagedPublishes: StagedPublishes }) {
+  const packageName = useSignal("");
+  const repositoryFullName = useSignal("");
+  const workflowFilename = useSignal(setupDefaults.npmWorkflowFilename);
+
+  const owner = useComputed(() => repositoryFullName.value.split("/", 2)[0]?.trim() ?? "");
+  const repo = useComputed(() => repositoryFullName.value.split("/", 2)[1]?.trim() ?? "");
+
+  const workflowYaml = useComputed(() =>
+    npmStagedPublishWorkflow({
+      packageName: packageName.value,
+      environment: setupDefaults.npmEnvironment,
+    }),
+  );
+  const trustCommand = useComputed(() =>
+    npmTrustCommand({
+      owner: owner.value,
+      repo: repo.value,
+      packageName: packageName.value,
+      workflowFilename: workflowFilename.value,
+      environment: setupDefaults.npmEnvironment,
+    }),
+  );
+
+  const connected = npm.connection.value !== null;
+  const validated = npm.validated.value;
+  const discovery = stagedPublishes.lastResult.value;
+  const discovered = discovery !== null && (discovery.found > 0 || discovery.created > 0);
+
+  return (
+    <div class="flex flex-col gap-4">
+      <StepCard
+        index="01"
+        title="Connect npm for staged-publish discovery"
+        status={validated ? "done" : "todo"}
+        summary="Drydock lists your staged publishes with a read-only npm token. It never publishes, and the token never reaches the sandbox."
+      >
+        <NpmConnectStep npm={npm} connected={connected} validated={validated} />
+      </StepCard>
+
+      <StepCard
+        index="02"
+        title="Add the staged-publish workflow"
+        status="manual"
+        summary="A tag-triggered GitHub Actions workflow that stages the tarball through npm trusted publishing (OIDC). No NPM_TOKEN — only the gated stage job can mint the OIDC token."
+      >
+        <Field label="Published package name" for="npmFlowPackage">
+          <Input
+            id="npmFlowPackage"
+            type="text"
+            value={packageName.value}
+            placeholder="@scope/pkg"
+            onInput={(e) => (packageName.value = (e.target as HTMLInputElement).value)}
+            autoComplete="off"
+            spellcheck={false}
+          />
+        </Field>
+        <CodeBlock
+          label={`.github/workflows/${workflowFilename.value}`}
+          code={workflowYaml.value}
+        />
+        <Muted class="text-[12px] leading-[1.55] m-0">
+          Commit this to{" "}
+          <code class="font-mono text-ink-subtle">.github/workflows/{workflowFilename.value}</code>.
+          Pushing a <code class="font-mono text-ink-subtle">v*</code> tag builds the tarball with no
+          credentials, then the <code class="font-mono text-ink-subtle">stage</code> job (gated by
+          the <code class="font-mono text-ink-subtle">{setupDefaults.npmEnvironment}</code>{" "}
+          environment) stages it. For supply-chain hardening, pin each action to a commit SHA.
+        </Muted>
+      </StepCard>
+
+      <StepCard
+        index="03"
+        title="Configure the npm package as stage-only"
+        status="manual"
+        summary="On npm, trust this repo + workflow for staged publishing only, and lock the package down so OIDC can stage but can never bypass review to publish."
+      >
+        <Field label="Repository (owner/repo)" for="npmFlowRepo">
+          <Input
+            id="npmFlowRepo"
+            type="text"
+            value={repositoryFullName.value}
+            placeholder="owner/repo"
+            onInput={(e) => (repositoryFullName.value = (e.target as HTMLInputElement).value)}
+            autoComplete="off"
+            spellcheck={false}
+          />
+        </Field>
+        <CodeBlock label="npm trust (stage-only)" code={trustCommand.value} />
+        <Checklist
+          items={[
+            <>
+              Trusted publisher is <strong>stage-only</strong> —{" "}
+              <code class="font-mono text-ink-subtle">--allow-stage-publish</code> with{" "}
+              <code class="font-mono text-ink-subtle">--no-allow-publish</code> — so OIDC can stage
+              but never publish directly.
+            </>,
+            <>
+              Require <strong>2FA</strong> for the public publish so a maintainer approves the
+              release after Drydock's review.
+            </>,
+            <>
+              Disallow long-lived tokens for publishing — staged publishing through trusted
+              publishing replaces <code class="font-mono text-ink-subtle">NPM_TOKEN</code> entirely.
+            </>,
+            <>
+              The workflow filename and environment here must match the workflow from step 02 (
+              <code class="font-mono text-ink-subtle">{workflowFilename.value}</code> /{" "}
+              <code class="font-mono text-ink-subtle">{setupDefaults.npmEnvironment}</code>).
+            </>,
+          ]}
+        />
+        <Muted class="text-[12px] leading-[1.55] m-0">
+          GitHub YAML alone does not enable trusted publishing — run the commands above (npm{" "}
+          <code class="font-mono text-ink-subtle">≥ 11.15.0</code>) before the workflow first fires.
+        </Muted>
+      </StepCard>
+
+      <StepCard
+        index="04"
+        title="Verify a staged publish is discoverable"
+        status={discovered ? "done" : "todo"}
+        summary="Push a v* tag to stage a release, then have Drydock check npm. A discovered staged publish confirms the token reaches the staging endpoints."
+      >
+        <VerifyStep stagedPublishes={stagedPublishes} ready={validated} />
+      </StepCard>
+    </div>
+  );
+}
+
+function NpmConnectStep({
+  npm,
+  connected,
+  validated,
+}: {
+  npm: Npm;
+  connected: boolean;
+  validated: boolean;
+}) {
+  const status = npm.status.value;
+  const busy = npm.busy.value;
+  const token = npm.token.value;
+  const error = npm.error.value;
+  const connection = npm.connection.value;
+
+  const onSave = async (event: Event) => {
+    event.preventDefault();
+    await npm.save();
+  };
+
+  return (
+    <>
+      <div class="flex items-center gap-2">
+        {validated ? (
+          <Badge tone="ok">connected · validated</Badge>
+        ) : connected ? (
+          <Badge tone="info">connected · {connection?.validationStatus ?? "unvalidated"}</Badge>
+        ) : (
+          <Badge tone="neutral">not connected</Badge>
+        )}
+      </div>
+
+      <Checklist
+        items={[
+          "Granular access token, read-only.",
+          "Scoped to only the packages you stage.",
+          "Short expiry with a rotation plan.",
+        ]}
+      />
+
+      <form
+        class="grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_auto] gap-3 items-end"
+        onSubmit={onSave}
+      >
+        <Field label={connected ? "Rotate npm token" : "npm token"} for="npmFlowToken">
+          <Input
+            id="npmFlowToken"
+            type="password"
+            value={token}
+            placeholder={connected ? "Paste a new token to rotate" : "npm_..."}
+            onInput={(e) => (npm.token.value = (e.target as HTMLInputElement).value)}
+            disabled={busy}
+            autoComplete="off"
+            spellcheck={false}
+          />
+        </Field>
+        <Button type="submit" disabled={busy || !token.trim()} class="shrink-0">
+          {status === "saving"
+            ? "Saving…"
+            : status === "validating"
+              ? "Checking…"
+              : connected
+                ? "Rotate"
+                : "Connect"}
+        </Button>
+      </form>
+
+      {connected ? (
+        <div class="flex items-center gap-3">
+          <Button variant="secondary" size="sm" onClick={() => void npm.validate()} disabled={busy}>
+            {status === "validating" ? "Checking…" : "Re-check access"}
+          </Button>
+          <Muted class="text-[12px] m-0">
+            Saving runs the npm auth check automatically. We don't keep the release archive.
+          </Muted>
+        </div>
+      ) : (
+        <Muted class="text-[12px] m-0">
+          Create one in{" "}
+          <a
+            class="underline"
+            href="https://docs.npmjs.com/creating-and-viewing-access-tokens/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            npm access token settings
+          </a>
+          .
+        </Muted>
+      )}
+
+      {error ? <Alert tone="critical">{error}</Alert> : null}
+    </>
+  );
+}
+
+function VerifyStep({
+  stagedPublishes,
+  ready,
+}: {
+  stagedPublishes: StagedPublishes;
+  ready: boolean;
+}) {
+  const refreshing = stagedPublishes.refreshing.value;
+  const error = stagedPublishes.error.value;
+  const result = stagedPublishes.lastResult.value;
+
+  return (
+    <>
+      <div class="flex flex-wrap items-center gap-3">
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => void stagedPublishes.discover()}
+          disabled={refreshing || !ready}
+        >
+          {refreshing ? "Checking…" : "Check npm"}
+        </Button>
+        {!ready ? (
+          <Muted class="text-[12px] m-0">Connect and validate npm in step 01 first.</Muted>
+        ) : null}
+      </div>
+
+      {error ? <Alert tone="critical">{error}</Alert> : null}
+
+      {result && !error ? (
+        result.found > 0 || result.created > 0 ? (
+          <Alert tone="ok">
+            Found {result.found} staged publish{result.found === 1 ? "" : "es"}
+            {result.created > 0
+              ? ` · started ${result.created} review${result.created === 1 ? "" : "s"}`
+              : ""}
+            . They'll show up on your dashboard.
+          </Alert>
+        ) : (
+          <Muted class="text-[13px] m-0">
+            No open staged publishes yet. Push a <code class="font-mono text-ink-subtle">v*</code>{" "}
+            tag to run the workflow, then check again.
+          </Muted>
+        )
+      ) : null}
+    </>
+  );
+}

--- a/src/pages/Dashboard/Setup/PypiFlow.tsx
+++ b/src/pages/Dashboard/Setup/PypiFlow.tsx
@@ -1,5 +1,9 @@
 import { useComputed, useModel, useSignal } from "@preact/signals";
-import type { GithubAppModel, PublicGithubAppInstallation } from "../../../models/github-app";
+import type {
+  GithubAppModel,
+  PublicGithubAppInstallation,
+  PublicReleaseTarget,
+} from "../../../models/github-app";
 import {
   Alert,
   Badge,
@@ -9,6 +13,7 @@ import {
   Input,
   LinkButton,
   Muted,
+  Select,
 } from "../../../components";
 import { ReleaseTargetForm } from "../Settings/ReleaseTargetForm";
 import { Checklist, StepCard } from "./StepCard";
@@ -19,6 +24,7 @@ type GithubApp = ReturnType<typeof useModel<typeof GithubAppModel.prototype>>;
 export function PypiFlow({ githubApp }: { githubApp: GithubApp }) {
   const environment = useSignal<string>(setupDefaults.pypiEnvironment);
   const pythonVersion = useSignal("3.12");
+  const selectedReleaseTargetId = useSignal("");
 
   const workflowYaml = useComputed(() =>
     pypiReleaseWorkflow({
@@ -32,6 +38,27 @@ export function PypiFlow({ githubApp }: { githubApp: GithubApp }) {
     (row: PublicGithubAppInstallation) => row.status === "active",
   );
   const releaseTargets = githubApp.releaseTargets.value;
+  const selectedReleaseTarget =
+    releaseTargets.find(
+      (target: PublicReleaseTarget) => target.id === selectedReleaseTargetId.value,
+    ) ?? null;
+  const normalizedFlowEnvironment = (environment.value || setupDefaults.pypiEnvironment)
+    .trim()
+    .toLowerCase();
+  const selectedTargetMatchesFlow =
+    selectedReleaseTarget !== null &&
+    selectedReleaseTarget.environment.toLowerCase() === normalizedFlowEnvironment;
+
+  const selectReleaseTarget = (targetId: string) => {
+    selectedReleaseTargetId.value = targetId;
+    const target = releaseTargets.find((row: PublicReleaseTarget) => row.id === targetId);
+    if (target) environment.value = target.environment;
+  };
+
+  const onReleaseTargetCreated = (target: PublicReleaseTarget) => {
+    selectedReleaseTargetId.value = target.id;
+    environment.value = target.environment;
+  };
 
   return (
     <div class="flex flex-col gap-4">
@@ -156,12 +183,41 @@ export function PypiFlow({ githubApp }: { githubApp: GithubApp }) {
       <StepCard
         index="04"
         title="Map the release target"
-        status={releaseTargets.length ? "done" : "todo"}
-        summary="Tell Drydock which package, repository, and environment to gate. It revalidates installation, repo access, and environment names before saving."
+        status={selectedTargetMatchesFlow ? "done" : "todo"}
+        summary="Tell Drydock which package, repository, and environment this flow gates. Pick an existing mapping explicitly or create a new one below."
       >
+        {releaseTargets.length ? (
+          <ExistingReleaseTargetPicker
+            releaseTargets={releaseTargets}
+            selectedId={selectedReleaseTargetId.value}
+            onSelect={selectReleaseTarget}
+          />
+        ) : null}
+        {selectedReleaseTarget && selectedTargetMatchesFlow ? (
+          <Muted class="text-[12px] m-0">
+            Using {selectedReleaseTarget.packageName} on{" "}
+            <code class="font-mono text-ink-subtle">
+              {selectedReleaseTarget.repositoryFullName}
+            </code>{" "}
+            / <code class="font-mono text-ink-subtle">{selectedReleaseTarget.environment}</code>.
+          </Muted>
+        ) : selectedReleaseTarget ? (
+          <Alert tone="warn">
+            The selected target uses environment {selectedReleaseTarget.environment}; update the
+            workflow environment or pick a matching target.
+          </Alert>
+        ) : releaseTargets.length ? (
+          <Muted class="text-[12px] m-0">
+            Existing mappings are available, but none is selected for this setup flow yet.
+          </Muted>
+        ) : null}
         {activeInstallations.length ? (
           <div class="border border-border rounded-lg overflow-hidden">
-            <ReleaseTargetForm githubApp={githubApp} activeInstallations={activeInstallations} />
+            <ReleaseTargetForm
+              githubApp={githubApp}
+              activeInstallations={activeInstallations}
+              onCreated={onReleaseTargetCreated}
+            />
           </div>
         ) : (
           <Muted class="text-[13px] m-0">
@@ -171,8 +227,8 @@ export function PypiFlow({ githubApp }: { githubApp: GithubApp }) {
         )}
         {releaseTargets.length ? (
           <Muted class="text-[12px] m-0">
-            {releaseTargets.length} release target{releaseTargets.length === 1 ? "" : "s"} mapped.
-            Manage them in{" "}
+            {releaseTargets.length} release target{releaseTargets.length === 1 ? "" : "s"} mapped in
+            this organization. Manage them in{" "}
             <a class="underline" href="/dashboard/settings">
               settings
             </a>
@@ -197,6 +253,29 @@ export function PypiFlow({ githubApp }: { githubApp: GithubApp }) {
         </LinkButton>
       </StepCard>
     </div>
+  );
+}
+
+function ExistingReleaseTargetPicker({
+  releaseTargets,
+  selectedId,
+  onSelect,
+}: {
+  releaseTargets: PublicReleaseTarget[];
+  selectedId: string;
+  onSelect: (targetId: string) => void;
+}) {
+  return (
+    <Field label="Release target for this flow" for="pypiFlowReleaseTarget">
+      <Select id="pypiFlowReleaseTarget" value={selectedId} onChange={onSelect}>
+        <option value="">Map a new target below…</option>
+        {releaseTargets.map((target) => (
+          <option key={target.id} value={target.id}>
+            {target.packageName} · {target.repositoryFullName} · env {target.environment}
+          </option>
+        ))}
+      </Select>
+    </Field>
   );
 }
 

--- a/src/pages/Dashboard/Setup/PypiFlow.tsx
+++ b/src/pages/Dashboard/Setup/PypiFlow.tsx
@@ -1,0 +1,255 @@
+import { useComputed, useModel, useSignal } from "@preact/signals";
+import type { GithubAppModel, PublicGithubAppInstallation } from "../../../models/github-app";
+import {
+  Alert,
+  Badge,
+  Button,
+  CodeBlock,
+  Field,
+  Input,
+  LinkButton,
+  Muted,
+} from "../../../components";
+import { ReleaseTargetForm } from "../Settings/ReleaseTargetForm";
+import { Checklist, StepCard } from "./StepCard";
+import { pypiReleaseWorkflow, setupDefaults } from "./workflow-templates";
+
+type GithubApp = ReturnType<typeof useModel<typeof GithubAppModel.prototype>>;
+
+export function PypiFlow({ githubApp }: { githubApp: GithubApp }) {
+  const environment = useSignal<string>(setupDefaults.pypiEnvironment);
+  const pythonVersion = useSignal("3.12");
+
+  const workflowYaml = useComputed(() =>
+    pypiReleaseWorkflow({
+      environment: environment.value,
+      pythonVersion: pythonVersion.value,
+    }),
+  );
+
+  const installations = githubApp.installations.value;
+  const activeInstallations = installations.filter(
+    (row: PublicGithubAppInstallation) => row.status === "active",
+  );
+  const releaseTargets = githubApp.releaseTargets.value;
+
+  return (
+    <div class="flex flex-col gap-4">
+      <StepCard
+        index="01"
+        title="Install the Drydock GitHub App"
+        status={activeInstallations.length ? "done" : "todo"}
+        summary="Install Drydock on the organization that owns the release repository so it can hold the deployment and post the approve/reject decision back to GitHub."
+      >
+        <InstallStep githubApp={githubApp} activeInstallations={activeInstallations} />
+      </StepCard>
+
+      <StepCard
+        index="02"
+        title="Add the PyPI release workflow"
+        status="manual"
+        summary="A tag-triggered workflow builds the wheel + sdist, uploads them for review, and publishes via Trusted Publishing — no PyPI token. The publish job never rebuilds."
+      >
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <Field label="GitHub environment" for="pypiFlowEnv">
+            <Input
+              id="pypiFlowEnv"
+              type="text"
+              value={environment.value}
+              placeholder={setupDefaults.pypiEnvironment}
+              onInput={(e) => (environment.value = (e.target as HTMLInputElement).value)}
+              autoComplete="off"
+              spellcheck={false}
+            />
+          </Field>
+          <Field label="Python version" for="pypiFlowPython">
+            <Input
+              id="pypiFlowPython"
+              type="text"
+              value={pythonVersion.value}
+              placeholder="3.12"
+              onInput={(e) => (pythonVersion.value = (e.target as HTMLInputElement).value)}
+              autoComplete="off"
+              spellcheck={false}
+            />
+          </Field>
+        </div>
+        <CodeBlock
+          label={`.github/workflows/${setupDefaults.pypiWorkflowFilename}`}
+          code={workflowYaml.value}
+        />
+        <Muted class="text-[12px] leading-[1.55] m-0">
+          Commit this to{" "}
+          <code class="font-mono text-ink-subtle">
+            .github/workflows/{setupDefaults.pypiWorkflowFilename}
+          </code>
+          . The <code class="font-mono text-ink-subtle">publish</code> job pauses on the{" "}
+          <code class="font-mono text-ink-subtle">
+            {environment.value || setupDefaults.pypiEnvironment}
+          </code>{" "}
+          environment and downloads exactly the reviewed artifact — it never rebuilds. For
+          hardening, pin each action to a commit SHA.
+        </Muted>
+      </StepCard>
+
+      <StepCard
+        index="03"
+        title="Configure the GitHub environment gate"
+        status="manual"
+        summary="Create the environment your publish job deploys to, add Drydock as a deployment protection rule, and point a PyPI Trusted Publisher at the same environment name."
+      >
+        <Checklist
+          items={[
+            <>
+              Create (or open) the{" "}
+              <code class="font-mono text-ink-subtle">
+                {environment.value || setupDefaults.pypiEnvironment}
+              </code>{" "}
+              GitHub Actions environment on the release repository. See{" "}
+              <a
+                class="underline"
+                href="https://docs.github.com/en/actions/deployment/targeting-different-environments/managing-environments-for-deployment"
+                target="_blank"
+                rel="noreferrer"
+              >
+                managing environments
+              </a>
+              .
+            </>,
+            <>
+              Enable Drydock as a{" "}
+              <a
+                class="underline"
+                href="https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-custom-deployment-protection-rules"
+                target="_blank"
+                rel="noreferrer"
+              >
+                custom deployment protection rule
+              </a>{" "}
+              on that environment so the publish job pauses for review.
+            </>,
+            <>
+              On PyPI, configure a{" "}
+              <a
+                class="underline"
+                href="https://docs.pypi.org/trusted-publishers/"
+                target="_blank"
+                rel="noreferrer"
+              >
+                Trusted Publisher
+              </a>{" "}
+              for the same repository and workflow, with its environment name matching{" "}
+              <code class="font-mono text-ink-subtle">
+                {environment.value || setupDefaults.pypiEnvironment}
+              </code>{" "}
+              exactly.
+            </>,
+          ]}
+        />
+        <Muted class="text-[12px] leading-[1.55] m-0">
+          The environment name must match across the workflow, the GitHub environment, and the PyPI
+          Trusted Publisher — that shared name is what ties the gate to the OIDC exchange. Drydock
+          never holds PyPI credentials.
+        </Muted>
+      </StepCard>
+
+      <StepCard
+        index="04"
+        title="Map the release target"
+        status={releaseTargets.length ? "done" : "todo"}
+        summary="Tell Drydock which package, repository, and environment to gate. It revalidates installation, repo access, and environment names before saving."
+      >
+        {activeInstallations.length ? (
+          <div class="border border-border rounded-lg overflow-hidden">
+            <ReleaseTargetForm githubApp={githubApp} activeInstallations={activeInstallations} />
+          </div>
+        ) : (
+          <Muted class="text-[13px] m-0">
+            Install the GitHub App on an organization with the repo you want to gate (step 01)
+            before mapping a release target.
+          </Muted>
+        )}
+        {releaseTargets.length ? (
+          <Muted class="text-[12px] m-0">
+            {releaseTargets.length} release target{releaseTargets.length === 1 ? "" : "s"} mapped.
+            Manage them in{" "}
+            <a class="underline" href="/dashboard/settings">
+              settings
+            </a>
+            .
+          </Muted>
+        ) : null}
+      </StepCard>
+
+      <StepCard
+        index="05"
+        title="Test the gate"
+        status="manual"
+        summary="Push a v* tag. The publish job pauses on the environment, the held release shows up on your dashboard, and your approval releases or blocks it."
+      >
+        <Muted class="text-[13px] leading-[1.55] m-0">
+          When the workflow reaches the <code class="font-mono text-ink-subtle">publish</code> job
+          it waits for Drydock's review. The held deployment appears on your dashboard as a gate;
+          once you approve, the same job resumes and publishes via Trusted Publishing.
+        </Muted>
+        <LinkButton variant="secondary" size="sm" href="/dashboard" class="self-start">
+          Open dashboard
+        </LinkButton>
+      </StepCard>
+    </div>
+  );
+}
+
+function InstallStep({
+  githubApp,
+  activeInstallations,
+}: {
+  githubApp: GithubApp;
+  activeInstallations: PublicGithubAppInstallation[];
+}) {
+  const configured = githubApp.config.value?.configured === true;
+  const appSlug = githubApp.config.value?.appSlug;
+  const status = githubApp.status.value;
+  const busy = githubApp.busy.value;
+  const error = githubApp.error.value;
+  const installations = githubApp.installations.value;
+
+  return (
+    <>
+      <div class="flex items-center gap-2">
+        {activeInstallations.length ? (
+          <Badge tone="ok">installed · {activeInstallations.length} active</Badge>
+        ) : configured ? (
+          <Badge tone="neutral">not installed</Badge>
+        ) : (
+          <Badge tone="info">not configured</Badge>
+        )}
+        {configured && appSlug ? (
+          <span class="font-mono text-[11px] text-ink-subtle">{appSlug}</span>
+        ) : null}
+      </div>
+
+      {!configured ? (
+        <Alert tone="warn">
+          The GitHub App isn't configured on this Drydock instance yet — ask the operator to add the
+          GitHub App secrets on the Worker before installing.
+        </Alert>
+      ) : null}
+
+      {error ? <Alert tone="critical">{error}</Alert> : null}
+
+      <div class="flex flex-wrap items-center gap-3">
+        <Button onClick={() => void githubApp.startInstall()} disabled={!configured || busy}>
+          {status === "starting"
+            ? "Redirecting…"
+            : installations.length
+              ? "Install on another organization"
+              : "Install GitHub App"}
+        </Button>
+        <Muted class="text-[12px] m-0">
+          You'll pick the account to install on at GitHub, then return here.
+        </Muted>
+      </div>
+    </>
+  );
+}

--- a/src/pages/Dashboard/Setup/PypiFlow.tsx
+++ b/src/pages/Dashboard/Setup/PypiFlow.tsx
@@ -195,7 +195,7 @@ export function PypiFlow({ githubApp }: { githubApp: GithubApp }) {
         ) : null}
         {selectedReleaseTarget && selectedTargetMatchesFlow ? (
           <Muted class="text-[12px] m-0">
-            Using {selectedReleaseTarget.packageName} on{" "}
+            Using{" "}
             <code class="font-mono text-ink-subtle">
               {selectedReleaseTarget.repositoryFullName}
             </code>{" "}
@@ -271,7 +271,7 @@ function ExistingReleaseTargetPicker({
         <option value="">Map a new target below…</option>
         {releaseTargets.map((target) => (
           <option key={target.id} value={target.id}>
-            {target.packageName} · {target.repositoryFullName} · env {target.environment}
+            {target.repositoryFullName} · env {target.environment}
           </option>
         ))}
       </Select>

--- a/src/pages/Dashboard/Setup/StepCard.tsx
+++ b/src/pages/Dashboard/Setup/StepCard.tsx
@@ -1,0 +1,75 @@
+import type { ComponentChildren } from "preact";
+import { Badge, Card, Muted } from "../../../components";
+
+export type StepStatus = "done" | "todo" | "manual";
+
+/**
+ * One step in a guided-setup flow. Steps render as a vertical stack rather than
+ * a step machine: each lights up `done` as its backing model state is satisfied,
+ * so the flow is mostly "confirm" rather than "fill in a form". Generate/manual
+ * steps (workflow YAML, npmjs.com / GitHub config) carry a neutral `manual`
+ * badge because Drydock can't observe their completion.
+ */
+export function StepCard({
+  index,
+  title,
+  status,
+  summary,
+  children,
+}: {
+  index: string;
+  title: string;
+  status: StepStatus;
+  summary?: ComponentChildren;
+  children: ComponentChildren;
+}) {
+  return (
+    <Card as="section" class="p-5">
+      <div class="flex items-start gap-3">
+        <span class="font-mono text-[11px] text-ink-subtle tabular-nums mt-1 shrink-0">
+          {index}
+        </span>
+        <div class="flex-1 min-w-0 flex flex-col gap-4">
+          <div class="flex items-start justify-between gap-3">
+            <div class="flex flex-col gap-1 min-w-0">
+              <h2 class="text-[16px] font-medium tracking-[-0.005em] m-0">{title}</h2>
+              {summary ? <Muted class="text-[13px] m-0">{summary}</Muted> : null}
+            </div>
+            <StepBadge status={status} />
+          </div>
+          <div class="flex flex-col gap-4 min-w-0">{children}</div>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function StepBadge({ status }: { status: StepStatus }) {
+  switch (status) {
+    case "done":
+      return <Badge tone="ok">done</Badge>;
+    case "manual":
+      return <Badge tone="info">manual</Badge>;
+    case "todo":
+      return <Badge tone="neutral">to do</Badge>;
+  }
+}
+
+/** Bulleted manual checklist used inside setup steps Drydock can't observe. */
+export function Checklist({ items }: { items: ComponentChildren[] }) {
+  return (
+    <ul class="m-0 p-0 list-none flex flex-col gap-2">
+      {items.map((item, index) => (
+        <li
+          key={index}
+          class="grid grid-cols-[16px_minmax(0,1fr)] gap-2.5 items-baseline text-[13px] leading-[1.55] text-ink-muted"
+        >
+          <span class="font-mono text-ink-subtle" aria-hidden>
+            •
+          </span>
+          <span class="min-w-0">{item}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/pages/Dashboard/Setup/index.tsx
+++ b/src/pages/Dashboard/Setup/index.tsx
@@ -1,0 +1,225 @@
+import type { ComponentChildren } from "preact";
+import { useEffect } from "preact/hooks";
+import { useModel, useSignal } from "@preact/signals";
+import { useLocation } from "preact-iso";
+import { useQuerySignal } from "../../../lib/query-state";
+import { sessionModel } from "../../../models/auth";
+import { NpmConnectionModel } from "../../../models/npm-connection";
+import { OrganizationModel } from "../../../models/organization";
+import { GithubAppModel } from "../../../models/github-app";
+import { StagedPublishesModel } from "../../../models/staged-publishes";
+import {
+  Button,
+  Card,
+  Eyebrow,
+  LinkButton,
+  LoadingState,
+  Muted,
+  OrgSwitcher,
+  PageShell,
+  SectionLabel,
+  UserMenu,
+} from "../../../components";
+import { NpmFlow } from "./NpmFlow";
+import { PypiFlow } from "./PypiFlow";
+
+type Flow = "npm" | "pypi" | null;
+
+function parseFlow(raw: string | undefined): Flow {
+  return raw === "npm" || raw === "pypi" ? raw : null;
+}
+
+export default function SetupPage() {
+  const location = useLocation();
+  const npm = useModel(NpmConnectionModel);
+  const organizations = useModel(OrganizationModel);
+  const githubApp = useModel(GithubAppModel);
+  const stagedPublishes = useModel(StagedPublishesModel);
+  const sessionChecked = useSignal(false);
+  const flow = useSignal<Flow>(null);
+
+  useQuerySignal(flow, {
+    name: "flow",
+    parse: parseFlow,
+    serialize: (value) => value,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const data = await sessionModel.load();
+      if (cancelled) return;
+      if (!data) {
+        location.route("/login", true);
+        return;
+      }
+      sessionChecked.value = true;
+      await Promise.all([organizations.load(), npm.load()]);
+      if (cancelled) return;
+      await Promise.all([
+        githubApp.loadConfig(),
+        githubApp.loadInstallations(),
+        githubApp.loadReleaseTargets(),
+      ]);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const reloadActiveOrgScopedData = async () => {
+    githubApp.clearForm();
+    stagedPublishes.reset();
+    await Promise.all([npm.load(), githubApp.loadInstallations(), githubApp.loadReleaseTargets()]);
+  };
+
+  const onSwitchOrganization = async (organizationId: string) => {
+    if (organizations.activate(organizationId)) {
+      await reloadActiveOrgScopedData();
+    }
+  };
+
+  const onCreateOrganization = async (name: string) => {
+    const created = await organizations.create(name);
+    if (created) {
+      await reloadActiveOrgScopedData();
+    }
+  };
+
+  const onSignOut = async () => {
+    await sessionModel.signOut();
+    location.route("/", true);
+  };
+
+  if (!sessionChecked.value) {
+    return (
+      <PageShell>
+        <SetupHeader />
+        <LoadingState title="Opening guided setup" detail="confirming session" />
+      </PageShell>
+    );
+  }
+
+  const user = sessionModel.user.value;
+  const workspaceLoaded = npm.loaded.value && githubApp.loaded.value;
+  const activeFlow = flow.value;
+
+  return (
+    <PageShell
+      headerActions={
+        <>
+          <LinkButton variant="ghost" size="sm" href="/dashboard">
+            Dashboard
+          </LinkButton>
+          <OrgSwitcher
+            organizations={organizations.organizations.value}
+            activeOrganizationId={organizations.activeOrganizationId.value}
+            busy={organizations.busy.value}
+            error={organizations.error.value}
+            onActivate={onSwitchOrganization}
+            onCreate={onCreateOrganization}
+          />
+          <UserMenu email={user?.email} name={user?.name} onSignOut={onSignOut} />
+        </>
+      }
+    >
+      <SetupHeader />
+
+      {!workspaceLoaded ? (
+        <LoadingState title="Loading guided setup" detail="checking npm and GitHub App" />
+      ) : activeFlow === "npm" ? (
+        <FlowFrame onBack={() => (flow.value = null)}>
+          <NpmFlow npm={npm} stagedPublishes={stagedPublishes} />
+        </FlowFrame>
+      ) : activeFlow === "pypi" ? (
+        <FlowFrame onBack={() => (flow.value = null)}>
+          <PypiFlow githubApp={githubApp} />
+        </FlowFrame>
+      ) : (
+        <EcosystemChooser onChoose={(next) => (flow.value = next)} />
+      )}
+    </PageShell>
+  );
+}
+
+function SetupHeader() {
+  return (
+    <header class="flex flex-col gap-2 max-w-[680px]">
+      <Eyebrow>Guided setup</Eyebrow>
+      <h1 class="text-3xl font-semibold tracking-[-0.02em] m-0">Set up a publishing flow</h1>
+      <Muted class="text-[14px] leading-[1.55] m-0">
+        Drydock generates best-practice config and walks you through the few steps it can't do for
+        you. Pick the ecosystem you publish to and work down the list — each step lights up as its
+        state is satisfied.
+      </Muted>
+    </header>
+  );
+}
+
+function FlowFrame({ onBack, children }: { onBack: () => void; children: ComponentChildren }) {
+  return (
+    <div class="flex flex-col gap-4">
+      <button
+        type="button"
+        onClick={onBack}
+        class="self-start font-mono text-[11px] text-ink-muted hover:text-ink transition-colors duration-150 ease-out cursor-pointer"
+      >
+        ← Choose a different ecosystem
+      </button>
+      {children}
+    </div>
+  );
+}
+
+function EcosystemChooser({ onChoose }: { onChoose: (flow: "npm" | "pypi") => void }) {
+  return (
+    <div class="flex flex-col gap-3">
+      <SectionLabel>Pick an ecosystem</SectionLabel>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <ChoiceCard
+          label="npm"
+          title="Staged publishing"
+          description="CI stages the tarball through npm trusted publishing (OIDC) — no NPM_TOKEN. Drydock reviews the staged release and a maintainer approves the public publish with 2FA."
+          cta="Set up npm staging"
+          onClick={() => onChoose("npm")}
+        />
+        <ChoiceCard
+          label="PyPI"
+          title="GitHub Actions release gate"
+          description="A tag-triggered workflow builds the wheel + sdist and pauses on a GitHub Environment. Drydock reviews the candidate, then the publish job resumes via Trusted Publishing — no PyPI token."
+          cta="Set up PyPI gate"
+          onClick={() => onChoose("pypi")}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ChoiceCard({
+  label,
+  title,
+  description,
+  cta,
+  onClick,
+}: {
+  label: string;
+  title: string;
+  description: string;
+  cta: string;
+  onClick: () => void;
+}) {
+  return (
+    <Card as="article" class="p-5 flex flex-col gap-4">
+      <div class="flex flex-col gap-1.5">
+        <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">
+          {label}
+        </span>
+        <h2 class="text-[18px] font-medium tracking-[-0.01em] m-0">{title}</h2>
+        <Muted class="text-[13px] leading-[1.55] m-0">{description}</Muted>
+      </div>
+      <Button variant="primary" size="sm" class="self-start" onClick={onClick}>
+        {cta}
+      </Button>
+    </Card>
+  );
+}

--- a/src/pages/Dashboard/Setup/workflow-templates.ts
+++ b/src/pages/Dashboard/Setup/workflow-templates.ts
@@ -37,9 +37,25 @@ export interface PypiWorkflowInput {
   pythonVersion?: string;
 }
 
-function safePackagePlaceholder(packageName: string): string {
-  const trimmed = packageName.trim();
-  return trimmed || "<package>";
+function safePackagePlaceholders(packageName: string): string[] {
+  const names = packageNamesFromInput(packageName);
+  return names.length ? names : ["<package>"];
+}
+
+function packageNamesFromInput(packageName: string): string[] {
+  const seen = new Set<string>();
+  const names: string[] = [];
+  for (const raw of packageName.split(/[,\n]+/)) {
+    const name = raw.trim();
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+    names.push(name);
+  }
+  return names;
+}
+
+function yamlSingleQuoted(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
 }
 
 /**
@@ -49,7 +65,9 @@ function safePackagePlaceholder(packageName: string): string {
  * package-manager cache, and validates the tarball identity before staging.
  */
 export function npmStagedPublishWorkflow(input: NpmWorkflowInput): string {
-  const pkg = safePackagePlaceholder(input.packageName);
+  const packages = safePackagePlaceholders(input.packageName);
+  const primaryPackage = packages[0];
+  const expectedPackagesJson = JSON.stringify(packages);
   const environment =
     (input.environment ?? DEFAULT_NPM_ENVIRONMENT).trim() || DEFAULT_NPM_ENVIRONMENT;
   return `name: Release (npm staged publish via trusted publishing)
@@ -85,11 +103,84 @@ jobs:
           # the tarball that gets staged.
           package-manager-cache: false
       - run: npm ci --ignore-scripts
-      - run: npm pack
+      - name: Pack release candidate
+        env:
+          EXPECTED_PACKAGES_JSON: ${yamlSingleQuoted(expectedPackagesJson)}
+        run: |
+          set -euo pipefail
+          rm -rf .drydock-npm-pack
+          mkdir -p .drydock-npm-pack
+          node <<'NODE'
+          const fs = require("fs");
+          const expected = JSON.parse(process.env.EXPECTED_PACKAGES_JSON);
+          fs.writeFileSync(".drydock-npm-pack/expected-packages.txt", expected.join("\\n") + "\\n");
+          NODE
+
+          ROOT_NAME="$(node -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync("package.json", "utf8")); process.stdout.write(pkg.name || "");')"
+          EXPECTED_COUNT="$(wc -l < .drydock-npm-pack/expected-packages.txt | tr -d ' ')"
+          if [ "$EXPECTED_COUNT" = "1" ] && [ "$ROOT_NAME" = "$(cat .drydock-npm-pack/expected-packages.txt)" ]; then
+            npm pack --json --pack-destination .drydock-npm-pack > .drydock-npm-pack/pack.json
+          else
+            PACK_ARGS=()
+            while IFS= read -r package; do
+              if [ "$package" = "$ROOT_NAME" ]; then
+                PACK_ARGS+=(--include-workspace-root)
+              else
+                PACK_ARGS+=(--workspace "$package")
+              fi
+            done < .drydock-npm-pack/expected-packages.txt
+            npm pack "\${PACK_ARGS[@]}" --json --pack-destination .drydock-npm-pack > .drydock-npm-pack/pack.json
+          fi
+
+          # Monorepos may produce more than one tarball. Select the one whose
+          # package identity matches this setup flow, and carry that exact
+          # allowlist to the credentialed stage job.
+          node <<'NODE'
+          const fs = require("fs");
+          const path = require("path");
+          const outputDir = ".drydock-npm-pack";
+          const expected = JSON.parse(process.env.EXPECTED_PACKAGES_JSON);
+          const expectedSet = new Set(expected);
+          const raw = JSON.parse(fs.readFileSync(path.join(outputDir, "pack.json"), "utf8"));
+          const packed = Array.isArray(raw) ? raw : [raw];
+          const byName = new Map();
+
+          for (const item of packed) {
+            if (!item || !expectedSet.has(item.name)) continue;
+            if (byName.has(item.name)) {
+              console.error("found more than one packed tarball for " + item.name);
+              process.exit(1);
+            }
+            byName.set(item.name, item);
+          }
+
+          const missing = expected.filter((name) => !byName.has(name));
+          if (missing.length) {
+            console.error("missing packed tarball(s): " + missing.join(", "));
+            console.error("packed packages:");
+            for (const item of packed) {
+              console.error("- " + (item?.name ?? "(unknown)") + " -> " + (item?.filename ?? "(no file)"));
+            }
+            process.exit(1);
+          }
+
+          const selected = [];
+          for (const name of expected) {
+            const item = byName.get(name);
+            const filename = path.basename(item.filename || "");
+            const tarball = path.join(outputDir, filename);
+            if (!filename || !fs.existsSync(tarball)) {
+              console.error("packed tarball not found: " + (item.filename || "(missing filename)"));
+              process.exit(1);
+            }
+            selected.push(filename);
+          }
+          fs.writeFileSync(path.join(outputDir, "selected-tarballs.txt"), selected.join("\\n") + "\\n");
+          NODE
       - uses: actions/upload-artifact@v4
         with:
           name: npm-tarball
-          path: "*.tgz"
+          path: .drydock-npm-pack
           if-no-files-found: error
 
   stage:
@@ -100,7 +191,7 @@ jobs:
     # policy applies before anything is staged.
     environment:
       name: ${environment}
-      url: https://www.npmjs.com/package/${pkg}
+      url: https://www.npmjs.com/package/${primaryPackage}
     permissions:
       contents: read
       id-token: write # OIDC token exchange for npm trusted publishing
@@ -108,6 +199,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: npm-tarball
+          path: .drydock-npm-pack
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -117,16 +209,24 @@ jobs:
       - name: Use npm with staged publishing
         run: npm install -g npm@^11.15.0
       - name: Stage the publish for review
+        env:
+          EXPECTED_PACKAGES_JSON: ${yamlSingleQuoted(expectedPackagesJson)}
         run: |
-          TARBALL="$(ls *.tgz)"
-          # Verify the tarball identity before staging; never stage an unexpected package.
-          tar -xOf "$TARBALL" package/package.json | node -e '
-            const p = JSON.parse(require("fs").readFileSync(0, "utf8"));
-            if (p.name !== "${pkg}") { console.error("package name mismatch: " + p.name); process.exit(1); }
-            console.log(p.name + "@" + p.version);
-          '
-          # Stage instead of publish — a maintainer approves the public release after Drydock review.
-          npm stage publish "$TARBALL" --access public --tag latest
+          set -euo pipefail
+          while IFS= read -r filename; do
+            [ -n "$filename" ] || continue
+            TARBALL=".drydock-npm-pack/$filename"
+            test -f "$TARBALL"
+            # Verify the tarball identity before staging; never stage an unexpected package.
+            tar -xOf "$TARBALL" package/package.json | node -e '
+              const expected = new Set(JSON.parse(process.env.EXPECTED_PACKAGES_JSON));
+              const p = JSON.parse(require("fs").readFileSync(0, "utf8"));
+              if (!expected.has(p.name)) { console.error("package name mismatch: " + p.name); process.exit(1); }
+              console.log(p.name + "@" + p.version);
+            '
+            # Stage instead of publish — a maintainer approves the public release after Drydock review.
+            npm stage publish "$TARBALL" --access public --tag latest
+          done < .drydock-npm-pack/selected-tarballs.txt
 `;
 }
 
@@ -135,7 +235,7 @@ jobs:
  * disallows `npm publish`, so OIDC cannot bypass the staged approval gate.
  */
 export function npmTrustCommand(input: NpmTrustInput): string {
-  const pkg = safePackagePlaceholder(input.packageName);
+  const packages = safePackagePlaceholders(input.packageName);
   const owner = input.owner.trim() || "<owner>";
   const repo = input.repo.trim() || "<repo>";
   const workflow =
@@ -143,9 +243,12 @@ export function npmTrustCommand(input: NpmTrustInput): string {
     DEFAULT_NPM_WORKFLOW_FILENAME;
   const environment =
     (input.environment ?? DEFAULT_NPM_ENVIRONMENT).trim() || DEFAULT_NPM_ENVIRONMENT;
-  return `npm install -g npm@^11.15.0
-npm trust github --repo ${owner}/${repo} --file ${workflow} --env ${environment} --allow-stage-publish --no-allow-publish ${pkg}
-npm trust list ${pkg}`;
+  const trustCommands = packages.map(
+    (pkg) =>
+      `npm trust github --repo ${owner}/${repo} --file ${workflow} --env ${environment} --allow-stage-publish --no-allow-publish ${pkg}`,
+  );
+  const listCommands = packages.map((pkg) => `npm trust list ${pkg}`);
+  return ["npm install -g npm@^11.15.0", ...trustCommands, ...listCommands].join("\n");
 }
 
 /**

--- a/src/pages/Dashboard/Setup/workflow-templates.ts
+++ b/src/pages/Dashboard/Setup/workflow-templates.ts
@@ -1,0 +1,236 @@
+// Pure generators for the guided-setup artifacts. These produce copy-paste
+// best-practice config; nothing here mutates a repo. The shapes mirror two
+// authoritative references:
+//   - npm staged publishing via trusted publishing (OIDC), per the
+//     npm-trusted-publishing skill: stage-only OIDC, no NPM_TOKEN, publish-path
+//     caching disabled, the credentialed job gated behind the `npm` environment.
+//   - The Drydock PyPI workflow gate, per drydock-ci-example/.github/workflows/
+//     release.yml: build → upload `pypi-release-candidate` → publish via Trusted
+//     Publishing gated on a GitHub Environment; the publish job never rebuilds.
+
+const DEFAULT_NPM_WORKFLOW_FILENAME = "release.yml";
+const DEFAULT_NPM_ENVIRONMENT = "npm";
+const DEFAULT_PYPI_ENVIRONMENT = "pypi";
+const DEFAULT_PYTHON_VERSION = "3.12";
+
+export interface NpmWorkflowInput {
+  /** Published package name, e.g. `@scope/pkg` or `pkg`. Used for the env URL and identity check. */
+  packageName: string;
+  /** GitHub environment that gates the credentialed stage job. */
+  environment?: string;
+}
+
+export interface NpmTrustInput {
+  /** GitHub owner/org login. */
+  owner: string;
+  /** GitHub repository name (without owner). */
+  repo: string;
+  packageName: string;
+  /** Workflow filename only (npm wants the filename, not the full path). */
+  workflowFilename?: string;
+  environment?: string;
+}
+
+export interface PypiWorkflowInput {
+  /** GitHub environment that gates the publish job (must match the PyPI Trusted Publisher env). */
+  environment?: string;
+  pythonVersion?: string;
+}
+
+function safePackagePlaceholder(packageName: string): string {
+  const trimmed = packageName.trim();
+  return trimmed || "<package>";
+}
+
+/**
+ * Generates a tag-triggered npm release workflow that stages the tarball through
+ * trusted publishing. The build job has no credentials; only the `stage` job
+ * gets `id-token: write`, runs behind the `npm` environment, disables the
+ * package-manager cache, and validates the tarball identity before staging.
+ */
+export function npmStagedPublishWorkflow(input: NpmWorkflowInput): string {
+  const pkg = safePackagePlaceholder(input.packageName);
+  const environment =
+    (input.environment ?? DEFAULT_NPM_ENVIRONMENT).trim() || DEFAULT_NPM_ENVIRONMENT;
+  return `name: Release (npm staged publish via trusted publishing)
+
+# Staged publishing: CI stages the tarball through npm trusted publishing (OIDC),
+# Drydock reviews the staged release, and a maintainer approves the public
+# release with 2FA. No long-lived NPM_TOKEN is used. Configure the npm trusted
+# publisher (stage-only) before this runs — GitHub YAML alone does not enable
+# trusted publishing.
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          # Never restore a dependency cache anywhere in the publish path, not
+          # even in the uncredentialed build — a poisoned cache must not reach
+          # the tarball that gets staged.
+          package-manager-cache: false
+      - run: npm ci --ignore-scripts
+      - run: npm pack
+      - uses: actions/upload-artifact@v4
+        with:
+          name: npm-tarball
+          path: "*.tgz"
+          if-no-files-found: error
+
+  stage:
+    needs: build
+    runs-on: ubuntu-latest
+    # The gate: only this job can mint the npm OIDC token, and it runs behind the
+    # \`${environment}\` GitHub Environment so a maintainer-controlled deployment
+    # policy applies before anything is staged.
+    environment:
+      name: ${environment}
+      url: https://www.npmjs.com/package/${pkg}
+    permissions:
+      contents: read
+      id-token: write # OIDC token exchange for npm trusted publishing
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: npm-tarball
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          # Never restore a dependency cache in the credentialed publish path.
+          package-manager-cache: false
+      - name: Use npm with staged publishing
+        run: npm install -g npm@^11.15.0
+      - name: Stage the publish for review
+        run: |
+          TARBALL="$(ls *.tgz)"
+          # Verify the tarball identity before staging; never stage an unexpected package.
+          tar -xOf "$TARBALL" package/package.json | node -e '
+            const p = JSON.parse(require("fs").readFileSync(0, "utf8"));
+            if (p.name !== "${pkg}") { console.error("package name mismatch: " + p.name); process.exit(1); }
+            console.log(p.name + "@" + p.version);
+          '
+          # Stage instead of publish — a maintainer approves the public release after Drydock review.
+          npm stage publish "$TARBALL" --access public --tag latest
+`;
+}
+
+/**
+ * The npm-side trust configuration. Stage-only: enables `npm stage publish` and
+ * disallows `npm publish`, so OIDC cannot bypass the staged approval gate.
+ */
+export function npmTrustCommand(input: NpmTrustInput): string {
+  const pkg = safePackagePlaceholder(input.packageName);
+  const owner = input.owner.trim() || "<owner>";
+  const repo = input.repo.trim() || "<repo>";
+  const workflow =
+    (input.workflowFilename ?? DEFAULT_NPM_WORKFLOW_FILENAME).trim() ||
+    DEFAULT_NPM_WORKFLOW_FILENAME;
+  const environment =
+    (input.environment ?? DEFAULT_NPM_ENVIRONMENT).trim() || DEFAULT_NPM_ENVIRONMENT;
+  return `npm install -g npm@^11.15.0
+npm trust github --repo ${owner}/${repo} --file ${workflow} --env ${environment} --allow-stage-publish --no-allow-publish ${pkg}
+npm trust list ${pkg}`;
+}
+
+/**
+ * The Drydock PyPI workflow gate, mirroring drydock-ci-example. Build uploads
+ * `dist/*` as `pypi-release-candidate`; Drydock derives + reviews the release;
+ * the publish job blocks on the GitHub Environment (where Drydock's deployment
+ * protection rule lives) and downloads — never rebuilds — the reviewed bytes,
+ * publishing via OIDC Trusted Publishing. No long-lived PyPI token is involved.
+ */
+export function pypiReleaseWorkflow(input: PypiWorkflowInput = {}): string {
+  const environment =
+    (input.environment ?? DEFAULT_PYPI_ENVIRONMENT).trim() || DEFAULT_PYPI_ENVIRONMENT;
+  const python = (input.pythonVersion ?? DEFAULT_PYTHON_VERSION).trim() || DEFAULT_PYTHON_VERSION;
+  return `name: Release (PyPI Trusted Publishing via Drydock gate)
+
+# build  ->  upload dist/*  ->  [Drydock derives + reviews]  ->  publish
+#
+# Tag-triggered: pushing a \`v*\` tag builds the wheel + sdist and uploads
+# dist/*. Drydock derives the release from the wheels/sdists (identity from
+# METADATA/PKG-INFO, digests from the bytes) and reviews it. The publish job
+# blocks on the \`${environment}\` GitHub Environment, where Drydock's deployment
+# protection rule lives, and only resumes once the review approves. It never
+# rebuilds — it downloads exactly what was reviewed, so integrity rests on
+# GitHub artifact immutability. Publishing uses OIDC Trusted Publishing; no
+# long-lived PyPI token is involved.
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  build-release-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "${python}"
+
+      - name: Build wheel + sdist
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+
+      - name: Upload release candidate for review
+        uses: actions/upload-artifact@v4
+        with:
+          # Drydock looks for an artifact named exactly "pypi-release-candidate".
+          name: pypi-release-candidate
+          path: dist/*
+          if-no-files-found: error
+
+  publish:
+    needs: build-release-artifacts
+    runs-on: ubuntu-latest
+    # This is the gate. Drydock's deployment protection rule lives on this
+    # environment; the job waits here until the review approves.
+    environment: ${environment}
+    permissions:
+      id-token: write # OIDC token exchange for PyPI Trusted Publishing
+      contents: read
+    steps:
+      # No checkout, no rebuild. We publish exactly the artifact Drydock
+      # reviewed — GitHub artifact storage is immutable, so the bytes the gate
+      # approved are the bytes we download here.
+      - name: Download the reviewed candidate
+        uses: actions/download-artifact@v4
+        with:
+          name: pypi-release-candidate
+          path: dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+`;
+}
+
+export const setupDefaults = {
+  npmWorkflowFilename: DEFAULT_NPM_WORKFLOW_FILENAME,
+  npmEnvironment: DEFAULT_NPM_ENVIRONMENT,
+  pypiEnvironment: DEFAULT_PYPI_ENVIRONMENT,
+  pypiWorkflowFilename: "release.yml",
+} as const;

--- a/src/pages/Dashboard/Setup/workflow-templates.ts
+++ b/src/pages/Dashboard/Setup/workflow-templates.ts
@@ -108,18 +108,18 @@ jobs:
           EXPECTED_PACKAGES_JSON: ${yamlSingleQuoted(expectedPackagesJson)}
         run: |
           set -euo pipefail
-          rm -rf .drydock-npm-pack
-          mkdir -p .drydock-npm-pack
+          rm -rf drydock-npm-pack
+          mkdir -p drydock-npm-pack
           node <<'NODE'
           const fs = require("fs");
           const expected = JSON.parse(process.env.EXPECTED_PACKAGES_JSON);
-          fs.writeFileSync(".drydock-npm-pack/expected-packages.txt", expected.join("\\n") + "\\n");
+          fs.writeFileSync("drydock-npm-pack/expected-packages.txt", expected.join("\\n") + "\\n");
           NODE
 
           ROOT_NAME="$(node -e 'const fs = require("fs"); const pkg = JSON.parse(fs.readFileSync("package.json", "utf8")); process.stdout.write(pkg.name || "");')"
-          EXPECTED_COUNT="$(wc -l < .drydock-npm-pack/expected-packages.txt | tr -d ' ')"
-          if [ "$EXPECTED_COUNT" = "1" ] && [ "$ROOT_NAME" = "$(cat .drydock-npm-pack/expected-packages.txt)" ]; then
-            npm pack --json --pack-destination .drydock-npm-pack > .drydock-npm-pack/pack.json
+          EXPECTED_COUNT="$(wc -l < drydock-npm-pack/expected-packages.txt | tr -d ' ')"
+          if [ "$EXPECTED_COUNT" = "1" ] && [ "$ROOT_NAME" = "$(cat drydock-npm-pack/expected-packages.txt)" ]; then
+            npm pack --json --pack-destination drydock-npm-pack > drydock-npm-pack/pack.json
           else
             PACK_ARGS=()
             while IFS= read -r package; do
@@ -128,8 +128,8 @@ jobs:
               else
                 PACK_ARGS+=(--workspace "$package")
               fi
-            done < .drydock-npm-pack/expected-packages.txt
-            npm pack "\${PACK_ARGS[@]}" --json --pack-destination .drydock-npm-pack > .drydock-npm-pack/pack.json
+            done < drydock-npm-pack/expected-packages.txt
+            npm pack "\${PACK_ARGS[@]}" --json --pack-destination drydock-npm-pack > drydock-npm-pack/pack.json
           fi
 
           # Monorepos may produce more than one tarball. Select the one whose
@@ -138,7 +138,7 @@ jobs:
           node <<'NODE'
           const fs = require("fs");
           const path = require("path");
-          const outputDir = ".drydock-npm-pack";
+          const outputDir = "drydock-npm-pack";
           const expected = JSON.parse(process.env.EXPECTED_PACKAGES_JSON);
           const expectedSet = new Set(expected);
           const raw = JSON.parse(fs.readFileSync(path.join(outputDir, "pack.json"), "utf8"));
@@ -180,7 +180,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: npm-tarball
-          path: .drydock-npm-pack
+          path: drydock-npm-pack
           if-no-files-found: error
 
   stage:
@@ -199,7 +199,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: npm-tarball
-          path: .drydock-npm-pack
+          path: drydock-npm-pack
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -215,7 +215,7 @@ jobs:
           set -euo pipefail
           while IFS= read -r filename; do
             [ -n "$filename" ] || continue
-            TARBALL=".drydock-npm-pack/$filename"
+            TARBALL="drydock-npm-pack/$filename"
             test -f "$TARBALL"
             # Verify the tarball identity before staging; never stage an unexpected package.
             tar -xOf "$TARBALL" package/package.json | node -e '
@@ -226,7 +226,7 @@ jobs:
             '
             # Stage instead of publish — a maintainer approves the public release after Drydock review.
             npm stage publish "$TARBALL" --access public --tag latest
-          done < .drydock-npm-pack/selected-tarballs.txt
+          done < drydock-npm-pack/selected-tarballs.txt
 `;
 }
 

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -110,6 +110,9 @@ export default function DashboardPage() {
     <PageShell
       headerActions={
         <>
+          <LinkButton variant="ghost" size="sm" href="/dashboard/setup">
+            Set up
+          </LinkButton>
           <LinkButton variant="ghost" size="sm" href="/dashboard/settings">
             Settings
           </LinkButton>
@@ -331,11 +334,12 @@ function NpmSetupCallout() {
       <div class="flex flex-col gap-1.5 min-w-0">
         <SectionLabel>npm not connected</SectionLabel>
         <Muted class="text-[13px] m-0">
-          Connect npm in settings so Drydock can fetch staged tarballs and run reviews.
+          Connect npm so Drydock can fetch staged tarballs and run reviews. The guided setup walks
+          you through staged publishing end to end.
         </Muted>
       </div>
-      <LinkButton variant="primary" size="sm" href="/dashboard/settings">
-        Open settings
+      <LinkButton variant="primary" size="sm" href="/dashboard/setup?flow=npm">
+        Set up staged publishing
       </LinkButton>
     </Card>
   );

--- a/test/setup-workflow-templates.test.ts
+++ b/test/setup-workflow-templates.test.ts
@@ -46,13 +46,14 @@ describe("npmStagedPublishWorkflow", () => {
   });
 
   it("isolates pack output and selects tarballs by package identity", () => {
-    expect(yaml).toContain("npm pack --json --pack-destination .drydock-npm-pack");
+    expect(yaml).toContain("npm pack --json --pack-destination drydock-npm-pack");
     expect(yaml).toContain('PACK_ARGS+=(--workspace "$package")');
     expect(yaml).toContain('npm pack "${PACK_ARGS[@]}" --json');
     expect(yaml).toContain("selected-tarballs.txt");
     expect(yaml).toContain("missing packed tarball(s)");
     expect(yaml).toContain("found more than one packed tarball");
-    expect(yaml).toContain("path: .drydock-npm-pack");
+    expect(yaml).toContain("path: drydock-npm-pack");
+    expect(yaml).not.toContain(".drydock-npm-pack");
     expect(yaml).not.toContain('path: "*.tgz"');
     expect(yaml).not.toContain('TARBALL="$(ls *.tgz)"');
   });
@@ -62,7 +63,7 @@ describe("npmStagedPublishWorkflow", () => {
     expect(monorepo).toContain(`EXPECTED_PACKAGES_JSON: '["@scope/a","@scope/b"]'`);
     expect(monorepo).toContain("expected.join");
     expect(monorepo).toContain("selected.join");
-    expect(monorepo).toContain("done < .drydock-npm-pack/selected-tarballs.txt");
+    expect(monorepo).toContain("done < drydock-npm-pack/selected-tarballs.txt");
   });
 
   it("honors a custom environment", () => {

--- a/test/setup-workflow-templates.test.ts
+++ b/test/setup-workflow-templates.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  npmStagedPublishWorkflow,
+  npmTrustCommand,
+  pypiReleaseWorkflow,
+  setupDefaults,
+} from "../src/pages/Dashboard/Setup/workflow-templates";
+
+function count(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+describe("npmStagedPublishWorkflow", () => {
+  const yaml = npmStagedPublishWorkflow({ packageName: "@scope/pkg" });
+
+  it("is tag-triggered and grants no credentials at the top level", () => {
+    expect(yaml).toContain('tags: ["v*"]');
+    expect(yaml).toContain("permissions:\n  contents: read");
+  });
+
+  it("mints the OIDC token in exactly one job", () => {
+    expect(count(yaml, "id-token: write")).toBe(1);
+  });
+
+  it("stages instead of publishing and never uses a long-lived token", () => {
+    expect(yaml).toContain("npm stage publish");
+    expect(yaml).not.toContain("npm publish");
+    // Trusted publishing uses no GitHub secrets and no token env binding.
+    expect(yaml).not.toContain("secrets.");
+    expect(yaml).not.toContain("NODE_AUTH_TOKEN");
+  });
+
+  it("disables the package-manager cache in every job on the publish path", () => {
+    expect(count(yaml, "package-manager-cache: false")).toBe(2);
+  });
+
+  it("gates the credentialed job behind the npm environment", () => {
+    expect(yaml).toContain(`name: ${setupDefaults.npmEnvironment}`);
+    expect(yaml).toContain("https://www.npmjs.com/package/@scope/pkg");
+  });
+
+  it("requires a staged-publishing-capable npm and verifies the tarball identity", () => {
+    expect(yaml).toContain("npm@^11.15.0");
+    expect(yaml).toContain('p.name !== "@scope/pkg"');
+  });
+
+  it("honors a custom environment", () => {
+    expect(npmStagedPublishWorkflow({ packageName: "pkg", environment: "release" })).toContain(
+      "name: release",
+    );
+  });
+
+  it("falls back to a placeholder when the package name is empty", () => {
+    const placeholder = npmStagedPublishWorkflow({ packageName: "" });
+    expect(placeholder).toContain("https://www.npmjs.com/package/<package>");
+  });
+});
+
+describe("npmTrustCommand", () => {
+  const command = npmTrustCommand({ owner: "acme", repo: "widgets", packageName: "@acme/widgets" });
+
+  it("is stage-only: allows stage publish and disallows direct publish", () => {
+    expect(command).toContain("--allow-stage-publish");
+    expect(command).toContain("--no-allow-publish");
+  });
+
+  it("binds trust to the repo, workflow file, environment, and package", () => {
+    expect(command).toContain("--repo acme/widgets");
+    expect(command).toContain(`--file ${setupDefaults.npmWorkflowFilename}`);
+    expect(command).toContain(`--env ${setupDefaults.npmEnvironment}`);
+    expect(command).toContain("@acme/widgets");
+  });
+
+  it("respects a custom workflow filename", () => {
+    expect(
+      npmTrustCommand({
+        owner: "acme",
+        repo: "widgets",
+        packageName: "@acme/widgets",
+        workflowFilename: "publish.yml",
+      }),
+    ).toContain("--file publish.yml");
+  });
+
+  it("falls back to placeholders for empty owner/repo", () => {
+    const command = npmTrustCommand({ owner: "", repo: "", packageName: "pkg" });
+    expect(command).toContain("--repo <owner>/<repo>");
+  });
+});
+
+describe("pypiReleaseWorkflow", () => {
+  const yaml = pypiReleaseWorkflow();
+
+  it("is a plain tag-triggered publish with no workflow_dispatch target picker", () => {
+    expect(yaml).toContain('tags: ["v*"]');
+    expect(yaml).not.toContain("workflow_dispatch");
+    expect(yaml).not.toContain("Where to publish");
+    expect(yaml).not.toContain("testpypi");
+    expect(yaml).not.toContain("dry-run");
+  });
+
+  it("uploads the artifact Drydock reviews by its expected name", () => {
+    expect(yaml).toContain("pypi-release-candidate");
+  });
+
+  it("gates the publish job on the environment and exchanges OIDC there", () => {
+    expect(yaml).toContain(`environment: ${setupDefaults.pypiEnvironment}`);
+    expect(count(yaml, "id-token: write")).toBe(1);
+  });
+
+  it("builds once and never rebuilds in the publish job", () => {
+    expect(count(yaml, "actions/checkout@")).toBe(1);
+    expect(count(yaml, "python -m build")).toBe(1);
+  });
+
+  it("publishes through the PyPI trusted-publishing action", () => {
+    expect(yaml).toContain("pypa/gh-action-pypi-publish@release/v1");
+  });
+
+  it("honors custom environment and python version", () => {
+    const custom = pypiReleaseWorkflow({ environment: "release", pythonVersion: "3.11" });
+    expect(custom).toContain("environment: release");
+    expect(custom).toContain('python-version: "3.11"');
+  });
+});

--- a/test/setup-workflow-templates.test.ts
+++ b/test/setup-workflow-templates.test.ts
@@ -41,7 +41,28 @@ describe("npmStagedPublishWorkflow", () => {
 
   it("requires a staged-publishing-capable npm and verifies the tarball identity", () => {
     expect(yaml).toContain("npm@^11.15.0");
-    expect(yaml).toContain('p.name !== "@scope/pkg"');
+    expect(yaml).toContain(`EXPECTED_PACKAGES_JSON: '["@scope/pkg"]'`);
+    expect(yaml).toContain("!expected.has(p.name)");
+  });
+
+  it("isolates pack output and selects tarballs by package identity", () => {
+    expect(yaml).toContain("npm pack --json --pack-destination .drydock-npm-pack");
+    expect(yaml).toContain('PACK_ARGS+=(--workspace "$package")');
+    expect(yaml).toContain('npm pack "${PACK_ARGS[@]}" --json');
+    expect(yaml).toContain("selected-tarballs.txt");
+    expect(yaml).toContain("missing packed tarball(s)");
+    expect(yaml).toContain("found more than one packed tarball");
+    expect(yaml).toContain("path: .drydock-npm-pack");
+    expect(yaml).not.toContain('path: "*.tgz"');
+    expect(yaml).not.toContain('TARBALL="$(ls *.tgz)"');
+  });
+
+  it("supports monorepo release flows that stage more than one selected package", () => {
+    const monorepo = npmStagedPublishWorkflow({ packageName: "@scope/a\n@scope/b" });
+    expect(monorepo).toContain(`EXPECTED_PACKAGES_JSON: '["@scope/a","@scope/b"]'`);
+    expect(monorepo).toContain("expected.join");
+    expect(monorepo).toContain("selected.join");
+    expect(monorepo).toContain("done < .drydock-npm-pack/selected-tarballs.txt");
   });
 
   it("honors a custom environment", () => {
@@ -85,6 +106,15 @@ describe("npmTrustCommand", () => {
   it("falls back to placeholders for empty owner/repo", () => {
     const command = npmTrustCommand({ owner: "", repo: "", packageName: "pkg" });
     expect(command).toContain("--repo <owner>/<repo>");
+  });
+
+  it("emits stage-only trust commands for each selected package", () => {
+    const command = npmTrustCommand({ owner: "acme", repo: "widgets", packageName: "a\nb" });
+    expect(count(command, "--allow-stage-publish")).toBe(2);
+    expect(command).toContain("--no-allow-publish a");
+    expect(command).toContain("--no-allow-publish b");
+    expect(command).toContain("npm trust list a");
+    expect(command).toContain("npm trust list b");
   });
 });
 


### PR DESCRIPTION
## Summary
Adds a `/dashboard/setup` guided wizard that generates best-practice publishing config and walks maintainers through the manual steps Drydock can't perform itself. The npm flow covers staged publishing via trusted publishing (OIDC, stage-only `npm trust`, cache disabled on the whole publish path, no `NPM_TOKEN`); the PyPI flow covers the GitHub Actions release gate (tag-triggered build/upload of `pypi-release-candidate`, an environment-gated publish via Trusted Publishing that never rebuilds). It reuses the existing npm-connection, GitHub App, release-target, and staged-publish-discovery models with no new backend endpoints, surfacing generated YAML/CLI via a new copy-to-clipboard `CodeBlock` and a vertical stack of status-aware `StepCard`s. Entry points are wired from the dashboard header and the npm-not-connected callout, plus the lazy-loaded route and a guided-setup doc. Pure config generators live in `workflow-templates.ts` and are pinned by invariant tests in `test/setup-workflow-templates.test.ts`.

## Test plan
- [ ] `pnpm run verify` (lint + format + typecheck + logic & worker tests) — green locally
- [ ] Manual: open `/dashboard/setup`, run both flows, confirm generated config copies and steps light up from model state