### PR TITLE
Align Send invite button height with form inputs

### DIFF
--- a/src/pages/Dashboard/Settings/NpmConnectionSection.tsx
+++ b/src/pages/Dashboard/Settings/NpmConnectionSection.tsx
@@ -104,7 +104,8 @@ export function NpmConnectionSection({
               spellcheck={false}
             />
           </Field>
-          <Button type="submit" disabled={busy || !token.trim()} class="shrink-0">
+          {/* h-[38px] matches the Input control height (13px × 1.55 line-height + padding + border); Button's leading-none makes it shorter otherwise. */}
+          <Button type="submit" disabled={busy || !token.trim()} class="shrink-0 h-[38px]">
             {status === "saving"
               ? "Saving…"
               : status === "validating"

--- a/src/pages/Dashboard/Settings/OrganizationMembersSection.tsx
+++ b/src/pages/Dashboard/Settings/OrganizationMembersSection.tsx
@@ -95,7 +95,12 @@ export function OrganizationMembersSection({
                 <option value="admin">admin</option>
               </Select>
             </Field>
-            <Button type="submit" disabled={busy || !inviteEmail.value.trim()} class="shrink-0">
+            {/* h-[38px] matches the Input control height (13px × 1.55 line-height + padding + border); Button's leading-none makes it shorter otherwise. */}
+            <Button
+              type="submit"
+              disabled={busy || !inviteEmail.value.trim()}
+              class="shrink-0 h-[38px]"
+            >
               {status === "inviting" ? "Sending…" : "Send invite"}
             </Button>
           </form>


### PR DESCRIPTION
## Summary

The Send invite button in the organization Members settings rendered shorter than the email input and role select beside it. The `Button` uses `leading-none` (~31px), while `Input`/`Select` inherit the body's `line-height: 1.55` (~38px), so the `items-end` row left the button visibly short. This pins the button to the input control height with `h-[38px]`.

## Test plan

- [ ] Open Settings → Members and confirm the Send invite button lines up with the email field and role dropdown.