### PR TITLE
Filter already-mapped repos from release target picker

### DIFF
--- a/src/models/github-app.ts
+++ b/src/models/github-app.ts
@@ -120,6 +120,19 @@ export type ReleaseTargetFormStatus = "idle" | "submitting";
 export type RepositoryListStatus = "idle" | "loading" | "error";
 export type EnvironmentListStatus = "idle" | "loading" | "error";
 
+// A release target is unique per (org, repositoryId, environment). The picker
+// already scopes to the org, so a repository that already has any release
+// target is dropped from the options to keep the user from re-submitting a
+// duplicate.
+export function selectUnmappedRepositories(
+  repositories: InstallationRepository[],
+  releaseTargets: Pick<PublicReleaseTarget, "repositoryId">[],
+): InstallationRepository[] {
+  if (!releaseTargets.length) return repositories;
+  const mapped = new Set(releaseTargets.map((target) => target.repositoryId));
+  return repositories.filter((repo) => !mapped.has(repo.id));
+}
+
 export const GithubAppModel = createModel(() => {
   const config = signal<GithubAppConfigState | null>(null);
   const installations = signal<PublicGithubAppInstallation[]>([]);
@@ -170,6 +183,9 @@ export const GithubAppModel = createModel(() => {
     const errors = repositoryErrors.value;
     return id ? (errors[id] ?? null) : null;
   });
+  const availableRepositories = computed<InstallationRepository[]>(() =>
+    selectUnmappedRepositories(activeRepositories.value, releaseTargets.value),
+  );
 
   const environmentCacheKey = computed<string>(() => {
     const installationId = formInstallationRowId.value;
@@ -256,6 +272,7 @@ export const GithubAppModel = createModel(() => {
     activeRepositories,
     activeRepositoryStatus,
     activeRepositoryError,
+    availableRepositories,
     activeEnvironments,
     activeEnvironmentStatus,
     activeEnvironmentError,

--- a/src/pages/Dashboard/Settings/ReleaseTargetForm.tsx
+++ b/src/pages/Dashboard/Settings/ReleaseTargetForm.tsx
@@ -57,9 +57,13 @@ function RepositorySelector({ githubApp }: { githubApp: GithubApp }) {
   const installationRowId = githubApp.formInstallationRowId.value;
   const repositoryFullName = githubApp.formRepositoryFullName.value;
   const submitting = githubApp.formSubmitting.value;
-  const repositories = githubApp.activeRepositories.value;
+  const repositories = githubApp.availableRepositories.value;
+  const accessibleCount = githubApp.activeRepositories.value.length;
   const repositoryStatus = githubApp.activeRepositoryStatus.value;
   const repositoryError = githubApp.activeRepositoryError.value;
+  // Repositories disappear from the picker once they have a release target, so
+  // an empty list with accessible repos behind it means every one is mapped.
+  const allMapped = accessibleCount > 0 && repositories.length === 0;
 
   return (
     <Field label="Repository" for="releaseTargetRepo">
@@ -76,7 +80,9 @@ function RepositorySelector({ githubApp }: { githubApp: GithubApp }) {
               ? "Loading repositories…"
               : repositories.length
                 ? "Pick a repository…"
-                : "No repositories visible"}
+                : allMapped
+                  ? "All repositories already mapped"
+                  : "No repositories visible"}
         </option>
         {repositories.map((repo: { id: number; fullName: string }) => (
           <option key={repo.id} value={repo.fullName}>
@@ -87,10 +93,16 @@ function RepositorySelector({ githubApp }: { githubApp: GithubApp }) {
       {repositoryError ? (
         <Muted class="text-[12px] mt-1.5 text-danger">{repositoryError}</Muted>
       ) : null}
+      {installationRowId && !repositoryError && repositoryStatus === "idle" && allMapped ? (
+        <Muted class="text-[12px] mt-1.5">
+          Every repository this installation can see already has a release target. Remove one below
+          to remap it, or grant the GitHub App access to another repository.
+        </Muted>
+      ) : null}
       {installationRowId &&
       !repositoryError &&
       repositoryStatus === "idle" &&
-      !repositories.length ? (
+      accessibleCount === 0 ? (
         <Muted class="text-[12px] mt-1.5">
           This installation has no accessible repositories. Grant the GitHub App access to a
           repository in{" "}

--- a/test/release-target-repository-filter.test.ts
+++ b/test/release-target-repository-filter.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vitest";
+import {
+  selectUnmappedRepositories,
+  type InstallationRepository,
+  type PublicReleaseTarget,
+} from "../src/models/github-app.ts";
+
+const repos: InstallationRepository[] = [
+  { id: 1, fullName: "octo/alpha", defaultBranch: "main" },
+  { id: 2, fullName: "octo/beta", defaultBranch: "main" },
+  { id: 3, fullName: "octo/gamma", defaultBranch: null },
+];
+
+function target(repositoryId: number): PublicReleaseTarget {
+  return {
+    id: `rt_${repositoryId}`,
+    organizationId: "org_1",
+    installationRowId: "inst_1",
+    ecosystem: "pypi",
+    repositoryId,
+    repositoryFullName: "octo/whatever",
+    environment: "pypi-release",
+    createdAt: "2026-06-01T00:00:00.000Z",
+    updatedAt: "2026-06-01T00:00:00.000Z",
+  };
+}
+
+describe("selectUnmappedRepositories", () => {
+  test("returns every repository when nothing is mapped yet", () => {
+    expect(selectUnmappedRepositories(repos, [])).toEqual(repos);
+  });
+
+  test("drops repositories that already have a release target", () => {
+    const available = selectUnmappedRepositories(repos, [target(2)]);
+    expect(available.map((repo) => repo.id)).toEqual([1, 3]);
+  });
+
+  test("matches on repository id, not full name, so renames still hide the repo", () => {
+    const renamed = target(1);
+    renamed.repositoryFullName = "octo/alpha-renamed";
+    const available = selectUnmappedRepositories(repos, [renamed]);
+    expect(available.map((repo) => repo.id)).toEqual([2, 3]);
+  });
+
+  test("returns an empty list once every accessible repo is mapped", () => {
+    const allMapped = selectUnmappedRepositories(repos, [target(1), target(2), target(3)]);
+    expect(allMapped).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- A release target is unique per `(org, repository, environment)`. Today the repository dropdown lists every accessible repo, so re-picking one that already has a target only fails on submit with `environment_already_mapped`.
- Filter the repository picker to hide repos that already have a release target in the org (matched on GitHub `repositoryId`, so renames still hide the repo).
- Add an "all repositories already mapped" empty state distinct from the existing "no accessible repositories" message.

## Note / tradeoff
The unique key is `(repo, environment)`, but environments are lazy-loaded per repo so we can't cheaply tell whether a repo still has *unmapped* environments. This filters at the repo level — i.e. one release target per repo. If you want a repo to support multiple environment targets, we'd instead filter the **environment** dropdown for the selected repo. Flagging in case multi-environment-per-repo is a real use case.

## Test plan
- [x] `pnpm run verify` (lint, format, typecheck, 472 tests)
- [x] New unit test `test/release-target-repository-filter.test.ts` covers: no-op when nothing mapped, drops mapped repos, matches on id (rename-safe), empty when all mapped
- [ ] Manual: open Settings → Release targets, confirm a mapped repo drops out of the picker after creating a target and the empty-state copy reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)