### PR TITLE
Make settings sections foldable and reorder Members first

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,5 +1,6 @@
 import type { ComponentChildren } from "preact";
 import { cn } from "./cn";
+import { SectionLabel } from "./Typography";
 
 export function Card({
   class: className,
@@ -12,6 +13,38 @@ export function Card({
 }) {
   return (
     <As class={cn("bg-surface border border-border rounded-lg p-6", className)}>{children}</As>
+  );
+}
+
+export function CollapsibleCard({
+  title,
+  aside,
+  defaultOpen = false,
+  class: className,
+  children,
+}: {
+  title: ComponentChildren;
+  aside?: ComponentChildren;
+  defaultOpen?: boolean;
+  class?: string;
+  children: ComponentChildren;
+}) {
+  return (
+    <Card as="section" class={cn("p-0 overflow-hidden", className)}>
+      <details open={defaultOpen} class="group">
+        <summary class="list-none cursor-pointer flex items-center gap-2.5 px-5 py-4 transition-colors hover:bg-surface-2">
+          <span
+            aria-hidden
+            class="text-ink-subtle text-[10px] inline-block transition-transform duration-150 ease-out group-open:rotate-90"
+          >
+            ▸
+          </span>
+          <SectionLabel class="flex-1">{title}</SectionLabel>
+          {aside ? <div class="flex items-center gap-2 shrink-0">{aside}</div> : null}
+        </summary>
+        <div class="border-t border-border">{children}</div>
+      </details>
+    </Card>
   );
 }
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,7 +9,7 @@ export type { Severity, Status, BadgeTone } from "./Badge";
 export { Alert } from "./Alert";
 export type { AlertTone } from "./Alert";
 export { Dialog } from "./Dialog";
-export { Card, SummaryCard } from "./Card";
+export { Card, CollapsibleCard, SummaryCard } from "./Card";
 export type { SummaryCardTone, SummaryCardValue } from "./Card";
 export { PageShell } from "./PageShell";
 export { BrandMark } from "./BrandMark";

--- a/src/pages/Dashboard/Settings/GithubAppSection.tsx
+++ b/src/pages/Dashboard/Settings/GithubAppSection.tsx
@@ -1,4 +1,3 @@
-import type { ComponentChildren } from "preact";
 import { useModel } from "@preact/signals";
 import { formatTimestamp } from "../../../lib/format";
 import {
@@ -11,7 +10,7 @@ import {
   Alert,
   Badge,
   Button,
-  Card,
+  CollapsibleCard,
   MonoDetail,
   Muted,
   SectionLabel,
@@ -42,35 +41,36 @@ export function GithubAppSection({
   };
 
   return (
-    <Card as="section" class="p-0 overflow-hidden">
+    <CollapsibleCard
+      title="GitHub App"
+      aside={
+        <div class="flex flex-col items-end gap-2">
+          {configured ? (
+            <Badge tone="ok">configured</Badge>
+          ) : (
+            <Badge tone="info">not configured</Badge>
+          )}
+          {configured && appSlug ? (
+            <span class="font-mono text-[11px] text-ink-subtle">{appSlug}</span>
+          ) : null}
+        </div>
+      }
+    >
       <div class="p-5 flex flex-col gap-5">
-        <div class="flex flex-wrap items-start justify-between gap-3">
-          <div class="flex flex-col gap-1.5 max-w-[760px]">
-            <SectionLabel>GitHub App</SectionLabel>
-            <Muted class="text-[13px] m-0">
-              Install the Drydock GitHub App on your organization so releases gated by a GitHub
-              Actions environment can be approved here. Drydock never asks for publish credentials —
-              your workflow keeps its own OIDC/Trusted Publishing trust and Drydock only acts as the
-              deployment-protection approver.
-            </Muted>
-            <MonoDetail
-              parts={[
-                <span key="ecosystem">workflow gate</span>,
-                <span key="oidc">no publish credentials</span>,
-                <span key="env">github environment required</span>,
-              ]}
-            />
-          </div>
-          <div class="flex flex-col items-end gap-2 shrink-0">
-            {configured ? (
-              <Badge tone="ok">configured</Badge>
-            ) : (
-              <Badge tone="info">not configured</Badge>
-            )}
-            {configured && appSlug ? (
-              <span class="font-mono text-[11px] text-ink-subtle">{appSlug}</span>
-            ) : null}
-          </div>
+        <div class="flex flex-col gap-1.5 max-w-[760px]">
+          <Muted class="text-[13px] m-0">
+            Install the Drydock GitHub App on your organization so releases gated by a GitHub
+            Actions environment can be approved here. Drydock never asks for publish credentials —
+            your workflow keeps its own OIDC/Trusted Publishing trust and Drydock only acts as the
+            deployment-protection approver.
+          </Muted>
+          <MonoDetail
+            parts={[
+              <span key="ecosystem">workflow gate</span>,
+              <span key="oidc">no publish credentials</span>,
+              <span key="env">github environment required</span>,
+            ]}
+          />
         </div>
 
         {!configured ? (
@@ -104,8 +104,6 @@ export function GithubAppSection({
             You'll be sent to GitHub to pick which account to install on, then returned here.
           </Muted>
         </div>
-
-        <PypiGateSetupGuide />
       </div>
 
       <div class="border-t border-border">
@@ -154,7 +152,7 @@ export function GithubAppSection({
           />
         ) : null}
       </div>
-    </Card>
+    </CollapsibleCard>
   );
 }
 
@@ -247,89 +245,4 @@ function installationStatusTone(status: InstallationStatus): BadgeTone {
     case "uninstalled":
       return "critical";
   }
-}
-
-function PypiGateSetupGuide() {
-  return (
-    <div class="border border-border rounded-lg bg-surface-2 px-4 py-3 flex flex-col gap-4">
-      <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">
-        gate setup
-      </span>
-      <ol class="m-0 p-0 list-none flex flex-col gap-3">
-        <SetupStep
-          index="01"
-          title="Install the GitHub App"
-          detail="Install Drydock on the GitHub organization that owns the release repository, using the button below. This lets Drydock read the held deployment and post the approve/reject decision back to GitHub."
-        />
-        <SetupStep
-          index="02"
-          title="Add a deployment protection rule"
-          detail={
-            <>
-              In the repository, open (or create) the GitHub Actions environment your publish job
-              deploys to, then enable Drydock as a custom deployment protection rule so the publish
-              job pauses for review. See{" "}
-              <a
-                class="underline"
-                href="https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-custom-deployment-protection-rules"
-                target="_blank"
-                rel="noreferrer"
-              >
-                custom deployment protection rules
-              </a>
-              .
-            </>
-          }
-        />
-        <SetupStep
-          index="03"
-          title="Match the PyPI Trusted Publisher environment"
-          detail={
-            <>
-              On PyPI, configure a Trusted Publisher for the same repository and workflow, and set
-              its environment name to match the GitHub environment exactly. The workflow keeps its
-              own OIDC trust with PyPI. See{" "}
-              <a
-                class="underline"
-                href="https://docs.pypi.org/trusted-publishers/"
-                target="_blank"
-                rel="noreferrer"
-              >
-                PyPI Trusted Publishers
-              </a>
-              .
-            </>
-          }
-        />
-      </ol>
-      <Muted as="p" class="text-[12px] leading-[1.55] m-0">
-        Drydock reviews the release candidate and your approval releases or blocks the held GitHub
-        job. Publishing happens through the workflow's Trusted Publishing OIDC exchange{" "}
-        <span class="font-mono text-ink-subtle">→</span> Drydock never holds or sees PyPI
-        credentials.
-      </Muted>
-    </div>
-  );
-}
-
-function SetupStep({
-  index,
-  title,
-  detail,
-}: {
-  index: string;
-  title: string;
-  detail: ComponentChildren;
-}) {
-  return (
-    <li class="grid grid-cols-[28px_minmax(0,1fr)] gap-3 items-baseline min-w-0">
-      <span class="font-mono text-[11px] text-ink-subtle tabular-nums">{index}</span>
-      <div class="flex flex-col gap-1 min-w-0">
-        <span class="text-[13px] font-medium text-ink">{title}</span>
-        <Muted as="p" class="text-[12px] leading-[1.55] m-0">
-          {detail}
-        </Muted>
-      </div>
-    </li>
-  );
 }

--- a/src/pages/Dashboard/Settings/NpmConnectionSection.tsx
+++ b/src/pages/Dashboard/Settings/NpmConnectionSection.tsx
@@ -5,12 +5,11 @@ import {
   Alert,
   Badge,
   Button,
-  Card,
+  CollapsibleCard,
   Field,
   Input,
   LinkButton,
   Muted,
-  SectionLabel,
 } from "../../../components";
 
 export function NpmConnectionSection({
@@ -33,28 +32,27 @@ export function NpmConnectionSection({
   };
 
   return (
-    <Card as="section" class="p-5">
-      <div class="flex flex-col gap-5">
-        <div class="flex flex-wrap items-start justify-between gap-3">
-          <div class="flex flex-col gap-1.5 max-w-[760px]">
-            <SectionLabel>npm access</SectionLabel>
-            <Muted class="text-[13px] m-0">
-              Add an organization npm token so reviews can fetch staged packages securely. We
-              encrypt it, hide it after save, and use it only to retrieve release evidence.
-            </Muted>
-          </div>
-          {connection ? (
-            <Badge
-              tone={
-                validated ? "ok" : connection.validationStatus === "invalid" ? "critical" : "info"
-              }
-            >
-              {connection.validationStatus}
-            </Badge>
-          ) : (
-            <Badge tone="info">not connected</Badge>
-          )}
-        </div>
+    <CollapsibleCard
+      title="npm access"
+      aside={
+        connection ? (
+          <Badge
+            tone={
+              validated ? "ok" : connection.validationStatus === "invalid" ? "critical" : "info"
+            }
+          >
+            {connection.validationStatus}
+          </Badge>
+        ) : (
+          <Badge tone="info">not connected</Badge>
+        )
+      }
+    >
+      <div class="p-5 flex flex-col gap-5">
+        <Muted class="text-[13px] m-0 max-w-[760px]">
+          Add an organization npm token so reviews can fetch staged packages securely. We encrypt
+          it, hide it after save, and use it only to retrieve release evidence.
+        </Muted>
 
         {connection ? (
           <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-x-6 gap-y-2 border-y border-border py-3">
@@ -71,8 +69,6 @@ export function NpmConnectionSection({
             />
           </div>
         ) : null}
-
-        <NpmTokenScopeGuide />
 
         <form
           class="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.5fr)_auto] gap-3 items-end"
@@ -136,45 +132,7 @@ export function NpmConnectionSection({
           </div>
         ) : null}
       </div>
-    </Card>
-  );
-}
-
-function NpmTokenScopeGuide() {
-  return (
-    <div class="border border-border rounded-lg bg-surface-2 px-4 py-3 flex flex-col gap-3">
-      <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">
-        recommended token scope
-      </span>
-      <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 m-0">
-        <ScopeRow term="token type" detail="Granular access token" />
-        <ScopeRow term="permission" detail="Read-only" />
-        <ScopeRow term="packages" detail="Only the packages you stage" />
-        <ScopeRow term="expiration" detail="Short, with planned rotation" />
-      </dl>
-      <Muted as="p" class="text-[12px] leading-[1.55] m-0">
-        Drydock only reads staged release evidence — it never publishes and the token never reaches
-        the sandbox, so read-only access to those packages is enough. Create one in{" "}
-        <a
-          class="underline"
-          href="https://docs.npmjs.com/creating-and-viewing-access-tokens/"
-          target="_blank"
-          rel="noreferrer"
-        >
-          npm access token settings
-        </a>
-        .
-      </Muted>
-    </div>
-  );
-}
-
-function ScopeRow({ term, detail }: { term: string; detail: string }) {
-  return (
-    <div class="grid grid-cols-[88px_minmax(0,1fr)] gap-3 items-baseline text-[13px] min-w-0">
-      <dt class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">{term}</dt>
-      <dd class="m-0 text-ink-muted break-words">{detail}</dd>
-    </div>
+    </CollapsibleCard>
   );
 }
 

--- a/src/pages/Dashboard/Settings/OrganizationMembersSection.tsx
+++ b/src/pages/Dashboard/Settings/OrganizationMembersSection.tsx
@@ -10,7 +10,7 @@ import {
   Alert,
   Badge,
   Button,
-  Card,
+  CollapsibleCard,
   Field,
   Input,
   MonoDetail,
@@ -50,21 +50,21 @@ export function OrganizationMembersSection({
   };
 
   return (
-    <Card as="section" class="p-0 overflow-hidden">
+    <CollapsibleCard
+      title="Members"
+      defaultOpen
+      aside={
+        <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
+          {memberList.length} {memberList.length === 1 ? "member" : "members"}
+        </span>
+      }
+    >
       <div class="p-5 flex flex-col gap-5">
-        <div class="flex flex-wrap items-start justify-between gap-3">
-          <div class="flex flex-col gap-1.5 max-w-[760px]">
-            <SectionLabel>Members</SectionLabel>
-            <Muted class="text-[13px] m-0">
-              Invite teammates to collaborate on this organization's release targets, integrations,
-              and gate reviews. Owners and admins manage membership; members get read access to
-              org-scoped scans and can act on releases.
-            </Muted>
-          </div>
-          <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle shrink-0">
-            {memberList.length} {memberList.length === 1 ? "member" : "members"}
-          </span>
-        </div>
+        <Muted class="text-[13px] m-0 max-w-[760px]">
+          Invite teammates to collaborate on this organization's release targets, integrations, and
+          gate reviews. Owners and admins manage membership; members get read access to org-scoped
+          scans and can act on releases.
+        </Muted>
 
         {error ? <Alert tone="critical">{error}</Alert> : null}
 
@@ -133,7 +133,7 @@ export function OrganizationMembersSection({
           )}
         </div>
       ) : null}
-    </Card>
+    </CollapsibleCard>
   );
 }
 

--- a/src/pages/Dashboard/Settings/index.tsx
+++ b/src/pages/Dashboard/Settings/index.tsx
@@ -120,13 +120,13 @@ export default function SettingsPage() {
 
       {workspaceLoaded ? (
         <div class="flex flex-col gap-6">
-          <NpmConnectionSection npm={npm} />
-          <GithubAppSection githubApp={githubApp} />
           <OrganizationMembersSection
             members={members}
             currentUserRole={activeRole(organizations)}
             currentUserId={user?.id ?? null}
           />
+          <NpmConnectionSection npm={npm} />
+          <GithubAppSection githubApp={githubApp} />
         </div>
       ) : (
         <LoadingState title="Loading settings" detail={loadingDetail(npmLoaded, githubAppLoaded)} />


### PR DESCRIPTION
## Summary
- Add a `CollapsibleCard` primitive (native `<details>`/`<summary>` + rotating `▸` glyph, matching the `FileTree` pattern) and use it for all three settings sections, so each box folds.
- Reorder the settings sections to **Members → npm → GitHub**. Members is open by default; npm and GitHub start folded with their status badge visible in the header.
- Fix the npm box padding mismatch. It previously applied `p-5` on top of `Card`'s default `p-6`, but `cn` is plain string concatenation (not tailwind-merge), so `.p-6` won in the cascade. All three sections now share the same `p-0` Card + `p-5` body layout.
- Remove the static "recommended token scope" (npm) and "gate setup" (GitHub) guide blobs.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `oxlint` passes
- [x] `oxfmt --check` passes
- [x] `vitest` full suite passes (468 tests)
- [x] `npm run build` compiles the Settings bundle
- [ ] Manual browser check of the settings screen (sections fold/unfold, ordering, npm padding now matches) — not done; the page is behind auth + an active org, so I could not drive it in a browser this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)