### PR TITLE
Add per-organization notification recipients

### DIFF
--- a/docs/organization-members.md
+++ b/docs/organization-members.md
@@ -44,7 +44,7 @@ and return `403 { error: "forbidden" }` when the guard fails:
 - GitHub App install + release targets — `server/routes/github-app.ts`
 - notification recipients — `server/routes/organizations.ts` lets any member
   list recipients for an org path they belong to, while owner/admin are required
-  for add/remove.
+  for add/remove. Each organization can configure up to five recipient emails.
 
 Org rename stays owner-only (`isOrganizationOwner`). Gate approvals and scan
 decisions stay open to any member by design.

--- a/docs/organization-members.md
+++ b/docs/organization-members.md
@@ -42,6 +42,9 @@ and return `403 { error: "forbidden" }` when the guard fails:
 - npm connections — `server/routes/npm-connection.ts` (POST, POST `/validate`,
   DELETE)
 - GitHub App install + release targets — `server/routes/github-app.ts`
+- notification recipients — `server/routes/organizations.ts` lets any member
+  list recipients for an org path they belong to, while owner/admin are required
+  for add/remove.
 
 Org rename stays owner-only (`isOrganizationOwner`). Gate approvals and scan
 decisions stay open to any member by design.

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -25,6 +25,7 @@ The prototype-to-product foundation is in place:
 - Dynamic Worker sandbox for archive parsing, with `NpmStageGateway` as the credentialed egress boundary.
 - Async-capable scan jobs with Queue support, retry classification, and scan lifecycle persistence.
 - Scheduled npm staged-publish discovery plus manual “Check npm” discovery.
+- Per-organization notification recipients for scan-completion and workflow-gate emails, falling back to the organization owner when unset.
 - Persisted scan reports with redacted file summaries, deterministic findings, risk summary, report digest metadata, and decision records.
 - Tag-aware npm baseline selection and alternate-version compare cache.
 - Security corpus and eval harness for deterministic detection.

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -595,19 +595,26 @@ and the consumer re-checks gate status, so a re-enqueue is safe.
 ### Notifying the maintainer
 
 Step 8 is the gate equivalent of the npm scan-completion email. It reuses the
-`sendNotificationEmail` primitive and goes to the organization owner
-(`getOrganizationOwnerUserId` → `getUserContact`; recipient/role resolution will
-follow the org membership model as that lands). The body carries only the
-release identity (`package@version`), the computed release risk, the repository,
-the environment, and a deep link to the review at
+`sendNotificationEmail` primitive and fans out to the organization's resolved
+recipient set (`resolveNotificationEmails`): the org's configured
+`organization_notification_recipients` when present, otherwise the owner's email
+(`getOrganizationOwnerUserId` → `getUserContact`) so an org that never touched
+the setting keeps today's behavior. Each address gets its own send — no shared
+`To`/`Cc` — so recipients are never disclosed to one another. The body carries
+only the release identity (`package@version`), the computed release risk, the
+repository, the environment, and a deep link to the review at
 `/dashboard/scans/<scanId>` — never a token, header, callback URL, or artifact
 bytes, per the observability rules in `AGENTS.md`.
 
-Delivery is best-effort and **never blocks or fails the gate**: the outcome is
-recorded as a `github_workflow_gate.notification_sent` or
-`github_workflow_gate.notification_failed` `scan_events` row (mirroring the
-`scan.notification_*` pattern), and a thrown send error is swallowed into a
-`github_workflow_gate.notification_error` operational event.
+Delivery is best-effort and **never blocks or fails the gate**: each send's
+outcome is recorded as a `github_workflow_gate.notification_sent` or
+`github_workflow_gate.notification_failed` `scan_events` row (one per recipient,
+with the destination in `metadata.recipient`, mirroring the `scan.notification_*`
+pattern), and a thrown send error is swallowed into a
+`github_workflow_gate.notification_error` operational event. When the recipient
+set is empty (no configured recipients and the owner has no email), a single
+`notification_failed` row with `reason: "no_recipients"` is recorded and no email
+is sent.
 
 The email is **send-once per gate**. Step 8 sits on the single review-ready
 transition, after the job re-confirms that the gate is still `pending` while

--- a/drizzle/0015_slippery_xavin.sql
+++ b/drizzle/0015_slippery_xavin.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `organization_notification_recipients` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`email` text NOT NULL,
+	`created_by_user_id` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`created_by_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `organization_notification_recipients_org_email_unique_idx` ON `organization_notification_recipients` (`organization_id`,`email`);

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,2061 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d36879bb-8265-463b-a818-3461538d2098",
+  "prevId": "1a9c6db1-85c1-4a99-bad7-28d19ce03bec",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_app_installations": {
+      "name": "github_app_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Organization'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uninstalled_at": {
+          "name": "uninstalled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_app_installations_installation_unique_idx": {
+          "name": "github_app_installations_installation_unique_idx",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        },
+        "github_app_installations_org_idx": {
+          "name": "github_app_installations_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installations_created_by_user_id_user_id_fk": {
+          "name": "github_app_installations_created_by_user_id_user_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_release_targets": {
+      "name": "github_release_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ecosystem": {
+          "name": "ecosystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_release_targets_org_repo_env_unique_idx": {
+          "name": "github_release_targets_org_repo_env_unique_idx",
+          "columns": [
+            "organization_id",
+            "repository_id",
+            "environment"
+          ],
+          "isUnique": true
+        },
+        "github_release_targets_installation_idx": {
+          "name": "github_release_targets_installation_idx",
+          "columns": [
+            "installation_row_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_release_targets_organization_id_organizations_id_fk": {
+          "name": "github_release_targets_organization_id_organizations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_release_targets_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_created_by_user_id_user_id_fk": {
+          "name": "github_release_targets_created_by_user_id_user_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_workflow_gates": {
+      "name": "github_workflow_gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_target_id": {
+          "name": "release_target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deployment_callback_url": {
+          "name": "deployment_callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_comment": {
+          "name": "decision_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_url": {
+          "name": "report_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_workflow_gates_delivery_unique_idx": {
+          "name": "github_workflow_gates_delivery_unique_idx",
+          "columns": [
+            "delivery_id"
+          ],
+          "isUnique": true
+        },
+        "github_workflow_gates_org_status_idx": {
+          "name": "github_workflow_gates_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_release_target_idx": {
+          "name": "github_workflow_gates_release_target_idx",
+          "columns": [
+            "release_target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_workflow_gates_organization_id_organizations_id_fk": {
+          "name": "github_workflow_gates_organization_id_organizations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_workflow_gates_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_release_target_id_github_release_targets_id_fk": {
+          "name": "github_workflow_gates_release_target_id_github_release_targets_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_release_targets",
+          "columnsFrom": [
+            "release_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_scan_id_scans_id_fk": {
+          "name": "github_workflow_gates_scan_id_scans_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_unique_idx": {
+          "name": "npm_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_invitations": {
+      "name": "organization_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_invitations_token_hash_unique_idx": {
+          "name": "organization_invitations_token_hash_unique_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "organization_invitations_org_status_idx": {
+          "name": "organization_invitations_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "organization_invitations_org_email_idx": {
+          "name": "organization_invitations_org_email_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_invitations_organization_id_organizations_id_fk": {
+          "name": "organization_invitations_organization_id_organizations_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_invited_by_user_id_user_id_fk": {
+          "name": "organization_invitations_invited_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_accepted_by_user_id_user_id_fk": {
+          "name": "organization_invitations_accepted_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_notification_recipients": {
+      "name": "organization_notification_recipients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_notification_recipients_org_email_unique_idx": {
+          "name": "organization_notification_recipients_org_email_unique_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_notification_recipients_organization_id_organizations_id_fk": {
+          "name": "organization_notification_recipients_organization_id_organizations_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_notification_recipients_created_by_user_id_user_id_fk": {
+          "name": "organization_notification_recipients_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_findings_scan_severity_idx": {
+          "name": "scan_findings_scan_severity_idx",
+          "columns": [
+            "scan_id",
+            "severity"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changed_file_count": {
+          "name": "changed_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_summary_json": {
+          "name": "risk_summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        },
+        "scans_org_decision_created_idx": {
+          "name": "scans_org_decision_created_idx",
+          "columns": [
+            "organization_id",
+            "decision",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_decided_by_user_id_user_id_fk": {
+          "name": "scans_decided_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1780331741530,
       "tag": "0014_tan_wrecking_crew",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1780333664282,
+      "tag": "0015_slippery_xavin",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/organizations.ts
+++ b/server/db/organizations.ts
@@ -1,7 +1,13 @@
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { personalOrganizationId } from "../lib/ownership";
 import type { AppDb, WorkspaceSession } from "./client";
-import { npmConnections, organizationMembers, organizations, user } from "./schema";
+import {
+  npmConnections,
+  organizationMembers,
+  organizationNotificationRecipients,
+  organizations,
+  user,
+} from "./schema";
 
 export async function ensurePersonalOrganization(db: AppDb, session: WorkspaceSession) {
   const organizationId = personalOrganizationId(session.userId);
@@ -155,4 +161,144 @@ export async function renameOrganization(db: AppDb, organizationId: string, name
     .update(organizations)
     .set({ name, updatedAt: new Date() })
     .where(eq(organizations.id, organizationId));
+}
+
+export interface NotificationRecipient {
+  id: string;
+  organizationId: string;
+  email: string;
+  createdByUserId: string | null;
+  createdAt: Date | string | number;
+  updatedAt: Date | string | number;
+}
+
+export async function listNotificationRecipients(
+  db: AppDb,
+  organizationId: string,
+): Promise<NotificationRecipient[]> {
+  return db
+    .select({
+      id: organizationNotificationRecipients.id,
+      organizationId: organizationNotificationRecipients.organizationId,
+      email: organizationNotificationRecipients.email,
+      createdByUserId: organizationNotificationRecipients.createdByUserId,
+      createdAt: organizationNotificationRecipients.createdAt,
+      updatedAt: organizationNotificationRecipients.updatedAt,
+    })
+    .from(organizationNotificationRecipients)
+    .where(eq(organizationNotificationRecipients.organizationId, organizationId))
+    .orderBy(asc(organizationNotificationRecipients.createdAt));
+}
+
+export interface AddNotificationRecipientInput {
+  organizationId: string;
+  email: string;
+  createdByUserId: string | null;
+}
+
+export async function addNotificationRecipient(
+  db: AppDb,
+  input: AddNotificationRecipientInput,
+): Promise<{ created: boolean; recipient: NotificationRecipient }> {
+  const email = input.email.trim().toLowerCase();
+  const now = new Date();
+  await db
+    .insert(organizationNotificationRecipients)
+    .values({
+      id: crypto.randomUUID(),
+      organizationId: input.organizationId,
+      email,
+      createdByUserId: input.createdByUserId,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing();
+
+  const [recipient] = await db
+    .select({
+      id: organizationNotificationRecipients.id,
+      organizationId: organizationNotificationRecipients.organizationId,
+      email: organizationNotificationRecipients.email,
+      createdByUserId: organizationNotificationRecipients.createdByUserId,
+      createdAt: organizationNotificationRecipients.createdAt,
+      updatedAt: organizationNotificationRecipients.updatedAt,
+    })
+    .from(organizationNotificationRecipients)
+    .where(
+      and(
+        eq(organizationNotificationRecipients.organizationId, input.organizationId),
+        eq(organizationNotificationRecipients.email, email),
+      ),
+    )
+    .limit(1);
+
+  const created = new Date(recipient.createdAt).getTime() === now.getTime();
+  return { created, recipient };
+}
+
+export async function deleteNotificationRecipient(
+  db: AppDb,
+  organizationId: string,
+  recipientId: string,
+): Promise<NotificationRecipient | null> {
+  const [removed] = await db
+    .delete(organizationNotificationRecipients)
+    .where(
+      and(
+        eq(organizationNotificationRecipients.id, recipientId),
+        eq(organizationNotificationRecipients.organizationId, organizationId),
+      ),
+    )
+    .returning({
+      id: organizationNotificationRecipients.id,
+      organizationId: organizationNotificationRecipients.organizationId,
+      email: organizationNotificationRecipients.email,
+      createdByUserId: organizationNotificationRecipients.createdByUserId,
+      createdAt: organizationNotificationRecipients.createdAt,
+      updatedAt: organizationNotificationRecipients.updatedAt,
+    });
+  return removed ?? null;
+}
+
+export async function countNotificationRecipients(
+  db: AppDb,
+  organizationId: string,
+): Promise<number> {
+  const rows = await db
+    .select({ id: organizationNotificationRecipients.id })
+    .from(organizationNotificationRecipients)
+    .where(eq(organizationNotificationRecipients.organizationId, organizationId));
+  return rows.length;
+}
+
+/**
+ * Resolve who receives a notification for an organization. When the org has
+ * configured recipients they fully define the set; otherwise we fall back to the
+ * owner's email so an org that never touched the setting keeps today's behavior
+ * (and a misconfiguration never silently drops a security alert). Addresses are
+ * lowercased and de-duplicated.
+ */
+export async function resolveNotificationEmails(
+  db: AppDb,
+  organizationId: string,
+  ownerUserId: string,
+): Promise<string[]> {
+  const configured = await listNotificationRecipients(db, organizationId);
+  if (configured.length > 0) {
+    return dedupeEmails(configured.map((row) => row.email));
+  }
+  const owner = await getUserContact(db, ownerUserId);
+  return owner?.email ? dedupeEmails([owner.email]) : [];
+}
+
+function dedupeEmails(emails: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const email of emails) {
+    const normalized = email.trim().toLowerCase();
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    out.push(normalized);
+  }
+  return out;
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -84,6 +84,26 @@ export const organizationInvitations = sqliteTable(
   }),
 );
 
+export const organizationNotificationRecipients = sqliteTable(
+  "organization_notification_recipients",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    email: text("email").notNull(),
+    createdByUserId: text("created_by_user_id").references(() => user.id, { onDelete: "set null" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+  },
+  (table) => ({
+    orgEmailUniqueIdx: uniqueIndex("organization_notification_recipients_org_email_unique_idx").on(
+      table.organizationId,
+      table.email,
+    ),
+  }),
+);
+
 export const scans = sqliteTable(
   "scans",
   {

--- a/server/lib/notify.ts
+++ b/server/lib/notify.ts
@@ -1,4 +1,10 @@
-import { getScan, recordScanEvent, resolveNotificationEmails, type AppDb } from "../db";
+import {
+  getOrganizationOwnerUserId,
+  getScan,
+  recordScanEvent,
+  resolveNotificationEmails,
+  type AppDb,
+} from "../db";
 import { sendNotificationEmail } from "./email";
 import type { RiskLevel } from "./review";
 import type { OrganizationRole } from "./roles";
@@ -15,14 +21,16 @@ export interface NotifyScanCompletionInput {
 
 export async function notifyScanCompletion(input: NotifyScanCompletionInput): Promise<void> {
   const { env, db, scanId, organizationId, ownerUserId, outcome, error } = input;
+  const notificationOwnerUserId =
+    (await getOrganizationOwnerUserId(db, organizationId)) ?? ownerUserId;
   const [recipients, detail] = await Promise.all([
-    resolveNotificationEmails(db, organizationId, ownerUserId),
+    resolveNotificationEmails(db, organizationId, notificationOwnerUserId),
     getScan(db, scanId, organizationId),
   ]);
   if (recipients.length === 0) {
     await recordScanEvent(db, {
       organizationId,
-      actorUserId: ownerUserId,
+      actorUserId: notificationOwnerUserId,
       scanId,
       type: "scan.notification_failed",
       metadata: { outcome, channel: "email", reason: "no_recipients" },
@@ -62,7 +70,7 @@ export async function notifyScanCompletion(input: NotifyScanCompletionInput): Pr
 
   await deliverToRecipients(env, db, recipients, { subject, text }, (recipient, result) => ({
     organizationId,
-    actorUserId: ownerUserId,
+    actorUserId: notificationOwnerUserId,
     scanId,
     type: result.ok ? "scan.notification_sent" : "scan.notification_failed",
     metadata: {

--- a/server/lib/notify.ts
+++ b/server/lib/notify.ts
@@ -1,4 +1,4 @@
-import { getScan, getUserContact, recordScanEvent, type AppDb } from "../db";
+import { getScan, recordScanEvent, resolveNotificationEmails, type AppDb } from "../db";
 import { sendNotificationEmail } from "./email";
 import type { RiskLevel } from "./review";
 import type { OrganizationRole } from "./roles";
@@ -15,14 +15,21 @@ export interface NotifyScanCompletionInput {
 
 export async function notifyScanCompletion(input: NotifyScanCompletionInput): Promise<void> {
   const { env, db, scanId, organizationId, ownerUserId, outcome, error } = input;
-  const [contact, detail] = await Promise.all([
-    getUserContact(db, ownerUserId),
+  const [recipients, detail] = await Promise.all([
+    resolveNotificationEmails(db, organizationId, ownerUserId),
     getScan(db, scanId, organizationId),
   ]);
-  if (!contact?.email) {
-    console.warn("scan notification skipped: no email on record", { scanId, ownerUserId });
+  if (recipients.length === 0) {
+    await recordScanEvent(db, {
+      organizationId,
+      actorUserId: ownerUserId,
+      scanId,
+      type: "scan.notification_failed",
+      metadata: { outcome, channel: "email", reason: "no_recipients" },
+    });
     return;
   }
+
   const scan = detail?.scan;
   const packageLabel = formatPackageLabel(scan?.packageName, scan?.stagedVersion);
   const dashboardUrl = scanUrl(env, scanId);
@@ -34,7 +41,7 @@ export async function notifyScanCompletion(input: NotifyScanCompletionInput): Pr
   const lines =
     outcome === "complete"
       ? [
-          `Hi ${contact.name ?? "there"},`,
+          "Hi there,",
           "",
           `We finished scanning the staged release ${packageLabel}.`,
           scan?.risk ? `Overall risk: ${scan.risk}.` : null,
@@ -43,7 +50,7 @@ export async function notifyScanCompletion(input: NotifyScanCompletionInput): Pr
           "— Drydock",
         ]
       : [
-          `Hi ${contact.name ?? "there"},`,
+          "Hi there,",
           "",
           `We could not complete the auto-discovered scan for ${packageLabel}.`,
           error?.message ? `Reason: ${error.message}` : null,
@@ -53,13 +60,7 @@ export async function notifyScanCompletion(input: NotifyScanCompletionInput): Pr
         ];
   const text = lines.filter((line): line is string => line !== null).join("\n");
 
-  const result = await sendNotificationEmail(env, {
-    to: contact.email,
-    subject,
-    text,
-  });
-
-  await recordScanEvent(db, {
+  await deliverToRecipients(env, db, recipients, { subject, text }, (recipient, result) => ({
     organizationId,
     actorUserId: ownerUserId,
     scanId,
@@ -67,9 +68,10 @@ export async function notifyScanCompletion(input: NotifyScanCompletionInput): Pr
     metadata: {
       outcome,
       channel: "email",
+      recipient,
       ...(result.ok ? {} : { reason: result.reason }),
     },
-  });
+  }));
 }
 
 export interface NotifyWorkflowGateReviewInput {
@@ -87,18 +89,21 @@ export interface NotifyWorkflowGateReviewInput {
 }
 
 /**
- * Email the maintainer that a workflow gate has a completed review parked
- * pending their decision. Drydock never auto-decides a gate, so this is the only
- * proactive signal that a held GitHub deployment is waiting on a human.
+ * Email the organization's notification recipients that a workflow gate has a
+ * completed review parked pending a decision. Drydock never auto-decides a gate,
+ * so this is the only proactive signal that a held GitHub deployment is waiting
+ * on a human.
  *
- * Send-once is owned by the caller: `executeWorkflowGateJob` only reaches the
- * review-ready path once per gate (a re-delivered gate with a completed scan
- * short-circuits at its `already_reviewed` guard), so a single review-ready
- * transition produces a single email. Delivery is best-effort — the outcome is
- * recorded as a `github_workflow_gate.notification_sent` /
- * `notification_failed` event and never blocks or fails the gate. The body
- * carries only release identity, risk, repo/environment, and a dashboard link;
- * no token, header, or artifact bytes ever reach the email.
+ * Recipients resolve via `resolveNotificationEmails`: the org's configured set
+ * when present, otherwise the owner's email. Send-once is owned by the caller:
+ * `executeWorkflowGateJob` only reaches the review-ready path once per gate (a
+ * re-delivered gate with a completed scan short-circuits at its
+ * `already_reviewed` guard), so a single review-ready transition produces a
+ * single email per recipient. Delivery is best-effort — each send is recorded as
+ * a `github_workflow_gate.notification_sent` / `notification_failed` event and
+ * never blocks or fails the gate. The body carries only release identity, risk,
+ * repo/environment, and a dashboard link; no token, header, or artifact bytes
+ * ever reach the email.
  */
 export async function notifyWorkflowGateReview(
   input: NotifyWorkflowGateReviewInput,
@@ -117,14 +122,14 @@ export async function notifyWorkflowGateReview(
     releaseRisk,
   } = input;
 
-  const contact = await getUserContact(db, ownerUserId);
-  if (!contact?.email) {
+  const recipients = await resolveNotificationEmails(db, organizationId, ownerUserId);
+  if (recipients.length === 0) {
     await recordScanEvent(db, {
       organizationId,
       actorUserId: ownerUserId,
       scanId,
       type: "github_workflow_gate.notification_failed",
-      metadata: { gateId, channel: "email", reason: "no_contact_email" },
+      metadata: { gateId, channel: "email", reason: "no_recipients" },
     });
     return;
   }
@@ -133,9 +138,9 @@ export async function notifyWorkflowGateReview(
   const dashboardUrl = scanUrl(env, scanId);
   const subject = `Release gate needs your review — ${packageLabel}`;
   const lines = [
-    `Hi ${contact.name ?? "there"},`,
+    "Hi there,",
     "",
-    `A staged release is held in ${repositoryFullName} and is waiting for your decision before it can publish.`,
+    `A staged release is held in ${repositoryFullName} and is waiting for a decision before it can publish.`,
     "",
     `Package: ${packageLabel}`,
     `Release risk: ${releaseRisk}`,
@@ -144,19 +149,13 @@ export async function notifyWorkflowGateReview(
     "",
     dashboardUrl ? `Approve or block the release: ${dashboardUrl}` : null,
     "",
-    "The held GitHub deployment stays blocked until you approve or reject it.",
+    "The held GitHub deployment stays blocked until someone approves or rejects it.",
     "",
     "— Drydock",
   ];
   const text = lines.filter((line): line is string => line !== null).join("\n");
 
-  const result = await sendNotificationEmail(env, {
-    to: contact.email,
-    subject,
-    text,
-  });
-
-  await recordScanEvent(db, {
+  await deliverToRecipients(env, db, recipients, { subject, text }, (recipient, result) => ({
     organizationId,
     actorUserId: ownerUserId,
     scanId,
@@ -167,9 +166,32 @@ export async function notifyWorkflowGateReview(
       gateId,
       channel: "email",
       releaseRisk,
+      recipient,
       ...(result.ok ? {} : { reason: result.reason }),
     },
-  });
+  }));
+}
+
+async function deliverToRecipients(
+  env: Cloudflare.Env,
+  db: AppDb,
+  recipients: string[],
+  message: { subject: string; text: string },
+  event: (
+    recipient: string,
+    result: { ok: boolean; reason?: string },
+  ) => Parameters<typeof recordScanEvent>[1],
+): Promise<void> {
+  await Promise.all(
+    recipients.map(async (recipient) => {
+      const result = await sendNotificationEmail(env, {
+        to: recipient,
+        subject: message.subject,
+        text: message.text,
+      });
+      await recordScanEvent(db, event(recipient, result));
+    }),
+  );
 }
 
 export interface NotifyOrganizationInviteInput {

--- a/server/routes/organizations.ts
+++ b/server/routes/organizations.ts
@@ -2,7 +2,6 @@ import { Hono } from "hono";
 import {
   RateLimitError,
   addNotificationRecipient,
-  countNotificationRecipients,
   createDb,
   createOrganization,
   deleteNotificationRecipient,
@@ -123,8 +122,15 @@ organizationsRoutes.post("/:id/notification-recipients", async (c) => {
     throw err;
   }
 
-  const existing = await countNotificationRecipients(db, organizationId);
-  if (existing >= MAX_NOTIFICATION_RECIPIENTS) {
+  const existingRecipients = await listNotificationRecipients(db, organizationId);
+  const existingRecipient = existingRecipients.find(
+    (recipient) => recipient.email === email.trim().toLowerCase(),
+  );
+  if (existingRecipient) {
+    return c.json({ recipient: publicRecipient(existingRecipient) }, 200);
+  }
+
+  if (existingRecipients.length >= MAX_NOTIFICATION_RECIPIENTS) {
     return c.json(
       { error: `at most ${MAX_NOTIFICATION_RECIPIENTS} notification recipients are allowed` },
       400,

--- a/server/routes/organizations.ts
+++ b/server/routes/organizations.ts
@@ -1,21 +1,28 @@
 import { Hono } from "hono";
 import {
   RateLimitError,
+  addNotificationRecipient,
+  countNotificationRecipients,
   createDb,
   createOrganization,
+  deleteNotificationRecipient,
   enforceRateLimit,
   ensurePersonalOrganization,
   isOrganizationOwner,
+  listNotificationRecipients,
   listUserOrganizations,
   recordScanEvent,
   renameOrganization,
+  type NotificationRecipient,
 } from "../db";
+import { sanitizeAddress } from "../lib/email";
 import { rateLimitResponse } from "../lib/http";
 import type { Bindings, Variables } from "../types";
 
 const NAME_RE = /^[\p{L}\p{N}][\p{L}\p{N} _\-./]{0,79}$/u;
 const ORGANIZATION_NAME_ERROR =
   "organization name must be 1-80 characters of letters, digits, or _-./";
+const MAX_NOTIFICATION_RECIPIENTS = 25;
 
 export const organizationsRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
@@ -78,6 +85,91 @@ organizationsRoutes.patch("/:id", async (c) => {
   });
   return c.json({ organization: { id: organizationId, name } });
 });
+
+organizationsRoutes.get("/:id/notification-recipients", async (c) => {
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const organizationId = c.req.param("id");
+  const owner = await isOrganizationOwner(db, organizationId, session.userId);
+  if (!owner) return c.json({ error: "not found" }, 404);
+  const recipients = await listNotificationRecipients(db, organizationId);
+  return c.json({ recipients: recipients.map(publicRecipient) });
+});
+
+organizationsRoutes.post("/:id/notification-recipients", async (c) => {
+  const body = (await c.req.json().catch(() => ({}))) as { email?: unknown };
+  const email = sanitizeAddress(body.email);
+  if (!email) return c.json({ error: "a valid email address is required" }, 400);
+
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const organizationId = c.req.param("id");
+  const owner = await isOrganizationOwner(db, organizationId, session.userId);
+  if (!owner) return c.json({ error: "not found" }, 404);
+
+  try {
+    await enforceRateLimit(db, {
+      key: `organizations:recipients:add:${session.userId}`,
+      limit: 30,
+      windowMs: 60 * 60 * 1000,
+    });
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      return rateLimitResponse(c, "notification recipient rate limit exceeded", err);
+    }
+    throw err;
+  }
+
+  const existing = await countNotificationRecipients(db, organizationId);
+  if (existing >= MAX_NOTIFICATION_RECIPIENTS) {
+    return c.json(
+      { error: `at most ${MAX_NOTIFICATION_RECIPIENTS} notification recipients are allowed` },
+      400,
+    );
+  }
+
+  const { created, recipient } = await addNotificationRecipient(db, {
+    organizationId,
+    email,
+    createdByUserId: session.userId,
+  });
+  if (created) {
+    await recordScanEvent(db, {
+      organizationId,
+      actorUserId: session.userId,
+      type: "organization.notification_recipient_added",
+      metadata: { recipient: recipient.email },
+    });
+  }
+  return c.json({ recipient: publicRecipient(recipient) }, created ? 201 : 200);
+});
+
+organizationsRoutes.delete("/:id/notification-recipients/:recipientId", async (c) => {
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const organizationId = c.req.param("id");
+  const recipientId = c.req.param("recipientId");
+  const owner = await isOrganizationOwner(db, organizationId, session.userId);
+  if (!owner) return c.json({ error: "not found" }, 404);
+
+  const removed = await deleteNotificationRecipient(db, organizationId, recipientId);
+  if (!removed) return c.json({ error: "not found" }, 404);
+  await recordScanEvent(db, {
+    organizationId,
+    actorUserId: session.userId,
+    type: "organization.notification_recipient_removed",
+    metadata: { recipient: removed.email },
+  });
+  return c.json({ ok: true });
+});
+
+function publicRecipient(recipient: NotificationRecipient) {
+  return {
+    id: recipient.id,
+    email: recipient.email,
+    createdAt: recipient.createdAt,
+  };
+}
 
 function parseOrganizationName(
   value: unknown,

--- a/server/routes/organizations.ts
+++ b/server/routes/organizations.ts
@@ -24,7 +24,7 @@ import type { Bindings, Variables } from "../types";
 const NAME_RE = /^[\p{L}\p{N}][\p{L}\p{N} _\-./]{0,79}$/u;
 const ORGANIZATION_NAME_ERROR =
   "organization name must be 1-80 characters of letters, digits, or _-./";
-const MAX_NOTIFICATION_RECIPIENTS = 25;
+const MAX_NOTIFICATION_RECIPIENTS = 5;
 
 export const organizationsRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 

--- a/server/routes/organizations.ts
+++ b/server/routes/organizations.ts
@@ -8,6 +8,7 @@ import {
   deleteNotificationRecipient,
   enforceRateLimit,
   ensurePersonalOrganization,
+  getOrganizationRole,
   isOrganizationOwner,
   listNotificationRecipients,
   listUserOrganizations,
@@ -17,6 +18,7 @@ import {
 } from "../db";
 import { sanitizeAddress } from "../lib/email";
 import { rateLimitResponse } from "../lib/http";
+import { roleCanManageIntegrations, type OrganizationRole } from "../lib/roles";
 import type { Bindings, Variables } from "../types";
 
 const NAME_RE = /^[\p{L}\p{N}][\p{L}\p{N} _\-./]{0,79}$/u;
@@ -90,8 +92,8 @@ organizationsRoutes.get("/:id/notification-recipients", async (c) => {
   const db = createDb(c.env.DB);
   const session = c.get("authSession");
   const organizationId = c.req.param("id");
-  const owner = await isOrganizationOwner(db, organizationId, session.userId);
-  if (!owner) return c.json({ error: "not found" }, 404);
+  const role = await requireOrganizationMember(db, organizationId, session.userId);
+  if (!role) return c.json({ error: "not found" }, 404);
   const recipients = await listNotificationRecipients(db, organizationId);
   return c.json({ recipients: recipients.map(publicRecipient) });
 });
@@ -104,8 +106,9 @@ organizationsRoutes.post("/:id/notification-recipients", async (c) => {
   const db = createDb(c.env.DB);
   const session = c.get("authSession");
   const organizationId = c.req.param("id");
-  const owner = await isOrganizationOwner(db, organizationId, session.userId);
-  if (!owner) return c.json({ error: "not found" }, 404);
+  const role = await requireOrganizationMember(db, organizationId, session.userId);
+  if (!role) return c.json({ error: "not found" }, 404);
+  if (!roleCanManageIntegrations(role)) return c.json({ error: "forbidden" }, 403);
 
   try {
     await enforceRateLimit(db, {
@@ -149,8 +152,9 @@ organizationsRoutes.delete("/:id/notification-recipients/:recipientId", async (c
   const session = c.get("authSession");
   const organizationId = c.req.param("id");
   const recipientId = c.req.param("recipientId");
-  const owner = await isOrganizationOwner(db, organizationId, session.userId);
-  if (!owner) return c.json({ error: "not found" }, 404);
+  const role = await requireOrganizationMember(db, organizationId, session.userId);
+  if (!role) return c.json({ error: "not found" }, 404);
+  if (!roleCanManageIntegrations(role)) return c.json({ error: "forbidden" }, 403);
 
   const removed = await deleteNotificationRecipient(db, organizationId, recipientId);
   if (!removed) return c.json({ error: "not found" }, 404);
@@ -169,6 +173,14 @@ function publicRecipient(recipient: NotificationRecipient) {
     email: recipient.email,
     createdAt: recipient.createdAt,
   };
+}
+
+function requireOrganizationMember(
+  db: ReturnType<typeof createDb>,
+  organizationId: string,
+  userId: string,
+): Promise<OrganizationRole | null> {
+  return getOrganizationRole(db, organizationId, userId);
 }
 
 function parseOrganizationName(

--- a/src/models/notification-recipients.ts
+++ b/src/models/notification-recipients.ts
@@ -24,6 +24,7 @@ export const NotificationRecipientsModel = createModel(() => {
   const error = signal<string | null>(null);
   const draftEmail = signal("");
   let loadRequestId = 0;
+  let currentOrganizationId: string | null = null;
 
   const busy = computed(() => status.value !== "idle");
 
@@ -37,6 +38,7 @@ export const NotificationRecipientsModel = createModel(() => {
 
     async load(organizationId: string | null): Promise<void> {
       const requestId = ++loadRequestId;
+      currentOrganizationId = organizationId;
       this.recipients.value = [];
       this.loaded.value = false;
       this.error.value = null;
@@ -65,6 +67,7 @@ export const NotificationRecipientsModel = createModel(() => {
     },
 
     async add(organizationId: string): Promise<boolean> {
+      if (currentOrganizationId === null) currentOrganizationId = organizationId;
       const email = this.draftEmail.value.trim();
       if (!email) {
         this.error.value = "Email is required.";
@@ -76,18 +79,24 @@ export const NotificationRecipientsModel = createModel(() => {
         await apiJson<{ recipient: NotificationRecipient }>(recipientsPath(organizationId), {
           email,
         });
+        if (currentOrganizationId !== organizationId) return true;
         this.draftEmail.value = "";
         await this.load(organizationId);
         return true;
       } catch (err) {
-        this.error.value = errorMessage(err);
+        if (currentOrganizationId === organizationId) {
+          this.error.value = errorMessage(err);
+        }
         return false;
       } finally {
-        this.status.value = "idle";
+        if (currentOrganizationId === organizationId) {
+          this.status.value = "idle";
+        }
       }
     },
 
     async remove(organizationId: string, recipientId: string): Promise<void> {
+      if (currentOrganizationId === null) currentOrganizationId = organizationId;
       this.status.value = "removing";
       this.error.value = null;
       try {
@@ -95,11 +104,16 @@ export const NotificationRecipientsModel = createModel(() => {
           `${recipientsPath(organizationId)}/${encodeURIComponent(recipientId)}`,
           { method: "DELETE" },
         );
+        if (currentOrganizationId !== organizationId) return;
         await this.load(organizationId);
       } catch (err) {
-        this.error.value = errorMessage(err);
+        if (currentOrganizationId === organizationId) {
+          this.error.value = errorMessage(err);
+        }
       } finally {
-        this.status.value = "idle";
+        if (currentOrganizationId === organizationId) {
+          this.status.value = "idle";
+        }
       }
     },
   };

--- a/src/models/notification-recipients.ts
+++ b/src/models/notification-recipients.ts
@@ -23,6 +23,7 @@ export const NotificationRecipientsModel = createModel(() => {
   const status = signal<NotificationRecipientsStatus>("idle");
   const error = signal<string | null>(null);
   const draftEmail = signal("");
+  let loadRequestId = 0;
 
   const busy = computed(() => status.value !== "idle");
 
@@ -35,17 +36,31 @@ export const NotificationRecipientsModel = createModel(() => {
     busy,
 
     async load(organizationId: string | null): Promise<void> {
-      if (!organizationId) return;
+      const requestId = ++loadRequestId;
+      this.recipients.value = [];
+      this.loaded.value = false;
+      this.error.value = null;
+      if (!organizationId) {
+        this.loaded.value = true;
+        this.status.value = "idle";
+        return;
+      }
       this.status.value = "loading";
       try {
         const data = await apiFetch<ListResponse>(recipientsPath(organizationId));
-        this.recipients.value = data.recipients;
-        this.error.value = null;
+        if (requestId === loadRequestId) {
+          this.recipients.value = data.recipients;
+          this.error.value = null;
+        }
       } catch (err) {
-        this.error.value = errorMessage(err);
+        if (requestId === loadRequestId) {
+          this.error.value = errorMessage(err);
+        }
       } finally {
-        this.loaded.value = true;
-        this.status.value = "idle";
+        if (requestId === loadRequestId) {
+          this.loaded.value = true;
+          this.status.value = "idle";
+        }
       }
     },
 

--- a/src/models/notification-recipients.ts
+++ b/src/models/notification-recipients.ts
@@ -1,0 +1,91 @@
+import { computed, createModel, signal } from "@preact/signals";
+import { apiFetch, apiJson, errorMessage } from "./api";
+
+export interface NotificationRecipient {
+  id: string;
+  email: string;
+  createdAt: string | number | Date;
+}
+
+interface ListResponse {
+  recipients: NotificationRecipient[];
+}
+
+export type NotificationRecipientsStatus = "idle" | "loading" | "adding" | "removing";
+
+function recipientsPath(organizationId: string): string {
+  return `/api/v1/organizations/${encodeURIComponent(organizationId)}/notification-recipients`;
+}
+
+export const NotificationRecipientsModel = createModel(() => {
+  const recipients = signal<NotificationRecipient[]>([]);
+  const loaded = signal(false);
+  const status = signal<NotificationRecipientsStatus>("idle");
+  const error = signal<string | null>(null);
+  const draftEmail = signal("");
+
+  const busy = computed(() => status.value !== "idle");
+
+  return {
+    recipients,
+    loaded,
+    status,
+    error,
+    draftEmail,
+    busy,
+
+    async load(organizationId: string | null): Promise<void> {
+      if (!organizationId) return;
+      this.status.value = "loading";
+      try {
+        const data = await apiFetch<ListResponse>(recipientsPath(organizationId));
+        this.recipients.value = data.recipients;
+        this.error.value = null;
+      } catch (err) {
+        this.error.value = errorMessage(err);
+      } finally {
+        this.loaded.value = true;
+        this.status.value = "idle";
+      }
+    },
+
+    async add(organizationId: string): Promise<boolean> {
+      const email = this.draftEmail.value.trim();
+      if (!email) {
+        this.error.value = "Email is required.";
+        return false;
+      }
+      this.status.value = "adding";
+      this.error.value = null;
+      try {
+        await apiJson<{ recipient: NotificationRecipient }>(recipientsPath(organizationId), {
+          email,
+        });
+        this.draftEmail.value = "";
+        await this.load(organizationId);
+        return true;
+      } catch (err) {
+        this.error.value = errorMessage(err);
+        return false;
+      } finally {
+        this.status.value = "idle";
+      }
+    },
+
+    async remove(organizationId: string, recipientId: string): Promise<void> {
+      this.status.value = "removing";
+      this.error.value = null;
+      try {
+        await apiFetch<{ ok: boolean }>(
+          `${recipientsPath(organizationId)}/${encodeURIComponent(recipientId)}`,
+          { method: "DELETE" },
+        );
+        await this.load(organizationId);
+      } catch (err) {
+        this.error.value = errorMessage(err);
+      } finally {
+        this.status.value = "idle";
+      }
+    },
+  };
+});

--- a/src/pages/Dashboard/Settings/NotificationRecipientsSection.tsx
+++ b/src/pages/Dashboard/Settings/NotificationRecipientsSection.tsx
@@ -17,10 +17,12 @@ import {
 export function NotificationRecipientsSection({
   recipients,
   organizationId,
+  canManage,
   fallbackEmail,
 }: {
   recipients: ReturnType<typeof useModel<typeof NotificationRecipientsModel.prototype>>;
   organizationId: string | null;
+  canManage: boolean;
   fallbackEmail?: string;
 }) {
   const list = recipients.recipients.value;
@@ -54,17 +56,19 @@ export function NotificationRecipientsSection({
             {list.map((recipient: NotificationRecipient) => (
               <li key={recipient.id} class="flex items-center justify-between gap-3">
                 <code class="text-[13px] text-ink-muted break-all">{recipient.email}</code>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() =>
-                    organizationId && void recipients.remove(organizationId, recipient.id)
-                  }
-                  disabled={busy || !organizationId}
-                  class="shrink-0"
-                >
-                  {status === "removing" ? "Removing…" : "Remove"}
-                </Button>
+                {canManage ? (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() =>
+                      organizationId && void recipients.remove(organizationId, recipient.id)
+                    }
+                    disabled={busy || !organizationId}
+                    class="shrink-0"
+                  >
+                    {status === "removing" ? "Removing…" : "Remove"}
+                  </Button>
+                ) : null}
               </li>
             ))}
           </ul>
@@ -75,30 +79,34 @@ export function NotificationRecipientsSection({
           </Muted>
         )}
 
-        <form
-          class="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_auto] gap-3 items-end"
-          onSubmit={onAdd}
-        >
-          <Field label="Add recipient email" for="recipientEmail">
-            <Input
-              id="recipientEmail"
-              type="email"
-              value={draft}
-              placeholder="security@example.com"
-              onInput={(e) => (recipients.draftEmail.value = (e.target as HTMLInputElement).value)}
-              disabled={busy || !organizationId}
-              autoComplete="off"
-              spellcheck={false}
-            />
-          </Field>
-          <Button
-            type="submit"
-            disabled={busy || !draft.trim() || !organizationId}
-            class="shrink-0"
+        {canManage ? (
+          <form
+            class="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_auto] gap-3 items-end"
+            onSubmit={onAdd}
           >
-            {status === "adding" ? "Adding…" : "Add recipient"}
-          </Button>
-        </form>
+            <Field label="Add recipient email" for="recipientEmail">
+              <Input
+                id="recipientEmail"
+                type="email"
+                value={draft}
+                placeholder="security@example.com"
+                onInput={(e) =>
+                  (recipients.draftEmail.value = (e.target as HTMLInputElement).value)
+                }
+                disabled={busy || !organizationId}
+                autoComplete="off"
+                spellcheck={false}
+              />
+            </Field>
+            <Button
+              type="submit"
+              disabled={busy || !draft.trim() || !organizationId}
+              class="shrink-0"
+            >
+              {status === "adding" ? "Adding…" : "Add recipient"}
+            </Button>
+          </form>
+        ) : null}
 
         {error ? <Alert tone="critical">{error}</Alert> : null}
       </div>

--- a/src/pages/Dashboard/Settings/NotificationRecipientsSection.tsx
+++ b/src/pages/Dashboard/Settings/NotificationRecipientsSection.tsx
@@ -7,12 +7,11 @@ import {
   Alert,
   Badge,
   Button,
-  Card,
+  CollapsibleCard,
   Field,
   Input,
   LoadingLine,
   Muted,
-  SectionLabel,
 } from "../../../components";
 
 export function NotificationRecipientsSection({
@@ -37,19 +36,16 @@ export function NotificationRecipientsSection({
   };
 
   return (
-    <Card as="section" class="p-5">
-      <div class="flex flex-col gap-5">
-        <div class="flex flex-wrap items-start justify-between gap-3">
-          <div class="flex flex-col gap-1.5 max-w-[760px]">
-            <SectionLabel>notification recipients</SectionLabel>
-            <Muted class="text-[13px] m-0">
-              Choose who gets emailed when an auto-discovered scan finishes or a release gate needs
-              a review decision. Add a shared inbox or teammates. When this list is empty, Drydock
-              emails the organization owner.
-            </Muted>
-          </div>
-          <Badge tone="info">{list.length} configured</Badge>
-        </div>
+    <CollapsibleCard
+      title="notification recipients"
+      aside={<Badge tone="info">{list.length} configured</Badge>}
+    >
+      <div class="p-5 flex flex-col gap-5">
+        <Muted class="text-[13px] m-0 max-w-[760px]">
+          Choose who gets emailed when an auto-discovered scan finishes or a release gate needs a
+          review decision. Add a shared inbox or teammates. When this list is empty, Drydock emails
+          the organization owner.
+        </Muted>
 
         {!loaded ? (
           <LoadingLine class="border-y border-border py-3">loading recipients</LoadingLine>
@@ -106,6 +102,6 @@ export function NotificationRecipientsSection({
 
         {error ? <Alert tone="critical">{error}</Alert> : null}
       </div>
-    </Card>
+    </CollapsibleCard>
   );
 }

--- a/src/pages/Dashboard/Settings/NotificationRecipientsSection.tsx
+++ b/src/pages/Dashboard/Settings/NotificationRecipientsSection.tsx
@@ -1,0 +1,111 @@
+import { useModel } from "@preact/signals";
+import {
+  NotificationRecipientsModel,
+  type NotificationRecipient,
+} from "../../../models/notification-recipients";
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Field,
+  Input,
+  LoadingLine,
+  Muted,
+  SectionLabel,
+} from "../../../components";
+
+export function NotificationRecipientsSection({
+  recipients,
+  organizationId,
+  fallbackEmail,
+}: {
+  recipients: ReturnType<typeof useModel<typeof NotificationRecipientsModel.prototype>>;
+  organizationId: string | null;
+  fallbackEmail?: string;
+}) {
+  const list = recipients.recipients.value;
+  const status = recipients.status.value;
+  const busy = recipients.busy.value;
+  const loaded = recipients.loaded.value;
+  const error = recipients.error.value;
+  const draft = recipients.draftEmail.value;
+
+  const onAdd = async (event: Event) => {
+    event.preventDefault();
+    if (organizationId) await recipients.add(organizationId);
+  };
+
+  return (
+    <Card as="section" class="p-5">
+      <div class="flex flex-col gap-5">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div class="flex flex-col gap-1.5 max-w-[760px]">
+            <SectionLabel>notification recipients</SectionLabel>
+            <Muted class="text-[13px] m-0">
+              Choose who gets emailed when an auto-discovered scan finishes or a release gate needs
+              a review decision. Add a shared inbox or teammates. When this list is empty, Drydock
+              emails the organization owner.
+            </Muted>
+          </div>
+          <Badge tone="info">{list.length} configured</Badge>
+        </div>
+
+        {!loaded ? (
+          <LoadingLine class="border-y border-border py-3">loading recipients</LoadingLine>
+        ) : list.length > 0 ? (
+          <ul class="flex flex-col gap-2 m-0 p-0 list-none border-y border-border py-3">
+            {list.map((recipient: NotificationRecipient) => (
+              <li key={recipient.id} class="flex items-center justify-between gap-3">
+                <code class="text-[13px] text-ink-muted break-all">{recipient.email}</code>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() =>
+                    organizationId && void recipients.remove(organizationId, recipient.id)
+                  }
+                  disabled={busy || !organizationId}
+                  class="shrink-0"
+                >
+                  {status === "removing" ? "Removing…" : "Remove"}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <Muted class="text-[13px] m-0 border-y border-border py-3">
+            No recipients configured — notifications go to{" "}
+            {fallbackEmail ?? "the organization owner"}.
+          </Muted>
+        )}
+
+        <form
+          class="grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_auto] gap-3 items-end"
+          onSubmit={onAdd}
+        >
+          <Field label="Add recipient email" for="recipientEmail">
+            <Input
+              id="recipientEmail"
+              type="email"
+              value={draft}
+              placeholder="security@example.com"
+              onInput={(e) => (recipients.draftEmail.value = (e.target as HTMLInputElement).value)}
+              disabled={busy || !organizationId}
+              autoComplete="off"
+              spellcheck={false}
+            />
+          </Field>
+          <Button
+            type="submit"
+            disabled={busy || !draft.trim() || !organizationId}
+            class="shrink-0"
+          >
+            {status === "adding" ? "Adding…" : "Add recipient"}
+          </Button>
+        </form>
+
+        {error ? <Alert tone="critical">{error}</Alert> : null}
+      </div>
+    </Card>
+  );
+}

--- a/src/pages/Dashboard/Settings/index.tsx
+++ b/src/pages/Dashboard/Settings/index.tsx
@@ -133,7 +133,7 @@ export default function SettingsPage() {
           <NotificationRecipientsSection
             recipients={recipients}
             organizationId={organizations.active.value?.id ?? null}
-            fallbackEmail={user?.email}
+            fallbackEmail={ownerFallbackEmail(organizations, user)}
           />
           <NpmConnectionSection npm={npm} />
           <GithubAppSection githubApp={githubApp} />
@@ -156,6 +156,15 @@ function canManageMembers(
   organizations: ReturnType<typeof useModel<typeof OrganizationModel.prototype>>,
 ): boolean {
   return roleCanManageMembers(activeRole(organizations));
+}
+
+function ownerFallbackEmail(
+  organizations: ReturnType<typeof useModel<typeof OrganizationModel.prototype>>,
+  user: { id?: string | null; email?: string | null } | null,
+): string | undefined {
+  const active = organizations.active.value;
+  if (!active?.ownerUserId || !user?.id || active.ownerUserId !== user.id) return undefined;
+  return user.email ?? undefined;
 }
 
 function loadingDetail(npmLoaded: boolean, githubAppLoaded: boolean): string {

--- a/src/pages/Dashboard/Settings/index.tsx
+++ b/src/pages/Dashboard/Settings/index.tsx
@@ -130,13 +130,13 @@ export default function SettingsPage() {
             currentUserRole={activeRole(organizations)}
             currentUserId={user?.id ?? null}
           />
-          <NpmConnectionSection npm={npm} />
-          <GithubAppSection githubApp={githubApp} />
           <NotificationRecipientsSection
             recipients={recipients}
             organizationId={organizations.active.value?.id ?? null}
             fallbackEmail={user?.email}
           />
+          <NpmConnectionSection npm={npm} />
+          <GithubAppSection githubApp={githubApp} />
         </div>
       ) : (
         <LoadingState title="Loading settings" detail={loadingDetail(npmLoaded, githubAppLoaded)} />

--- a/src/pages/Dashboard/Settings/index.tsx
+++ b/src/pages/Dashboard/Settings/index.tsx
@@ -4,6 +4,7 @@ import { useLocation } from "preact-iso";
 import { rememberDashboardReturnUrl } from "../../../lib/query-state";
 import { sessionModel } from "../../../models/auth";
 import { NpmConnectionModel } from "../../../models/npm-connection";
+import { NotificationRecipientsModel } from "../../../models/notification-recipients";
 import { OrganizationModel } from "../../../models/organization";
 import { GithubAppModel } from "../../../models/github-app";
 import { MembersModel } from "../../../models/organization-members";
@@ -21,6 +22,7 @@ import {
   UserMenu,
 } from "../../../components";
 import { GithubAppSection } from "./GithubAppSection";
+import { NotificationRecipientsSection } from "./NotificationRecipientsSection";
 import { NpmConnectionSection } from "./NpmConnectionSection";
 import { OrganizationMembersSection } from "./OrganizationMembersSection";
 
@@ -30,6 +32,7 @@ export default function SettingsPage() {
   const organizations = useModel(OrganizationModel);
   const githubApp = useModel(GithubAppModel);
   const members = useModel(MembersModel);
+  const recipients = useModel(NotificationRecipientsModel);
   const sessionChecked = useSignal(false);
 
   useEffect(() => {
@@ -53,6 +56,7 @@ export default function SettingsPage() {
         githubApp.loadInstallations(),
         githubApp.loadReleaseTargets(),
         members.load(canManageMembers(organizations)),
+        recipients.load(organizations.active.peek()?.id ?? null),
       ]);
     })();
     return () => {
@@ -65,6 +69,7 @@ export default function SettingsPage() {
     githubApp.clearForm();
     if (!githubApp.configLoaded.peek()) loaders.push(githubApp.loadConfig());
     loaders.push(githubApp.loadInstallations(), githubApp.loadReleaseTargets());
+    loaders.push(recipients.load(organizations.active.peek()?.id ?? null));
     await Promise.all(loaders);
   };
 
@@ -127,6 +132,11 @@ export default function SettingsPage() {
           />
           <NpmConnectionSection npm={npm} />
           <GithubAppSection githubApp={githubApp} />
+          <NotificationRecipientsSection
+            recipients={recipients}
+            organizationId={organizations.active.value?.id ?? null}
+            fallbackEmail={user?.email}
+          />
         </div>
       ) : (
         <LoadingState title="Loading settings" detail={loadingDetail(npmLoaded, githubAppLoaded)} />

--- a/src/pages/Dashboard/Settings/index.tsx
+++ b/src/pages/Dashboard/Settings/index.tsx
@@ -10,6 +10,7 @@ import { GithubAppModel } from "../../../models/github-app";
 import { MembersModel } from "../../../models/organization-members";
 import {
   normalizeRole,
+  roleCanManageIntegrations,
   roleCanManageMembers,
   type OrganizationRole,
 } from "../../../../server/lib/roles";
@@ -133,6 +134,7 @@ export default function SettingsPage() {
           <NotificationRecipientsSection
             recipients={recipients}
             organizationId={organizations.active.value?.id ?? null}
+            canManage={canManageIntegrations(organizations)}
             fallbackEmail={ownerFallbackEmail(organizations, user)}
           />
           <NpmConnectionSection npm={npm} />
@@ -156,6 +158,12 @@ function canManageMembers(
   organizations: ReturnType<typeof useModel<typeof OrganizationModel.prototype>>,
 ): boolean {
   return roleCanManageMembers(activeRole(organizations));
+}
+
+function canManageIntegrations(
+  organizations: ReturnType<typeof useModel<typeof OrganizationModel.prototype>>,
+): boolean {
+  return roleCanManageIntegrations(activeRole(organizations));
 }
 
 function ownerFallbackEmail(

--- a/test/notification-recipients-model.test.ts
+++ b/test/notification-recipients-model.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { NotificationRecipientsModel } from "../src/models/notification-recipients";
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function deferredResponse() {
+  let resolve!: (response: Response) => void;
+  const promise = new Promise<Response>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("NotificationRecipientsModel", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test("does not let a stale add reload overwrite a later organization load", async () => {
+    const addOrgA = deferredResponse();
+    const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes("/org-a/notification-recipients") && init?.method === "POST") {
+        return addOrgA.promise;
+      }
+      if (url.includes("/org-a/notification-recipients")) {
+        return Promise.resolve(jsonResponse({ recipients: [{ id: "a", email: "a@example.com" }] }));
+      }
+      if (url.includes("/org-b/notification-recipients")) {
+        return Promise.resolve(jsonResponse({ recipients: [{ id: "b", email: "b@example.com" }] }));
+      }
+      return Promise.resolve(jsonResponse({ recipients: [] }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const model = new NotificationRecipientsModel();
+    await model.load("org-a");
+    expect(model.recipients.value.map((recipient) => recipient.email)).toEqual(["a@example.com"]);
+
+    model.draftEmail.value = "new-a@example.com";
+    const add = model.add("org-a");
+    await model.load("org-b");
+    model.draftEmail.value = "new-b@example.com";
+
+    addOrgA.resolve(jsonResponse({ recipient: { id: "new-a", email: "new-a@example.com" } }));
+    await add;
+
+    expect(model.recipients.value.map((recipient) => recipient.email)).toEqual(["b@example.com"]);
+    expect(model.draftEmail.value).toBe("new-b@example.com");
+  });
+});

--- a/test/notify.test.mjs
+++ b/test/notify.test.mjs
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const dbMock = vi.hoisted(() => ({
   getScan: vi.fn(),
-  getUserContact: vi.fn(),
+  resolveNotificationEmails: vi.fn(),
   recordScanEvent: vi.fn().mockResolvedValue(undefined),
 }));
 const emailMock = vi.hoisted(() => ({
@@ -12,9 +12,9 @@ const emailMock = vi.hoisted(() => ({
 vi.mock("../server/db/index.ts", () => dbMock);
 vi.mock("../server/lib/email.ts", () => emailMock);
 
-const { notifyWorkflowGateReview } = await import("../server/lib/notify.ts");
+const { notifyScanCompletion, notifyWorkflowGateReview } = await import("../server/lib/notify.ts");
 
-function baseInput(overrides = {}) {
+function gateInput(overrides = {}) {
   return {
     env: { BETTER_AUTH_URL: "https://drydock.test" },
     db: {},
@@ -31,24 +31,36 @@ function baseInput(overrides = {}) {
   };
 }
 
+function scanInput(overrides = {}) {
+  return {
+    env: { BETTER_AUTH_URL: "https://drydock.test" },
+    db: {},
+    scanId: "scan_1",
+    organizationId: "org_1",
+    ownerUserId: "user_1",
+    outcome: "complete",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  dbMock.resolveNotificationEmails.mockResolvedValue(["owner@example.com"]);
+  dbMock.getScan.mockResolvedValue({
+    scan: { packageName: "demo-package", stagedVersion: "1.2.0", risk: "high" },
+  });
+  emailMock.sendNotificationEmail.mockResolvedValue({ ok: true });
+});
+
+afterEach(() => {
+  dbMock.resolveNotificationEmails.mockReset();
+  dbMock.getScan.mockReset();
+  dbMock.recordScanEvent.mockClear();
+  emailMock.sendNotificationEmail.mockReset();
+});
+
 describe("notifyWorkflowGateReview", () => {
-  beforeEach(() => {
-    dbMock.getUserContact.mockResolvedValue({
-      id: "user_1",
-      email: "owner@example.com",
-      name: "Olga",
-    });
-    emailMock.sendNotificationEmail.mockResolvedValue({ ok: true });
-  });
-
-  afterEach(() => {
-    dbMock.getUserContact.mockReset();
-    dbMock.recordScanEvent.mockClear();
-    emailMock.sendNotificationEmail.mockReset();
-  });
-
-  test("emails the owner with release identity, risk, repo, environment and a dashboard link", async () => {
-    await notifyWorkflowGateReview(baseInput());
+  test("emails the resolved recipient with release identity, risk, repo, environment and a link", async () => {
+    await notifyWorkflowGateReview(gateInput());
 
     expect(emailMock.sendNotificationEmail).toHaveBeenCalledTimes(1);
     const [, message] = emailMock.sendNotificationEmail.mock.calls[0];
@@ -67,12 +79,37 @@ describe("notifyWorkflowGateReview", () => {
       actorUserId: "user_1",
       scanId: "scan_1",
       type: "github_workflow_gate.notification_sent",
-      metadata: { gateId: "gate_1", channel: "email", releaseRisk: "high" },
+      metadata: {
+        gateId: "gate_1",
+        channel: "email",
+        releaseRisk: "high",
+        recipient: "owner@example.com",
+      },
     });
   });
 
+  test("fans out to every configured recipient and records one event each", async () => {
+    dbMock.resolveNotificationEmails.mockResolvedValue([
+      "security@example.com",
+      "lead@example.com",
+    ]);
+
+    await notifyWorkflowGateReview(gateInput());
+
+    expect(emailMock.sendNotificationEmail).toHaveBeenCalledTimes(2);
+    const recipients = emailMock.sendNotificationEmail.mock.calls.map(([, m]) => m.to).sort();
+    expect(recipients).toEqual(["lead@example.com", "security@example.com"]);
+
+    expect(dbMock.recordScanEvent).toHaveBeenCalledTimes(2);
+    const eventRecipients = dbMock.recordScanEvent.mock.calls.map(([, e]) => e.metadata.recipient);
+    expect(eventRecipients.sort()).toEqual(["lead@example.com", "security@example.com"]);
+    for (const [, event] of dbMock.recordScanEvent.mock.calls) {
+      expect(event.type).toBe("github_workflow_gate.notification_sent");
+    }
+  });
+
   test("never leaks token, header, or callback material into the email", async () => {
-    await notifyWorkflowGateReview(baseInput());
+    await notifyWorkflowGateReview(gateInput());
 
     const [, message] = emailMock.sendNotificationEmail.mock.calls[0];
     const payload = `${message.subject}\n${message.text}`;
@@ -91,7 +128,7 @@ describe("notifyWorkflowGateReview", () => {
   test("records a delivery failure without throwing", async () => {
     emailMock.sendNotificationEmail.mockResolvedValue({ ok: false, reason: "smtp down" });
 
-    await expect(notifyWorkflowGateReview(baseInput())).resolves.toBeUndefined();
+    await expect(notifyWorkflowGateReview(gateInput())).resolves.toBeUndefined();
 
     const [, event] = dbMock.recordScanEvent.mock.calls[0];
     expect(event.type).toBe("github_workflow_gate.notification_failed");
@@ -99,17 +136,66 @@ describe("notifyWorkflowGateReview", () => {
       gateId: "gate_1",
       channel: "email",
       reason: "smtp down",
+      recipient: "owner@example.com",
     });
   });
 
-  test("skips delivery and records a failure when the owner has no email on record", async () => {
-    dbMock.getUserContact.mockResolvedValue({ id: "user_1", email: null, name: "Olga" });
+  test("skips delivery and records a failure when no recipients resolve", async () => {
+    dbMock.resolveNotificationEmails.mockResolvedValue([]);
 
-    await notifyWorkflowGateReview(baseInput());
+    await notifyWorkflowGateReview(gateInput());
+
+    expect(emailMock.sendNotificationEmail).not.toHaveBeenCalled();
+    expect(dbMock.recordScanEvent).toHaveBeenCalledTimes(1);
+    const [, event] = dbMock.recordScanEvent.mock.calls[0];
+    expect(event.type).toBe("github_workflow_gate.notification_failed");
+    expect(event.metadata).toMatchObject({ gateId: "gate_1", reason: "no_recipients" });
+  });
+});
+
+describe("notifyScanCompletion", () => {
+  test("emails the resolved recipients on success with package and risk", async () => {
+    dbMock.resolveNotificationEmails.mockResolvedValue([
+      "security@example.com",
+      "lead@example.com",
+    ]);
+
+    await notifyScanCompletion(scanInput());
+
+    expect(emailMock.sendNotificationEmail).toHaveBeenCalledTimes(2);
+    const [, message] = emailMock.sendNotificationEmail.mock.calls[0];
+    expect(message.subject).toContain("demo-package@1.2.0");
+    expect(message.text).toContain("Overall risk: high");
+    expect(message.text).toContain("https://drydock.test/dashboard/scans/scan_1");
+
+    expect(dbMock.recordScanEvent).toHaveBeenCalledTimes(2);
+    for (const [, event] of dbMock.recordScanEvent.mock.calls) {
+      expect(event.type).toBe("scan.notification_sent");
+      expect(event.metadata).toMatchObject({ outcome: "complete", channel: "email" });
+    }
+  });
+
+  test("reports the failure reason on a failed scan", async () => {
+    await notifyScanCompletion(
+      scanInput({ outcome: "failed", error: { code: "boom", message: "tarball unavailable" } }),
+    );
+
+    const [, message] = emailMock.sendNotificationEmail.mock.calls[0];
+    expect(message.subject).toContain("Staged release scan failed");
+    expect(message.text).toContain("Reason: tarball unavailable");
+    const [, event] = dbMock.recordScanEvent.mock.calls[0];
+    expect(event.type).toBe("scan.notification_sent");
+    expect(event.metadata.outcome).toBe("failed");
+  });
+
+  test("records a failure event when no recipients resolve", async () => {
+    dbMock.resolveNotificationEmails.mockResolvedValue([]);
+
+    await notifyScanCompletion(scanInput());
 
     expect(emailMock.sendNotificationEmail).not.toHaveBeenCalled();
     const [, event] = dbMock.recordScanEvent.mock.calls[0];
-    expect(event.type).toBe("github_workflow_gate.notification_failed");
-    expect(event.metadata).toMatchObject({ gateId: "gate_1", reason: "no_contact_email" });
+    expect(event.type).toBe("scan.notification_failed");
+    expect(event.metadata).toMatchObject({ outcome: "complete", reason: "no_recipients" });
   });
 });

--- a/test/notify.test.mjs
+++ b/test/notify.test.mjs
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const dbMock = vi.hoisted(() => ({
+  getOrganizationOwnerUserId: vi.fn(),
   getScan: vi.fn(),
   resolveNotificationEmails: vi.fn(),
   recordScanEvent: vi.fn().mockResolvedValue(undefined),
@@ -44,6 +45,7 @@ function scanInput(overrides = {}) {
 }
 
 beforeEach(() => {
+  dbMock.getOrganizationOwnerUserId.mockResolvedValue("user_1");
   dbMock.resolveNotificationEmails.mockResolvedValue(["owner@example.com"]);
   dbMock.getScan.mockResolvedValue({
     scan: { packageName: "demo-package", stagedVersion: "1.2.0", risk: "high" },
@@ -52,6 +54,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  dbMock.getOrganizationOwnerUserId.mockReset();
   dbMock.resolveNotificationEmails.mockReset();
   dbMock.getScan.mockReset();
   dbMock.recordScanEvent.mockClear();
@@ -154,6 +157,13 @@ describe("notifyWorkflowGateReview", () => {
 });
 
 describe("notifyScanCompletion", () => {
+  test("resolves fallback recipients through the organization owner", async () => {
+    await notifyScanCompletion(scanInput({ ownerUserId: "admin_1" }));
+
+    expect(dbMock.getOrganizationOwnerUserId).toHaveBeenCalledWith({}, "org_1");
+    expect(dbMock.resolveNotificationEmails).toHaveBeenCalledWith({}, "org_1", "user_1");
+  });
+
   test("emails the resolved recipients on success with package and risk", async () => {
     dbMock.resolveNotificationEmails.mockResolvedValue([
       "security@example.com",

--- a/test/workers/organizations-routes.test.ts
+++ b/test/workers/organizations-routes.test.ts
@@ -361,6 +361,31 @@ describe("organization notification recipients", () => {
     expect(await listNotificationRecipients(db, orgId)).toHaveLength(0);
   });
 
+  test("limits notification recipients to five addresses", async () => {
+    const owner = await seedUser();
+    const orgId = owner.personalOrganizationId;
+
+    for (let i = 0; i < 5; i++) {
+      const add = await call(
+        buildTestApp(owner),
+        "POST",
+        `/api/v1/organizations/${orgId}/notification-recipients`,
+        { body: { email: `recipient-${i}@example.com` } },
+      );
+      expect(add.status).toBe(201);
+    }
+
+    const overflow = await call(
+      buildTestApp(owner),
+      "POST",
+      `/api/v1/organizations/${orgId}/notification-recipients`,
+      { body: { email: "recipient-5@example.com" } },
+    );
+    expect(overflow.status).toBe(400);
+    const body = (await overflow.json()) as { error: string };
+    expect(body.error).toBe("at most 5 notification recipients are allowed");
+  });
+
   test("resolveNotificationEmails falls back to the owner only when no recipients exist", async () => {
     const owner = await seedUser();
     const orgId = owner.personalOrganizationId;

--- a/test/workers/organizations-routes.test.ts
+++ b/test/workers/organizations-routes.test.ts
@@ -375,6 +375,15 @@ describe("organization notification recipients", () => {
       expect(add.status).toBe(201);
     }
 
+    const duplicate = await call(
+      buildTestApp(owner),
+      "POST",
+      `/api/v1/organizations/${orgId}/notification-recipients`,
+      { body: { email: "recipient-4@example.com" } },
+    );
+    expect(duplicate.status).toBe(200);
+    expect(await listNotificationRecipients(createDb(env.DB), orgId)).toHaveLength(5);
+
     const overflow = await call(
       buildTestApp(owner),
       "POST",

--- a/test/workers/organizations-routes.test.ts
+++ b/test/workers/organizations-routes.test.ts
@@ -1,7 +1,13 @@
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
 import { Hono } from "hono";
 import { describe, expect, test } from "vitest";
-import { createDb, ensurePersonalOrganization, getNpmConnection } from "../../server/db";
+import {
+  createDb,
+  ensurePersonalOrganization,
+  getNpmConnection,
+  listNotificationRecipients,
+  resolveNotificationEmails,
+} from "../../server/db";
 import * as schema from "../../server/db/schema";
 import { ACTIVE_ORG_HEADER } from "../../server/lib/active-organization";
 import { npmConnectionRoutes } from "../../server/routes/npm-connection";
@@ -196,5 +202,130 @@ describe("organizations routes", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { connection: unknown };
     expect(body.connection).toBeNull();
+  });
+});
+
+describe("organization notification recipients", () => {
+  test("lists, adds (lowercased), and the list is scoped to the owner", async () => {
+    const owner = await seedUser();
+    const stranger = await seedUser();
+    const orgId = owner.personalOrganizationId;
+
+    const empty = await call(
+      buildTestApp(owner),
+      "GET",
+      `/api/v1/organizations/${orgId}/notification-recipients`,
+    );
+    expect(empty.status).toBe(200);
+    expect(((await empty.json()) as { recipients: unknown[] }).recipients).toHaveLength(0);
+
+    const add = await call(
+      buildTestApp(owner),
+      "POST",
+      `/api/v1/organizations/${orgId}/notification-recipients`,
+      { body: { email: "Security@Example.com" } },
+    );
+    expect(add.status).toBe(201);
+    const added = (await add.json()) as { recipient: { id: string; email: string } };
+    expect(added.recipient.email).toBe("security@example.com");
+
+    const listed = await call(
+      buildTestApp(owner),
+      "GET",
+      `/api/v1/organizations/${orgId}/notification-recipients`,
+    );
+    const listedBody = (await listed.json()) as { recipients: Array<{ email: string }> };
+    expect(listedBody.recipients.map((r) => r.email)).toEqual(["security@example.com"]);
+
+    const intruder = await call(
+      buildTestApp(stranger),
+      "GET",
+      `/api/v1/organizations/${orgId}/notification-recipients`,
+    );
+    expect(intruder.status).toBe(404);
+  });
+
+  test("rejects invalid emails and is idempotent on duplicates", async () => {
+    const owner = await seedUser();
+    const orgId = owner.personalOrganizationId;
+
+    const bad = await call(
+      buildTestApp(owner),
+      "POST",
+      `/api/v1/organizations/${orgId}/notification-recipients`,
+      { body: { email: "not-an-email" } },
+    );
+    expect(bad.status).toBe(400);
+
+    const first = await call(
+      buildTestApp(owner),
+      "POST",
+      `/api/v1/organizations/${orgId}/notification-recipients`,
+      { body: { email: "dupe@example.com" } },
+    );
+    expect(first.status).toBe(201);
+
+    const second = await call(
+      buildTestApp(owner),
+      "POST",
+      `/api/v1/organizations/${orgId}/notification-recipients`,
+      { body: { email: "dupe@example.com" } },
+    );
+    expect(second.status).toBe(200);
+
+    const db = createDb(env.DB);
+    expect(await listNotificationRecipients(db, orgId)).toHaveLength(1);
+  });
+
+  test("DELETE removes an owned recipient and rejects non-owners", async () => {
+    const owner = await seedUser();
+    const stranger = await seedUser();
+    const orgId = owner.personalOrganizationId;
+
+    const add = await call(
+      buildTestApp(owner),
+      "POST",
+      `/api/v1/organizations/${orgId}/notification-recipients`,
+      { body: { email: "drop@example.com" } },
+    );
+    const recipientId = ((await add.json()) as { recipient: { id: string } }).recipient.id;
+
+    const intruder = await call(
+      buildTestApp(stranger),
+      "DELETE",
+      `/api/v1/organizations/${orgId}/notification-recipients/${recipientId}`,
+    );
+    expect(intruder.status).toBe(404);
+
+    const removed = await call(
+      buildTestApp(owner),
+      "DELETE",
+      `/api/v1/organizations/${orgId}/notification-recipients/${recipientId}`,
+    );
+    expect(removed.status).toBe(200);
+
+    const db = createDb(env.DB);
+    expect(await listNotificationRecipients(db, orgId)).toHaveLength(0);
+  });
+
+  test("resolveNotificationEmails falls back to the owner only when no recipients exist", async () => {
+    const owner = await seedUser();
+    const orgId = owner.personalOrganizationId;
+    const db = createDb(env.DB);
+
+    expect(await resolveNotificationEmails(db, orgId, owner.userId)).toEqual([
+      `${owner.userId}@example.com`,
+    ]);
+
+    await call(
+      buildTestApp(owner),
+      "POST",
+      `/api/v1/organizations/${orgId}/notification-recipients`,
+      {
+        body: { email: "team@example.com" },
+      },
+    );
+
+    expect(await resolveNotificationEmails(db, orgId, owner.userId)).toEqual(["team@example.com"]);
   });
 });

--- a/test/workers/organizations-routes.test.ts
+++ b/test/workers/organizations-routes.test.ts
@@ -2,6 +2,7 @@ import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:
 import { Hono } from "hono";
 import { describe, expect, test } from "vitest";
 import {
+  addOrganizationMember,
   createDb,
   ensurePersonalOrganization,
   getNpmConnection,
@@ -275,6 +276,58 @@ describe("organization notification recipients", () => {
 
     const db = createDb(env.DB);
     expect(await listNotificationRecipients(db, orgId)).toHaveLength(1);
+  });
+
+  test("admins can manage recipients while members can only read them", async () => {
+    const owner = await seedUser();
+    const admin = await seedUser();
+    const member = await seedUser();
+    const db = createDb(env.DB);
+    const orgId = owner.personalOrganizationId;
+
+    await addOrganizationMember(db, {
+      organizationId: orgId,
+      userId: admin.userId,
+      role: "admin",
+    });
+    await addOrganizationMember(db, {
+      organizationId: orgId,
+      userId: member.userId,
+      role: "member",
+    });
+
+    const add = await call(
+      buildTestApp(admin),
+      "POST",
+      `/api/v1/organizations/${orgId}/notification-recipients`,
+      { body: { email: "reviewers@example.com" } },
+    );
+    expect(add.status).toBe(201);
+    const recipientId = ((await add.json()) as { recipient: { id: string } }).recipient.id;
+
+    const listed = await call(
+      buildTestApp(member),
+      "GET",
+      `/api/v1/organizations/${orgId}/notification-recipients`,
+    );
+    expect(listed.status).toBe(200);
+    const listedBody = (await listed.json()) as { recipients: Array<{ email: string }> };
+    expect(listedBody.recipients.map((r) => r.email)).toEqual(["reviewers@example.com"]);
+
+    const memberAdd = await call(
+      buildTestApp(member),
+      "POST",
+      `/api/v1/organizations/${orgId}/notification-recipients`,
+      { body: { email: "member-write@example.com" } },
+    );
+    expect(memberAdd.status).toBe(403);
+
+    const memberRemove = await call(
+      buildTestApp(member),
+      "DELETE",
+      `/api/v1/organizations/${orgId}/notification-recipients/${recipientId}`,
+    );
+    expect(memberRemove.status).toBe(403);
   });
 
   test("DELETE removes an owned recipient and rejects non-owners", async () => {


### PR DESCRIPTION
## Summary
- Adds an `organization_notification_recipients` table (migration `0014`) plus owner-gated CRUD routes under `/api/v1/organizations/:id/notification-recipients` and a Settings UI section so an org can configure a set of notification emails instead of only the owner.
- Both the auto-discovery scan-completion emails and the workflow-gate review emails now resolve the recipient set via `resolveNotificationEmails` and fan out one send per address (no shared To/Cc), recording one `notification_sent`/`notification_failed` event per recipient.
- When no recipients are configured, delivery falls back to the organization owner, so every existing org keeps today's behavior with no backfill.
- Covered by new notify fan-out tests and recipient CRUD/auth/dedupe/resolution worker tests, plus docs updates.

## Test plan
- [x] `pnpm run test` (445 passing / 7 skipped)
- [x] typecheck, oxlint, and oxfmt all clean
- [ ] Manually exercise add/remove recipients in the Settings UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)