### PR TITLE
Add organization member invitations and RBAC

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -212,7 +212,9 @@ Organization-owned resources scope by the active org:
 - future report signatures;
 - future artifact retention settings.
 
-Invitations, team membership, RBAC, deletion, audit-log UI, billing, and quotas are deferred (see Phase 12 in `docs/production-roadmap.md`). Until they ship, every member of an organization is effectively an owner, and route guards must continue to verify membership through `organization_members` rather than trusting client-supplied org ids.
+Team membership, invitations, and RBAC ship today — see [`organization-members.md`](./organization-members.md). Each membership row carries one of three roles (`owner`, `admin`, `member`) defined in `server/lib/roles.ts`. Owners and admins manage members, invitations, npm connections, and GitHub release targets; members get read access to org-scoped resources and can act on releases. The owner is the `organizations.ownerUserId` and cannot be removed or demoted through the API. Route guards still verify membership through `organization_members` via `requireActiveOrganization`; sensitive mutations additionally resolve the caller's role with `requireActiveOrganizationContext` and gate on `roleCanManageMembers` / `roleCanManageIntegrations` rather than trusting client-supplied org ids.
+
+Deletion, audit-log UI, billing, and quotas remain deferred (see Phase 12 in `docs/production-roadmap.md`).
 
 ## npm connection model
 
@@ -272,6 +274,12 @@ Current API:
 - `GET /api/v1/organizations` — list the caller's organizations (personal first), each with `npmConnectionConfigured`;
 - `POST /api/v1/organizations` — create a new organization owned by the caller;
 - `PATCH /api/v1/organizations/:id` — rename (owner-only);
+- `GET /api/v1/organizations/members` — list members (any member);
+- `DELETE /api/v1/organizations/members/:userId` — remove a member (owner/admin; the owner cannot be removed);
+- `GET /api/v1/organizations/invitations` — list pending invitations (owner/admin);
+- `POST /api/v1/organizations/invitations` — invite an email at a chosen role (owner/admin; rate-limited; the raw token is emailed, never returned);
+- `DELETE /api/v1/organizations/invitations/:invitationId` — revoke a pending invitation (owner/admin);
+- `POST /api/v1/organizations/invitations/accept` — accept an invitation by token (authenticated invitee; **not** org-header scoped — the org is resolved from the token and the caller's account email must equal the invited address);
 - `GET /api/v1/github-app/config`, `POST /api/v1/github-app/install`, `POST /api/v1/github-app/install/callback`, installation/repository/environment proxy reads, release-target CRUD, and workflow-gate decision endpoints — see [`pypi-workflow-gate.md`](./pypi-workflow-gate.md) for the full GitHub App surface.
 
 All other `/api/v1/*` endpoints honor the `x-organization-id` request header to pick the active org; absent or non-member ids silently fall back to the caller's personal org.

--- a/docs/organization-members.md
+++ b/docs/organization-members.md
@@ -1,0 +1,116 @@
+# Organization members & invitations
+
+Drydock organizations are multi-user. This document describes the membership
+model, the role-based access guards, and the email-token invitation flow.
+
+## Roles
+
+`server/lib/roles.ts` is the single source of truth:
+
+- `owner` — the `organizations.ownerUserId`. Exactly one per org. Cannot be
+  removed or demoted through the API. Created implicitly when an org is created
+  (`createOrganization` / `ensurePersonalOrganization` insert the owner's
+  `organization_members` row with role `owner`).
+- `admin` — full management of members, invitations, npm connections, and GitHub
+  release targets.
+- `member` — read access to org-scoped resources; can act on releases (record
+  scan decisions, decide workflow gates). Cannot manage membership or
+  integrations.
+
+Helpers:
+
+- `roleCanManageMembers(role)` — `owner` or `admin`. Gates invite/revoke/remove.
+- `roleCanManageIntegrations(role)` — `owner` or `admin`. Gates npm-connection
+  mutations and GitHub App install / release-target CRUD.
+- `isInvitableRole(value)` — only `admin` or `member` may be invited; you cannot
+  invite a second `owner`.
+- `normalizeRole(value)` — coerces an unknown/stored string to a valid role,
+  defaulting to `member`.
+
+`getOrganizationRole(db, orgId, userId)` returns the effective role: `owner` when
+the user is the org's `ownerUserId`, otherwise the stored membership role, or
+`null` when the user is not a member.
+
+## Where roles are enforced
+
+Reads (`GET`) stay open to any member and use `requireActiveOrganization`.
+Sensitive mutations resolve the caller's role with
+`requireActiveOrganizationContext(c, db)` (returns `{ organizationId, role }`)
+and return `403 { error: "forbidden" }` when the guard fails:
+
+- member management — `server/routes/organization-members.ts`
+- npm connections — `server/routes/npm-connection.ts` (POST, POST `/validate`,
+  DELETE)
+- GitHub App install + release targets — `server/routes/github-app.ts`
+
+Org rename stays owner-only (`isOrganizationOwner`). Gate approvals and scan
+decisions stay open to any member by design.
+
+## Invitation flow
+
+Schema: `organization_invitations` (`server/db/schema.ts`). One **live** invite
+per `(organization_id, email)`: re-inviting an address rotates the token and
+extends the expiry on the existing pending row (`upsertInvitation`) instead of
+stacking rows. Status is `pending` → `accepted` | `revoked`. Invites expire after
+7 days (`INVITE_TTL_MS`).
+
+### Token handling
+
+Invitation links carry a 32-byte high-entropy bearer token. Only its SHA-256
+hash (`token_hash`) is persisted — mirroring the password-reset pattern — so a
+database read never yields a usable link and revocation is a single row update.
+The raw token exists only in the invite email and the accept request; it is
+**never** returned by any API response (`publicInvitation` omits it). See
+`server/lib/invitation-token.ts`.
+
+### Create → email → accept
+
+1. **Create** (`POST /invitations`, owner/admin): validates the email
+   (`sanitizeAddress`) and role (`isInvitableRole`, default `member`),
+   rate-limits at 30/hour per org, rejects an address that is already a member
+   (409), then `upsertInvitation` + `notifyOrganizationInvite`. Returns the
+   public invitation (no token).
+2. **Email**: `notifyOrganizationInvite` sends a link to
+   `${BETTER_AUTH_URL}/dashboard/invite?token=…` and records an
+   `organization.member_invited` (or `…_invite_failed`) audit event. Email
+   delivery is best-effort and never blocks the invite.
+3. **Accept** (`POST /invitations/accept`, authenticated invitee): this route is
+   deliberately **not** scoped by the `x-organization-id` header — an invitee is
+   not a member yet, so the org is determined solely by the token (matched by
+   hash). The caller's account email must equal the invited address, so a leaked
+   link cannot enroll a third party. The transition out of `pending` is a
+   compare-and-swap (`markInvitationAccepted`), so concurrent accepts race and
+   only one wins. On success it adds the member, records
+   `organization.member_joined`, and returns `{ organizationId, role }`.
+
+Accept failure codes: `404` unknown token, `409` already used/revoked (or lost
+the CAS race), `410` expired, `403` the caller's email does not match the invite.
+
+### Front end
+
+- `src/models/organization-members.ts` (`MembersModel`) — load/invite/revoke/
+  remove, used by the settings page.
+- `src/pages/Dashboard/Settings/OrganizationMembersSection.tsx` — member roster,
+  invite form, and pending-invite list. The invite form and management controls
+  only render for owners/admins.
+- `src/pages/Dashboard/Invite/index.tsx` (`/dashboard/invite`) — reads `?token`,
+  redirects unauthenticated visitors to `/login?returnTo=…` (the login and
+  register pages forward `returnTo` so a brand-new invitee can create an account
+  and land back on the invite), then POSTs the token, sets the joined org active,
+  and routes to the dashboard.
+
+## Audit events
+
+All recorded via `recordScanEvent` into `scan_events`:
+
+- `organization.member_invited` / `organization.member_invite_failed`
+- `organization.member_invitation_revoked`
+- `organization.member_joined`
+- `organization.member_removed`
+
+## Tests
+
+`test/workers/organization-members-routes.test.ts` covers invite creation,
+token-never-leaked, role enforcement (member 403, admin allowed), accept →
+membership, leaked-link rejection, expiry, revoke-then-accept, owner-removal
+guard, and roster ordering.

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -1,11 +1,11 @@
 # Production roadmap
 
-This roadmap converts the current staged-publish sandbox into a SaaS product while preserving the core safety boundaries. Phases 1–4, most of Phase 5, Phase 8 multi-organization workspaces, the scheduled npm discovery foundation, and the PyPI workflow-gate foundation have shipped. Remaining sections track production hardening, report/provenance work, UX polish, team/commercial features, and detection quality.
+This roadmap converts the current staged-publish sandbox into a SaaS product while preserving the core safety boundaries. Phases 1–4, most of Phase 5, Phase 8 multi-organization workspaces, the team membership/RBAC foundation, the scheduled npm discovery foundation, and the PyPI workflow-gate foundation have shipped. Remaining sections track production hardening, report/provenance work, UX polish, commercial features, and detection quality.
 
 ## Product assumptions
 
 - SaaS product with organization-scoped data.
-- No full team RBAC in the first production slice.
+- Basic organization RBAC ships with `owner`, `admin`, and `member` roles. Billing, quotas, audit-log UI, deletion/export, and operator tooling remain later commercial-readiness work.
 - Per-organization npm credentials, not a global production npm token.
 - npm approval remains manual and 2FA-protected outside the product.
 - Cloudflare Workers AI is the production AI provider. AI review is wired through `maybeRunAiReview` but gated off by default behind the per-organization Flagship `ai-review` flag for the planned paid-tier feature; see [`docs/architecture.md`](./architecture.md#workers-ai-flagship-gated) and [`docs/cost-model.md`](./cost-model.md#ai-model-strategy-flagship-gated-planned-paid-tier).
@@ -14,7 +14,7 @@ This roadmap converts the current staged-publish sandbox into a SaaS product whi
 
 ## Current cut line
 
-The prototype-to-product foundation is in place: authenticated organization-scoped scans, encrypted organization npm connections, multi-organization switching, async-capable scan jobs (idempotent across retries), scheduled npm staged-publish discovery, persisted report metadata, and a text-only release diff workbench all exist.
+The prototype-to-product foundation is in place: authenticated organization-scoped scans, encrypted organization npm connections, multi-organization switching, owner/admin/member RBAC, email-token organization invitations, async-capable scan jobs (idempotent across retries), scheduled npm staged-publish discovery, persisted report metadata, and a text-only release diff workbench all exist.
 
 Closed: tenant-boundary, sandbox-gateway, and archive-parser regression tests now have route- and unit-level coverage (`test/workers/cross-org-routes.test.ts`, `test/workers/cross-org-npm-connection.test.ts`, `test/workers/sandbox-gateway-runtime.test.ts`, `test/tar-parser.test.mjs`).
 
@@ -88,8 +88,9 @@ Implemented:
 - `routes/organizations.ts` exposes `GET /api/v1/organizations`, `POST /api/v1/organizations`, and `PATCH /api/v1/organizations/:id`.
 - `src/models/active-organization.ts`, `src/models/organization.ts`, and `OrgSwitcher` provide per-device organization switching backed by localStorage.
 - Cross-org isolation and organization route tests cover header-scoped scans/connections and non-member fallback.
+- `server/routes/organization-members.ts`, `server/lib/roles.ts`, and `docs/organization-members.md` cover member rosters, email-token invitations, owner/admin/member role gates, and invite acceptance.
 
-Out of scope (kept in Phase 12): invitations, RBAC beyond owner, org deletion, audit log UI, billing, quotas, cross-device active-org sync, and multiple npm connections per organization.
+Out of scope (kept in Phase 12): org deletion/export, audit log UI, billing, quotas, cross-device active-org sync, and multiple npm connections per organization.
 
 ## Phase 9 — Trustworthy report artifacts
 
@@ -173,21 +174,19 @@ Exit criteria:
 - Users receive an email with a link to the persisted scan report when the automatic scan reaches a terminal state.
 - The product still makes clear that npm approval remains manual outside the product.
 
-## Phase 12 — Team and commercial readiness
+## Phase 12 — Commercial readiness and administration
 
 Priority: medium after private beta proves value.
 
 Goals:
 
-- Support multi-member organizations instead of only single-owner organization workspaces.
-- Prepare the product for team usage, billing, and operator administration.
+- Build on the shipped multi-member organization foundation with billing, quotas, customer-facing audit surfaces, and operator administration.
+- Add the remaining account/organization lifecycle controls needed for paid team usage.
 
 Tasks:
 
 - Add multiple npm connections per organization so maintainers can segment tokens by npm scope, package, or release workflow.
 - Add per-scan npm connection selection and organization-level defaults once multiple connections exist.
-- Add invitations and membership management.
-- Add RBAC after the organization model is stable.
 - Add audit log UI for npm credential events, scan events, report exports, and future reviewer decisions.
 - Add organization usage and quota pages.
 - Add billing integration and plan limits.
@@ -196,8 +195,8 @@ Tasks:
 
 Exit criteria:
 
-- Multiple maintainers can collaborate safely in one organization.
 - Usage, billing, and audit data are visible to customers and operators.
+- Customers can manage organization lifecycle, account data, quotas, and plan limits without support intervention.
 - Support can diagnose common tenant issues without direct database access.
 
 ## Phase 13 — Security-product defensibility

--- a/drizzle/0014_tan_wrecking_crew.sql
+++ b/drizzle/0014_tan_wrecking_crew.sql
@@ -1,0 +1,21 @@
+CREATE TABLE `organization_invitations` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`email` text NOT NULL,
+	`role` text DEFAULT 'member' NOT NULL,
+	`token_hash` text NOT NULL,
+	`status` text DEFAULT 'pending' NOT NULL,
+	`invited_by_user_id` text,
+	`accepted_by_user_id` text,
+	`accepted_at` integer,
+	`expires_at` integer NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`invited_by_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`accepted_by_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `organization_invitations_token_hash_unique_idx` ON `organization_invitations` (`token_hash`);--> statement-breakpoint
+CREATE INDEX `organization_invitations_org_status_idx` ON `organization_invitations` (`organization_id`,`status`);--> statement-breakpoint
+CREATE INDEX `organization_invitations_org_email_idx` ON `organization_invitations` (`organization_id`,`email`);

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1973 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1a9c6db1-85c1-4a99-bad7-28d19ce03bec",
+  "prevId": "1b745129-168c-461c-99dc-8b26f5851fcc",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_app_installations": {
+      "name": "github_app_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Organization'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uninstalled_at": {
+          "name": "uninstalled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_app_installations_installation_unique_idx": {
+          "name": "github_app_installations_installation_unique_idx",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        },
+        "github_app_installations_org_idx": {
+          "name": "github_app_installations_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installations_created_by_user_id_user_id_fk": {
+          "name": "github_app_installations_created_by_user_id_user_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_release_targets": {
+      "name": "github_release_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ecosystem": {
+          "name": "ecosystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_release_targets_org_repo_env_unique_idx": {
+          "name": "github_release_targets_org_repo_env_unique_idx",
+          "columns": [
+            "organization_id",
+            "repository_id",
+            "environment"
+          ],
+          "isUnique": true
+        },
+        "github_release_targets_installation_idx": {
+          "name": "github_release_targets_installation_idx",
+          "columns": [
+            "installation_row_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_release_targets_organization_id_organizations_id_fk": {
+          "name": "github_release_targets_organization_id_organizations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_release_targets_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_created_by_user_id_user_id_fk": {
+          "name": "github_release_targets_created_by_user_id_user_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_workflow_gates": {
+      "name": "github_workflow_gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_target_id": {
+          "name": "release_target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deployment_callback_url": {
+          "name": "deployment_callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_comment": {
+          "name": "decision_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_url": {
+          "name": "report_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_workflow_gates_delivery_unique_idx": {
+          "name": "github_workflow_gates_delivery_unique_idx",
+          "columns": [
+            "delivery_id"
+          ],
+          "isUnique": true
+        },
+        "github_workflow_gates_org_status_idx": {
+          "name": "github_workflow_gates_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_release_target_idx": {
+          "name": "github_workflow_gates_release_target_idx",
+          "columns": [
+            "release_target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_workflow_gates_organization_id_organizations_id_fk": {
+          "name": "github_workflow_gates_organization_id_organizations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_workflow_gates_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_release_target_id_github_release_targets_id_fk": {
+          "name": "github_workflow_gates_release_target_id_github_release_targets_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_release_targets",
+          "columnsFrom": [
+            "release_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_scan_id_scans_id_fk": {
+          "name": "github_workflow_gates_scan_id_scans_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_unique_idx": {
+          "name": "npm_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_invitations": {
+      "name": "organization_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_invitations_token_hash_unique_idx": {
+          "name": "organization_invitations_token_hash_unique_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "organization_invitations_org_status_idx": {
+          "name": "organization_invitations_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "organization_invitations_org_email_idx": {
+          "name": "organization_invitations_org_email_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_invitations_organization_id_organizations_id_fk": {
+          "name": "organization_invitations_organization_id_organizations_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_invited_by_user_id_user_id_fk": {
+          "name": "organization_invitations_invited_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_accepted_by_user_id_user_id_fk": {
+          "name": "organization_invitations_accepted_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_findings_scan_severity_idx": {
+          "name": "scan_findings_scan_severity_idx",
+          "columns": [
+            "scan_id",
+            "severity"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changed_file_count": {
+          "name": "changed_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_summary_json": {
+          "name": "risk_summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        },
+        "scans_org_decision_created_idx": {
+          "name": "scans_org_decision_created_idx",
+          "columns": [
+            "organization_id",
+            "decision",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_decided_by_user_id_user_id_fk": {
+          "name": "scans_decided_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1780124308761,
       "tag": "0013_simple_blue_blade",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "6",
+      "when": 1780331741530,
+      "tag": "0014_tan_wrecking_crew",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -2,5 +2,6 @@ export * from "./client";
 export * from "./rate-limit";
 export * from "./events";
 export * from "./organizations";
+export * from "./invitations";
 export * from "./npm-connections";
 export * from "./scans";

--- a/server/db/invitations.ts
+++ b/server/db/invitations.ts
@@ -1,0 +1,294 @@
+import { and, desc, eq, sql } from "drizzle-orm";
+import { normalizeRole, type OrganizationRole } from "../lib/roles";
+import type { AppDb } from "./client";
+import { organizationInvitations, organizationMembers, organizations, user } from "./schema";
+
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export async function findUserByEmail(db: AppDb, email: string) {
+  const [row] = await db
+    .select({ id: user.id, email: user.email, name: user.name })
+    .from(user)
+    .where(eq(user.email, normalizeEmail(email)))
+    .limit(1);
+  return row ?? null;
+}
+
+export async function getOrganizationRole(
+  db: AppDb,
+  organizationId: string,
+  userId: string,
+): Promise<OrganizationRole | null> {
+  const [row] = await db
+    .select({ role: organizationMembers.role, ownerUserId: organizations.ownerUserId })
+    .from(organizationMembers)
+    .innerJoin(organizations, eq(organizations.id, organizationMembers.organizationId))
+    .where(
+      and(
+        eq(organizationMembers.organizationId, organizationId),
+        eq(organizationMembers.userId, userId),
+      ),
+    )
+    .limit(1);
+  if (!row) return null;
+  if (row.ownerUserId === userId) return "owner";
+  return normalizeRole(row.role);
+}
+
+export interface OrganizationMemberEntry {
+  userId: string;
+  email: string | null;
+  name: string | null;
+  role: OrganizationRole;
+  isOwner: boolean;
+  joinedAt: Date;
+}
+
+export async function listOrganizationMembers(
+  db: AppDb,
+  organizationId: string,
+): Promise<OrganizationMemberEntry[]> {
+  const [ownerRow] = await db
+    .select({ ownerUserId: organizations.ownerUserId })
+    .from(organizations)
+    .where(eq(organizations.id, organizationId))
+    .limit(1);
+  const ownerUserId = ownerRow?.ownerUserId ?? null;
+
+  const rows = await db
+    .select({
+      userId: organizationMembers.userId,
+      role: organizationMembers.role,
+      joinedAt: organizationMembers.createdAt,
+      email: user.email,
+      name: user.name,
+    })
+    .from(organizationMembers)
+    .leftJoin(user, eq(user.id, organizationMembers.userId))
+    .where(eq(organizationMembers.organizationId, organizationId));
+
+  return rows
+    .map((row) => {
+      const isOwner = row.userId === ownerUserId;
+      return {
+        userId: row.userId,
+        email: row.email ?? null,
+        name: row.name ?? null,
+        role: isOwner ? ("owner" as OrganizationRole) : normalizeRole(row.role),
+        isOwner,
+        joinedAt: row.joinedAt,
+      };
+    })
+    .sort((a, b) => {
+      if (a.isOwner !== b.isOwner) return a.isOwner ? -1 : 1;
+      return a.joinedAt.getTime() - b.joinedAt.getTime();
+    });
+}
+
+export async function addOrganizationMember(
+  db: AppDb,
+  input: { organizationId: string; userId: string; role: OrganizationRole },
+): Promise<void> {
+  const now = new Date();
+  await db
+    .insert(organizationMembers)
+    .values({
+      id: `member:${input.organizationId}:${input.userId}`,
+      organizationId: input.organizationId,
+      userId: input.userId,
+      role: input.role,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [organizationMembers.organizationId, organizationMembers.userId],
+      set: { role: input.role, updatedAt: now },
+    });
+}
+
+export async function removeOrganizationMember(
+  db: AppDb,
+  organizationId: string,
+  userId: string,
+): Promise<boolean> {
+  const result = await db
+    .delete(organizationMembers)
+    .where(
+      and(
+        eq(organizationMembers.organizationId, organizationId),
+        eq(organizationMembers.userId, userId),
+      ),
+    )
+    .returning({ id: organizationMembers.id });
+  return result.length > 0;
+}
+
+export interface InvitationRecord {
+  id: string;
+  organizationId: string;
+  email: string;
+  role: OrganizationRole;
+  status: string;
+  invitedByUserId: string | null;
+  acceptedByUserId: string | null;
+  acceptedAt: Date | null;
+  expiresAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+function readInvitationRow(row: typeof organizationInvitations.$inferSelect): InvitationRecord {
+  return {
+    id: row.id,
+    organizationId: row.organizationId,
+    email: row.email,
+    role: normalizeRole(row.role),
+    status: row.status,
+    invitedByUserId: row.invitedByUserId,
+    acceptedByUserId: row.acceptedByUserId,
+    acceptedAt: row.acceptedAt,
+    expiresAt: row.expiresAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export interface UpsertInvitationInput {
+  organizationId: string;
+  email: string;
+  role: OrganizationRole;
+  tokenHash: string;
+  invitedByUserId: string;
+  expiresAt: Date;
+}
+
+// One live invite per (org, email): re-inviting an address that already has a
+// pending invite rotates its token and extends the expiry on the same row, so a
+// resend silently invalidates the previous link instead of stacking invites.
+export async function upsertInvitation(
+  db: AppDb,
+  input: UpsertInvitationInput,
+): Promise<InvitationRecord> {
+  const email = normalizeEmail(input.email);
+  const now = new Date();
+  const [existing] = await db
+    .select()
+    .from(organizationInvitations)
+    .where(
+      and(
+        eq(organizationInvitations.organizationId, input.organizationId),
+        eq(organizationInvitations.email, email),
+        eq(organizationInvitations.status, "pending"),
+      ),
+    )
+    .limit(1);
+
+  if (existing) {
+    const [updated] = await db
+      .update(organizationInvitations)
+      .set({
+        role: input.role,
+        tokenHash: input.tokenHash,
+        invitedByUserId: input.invitedByUserId,
+        expiresAt: input.expiresAt,
+        updatedAt: now,
+      })
+      .where(eq(organizationInvitations.id, existing.id))
+      .returning();
+    return readInvitationRow(updated);
+  }
+
+  const [created] = await db
+    .insert(organizationInvitations)
+    .values({
+      id: crypto.randomUUID(),
+      organizationId: input.organizationId,
+      email,
+      role: input.role,
+      tokenHash: input.tokenHash,
+      status: "pending",
+      invitedByUserId: input.invitedByUserId,
+      expiresAt: input.expiresAt,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+  return readInvitationRow(created);
+}
+
+export async function listPendingInvitations(
+  db: AppDb,
+  organizationId: string,
+): Promise<InvitationRecord[]> {
+  const rows = await db
+    .select()
+    .from(organizationInvitations)
+    .where(
+      and(
+        eq(organizationInvitations.organizationId, organizationId),
+        eq(organizationInvitations.status, "pending"),
+      ),
+    )
+    .orderBy(desc(organizationInvitations.createdAt));
+  return rows.map(readInvitationRow);
+}
+
+export async function getInvitationByTokenHash(
+  db: AppDb,
+  tokenHash: string,
+): Promise<InvitationRecord | null> {
+  const [row] = await db
+    .select()
+    .from(organizationInvitations)
+    .where(eq(organizationInvitations.tokenHash, tokenHash))
+    .limit(1);
+  return row ? readInvitationRow(row) : null;
+}
+
+export async function revokeInvitation(
+  db: AppDb,
+  organizationId: string,
+  invitationId: string,
+): Promise<boolean> {
+  const result = await db
+    .update(organizationInvitations)
+    .set({ status: "revoked", updatedAt: new Date() })
+    .where(
+      and(
+        eq(organizationInvitations.id, invitationId),
+        eq(organizationInvitations.organizationId, organizationId),
+        eq(organizationInvitations.status, "pending"),
+      ),
+    )
+    .returning({ id: organizationInvitations.id });
+  return result.length > 0;
+}
+
+// Compare-and-swap out of `pending`: the WHERE clause is the single transition,
+// so two concurrent accepts of the same link race and only one wins (the loser
+// sees zero rows and is treated as already-accepted/expired by the caller).
+export async function markInvitationAccepted(
+  db: AppDb,
+  input: { invitationId: string; acceptedByUserId: string },
+): Promise<boolean> {
+  const now = new Date();
+  const result = await db
+    .update(organizationInvitations)
+    .set({
+      status: "accepted",
+      acceptedByUserId: input.acceptedByUserId,
+      acceptedAt: now,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(organizationInvitations.id, input.invitationId),
+        eq(organizationInvitations.status, "pending"),
+        sql`${organizationInvitations.expiresAt} > ${now.getTime()}`,
+      ),
+    )
+    .returning({ id: organizationInvitations.id });
+  return result.length > 0;
+}

--- a/server/db/organizations.ts
+++ b/server/db/organizations.ts
@@ -43,6 +43,15 @@ export async function getUserContact(db: AppDb, userId: string) {
   return row ?? null;
 }
 
+export async function getOrganizationName(db: AppDb, organizationId: string) {
+  const [row] = await db
+    .select({ name: organizations.name })
+    .from(organizations)
+    .where(eq(organizations.id, organizationId))
+    .limit(1);
+  return row?.name ?? null;
+}
+
 export async function getOrganizationOwnerUserId(db: AppDb, organizationId: string) {
   const [row] = await db
     .select({ ownerUserId: organizations.ownerUserId })

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -49,6 +49,41 @@ export const organizationMembers = sqliteTable(
   }),
 );
 
+export const organizationInvitations = sqliteTable(
+  "organization_invitations",
+  {
+    id: text("id").primaryKey(),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    email: text("email").notNull(),
+    role: text("role").notNull().default("member"),
+    tokenHash: text("token_hash").notNull(),
+    status: text("status").notNull().default("pending"),
+    invitedByUserId: text("invited_by_user_id").references(() => user.id, { onDelete: "set null" }),
+    acceptedByUserId: text("accepted_by_user_id").references(() => user.id, {
+      onDelete: "set null",
+    }),
+    acceptedAt: integer("accepted_at", { mode: "timestamp_ms" }),
+    expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+  },
+  (table) => ({
+    tokenHashUniqueIdx: uniqueIndex("organization_invitations_token_hash_unique_idx").on(
+      table.tokenHash,
+    ),
+    orgStatusIdx: index("organization_invitations_org_status_idx").on(
+      table.organizationId,
+      table.status,
+    ),
+    orgEmailIdx: index("organization_invitations_org_email_idx").on(
+      table.organizationId,
+      table.email,
+    ),
+  }),
+);
+
 export const scans = sqliteTable(
   "scans",
   {

--- a/server/index.ts
+++ b/server/index.ts
@@ -33,6 +33,7 @@ import {
 import { githubAppRoutes } from "./routes/github-app";
 import { githubWebhookRoutes } from "./routes/github-webhooks";
 import { npmConnectionRoutes } from "./routes/npm-connection";
+import { organizationMembersRoutes } from "./routes/organization-members";
 import { organizationsRoutes } from "./routes/organizations";
 import { scanRoutes } from "./routes/scan";
 import { scansRoutes } from "./routes/scans";
@@ -199,6 +200,8 @@ app.get("/api", (c) =>
       npmConnection: "GET/POST/DELETE /api/v1/npm-connection; POST /api/v1/npm-connection/validate",
       organizations:
         "GET /api/v1/organizations; POST /api/v1/organizations; PATCH /api/v1/organizations/:id",
+      organizationMembers:
+        "GET /api/v1/organizations/members; DELETE /api/v1/organizations/members/:userId; GET/POST /api/v1/organizations/invitations; DELETE /api/v1/organizations/invitations/:invitationId; POST /api/v1/organizations/invitations/accept",
       githubApp:
         "GET /api/v1/github-app/config; POST /api/v1/github-app/install; POST /api/v1/github-app/install/callback; GET /api/v1/github-app/installations; GET/POST /api/v1/github-app/release-targets; DELETE /api/v1/github-app/release-targets/:id; GET /api/v1/github-app/workflow-gates/by-scan/:scanId; POST /api/v1/github-app/workflow-gates/:gateId/decision",
       githubWebhooks: "POST /webhooks/github (signed by GitHub App webhook secret)",
@@ -212,6 +215,7 @@ app.get("/api", (c) =>
 app.route("/api/v1/github-app", githubAppRoutes);
 app.route("/api/v1/npm-connection", npmConnectionRoutes);
 app.route("/api/v1/organizations", organizationsRoutes);
+app.route("/api/v1/organizations", organizationMembersRoutes);
 // Two scan-submit surfaces, both sharing executeScanJob/runScanPipeline; they
 // differ only in how the caller waits for the result:
 //   /api/v1/scan  (scanRoutes)  — synchronous shim: runs the pipeline inline

--- a/server/lib/active-organization.ts
+++ b/server/lib/active-organization.ts
@@ -1,9 +1,10 @@
 import type { Context } from "hono";
 import { and, eq } from "drizzle-orm";
 import type { AppDb } from "../db";
-import { ensurePersonalOrganization } from "../db";
+import { ensurePersonalOrganization, getOrganizationRole } from "../db";
 import { organizationMembers } from "../db/schema";
 import { personalOrganizationId } from "./ownership";
+import type { OrganizationRole } from "./roles";
 import type { Bindings, Variables } from "../types";
 
 export const ACTIVE_ORG_HEADER = "x-organization-id";
@@ -29,4 +30,23 @@ export async function requireActiveOrganization(
   }
   await ensurePersonalOrganization(db, session);
   return personalOrganizationId(session.userId);
+}
+
+export interface ActiveOrganizationContext {
+  organizationId: string;
+  role: OrganizationRole;
+}
+
+// Resolve the active organization and the caller's role within it. Because
+// requireActiveOrganization only returns an org the caller is a member of (or
+// their own personal org), a membership row always exists, so role defaults to
+// "member" only defensively.
+export async function requireActiveOrganizationContext(
+  c: Context<{ Bindings: Bindings; Variables: Variables }>,
+  db: AppDb,
+): Promise<ActiveOrganizationContext> {
+  const organizationId = await requireActiveOrganization(c, db);
+  const session = c.get("authSession");
+  const role = (await getOrganizationRole(db, organizationId, session.userId)) ?? "member";
+  return { organizationId, role };
 }

--- a/server/lib/invitation-token.ts
+++ b/server/lib/invitation-token.ts
@@ -1,0 +1,28 @@
+// Invitation links carry a high-entropy bearer token. Only its SHA-256 hash is
+// persisted (organization_invitations.token_hash), so a database read never
+// yields a usable link and revocation is a single row update. This mirrors the
+// password-reset token pattern: the raw token exists only in the email.
+
+const TOKEN_BYTES = 32;
+
+export interface InvitationToken {
+  token: string;
+  tokenHash: string;
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export async function hashInvitationToken(token: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token));
+  return toBase64Url(new Uint8Array(digest));
+}
+
+export async function generateInvitationToken(): Promise<InvitationToken> {
+  const token = toBase64Url(crypto.getRandomValues(new Uint8Array(TOKEN_BYTES)));
+  const tokenHash = await hashInvitationToken(token);
+  return { token, tokenHash };
+}

--- a/server/lib/notify.ts
+++ b/server/lib/notify.ts
@@ -1,6 +1,7 @@
 import { getScan, getUserContact, recordScanEvent, type AppDb } from "../db";
 import { sendNotificationEmail } from "./email";
 import type { RiskLevel } from "./review";
+import type { OrganizationRole } from "./roles";
 
 export interface NotifyScanCompletionInput {
   env: Cloudflare.Env;
@@ -169,6 +170,76 @@ export async function notifyWorkflowGateReview(
       ...(result.ok ? {} : { reason: result.reason }),
     },
   });
+}
+
+export interface NotifyOrganizationInviteInput {
+  env: Cloudflare.Env;
+  db: AppDb;
+  organizationId: string;
+  organizationName: string;
+  email: string;
+  role: OrganizationRole;
+  token: string;
+  invitedByUserId: string;
+  invitedByName?: string | null;
+}
+
+/**
+ * Email an invitee their organization invite link and record the
+ * `organization.member_invited` audit event. The link carries the raw bearer
+ * token (only its hash is persisted); the body contains no other secrets. The
+ * audit event is always recorded — even when email delivery is unavailable — so
+ * the pending invite is traceable and the failure reason is captured.
+ */
+export async function notifyOrganizationInvite(
+  input: NotifyOrganizationInviteInput,
+): Promise<void> {
+  const { env, db, organizationId, organizationName, email, role, token, invitedByUserId } = input;
+  const inviteUrl = inviteAcceptUrl(env, token);
+
+  const result = inviteUrl
+    ? await sendNotificationEmail(env, {
+        to: email,
+        subject: `You're invited to ${organizationName} on Drydock`,
+        text: [
+          "Hi there,",
+          "",
+          `${input.invitedByName ? input.invitedByName : "An organization owner"} invited you to join ${organizationName} on Drydock as a ${role}.`,
+          "",
+          `Accept the invitation: ${inviteUrl}`,
+          "",
+          "If you don't have a Drydock account yet, create one with this email address and the link will add you to the organization.",
+          "",
+          "This invitation expires in 7 days.",
+          "",
+          "— Drydock",
+        ].join("\n"),
+      })
+    : { ok: false, reason: "BETTER_AUTH_URL is not configured" };
+
+  await recordScanEvent(db, {
+    organizationId,
+    actorUserId: invitedByUserId,
+    type: result.ok ? "organization.member_invited" : "organization.member_invite_failed",
+    metadata: {
+      email,
+      role,
+      channel: "email",
+      ...(result.ok ? {} : { reason: result.reason }),
+    },
+  });
+}
+
+function inviteAcceptUrl(env: Cloudflare.Env, token: string): string | null {
+  const base = env.BETTER_AUTH_URL;
+  if (typeof base !== "string" || !base) return null;
+  try {
+    const url = new URL("/dashboard/invite", base);
+    url.searchParams.set("token", token);
+    return url.toString();
+  } catch {
+    return null;
+  }
 }
 
 function formatPackageLabel(

--- a/server/lib/roles.ts
+++ b/server/lib/roles.ts
@@ -1,0 +1,26 @@
+export type OrganizationRole = "owner" | "admin" | "member";
+
+export const ORGANIZATION_ROLES: readonly OrganizationRole[] = ["owner", "admin", "member"];
+
+// Roles an owner/admin may hand out via an invite. Ownership is never granted by
+// invite — there is exactly one owner per org (organizations.ownerUserId).
+export const INVITABLE_ROLES: readonly OrganizationRole[] = ["admin", "member"];
+
+export function normalizeRole(value: unknown): OrganizationRole {
+  return value === "owner" || value === "admin" ? value : "member";
+}
+
+export function isInvitableRole(value: unknown): value is OrganizationRole {
+  return value === "admin" || value === "member";
+}
+
+// Member management and integration management both require elevated access.
+// A plain member can read org-scoped data and act on scans, but cannot change
+// who is in the org or rewire its credentials/release targets.
+export function roleCanManageMembers(role: OrganizationRole | null): boolean {
+  return role === "owner" || role === "admin";
+}
+
+export function roleCanManageIntegrations(role: OrganizationRole | null): boolean {
+  return role === "owner" || role === "admin";
+}

--- a/server/routes/github-app.ts
+++ b/server/routes/github-app.ts
@@ -7,7 +7,11 @@ import {
   recordScanDecision,
   recordScanEvent,
 } from "../db";
-import { requireActiveOrganization } from "../lib/active-organization";
+import {
+  requireActiveOrganization,
+  requireActiveOrganizationContext,
+} from "../lib/active-organization";
+import { roleCanManageIntegrations } from "../lib/roles";
 import { rateLimitResponse } from "../lib/http";
 import { describeOperationalError, emitOperationalEvent } from "../lib/observability";
 import {
@@ -71,7 +75,8 @@ githubAppRoutes.post("/install", async (c) => {
   }
   const db = createDb(c.env.DB);
   const session = c.get("authSession");
-  const organizationId = await requireActiveOrganization(c, db);
+  const { organizationId, role } = await requireActiveOrganizationContext(c, db);
+  if (!roleCanManageIntegrations(role)) return c.json({ error: "forbidden" }, 403);
   try {
     await enforceRateLimit(db, {
       key: `github-app:install:${organizationId}`,
@@ -138,10 +143,11 @@ githubAppRoutes.post("/install/callback", async (c) => {
 
   const db = createDb(c.env.DB);
   // Confirm the caller still has access to the org the state was issued for.
-  const organizationId = await requireActiveOrganization(c, db);
+  const { organizationId, role } = await requireActiveOrganizationContext(c, db);
   if (organizationId !== claims.organizationId) {
     return c.json({ error: "state token does not match active organization" }, 403);
   }
+  if (!roleCanManageIntegrations(role)) return c.json({ error: "forbidden" }, 403);
 
   try {
     await verifyUserCanAccessInstallation(config, { code, installationId });
@@ -303,7 +309,8 @@ githubAppRoutes.post("/release-targets", async (c) => {
 
   const db = createDb(c.env.DB);
   const session = c.get("authSession");
-  const organizationId = await requireActiveOrganization(c, db);
+  const { organizationId, role } = await requireActiveOrganizationContext(c, db);
+  if (!roleCanManageIntegrations(role)) return c.json({ error: "forbidden" }, 403);
   try {
     await enforceRateLimit(db, {
       key: `github-app:release-target:${organizationId}`,
@@ -356,7 +363,8 @@ githubAppRoutes.post("/release-targets", async (c) => {
 githubAppRoutes.delete("/release-targets/:id", async (c) => {
   const db = createDb(c.env.DB);
   const session = c.get("authSession");
-  const organizationId = await requireActiveOrganization(c, db);
+  const { organizationId, role } = await requireActiveOrganizationContext(c, db);
+  if (!roleCanManageIntegrations(role)) return c.json({ error: "forbidden" }, 403);
   const id = c.req.param("id");
   const removed = await deleteReleaseTarget(db, organizationId, id);
   if (!removed) return c.json({ error: "not found" }, 404);

--- a/server/routes/npm-connection.ts
+++ b/server/routes/npm-connection.ts
@@ -9,7 +9,11 @@ import {
   updateNpmConnectionValidation,
   upsertNpmConnection,
 } from "../db";
-import { requireActiveOrganization } from "../lib/active-organization";
+import {
+  requireActiveOrganization,
+  requireActiveOrganizationContext,
+} from "../lib/active-organization";
+import { roleCanManageIntegrations } from "../lib/roles";
 import {
   allowInsecureLocalRegistry,
   decryptNpmToken,
@@ -58,7 +62,8 @@ npmConnectionRoutes.post("/", async (c) => {
   try {
     const db = createDb(c.env.DB);
     const session = c.get("authSession");
-    const organizationId = await requireActiveOrganization(c, db);
+    const { organizationId, role } = await requireActiveOrganizationContext(c, db);
+    if (!roleCanManageIntegrations(role)) return c.json({ error: "forbidden" }, 403);
     const [, encrypted] = await Promise.all([
       enforceRateLimit(db, {
         key: `npm-connection:save:${organizationId}`,
@@ -106,7 +111,8 @@ npmConnectionRoutes.post("/validate", async (c) => {
   try {
     const db = createDb(c.env.DB);
     const session = c.get("authSession");
-    const organizationId = await requireActiveOrganization(c, db);
+    const { organizationId, role } = await requireActiveOrganizationContext(c, db);
+    if (!roleCanManageIntegrations(role)) return c.json({ error: "forbidden" }, 403);
     await enforceRateLimit(db, {
       key: `npm-connection:validate:${organizationId}`,
       limit: 12,
@@ -153,7 +159,8 @@ npmConnectionRoutes.post("/validate", async (c) => {
 npmConnectionRoutes.delete("/", async (c) => {
   const db = createDb(c.env.DB);
   const session = c.get("authSession");
-  const organizationId = await requireActiveOrganization(c, db);
+  const { organizationId, role } = await requireActiveOrganizationContext(c, db);
+  if (!roleCanManageIntegrations(role)) return c.json({ error: "forbidden" }, 403);
   const existing = await getNpmConnection(db, organizationId);
   await Promise.all([
     deleteNpmConnection(db, organizationId),

--- a/server/routes/organization-members.ts
+++ b/server/routes/organization-members.ts
@@ -1,0 +1,230 @@
+import { Hono } from "hono";
+import {
+  RateLimitError,
+  addOrganizationMember,
+  createDb,
+  enforceRateLimit,
+  findUserByEmail,
+  getInvitationByTokenHash,
+  getOrganizationName,
+  getOrganizationOwnerUserId,
+  getOrganizationRole,
+  getUserContact,
+  listOrganizationMembers,
+  listPendingInvitations,
+  markInvitationAccepted,
+  normalizeEmail,
+  recordScanEvent,
+  removeOrganizationMember,
+  revokeInvitation,
+  upsertInvitation,
+  type InvitationRecord,
+  type OrganizationMemberEntry,
+} from "../db";
+import {
+  requireActiveOrganization,
+  requireActiveOrganizationContext,
+} from "../lib/active-organization";
+import { sanitizeAddress } from "../lib/email";
+import { rateLimitResponse } from "../lib/http";
+import { generateInvitationToken, hashInvitationToken } from "../lib/invitation-token";
+import { notifyOrganizationInvite } from "../lib/notify";
+import { isInvitableRole, roleCanManageMembers, type OrganizationRole } from "../lib/roles";
+import type { Bindings, Variables } from "../types";
+
+const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export const organizationMembersRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+organizationMembersRoutes.get("/members", async (c) => {
+  const db = createDb(c.env.DB);
+  const organizationId = await requireActiveOrganization(c, db);
+  const members = await listOrganizationMembers(db, organizationId);
+  return c.json({ members: members.map(publicMember) });
+});
+
+organizationMembersRoutes.delete("/members/:userId", async (c) => {
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const { organizationId, role } = await requireActiveOrganizationContext(c, db);
+  if (!roleCanManageMembers(role)) return c.json({ error: "forbidden" }, 403);
+
+  const targetUserId = c.req.param("userId");
+  const ownerUserId = await getOrganizationOwnerUserId(db, organizationId);
+  if (targetUserId === ownerUserId) {
+    return c.json({ error: "cannot remove the organization owner" }, 400);
+  }
+
+  const removed = await removeOrganizationMember(db, organizationId, targetUserId);
+  if (!removed) return c.json({ error: "not found" }, 404);
+
+  await recordScanEvent(db, {
+    organizationId,
+    actorUserId: session.userId,
+    type: "organization.member_removed",
+    metadata: { userId: targetUserId },
+  });
+  return c.json({ ok: true });
+});
+
+organizationMembersRoutes.get("/invitations", async (c) => {
+  const db = createDb(c.env.DB);
+  const { organizationId, role } = await requireActiveOrganizationContext(c, db);
+  if (!roleCanManageMembers(role)) return c.json({ error: "forbidden" }, 403);
+  const invitations = await listPendingInvitations(db, organizationId);
+  return c.json({ invitations: invitations.map(publicInvitation) });
+});
+
+organizationMembersRoutes.post("/invitations", async (c) => {
+  const body = (await c.req.json().catch(() => ({}))) as { email?: unknown; role?: unknown };
+  const email = sanitizeAddress(body.email);
+  if (!email) return c.json({ error: "a valid email is required" }, 400);
+  const normalizedEmail = normalizeEmail(email);
+  const role: OrganizationRole = isInvitableRole(body.role) ? body.role : "member";
+
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const { organizationId, role: actorRole } = await requireActiveOrganizationContext(c, db);
+  if (!roleCanManageMembers(actorRole)) return c.json({ error: "forbidden" }, 403);
+
+  try {
+    await enforceRateLimit(db, {
+      key: `organizations:invite:${organizationId}`,
+      limit: 30,
+      windowMs: 60 * 60 * 1000,
+    });
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      return rateLimitResponse(c, "organization invite rate limit exceeded", err);
+    }
+    throw err;
+  }
+
+  const existingUser = await findUserByEmail(db, normalizedEmail);
+  if (existingUser) {
+    const existingRole = await getOrganizationRole(db, organizationId, existingUser.id);
+    if (existingRole) {
+      return c.json({ error: "that user is already a member of this organization" }, 409);
+    }
+  }
+
+  const { token, tokenHash } = await generateInvitationToken();
+  const invitation = await upsertInvitation(db, {
+    organizationId,
+    email: normalizedEmail,
+    role,
+    tokenHash,
+    invitedByUserId: session.userId,
+    expiresAt: new Date(Date.now() + INVITE_TTL_MS),
+  });
+
+  const [organizationName, inviter] = await Promise.all([
+    getOrganizationName(db, organizationId),
+    getUserContact(db, session.userId),
+  ]);
+  await notifyOrganizationInvite({
+    env: c.env,
+    db,
+    organizationId,
+    organizationName: organizationName ?? "an organization",
+    email: normalizedEmail,
+    role,
+    token,
+    invitedByUserId: session.userId,
+    invitedByName: inviter?.name ?? null,
+  });
+
+  return c.json({ invitation: publicInvitation(invitation) }, 201);
+});
+
+organizationMembersRoutes.delete("/invitations/:invitationId", async (c) => {
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const { organizationId, role } = await requireActiveOrganizationContext(c, db);
+  if (!roleCanManageMembers(role)) return c.json({ error: "forbidden" }, 403);
+
+  const invitationId = c.req.param("invitationId");
+  const revoked = await revokeInvitation(db, organizationId, invitationId);
+  if (!revoked) return c.json({ error: "not found" }, 404);
+
+  await recordScanEvent(db, {
+    organizationId,
+    actorUserId: session.userId,
+    type: "organization.member_invitation_revoked",
+    metadata: { invitationId },
+  });
+  return c.json({ ok: true });
+});
+
+// The accept path is deliberately NOT scoped by the active-organization header:
+// an invitee is not a member yet, so the invitation token alone determines which
+// org they join. The token is matched by hash and the caller's account email
+// must equal the invited address, so a leaked link cannot enroll a third party.
+organizationMembersRoutes.post("/invitations/accept", async (c) => {
+  const body = (await c.req.json().catch(() => ({}))) as { token?: unknown };
+  const token = typeof body.token === "string" ? body.token.trim() : "";
+  if (!token) return c.json({ error: "token is required" }, 400);
+
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+
+  const invitation = await getInvitationByTokenHash(db, await hashInvitationToken(token));
+  if (!invitation) return c.json({ error: "invitation not found" }, 404);
+  if (invitation.status !== "pending") {
+    return c.json({ error: "invitation has already been used or revoked" }, 409);
+  }
+  if (invitation.expiresAt.getTime() <= Date.now()) {
+    return c.json({ error: "invitation has expired" }, 410);
+  }
+
+  const contact = await getUserContact(db, session.userId);
+  if (!contact?.email || normalizeEmail(contact.email) !== invitation.email) {
+    return c.json({ error: "this invitation was sent to a different email address" }, 403);
+  }
+
+  const accepted = await markInvitationAccepted(db, {
+    invitationId: invitation.id,
+    acceptedByUserId: session.userId,
+  });
+  if (!accepted) {
+    return c.json({ error: "invitation is no longer valid" }, 409);
+  }
+
+  await addOrganizationMember(db, {
+    organizationId: invitation.organizationId,
+    userId: session.userId,
+    role: invitation.role,
+  });
+  await recordScanEvent(db, {
+    organizationId: invitation.organizationId,
+    actorUserId: session.userId,
+    type: "organization.member_joined",
+    metadata: { role: invitation.role, invitedByUserId: invitation.invitedByUserId },
+  });
+
+  return c.json({ organizationId: invitation.organizationId, role: invitation.role });
+});
+
+function publicMember(member: OrganizationMemberEntry) {
+  return {
+    userId: member.userId,
+    email: member.email,
+    name: member.name,
+    role: member.role,
+    isOwner: member.isOwner,
+    joinedAt: member.joinedAt.toISOString(),
+  };
+}
+
+function publicInvitation(invitation: InvitationRecord) {
+  return {
+    id: invitation.id,
+    email: invitation.email,
+    role: invitation.role,
+    status: invitation.status,
+    invitedByUserId: invitation.invitedByUserId,
+    expiresAt: invitation.expiresAt.toISOString(),
+    createdAt: invitation.createdAt.toISOString(),
+    expired: invitation.expiresAt.getTime() <= Date.now(),
+  };
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,6 +9,7 @@ const RegisterPage = lazy(() => import("./pages/Auth/Register"));
 const DashboardPage = lazy(() => import("./pages/Dashboard"));
 const ScanDetailPage = lazy(() => import("./pages/Dashboard/ScanDetail"));
 const SettingsPage = lazy(() => import("./pages/Dashboard/Settings"));
+const InvitePage = lazy(() => import("./pages/Dashboard/Invite"));
 const GithubAppCallbackPage = lazy(() => import("./pages/Dashboard/GithubAppCallback"));
 const NotFoundPage = lazy(() => import("./pages/NotFound"));
 
@@ -24,6 +25,7 @@ export function App() {
           <Route path="/dashboard" component={DashboardPage} />
           <Route path="/dashboard/scans/:id" component={ScanDetailPage} />
           <Route path="/dashboard/settings" component={SettingsPage} />
+          <Route path="/dashboard/invite" component={InvitePage} />
           <Route path="/dashboard/settings/github-app/callback" component={GithubAppCallbackPage} />
           <Route default component={NotFoundPage} />
         </Router>

--- a/src/models/organization-members.ts
+++ b/src/models/organization-members.ts
@@ -1,0 +1,130 @@
+import { computed, createModel, signal } from "@preact/signals";
+import type { OrganizationRole } from "../../server/lib/roles";
+import { apiFetch, apiJson, errorMessage } from "./api";
+
+export interface OrganizationMember {
+  userId: string;
+  email: string | null;
+  name: string | null;
+  role: OrganizationRole;
+  isOwner: boolean;
+  joinedAt: string;
+}
+
+export interface OrganizationInvitation {
+  id: string;
+  email: string;
+  role: OrganizationRole;
+  status: string;
+  invitedByUserId: string | null;
+  expiresAt: string;
+  createdAt: string;
+  expired: boolean;
+}
+
+type MembersStatus = "idle" | "loading" | "inviting" | "revoking" | "removing";
+
+export const MembersModel = createModel(() => {
+  const members = signal<OrganizationMember[]>([]);
+  const invitations = signal<OrganizationInvitation[]>([]);
+  const loaded = signal(false);
+  const status = signal<MembersStatus>("idle");
+  const error = signal<string | null>(null);
+  const busy = computed(() => status.value !== "idle");
+
+  return {
+    members,
+    invitations,
+    loaded,
+    status,
+    error,
+    busy,
+
+    async load(canManage: boolean): Promise<void> {
+      this.status.value = "loading";
+      this.error.value = null;
+      try {
+        const memberData = await apiFetch<{ members: OrganizationMember[] }>(
+          "/api/v1/organizations/members",
+        );
+        this.members.value = memberData.members;
+        if (canManage) {
+          const inviteData = await apiFetch<{ invitations: OrganizationInvitation[] }>(
+            "/api/v1/organizations/invitations",
+          );
+          this.invitations.value = inviteData.invitations;
+        } else {
+          this.invitations.value = [];
+        }
+      } catch (err) {
+        this.error.value = errorMessage(err);
+      } finally {
+        this.loaded.value = true;
+        this.status.value = "idle";
+      }
+    },
+
+    async invite(email: string, role: OrganizationRole): Promise<boolean> {
+      const trimmed = email.trim();
+      if (!trimmed) {
+        this.error.value = "Email is required.";
+        return false;
+      }
+      this.status.value = "inviting";
+      this.error.value = null;
+      try {
+        await apiJson<{ invitation: OrganizationInvitation }>("/api/v1/organizations/invitations", {
+          email: trimmed,
+          role,
+        });
+        await this.refreshInvitations();
+        return true;
+      } catch (err) {
+        this.error.value = errorMessage(err);
+        return false;
+      } finally {
+        this.status.value = "idle";
+      }
+    },
+
+    async revokeInvitation(invitationId: string): Promise<void> {
+      this.status.value = "revoking";
+      this.error.value = null;
+      try {
+        await apiFetch(`/api/v1/organizations/invitations/${encodeURIComponent(invitationId)}`, {
+          method: "DELETE",
+        });
+        await this.refreshInvitations();
+      } catch (err) {
+        this.error.value = errorMessage(err);
+      } finally {
+        this.status.value = "idle";
+      }
+    },
+
+    async removeMember(userId: string): Promise<void> {
+      this.status.value = "removing";
+      this.error.value = null;
+      try {
+        await apiFetch(`/api/v1/organizations/members/${encodeURIComponent(userId)}`, {
+          method: "DELETE",
+        });
+        const memberData = await apiFetch<{ members: OrganizationMember[] }>(
+          "/api/v1/organizations/members",
+        );
+        this.members.value = memberData.members;
+      } catch (err) {
+        this.error.value = errorMessage(err);
+      } finally {
+        this.status.value = "idle";
+      }
+    },
+
+    async refreshInvitations(): Promise<void> {
+      const inviteData = await apiFetch<{ invitations: OrganizationInvitation[] }>(
+        "/api/v1/organizations/invitations",
+      );
+      this.invitations.value = inviteData.invitations;
+    },
+  };
+});

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -13,6 +13,8 @@ export default function LoginPage() {
   const error = useSignal<string | null>(null);
   const loading = useSignal(false);
   const returnTo = normalizeAuthReturnTo(location.query.returnTo);
+  const registerHref =
+    returnTo === "/dashboard" ? "/register" : `/register?returnTo=${encodeURIComponent(returnTo)}`;
 
   useEffect(() => {
     let cancelled = false;
@@ -80,7 +82,7 @@ export default function LoginPage() {
         </form>
 
         <p class="text-[13px] text-ink-muted m-0">
-          New here? <a href="/register">Create an account</a>
+          New here? <a href={registerHref}>Create an account</a>
         </p>
       </Card>
     </PageShell>

--- a/src/pages/Auth/Register.tsx
+++ b/src/pages/Auth/Register.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "preact/hooks";
 import { useSignal } from "@preact/signals";
 import { useLocation } from "preact-iso";
+import { normalizeAuthReturnTo } from "../../lib/auth-return";
 import { sessionModel } from "../../models/auth";
 import { errorMessage } from "../../models/api";
 import { Alert, Button, Card, Eyebrow, Field, Input, PageShell, Muted } from "../../components";
@@ -12,17 +13,20 @@ export default function RegisterPage() {
   const password = useSignal("");
   const error = useSignal<string | null>(null);
   const loading = useSignal(false);
+  const returnTo = normalizeAuthReturnTo(location.query.returnTo);
+  const signInHref =
+    returnTo === "/dashboard" ? "/login" : `/login?returnTo=${encodeURIComponent(returnTo)}`;
 
   useEffect(() => {
     let cancelled = false;
     void sessionModel.load().then((session) => {
       if (cancelled) return;
-      if (session?.user) location.route("/dashboard", true);
+      if (session?.user) location.route(returnTo, true);
     });
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [returnTo]);
 
   const onSubmit = async (event: Event) => {
     event.preventDefault();
@@ -34,7 +38,7 @@ export default function RegisterPage() {
     try {
       await sessionModel.signUp(submittedName, submittedEmail, submittedPassword);
       await sessionModel.signIn(submittedEmail, submittedPassword).catch(() => undefined);
-      location.route("/dashboard", true);
+      location.route(returnTo, true);
     } catch (err) {
       error.value = errorMessage(err);
     } finally {
@@ -92,7 +96,7 @@ export default function RegisterPage() {
         </form>
 
         <p class="text-[13px] text-ink-muted m-0">
-          Already have an account? <a href="/login">Sign in</a>
+          Already have an account? <a href={signInHref}>Sign in</a>
         </p>
       </Card>
     </PageShell>

--- a/src/pages/Dashboard/Invite/index.tsx
+++ b/src/pages/Dashboard/Invite/index.tsx
@@ -1,0 +1,95 @@
+import { useEffect } from "preact/hooks";
+import { useSignal } from "@preact/signals";
+import { useLocation } from "preact-iso";
+import { sessionModel } from "../../../models/auth";
+import { ApiError, apiJson, errorMessage } from "../../../models/api";
+import { setActiveOrganizationId } from "../../../models/active-organization";
+import {
+  Alert,
+  Card,
+  Eyebrow,
+  LinkButton,
+  LoadingState,
+  Muted,
+  PageShell,
+} from "../../../components";
+
+type InviteState = "checking" | "accepting" | "error";
+
+export default function InvitePage() {
+  const location = useLocation();
+  const token = typeof location.query.token === "string" ? location.query.token : "";
+  const state = useSignal<InviteState>("checking");
+  const error = useSignal<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      if (!token) {
+        if (cancelled) return;
+        error.value = "This invitation link is missing its token.";
+        state.value = "error";
+        return;
+      }
+      const session = await sessionModel.load();
+      if (cancelled) return;
+      if (!session?.user) {
+        redirectToLogin(location, token);
+        return;
+      }
+      state.value = "accepting";
+      try {
+        const data = await apiJson<{ organizationId: string; role: string }>(
+          "/api/v1/organizations/invitations/accept",
+          { token },
+        );
+        if (cancelled) return;
+        setActiveOrganizationId(data.organizationId);
+        location.route("/dashboard", true);
+      } catch (err) {
+        if (cancelled) return;
+        if (err instanceof ApiError && err.status === 401) {
+          redirectToLogin(location, token);
+          return;
+        }
+        error.value = errorMessage(err);
+        state.value = "error";
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  if (state.value === "error") {
+    return (
+      <PageShell width="narrow">
+        <Card class="flex flex-col gap-4">
+          <Eyebrow>Organization invitation</Eyebrow>
+          <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">
+            We couldn't accept this invite
+          </h1>
+          {error.value ? <Alert tone="critical">{error.value}</Alert> : null}
+          <Muted class="text-[13px] m-0">
+            Ask the person who invited you to send a fresh invitation, then open the new link.
+          </Muted>
+          <LinkButton href="/dashboard">Go to dashboard</LinkButton>
+        </Card>
+      </PageShell>
+    );
+  }
+
+  return (
+    <PageShell width="narrow">
+      <LoadingState
+        title="Joining organization"
+        detail={state.value === "accepting" ? "accepting invitation" : "confirming session"}
+      />
+    </PageShell>
+  );
+}
+
+function redirectToLogin(location: ReturnType<typeof useLocation>, token: string): void {
+  const returnTo = `/dashboard/invite?token=${encodeURIComponent(token)}`;
+  location.route(`/login?returnTo=${encodeURIComponent(returnTo)}`, true);
+}

--- a/src/pages/Dashboard/Settings/OrganizationMembersSection.tsx
+++ b/src/pages/Dashboard/Settings/OrganizationMembersSection.tsx
@@ -1,0 +1,243 @@
+import { useModel, useSignal } from "@preact/signals";
+import type { OrganizationRole } from "../../../../server/lib/roles";
+import { formatTimestamp } from "../../../lib/format";
+import {
+  MembersModel,
+  type OrganizationInvitation,
+  type OrganizationMember,
+} from "../../../models/organization-members";
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  Field,
+  Input,
+  MonoDetail,
+  Muted,
+  SectionLabel,
+  Select,
+  type BadgeTone,
+} from "../../../components";
+
+export function OrganizationMembersSection({
+  members,
+  currentUserRole,
+  currentUserId,
+}: {
+  members: ReturnType<typeof useModel<typeof MembersModel.prototype>>;
+  currentUserRole: OrganizationRole | null;
+  currentUserId: string | null;
+}) {
+  const canManage = currentUserRole === "owner" || currentUserRole === "admin";
+  const inviteEmail = useSignal("");
+  const inviteRole = useSignal<OrganizationRole>("member");
+  const memberList: OrganizationMember[] = members.members.value;
+  const invitations: OrganizationInvitation[] = members.invitations.value;
+  const status = members.status.value;
+  const busy = members.busy.value;
+  const error = members.error.value;
+
+  const onInvite = async (event: Event) => {
+    event.preventDefault();
+    const email = inviteEmail.value;
+    const role = inviteRole.value;
+    const ok = await members.invite(email, role);
+    if (ok) {
+      inviteEmail.value = "";
+      inviteRole.value = "member";
+    }
+  };
+
+  return (
+    <Card as="section" class="p-0 overflow-hidden">
+      <div class="p-5 flex flex-col gap-5">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+          <div class="flex flex-col gap-1.5 max-w-[760px]">
+            <SectionLabel>Members</SectionLabel>
+            <Muted class="text-[13px] m-0">
+              Invite teammates to collaborate on this organization's release targets, integrations,
+              and gate reviews. Owners and admins manage membership; members get read access to
+              org-scoped scans and can act on releases.
+            </Muted>
+          </div>
+          <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle shrink-0">
+            {memberList.length} {memberList.length === 1 ? "member" : "members"}
+          </span>
+        </div>
+
+        {error ? <Alert tone="critical">{error}</Alert> : null}
+
+        {canManage ? (
+          <form
+            class="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,200px)_auto] gap-3 items-end"
+            onSubmit={onInvite}
+          >
+            <Field label="Invite by email" for="inviteEmail">
+              <Input
+                id="inviteEmail"
+                type="email"
+                value={inviteEmail}
+                placeholder="teammate@example.com"
+                onInput={(e) => (inviteEmail.value = (e.target as HTMLInputElement).value)}
+                disabled={busy}
+                autoComplete="off"
+              />
+            </Field>
+            <Field label="Role" for="inviteRole">
+              <Select
+                id="inviteRole"
+                value={inviteRole.value}
+                disabled={busy}
+                onChange={(value) => (inviteRole.value = value as OrganizationRole)}
+              >
+                <option value="member">member</option>
+                <option value="admin">admin</option>
+              </Select>
+            </Field>
+            <Button type="submit" disabled={busy || !inviteEmail.value.trim()} class="shrink-0">
+              {status === "inviting" ? "Sending…" : "Send invite"}
+            </Button>
+          </form>
+        ) : null}
+      </div>
+
+      <div class="border-t border-border">
+        <MemberList
+          members={memberList}
+          canManage={canManage}
+          currentUserId={currentUserId}
+          busy={busy}
+          onRemove={(userId) => void members.removeMember(userId)}
+        />
+      </div>
+
+      {canManage ? (
+        <div class="border-t border-border">
+          <div class="px-5 py-4 flex items-center justify-between gap-3">
+            <SectionLabel>Pending invites</SectionLabel>
+            <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
+              {invitations.length} pending
+            </span>
+          </div>
+          {invitations.length ? (
+            <InvitationList
+              invitations={invitations}
+              busy={busy}
+              onRevoke={(id) => void members.revokeInvitation(id)}
+            />
+          ) : (
+            <div class="px-5 pb-5">
+              <Muted class="text-[13px] m-0">No pending invitations.</Muted>
+            </div>
+          )}
+        </div>
+      ) : null}
+    </Card>
+  );
+}
+
+function MemberList({
+  members,
+  canManage,
+  currentUserId,
+  busy,
+  onRemove,
+}: {
+  members: OrganizationMember[];
+  canManage: boolean;
+  currentUserId: string | null;
+  busy: boolean;
+  onRemove: (userId: string) => void;
+}) {
+  return (
+    <ul class="m-0 p-0 list-none">
+      {members.map((member) => {
+        const removable = canManage && !member.isOwner && member.userId !== currentUserId;
+        return (
+          <li
+            key={member.userId}
+            class="border-b border-border last:border-b-0 px-5 py-4 flex flex-wrap items-center justify-between gap-3"
+          >
+            <div class="flex flex-col gap-1.5 min-w-0">
+              <div class="flex items-center gap-2 flex-wrap">
+                <span class="text-[14px] font-medium text-ink truncate">
+                  {member.name || member.email || member.userId}
+                </span>
+                <Badge tone={roleTone(member.role)}>{member.role}</Badge>
+              </div>
+              <MonoDetail
+                parts={[
+                  <span key="email">{member.email ?? "no email on record"}</span>,
+                  <span key="joined">joined {formatTimestamp(member.joinedAt)}</span>,
+                ]}
+              />
+            </div>
+            {removable ? (
+              <Button
+                variant="danger"
+                size="sm"
+                disabled={busy}
+                onClick={() => onRemove(member.userId)}
+                class="shrink-0"
+              >
+                Remove
+              </Button>
+            ) : null}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+function InvitationList({
+  invitations,
+  busy,
+  onRevoke,
+}: {
+  invitations: OrganizationInvitation[];
+  busy: boolean;
+  onRevoke: (id: string) => void;
+}) {
+  return (
+    <ul class="m-0 p-0 list-none border-t border-border">
+      {invitations.map((invitation) => (
+        <li
+          key={invitation.id}
+          class="border-b border-border last:border-b-0 px-5 py-4 flex flex-wrap items-center justify-between gap-3"
+        >
+          <div class="flex flex-col gap-1.5 min-w-0">
+            <div class="flex items-center gap-2 flex-wrap">
+              <span class="text-[14px] font-medium text-ink truncate">{invitation.email}</span>
+              <Badge tone={roleTone(invitation.role)}>{invitation.role}</Badge>
+              {invitation.expired ? <Badge tone="critical">expired</Badge> : null}
+            </div>
+            <MonoDetail
+              parts={[
+                <span key="expires">
+                  {invitation.expired ? "expired" : "expires"}{" "}
+                  {formatTimestamp(invitation.expiresAt)}
+                </span>,
+                <span key="created">invited {formatTimestamp(invitation.createdAt)}</span>,
+              ]}
+            />
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={busy}
+            onClick={() => onRevoke(invitation.id)}
+            class="shrink-0"
+          >
+            Revoke
+          </Button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function roleTone(role: OrganizationRole): BadgeTone {
+  return role === "owner" ? "info" : "neutral";
+}

--- a/src/pages/Dashboard/Settings/index.tsx
+++ b/src/pages/Dashboard/Settings/index.tsx
@@ -6,6 +6,12 @@ import { sessionModel } from "../../../models/auth";
 import { NpmConnectionModel } from "../../../models/npm-connection";
 import { OrganizationModel } from "../../../models/organization";
 import { GithubAppModel } from "../../../models/github-app";
+import { MembersModel } from "../../../models/organization-members";
+import {
+  normalizeRole,
+  roleCanManageMembers,
+  type OrganizationRole,
+} from "../../../../server/lib/roles";
 import {
   Eyebrow,
   LoadingState,
@@ -16,12 +22,14 @@ import {
 } from "../../../components";
 import { GithubAppSection } from "./GithubAppSection";
 import { NpmConnectionSection } from "./NpmConnectionSection";
+import { OrganizationMembersSection } from "./OrganizationMembersSection";
 
 export default function SettingsPage() {
   const location = useLocation();
   const npm = useModel(NpmConnectionModel);
   const organizations = useModel(OrganizationModel);
   const githubApp = useModel(GithubAppModel);
+  const members = useModel(MembersModel);
   const sessionChecked = useSignal(false);
 
   useEffect(() => {
@@ -44,6 +52,7 @@ export default function SettingsPage() {
         githubApp.loadConfig(),
         githubApp.loadInstallations(),
         githubApp.loadReleaseTargets(),
+        members.load(canManageMembers(organizations)),
       ]);
     })();
     return () => {
@@ -52,7 +61,7 @@ export default function SettingsPage() {
   }, []);
 
   const reloadActiveOrgScopedData = async () => {
-    const loaders: Promise<unknown>[] = [npm.load()];
+    const loaders: Promise<unknown>[] = [npm.load(), members.load(canManageMembers(organizations))];
     githubApp.clearForm();
     if (!githubApp.configLoaded.peek()) loaders.push(githubApp.loadConfig());
     loaders.push(githubApp.loadInstallations(), githubApp.loadReleaseTargets());
@@ -113,12 +122,30 @@ export default function SettingsPage() {
         <div class="flex flex-col gap-6">
           <NpmConnectionSection npm={npm} />
           <GithubAppSection githubApp={githubApp} />
+          <OrganizationMembersSection
+            members={members}
+            currentUserRole={activeRole(organizations)}
+            currentUserId={user?.id ?? null}
+          />
         </div>
       ) : (
         <LoadingState title="Loading settings" detail={loadingDetail(npmLoaded, githubAppLoaded)} />
       )}
     </PageShell>
   );
+}
+
+function activeRole(
+  organizations: ReturnType<typeof useModel<typeof OrganizationModel.prototype>>,
+): OrganizationRole | null {
+  const role = organizations.active.value?.role;
+  return role ? normalizeRole(role) : null;
+}
+
+function canManageMembers(
+  organizations: ReturnType<typeof useModel<typeof OrganizationModel.prototype>>,
+): boolean {
+  return roleCanManageMembers(activeRole(organizations));
 }
 
 function loadingDetail(npmLoaded: boolean, githubAppLoaded: boolean): string {

--- a/test/workers/organization-members-routes.test.ts
+++ b/test/workers/organization-members-routes.test.ts
@@ -1,0 +1,339 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { describe, expect, test } from "vitest";
+import {
+  addOrganizationMember,
+  createDb,
+  ensurePersonalOrganization,
+  getOrganizationRole,
+  listPendingInvitations,
+  upsertInvitation,
+} from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { ACTIVE_ORG_HEADER } from "../../server/lib/active-organization";
+import { generateInvitationToken } from "../../server/lib/invitation-token";
+import type { OrganizationRole } from "../../server/lib/roles";
+import { organizationMembersRoutes } from "../../server/routes/organization-members";
+import { organizationsRoutes } from "../../server/routes/organizations";
+import type { Bindings, Variables } from "../../server/types";
+
+interface SeededUser {
+  userId: string;
+  email: string;
+  personalOrganizationId: string;
+}
+
+async function seedUser(): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  const email = `${userId}@example.com`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const personalOrganizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, email, personalOrganizationId };
+}
+
+function buildTestApp(session: { userId: string }) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.use("*", async (c, next) => {
+    c.set("authSession", { userId: session.userId });
+    await next();
+  });
+  app.route("/api/v1/organizations", organizationsRoutes);
+  app.route("/api/v1/organizations", organizationMembersRoutes);
+  return app;
+}
+
+async function call(
+  app: Hono<{ Bindings: Bindings; Variables: Variables }>,
+  method: string,
+  path: string,
+  options: { body?: unknown; activeOrganizationId?: string } = {},
+) {
+  const ctx = createExecutionContext();
+  const headers: Record<string, string> = {};
+  const init: RequestInit = { method };
+  if (options.body !== undefined) {
+    init.body = JSON.stringify(options.body);
+    headers["content-type"] = "application/json";
+  }
+  if (options.activeOrganizationId) {
+    headers[ACTIVE_ORG_HEADER] = options.activeOrganizationId;
+  }
+  init.headers = headers;
+  const res = await app.fetch(new Request(`http://test.local${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+async function createOrganization(owner: SeededUser, name: string): Promise<string> {
+  const res = await call(buildTestApp(owner), "POST", "/api/v1/organizations", { body: { name } });
+  const body = (await res.json()) as { organization: { id: string } };
+  return body.organization.id;
+}
+
+async function seedInvitation(input: {
+  owner: SeededUser;
+  organizationId: string;
+  email: string;
+  role: OrganizationRole;
+  expiresAt?: Date;
+}): Promise<{ id: string; token: string }> {
+  const db = createDb(env.DB);
+  const { token, tokenHash } = await generateInvitationToken();
+  const invitation = await upsertInvitation(db, {
+    organizationId: input.organizationId,
+    email: input.email,
+    role: input.role,
+    tokenHash,
+    invitedByUserId: input.owner.userId,
+    expiresAt: input.expiresAt ?? new Date(Date.now() + 60_000),
+  });
+  return { id: invitation.id, token };
+}
+
+describe("organization member routes", () => {
+  test("owner invites a teammate and the invite appears as pending", async () => {
+    const owner = await seedUser();
+    const organizationId = await createOrganization(owner, "acme");
+
+    const invite = await call(buildTestApp(owner), "POST", "/api/v1/organizations/invitations", {
+      body: { email: "teammate@example.com", role: "admin" },
+      activeOrganizationId: organizationId,
+    });
+    expect(invite.status).toBe(201);
+    const invited = (await invite.json()) as {
+      invitation: { email: string; role: string; status: string };
+    };
+    expect(invited.invitation.email).toBe("teammate@example.com");
+    expect(invited.invitation.role).toBe("admin");
+
+    const list = await call(buildTestApp(owner), "GET", "/api/v1/organizations/invitations", {
+      activeOrganizationId: organizationId,
+    });
+    const listed = (await list.json()) as { invitations: Array<{ email: string }> };
+    expect(listed.invitations.map((i) => i.email)).toContain("teammate@example.com");
+  });
+
+  test("the invite response never leaks the bearer token", async () => {
+    const owner = await seedUser();
+    const organizationId = await createOrganization(owner, "leak-check");
+
+    const invite = await call(buildTestApp(owner), "POST", "/api/v1/organizations/invitations", {
+      body: { email: "teammate@example.com" },
+      activeOrganizationId: organizationId,
+    });
+    const text = await invite.text();
+    expect(text).not.toContain("token");
+  });
+
+  test("a plain member cannot manage membership", async () => {
+    const owner = await seedUser();
+    const member = await seedUser();
+    const organizationId = await createOrganization(owner, "scoped");
+    const db = createDb(env.DB);
+    await addOrganizationMember(db, { organizationId, userId: member.userId, role: "member" });
+
+    const memberApp = buildTestApp(member);
+    const listInvites = await call(memberApp, "GET", "/api/v1/organizations/invitations", {
+      activeOrganizationId: organizationId,
+    });
+    expect(listInvites.status).toBe(403);
+
+    const invite = await call(memberApp, "POST", "/api/v1/organizations/invitations", {
+      body: { email: "nope@example.com" },
+      activeOrganizationId: organizationId,
+    });
+    expect(invite.status).toBe(403);
+
+    const remove = await call(
+      memberApp,
+      "DELETE",
+      `/api/v1/organizations/members/${owner.userId}`,
+      { activeOrganizationId: organizationId },
+    );
+    expect(remove.status).toBe(403);
+
+    // A member can still read the roster.
+    const members = await call(memberApp, "GET", "/api/v1/organizations/members", {
+      activeOrganizationId: organizationId,
+    });
+    expect(members.status).toBe(200);
+  });
+
+  test("an admin can invite teammates", async () => {
+    const owner = await seedUser();
+    const admin = await seedUser();
+    const organizationId = await createOrganization(owner, "admin-org");
+    const db = createDb(env.DB);
+    await addOrganizationMember(db, { organizationId, userId: admin.userId, role: "admin" });
+
+    const invite = await call(buildTestApp(admin), "POST", "/api/v1/organizations/invitations", {
+      body: { email: "fromadmin@example.com" },
+      activeOrganizationId: organizationId,
+    });
+    expect(invite.status).toBe(201);
+  });
+
+  test("the invited user accepts and becomes a member with the invited role", async () => {
+    const owner = await seedUser();
+    const invitee = await seedUser();
+    const organizationId = await createOrganization(owner, "join-me");
+    const { token } = await seedInvitation({
+      owner,
+      organizationId,
+      email: invitee.email,
+      role: "admin",
+    });
+
+    const accept = await call(
+      buildTestApp(invitee),
+      "POST",
+      "/api/v1/organizations/invitations/accept",
+      { body: { token } },
+    );
+    expect(accept.status).toBe(200);
+    const accepted = (await accept.json()) as { organizationId: string; role: string };
+    expect(accepted.organizationId).toBe(organizationId);
+    expect(accepted.role).toBe("admin");
+
+    const db = createDb(env.DB);
+    expect(await getOrganizationRole(db, organizationId, invitee.userId)).toBe("admin");
+  });
+
+  test("a leaked link cannot enroll a different account", async () => {
+    const owner = await seedUser();
+    const invitee = await seedUser();
+    const stranger = await seedUser();
+    const organizationId = await createOrganization(owner, "leak-target");
+    const { token } = await seedInvitation({
+      owner,
+      organizationId,
+      email: invitee.email,
+      role: "member",
+    });
+
+    const accept = await call(
+      buildTestApp(stranger),
+      "POST",
+      "/api/v1/organizations/invitations/accept",
+      { body: { token } },
+    );
+    expect(accept.status).toBe(403);
+
+    const db = createDb(env.DB);
+    expect(await getOrganizationRole(db, organizationId, stranger.userId)).toBeNull();
+  });
+
+  test("an expired invitation cannot be accepted", async () => {
+    const owner = await seedUser();
+    const invitee = await seedUser();
+    const organizationId = await createOrganization(owner, "expired-org");
+    const { token } = await seedInvitation({
+      owner,
+      organizationId,
+      email: invitee.email,
+      role: "member",
+      expiresAt: new Date(Date.now() - 1_000),
+    });
+
+    const accept = await call(
+      buildTestApp(invitee),
+      "POST",
+      "/api/v1/organizations/invitations/accept",
+      { body: { token } },
+    );
+    expect(accept.status).toBe(410);
+  });
+
+  test("revoking an invite prevents it from being accepted", async () => {
+    const owner = await seedUser();
+    const invitee = await seedUser();
+    const organizationId = await createOrganization(owner, "revoke-org");
+    const { id, token } = await seedInvitation({
+      owner,
+      organizationId,
+      email: invitee.email,
+      role: "member",
+    });
+
+    const revoke = await call(
+      buildTestApp(owner),
+      "DELETE",
+      `/api/v1/organizations/invitations/${id}`,
+      { activeOrganizationId: organizationId },
+    );
+    expect(revoke.status).toBe(200);
+
+    const db = createDb(env.DB);
+    expect(await listPendingInvitations(db, organizationId)).toHaveLength(0);
+
+    const accept = await call(
+      buildTestApp(invitee),
+      "POST",
+      "/api/v1/organizations/invitations/accept",
+      { body: { token } },
+    );
+    expect(accept.status).toBe(409);
+  });
+
+  test("owner removes a member but cannot remove the owner", async () => {
+    const owner = await seedUser();
+    const member = await seedUser();
+    const organizationId = await createOrganization(owner, "remove-org");
+    const db = createDb(env.DB);
+    await addOrganizationMember(db, { organizationId, userId: member.userId, role: "member" });
+
+    const removeOwner = await call(
+      buildTestApp(owner),
+      "DELETE",
+      `/api/v1/organizations/members/${owner.userId}`,
+      { activeOrganizationId: organizationId },
+    );
+    expect(removeOwner.status).toBe(400);
+
+    const removeMember = await call(
+      buildTestApp(owner),
+      "DELETE",
+      `/api/v1/organizations/members/${member.userId}`,
+      { activeOrganizationId: organizationId },
+    );
+    expect(removeMember.status).toBe(200);
+    expect(await getOrganizationRole(db, organizationId, member.userId)).toBeNull();
+
+    const removeAgain = await call(
+      buildTestApp(owner),
+      "DELETE",
+      `/api/v1/organizations/members/${member.userId}`,
+      { activeOrganizationId: organizationId },
+    );
+    expect(removeAgain.status).toBe(404);
+  });
+
+  test("GET /members lists the owner first", async () => {
+    const owner = await seedUser();
+    const member = await seedUser();
+    const organizationId = await createOrganization(owner, "roster");
+    const db = createDb(env.DB);
+    await addOrganizationMember(db, { organizationId, userId: member.userId, role: "member" });
+
+    const res = await call(buildTestApp(owner), "GET", "/api/v1/organizations/members", {
+      activeOrganizationId: organizationId,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      members: Array<{ userId: string; isOwner: boolean; role: string }>;
+    };
+    expect(body.members).toHaveLength(2);
+    expect(body.members[0]?.isOwner).toBe(true);
+    expect(body.members[0]?.userId).toBe(owner.userId);
+    expect(body.members[0]?.role).toBe("owner");
+  });
+});


### PR DESCRIPTION
## Summary

Implements [#163](https://github.com/JoviDeCroock/drydock/issues/163) — invite teammates to an organization by email, accept via a hashed bearer-token link, and gate sensitive actions by role.

- **Roles**: three roles (`owner`/`admin`/`member`) in `server/lib/roles.ts`. Owner/admin gate member management, npm-connection mutations, and GitHub App install / release-target CRUD; members keep read access and can act on releases. The owner can't be removed or demoted via the API.
- **Invitations**: new `organization_invitations` table (migration `0014`) storing only the SHA-256 hash of a 32-byte bearer token, with a 7-day expiry and one live invite per `(org, email)` (re-invite rotates the token in place). The raw token is emailed via `notifyOrganizationInvite` and is **never** returned by any API response.
- **API** (mounted at `/api/v1/organizations`): list/remove members, list/create/revoke invitations (owner/admin), and a token `accept` endpoint that is deliberately **not** `x-organization-id` scoped — the org is resolved from the token and the caller's account email must equal the invited address, so a leaked link can't enroll a third party. Accept out of `pending` is a compare-and-swap. Audit events recorded throughout.
- **UI**: a Members section in settings (roster + invite form + pending invites, management controls only for owners/admins) and a `/dashboard/invite` accept page. Login/Register now forward `returnTo` so a brand-new invitee can sign up and land back on the invite.

## Test plan

- [x] `pnpm run verify` (lint + format + typecheck + 468 tests) green
- [x] 10 new worker route tests in `test/workers/organization-members-routes.test.ts`: invite creation, token-never-leaked, role enforcement (member 403 / admin allowed), accept → membership, leaked-link rejection, expiry (410), revoke-then-accept (409), owner-removal guard (400/404), roster ordering
- [ ] Manual: send an invite, accept it from a fresh account, confirm role + active-org switch
- [ ] Manual: verify a `member` sees no management controls and gets 403 on management routes

Note: `pnpm run test:e2e` not run — changes don't touch registry / staged-publish / scan-workflow / credential paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)