### PR TITLE
Generalize workflow gates to monorepo per-package review (#164)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -313,7 +313,7 @@ Implemented pieces:
 - GitHub App install/callback, installation listing, repository/environment proxy reads, and PyPI release-target CRUD in `server/routes/github-app.ts`;
 - `deployment_protection_rule` webhook handling in `server/routes/github-webhooks.ts`, backed by `github_workflow_gates`;
 - queue-driven gate review in `server/lib/workflow-gate-job.ts`, including fail-closed rejection for unverifiable artifact bundles and human approve/reject delivery back to GitHub;
-- release-candidate derivation from the `pypi-release-candidate` GitHub Actions artifact bundle: every wheel/sdist SHA-256 is recomputed from the bundle bytes, package identity is derived from wheel `METADATA` / sdist `PKG-INFO`, and no maintainer-declared manifest is required;
+- release-candidate derivation from the held workflow run's uploaded GitHub Actions artifacts: every wheel/sdist SHA-256 is recomputed from upload bytes, package identity is derived from wheel `METADATA` / sdist `PKG-INFO`, and no maintainer-declared manifest is required;
 - PyPI wheel/sdist artifact normalization and metadata extraction;
 - safe ZIP parsing for `.whl` archives in the sandbox parser;
 - PyPI-specific deterministic findings for manifest/metadata mismatches, missing wheel `RECORD`, `.pth` startup hooks, custom `setup.py` install commands, unusual dependencies, and `.pyd` native extensions;

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -166,8 +166,12 @@ organization (`x-organization-id` header to scope writes).
     per-package roster so the workbench can show "N of M approved" (HTTP 200, no
     GitHub callback yet).
 
-  `markGateDecided` is the single CAS out of `pending`, so a double-submit (or a
-  race with the fail-closed artifact reject) returns 409. Delivery to GitHub is
+  Each package scan can be decided once while the gate is pending; stale
+  re-submits for an already-decided package return 409
+  (`package has already been decided`) and cannot overwrite the package roster.
+  The aggregate decision is also rechecked in the database during the CAS out of
+  `pending`, so concurrent package decisions cannot release a gate whose live
+  package state no longer matches the requested aggregate. Delivery to GitHub is
   scheduled immediately after the CAS, before best-effort audit mirroring, and is
   handed to the gate job (over `SCAN_QUEUE`, with inline fallback) so the decided
   gate posts its stored decision. Rate-limited to 60/min per org. The public gate

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -35,12 +35,13 @@ The sandbox parser now supports safe ZIP archive parsing for wheels in addition 
 ## Release set derivation
 
 There is no manifest file. The boundary between the GitHub workflow and Drydock
-is the workflow run's uploaded artifacts: CI uploads `dist/*` and, unless a
-release target narrows discovery with `artifactName`, Drydock inspects every
-non-expired upload from the held run. Every `.whl` / `.tar.gz` / `.tgz` found in
-those uploads becomes part of the release set, then those files are grouped by
-package into one `drydock.release-artifacts.v1` release per distinct package (a
-monorepo publishes several) — the same shape the rest of the pipeline consumes:
+is the workflow run's uploaded artifacts: CI uploads `dist/*`, and Drydock
+inspects either every non-expired upload from the held run (auto-detect targets),
+a configured `artifactName`, or the pinned ecosystem adapter's default artifact
+name. Every `.whl` / `.tar.gz` / `.tgz` found in the selected uploads becomes
+part of the release set, then those files are grouped by package into one
+`drydock.release-artifacts.v1` release per distinct package (a monorepo publishes
+several) — the same shape the rest of the pipeline consumes:
 
 - `package` / `version` come from each wheel's `METADATA` and each sdist's
   `PKG-INFO`. Every artifact must expose a `Name`/`Version`; files are grouped by
@@ -219,13 +220,13 @@ organization (`x-organization-id` header to scope writes).
   stores `null`, which means "auto-detect each package's ecosystem from the
   uploaded artifacts" — the monorepo-friendly default, where one gate covers
   every package the environment publishes. A non-empty value pins ecosystem
-  detection to that adapter; artifact discovery still scans every upload unless
-  `artifactName` narrows it.
+  detection to that adapter; when no `artifactName` is set, pinned targets use
+  that adapter's default artifact name (for PyPI, `pypi-release-candidate`).
 
 `artifactName` is also optional: when set, it narrows discovery to that GitHub
-Actions artifact name. When unset, Drydock scans every non-expired artifact
-uploaded by the held workflow run and lets the ecosystem classifier decide which
-inner files are reviewable.
+Actions artifact name. When unset on an auto-detect target, Drydock scans every
+non-expired artifact uploaded by the held workflow run and lets the ecosystem
+classifier decide which inner files are reviewable.
 
 ### Webhook resolution
 
@@ -520,8 +521,9 @@ therefore covers a **set** of packages, not just one:
   ecosystem's slice to its adapter. `artifactName` is only a narrowing override;
   when it is blank, Drydock scans every non-expired upload in the held run.
   Pinning a single ecosystem keeps ecosystem classification constrained to that
-  adapter and surfaces an unknown ecosystem as a configuration error (gate left
-  pending) rather than a fail-closed reject.
+  adapter, falls back to that adapter's default artifact name when `artifactName`
+  is blank, and surfaces an unknown ecosystem as a configuration error (gate
+  left pending) rather than a fail-closed reject.
 - **One scan per package.** Each adapter splits its slice into one prepared
   candidate per distinct package, and `reviewGatePackages` runs a full scan for
   each against its **own** baseline, linking every scan to the gate via

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -534,8 +534,9 @@ therefore covers a **set** of packages, not just one:
   is blocked immediately; all approved → the gate is approved and the job is
   released; otherwise the gate stays pending and the workbench shows the
   remaining packages ("N of M approved"). AI/release-risk recommendations are
-  advisory: a human can still approve after reading the review, and a failed
-  automated package review can be approved, rejected, or retried.
+  advisory: a human can still approve after reading a completed batch. A failed
+  partial batch has no representative scan attached, so it can be retried or
+  rejected, but it cannot be approved as complete.
 - **All-or-nothing batch.** The per-package scans are run as one batch under a
   `review_started_at` claim. If any package's pipeline throws, the claim is
   released and the gate stays pending with no representative attached, so a

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -155,7 +155,7 @@ organization (`x-organization-id` header to scope writes).
   when the scan is not a gate review or belongs to another org.
 - `POST /workflow-gates/:gateId/decision` — records a maintainer's decision on
   **one package** of the gate: `{ scanId, decision: "approved" | "rejected",
-  comment?, totpCode? }`, where `scanId` is the completed or failed
+comment?, totpCode? }`, where `scanId` is the completed or failed
   `workflow_gate` scan of the package being decided. `scanId` is required (400 if
   missing); a scan that has not reached a human decision point for this gate
   returns 409
@@ -179,7 +179,7 @@ organization (`x-organization-id` header to scope writes).
   handed to the gate job (over `SCAN_QUEUE`, with inline fallback) so the decided
   gate posts its stored decision. Rate-limited to 60/min per org. The public gate
   shape carries a `packages: [{ scanId, packageName, version, status,
-  releaseRisk, decision }]` array (one entry per distinct package).
+releaseRisk, decision }]` array (one entry per distinct package).
   - **2FA step-up (issue #162):** releasing or blocking a held deployment is
     irreversible (approval immediately releases the job and publishing proceeds
     over Trusted Publishing/OIDC), so when the deciding maintainer has two-factor

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -22,7 +22,7 @@ The repo now has a backend-only PyPI foundation in `server/lib/adapters/pypi/ind
 - parses wheel `METADATA`, `WHEEL`, and `RECORD` evidence from ZIP archives;
 - strips the common root directory from sdists before reading `PKG-INFO`;
 - compares flattened candidate artifact files against the previous PyPI release using stable wheel/sdist namespaces instead of versioned artifact filenames (callers may inject explicit `previousArtifacts`, otherwise the adapter resolves and downloads the baseline itself);
-- requires every artifact in the bundle to agree on the normalized package name and version before forming a reviewable release;
+- groups the bundle's artifacts by normalized (PEP 503) package name into one reviewable release per distinct package (a monorepo publishes several), requiring artifacts that share a name to agree on the version before forming that package's release;
 - adds PyPI-specific deterministic findings for metadata mismatches, missing wheel `RECORD`, `.pth` startup hooks, custom `setup.py` install commands, and `.pyd` native extensions;
 - fetches PyPI project metadata from `GET /pypi/<project>/json`;
 - selects a default PyPI baseline release from `info.version`, falling back to newest non-yanked upload time;
@@ -35,15 +35,18 @@ The sandbox parser now supports safe ZIP archive parsing for wheels in addition 
 ## Release set derivation
 
 There is no manifest file. The boundary between the GitHub workflow and Drydock
-is simply the `pypi-release-candidate` artifact bundle: CI uploads `dist/*` and
-Drydock treats every `.whl` / `.tar.gz` / `.tgz` in the bundle as the release
-set. The reviewable identity is derived internally into the same
-`drydock.release-artifacts.v1` shape the rest of the pipeline consumes:
+is simply the release-candidate artifact bundle: CI uploads `dist/*` and Drydock
+treats every `.whl` / `.tar.gz` / `.tgz` in the bundle as the release set, then
+groups those files by package into one `drydock.release-artifacts.v1` release per
+distinct package (a monorepo publishes several) — the same shape the rest of the
+pipeline consumes:
 
 - `package` / `version` come from each wheel's `METADATA` and each sdist's
-  `PKG-INFO`. Every artifact must expose a `Name`/`Version` and agree on the
-  normalized (PEP 503) name and the version, so a foreign or version-skewed file
-  in `dist/` is rejected, not silently shipped.
+  `PKG-INFO`. Every artifact must expose a `Name`/`Version`; files are grouped by
+  normalized (PEP 503) name, and artifacts that share a name must agree on the
+  version, so a metadata-less or version-skewed file in a package's set is
+  rejected, not silently shipped. Distinct package names are kept apart as
+  separate releases — that is the expected monorepo shape, not a conflict.
 - each artifact's `sha256` is recomputed server-side from the bundle bytes.
 
 ### Trust tradeoff (deliberate)
@@ -148,18 +151,28 @@ organization (`x-organization-id` header to scope writes).
   belongs to so the scan workbench can render gate status and the decision
   controls. Returns the public gate shape (no `deployment_callback_url`); 404
   when the scan is not a gate review or belongs to another org.
-- `POST /workflow-gates/:gateId/decision` — records a maintainer's
-  `{ decision: "approved" | "rejected", comment?, totpCode? }` and releases/blocks
-  the held GitHub job. `markGateDecided` is the single CAS out of `pending`, so a
-  double-submit (or a race with the fail-closed artifact reject) returns 409.
-  Approval requires the gate to be linked to a completed `workflow_gate` scan;
-  rejection is allowed without one so maintainers can still fail closed.
-  Delivery to GitHub is scheduled immediately after the CAS, before best-effort
-  scan/audit mirroring, and is handed to the gate job (over `SCAN_QUEUE`, with
-  inline fallback) so the decided gate posts its stored decision. The decision is
-  also mirrored onto the underlying scan as `publish` for approved gates or
-  `no_publish` for rejected gates when that write succeeds. Rate-limited to
-  60/min per org.
+- `POST /workflow-gates/:gateId/decision` — records a maintainer's decision on
+  **one package** of the gate: `{ scanId, decision: "approved" | "rejected",
+  comment?, totpCode? }`, where `scanId` is the completed `workflow_gate` scan of
+  the package being decided. `scanId` is required (400 if missing); a scan that is
+  not a completed reviewable package of this gate returns 409
+  (`scanId is not a reviewable package of this gate`). The per-package decision is
+  persisted (`publish` for approved, `no_publish` for rejected), then the gate is
+  aggregated over **every** package scan linked via `scans.gate_id`:
+  - any package rejected → the gate is rejected and the held job is blocked
+    immediately (one bad package fails the whole release);
+  - every package approved → the gate is approved and the held job is released;
+  - otherwise the gate stays `pending` and the response returns the gate with its
+    per-package roster so the workbench can show "N of M approved" (HTTP 200, no
+    GitHub callback yet).
+
+  `markGateDecided` is the single CAS out of `pending`, so a double-submit (or a
+  race with the fail-closed artifact reject) returns 409. Delivery to GitHub is
+  scheduled immediately after the CAS, before best-effort audit mirroring, and is
+  handed to the gate job (over `SCAN_QUEUE`, with inline fallback) so the decided
+  gate posts its stored decision. Rate-limited to 60/min per org. The public gate
+  shape carries a `packages: [{ scanId, packageName, version, status,
+  releaseRisk, decision }]` array (one entry per distinct package).
   - **2FA step-up (issue #162):** releasing or blocking a held deployment is
     irreversible (approval immediately releases the job and publishing proceeds
     over Trusted Publishing/OIDC), so when the deciding maintainer has two-factor
@@ -189,6 +202,17 @@ organization (`x-organization-id` header to scope writes).
   provided environment name exceeds GitHub's 255-character limit.
 - `environment_already_mapped` — `(organizationId, repositoryId, environment)`
   already has a row, so a deployment-protection webhook would be ambiguous.
+- `unsupported_ecosystem` — a non-empty `ecosystem` that names no registered
+  ecosystem. `ecosystem` is **optional**: omitting it (or sending `""`/`"auto"`)
+  stores `null`, which means "auto-detect each package's ecosystem from the
+  uploaded artifacts" — the monorepo-friendly default, where one gate covers
+  every package the environment publishes. A non-empty value pins detection and
+  the default artifact name to that one ecosystem.
+
+`artifactName` is also optional: it overrides the GitHub Actions artifact the
+release bundle is downloaded from. When unset, an auto-detect target falls back
+to `release-candidate` and a pinned target falls back to its ecosystem adapter's
+default (PyPI: `pypi-release-candidate`).
 
 ### Webhook resolution
 
@@ -352,10 +376,13 @@ the install:
 5. Below the linked installations, a "Release targets" form lets the user
    register a `(repo, environment)` mapping. The installation defaults to the one
    linked for the org; repository and environment are dropdowns populated from
-   the proxy endpoints. The server still revalidates installation ownership, repo
-   access, and environment names on `POST /release-targets`, so the UI cannot
-   bypass the rules. Empty states link to GitHub App settings (no repos) and
-   GitHub Actions environments docs (no environments).
+   the proxy endpoints. A target left unpinned (no ecosystem) auto-detects each
+   package's ecosystem from the uploaded artifacts, so a single target gates every
+   package a monorepo publishes from that environment. The server still
+   revalidates installation ownership, repo access, and environment names on
+   `POST /release-targets`, so the UI cannot bypass the rules. Empty states link
+   to GitHub App settings (no repos) and GitHub Actions environments docs (no
+   environments).
 6. Above the release-targets form, a "gate setup" guide walks through installing
    the App, adding a GitHub Environment custom deployment protection rule, and
    matching the PyPI Trusted Publisher environment. It states plainly that
@@ -376,6 +403,15 @@ surface are identical to npm reviews. A decided gate shows its stored decision
 and comment instead of the controls. Failed review scans also resolve their
 linked gate so the workbench can show the held GitHub job context instead of a
 detached failure.
+
+Because one monorepo release fans out into one scan per package, the gate's
+`packages` roster is surfaced in the workbench: each package is a cross-link to
+its own scan with its release risk and per-package decision, and the gate header
+shows an "N of M approved" progress line. The decision controls always carry the
+current scan's `scanId`, so approving/rejecting acts on **that** package only;
+the gate stays pending until every package is individually approved (any one
+rejected blocks the whole release). A package opened from the roster is the same
+diff-first workbench scoped to that package's baseline.
 
 ### Resolving artifacts for a pending gate
 
@@ -417,11 +453,13 @@ What the resolver enforces, in order:
    with no wheels/sdists is `bundle_empty`; more than 20 is `bundle_too_large`.
 5. Each wheel/sdist's bytes cross into the credentials-free sandbox, which
    parses `METADATA`/`PKG-INFO` into bounded evidence.
-6. The release identity is derived from that parsed metadata: every artifact
-   must expose a `Name`/`Version` and agree on the normalized package name and
-   the version. The synthesized `drydock.release-artifacts.v1` shape (PEP 503
-   project name, safe version, ≤20 artifacts, safe artifact paths) is then
-   re-validated before scanning.
+6. The release identities are derived from that parsed metadata: every artifact
+   must expose a `Name`/`Version`, and the artifacts are grouped by normalized
+   package name into one release per distinct package (a monorepo yields
+   several). Artifacts sharing a name must agree on the version. Each group's
+   synthesized `drydock.release-artifacts.v1` shape (PEP 503 project name, safe
+   version, ≤20 artifacts, safe artifact paths) is then re-validated before
+   scanning.
 
 Typed errors returned by `WorkflowArtifactError.code`:
 
@@ -432,10 +470,11 @@ Typed errors returned by `WorkflowArtifactError.code`:
 - `artifact_path_unsafe` — bundle entry path contained traversal segments.
 - `artifact_identity_missing` — an artifact exposed no usable `Name`/`Version`
   (or the derived identity failed validation).
-- `artifact_identity_inconsistent` — artifacts disagreed on the normalized
-  package name or the version.
+- `artifact_identity_inconsistent` — two artifacts sharing a normalized package
+  name disagreed on the version. (Distinct names are not a conflict — they become
+  separate package releases.)
 
-`prepareReleaseCandidateForGate(env, ctx, db, { config, organizationId,
+`prepareReleaseCandidatesForGate(env, ctx, db, { config, organizationId,
 gateId })` (`server/lib/workflow-gates/prepare.ts`) is the gate-aware wrapper. It
 looks up the gate row, selects the `WorkflowGateAdapter` for the release target's
 ecosystem, swaps the App JWT for a fresh installation access token, and on any
@@ -448,6 +487,41 @@ public-artifact allowlist, `subRequests: 0`). Because identity is derived from
 the sandbox-parsed metadata, package identity is known only after the artifacts
 have crossed the untrusted-archive parser; the release target itself binds the
 review to the GitHub repository and environment.
+
+## Monorepo gates (per-package fan-out)
+
+One GitHub environment can publish several distinct packages from a single
+workflow run (a monorepo cutting many wheels/sdists at once). A workflow gate
+therefore covers a **set** of packages, not just one:
+
+- **Auto-detect ecosystem.** A release target with `ecosystem = null` (the
+  default — left unpinned in the UI, or sent as `""`/`"auto"`) does not assume an
+  ecosystem up front. `prepareReleaseCandidatesForGate` classifies every bundle
+  entry across all registered ecosystems, groups the verified artifacts by
+  ecosystem, and hands each ecosystem's slice to its adapter. An unpinned target
+  downloads from the artifact named `release-candidate` unless `artifactName`
+  overrides it; a pinned target uses its ecosystem adapter's own default
+  (`pypi-release-candidate`). Pinning a single ecosystem keeps the legacy
+  single-ecosystem behavior and surfaces an unknown ecosystem as a configuration
+  error (gate left pending) rather than a fail-closed reject.
+- **One scan per package.** Each adapter splits its slice into one prepared
+  candidate per distinct package, and `reviewGatePackages` runs a full scan for
+  each against its **own** baseline, linking every scan to the gate via
+  `scans.gate_id`. The diff, deterministic findings, and risk are computed
+  per package exactly as a standalone npm/PyPI review would be.
+- **Every package must be approved.** The held GitHub deployment is released
+  only when **every** discovered package is individually approved. The decision
+  route names one package's `scanId` per call and aggregates over all package
+  scans linked to the gate: any one rejected → the gate is rejected and the job
+  is blocked immediately; all approved → the gate is approved and the job is
+  released; otherwise the gate stays pending and the workbench shows the
+  remaining packages ("N of M approved"). A single bad package blocks the whole
+  release.
+- **All-or-nothing batch.** The per-package scans are run as one batch under a
+  `review_started_at` claim. If any package's pipeline throws, the claim is
+  released and the gate stays pending with no representative attached, so a
+  half-reviewed monorepo never becomes review-ready; a retry discards the
+  half-finished scans (`discardGateScans`) and re-runs the whole set.
 
 ## Multi-ecosystem workflow gates
 
@@ -468,7 +542,7 @@ involved — do not conflate them:
 
 The **shared runner** owns every GitHub-shaped and persistence concern, in
 `server/lib/workflow-gate-job.ts` (`executeWorkflowGateJob`) plus
-`server/lib/workflow-gates/prepare.ts` (`prepareReleaseCandidateForGate`):
+`server/lib/workflow-gates/prepare.ts` (`prepareReleaseCandidatesForGate`):
 
 - loading the `github_workflow_gates` row, installation, and release target;
 - selecting the adapter from `github_release_targets.ecosystem`;
@@ -569,12 +643,12 @@ and the consumer re-checks gate status, so a re-enqueue is safe.
 2. Load the gate. A gate that is already `approved`/`rejected` triggers a
    **redelivery** of the stored decision to GitHub (idempotent re-POST) instead
    of re-running the review; callback failures rethrow so the queue retries. A
-   pending gate with an attached completed review is skipped because it is
-   waiting for a human decision; a pending gate with an attached failed review
-   is retried and relinked to the new scan if the retry succeeds. A non-pending,
-   non-decided status is skipped with a warning.
+   pending gate that already has a representative scan attached (`gate.scanId`
+   set) is skipped as `already_reviewed` — the per-package batch finished and the
+   gate is waiting on a human. A non-pending, non-decided status is skipped with a
+   warning.
 3. Record `github_workflow_gate.received`.
-4. Call `prepareReleaseCandidateForGate` to select the ecosystem adapter and
+4. Call `prepareReleaseCandidatesForGate` to select the ecosystem adapter and
    resolve + verify the bundle.
    - A `WorkflowArtifactError` (e.g. `bundle_unavailable` or
      `artifact_identity_inconsistent`)
@@ -586,26 +660,41 @@ and the consumer re-checks gate status, so a re-enqueue is safe.
    - Any other error (sandbox/review failure) leaves the gate **pending**,
      records `github_workflow_gate.review_failed`, and returns without POSTing —
      the operator can retry.
-5. Resolve the organization owner (so the persisted scan has an owner). A
+5. Resolve the organization owner (so the persisted scans have an owner). A
    missing owner records `review_failed` and leaves the gate pending.
-6. Create a scan job (`source: "workflow_gate"`, synthetic
-   `stageId: "workflow-gate:<gateId>"`), claim the gate's `scanId` with a CAS
-   against the scan link the worker observed, and run `runScanPipeline` with the
-   selected adapter's `packageAdapter` over the verified pipeline input. If
-   another delivery
-   already claimed the gate, the worker deletes its just-created pending scan
-   and exits. A pipeline throw marks the linked scan failed, records
-   `review_failed`, and leaves the gate pending; a later retry can replace that
-   failed link with a completed scan.
-7. Compute an **advisory** recommendation from the release risk
+6. Claim the review batch with `claimGateReviewStart` (a CAS on
+   `review_started_at`). Only the first delivery to win the claim runs the scans;
+   a concurrent re-delivery loses the CAS and skips, so the batch never
+   double-runs. A retried batch (a prior attempt released its claim mid-flight)
+   first calls `discardGateScans` to drop the half-finished package scans, so the
+   gate's package set is exactly this batch.
+7. Run one scan **per discovered package** (`reviewGatePackages`). Each package
+   gets its own `scans` row (`source: "workflow_gate"`, synthetic
+   `stageId: "workflow-gate:<gateId>:<ecosystem>:<package>"`) linked to the gate
+   via `scans.gate_id`, and is scanned against its own baseline with that
+   ecosystem's `packageAdapter`. A monorepo release bundle fans out into several
+   such scans here. Any single package's pipeline throw marks that scan failed,
+   releases the review claim, records `review_failed`, and leaves the gate
+   pending — a half-reviewed gate must never become review-ready, and a retry
+   re-runs the whole batch.
+8. Aggregate the batch: the gate's headline release risk is the worst package's
+   (`combineRisk`) and the representative scan is the (first) package carrying it.
+   Compute an **advisory** recommendation from that aggregate risk
    (`recommendationForReleaseRisk`: `high`/`critical` → `rejected`, otherwise
-   `approved`) and record `github_workflow_gate.reviewed` with it. Then link the
-   scan to the gate via `attachScanToGate` and **leave the gate pending** — the
-   review never posts to GitHub.
-8. Classify the review against GitHub's deployment-protection **callback
+   `approved`) and record `github_workflow_gate.reviewed` with the
+   recommendation, the aggregate risk, and the per-package roster. Then attach
+   the representative scan as the gate headline via `attachScanToGate` (a CAS
+   expecting no scan yet, so a racing decision or fail-closed reject wins) and
+   **leave the gate pending** — the review never posts to GitHub. `gate.scanId`
+   is set only on this success; on any failure it stays null and the failed
+   package scans remain linked via `scans.gate_id` only, to be discarded on the
+   next retry.
+9. Classify the review against GitHub's deployment-protection **callback
    window** (`classifyGateTimeout`) and email the maintainer the matching
    notice. A gate still inside its window gets the "parked pending your
-   decision" email (`notifyWorkflowGateReview`); a gate whose review outran the
+   decision" email (`notifyWorkflowGateReview` in `server/lib/notify.ts`); for a
+   monorepo bundle that email names the representative package and flags that
+   every package in the release must be approved. A gate whose review outran the
    window gets the timeout notice (`notifyWorkflowGateTimeout`) instead, because
    GitHub has most likely already auto-rejected it. Because Drydock never
    auto-decides, this email is the only proactive signal that a held GitHub
@@ -613,7 +702,7 @@ and the consumer re-checks gate status, so a re-enqueue is safe.
 
 ### Notifying the maintainer
 
-Step 8 is the gate equivalent of the npm scan-completion email. It reuses the
+Step 9 is the gate equivalent of the npm scan-completion email. It reuses the
 `sendNotificationEmail` primitive and fans out to the organization's resolved
 recipient set (`resolveNotificationEmails`): the org's configured
 `organization_notification_recipients` when present, otherwise the owner's email
@@ -623,7 +712,11 @@ the setting keeps today's behavior. Each address gets its own send — no shared
 only the release identity (`package@version`), the computed release risk, the
 repository, the environment, and a deep link to the review at
 `/dashboard/scans/<scanId>` — never a token, header, callback URL, or artifact
-bytes, per the observability rules in `AGENTS.md`.
+bytes, per the observability rules in `AGENTS.md`. For a monorepo bundle
+(`packageCount > 1`) the identity line flags the extra packages
+(`package@version (+N more in this release; each must be approved)`) so the
+maintainer knows the single email covers a release that needs every package
+approved.
 
 Delivery is best-effort and **never blocks or fails the gate**: each send's
 outcome is recorded as a `github_workflow_gate.notification_sent` or
@@ -635,11 +728,11 @@ set is empty (no configured recipients and the owner has no email), a single
 `notification_failed` row with `reason: "no_recipients"` is recorded and no email
 is sent.
 
-The email is **send-once per gate**. Step 8 sits on the single review-ready
+The email is **send-once per gate**. Step 9 sits on the single review-ready
 transition, after the job re-confirms that the gate is still `pending` while
-linking the completed scan. If a maintainer has already decided the gate during
-the review, that compare-and-set fails and no stale "needs review" email is
-sent. A GitHub re-delivery of the same `deployment_protection_rule` event
+attaching the representative scan. If a maintainer has already decided the gate
+during the review, that compare-and-set fails and no stale "needs review" email
+is sent. A GitHub re-delivery of the same `deployment_protection_rule` event
 short-circuits earlier at the `already_reviewed` guard (a pending gate with a
 completed attached scan is never re-reviewed), so one review-ready gate produces
 exactly one email. A failed first review records no email; a later retry that
@@ -649,17 +742,20 @@ The job never auto-approves a release: approving releases the GitHub job and
 publishing happens immediately through Trusted Publishing/OIDC, which is too
 late to reverse. A maintainer drives the actual decision from the scan
 workbench via `POST /workflow-gates/:gateId/decision`; the recommendation
-recorded in step 7 is advisory only. Once decided, the gate job's redelivery
+recorded in step 8 is advisory only. Once decided, the gate job's redelivery
 path (step 2) is what POSTs the stored decision to GitHub. The decision route
 schedules that redelivery immediately after `markGateDecided`, before scan
 decision mirroring or audit events, so post-CAS bookkeeping cannot strand the
 held GitHub job behind a future 409; callback failure rethrows so the queue
 retries rather than re-running the review or double-deciding.
 
-The persisted review is an ordinary `scans` row scoped to the org with
+Each persisted review is an ordinary `scans` row scoped to the org with
 `source: "workflow_gate"`, reachable at `/dashboard/scans/<scanId>` — no
-separate review table. The gate row already links scan ↔ release target, so no
-schema change was needed.
+separate review table. A monorepo release produces one such row per package, all
+linked to the gate via the `scans.gate_id` column; the gate's own `scanId`
+points at the representative (worst-risk) package as the headline. The gate row
+already links scan ↔ release target, so no schema change beyond the
+`scans.gate_id` column was needed.
 
 ### Callback-window timeout
 

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -2,7 +2,7 @@
 
 PyPI support uses a different product shape from npm staged publishing.
 
-npm owns a pending staged tarball, so Drydock can fetch `/-/stage/<stage-id>/tarball` and leave final approval in npm. PyPI does not expose an equivalent registry-staged artifact. The PyPI path is therefore **workflow gate mode**: CI builds wheels/sdists first, uploads them as a `pypi-release-candidate` bundle for review, and a GitHub Environment blocks the publish job until the reviewed release is approved. There is no `drydock-manifest.json` to write — the release set is whatever wheels/sdists the bundle contains, and the package identity is derived from the artifacts themselves.
+npm owns a pending staged tarball, so Drydock can fetch `/-/stage/<stage-id>/tarball` and leave final approval in npm. PyPI does not expose an equivalent registry-staged artifact. The PyPI path is therefore **workflow gate mode**: CI builds wheels/sdists first, uploads them as GitHub Actions artifacts for review, and a GitHub Environment blocks the publish job until the reviewed release is approved. There is no `drydock-manifest.json` to write — the release set is whatever wheels/sdists the workflow uploads, and the package identity is derived from the artifacts themselves.
 
 Official references:
 
@@ -35,11 +35,12 @@ The sandbox parser now supports safe ZIP archive parsing for wheels in addition 
 ## Release set derivation
 
 There is no manifest file. The boundary between the GitHub workflow and Drydock
-is simply the release-candidate artifact bundle: CI uploads `dist/*` and Drydock
-treats every `.whl` / `.tar.gz` / `.tgz` in the bundle as the release set, then
-groups those files by package into one `drydock.release-artifacts.v1` release per
-distinct package (a monorepo publishes several) — the same shape the rest of the
-pipeline consumes:
+is the workflow run's uploaded artifacts: CI uploads `dist/*` and, unless a
+release target narrows discovery with `artifactName`, Drydock inspects every
+non-expired upload from the held run. Every `.whl` / `.tar.gz` / `.tgz` found in
+those uploads becomes part of the release set, then those files are grouped by
+package into one `drydock.release-artifacts.v1` release per distinct package (a
+monorepo publishes several) — the same shape the rest of the pipeline consumes:
 
 - `package` / `version` come from each wheel's `METADATA` and each sdist's
   `PKG-INFO`. Every artifact must expose a `Name`/`Version`; files are grouped by
@@ -153,9 +154,10 @@ organization (`x-organization-id` header to scope writes).
   when the scan is not a gate review or belongs to another org.
 - `POST /workflow-gates/:gateId/decision` — records a maintainer's decision on
   **one package** of the gate: `{ scanId, decision: "approved" | "rejected",
-  comment?, totpCode? }`, where `scanId` is the completed `workflow_gate` scan of
-  the package being decided. `scanId` is required (400 if missing); a scan that is
-  not a completed reviewable package of this gate returns 409
+  comment?, totpCode? }`, where `scanId` is the completed or failed
+  `workflow_gate` scan of the package being decided. `scanId` is required (400 if
+  missing); a scan that has not reached a human decision point for this gate
+  returns 409
   (`scanId is not a reviewable package of this gate`). The per-package decision is
   persisted (`publish` for approved, `no_publish` for rejected), then the gate is
   aggregated over **every** package scan linked via `scans.gate_id`:
@@ -193,6 +195,12 @@ organization (`x-organization-id` header to scope writes).
     record only — it never publishes or cancels anything — and deliberately does
     not require a step-up.
 
+- `POST /workflow-gates/:gateId/retry` — requeues a failed package-review batch
+  while the gate is still pending. It is only accepted when at least one package
+  scan is failed and no package decision has been recorded; retrying clears the
+  representative pointer and the next gate job discards the failed batch before
+  rerunning every package from the workflow artifacts.
+
 `POST /release-targets` enforces every validation listed in issue #114:
 
 - `installation_missing` — caller supplied an `installationRowId` that does not
@@ -210,13 +218,14 @@ organization (`x-organization-id` header to scope writes).
   ecosystem. `ecosystem` is **optional**: omitting it (or sending `""`/`"auto"`)
   stores `null`, which means "auto-detect each package's ecosystem from the
   uploaded artifacts" — the monorepo-friendly default, where one gate covers
-  every package the environment publishes. A non-empty value pins detection and
-  the default artifact name to that one ecosystem.
+  every package the environment publishes. A non-empty value pins ecosystem
+  detection to that adapter; artifact discovery still scans every upload unless
+  `artifactName` narrows it.
 
-`artifactName` is also optional: it overrides the GitHub Actions artifact the
-release bundle is downloaded from. When unset, an auto-detect target falls back
-to `release-candidate` and a pinned target falls back to its ecosystem adapter's
-default (PyPI: `pypi-release-candidate`).
+`artifactName` is also optional: when set, it narrows discovery to that GitHub
+Actions artifact name. When unset, Drydock scans every non-expired artifact
+uploaded by the held workflow run and lets the ecosystem classifier decide which
+inner files are reviewable.
 
 ### Webhook resolution
 
@@ -432,10 +441,11 @@ target loading, adapter selection, bundle fetch) lives in
 What the resolver enforces, in order:
 
 1. `GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts` with an
-   installation token — find the first non-expired artifact named
-   `pypi-release-candidate` (configurable). Requires the **Actions: Read**
-   repository permission on the GitHub App.
-2. `GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/zip` answers with
+   installation token — enumerate non-expired workflow artifacts, or narrow to a
+   configured `artifactName` when the release target supplies one. Requires the
+   **Actions: Read** repository permission on the GitHub App.
+2. For each selected upload,
+   `GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/zip` answers with
    a 302 to a signed artifact-storage URL. The redirect is followed manually
    (`redirect: "manual"`) through an egress allowlist
    (`evaluateGithubArtifactEgress`, mirroring the `NpmStageGateway` credential
@@ -445,8 +455,10 @@ What the resolver enforces, in order:
    `*.blob.core.windows.net/actions-results/...`), which carry their own auth
    in the URL. A redirect to any other host fails closed with
    `bundle_unavailable` before the request is issued, so a spoofed `Location`
-   cannot leak the token. The outer ZIP is capped at 25 MiB; Content-Length is
-   rejected before reading, and the streamed body is also bounded.
+   cannot leak the token. Each outer ZIP is capped at 25 MiB, total downloaded
+   artifact ZIP bytes are capped at 50 MiB, and at most 50 workflow artifacts are
+   inspected; Content-Length is rejected before reading, and streamed bodies are
+   also bounded.
 3. The outer ZIP is parsed with a focused central-directory walker that
    reuses the hardened primitives from `server/lib/tar-parser.js`
    (`findZipEndOfCentralDirectory`, `inflateRawBounded`, `normalizeZipPath`).
@@ -467,10 +479,12 @@ What the resolver enforces, in order:
 
 Typed errors returned by `WorkflowArtifactError.code`:
 
-- `bundle_unavailable` — workflow run / artifact name is unreachable.
-- `bundle_too_large` — outer ZIP exceeded the size/entry cap, or the bundle held
-  more than 20 wheel/sdist files.
-- `bundle_empty` — the bundle contained no `.whl` / `.tar.gz` / `.tgz` files.
+- `bundle_unavailable` — workflow run or configured artifact name is unreachable.
+- `bundle_too_large` — selected uploads exceeded the size/entry cap, there were
+  too many matching workflow artifacts, or the release set held more than 20
+  wheel/sdist files.
+- `bundle_empty` — the selected uploads contained no `.whl` / `.tar.gz` /
+  `.tgz` files.
 - `artifact_path_unsafe` — bundle entry path contained traversal segments.
 - `artifact_identity_missing` — an artifact exposed no usable `Name`/`Version`
   (or the derived identity failed validation).
@@ -500,14 +514,14 @@ therefore covers a **set** of packages, not just one:
 
 - **Auto-detect ecosystem.** A release target with `ecosystem = null` (the
   default — left unpinned in the UI, or sent as `""`/`"auto"`) does not assume an
-  ecosystem up front. `prepareReleaseCandidatesForGate` classifies every bundle
-  entry across all registered ecosystems, groups the verified artifacts by
-  ecosystem, and hands each ecosystem's slice to its adapter. An unpinned target
-  downloads from the artifact named `release-candidate` unless `artifactName`
-  overrides it; a pinned target uses its ecosystem adapter's own default
-  (`pypi-release-candidate`). Pinning a single ecosystem keeps the legacy
-  single-ecosystem behavior and surfaces an unknown ecosystem as a configuration
-  error (gate left pending) rather than a fail-closed reject.
+  ecosystem up front. `prepareReleaseCandidatesForGate` classifies every
+  reviewable file from the run's selected uploads across all registered
+  ecosystems, groups the verified artifacts by ecosystem, and hands each
+  ecosystem's slice to its adapter. `artifactName` is only a narrowing override;
+  when it is blank, Drydock scans every non-expired upload in the held run.
+  Pinning a single ecosystem keeps ecosystem classification constrained to that
+  adapter and surfaces an unknown ecosystem as a configuration error (gate left
+  pending) rather than a fail-closed reject.
 - **One scan per package.** Each adapter splits its slice into one prepared
   candidate per distinct package, and `reviewGatePackages` runs a full scan for
   each against its **own** baseline, linking every scan to the gate via
@@ -519,8 +533,9 @@ therefore covers a **set** of packages, not just one:
   scans linked to the gate: any one rejected → the gate is rejected and the job
   is blocked immediately; all approved → the gate is approved and the job is
   released; otherwise the gate stays pending and the workbench shows the
-  remaining packages ("N of M approved"). A single bad package blocks the whole
-  release.
+  remaining packages ("N of M approved"). AI/release-risk recommendations are
+  advisory: a human can still approve after reading the review, and a failed
+  automated package review can be approved, rejected, or retried.
 - **All-or-nothing batch.** The per-package scans are run as one batch under a
   `review_started_at` claim. If any package's pipeline throws, the claim is
   released and the gate stays pending with no representative attached, so a
@@ -535,9 +550,8 @@ ecosystem's artifact semantics are pluggable. Two distinct adapter layers are
 involved — do not conflate them:
 
 - **`WorkflowGateAdapter`** (`server/lib/workflow-gates/types.ts`) — gate-time
-  artifact semantics: which GitHub Actions artifact to download, which bundle
-  entries are reviewable, and how to derive the package identity + scan-pipeline
-  input from the verified bytes.
+  artifact semantics: which uploaded files are reviewable, and how to derive the
+  package identity + scan-pipeline input from the verified bytes.
 - **`PackageAdapter`** (`server/lib/adapters/types.ts`) — the deterministic
   review/baseline/findings pipeline `runScanPipeline` already drives for npm and
   PyPI. A `WorkflowGateAdapter` references one via `packageAdapter`.
@@ -550,7 +564,7 @@ The **shared runner** owns every GitHub-shaped and persistence concern, in
 
 - loading the `github_workflow_gates` row, installation, and release target;
 - selecting the adapter from `github_release_targets.ecosystem`;
-- fetching the GitHub Actions artifact bundle, bounded ZIP parsing, unsafe-path
+- fetching selected GitHub Actions uploads, bounded ZIP parsing, unsafe-path
   rejection, and SHA-256 recomputation (the installation token is swapped + used
   only in the control plane, never in the sandbox);
 - persisting gate status / decision / audit events with ecosystem-neutral names
@@ -563,11 +577,9 @@ The **shared runner** owns every GitHub-shaped and persistence concern, in
 
 A **`WorkflowGateAdapter`** owns only the ecosystem-specific surface:
 
-- `artifactName` — the default GitHub Actions artifact the bundle is downloaded
-  from;
 - `classifyArtifact(path)` — which bundle entries are reviewable artifacts (the
   returned kind is opaque to the shared fetcher; `null` drops the entry);
-- `prepareReleaseCandidate(...)` — parse the verified bytes through the
+- `prepareReleaseCandidates(...)` — parse the verified bytes through the
   credentials-free sandbox, derive the package identity, reject a bundle that
   does not match the configured release target, and return the
   `pipelineInput` (`Record<string, unknown>` spread into `runScanPipeline`, so

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -128,7 +128,7 @@ Additional boundaries for PyPI:
 
 - Do not mint PyPI OIDC tokens or upload to PyPI.
 - Do not rebuild artifacts after review; the publish job must download the reviewed GitHub Actions artifact bundle and publish those bytes.
-- Treat the `pypi-release-candidate` GitHub Actions artifact bundle as the release set. Recompute each wheel/sdist SHA-256 from bundle bytes, derive package name/version from wheel `METADATA` and sdist `PKG-INFO`, and reject missing identity, cross-artifact identity/version mismatch, or release-target mismatch.
+- Treat the held workflow run's uploaded GitHub Actions artifacts as the release set, optionally narrowed by a configured artifact name. Recompute each wheel/sdist SHA-256 from upload bytes, derive package name/version from wheel `METADATA` and sdist `PKG-INFO`, and reject missing identity, cross-artifact identity/version mismatch, or release-target mismatch.
 - There is no maintainer-declared manifest or publish-side digest-match contract today. Byte continuity rests on GitHub artifact immutability plus workflow discipline that forbids rebuilding after the gate.
 - Treat wheel ZIP and sdist tar contents as hostile evidence, with the same no-execution and bounded-sample rules as npm tarballs.
 - Keep GitHub Actions artifact credentials in the trusted parent/GitHub integration path; do not pass them into the sandbox.

--- a/drizzle/0017_normal_zodiak.sql
+++ b/drizzle/0017_normal_zodiak.sql
@@ -1,0 +1,29 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_github_release_targets` (
+	`id` text PRIMARY KEY NOT NULL,
+	`organization_id` text NOT NULL,
+	`installation_row_id` text NOT NULL,
+	`ecosystem` text,
+	`artifact_name` text,
+	`repository_id` integer NOT NULL,
+	`repository_full_name` text NOT NULL,
+	`environment` text NOT NULL,
+	`created_by_user_id` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`installation_row_id`) REFERENCES `github_app_installations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`created_by_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+-- artifact_name is new on this rebuild; existing rows inherit NULL. Omit it
+-- from the SELECT because the old table does not have that column yet.
+INSERT INTO `__new_github_release_targets`("id", "organization_id", "installation_row_id", "ecosystem", "repository_id", "repository_full_name", "environment", "created_by_user_id", "created_at", "updated_at") SELECT "id", "organization_id", "installation_row_id", "ecosystem", "repository_id", "repository_full_name", "environment", "created_by_user_id", "created_at", "updated_at" FROM `github_release_targets`;--> statement-breakpoint
+DROP TABLE `github_release_targets`;--> statement-breakpoint
+ALTER TABLE `__new_github_release_targets` RENAME TO `github_release_targets`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `github_release_targets_org_repo_env_unique_idx` ON `github_release_targets` (`organization_id`,`repository_id`,`environment`);--> statement-breakpoint
+CREATE INDEX `github_release_targets_installation_idx` ON `github_release_targets` (`installation_row_id`);--> statement-breakpoint
+ALTER TABLE `github_workflow_gates` ADD `review_started_at` integer;--> statement-breakpoint
+ALTER TABLE `scans` ADD `gate_id` text REFERENCES github_workflow_gates(id) ON DELETE set null;--> statement-breakpoint
+CREATE INDEX `scans_gate_org_idx` ON `scans` (`gate_id`,`organization_id`);

--- a/drizzle/meta/0017_snapshot.json
+++ b/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,2169 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6e2d4ce9-db02-4e55-84a6-7a176155a88e",
+  "prevId": "d174cbd6-bbfd-4216-9e59-85dcb351d96b",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_app_installations": {
+      "name": "github_app_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Organization'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uninstalled_at": {
+          "name": "uninstalled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_app_installations_installation_unique_idx": {
+          "name": "github_app_installations_installation_unique_idx",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        },
+        "github_app_installations_org_idx": {
+          "name": "github_app_installations_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installations_created_by_user_id_user_id_fk": {
+          "name": "github_app_installations_created_by_user_id_user_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_release_targets": {
+      "name": "github_release_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ecosystem": {
+          "name": "ecosystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_release_targets_org_repo_env_unique_idx": {
+          "name": "github_release_targets_org_repo_env_unique_idx",
+          "columns": [
+            "organization_id",
+            "repository_id",
+            "environment"
+          ],
+          "isUnique": true
+        },
+        "github_release_targets_installation_idx": {
+          "name": "github_release_targets_installation_idx",
+          "columns": [
+            "installation_row_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_release_targets_organization_id_organizations_id_fk": {
+          "name": "github_release_targets_organization_id_organizations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_release_targets_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_created_by_user_id_user_id_fk": {
+          "name": "github_release_targets_created_by_user_id_user_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_workflow_gates": {
+      "name": "github_workflow_gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_target_id": {
+          "name": "release_target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deployment_callback_url": {
+          "name": "deployment_callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_comment": {
+          "name": "decision_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_url": {
+          "name": "report_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_started_at": {
+          "name": "review_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_workflow_gates_delivery_unique_idx": {
+          "name": "github_workflow_gates_delivery_unique_idx",
+          "columns": [
+            "delivery_id"
+          ],
+          "isUnique": true
+        },
+        "github_workflow_gates_org_status_idx": {
+          "name": "github_workflow_gates_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_release_target_idx": {
+          "name": "github_workflow_gates_release_target_idx",
+          "columns": [
+            "release_target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_workflow_gates_organization_id_organizations_id_fk": {
+          "name": "github_workflow_gates_organization_id_organizations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_workflow_gates_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_release_target_id_github_release_targets_id_fk": {
+          "name": "github_workflow_gates_release_target_id_github_release_targets_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_release_targets",
+          "columnsFrom": [
+            "release_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_scan_id_scans_id_fk": {
+          "name": "github_workflow_gates_scan_id_scans_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_unique_idx": {
+          "name": "npm_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_invitations": {
+      "name": "organization_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_invitations_token_hash_unique_idx": {
+          "name": "organization_invitations_token_hash_unique_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "organization_invitations_org_status_idx": {
+          "name": "organization_invitations_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "organization_invitations_org_email_idx": {
+          "name": "organization_invitations_org_email_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_invitations_organization_id_organizations_id_fk": {
+          "name": "organization_invitations_organization_id_organizations_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_invited_by_user_id_user_id_fk": {
+          "name": "organization_invitations_invited_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_accepted_by_user_id_user_id_fk": {
+          "name": "organization_invitations_accepted_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_notification_recipients": {
+      "name": "organization_notification_recipients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_notification_recipients_org_email_unique_idx": {
+          "name": "organization_notification_recipients_org_email_unique_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_notification_recipients_organization_id_organizations_id_fk": {
+          "name": "organization_notification_recipients_organization_id_organizations_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_notification_recipients_created_by_user_id_user_id_fk": {
+          "name": "organization_notification_recipients_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_findings_scan_severity_idx": {
+          "name": "scan_findings_scan_severity_idx",
+          "columns": [
+            "scan_id",
+            "severity"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changed_file_count": {
+          "name": "changed_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_summary_json": {
+          "name": "risk_summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        },
+        "scans_gate_org_idx": {
+          "name": "scans_gate_org_idx",
+          "columns": [
+            "gate_id",
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_org_decision_created_idx": {
+          "name": "scans_org_decision_created_idx",
+          "columns": [
+            "organization_id",
+            "decision",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_gate_id_github_workflow_gates_id_fk": {
+          "name": "scans_gate_id_github_workflow_gates_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "github_workflow_gates",
+          "columnsFrom": [
+            "gate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_decided_by_user_id_user_id_fk": {
+          "name": "scans_decided_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "two_factor": {
+      "name": "two_factor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1780377399680,
       "tag": "0016_lovely_madrox",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "6",
+      "when": 1780630576632,
+      "tag": "0017_normal_zodiak",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -51,6 +51,8 @@ export interface CreateScanJobInput {
   organizationId: string;
   ownerUserId: string;
   source?: ScanSource;
+  /** Links a workflow-gate review scan back to its gate. */
+  gateId?: string | null;
 }
 
 export const SCAN_SOURCES = ["manual", "auto_discovery", "workflow_gate"] as const;
@@ -63,6 +65,7 @@ export async function createScanJob(db: AppDb, input: CreateScanJobInput) {
     stageId: input.stageId,
     organizationId: input.organizationId,
     ownerUserId: input.ownerUserId,
+    gateId: input.gateId ?? null,
     risk: "unknown",
     status: "pending",
     source: input.source ?? "manual",
@@ -146,6 +149,19 @@ export async function markScanFailed(
 
 export async function discardScanAttempt(db: AppDb, scanId: string, organizationId: string) {
   await db.delete(scans).where(and(eq(scans.id, scanId), eq(scans.organizationId, organizationId)));
+}
+
+/**
+ * Remove every scan attached to a gate. Used to discard a partially-completed
+ * review batch before it is re-run, so a retry does not leave orphaned
+ * per-package scans behind (cascades to scan_files / scan_findings). Safe only
+ * once the caller holds the gate's review claim and no representative scan is
+ * attached.
+ */
+export async function discardGateScans(db: AppDb, gateId: string, organizationId: string) {
+  await db
+    .delete(scans)
+    .where(and(eq(scans.gateId, gateId), eq(scans.organizationId, organizationId)));
 }
 
 export async function persistScan(db: AppDb, input: PersistedScanInput) {

--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, isNull, lt, or } from "drizzle-orm";
+import { and, asc, desc, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
 import {
   annotateFindingsWithDiffStatus,
   type CodePatternSet,
@@ -14,7 +14,7 @@ import {
 import { normalizeScanRiskBreakdown, type ScanRiskBreakdown } from "../lib/risk";
 import type { AppDb } from "./client";
 import { recordScanEvent, redactScanEventForClient } from "./events";
-import { scanEvents, scanFiles, scanFindings, scans } from "./schema";
+import { githubWorkflowGates, scanEvents, scanFiles, scanFindings, scans } from "./schema";
 
 export interface PersistedScanInput {
   id: string;
@@ -561,6 +561,58 @@ export async function recordScanDecision(db: AppDb, input: RecordScanDecisionInp
         eq(scans.id, input.scanId),
         eq(scans.organizationId, input.organizationId),
         eq(scans.status, "complete"),
+      ),
+    )
+    .returning({ id: scans.id });
+
+  if (updated.length === 0) return null;
+
+  await recordScanEvent(db, {
+    organizationId: input.organizationId,
+    actorUserId: input.actorUserId,
+    scanId: input.scanId,
+    type: "scan.decided",
+    metadata: { decision: input.decision, reason },
+  });
+
+  return getScan(db, input.scanId, input.organizationId);
+}
+
+export interface RecordGatePackageDecisionInput extends RecordScanDecisionInput {
+  gateId: string;
+}
+
+/**
+ * Record the one allowed decision for a workflow-gate package while the gate is
+ * still pending. This keeps stale concurrent submits from mutating package state
+ * after the aggregate gate decision has already released or blocked GitHub.
+ */
+export async function recordGatePackageDecision(db: AppDb, input: RecordGatePackageDecisionInput) {
+  const now = new Date();
+  const reason = input.reason?.trim() ? input.reason.trim() : null;
+  const updated = await db
+    .update(scans)
+    .set({
+      decision: input.decision,
+      decisionReason: reason,
+      decidedByUserId: input.actorUserId,
+      decidedAt: now,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(scans.id, input.scanId),
+        eq(scans.organizationId, input.organizationId),
+        eq(scans.gateId, input.gateId),
+        eq(scans.source, "workflow_gate"),
+        eq(scans.status, "complete"),
+        isNull(scans.decision),
+        sql`exists (
+          select 1
+          from ${githubWorkflowGates}
+          where ${githubWorkflowGates.id} = ${input.gateId}
+            and ${githubWorkflowGates.status} = 'pending'
+        )`,
       ),
     )
     .returning({ id: scans.id });

--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -605,7 +605,7 @@ export async function recordGatePackageDecision(db: AppDb, input: RecordGatePack
         eq(scans.organizationId, input.organizationId),
         eq(scans.gateId, input.gateId),
         eq(scans.source, "workflow_gate"),
-        eq(scans.status, "complete"),
+        sql`${scans.status} in ('complete', 'failed')`,
         isNull(scans.decision),
         sql`exists (
           select 1

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -1,4 +1,11 @@
-import { sqliteTable, text, integer, index, uniqueIndex } from "drizzle-orm/sqlite-core";
+import {
+  sqliteTable,
+  text,
+  integer,
+  index,
+  uniqueIndex,
+  type AnySQLiteColumn,
+} from "drizzle-orm/sqlite-core";
 
 export const user = sqliteTable("user", {
   id: text("id").primaryKey(),
@@ -114,6 +121,13 @@ export const scans = sqliteTable(
       onDelete: "cascade",
     }),
     ownerUserId: text("owner_user_id").references(() => user.id, { onDelete: "set null" }),
+    // Workflow-gate reviews link each per-package scan back to its gate. A
+    // monorepo release bundle produces several `workflow_gate` scans that share
+    // one `gate_id`; the gate decision aggregates across them. Null for ordinary
+    // (npm/manual) scans.
+    gateId: text("gate_id").references((): AnySQLiteColumn => githubWorkflowGates.id, {
+      onDelete: "set null",
+    }),
     packageName: text("package_name"),
     stagedVersion: text("staged_version"),
     previousVersion: text("previous_version"),
@@ -288,7 +302,14 @@ export const githubReleaseTargets = sqliteTable(
     installationRowId: text("installation_row_id")
       .notNull()
       .references(() => githubAppInstallations.id, { onDelete: "cascade" }),
-    ecosystem: text("ecosystem").notNull(),
+    // Null means "auto-detect the ecosystem from the uploaded artifacts" (one
+    // gate covers every package a monorepo publishes from the environment). A
+    // non-null value pins detection + the default artifact name to one ecosystem
+    // (the legacy single-ecosystem behavior).
+    ecosystem: text("ecosystem"),
+    // Optional override for the GitHub Actions artifact the release bundle is
+    // downloaded from. Null falls back to the ecosystem default.
+    artifactName: text("artifact_name"),
     repositoryId: integer("repository_id").notNull(),
     repositoryFullName: text("repository_full_name").notNull(),
     environment: text("environment").notNull(),
@@ -331,7 +352,13 @@ export const githubWorkflowGates = sqliteTable(
     decision: text("decision"),
     decisionComment: text("decision_comment"),
     reportUrl: text("report_url"),
+    // Representative (highest-risk) package scan for the gate. The full set of
+    // per-package scans is found via `scans.gate_id = github_workflow_gates.id`.
     scanId: text("scan_id").references(() => scans.id, { onDelete: "set null" }),
+    // CAS claim so concurrent webhook re-deliveries don't double-run the review
+    // batch. Set once when a delivery starts reviewing; a later delivery retries
+    // only when the batch is incomplete.
+    reviewStartedAt: integer("review_started_at", { mode: "timestamp_ms" }),
     failureReason: text("failure_reason"),
     requestedAt: integer("requested_at", { mode: "timestamp_ms" }).notNull(),
     decidedAt: integer("decided_at", { mode: "timestamp_ms" }),

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -158,6 +158,7 @@ export const scans = sqliteTable(
     ownerIdx: index("scans_owner_idx").on(table.ownerUserId),
     stageIdx: index("scans_stage_id_idx").on(table.stageId),
     packageIdx: index("scans_package_idx").on(table.packageName),
+    gateIdx: index("scans_gate_org_idx").on(table.gateId, table.organizationId),
     orgDecisionCreatedIdx: index("scans_org_decision_created_idx").on(
       table.organizationId,
       table.decision,

--- a/server/lib/github-app/artifacts.ts
+++ b/server/lib/github-app/artifacts.ts
@@ -14,17 +14,22 @@ export interface WorkflowArtifactSource {
 }
 
 /**
- * Decide whether a bundle entry is a reviewable artifact. The shared fetcher is
- * ecosystem-agnostic: the workflow-gate adapter supplies this so the kind is
- * opaque here (PyPI returns `"wheel" | "sdist"`; other ecosystems pick their
- * own). Returning `null` drops the entry — it is never collected or scanned.
+ * Decide whether a bundle entry is a reviewable artifact and which ecosystem it
+ * belongs to. The shared fetcher is ecosystem-agnostic: a single-ecosystem
+ * workflow-gate adapter (pinned targets) or the registry's combined classifier
+ * (auto-detect targets) supplies this. Both `ecosystem` and `kind` are opaque
+ * here — PyPI returns `{ ecosystem: "pypi", kind: "wheel" | "sdist" }`; other
+ * ecosystems pick their own. Returning `null` drops the entry — it is never
+ * collected or scanned. Tagging each kept entry with its ecosystem is what lets
+ * one monorepo bundle fan out into per-ecosystem, per-package reviews.
  */
-export type ClassifyArtifact = (path: string) => string | null;
+export type ClassifyArtifact = (path: string) => { ecosystem: string; kind: string } | null;
 
 export interface ResolvedReleaseFile {
   path: string;
   bytes: Uint8Array;
   sha256: string;
+  ecosystem: string;
   kind: string;
 }
 
@@ -158,10 +163,16 @@ export async function fetchReleaseBundleWithToken(
   // influence the review.
   const candidateArtifacts: ResolvedReleaseFile[] = [];
   for (const entry of entries) {
-    const kind = classifyArtifact(entry.path);
-    if (!kind) continue;
+    const classified = classifyArtifact(entry.path);
+    if (!classified) continue;
     const sha256 = await sha256Hex(entry.bytes);
-    candidateArtifacts.push({ path: entry.path, bytes: entry.bytes, sha256, kind });
+    candidateArtifacts.push({
+      path: entry.path,
+      bytes: entry.bytes,
+      sha256,
+      ecosystem: classified.ecosystem,
+      kind: classified.kind,
+    });
   }
   if (candidateArtifacts.length === 0) {
     throw new WorkflowArtifactError(

--- a/server/lib/github-app/artifacts.ts
+++ b/server/lib/github-app/artifacts.ts
@@ -35,8 +35,11 @@ export interface ResolvedReleaseFile {
 
 export interface ResolvedReleaseBundle {
   artifacts: ResolvedReleaseFile[];
+  /** First downloaded GitHub Actions artifact id; retained for old callers/tests. */
   artifactId: number;
+  /** First downloaded GitHub Actions artifact name, or "all" when several were inspected. */
   artifactName: string;
+  /** Total downloaded GitHub Actions artifact ZIP bytes. */
   artifactSizeBytes: number;
 }
 
@@ -60,12 +63,12 @@ export class WorkflowArtifactError extends Error {
 
 // ── Configuration ────────────────────────────────────────────────────────────
 
-const DEFAULT_ARTIFACT_NAME = "pypi-release-candidate";
-
 export const MAX_OUTER_ZIP_BYTES = 25 * 1024 * 1024;
+export const MAX_TOTAL_ARTIFACT_ZIP_BYTES = 50 * 1024 * 1024;
 export const MAX_OUTER_ZIP_ENTRIES = 256;
 export const MAX_PER_ENTRY_BYTES = 25 * 1024 * 1024;
 const MAX_RELEASE_ARTIFACTS = 20;
+const MAX_RUN_ARTIFACTS = 50;
 const MAX_LIST_PAGES = 4;
 const MAX_DOWNLOAD_REDIRECTS = 4;
 
@@ -123,8 +126,10 @@ export function evaluateGithubArtifactEgress(requestUrl: string): GithubArtifact
  * Identity (`package`/`version`) is derived from the artifacts themselves
  * downstream by the ecosystem's `WorkflowGateAdapter`
  * (`server/lib/workflow-gates`) once the bytes have been parsed in the sandbox.
- * This stage only collects the artifact bytes the supplied `classifyArtifact`
- * keeps and recomputes their SHA-256; every other file in the bundle is ignored.
+ * This stage enumerates the workflow run's non-expired GitHub Actions artifacts
+ * unless `source.artifactName` narrows it to one named upload. It then collects
+ * only the inner files the supplied `classifyArtifact` keeps and recomputes
+ * their SHA-256; every other file in every upload is ignored.
  */
 export async function fetchReleaseBundleWithToken(
   installationToken: string,
@@ -140,39 +145,53 @@ export async function fetchReleaseBundleWithToken(
   if (!Number.isInteger(source.runId) || source.runId <= 0) {
     throw new WorkflowArtifactError("bundle_unavailable", "runId must be a positive integer");
   }
-  const artifactName =
-    (source.artifactName ?? DEFAULT_ARTIFACT_NAME).trim() || DEFAULT_ARTIFACT_NAME;
-
-  const artifact = await findRunArtifact(
+  const artifactName = typeof source.artifactName === "string" ? source.artifactName.trim() : "";
+  const runArtifacts = await listRunArtifacts(
     installationToken,
     source.repositoryFullName,
     source.runId,
-    artifactName,
+    artifactName || undefined,
   );
-  const zipBytes = await downloadArtifactZip(
-    installationToken,
-    source.repositoryFullName,
-    artifact.id,
-  );
-
-  const entries = await extractOuterZipEntries(zipBytes);
 
   // The release set is every entry the adapter classifies as an artifact.
   // Non-artifact files (checksums, READMEs, anything else upload-artifact
   // happened to include) are ignored — they are never scanned, so they cannot
   // influence the review.
   const candidateArtifacts: ResolvedReleaseFile[] = [];
-  for (const entry of entries) {
-    const classified = classifyArtifact(entry.path);
-    if (!classified) continue;
-    const sha256 = await sha256Hex(entry.bytes);
-    candidateArtifacts.push({
-      path: entry.path,
-      bytes: entry.bytes,
-      sha256,
-      ecosystem: classified.ecosystem,
-      kind: classified.kind,
-    });
+  let totalZipBytes = 0;
+  for (const artifact of runArtifacts) {
+    const zipBytes = await downloadArtifactZip(
+      installationToken,
+      source.repositoryFullName,
+      artifact.id,
+    );
+    totalZipBytes += zipBytes.byteLength;
+    if (totalZipBytes > MAX_TOTAL_ARTIFACT_ZIP_BYTES) {
+      throw new WorkflowArtifactError(
+        "bundle_too_large",
+        `artifact downloads exceed ${MAX_TOTAL_ARTIFACT_ZIP_BYTES} bytes`,
+      );
+    }
+
+    const entries = await extractOuterZipEntries(zipBytes);
+    for (const entry of entries) {
+      const classified = classifyArtifact(entry.path);
+      if (!classified) continue;
+      const sha256 = await sha256Hex(entry.bytes);
+      candidateArtifacts.push({
+        path: entry.path,
+        bytes: entry.bytes,
+        sha256,
+        ecosystem: classified.ecosystem,
+        kind: classified.kind,
+      });
+    }
+    if (candidateArtifacts.length > MAX_RELEASE_ARTIFACTS) {
+      throw new WorkflowArtifactError(
+        "bundle_too_large",
+        `artifact bundle contains more than ${MAX_RELEASE_ARTIFACTS} wheel/sdist files`,
+      );
+    }
   }
   if (candidateArtifacts.length === 0) {
     throw new WorkflowArtifactError(
@@ -180,18 +199,12 @@ export async function fetchReleaseBundleWithToken(
       "artifact bundle contained no reviewable artifacts",
     );
   }
-  if (candidateArtifacts.length > MAX_RELEASE_ARTIFACTS) {
-    throw new WorkflowArtifactError(
-      "bundle_too_large",
-      `artifact bundle contains more than ${MAX_RELEASE_ARTIFACTS} wheel/sdist files`,
-    );
-  }
 
   return {
     artifacts: candidateArtifacts,
-    artifactId: artifact.id,
-    artifactName: artifact.name,
-    artifactSizeBytes: zipBytes.byteLength,
+    artifactId: runArtifacts[0]?.id ?? 0,
+    artifactName: runArtifacts.length === 1 ? (runArtifacts[0]?.name ?? "") : "all",
+    artifactSizeBytes: totalZipBytes,
   };
 }
 
@@ -218,16 +231,17 @@ interface RunArtifactRef {
   expired: boolean;
 }
 
-async function findRunArtifact(
+async function listRunArtifacts(
   token: string,
   repositoryFullName: string,
   runId: number,
-  artifactName: string,
-): Promise<RunArtifactRef> {
+  artifactName?: string,
+): Promise<RunArtifactRef[]> {
   const [owner, repo] = repositoryFullName.split("/");
   let url: string | null =
     `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}` +
     `/actions/runs/${runId}/artifacts?per_page=100`;
+  const found: RunArtifactRef[] = [];
   for (let page = 0; page < MAX_LIST_PAGES && url; page += 1) {
     const response = await fetch(url, { headers: githubInstallationHeaders(token) });
     if (response.status === 404) {
@@ -254,15 +268,22 @@ async function findRunArtifact(
       if (
         typeof candidate.id === "number" &&
         candidate.id > 0 &&
-        candidate.name === artifactName &&
+        typeof candidate.name === "string" &&
+        (!artifactName || candidate.name === artifactName) &&
         candidate.expired !== true
       ) {
-        return {
+        found.push({
           id: candidate.id,
           name: candidate.name,
           sizeInBytes: typeof candidate.size_in_bytes === "number" ? candidate.size_in_bytes : null,
           expired: false,
-        };
+        });
+        if (found.length > MAX_RUN_ARTIFACTS) {
+          throw new WorkflowArtifactError(
+            "bundle_too_large",
+            `workflow run has more than ${MAX_RUN_ARTIFACTS} matching artifacts`,
+          );
+        }
       }
     }
     const next = nextLink(response.headers.get("link"));
@@ -270,10 +291,11 @@ async function findRunArtifact(
     // a forged `Link` header cannot redirect the token-bearing listing call.
     url = next && evaluateGithubArtifactEgress(next).host === "api.github.com" ? next : null;
   }
-  throw new WorkflowArtifactError(
-    "bundle_unavailable",
-    `no non-expired artifact named ${artifactName} on run ${runId}`,
-  );
+  if (found.length > 0) return found;
+  const detail = artifactName
+    ? `no non-expired artifact named ${artifactName} on run ${runId}`
+    : `no non-expired artifacts on run ${runId}`;
+  throw new WorkflowArtifactError("bundle_unavailable", detail);
 }
 
 async function downloadArtifactZip(

--- a/server/lib/github-app/persistence.ts
+++ b/server/lib/github-app/persistence.ts
@@ -26,7 +26,12 @@ export interface ReleaseTargetRecord {
   id: string;
   organizationId: string;
   installationRowId: string;
-  ecosystem: SupportedEcosystem;
+  // Null means "auto-detect the ecosystem from the uploaded artifacts" so one
+  // gate can cover every package a monorepo publishes from the environment.
+  ecosystem: SupportedEcosystem | null;
+  // Null falls back to the resolved ecosystem's default GitHub Actions artifact
+  // name (or the auto-detect default for unpinned targets).
+  artifactName: string | null;
   repositoryId: number;
   repositoryFullName: string;
   environment: string;
@@ -174,7 +179,10 @@ export async function markInstallationStatus(
 export interface CreateReleaseTargetInput {
   organizationId: string;
   installationRowId: string;
-  ecosystem: SupportedEcosystem;
+  /** Null = auto-detect the ecosystem from the uploaded artifacts. */
+  ecosystem: SupportedEcosystem | null;
+  /** Optional override for the GitHub Actions artifact name. */
+  artifactName?: string | null;
   repositoryId: number;
   repositoryFullName: string;
   environment: string;
@@ -207,12 +215,14 @@ export async function createReleaseTarget(
 
   const id = crypto.randomUUID();
   const now = new Date();
+  const artifactName = normalizeArtifactName(input.artifactName);
   try {
     await db.insert(githubReleaseTargets).values({
       id,
       organizationId: input.organizationId,
       installationRowId: input.installationRowId,
       ecosystem: input.ecosystem,
+      artifactName,
       repositoryId: input.repositoryId,
       repositoryFullName: input.repositoryFullName,
       environment,
@@ -234,12 +244,19 @@ export async function createReleaseTarget(
     organizationId: input.organizationId,
     installationRowId: input.installationRowId,
     ecosystem: input.ecosystem,
+    artifactName,
     repositoryId: input.repositoryId,
     repositoryFullName: input.repositoryFullName,
     environment,
     createdAt: now,
     updatedAt: now,
   };
+}
+
+function normalizeArtifactName(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 export async function listReleaseTargetsForOrganization(
@@ -343,7 +360,8 @@ function readReleaseTargetRow(row: {
   id: string;
   organizationId: string;
   installationRowId: string;
-  ecosystem: string;
+  ecosystem: string | null;
+  artifactName: string | null;
   repositoryId: number;
   repositoryFullName: string;
   environment: string;
@@ -354,7 +372,8 @@ function readReleaseTargetRow(row: {
     id: row.id,
     organizationId: row.organizationId,
     installationRowId: row.installationRowId,
-    ecosystem: row.ecosystem as SupportedEcosystem,
+    ecosystem: row.ecosystem === null ? null : (row.ecosystem as SupportedEcosystem),
+    artifactName: row.artifactName,
     repositoryId: row.repositoryId,
     repositoryFullName: row.repositoryFullName,
     environment: row.environment,

--- a/server/lib/github-app/persistence.ts
+++ b/server/lib/github-app/persistence.ts
@@ -29,8 +29,8 @@ export interface ReleaseTargetRecord {
   // Null means "auto-detect the ecosystem from the uploaded artifacts" so one
   // gate can cover every package a monorepo publishes from the environment.
   ecosystem: SupportedEcosystem | null;
-  // Null falls back to the resolved ecosystem's default GitHub Actions artifact
-  // name (or the auto-detect default for unpinned targets).
+  // Null inspects every non-expired workflow artifact; non-null narrows to one
+  // GitHub Actions artifact name.
   artifactName: string | null;
   repositoryId: number;
   repositoryFullName: string;
@@ -181,7 +181,7 @@ export interface CreateReleaseTargetInput {
   installationRowId: string;
   /** Null = auto-detect the ecosystem from the uploaded artifacts. */
   ecosystem: SupportedEcosystem | null;
-  /** Optional override for the GitHub Actions artifact name. */
+  /** Optional narrowing override for the GitHub Actions artifact name. */
   artifactName?: string | null;
   repositoryId: number;
   repositoryFullName: string;

--- a/server/lib/github-app/validation.ts
+++ b/server/lib/github-app/validation.ts
@@ -10,7 +10,9 @@ const REPO_OWNER_RE = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/;
 const REPO_NAME_RE = /^[A-Za-z0-9._-]+$/;
 
 export function validateReleaseTargetShape(input: CreateReleaseTargetInput) {
-  if (!SUPPORTED_ECOSYSTEMS.includes(input.ecosystem)) {
+  // Null pins nothing: the runner auto-detects the ecosystem from the uploaded
+  // artifacts. A non-null value must be a supported ecosystem.
+  if (input.ecosystem !== null && !SUPPORTED_ECOSYSTEMS.includes(input.ecosystem)) {
     throw new GithubAppValidationError(
       "unsupported_ecosystem",
       `unsupported ecosystem: ${input.ecosystem}`,

--- a/server/lib/github-app/webhook-gates.ts
+++ b/server/lib/github-app/webhook-gates.ts
@@ -404,6 +404,7 @@ export async function markGateDecidedForPackageAggregate(
         eq(githubWorkflowGates.id, input.gateId),
         eq(githubWorkflowGates.organizationId, input.organizationId),
         eq(githubWorkflowGates.status, "pending"),
+        input.decision === "approved" ? sql`${githubWorkflowGates.scanId} is not null` : sql`1 = 1`,
         packageDecisionCondition,
       ),
     )

--- a/server/lib/github-app/webhook-gates.ts
+++ b/server/lib/github-app/webhook-gates.ts
@@ -1,6 +1,6 @@
 import { and, eq, isNull } from "drizzle-orm";
 import type { AppDb } from "../../db";
-import { githubWorkflowGates } from "../../db/schema";
+import { githubWorkflowGates, scans } from "../../db/schema";
 import type { InstallationRecord, ReleaseTargetRecord } from "./persistence";
 import type { ParsedDeploymentProtectionEvent } from "./webhook";
 
@@ -23,7 +23,13 @@ export interface WorkflowGateRecord {
   decision: "approved" | "rejected" | null;
   decisionComment: string | null;
   reportUrl: string | null;
+  // Representative (highest-risk) package scan. A monorepo gate fans out into
+  // several per-package scans (`scans.gate_id = this.id`); this points at the
+  // one surfaced as the gate's headline.
   scanId: string | null;
+  // CAS claim flipped once when a delivery starts the review batch, so a
+  // concurrent re-delivery does not double-run the per-package scans.
+  reviewStartedAt: Date | null;
   failureReason: string | null;
   requestedAt: Date;
   decidedAt: Date | null;
@@ -105,11 +111,26 @@ export async function getGateForOrganization(
   return row ? readGateRow(row) : null;
 }
 
+/**
+ * Resolve the gate a scan belongs to. A monorepo gate fans out into several
+ * per-package scans, so the authoritative link is `scans.gate_id`; only the
+ * representative scan is also reachable via `github_workflow_gates.scan_id`. We
+ * resolve via `scans.gate_id` first and fall back to the representative pointer
+ * for any pre-migration row that lacks a back-link.
+ */
 export async function getGateByScanId(
   db: AppDb,
   organizationId: string,
   scanId: string,
 ): Promise<WorkflowGateRecord | null> {
+  const [scanRow] = await db
+    .select({ gateId: scans.gateId })
+    .from(scans)
+    .where(and(eq(scans.id, scanId), eq(scans.organizationId, organizationId)))
+    .limit(1);
+  if (scanRow?.gateId) {
+    return getGateForOrganization(db, organizationId, scanRow.gateId);
+  }
   const [row] = await db
     .select()
     .from(githubWorkflowGates)
@@ -121,6 +142,106 @@ export async function getGateByScanId(
     )
     .limit(1);
   return row ? readGateRow(row) : null;
+}
+
+/** One per-package scan attached to a gate, as the gate decision aggregates them. */
+export interface GatePackageScan {
+  scanId: string;
+  packageName: string | null;
+  stagedVersion: string | null;
+  risk: string;
+  status: string;
+  decision: string | null;
+  releaseRisk: string | null;
+}
+
+/**
+ * List every per-package scan attached to a gate (`scans.gate_id = gateId`),
+ * oldest first. The gate decision is the aggregate over these: it releases the
+ * held deployment only once every package is individually approved, and blocks
+ * it the moment any one is rejected.
+ */
+export async function listGatePackageScans(
+  db: AppDb,
+  organizationId: string,
+  gateId: string,
+): Promise<GatePackageScan[]> {
+  const rows = await db
+    .select({
+      scanId: scans.id,
+      packageName: scans.packageName,
+      stagedVersion: scans.stagedVersion,
+      risk: scans.risk,
+      status: scans.status,
+      decision: scans.decision,
+      riskSummaryJson: scans.riskSummaryJson,
+      createdAt: scans.createdAt,
+    })
+    .from(scans)
+    .where(and(eq(scans.gateId, gateId), eq(scans.organizationId, organizationId)));
+  return rows
+    .slice()
+    .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+    .map((row) => ({
+      scanId: row.scanId,
+      packageName: row.packageName,
+      stagedVersion: row.stagedVersion,
+      risk: row.risk,
+      status: row.status,
+      decision: row.decision,
+      releaseRisk: readReleaseRisk(row.riskSummaryJson),
+    }));
+}
+
+function readReleaseRisk(riskSummaryJson: unknown): string | null {
+  if (!riskSummaryJson || typeof riskSummaryJson !== "object" || Array.isArray(riskSummaryJson)) {
+    return null;
+  }
+  const value = (riskSummaryJson as { releaseRisk?: unknown }).releaseRisk;
+  return typeof value === "string" ? value : null;
+}
+
+/**
+ * CAS-claim the review batch for a gate. Returns true for exactly the first
+ * delivery that flips `review_started_at` from null while the gate is still
+ * pending; a concurrent re-delivery loses the claim and skips. A claim that is
+ * never finalized (a delivery that fails mid-batch releases it via
+ * `releaseGateReviewClaim`; a hard crash leaves the gate pending — safe, never
+ * auto-approved).
+ */
+export async function claimGateReviewStart(db: AppDb, gateId: string): Promise<boolean> {
+  const now = new Date();
+  const updated = await db
+    .update(githubWorkflowGates)
+    .set({ reviewStartedAt: now, updatedAt: now })
+    .where(
+      and(
+        eq(githubWorkflowGates.id, gateId),
+        eq(githubWorkflowGates.status, "pending"),
+        isNull(githubWorkflowGates.reviewStartedAt),
+      ),
+    )
+    .returning({ id: githubWorkflowGates.id });
+  return updated.length > 0;
+}
+
+/**
+ * Release a review-batch claim so a later delivery can retry. Only clears the
+ * claim while the gate is still pending and no representative scan is attached,
+ * so it can never reopen a gate that already reached a decision or a review.
+ */
+export async function releaseGateReviewClaim(db: AppDb, gateId: string): Promise<void> {
+  const now = new Date();
+  await db
+    .update(githubWorkflowGates)
+    .set({ reviewStartedAt: null, updatedAt: now })
+    .where(
+      and(
+        eq(githubWorkflowGates.id, gateId),
+        eq(githubWorkflowGates.status, "pending"),
+        isNull(githubWorkflowGates.scanId),
+      ),
+    );
 }
 
 export async function attachScanToGate(
@@ -225,6 +346,7 @@ function readGateRow(row: {
   decisionComment: string | null;
   reportUrl: string | null;
   scanId: string | null;
+  reviewStartedAt: Date | string | number | null;
   failureReason: string | null;
   requestedAt: Date | string | number;
   decidedAt: Date | string | number | null;
@@ -249,6 +371,7 @@ function readGateRow(row: {
     decisionComment: row.decisionComment,
     reportUrl: row.reportUrl,
     scanId: row.scanId,
+    reviewStartedAt: row.reviewStartedAt ? new Date(row.reviewStartedAt) : null,
     failureReason: row.failureReason,
     requestedAt: new Date(row.requestedAt),
     decidedAt: row.decidedAt ? new Date(row.decidedAt) : null,

--- a/server/lib/github-app/webhook-gates.ts
+++ b/server/lib/github-app/webhook-gates.ts
@@ -244,6 +244,50 @@ export async function releaseGateReviewClaim(db: AppDb, gateId: string): Promise
     );
 }
 
+/**
+ * Reopen a failed, still-pending review batch so the next gate job can discard
+ * the failed package scans and re-run the whole set. This refuses to run once a
+ * package decision has been recorded, because retrying would otherwise replace
+ * already-reviewed package state.
+ */
+export async function resetGateReviewForRetry(
+  db: AppDb,
+  input: { gateId: string; organizationId: string },
+): Promise<boolean> {
+  const now = new Date();
+  const updated = await db
+    .update(githubWorkflowGates)
+    .set({
+      scanId: null,
+      reviewStartedAt: null,
+      failureReason: null,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(githubWorkflowGates.id, input.gateId),
+        eq(githubWorkflowGates.organizationId, input.organizationId),
+        eq(githubWorkflowGates.status, "pending"),
+        sql`exists (
+          select 1
+          from ${scans}
+          where ${scans.gateId} = ${input.gateId}
+            and ${scans.organizationId} = ${input.organizationId}
+            and ${scans.status} = 'failed'
+        )`,
+        sql`not exists (
+          select 1
+          from ${scans}
+          where ${scans.gateId} = ${input.gateId}
+            and ${scans.organizationId} = ${input.organizationId}
+            and ${scans.decision} is not null
+        )`,
+      ),
+    )
+    .returning({ id: githubWorkflowGates.id });
+  return updated.length > 0;
+}
+
 export async function attachScanToGate(
   db: AppDb,
   gateId: string,

--- a/server/lib/github-app/webhook-gates.ts
+++ b/server/lib/github-app/webhook-gates.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import type { AppDb } from "../../db";
 import { githubWorkflowGates, scans } from "../../db/schema";
 import type { InstallationRecord, ReleaseTargetRecord } from "./persistence";
@@ -298,6 +298,71 @@ export async function markGateDecided(
       updatedAt: now,
     })
     .where(and(eq(githubWorkflowGates.id, input.gateId), eq(githubWorkflowGates.status, "pending")))
+    .returning({ id: githubWorkflowGates.id });
+  if (updated.length === 0) return null;
+  const [row] = await db
+    .select()
+    .from(githubWorkflowGates)
+    .where(eq(githubWorkflowGates.id, input.gateId))
+    .limit(1);
+  return row ? readGateRow(row) : null;
+}
+
+interface DecideGateWithPackageAggregateInput extends DecideGateInput {
+  organizationId: string;
+}
+
+/**
+ * Atomically finalize a pending gate only if the current per-package scan
+ * decisions still justify that aggregate decision. This closes the race where a
+ * sibling package decision changes between a route's in-memory aggregation and
+ * the gate CAS.
+ */
+export async function markGateDecidedForPackageAggregate(
+  db: AppDb,
+  input: DecideGateWithPackageAggregateInput,
+): Promise<WorkflowGateRecord | null> {
+  const now = new Date();
+  const packageDecisionCondition =
+    input.decision === "approved"
+      ? sql`exists (
+          select 1
+          from ${scans}
+          where ${scans.gateId} = ${input.gateId}
+            and ${scans.organizationId} = ${input.organizationId}
+        )
+        and not exists (
+          select 1
+          from ${scans}
+          where ${scans.gateId} = ${input.gateId}
+            and ${scans.organizationId} = ${input.organizationId}
+            and (${scans.decision} is null or ${scans.decision} <> 'publish')
+        )`
+      : sql`exists (
+          select 1
+          from ${scans}
+          where ${scans.gateId} = ${input.gateId}
+            and ${scans.organizationId} = ${input.organizationId}
+            and ${scans.decision} = 'no_publish'
+        )`;
+  const updated = await db
+    .update(githubWorkflowGates)
+    .set({
+      status: input.decision,
+      decision: input.decision,
+      decisionComment: input.comment,
+      reportUrl: input.reportUrl ?? null,
+      decidedAt: now,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(githubWorkflowGates.id, input.gateId),
+        eq(githubWorkflowGates.organizationId, input.organizationId),
+        eq(githubWorkflowGates.status, "pending"),
+        packageDecisionCondition,
+      ),
+    )
     .returning({ id: githubWorkflowGates.id });
   if (updated.length === 0) return null;
   const [row] = await db

--- a/server/lib/notify.ts
+++ b/server/lib/notify.ts
@@ -161,6 +161,8 @@ export interface NotifyWorkflowGateReviewInput {
   packageName: string | null;
   version: string | null;
   releaseRisk: RiskLevel;
+  /** Total packages in the release; >1 means a monorepo bundle fanned out. */
+  packageCount?: number;
 }
 
 /**
@@ -195,6 +197,7 @@ export async function notifyWorkflowGateReview(
     packageName,
     version,
     releaseRisk,
+    packageCount,
   } = input;
 
   const recipients = await resolveNotificationEmails(db, organizationId, ownerUserId);
@@ -211,13 +214,17 @@ export async function notifyWorkflowGateReview(
 
   const packageLabel = formatPackageLabel(packageName, version);
   const dashboardUrl = scanUrl(env, scanId);
+  const otherPackages = packageCount && packageCount > 1 ? packageCount - 1 : 0;
+  const packageLine = otherPackages
+    ? `Package: ${packageLabel} (+${otherPackages} more in this release; each must be approved)`
+    : `Package: ${packageLabel}`;
   const subject = `Release gate needs your review — ${packageLabel}`;
   const lines = [
     "Hi there,",
     "",
     `A staged release is held in ${repositoryFullName} and is waiting for a decision before it can publish.`,
     "",
-    `Package: ${packageLabel}`,
+    packageLine,
     `Release risk: ${releaseRisk}`,
     `Repository: ${repositoryFullName}`,
     `Environment: ${environment}`,

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -2,28 +2,34 @@ import { and, eq } from "drizzle-orm";
 import {
   createDb,
   createScanJob,
-  deletePendingScanJob,
+  discardGateScans,
   getOrganizationOwnerUserId,
   markScanFailed,
   recordScanEvent,
   type AppDb,
 } from "../db";
-import { githubAppInstallations, scans } from "../db/schema";
+import { githubAppInstallations } from "../db/schema";
 import {
   attachScanToGate,
+  claimGateReviewStart,
   GithubAppConfigError,
   type GithubAppConfig,
   getGateForOrganization,
   markGateDecided,
   postDeploymentProtectionDecision,
   readGithubAppConfig,
+  releaseGateReviewClaim,
   WorkflowArtifactError,
   type WorkflowGateRecord,
 } from "./github-app";
 import { notifyWorkflowGateReview, notifyWorkflowGateTimeout } from "./notify";
 import { describeOperationalError, durationMsSince, emitOperationalEvent } from "./observability";
-import { prepareReleaseCandidateForGate } from "./workflow-gates";
-import type { RiskLevel } from "./review";
+import {
+  prepareReleaseCandidatesForGate,
+  type PreparedGatePackage,
+  type PreparedGateRelease,
+} from "./workflow-gates";
+import { combineRisk, type RiskLevel } from "./review";
 import { runScanPipeline } from "./scan-pipeline";
 import { classifyScanError, type WorkflowGateQueueMessage } from "./scan-job";
 
@@ -70,7 +76,7 @@ export function classifyGateTimeout(
  *
  * Trust boundary: the installation token never enters the sandbox. Artifact
  * bytes are fetched + SHA-256-verified in the control plane
- * (`prepareReleaseCandidateForGate`), then the credentials-free sandbox parser
+ * (`prepareReleaseCandidatesForGate`), then the credentials-free sandbox parser
  * turns them into evidence the deterministic rules run against via
  * `runScanPipeline`.
  *
@@ -142,40 +148,20 @@ export async function executeWorkflowGateJob(
     return;
   }
 
+  // A finished batch attaches a representative scan to the gate. A re-delivery
+  // must not re-run the per-package scans; the gate is waiting on a human.
   if (gate.scanId) {
-    const attachedScan = await getAttachedGateScan(db, organizationId, gate.scanId);
-    if (attachedScan?.status === "complete") {
-      // A prior delivery already reviewed this gate and attached its completed
-      // scan; it is waiting on a human decision. Re-enqueues must not re-run the
-      // pipeline.
-      emitOperationalEvent("info", "github_workflow_gate.job_skipped", {
-        organizationId,
-        gateId,
-        scanId: gate.scanId,
-        reason: "already_reviewed",
-      });
-      return;
-    }
-    if (attachedScan?.status === "pending" || attachedScan?.status === "running") {
-      emitOperationalEvent("info", "github_workflow_gate.job_skipped", {
-        organizationId,
-        gateId,
-        scanId: gate.scanId,
-        reason: `scan_${attachedScan.status}`,
-      });
-      return;
-    }
-    emitOperationalEvent("info", "github_workflow_gate.review_retrying", {
+    emitOperationalEvent("info", "github_workflow_gate.job_skipped", {
       organizationId,
       gateId,
       scanId: gate.scanId,
-      priorStatus: attachedScan?.status ?? "missing",
+      reason: "already_reviewed",
     });
+    return;
   }
 
   await recordScanEvent(db, {
     organizationId,
-    scanId: gate.scanId,
     type: "github_workflow_gate.received",
     metadata: {
       gateId: gate.id,
@@ -185,9 +171,9 @@ export async function executeWorkflowGateJob(
     },
   });
 
-  let prepared;
+  let prepared: PreparedGateRelease;
   try {
-    prepared = await prepareReleaseCandidateForGate(env, executionCtx, db, {
+    prepared = await prepareReleaseCandidatesForGate(env, executionCtx, db, {
       config,
       organizationId,
       gateId,
@@ -197,7 +183,7 @@ export async function executeWorkflowGateJob(
       // The published artifacts could not be verified against the reviewed
       // manifest (missing bundle, tampered digest, package mismatch, …). Block
       // the deployment with a generic comment; the typed reason is already
-      // stored on the gate by `prepareReleaseCandidateForGate`.
+      // stored on the gate by `prepareReleaseCandidatesForGate`.
       await rejectGateForArtifactError(env, db, config, gate, err);
       emitOperationalEvent("warn", "github_workflow_gate.rejected_artifact_error", {
         organizationId,
@@ -212,7 +198,6 @@ export async function executeWorkflowGateJob(
     const safe = classifyScanError(err);
     await recordScanEvent(db, {
       organizationId,
-      scanId: gate.scanId,
       type: "github_workflow_gate.review_failed",
       metadata: { gateId: gate.id, error: safe },
     });
@@ -240,88 +225,87 @@ export async function executeWorkflowGateJob(
     return;
   }
 
-  const scanId = crypto.randomUUID();
-  const stageId = `workflow-gate:${gate.id}`;
-  await createScanJob(db, {
-    id: scanId,
-    stageId,
-    organizationId,
-    ownerUserId,
-    source: "workflow_gate",
-  });
-  const claimedGate = await attachScanToGate(db, gate.id, scanId, gate.scanId);
-  if (!claimedGate) {
-    await deletePendingScanJob(db, scanId, organizationId);
+  // Claim the review batch. Only the first delivery to flip `review_started_at`
+  // runs the per-package scans; a concurrent re-delivery loses the CAS and skips
+  // here rather than double-running. Early returns above leave the claim unset,
+  // so a transient prepare/owner failure stays retryable.
+  const claimed = await claimGateReviewStart(db, gate.id);
+  if (!claimed) {
     emitOperationalEvent("info", "github_workflow_gate.job_skipped", {
       organizationId,
       gateId,
-      scanId,
-      reason: "scan_claim_lost",
+      reason: "review_claim_lost",
     });
     return;
   }
 
-  let result;
+  let reviewed: ReviewedPackage[];
   try {
-    result = await runScanPipeline(
-      { env, executionCtx, db, session: { userId: ownerUserId } },
-      prepared.adapter.packageAdapter,
-      {
-        scanId,
-        stageId,
-        organizationId,
-        ...prepared.candidate.pipelineInput,
-      },
+    // A retried batch (a prior attempt released its claim mid-flight) discards
+    // the half-finished scans first so the gate's package set is exactly this
+    // batch.
+    await discardGateScans(db, gate.id, organizationId);
+    reviewed = await reviewGatePackages(
+      { env, executionCtx, db },
+      { gate, ownerUserId, packages: prepared.packages },
     );
   } catch (err) {
+    // A per-package scan failed. Release the claim so a retry re-runs the whole
+    // batch, and leave the deployment pending (never auto-approved on error).
+    await releaseGateReviewClaim(db, gate.id);
     const safe = classifyScanError(err);
-    await markScanFailed(db, scanId, organizationId, safe);
     await recordScanEvent(db, {
       organizationId,
       actorUserId: ownerUserId,
-      scanId,
       type: "github_workflow_gate.review_failed",
       metadata: { gateId: gate.id, error: safe },
     });
     emitOperationalEvent("error", "github_workflow_gate.review_failed", {
       organizationId,
       gateId,
-      scanId,
       durationMs: durationMsSince(startedAtMs),
       error: safe,
     });
     return;
   }
 
-  const releaseRisk = result.riskSummary.releaseRisk;
-  const recommendation = recommendationForReleaseRisk(releaseRisk);
+  // The gate's headline risk is the worst package's release risk; the
+  // representative scan is the (first) package carrying it.
+  const aggregateReleaseRisk = combineRisk(...reviewed.map((pkg) => pkg.releaseRisk));
+  const representative =
+    reviewed.find((pkg) => pkg.releaseRisk === aggregateReleaseRisk) ?? reviewed[0];
+  const recommendation = recommendationForReleaseRisk(aggregateReleaseRisk);
 
   await recordScanEvent(db, {
     organizationId,
     actorUserId: ownerUserId,
-    scanId,
+    scanId: representative.scanId,
     type: "github_workflow_gate.reviewed",
     metadata: {
       gateId: gate.id,
       recommendation,
-      releaseRisk,
-      artifactRisk: result.risk,
-      contextRisk: result.riskSummary.contextRisk,
-      packageName: result.package.name,
-      stagedVersion: result.package.stagedVersion,
+      releaseRisk: aggregateReleaseRisk,
+      packageCount: reviewed.length,
+      packages: reviewed.map((pkg) => ({
+        scanId: pkg.scanId,
+        packageName: pkg.packageName,
+        stagedVersion: pkg.version,
+        releaseRisk: pkg.releaseRisk,
+      })),
     },
   });
 
-  // Keep the completed review linked and leave the gate PENDING. A maintainer
-  // drives the decision from the workbench; the recommendation above is
-  // advisory.
-  const reviewStillPending = await attachScanToGate(db, gate.id, scanId, scanId);
-  if (!reviewStillPending) {
+  // Attach the representative scan as the gate headline and leave the gate
+  // PENDING. The CAS (expecting no scan yet) guards against a racing decision or
+  // fail-closed artifact reject. A maintainer drives the decision; every package
+  // must be approved before the gate releases.
+  const reviewReady = await attachScanToGate(db, gate.id, representative.scanId, null);
+  if (!reviewReady) {
     const currentGate = await getGateForOrganization(db, organizationId, gate.id);
     emitOperationalEvent("info", "github_workflow_gate.job_skipped", {
       organizationId,
       gateId,
-      scanId,
+      scanId: representative.scanId,
       reason: currentGate
         ? `review_ready_lost_to_status_${currentGate.status}`
         : "review_ready_gate_missing",
@@ -341,7 +325,7 @@ export async function executeWorkflowGateJob(
     await recordScanEvent(db, {
       organizationId,
       actorUserId: ownerUserId,
-      scanId,
+      scanId: representative.scanId,
       type:
         timeoutState === "missed"
           ? "github_workflow_gate.timeout_missed"
@@ -353,7 +337,7 @@ export async function executeWorkflowGateJob(
       timeoutState === "missed"
         ? "github_workflow_gate.timeout_missed"
         : "github_workflow_gate.timeout_imminent",
-      { organizationId, gateId, scanId, elapsedMs: gateElapsedMs, windowMs },
+      { organizationId, gateId, scanId: representative.scanId, elapsedMs: gateElapsedMs, windowMs },
     );
   }
 
@@ -372,9 +356,9 @@ export async function executeWorkflowGateJob(
         gateId: gate.id,
         repositoryFullName: gate.repositoryFullName,
         environment: gate.environment,
-        scanId,
-        packageName: result.package.name,
-        version: result.package.stagedVersion,
+        scanId: representative.scanId,
+        packageName: representative.packageName,
+        version: representative.version,
       });
     } else {
       await notifyWorkflowGateReview({
@@ -385,17 +369,18 @@ export async function executeWorkflowGateJob(
         gateId: gate.id,
         repositoryFullName: gate.repositoryFullName,
         environment: gate.environment,
-        scanId,
-        packageName: result.package.name,
-        version: result.package.stagedVersion,
-        releaseRisk,
+        scanId: representative.scanId,
+        packageName: representative.packageName,
+        version: representative.version,
+        releaseRisk: aggregateReleaseRisk,
+        packageCount: reviewed.length,
       });
     }
   } catch (err) {
     emitOperationalEvent("warn", "github_workflow_gate.notification_error", {
       organizationId,
       gateId,
-      scanId,
+      scanId: representative.scanId,
       error: describeOperationalError(err),
     });
   }
@@ -403,12 +388,71 @@ export async function executeWorkflowGateJob(
   emitOperationalEvent("info", "github_workflow_gate.review_ready", {
     organizationId,
     gateId,
-    scanId,
-    releaseRisk,
+    scanId: representative.scanId,
+    packageCount: reviewed.length,
+    releaseRisk: aggregateReleaseRisk,
     recommendation,
     timeoutState,
     durationMs: jobDurationMs,
   });
+}
+
+interface ReviewedPackage {
+  scanId: string;
+  packageName: string | null;
+  version: string | null;
+  releaseRisk: RiskLevel;
+}
+
+/**
+ * Run one scan per discovered package, each against its own baseline, and link
+ * every scan back to the gate via `scans.gate_id`. A monorepo release bundle
+ * fans out into several packages here; the gate decision later aggregates them
+ * (release only when all are approved). A pipeline failure on any package
+ * rethrows so the caller fail-closes the batch — a half-reviewed gate must never
+ * become review-ready.
+ */
+async function reviewGatePackages(
+  ctx: { env: Cloudflare.Env; executionCtx: ExecutionContext; db: AppDb },
+  args: { gate: WorkflowGateRecord; ownerUserId: string; packages: PreparedGatePackage[] },
+): Promise<ReviewedPackage[]> {
+  const { env, executionCtx, db } = ctx;
+  const { gate, ownerUserId, packages } = args;
+  const organizationId = gate.organizationId;
+  const reviewed: ReviewedPackage[] = [];
+
+  for (const pkg of packages) {
+    const { candidate, packageAdapter } = pkg;
+    const scanId = crypto.randomUUID();
+    const stageId = `workflow-gate:${gate.id}:${candidate.ecosystem}:${candidate.package.name}`;
+    await createScanJob(db, {
+      id: scanId,
+      stageId,
+      organizationId,
+      ownerUserId,
+      source: "workflow_gate",
+      gateId: gate.id,
+    });
+
+    try {
+      const result = await runScanPipeline(
+        { env, executionCtx, db, session: { userId: ownerUserId } },
+        packageAdapter,
+        { scanId, stageId, organizationId, ...candidate.pipelineInput },
+      );
+      reviewed.push({
+        scanId,
+        packageName: result.package.name,
+        version: result.package.stagedVersion,
+        releaseRisk: result.riskSummary.releaseRisk,
+      });
+    } catch (err) {
+      await markScanFailed(db, scanId, organizationId, classifyScanError(err));
+      throw err;
+    }
+  }
+
+  return reviewed;
 }
 
 // ── Internals ────────────────────────────────────────────────────────────────
@@ -435,20 +479,6 @@ async function rejectGateForArtifactError(
     type: "github_workflow_gate.rejected",
     metadata: { gateId: gate.id, reason: error.code },
   });
-}
-
-async function getAttachedGateScan(
-  db: AppDb,
-  organizationId: string,
-  scanId: string,
-): Promise<{ status: string; source: string } | null> {
-  const [row] = await db
-    .select({ status: scans.status, source: scans.source })
-    .from(scans)
-    .where(and(eq(scans.id, scanId), eq(scans.organizationId, organizationId)))
-    .limit(1);
-  if (!row || row.source !== "workflow_gate") return null;
-  return row;
 }
 
 /**

--- a/server/lib/workflow-gates/prepare.ts
+++ b/server/lib/workflow-gates/prepare.ts
@@ -162,9 +162,9 @@ export async function prepareReleaseCandidatesForGate(
  * target. A pinned ecosystem resolves its adapter up front so an unknown
  * ecosystem is surfaced as a configuration error (gate left pending, never
  * auto-approved) rather than a fail-closed artifact rejection; an unpinned target
- * classifies across every registered ecosystem. When no artifact name override
- * is present, the fetcher enumerates every non-expired upload from the workflow
- * run and the classifier decides which inner files are reviewable.
+ * classifies across every registered ecosystem. Unpinned targets inspect every
+ * non-expired upload by default, while pinned targets use the adapter's default
+ * artifact name unless the release target supplies an override.
  */
 function resolveBundleClassifier(
   db: AppDb,
@@ -202,7 +202,7 @@ function resolveBundleClassifier(
       const kind = adapter.classifyArtifact(path);
       return kind ? { ecosystem: adapter.ecosystem, kind } : null;
     },
-    ...(override ? { artifactName: override } : {}),
+    artifactName: override ?? adapter.artifactName,
   };
 }
 

--- a/server/lib/workflow-gates/prepare.ts
+++ b/server/lib/workflow-gates/prepare.ts
@@ -1,50 +1,73 @@
 import { and, eq } from "drizzle-orm";
 import type { AppDb } from "../../db";
 import { githubAppInstallations, githubReleaseTargets } from "../../db/schema";
+import type { AdapterBroker, PackageAdapter } from "../adapters/types";
 import {
+  type ClassifyArtifact,
   fetchReleaseBundleForGate,
   getGateForOrganization,
   type GithubAppConfig,
   markGateErrored,
+  type ResolvedReleaseBundle,
+  type ResolvedReleaseFile,
   WorkflowArtifactError,
   type WorkflowGateRecord,
 } from "../github-app";
 import { describeOperationalError, emitOperationalEvent } from "../observability";
-import { getWorkflowGateAdapter, UnsupportedEcosystemError } from "./registry";
+import {
+  classifyBundleArtifact,
+  getWorkflowGateAdapter,
+  UnsupportedEcosystemError,
+} from "./registry";
 import type { PreparedReleaseCandidate, WorkflowGateAdapter } from "./types";
+
+// The GitHub Actions artifact name an auto-detect (unpinned) release target
+// downloads from when nothing overrides it. A pinned target falls back to its
+// ecosystem adapter's own default instead.
+const DEFAULT_AUTO_DETECT_ARTIFACT_NAME = "release-candidate";
 
 export interface PrepareForGateInput {
   config: GithubAppConfig;
   organizationId: string;
   gateId: string;
-  /** Overrides the adapter's default GitHub Actions artifact name. */
+  /** Overrides the release target's configured / default artifact name. */
   artifactName?: string;
 }
 
-export interface PreparedGateReleaseCandidate {
-  gate: WorkflowGateRecord;
-  adapter: WorkflowGateAdapter;
+/** One reviewable package derived from the bundle, paired with its review adapter. */
+export interface PreparedGatePackage {
   candidate: PreparedReleaseCandidate;
+  packageAdapter: PackageAdapter<unknown, AdapterBroker>;
+}
+
+export interface PreparedGateRelease {
+  gate: WorkflowGateRecord;
+  /** One entry per distinct package the bundle publishes (≥ 1). */
+  packages: PreparedGatePackage[];
 }
 
 /**
- * Resolve a pending workflow gate into the scan-pipeline input its ecosystem
- * adapter produces.
+ * Resolve a pending workflow gate into the per-package scan-pipeline inputs its
+ * ecosystem adapter(s) produce.
  *
  * Ecosystem-neutral plumbing lives here: load the gate + installation + release
- * target, select the adapter by `release_target.ecosystem`, fetch the GitHub
- * Actions artifact bundle (the installation token is swapped + used only in the
- * control plane, never in the sandbox), and hand the verified bundle to the
- * adapter. Any `WorkflowArtifactError` (or downstream sandbox parse failure)
+ * target, pick the classifier (a pinned ecosystem uses that adapter's
+ * classifier; an unpinned target auto-detects across every registered
+ * ecosystem), fetch the GitHub Actions artifact bundle (the installation token
+ * is swapped + used only in the control plane, never in the sandbox), group the
+ * verified artifacts by ecosystem, and hand each ecosystem's slice to its
+ * adapter — which splits it into one candidate per distinct package. A monorepo
+ * release therefore fans out into several packages, each scanned against its own
+ * baseline. Any `WorkflowArtifactError` (or downstream sandbox parse failure)
  * transitions the pending gate to `errored` with the typed code so it cannot
  * advance to scanning.
  */
-export async function prepareReleaseCandidateForGate(
+export async function prepareReleaseCandidatesForGate(
   env: Cloudflare.Env,
   ctx: ExecutionContext,
   db: AppDb,
   input: PrepareForGateInput,
-): Promise<PreparedGateReleaseCandidate> {
+): Promise<PreparedGateRelease> {
   const gate = await getGateForOrganization(db, input.organizationId, input.gateId);
   if (!gate) {
     throw new WorkflowArtifactError(
@@ -102,23 +125,8 @@ export async function prepareReleaseCandidateForGate(
     );
   }
 
-  let adapter: WorkflowGateAdapter;
-  try {
-    adapter = getWorkflowGateAdapter(releaseTarget.ecosystem);
-  } catch (err) {
-    if (err instanceof UnsupportedEcosystemError) {
-      // A configuration/data problem, not an artifact verification failure: mark
-      // the gate errored for visibility and rethrow so the runner leaves it
-      // pending (never auto-approved) rather than fail-closing the deployment.
-      await markGateErroredSafe(db, gate.id, "unsupported_ecosystem");
-      emitOperationalEvent("error", "github_workflow_gate.unsupported_ecosystem", {
-        gateId: gate.id,
-        organizationId: gate.organizationId,
-        ecosystem: releaseTarget.ecosystem,
-      });
-    }
-    throw err;
-  }
+  const ecosystemLabel = releaseTarget.ecosystem ?? "auto";
+  const { classify, artifactName } = resolveBundleClassifier(db, gate, releaseTarget, input);
 
   try {
     const bundle = await fetchReleaseBundleForGate(
@@ -127,26 +135,107 @@ export async function prepareReleaseCandidateForGate(
         installationExternalId: installation.installationId,
         repositoryFullName: gate.repositoryFullName,
         runId: gate.runId,
-        artifactName: input.artifactName ?? adapter.artifactName,
+        artifactName,
       },
-      adapter.classifyArtifact,
+      classify,
     );
-    const candidate = await adapter.prepareReleaseCandidate(env, ctx, { bundle });
-    return { gate, adapter, candidate };
+    const packages = await prepareBundlePackages(env, ctx, bundle);
+    return { gate, packages };
   } catch (err) {
-    const reason = err instanceof WorkflowArtifactError ? err.code : "preparation_failed";
+    const reason =
+      err instanceof WorkflowArtifactError
+        ? err.code
+        : err instanceof UnsupportedEcosystemError
+          ? "unsupported_ecosystem"
+          : "preparation_failed";
     await markGateErroredSafe(db, gate.id, reason);
     emitOperationalEvent("error", "github_workflow_gate.bundle_failed", {
       gateId: gate.id,
       organizationId: gate.organizationId,
       repositoryFullName: gate.repositoryFullName,
       runId: gate.runId,
-      ecosystem: releaseTarget.ecosystem,
+      ecosystem: ecosystemLabel,
       reason,
       error: describeOperationalError(err),
     });
     throw err;
   }
+}
+
+/**
+ * Pick the artifact classifier + download name for a release target. A pinned
+ * ecosystem resolves its adapter up front so an unknown ecosystem is surfaced as
+ * a configuration error (gate left pending, never auto-approved) rather than a
+ * fail-closed artifact rejection; an unpinned target classifies across every
+ * registered ecosystem.
+ */
+function resolveBundleClassifier(
+  db: AppDb,
+  gate: WorkflowGateRecord,
+  releaseTarget: { ecosystem: string | null; artifactName: string | null },
+  input: PrepareForGateInput,
+): { classify: ClassifyArtifact; artifactName: string } {
+  const override = input.artifactName ?? releaseTarget.artifactName ?? undefined;
+  if (releaseTarget.ecosystem === null) {
+    return {
+      classify: classifyBundleArtifact,
+      artifactName: override ?? DEFAULT_AUTO_DETECT_ARTIFACT_NAME,
+    };
+  }
+
+  let adapter: WorkflowGateAdapter;
+  try {
+    adapter = getWorkflowGateAdapter(releaseTarget.ecosystem);
+  } catch (err) {
+    if (err instanceof UnsupportedEcosystemError) {
+      // A configuration/data problem, not an artifact verification failure: mark
+      // the gate errored for visibility and rethrow so the runner leaves it
+      // pending (never auto-approved) rather than fail-closing the deployment.
+      void markGateErroredSafe(db, gate.id, "unsupported_ecosystem");
+      emitOperationalEvent("error", "github_workflow_gate.unsupported_ecosystem", {
+        gateId: gate.id,
+        organizationId: gate.organizationId,
+        ecosystem: releaseTarget.ecosystem,
+      });
+    }
+    throw err;
+  }
+  return {
+    classify: (path) => {
+      const kind = adapter.classifyArtifact(path);
+      return kind ? { ecosystem: adapter.ecosystem, kind } : null;
+    },
+    artifactName: override ?? adapter.artifactName,
+  };
+}
+
+/**
+ * Group the verified artifacts by ecosystem and let each ecosystem's adapter
+ * split its slice into one prepared candidate per distinct package.
+ */
+async function prepareBundlePackages(
+  env: Cloudflare.Env,
+  ctx: ExecutionContext,
+  bundle: ResolvedReleaseBundle,
+): Promise<PreparedGatePackage[]> {
+  const byEcosystem = new Map<string, ResolvedReleaseFile[]>();
+  for (const file of bundle.artifacts) {
+    const slice = byEcosystem.get(file.ecosystem);
+    if (slice) slice.push(file);
+    else byEcosystem.set(file.ecosystem, [file]);
+  }
+
+  const packages: PreparedGatePackage[] = [];
+  for (const [ecosystem, artifacts] of byEcosystem) {
+    const adapter = getWorkflowGateAdapter(ecosystem);
+    const candidates = await adapter.prepareReleaseCandidates(env, ctx, {
+      bundle: { ...bundle, artifacts },
+    });
+    for (const candidate of candidates) {
+      packages.push({ candidate, packageAdapter: adapter.packageAdapter });
+    }
+  }
+  return packages;
 }
 
 async function markGateErroredSafe(db: AppDb, gateId: string, reason: string): Promise<void> {

--- a/server/lib/workflow-gates/prepare.ts
+++ b/server/lib/workflow-gates/prepare.ts
@@ -21,16 +21,11 @@ import {
 } from "./registry";
 import type { PreparedReleaseCandidate, WorkflowGateAdapter } from "./types";
 
-// The GitHub Actions artifact name an auto-detect (unpinned) release target
-// downloads from when nothing overrides it. A pinned target falls back to its
-// ecosystem adapter's own default instead.
-const DEFAULT_AUTO_DETECT_ARTIFACT_NAME = "release-candidate";
-
 export interface PrepareForGateInput {
   config: GithubAppConfig;
   organizationId: string;
   gateId: string;
-  /** Overrides the release target's configured / default artifact name. */
+  /** Narrows artifact discovery to one GitHub Actions artifact name. */
   artifactName?: string;
 }
 
@@ -135,7 +130,7 @@ export async function prepareReleaseCandidatesForGate(
         installationExternalId: installation.installationId,
         repositoryFullName: gate.repositoryFullName,
         runId: gate.runId,
-        artifactName,
+        ...(artifactName ? { artifactName } : {}),
       },
       classify,
     );
@@ -163,23 +158,25 @@ export async function prepareReleaseCandidatesForGate(
 }
 
 /**
- * Pick the artifact classifier + download name for a release target. A pinned
- * ecosystem resolves its adapter up front so an unknown ecosystem is surfaced as
- * a configuration error (gate left pending, never auto-approved) rather than a
- * fail-closed artifact rejection; an unpinned target classifies across every
- * registered ecosystem.
+ * Pick the artifact classifier + optional upload-name narrowing for a release
+ * target. A pinned ecosystem resolves its adapter up front so an unknown
+ * ecosystem is surfaced as a configuration error (gate left pending, never
+ * auto-approved) rather than a fail-closed artifact rejection; an unpinned target
+ * classifies across every registered ecosystem. When no artifact name override
+ * is present, the fetcher enumerates every non-expired upload from the workflow
+ * run and the classifier decides which inner files are reviewable.
  */
 function resolveBundleClassifier(
   db: AppDb,
   gate: WorkflowGateRecord,
   releaseTarget: { ecosystem: string | null; artifactName: string | null },
   input: PrepareForGateInput,
-): { classify: ClassifyArtifact; artifactName: string } {
+): { classify: ClassifyArtifact; artifactName?: string } {
   const override = input.artifactName ?? releaseTarget.artifactName ?? undefined;
   if (releaseTarget.ecosystem === null) {
     return {
       classify: classifyBundleArtifact,
-      artifactName: override ?? DEFAULT_AUTO_DETECT_ARTIFACT_NAME,
+      ...(override ? { artifactName: override } : {}),
     };
   }
 
@@ -205,7 +202,7 @@ function resolveBundleClassifier(
       const kind = adapter.classifyArtifact(path);
       return kind ? { ecosystem: adapter.ecosystem, kind } : null;
     },
-    artifactName: override ?? adapter.artifactName,
+    ...(override ? { artifactName: override } : {}),
   };
 }
 

--- a/server/lib/workflow-gates/pypi.ts
+++ b/server/lib/workflow-gates/pypi.ts
@@ -38,80 +38,97 @@ export const pypiWorkflowGateAdapter: WorkflowGateAdapter = {
     return inferPyPiArtifactKind(path);
   },
 
-  async prepareReleaseCandidate(
+  async prepareReleaseCandidates(
     env: Cloudflare.Env,
     ctx: ExecutionContext,
     { bundle }: { bundle: ResolvedReleaseBundle },
-  ): Promise<PreparedReleaseCandidate> {
-    const artifacts: PyPiArtifactInput[] = [];
-    for (const artifact of bundle.artifacts) {
-      const files = await parseArtifactBytes(env, ctx, artifact);
-      artifacts.push({ path: artifact.path, files });
+  ): Promise<PreparedReleaseCandidate[]> {
+    const entries: PreparedArtifactEntry[] = [];
+    for (const file of bundle.artifacts) {
+      const files = await parseArtifactBytes(env, ctx, file);
+      const input: PyPiArtifactInput = { path: file.path, files };
+      entries.push({ file, input, prepared: preparePyPiArtifact(input) });
     }
-    const prepared = artifacts.map(preparePyPiArtifact);
-    const manifest = deriveReleaseManifest(bundle, prepared);
-
-    return {
-      pipelineInput: { manifest, artifacts },
-      package: { name: manifest.package, version: manifest.version },
-    };
+    return deriveReleaseCandidates(entries);
   },
 };
 
+interface PreparedArtifactEntry {
+  file: ResolvedReleaseFile;
+  input: PyPiArtifactInput;
+  prepared: PyPiPreparedArtifact;
+}
+
 /**
- * Synthesize the `PyPiReleaseManifest` the rest of the pipeline consumes from
- * the artifacts themselves. Identity comes from each wheel's `METADATA` /
- * sdist's `PKG-INFO`, and the SHA-256 is the digest already recomputed from the
- * bundle bytes.
+ * Split the bundle's PyPI artifacts into one candidate per distinct package.
  *
- * Every artifact must expose a `Name`/`Version` and agree on the normalized
- * (PEP 503) name and the version, so a foreign or version-skewed file slipped
- * into the bundle is rejected rather than silently shipped.
+ * A monorepo publishes several packages from one release, so artifacts are
+ * grouped by their normalized (PEP 503) name and each group becomes its own
+ * candidate → its own scan against its own baseline. Identity comes from each
+ * wheel's `METADATA` / sdist's `PKG-INFO`; the SHA-256 is the digest already
+ * recomputed from the bundle bytes.
+ *
+ * Every artifact must expose a `Name`/`Version`, and all artifacts that share a
+ * normalized name must agree on the version, so a metadata-less or
+ * version-skewed file slipped into a package's set is rejected rather than
+ * silently shipped. Distinct packages with distinct names are kept apart — that
+ * is the expected monorepo shape, not a conflict.
  */
-function deriveReleaseManifest(
-  bundle: ResolvedReleaseBundle,
-  prepared: PyPiPreparedArtifact[],
-): PyPiReleaseManifest {
-  let name: string | null = null;
-  let normalizedName: string | null = null;
-  let version: string | null = null;
-  for (const artifact of prepared) {
-    const { summary } = artifact;
+function deriveReleaseCandidates(entries: PreparedArtifactEntry[]): PreparedReleaseCandidate[] {
+  const groups = new Map<
+    string,
+    { name: string; version: string; entries: PreparedArtifactEntry[] }
+  >();
+  for (const entry of entries) {
+    const { summary } = entry.prepared;
     if (!summary.name || !summary.version) {
       throw new WorkflowArtifactError(
         "artifact_identity_missing",
-        `${artifact.path} does not expose a PyPI Name/Version in its metadata`,
+        `${entry.file.path} does not expose a PyPI Name/Version in its metadata`,
       );
     }
     const normalized = normalizePyPiProjectName(summary.name);
-    if (name === null) {
-      name = summary.name;
-      normalizedName = normalized;
-      version = summary.version;
+    const group = groups.get(normalized);
+    if (!group) {
+      groups.set(normalized, { name: summary.name, version: summary.version, entries: [entry] });
       continue;
     }
-    if (normalized !== normalizedName) {
+    if (summary.version !== group.version) {
       throw new WorkflowArtifactError(
         "artifact_identity_inconsistent",
-        `${artifact.path} package ${summary.name} disagrees with ${name}`,
+        `${entry.file.path} version ${summary.version} disagrees with ${group.version} for ${group.name}`,
       );
     }
-    if (summary.version !== version) {
-      throw new WorkflowArtifactError(
-        "artifact_identity_inconsistent",
-        `${artifact.path} version ${summary.version} disagrees with ${version}`,
-      );
-    }
+    group.entries.push(entry);
   }
 
-  // `prepared` is non-empty: the resolver throws `bundle_empty` when a bundle
-  // has no wheels/sdists, so `name`/`version` are always set here.
+  // `entries` is non-empty: the resolver throws `bundle_empty` when a bundle has
+  // no wheels/sdists, so `groups` always has at least one package here.
+  return [...groups.values()].map((group) => {
+    const manifest = buildReleaseManifest(
+      group.name,
+      group.version,
+      group.entries.map((entry) => entry.file),
+    );
+    return {
+      ecosystem: "pypi",
+      pipelineInput: { manifest, artifacts: group.entries.map((entry) => entry.input) },
+      package: { name: manifest.package, version: manifest.version },
+    };
+  });
+}
+
+function buildReleaseManifest(
+  name: string,
+  version: string,
+  files: ResolvedReleaseFile[],
+): PyPiReleaseManifest {
   const candidate = {
     schema: PYPI_RELEASE_MANIFEST_SCHEMA,
     ecosystem: "pypi",
     package: name,
     version,
-    artifacts: bundle.artifacts.map((file) => ({ path: file.path, sha256: file.sha256 })),
+    artifacts: files.map((file) => ({ path: file.path, sha256: file.sha256 })),
   };
   try {
     return parsePyPiReleaseManifest(candidate);

--- a/server/lib/workflow-gates/registry.ts
+++ b/server/lib/workflow-gates/registry.ts
@@ -25,6 +25,24 @@ export function getWorkflowGateAdapter(ecosystem: string): WorkflowGateAdapter {
   return adapter;
 }
 
+/**
+ * Classify a bundle entry across every registered ecosystem for an auto-detect
+ * release target (one that does not pin an ecosystem). The first adapter whose
+ * `classifyArtifact` claims the path wins; entries no adapter claims are dropped.
+ *
+ * A path can in principle look like two ecosystems' artifacts, but in practice
+ * the suffixes are disjoint (`.whl`/`.tar.gz` vs other ecosystems'), so order
+ * only matters for genuinely ambiguous names — which we treat as the first
+ * registered match deterministically rather than erroring.
+ */
+export function classifyBundleArtifact(path: string): { ecosystem: string; kind: string } | null {
+  for (const adapter of Object.values(WORKFLOW_GATE_ADAPTERS)) {
+    const kind = adapter.classifyArtifact(path);
+    if (kind) return { ecosystem: adapter.ecosystem, kind };
+  }
+  return null;
+}
+
 /** Ecosystems that currently have a registered workflow-gate adapter. */
 export function supportedWorkflowGateEcosystems(): string[] {
   return Object.keys(WORKFLOW_GATE_ADAPTERS);

--- a/server/lib/workflow-gates/types.ts
+++ b/server/lib/workflow-gates/types.ts
@@ -38,8 +38,6 @@ export interface PreparedReleaseCandidate {
  * events. An adapter only describes the ecosystem's artifact semantics and
  * review wiring:
  *
- *  - `artifactName` — the default GitHub Actions artifact the bundle is
- *    downloaded from when a release target pins this ecosystem.
  *  - `classifyArtifact` — which bundle entries are this ecosystem's reviewable
  *    artifacts.
  *  - `prepareReleaseCandidates` — split the ecosystem's slice of the verified
@@ -54,7 +52,7 @@ export interface WorkflowGateAdapter {
   /** Stable ecosystem id; matches `github_release_targets.ecosystem`. */
   readonly ecosystem: string;
 
-  /** Default GitHub Actions artifact name the release bundle is downloaded from. */
+  /** Suggested artifact name for workflows that choose to narrow discovery. */
   readonly artifactName: string;
 
   /** Review adapter driven by `runScanPipeline` for this ecosystem. */

--- a/server/lib/workflow-gates/types.ts
+++ b/server/lib/workflow-gates/types.ts
@@ -10,14 +10,20 @@ import type { AdapterBroker, PackageAdapter } from "../adapters/types";
 export type WorkflowArtifactKind = string;
 
 /**
- * Result of turning a verified artifact bundle into the input the scan pipeline
- * runs against, plus the derived package identity.
+ * Result of turning one package's slice of a verified artifact bundle into the
+ * input the scan pipeline runs against, plus the derived package identity.
+ *
+ * One bundle can yield several candidates: a monorepo publishes multiple
+ * packages (and potentially several ecosystems) from one release, and each
+ * package becomes its own candidate → its own scan against its own baseline.
  *
  * `pipelineInput` is spread into `runScanPipeline` options, so its keys must
  * match what `packageAdapter.parseInput` expects (for PyPI: `manifest` +
  * `artifacts`). The shared runner never interprets it.
  */
 export interface PreparedReleaseCandidate {
+  /** Ecosystem this package belongs to; matches a registered adapter id. */
+  ecosystem: string;
   pipelineInput: Record<string, unknown>;
   package: { name: string; version: string };
 }
@@ -32,11 +38,14 @@ export interface PreparedReleaseCandidate {
  * events. An adapter only describes the ecosystem's artifact semantics and
  * review wiring:
  *
- *  - `artifactName` — the GitHub Actions artifact the bundle is downloaded from.
- *  - `classifyArtifact` — which bundle entries are reviewable artifacts.
- *  - `prepareReleaseCandidate` — derive package identity + pipeline input from
- *    the verified bundle, rejecting a bundle whose artifacts disagree on the
- *    package identity they carry.
+ *  - `artifactName` — the default GitHub Actions artifact the bundle is
+ *    downloaded from when a release target pins this ecosystem.
+ *  - `classifyArtifact` — which bundle entries are this ecosystem's reviewable
+ *    artifacts.
+ *  - `prepareReleaseCandidates` — split the ecosystem's slice of the verified
+ *    bundle into one candidate per distinct package (grouping the bundle's
+ *    artifacts by package identity), rejecting a group whose artifacts disagree
+ *    on the identity they carry.
  *  - `packageAdapter` — the deterministic review/baseline/findings adapter the
  *    shared pipeline runs (see `server/lib/adapters/types.ts`); risk-to-decision
  *    mapping stays shared in `recommendationForReleaseRisk`.
@@ -59,18 +68,21 @@ export interface WorkflowGateAdapter {
   classifyArtifact(path: string): WorkflowArtifactKind | null;
 
   /**
-   * Turn the verified bundle into the scan-pipeline input and derived identity.
+   * Split this ecosystem's slice of the verified bundle into one prepared
+   * candidate per distinct package. `bundle.artifacts` has already been narrowed
+   * to entries this adapter's `classifyArtifact` kept, so the adapter only needs
+   * to group them by package identity and synthesize each group's pipeline input.
    *
    * Trust boundary: the installation token is already gone — `bundle` holds only
    * artifact bytes whose SHA-256 was recomputed in the control plane. The
    * adapter parses those bytes through the credentials-free sandbox. It must
-   * throw `WorkflowArtifactError` when the bundle cannot be trusted (missing or
+   * throw `WorkflowArtifactError` when a group cannot be trusted (missing or
    * inconsistent artifact identity) so the shared runner fail-closes the
    * deployment.
    */
-  prepareReleaseCandidate(
+  prepareReleaseCandidates(
     env: Cloudflare.Env,
     ctx: ExecutionContext,
     args: { bundle: ResolvedReleaseBundle },
-  ): Promise<PreparedReleaseCandidate>;
+  ): Promise<PreparedReleaseCandidate[]>;
 }

--- a/server/routes/github-app.ts
+++ b/server/routes/github-app.ts
@@ -464,40 +464,6 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
     return c.json({ error: "gate has already been decided" }, 409);
   }
 
-  // 2FA step-up. Releasing or blocking a held deployment is a high-trust action
-  // — approval immediately releases the GitHub job and publishing proceeds via
-  // Trusted Publishing/OIDC, which can't be reversed. So a maintainer who has
-  // enrolled in two-factor auth must prove a *fresh* second factor here; an
-  // existing session is not enough. Members without 2FA decide as before. (The
-  // staged-publish decision in scans.ts is an audit record only — it never
-  // publishes or cancels anything — and deliberately never requires this.)
-  let twoFactorVerified = false;
-  if (await userHasTwoFactor(db, session.userId)) {
-    try {
-      await enforceRateLimit(db, {
-        key: `github-app:gate-decision-2fa:${session.userId}`,
-        limit: 10,
-        windowMs: 15 * 60 * 1000,
-      });
-    } catch (err) {
-      if (err instanceof RateLimitError) {
-        return rateLimitResponse(c, "too many two-factor attempts", err);
-      }
-      throw err;
-    }
-    const totpCode = typeof body.totpCode === "string" ? body.totpCode.trim() : "";
-    if (!totpCode) {
-      return c.json(
-        { error: "two-factor verification required", code: "two_factor_required" },
-        401,
-      );
-    }
-    if (!(await verifyTotpStepUp(c.get("auth"), c.req.raw, totpCode))) {
-      return c.json({ error: "invalid two-factor code", code: "two_factor_invalid" }, 401);
-    }
-    twoFactorVerified = true;
-  }
-
   // The decision targets one package scan that has reached a human decision
   // point. A completed review gives the maintainer the full diff; a failed
   // package can still be rejected by the human, or retried through the retry
@@ -524,6 +490,42 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
       },
       409,
     );
+  }
+
+  // 2FA step-up. Releasing or blocking a held deployment is a high-trust action
+  // — approval immediately releases the GitHub job and publishing proceeds via
+  // Trusted Publishing/OIDC, which can't be reversed. So a maintainer who has
+  // enrolled in two-factor auth must prove a *fresh* second factor here; an
+  // existing session is not enough. Members without 2FA decide as before. This
+  // runs only after the decision is confirmed actionable above, so an enrolled
+  // maintainer is never prompted for a code on a decision that would 409 anyway.
+  // (The staged-publish decision in scans.ts is an audit record only — it never
+  // publishes or cancels anything — and deliberately never requires this.)
+  let twoFactorVerified = false;
+  if (await userHasTwoFactor(db, session.userId)) {
+    try {
+      await enforceRateLimit(db, {
+        key: `github-app:gate-decision-2fa:${session.userId}`,
+        limit: 10,
+        windowMs: 15 * 60 * 1000,
+      });
+    } catch (err) {
+      if (err instanceof RateLimitError) {
+        return rateLimitResponse(c, "too many two-factor attempts", err);
+      }
+      throw err;
+    }
+    const totpCode = typeof body.totpCode === "string" ? body.totpCode.trim() : "";
+    if (!totpCode) {
+      return c.json(
+        { error: "two-factor verification required", code: "two_factor_required" },
+        401,
+      );
+    }
+    if (!(await verifyTotpStepUp(c.get("auth"), c.req.raw, totpCode))) {
+      return c.json({ error: "invalid two-factor code", code: "two_factor_invalid" }, 401);
+    }
+    twoFactorVerified = true;
   }
 
   // Persist the per-package decision while the gate is still pending.

--- a/server/routes/github-app.ts
+++ b/server/routes/github-app.ts
@@ -24,6 +24,7 @@ import {
   GithubAppConfigError,
   GithubAppValidationError,
   SUPPORTED_ECOSYSTEMS,
+  type GatePackageScan,
   type GithubAppConfig,
   type GithubAppValidationCode,
   type InstallationRecord,
@@ -38,6 +39,7 @@ import {
   getGateByScanId,
   getGateForOrganization,
   isGithubAppConfigured,
+  listGatePackageScans,
   listInstallationRepositories,
   listInstallationsForOrganization,
   listReleaseTargetsForOrganization,
@@ -289,14 +291,23 @@ githubAppRoutes.post("/release-targets", async (c) => {
   const body = (await c.req.json().catch(() => ({}))) as {
     installationRowId?: unknown;
     ecosystem?: unknown;
+    artifactName?: unknown;
     repositoryFullName?: unknown;
     environment?: unknown;
   };
 
   const installationRowId =
     typeof body.installationRowId === "string" ? body.installationRowId.trim() : "";
-  const ecosystem =
-    typeof body.ecosystem === "string" ? (body.ecosystem.trim() as SupportedEcosystem) : "pypi";
+  // Null/"auto"/absent pins nothing: the runner auto-detects each package's
+  // ecosystem from the uploaded artifacts (the monorepo-friendly default). A
+  // non-empty string must name a supported ecosystem.
+  const ecosystemRaw = typeof body.ecosystem === "string" ? body.ecosystem.trim() : "";
+  const ecosystem: SupportedEcosystem | null =
+    ecosystemRaw === "" || ecosystemRaw === "auto" ? null : (ecosystemRaw as SupportedEcosystem);
+  const artifactName =
+    typeof body.artifactName === "string" && body.artifactName.trim()
+      ? body.artifactName.trim()
+      : null;
   const repositoryFullName =
     typeof body.repositoryFullName === "string" ? body.repositoryFullName.trim() : "";
   const environment = typeof body.environment === "string" ? body.environment.trim() : "";
@@ -304,7 +315,7 @@ githubAppRoutes.post("/release-targets", async (c) => {
   if (!installationRowId) return c.json({ error: "installationRowId is required" }, 400);
   if (!repositoryFullName) return c.json({ error: "repositoryFullName is required" }, 400);
   if (!environment) return c.json({ error: "environment is required" }, 400);
-  if (!SUPPORTED_ECOSYSTEMS.includes(ecosystem)) {
+  if (ecosystem !== null && !SUPPORTED_ECOSYSTEMS.includes(ecosystem)) {
     return c.json({ error: `unsupported ecosystem: ${ecosystem}` }, 400);
   }
 
@@ -339,6 +350,7 @@ githubAppRoutes.post("/release-targets", async (c) => {
       organizationId,
       installationRowId: installation.id,
       ecosystem,
+      artifactName,
       repositoryId: repo.id,
       repositoryFullName: repo.fullName,
       environment,
@@ -349,7 +361,8 @@ githubAppRoutes.post("/release-targets", async (c) => {
       actorUserId: session.userId,
       type: "github_app_release_target.created",
       metadata: {
-        ecosystem: record.ecosystem,
+        ecosystem: record.ecosystem ?? "auto",
+        artifactName: record.artifactName,
         repositoryFullName: record.repositoryFullName,
         repositoryId: record.repositoryId,
         environment: record.environment,
@@ -389,10 +402,19 @@ githubAppRoutes.get("/workflow-gates/by-scan/:scanId", async (c) => {
   const scanId = c.req.param("scanId");
   const gate = await getGateByScanId(db, organizationId, scanId);
   if (!gate) return c.json({ error: "not found" }, 404);
-  return c.json({ gate: publicWorkflowGate(gate) });
+  const packages = await listGatePackageScans(db, organizationId, gate.id);
+  return c.json({ gate: publicWorkflowGate(gate, packages) });
 });
 
-// Record a maintainer's decision and release/block the GitHub Actions job.
+// Record a maintainer's decision on one package of a gate and, once the whole
+// release resolves, release or block the held GitHub Actions job.
+//
+// A monorepo gate fans out into one scan per package. Each call decides a single
+// package (`scanId`): the per-package decision is persisted, then the gate is
+// finalized only when the release as a whole resolves — `approved` once every
+// package is approved, `rejected` the moment any one is rejected. Until then the
+// gate stays pending and the held deployment waits.
+//
 // The CAS in `markGateDecided` is the single transition out of `pending`, so a
 // double-submit (or a race with the fail-closed artifact reject) returns 409.
 // Posting the decision to GitHub is delegated to the gate job, which sees the
@@ -403,11 +425,16 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
     decision: string;
     comment: string;
     totpCode: string;
+    scanId: string;
   }>;
   if (!GATE_DECISION_SET.has(body.decision as GateDecision)) {
     return c.json({ error: "decision must be 'approved' or 'rejected'" }, 400);
   }
   const decision = body.decision as GateDecision;
+  const packageScanId = typeof body.scanId === "string" ? body.scanId.trim() : "";
+  if (!packageScanId) {
+    return c.json({ error: "scanId of the package being decided is required" }, 400);
+  }
   const comment = typeof body.comment === "string" ? body.comment.trim() : "";
   if (comment.length > GATE_DECISION_COMMENT_MAX) {
     return c.json({ error: `comment must be <= ${GATE_DECISION_COMMENT_MAX} characters` }, 400);
@@ -432,14 +459,8 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
   const gateId = c.req.param("gateId");
   const existing = await getGateForOrganization(db, organizationId, gateId);
   if (!existing) return c.json({ error: "not found" }, 404);
-  if (decision === "approved") {
-    if (!existing.scanId) {
-      return c.json({ error: "approval requires a completed workflow-gate review" }, 409);
-    }
-    const scan = await getScan(db, existing.scanId, organizationId);
-    if (!scan || scan.scan.source !== "workflow_gate" || scan.scan.status !== "complete") {
-      return c.json({ error: "approval requires a completed workflow-gate review" }, 409);
-    }
+  if (existing.status !== "pending") {
+    return c.json({ error: "gate has already been decided" }, 409);
   }
 
   // 2FA step-up. Releasing or blocking a held deployment is a high-trust action
@@ -476,15 +497,57 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
     twoFactorVerified = true;
   }
 
+  // The decision targets one package's completed scan, which must belong to
+  // this gate. A scan that is not this gate's reviewable package is rejected.
+  const scan = await getScan(db, packageScanId, organizationId);
+  if (
+    !scan ||
+    scan.scan.source !== "workflow_gate" ||
+    scan.scan.gateId !== gateId ||
+    scan.scan.status !== "complete"
+  ) {
+    return c.json({ error: "scanId is not a reviewable package of this gate" }, 409);
+  }
+
+  // Persist the per-package decision. `recordScanDecision` also writes the
+  // `scan.decided` audit event and keeps the workbench decision filters
+  // consistent (approved → publish, rejected → no_publish).
+  await recordScanDecision(db, {
+    scanId: packageScanId,
+    organizationId,
+    actorUserId: session.userId,
+    decision: decision === "approved" ? "publish" : "no_publish",
+    reason: comment || null,
+  });
+
+  // Aggregate over every package: release only when all are approved; block the
+  // moment any one is rejected.
+  const packages = await listGatePackageScans(db, organizationId, gateId);
+  const anyRejected = packages.some((pkg) => pkg.decision === "no_publish");
+  const allApproved = packages.length > 0 && packages.every((pkg) => pkg.decision === "publish");
+  if (!anyRejected && !allApproved) {
+    // Other packages still need a decision; keep the deployment held.
+    return c.json({ gate: publicWorkflowGate(existing, packages) });
+  }
+
+  const gateDecision: GateDecision = anyRejected ? "rejected" : "approved";
   const reportUrl = buildReportUrl(c.env, existing.scanId);
   const decided = await markGateDecided(db, {
     gateId,
-    decision,
-    comment: comment || buildHumanDecisionComment(decision, reportUrl),
+    decision: gateDecision,
+    comment: comment || buildHumanDecisionComment(gateDecision, reportUrl),
     reportUrl,
   });
   if (!decided) {
-    return c.json({ error: "gate has already been decided" }, 409);
+    // Lost a race to a concurrent finalize or a fail-closed artifact reject.
+    const current = await getGateForOrganization(db, organizationId, gateId);
+    return c.json(
+      {
+        gate: current ? publicWorkflowGate(current, packages) : null,
+        error: "gate has already been decided",
+      },
+      409,
+    );
   }
 
   // Schedule delivery immediately after the CAS. Everything below is
@@ -493,30 +556,20 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
   const message = { kind: "workflow_gate" as const, organizationId, gateId };
   c.executionCtx.waitUntil(deliverGateDecisionJob(c, db, message));
 
-  // Mirror the decision onto the underlying scan so the workbench audit trail
-  // and decision filters stay consistent (approved → publish, rejected →
-  // no_publish). Best effort: only applies once the review scan is complete.
   try {
-    if (decided.scanId) {
-      await recordScanDecision(db, {
-        scanId: decided.scanId,
-        organizationId,
-        actorUserId: session.userId,
-        decision: decision === "approved" ? "publish" : "no_publish",
-        reason: comment || null,
-      });
-    }
-
     await recordScanEvent(db, {
       organizationId,
       actorUserId: session.userId,
       scanId: decided.scanId,
       type:
-        decision === "approved" ? "github_workflow_gate.approved" : "github_workflow_gate.rejected",
+        gateDecision === "approved"
+          ? "github_workflow_gate.approved"
+          : "github_workflow_gate.rejected",
       metadata: {
         gateId,
         decidedBy: "human",
         reportUrl,
+        packageCount: packages.length,
         twoFactor: twoFactorVerified,
         twoFactorMethod: twoFactorVerified ? "totp" : null,
       },
@@ -525,12 +578,12 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
     emitOperationalEvent("warn", "github_workflow_gate.decision_bookkeeping_failed", {
       organizationId,
       gateId,
-      decision,
+      decision: gateDecision,
       error: describeOperationalError(err),
     });
   }
 
-  return c.json({ gate: publicWorkflowGate(decided) });
+  return c.json({ gate: publicWorkflowGate(decided, packages) });
 });
 
 async function deliverGateDecisionJob(
@@ -592,7 +645,9 @@ function publicReleaseTarget(record: ReleaseTargetRecord) {
     id: record.id,
     organizationId: record.organizationId,
     installationRowId: record.installationRowId,
+    // Null = auto-detect the ecosystem from the uploaded artifacts.
     ecosystem: record.ecosystem,
+    artifactName: record.artifactName,
     repositoryId: record.repositoryId,
     repositoryFullName: record.repositoryFullName,
     environment: record.environment,
@@ -602,8 +657,10 @@ function publicReleaseTarget(record: ReleaseTargetRecord) {
 }
 
 // Excludes the deployment callback URL (and other GitHub-internal identifiers)
-// so the credentialed egress target is never exposed to the browser.
-function publicWorkflowGate(record: WorkflowGateRecord) {
+// so the credentialed egress target is never exposed to the browser. `packages`
+// is one entry per distinct package the release publishes (a monorepo fans out
+// into several); the gate releases only once every package is approved.
+function publicWorkflowGate(record: WorkflowGateRecord, packages: GatePackageScan[] = []) {
   return {
     id: record.id,
     organizationId: record.organizationId,
@@ -617,6 +674,14 @@ function publicWorkflowGate(record: WorkflowGateRecord) {
     reportUrl: record.reportUrl,
     scanId: record.scanId,
     failureReason: record.failureReason,
+    packages: packages.map((pkg) => ({
+      scanId: pkg.scanId,
+      packageName: pkg.packageName,
+      version: pkg.stagedVersion,
+      status: pkg.status,
+      releaseRisk: pkg.releaseRisk,
+      decision: pkg.decision,
+    })),
     requestedAt: record.requestedAt.toISOString(),
     decidedAt: record.decidedAt ? record.decidedAt.toISOString() : null,
     createdAt: record.createdAt.toISOString(),

--- a/server/routes/github-app.ts
+++ b/server/routes/github-app.ts
@@ -4,7 +4,7 @@ import {
   createDb,
   enforceRateLimit,
   getScan,
-  recordScanDecision,
+  recordGatePackageDecision,
   recordScanEvent,
 } from "../db";
 import {
@@ -44,7 +44,7 @@ import {
   listInstallationsForOrganization,
   listReleaseTargetsForOrganization,
   listRepositoryEnvironments,
-  markGateDecided,
+  markGateDecidedForPackageAggregate,
   readGithubAppConfig,
   signOAuthState,
   upsertInstallation,
@@ -415,7 +415,7 @@ githubAppRoutes.get("/workflow-gates/by-scan/:scanId", async (c) => {
 // package is approved, `rejected` the moment any one is rejected. Until then the
 // gate stays pending and the held deployment waits.
 //
-// The CAS in `markGateDecided` is the single transition out of `pending`, so a
+// The aggregate CAS is the single transition out of `pending`, so a
 // double-submit (or a race with the fail-closed artifact reject) returns 409.
 // Posting the decision to GitHub is delegated to the gate job, which sees the
 // now-decided gate and delivers its stored decision — either over the queue or
@@ -509,16 +509,32 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
     return c.json({ error: "scanId is not a reviewable package of this gate" }, 409);
   }
 
-  // Persist the per-package decision. `recordScanDecision` also writes the
-  // `scan.decided` audit event and keeps the workbench decision filters
-  // consistent (approved → publish, rejected → no_publish).
-  await recordScanDecision(db, {
+  // Persist the per-package decision while the gate is still pending.
+  // `recordGatePackageDecision` also writes the `scan.decided` audit event and
+  // keeps the workbench decision filters consistent (approved → publish,
+  // rejected → no_publish).
+  const decidedPackage = await recordGatePackageDecision(db, {
     scanId: packageScanId,
     organizationId,
+    gateId,
     actorUserId: session.userId,
     decision: decision === "approved" ? "publish" : "no_publish",
     reason: comment || null,
   });
+  if (!decidedPackage) {
+    const current = await getGateForOrganization(db, organizationId, gateId);
+    const currentPackages = await listGatePackageScans(db, organizationId, gateId);
+    return c.json(
+      {
+        gate: current ? publicWorkflowGate(current, currentPackages) : null,
+        error:
+          current?.status === "pending"
+            ? "package has already been decided"
+            : "gate has already been decided",
+      },
+      409,
+    );
+  }
 
   // Aggregate over every package: release only when all are approved; block the
   // moment any one is rejected.
@@ -532,8 +548,9 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
 
   const gateDecision: GateDecision = anyRejected ? "rejected" : "approved";
   const reportUrl = buildReportUrl(c.env, existing.scanId);
-  const decided = await markGateDecided(db, {
+  const decided = await markGateDecidedForPackageAggregate(db, {
     gateId,
+    organizationId,
     decision: gateDecision,
     comment: comment || buildHumanDecisionComment(gateDecision, reportUrl),
     reportUrl,

--- a/server/routes/github-app.ts
+++ b/server/routes/github-app.ts
@@ -500,8 +500,10 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
 
   // The decision targets one package scan that has reached a human decision
   // point. A completed review gives the maintainer the full diff; a failed
-  // review can still be explicitly accepted/rejected by the human, or retried
-  // through the retry endpoint before deciding.
+  // package can still be rejected by the human, or retried through the retry
+  // endpoint before deciding. Approval additionally requires the batch to have
+  // reached review-ready (`gate.scanId` attached), so a partial failed batch
+  // cannot be approved as if every package had been reviewed.
   const scan = await getScan(db, packageScanId, organizationId);
   const scanReachedDecisionPoint =
     scan?.scan.status === "complete" || scan?.scan.status === "failed";
@@ -512,6 +514,16 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
     !scanReachedDecisionPoint
   ) {
     return c.json({ error: "scanId is not a reviewable package of this gate" }, 409);
+  }
+  if (decision === "approved" && !existing.scanId) {
+    const packages = await listGatePackageScans(db, organizationId, gateId);
+    return c.json(
+      {
+        gate: publicWorkflowGate(existing, packages),
+        error: "approval requires a completed workflow-gate review batch",
+      },
+      409,
+    );
   }
 
   // Persist the per-package decision while the gate is still pending.
@@ -549,6 +561,15 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
   if (!anyRejected && !allApproved) {
     // Other packages still need a decision; keep the deployment held.
     return c.json({ gate: publicWorkflowGate(existing, packages) });
+  }
+  if (allApproved && !existing.scanId) {
+    return c.json(
+      {
+        gate: publicWorkflowGate(existing, packages),
+        error: "approval requires a completed workflow-gate review batch",
+      },
+      409,
+    );
   }
 
   const gateDecision: GateDecision = anyRejected ? "rejected" : "approved";

--- a/server/routes/github-app.ts
+++ b/server/routes/github-app.ts
@@ -46,6 +46,7 @@ import {
   listRepositoryEnvironments,
   markGateDecidedForPackageAggregate,
   readGithubAppConfig,
+  resetGateReviewForRetry,
   signOAuthState,
   upsertInstallation,
   verifyUserCanAccessInstallation,
@@ -497,14 +498,18 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
     twoFactorVerified = true;
   }
 
-  // The decision targets one package's completed scan, which must belong to
-  // this gate. A scan that is not this gate's reviewable package is rejected.
+  // The decision targets one package scan that has reached a human decision
+  // point. A completed review gives the maintainer the full diff; a failed
+  // review can still be explicitly accepted/rejected by the human, or retried
+  // through the retry endpoint before deciding.
   const scan = await getScan(db, packageScanId, organizationId);
+  const scanReachedDecisionPoint =
+    scan?.scan.status === "complete" || scan?.scan.status === "failed";
   if (
     !scan ||
     scan.scan.source !== "workflow_gate" ||
     scan.scan.gateId !== gateId ||
-    scan.scan.status !== "complete"
+    !scanReachedDecisionPoint
   ) {
     return c.json({ error: "scanId is not a reviewable package of this gate" }, 409);
   }
@@ -603,7 +608,72 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
   return c.json({ gate: publicWorkflowGate(decided, packages) });
 });
 
+// Re-run a failed workflow-gate review batch. The retry is intentionally scoped
+// to pending gates whose package scans have no recorded decisions: once a human
+// has accepted or rejected a package, retrying must not replace that decision.
+githubAppRoutes.post("/workflow-gates/:gateId/retry", async (c) => {
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const organizationId = await requireActiveOrganization(c, db);
+  try {
+    await enforceRateLimit(db, {
+      key: `github-app:gate-retry:${organizationId}`,
+      limit: 20,
+      windowMs: 60 * 1000,
+    });
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      return rateLimitResponse(c, "gate retry rate limit exceeded", err);
+    }
+    throw err;
+  }
+
+  const gateId = c.req.param("gateId");
+  const existing = await getGateForOrganization(db, organizationId, gateId);
+  if (!existing) return c.json({ error: "not found" }, 404);
+  if (existing.status !== "pending") {
+    return c.json({ error: "gate has already been decided" }, 409);
+  }
+
+  const reset = await resetGateReviewForRetry(db, { gateId, organizationId });
+  const packages = await listGatePackageScans(db, organizationId, gateId);
+  if (!reset) {
+    return c.json(
+      {
+        gate: publicWorkflowGate(existing, packages),
+        error: "gate review is not retryable",
+      },
+      409,
+    );
+  }
+
+  await recordScanEvent(db, {
+    organizationId,
+    actorUserId: session.userId,
+    scanId: existing.scanId,
+    type: "github_workflow_gate.retry_requested",
+    metadata: { gateId, packageCount: packages.length },
+  });
+
+  const message = { kind: "workflow_gate" as const, organizationId, gateId };
+  c.executionCtx.waitUntil(runWorkflowGateJob(c, db, message));
+
+  const gate = await getGateForOrganization(db, organizationId, gateId);
+  return c.json(
+    { gate: publicWorkflowGate(gate ?? existing, packages), queued: Boolean(c.env.SCAN_QUEUE) },
+    202,
+  );
+});
+
 async function deliverGateDecisionJob(
+  c: RouteContext,
+  db: ReturnType<typeof createDb>,
+  message: { kind: "workflow_gate"; organizationId: string; gateId: string },
+) {
+  await runWorkflowGateJob(c, db, message);
+}
+
+async function runWorkflowGateJob(
   c: RouteContext,
   db: ReturnType<typeof createDb>,
   message: { kind: "workflow_gate"; organizationId: string; gateId: string },

--- a/src/models/github-app.ts
+++ b/src/models/github-app.ts
@@ -16,11 +16,17 @@ export interface PublicGithubAppInstallation {
   updatedAt: string;
 }
 
+export type SupportedEcosystem = "pypi";
+
 export interface PublicReleaseTarget {
   id: string;
   organizationId: string;
   installationRowId: string;
-  ecosystem: "pypi";
+  // null = auto-detect each package's ecosystem from the uploaded artifacts
+  // (the monorepo-friendly default).
+  ecosystem: SupportedEcosystem | null;
+  // null = no artifact-name filter; the runner consumes every uploaded artifact.
+  artifactName: string | null;
   repositoryId: number;
   repositoryFullName: string;
   environment: string;
@@ -30,6 +36,18 @@ export interface PublicReleaseTarget {
 
 export type WorkflowGateStatus = "pending" | "approved" | "rejected" | "errored";
 export type WorkflowGateDecision = "approved" | "rejected";
+export type GatePackageDecision = "publish" | "no_publish";
+
+// One entry per distinct package the gated release publishes. A monorepo fans
+// out into several; the gate releases only once every package is approved.
+export interface GatePackageScan {
+  scanId: string;
+  packageName: string | null;
+  version: string | null;
+  status: string;
+  releaseRisk: string | null;
+  decision: GatePackageDecision | null;
+}
 
 export interface PublicWorkflowGate {
   id: string;
@@ -44,6 +62,7 @@ export interface PublicWorkflowGate {
   reportUrl: string | null;
   scanId: string | null;
   failureReason: string | null;
+  packages: GatePackageScan[];
   requestedAt: string;
   decidedAt: string | null;
   createdAt: string;
@@ -64,15 +83,22 @@ export async function getWorkflowGateByScan(scanId: string): Promise<PublicWorkf
   }
 }
 
+// Records a decision for a single package of the gate (`scanId`). The gate only
+// finalizes — releasing or blocking the held GitHub job — once every package is
+// approved, or the moment any one is rejected.
 export function decideWorkflowGate(
   gateId: string,
+  scanId: string,
   decision: WorkflowGateDecision,
   comment: string | null,
   totpCode?: string | null,
 ): Promise<{ gate: PublicWorkflowGate }> {
-  const payload: { decision: WorkflowGateDecision; comment?: string; totpCode?: string } = {
-    decision,
-  };
+  const payload: {
+    scanId: string;
+    decision: WorkflowGateDecision;
+    comment?: string;
+    totpCode?: string;
+  } = { scanId, decision };
   if (comment) payload.comment = comment;
   if (totpCode) payload.totpCode = totpCode;
   return apiJson<{ gate: PublicWorkflowGate }>(
@@ -171,6 +197,10 @@ export const GithubAppModel = createModel(() => {
   const formInstallationRowId = signal<string>("");
   const formRepositoryFullName = signal<string>("");
   const formEnvironment = signal<string>("");
+  // "auto" lets the runner derive each package's ecosystem from the uploaded
+  // artifacts (the monorepo-friendly default); a named ecosystem pins it.
+  const formEcosystem = signal<"auto" | SupportedEcosystem>("auto");
+  const formArtifactName = signal<string>("");
   const formStatus = signal<ReleaseTargetFormStatus>("idle");
   const formError = signal<string | null>(null);
 
@@ -262,6 +292,8 @@ export const GithubAppModel = createModel(() => {
     formInstallationRowId.value = "";
     formRepositoryFullName.value = "";
     formEnvironment.value = "";
+    formEcosystem.value = "auto";
+    formArtifactName.value = "";
     formError.value = null;
   }
 
@@ -285,6 +317,8 @@ export const GithubAppModel = createModel(() => {
     formInstallationRowId,
     formRepositoryFullName,
     formEnvironment,
+    formEcosystem,
+    formArtifactName,
     formStatus,
     formError,
     formSubmitting,
@@ -420,12 +454,15 @@ export const GithubAppModel = createModel(() => {
       formStatus.value = "submitting";
       formError.value = null;
       try {
+        const artifactName = formArtifactName.value.trim();
         const payload: Record<string, string> = {
           installationRowId: formInstallationRowId.value.trim(),
-          ecosystem: "pypi",
+          // "auto" maps to a null ecosystem server-side (artifact-derived).
+          ecosystem: formEcosystem.value,
           repositoryFullName: formRepositoryFullName.value.trim(),
           environment: formEnvironment.value.trim(),
         };
+        if (artifactName) payload.artifactName = artifactName;
         const data = await apiJson<{ releaseTarget: PublicReleaseTarget }>(
           "/api/v1/github-app/release-targets",
           payload,

--- a/src/models/github-app.ts
+++ b/src/models/github-app.ts
@@ -25,7 +25,7 @@ export interface PublicReleaseTarget {
   // null = auto-detect each package's ecosystem from the uploaded artifacts
   // (the monorepo-friendly default).
   ecosystem: SupportedEcosystem | null;
-  // null = no artifact-name filter; the runner consumes every uploaded artifact.
+  // null = use the runner's default artifact name for the selected ecosystem mode.
   artifactName: string | null;
   repositoryId: number;
   repositoryFullName: string;

--- a/src/models/github-app.ts
+++ b/src/models/github-app.ts
@@ -25,7 +25,8 @@ export interface PublicReleaseTarget {
   // null = auto-detect each package's ecosystem from the uploaded artifacts
   // (the monorepo-friendly default).
   ecosystem: SupportedEcosystem | null;
-  // null = use the runner's default artifact name for the selected ecosystem mode.
+  // null = inspect every non-expired workflow artifact; non-null narrows to one
+  // GitHub Actions artifact name.
   artifactName: string | null;
   repositoryId: number;
   repositoryFullName: string;
@@ -120,6 +121,13 @@ export function decideWorkflowGate(
     }
     throw err;
   });
+}
+
+export function retryWorkflowGate(gateId: string): Promise<{ gate: PublicWorkflowGate }> {
+  return apiJson<{ gate: PublicWorkflowGate }>(
+    `/api/v1/github-app/workflow-gates/${encodeURIComponent(gateId)}/retry`,
+    {},
+  );
 }
 
 export interface InstallationRepository {

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -9,6 +9,7 @@ import { apiFetch, apiJson, errorMessage } from "./api";
 import {
   decideWorkflowGate,
   getWorkflowGateByScan,
+  retryWorkflowGate,
   type PublicWorkflowGate,
   type WorkflowGateDecision,
 } from "./github-app";
@@ -256,6 +257,8 @@ export const ScanDetailModel = createModel((id: string) => {
   const gateLoaded = signal(false);
   const gateDecisionStatus = signal<DecisionStatus>("idle");
   const gateDecisionError = signal<string | null>(null);
+  const gateRetryStatus = signal<DecisionStatus>("idle");
+  const gateRetryError = signal<string | null>(null);
 
   const isWorkflowGate = computed(() => detail.value?.scan.source === "workflow_gate");
   const status = computed(() => detail.value?.scan.status ?? null);
@@ -339,6 +342,8 @@ export const ScanDetailModel = createModel((id: string) => {
     gateLoaded,
     gateDecisionStatus,
     gateDecisionError,
+    gateRetryStatus,
+    gateRetryError,
     isWorkflowGate,
     status,
     isPolling,
@@ -445,6 +450,22 @@ export const ScanDetailModel = createModel((id: string) => {
       } catch (err) {
         this.gateDecisionError.value = errorMessage(err);
         this.gateDecisionStatus.value = "error";
+      }
+    },
+
+    async retryGate(): Promise<void> {
+      const current = this.gate.peek();
+      if (!current) return;
+      this.gateRetryStatus.value = "saving";
+      this.gateRetryError.value = null;
+      try {
+        const { gate: updated } = await retryWorkflowGate(current.id);
+        this.gate.value = updated;
+        this.gateLoaded.value = true;
+        this.gateRetryStatus.value = "idle";
+      } catch (err) {
+        this.gateRetryError.value = errorMessage(err);
+        this.gateRetryStatus.value = "error";
       }
     },
 

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -415,6 +415,10 @@ export const ScanDetailModel = createModel((id: string) => {
       }
     },
 
+    // Decides the package this detail page is reviewing (its own scanId). The
+    // gate only finalizes once every package is approved (or any is rejected);
+    // until then the returned gate stays pending and other packages still need
+    // a decision on their own detail pages.
     async decideGate(
       decision: WorkflowGateDecision,
       comment: string | null,
@@ -422,10 +426,17 @@ export const ScanDetailModel = createModel((id: string) => {
     ): Promise<void> {
       const current = this.gate.peek();
       if (!current) return;
+      const packageScanId = this.scanId.peek();
       this.gateDecisionStatus.value = "saving";
       this.gateDecisionError.value = null;
       try {
-        const { gate: updated } = await decideWorkflowGate(current.id, decision, comment, totpCode);
+        const { gate: updated } = await decideWorkflowGate(
+          current.id,
+          packageScanId,
+          decision,
+          comment,
+          totpCode,
+        );
         this.gate.value = updated;
         this.gateDecisionStatus.value = "idle";
         // The decision also writes the scan's publish/no_publish decision and an

--- a/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
@@ -379,8 +379,8 @@ export function GateDecisionDialog({
       )}
       {!gateDecided && !canApprove ? (
         <Muted class="m-0 text-[13px]">
-          Approval requires the review to reach a decision point. Rejecting blocks the held GitHub
-          job.
+          Approval requires a completed review batch. Retry the review or reject to block the held
+          GitHub job.
         </Muted>
       ) : null}
       {error ? <Alert tone="critical">{error}</Alert> : null}

--- a/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
@@ -1,7 +1,12 @@
 import { useEffect } from "preact/hooks";
 import { useSignal } from "@preact/signals";
 import type { DecisionStatus } from "../../../models/scan";
-import type { PublicWorkflowGate, WorkflowGateDecision } from "../../../models/github-app";
+import type {
+  GatePackageDecision,
+  GatePackageScan,
+  PublicWorkflowGate,
+  WorkflowGateDecision,
+} from "../../../models/github-app";
 import {
   Alert,
   Badge,
@@ -13,6 +18,7 @@ import {
   MonoDetail,
   Muted,
   SectionLabel,
+  severityTone,
 } from "../../../components";
 
 export function gateStatusTone(status: PublicWorkflowGate["status"]) {
@@ -38,6 +44,101 @@ export function gateStatusLabel(status: PublicWorkflowGate["status"]): string {
     default:
       return "awaiting decision";
   }
+}
+
+function packageDecisionTone(pkg: GatePackageScan) {
+  if (pkg.decision === "publish") return "ok" as const;
+  if (pkg.decision === "no_publish") return "critical" as const;
+  if (pkg.status === "failed") return "critical" as const;
+  if (pkg.status !== "complete") return "neutral" as const;
+  return "medium" as const;
+}
+
+function packageDecisionLabel(pkg: GatePackageScan): string {
+  if (pkg.decision === "publish") return "approved";
+  if (pkg.decision === "no_publish") return "rejected";
+  if (pkg.status === "failed") return "review failed";
+  if (pkg.status !== "complete") return "reviewing";
+  return "awaiting decision";
+}
+
+function packageLabel(pkg: GatePackageScan): string {
+  if (pkg.packageName && pkg.version) return `${pkg.packageName}@${pkg.version}`;
+  return pkg.packageName ?? "package";
+}
+
+/**
+ * Roster of every package the gated release publishes. A monorepo fans the gate
+ * out into one scan per package and the held deployment only releases once all
+ * of them are approved — so this panel makes the sibling packages and their
+ * per-package decision state visible from any one package's review page, with a
+ * link to open each sibling's own review.
+ *
+ * Renders nothing for a single-package gate, where the roster would just echo
+ * the page you're already on.
+ */
+export function GatePackagesPanel({
+  gate,
+  currentScanId,
+}: {
+  gate: PublicWorkflowGate;
+  currentScanId: string;
+}) {
+  const packages = gate.packages;
+  if (packages.length <= 1) return null;
+  const approved = packages.filter((pkg) => pkg.decision === "publish").length;
+  const rejected = packages.filter((pkg) => pkg.decision === "no_publish").length;
+  const pending = gate.status === "pending";
+
+  return (
+    <section class="flex flex-col gap-3 border border-border rounded-lg p-4">
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <SectionLabel>Release packages</SectionLabel>
+        <span class="font-mono text-[11px] uppercase tracking-[0.08em] text-ink-subtle">
+          {approved} of {packages.length} approved
+          {rejected ? ` · ${rejected} rejected` : ""}
+        </span>
+      </div>
+      <p class="m-0 max-w-[760px] text-[13px] leading-[1.55] text-ink-muted">
+        This release publishes {packages.length} packages. Every one must be approved before the
+        held deployment releases; rejecting any single package blocks the whole release.
+      </p>
+      <ul class="m-0 p-0 list-none flex flex-col">
+        {packages.map((pkg) => {
+          const isCurrent = pkg.scanId === currentScanId;
+          return (
+            <li
+              key={pkg.scanId}
+              class="border-t border-border first:border-t-0 py-2.5 flex flex-wrap items-center justify-between gap-2"
+            >
+              <div class="flex items-center gap-2 flex-wrap min-w-0">
+                <span class="font-mono text-[13px] font-medium truncate">{packageLabel(pkg)}</span>
+                {pkg.releaseRisk ? (
+                  <Badge tone={severityTone(pkg.releaseRisk)}>{pkg.releaseRisk}</Badge>
+                ) : null}
+                {isCurrent ? <Badge tone="neutral">this package</Badge> : null}
+              </div>
+              <div class="flex items-center gap-3 shrink-0">
+                <Badge tone={packageDecisionTone(pkg)}>{packageDecisionLabel(pkg)}</Badge>
+                {isCurrent ? (
+                  <span class="font-mono text-[11px] text-ink-subtle">
+                    {pending && !pkg.decision ? "decide below" : "shown here"}
+                  </span>
+                ) : (
+                  <a
+                    class="font-mono text-[11px] underline text-accent"
+                    href={`/dashboard/scans/${encodeURIComponent(pkg.scanId)}`}
+                  >
+                    {pending && !pkg.decision ? "review →" : "open →"}
+                  </a>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
 }
 
 export function GateContextPanel({
@@ -91,6 +192,7 @@ export function GateDecisionDialog({
   onClose,
   gate,
   packageName,
+  packageDecision,
   status,
   error,
   canApprove,
@@ -101,6 +203,8 @@ export function GateDecisionDialog({
   onClose: () => void;
   gate: PublicWorkflowGate;
   packageName: string | null;
+  /** This package's recorded decision, if it has already been decided. */
+  packageDecision: GatePackageDecision | null;
   status: DecisionStatus;
   error: string | null;
   canApprove: boolean;
@@ -114,8 +218,11 @@ export function GateDecisionDialog({
   const commentDraft = useSignal("");
   const codeDraft = useSignal("");
   const saving = status === "saving";
-  const decided = gate.status === "approved" || gate.status === "rejected";
-  const needsCode = requireTwoFactor && !decided;
+  const gateDecided = gate.status === "approved" || gate.status === "rejected";
+  const packages = gate.packages;
+  const multi = packages.length > 1;
+  const approvedCount = packages.filter((pkg) => pkg.decision === "publish").length;
+  const needsCode = requireTwoFactor && !gateDecided;
   const code = codeDraft.value.trim();
   const blockedOnCode = needsCode && code.length === 0;
 
@@ -127,7 +234,7 @@ export function GateDecisionDialog({
   }, [open]);
 
   const submit = (next: WorkflowGateDecision) => {
-    if (saving || decided || blockedOnCode) return;
+    if (saving || gateDecided || blockedOnCode) return;
     const trimmed = commentDraft.value.trim();
     void onSubmit(next, trimmed.length ? trimmed : null, needsCode ? code : null);
   };
@@ -141,8 +248,12 @@ export function GateDecisionDialog({
     <Dialog
       open={open}
       onClose={handleClose}
-      title="Release decision"
-      description="Approve to release the held GitHub Actions job — publishing then proceeds through PyPI Trusted Publishing (OIDC). Reject to block the job. Drydock never holds PyPI credentials or uploads the package."
+      title={multi ? "Package decision" : "Release decision"}
+      description={
+        multi
+          ? "Decide this package. The held GitHub Actions job releases only once every package in the release is approved; rejecting any one blocks the whole release. Publishing then proceeds through PyPI Trusted Publishing (OIDC) — Drydock never holds PyPI credentials."
+          : "Approve to release the held GitHub Actions job — publishing then proceeds through PyPI Trusted Publishing (OIDC). Reject to block the job. Drydock never holds PyPI credentials or uploads the package."
+      }
     >
       <div class="flex flex-col gap-2 border border-border rounded-md p-3">
         <MonoDetail
@@ -153,10 +264,21 @@ export function GateDecisionDialog({
             <span key="run">run #{gate.runId}</span>,
           ]}
         />
-        {decided ? (
+        {gateDecided ? (
           <Badge tone={gateStatusTone(gate.status)}>{gateStatusLabel(gate.status)}</Badge>
+        ) : packageDecision ? (
+          <Badge tone={packageDecision === "publish" ? "ok" : "critical"}>
+            this package {packageDecision === "publish" ? "approved" : "rejected"}
+          </Badge>
         ) : null}
       </div>
+
+      {multi && !gateDecided ? (
+        <Muted class="m-0 text-[13px]">
+          {approvedCount} of {packages.length} packages approved. All must be approved before the
+          held deployment releases.
+        </Muted>
+      ) : null}
 
       <Field label="Comment (optional · shown in the GitHub run log)" for="gateComment">
         <Input
@@ -165,7 +287,7 @@ export function GateDecisionDialog({
           value={commentDraft.value}
           placeholder="e.g. reviewed changed files, no risk signals"
           onInput={(e) => (commentDraft.value = (e.target as HTMLInputElement).value)}
-          disabled={saving || decided}
+          disabled={saving || gateDecided}
           maxLength={500}
           autoComplete="off"
           spellcheck={false}
@@ -192,7 +314,7 @@ export function GateDecisionDialog({
         </Field>
       ) : null}
 
-      {decided ? (
+      {gateDecided ? (
         <Muted class="m-0 text-[13px]">
           This gate has already been decided. The decision is final — GitHub has been notified.
         </Muted>
@@ -200,7 +322,13 @@ export function GateDecisionDialog({
         <div class="flex flex-wrap gap-2">
           {canApprove ? (
             <Button onClick={() => submit("approved")} disabled={saving || blockedOnCode}>
-              {saving ? "Submitting…" : "Approve & release"}
+              {saving
+                ? "Submitting…"
+                : packageDecision === "publish"
+                  ? "Re-approve package"
+                  : multi
+                    ? "Approve package"
+                    : "Approve & release"}
             </Button>
           ) : null}
           <Button
@@ -208,11 +336,11 @@ export function GateDecisionDialog({
             onClick={() => submit("rejected")}
             disabled={saving || blockedOnCode}
           >
-            {saving ? "Submitting…" : "Reject & block"}
+            {saving ? "Submitting…" : "Reject & block release"}
           </Button>
         </div>
       )}
-      {!decided && !canApprove ? (
+      {!gateDecided && !canApprove ? (
         <Muted class="m-0 text-[13px]">
           Approval requires a completed review. Rejecting blocks the held GitHub job.
         </Muted>

--- a/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
@@ -144,10 +144,19 @@ export function GatePackagesPanel({
 export function GateContextPanel({
   gate,
   packageName,
+  canRetry,
+  retryStatus,
+  retryError,
+  onRetry,
 }: {
   gate: PublicWorkflowGate | null;
   packageName: string | null;
+  canRetry?: boolean;
+  retryStatus?: DecisionStatus;
+  retryError?: string | null;
+  onRetry?: () => void;
 }) {
+  const retrying = retryStatus === "saving";
   return (
     <section class="flex flex-col gap-3 border border-border rounded-lg p-4">
       <div class="flex flex-wrap items-center justify-between gap-2">
@@ -183,6 +192,17 @@ export function GateContextPanel({
           against the reviewed manifest ({gate.failureReason}).
         </Alert>
       ) : null}
+      {canRetry && onRetry ? (
+        <div class="flex flex-wrap items-center gap-3">
+          <Button variant="secondary" onClick={onRetry} disabled={retrying}>
+            {retrying ? "Retrying…" : "Retry review"}
+          </Button>
+          <Muted class="m-0 text-[12px]">
+            Re-runs the gate review from the workflow artifacts and replaces the failed batch.
+          </Muted>
+        </div>
+      ) : null}
+      {retryError ? <Alert tone="critical">{retryError}</Alert> : null}
     </section>
   );
 }
@@ -197,6 +217,7 @@ export function GateDecisionDialog({
   error,
   canApprove,
   requireTwoFactor,
+  reviewFailed,
   onSubmit,
 }: {
   open: boolean;
@@ -209,6 +230,7 @@ export function GateDecisionDialog({
   error: string | null;
   canApprove: boolean;
   requireTwoFactor: boolean;
+  reviewFailed?: boolean;
   onSubmit: (
     decision: WorkflowGateDecision,
     comment: string | null,
@@ -281,6 +303,13 @@ export function GateDecisionDialog({
         </Muted>
       ) : null}
 
+      {reviewFailed && !gateDecided && !packageAlreadyDecided ? (
+        <Alert tone="warn">
+          This package review failed. Retry the review, or record a human decision based on the
+          release evidence you have inspected.
+        </Alert>
+      ) : null}
+
       <Field label="Comment (optional · shown in the GitHub run log)" for="gateComment">
         <Input
           id="gateComment"
@@ -328,7 +357,15 @@ export function GateDecisionDialog({
         <div class="flex flex-wrap gap-2">
           {canApprove ? (
             <Button onClick={() => submit("approved")} disabled={saving || blockedOnCode}>
-              {saving ? "Submitting…" : multi ? "Approve package" : "Approve & release"}
+              {saving
+                ? "Submitting…"
+                : reviewFailed
+                  ? multi
+                    ? "Approve package anyway"
+                    : "Approve anyway & release"
+                  : multi
+                    ? "Approve package"
+                    : "Approve & release"}
             </Button>
           ) : null}
           <Button
@@ -342,7 +379,8 @@ export function GateDecisionDialog({
       )}
       {!gateDecided && !canApprove ? (
         <Muted class="m-0 text-[13px]">
-          Approval requires a completed review. Rejecting blocks the held GitHub job.
+          Approval requires the review to reach a decision point. Rejecting blocks the held GitHub
+          job.
         </Muted>
       ) : null}
       {error ? <Alert tone="critical">{error}</Alert> : null}

--- a/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
@@ -219,6 +219,7 @@ export function GateDecisionDialog({
   const codeDraft = useSignal("");
   const saving = status === "saving";
   const gateDecided = gate.status === "approved" || gate.status === "rejected";
+  const packageAlreadyDecided = packageDecision !== null;
   const packages = gate.packages;
   const multi = packages.length > 1;
   const approvedCount = packages.filter((pkg) => pkg.decision === "publish").length;
@@ -234,7 +235,7 @@ export function GateDecisionDialog({
   }, [open]);
 
   const submit = (next: WorkflowGateDecision) => {
-    if (saving || gateDecided || blockedOnCode) return;
+    if (saving || gateDecided || packageAlreadyDecided || blockedOnCode) return;
     const trimmed = commentDraft.value.trim();
     void onSubmit(next, trimmed.length ? trimmed : null, needsCode ? code : null);
   };
@@ -287,7 +288,7 @@ export function GateDecisionDialog({
           value={commentDraft.value}
           placeholder="e.g. reviewed changed files, no risk signals"
           onInput={(e) => (commentDraft.value = (e.target as HTMLInputElement).value)}
-          disabled={saving || gateDecided}
+          disabled={saving || gateDecided || packageAlreadyDecided}
           maxLength={500}
           autoComplete="off"
           spellcheck={false}
@@ -318,17 +319,16 @@ export function GateDecisionDialog({
         <Muted class="m-0 text-[13px]">
           This gate has already been decided. The decision is final — GitHub has been notified.
         </Muted>
+      ) : packageAlreadyDecided ? (
+        <Muted class="m-0 text-[13px]">
+          This package decision has been recorded. The held deployment stays pending until the
+          remaining packages are decided.
+        </Muted>
       ) : (
         <div class="flex flex-wrap gap-2">
           {canApprove ? (
             <Button onClick={() => submit("approved")} disabled={saving || blockedOnCode}>
-              {saving
-                ? "Submitting…"
-                : packageDecision === "publish"
-                  ? "Re-approve package"
-                  : multi
-                    ? "Approve package"
-                    : "Approve & release"}
+              {saving ? "Submitting…" : multi ? "Approve package" : "Approve & release"}
             </Button>
           ) : null}
           <Button

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -201,12 +201,17 @@ export default function ScanDetailPage() {
     }
   };
 
+  const handleGateRetry = async () => {
+    await model.retryGate();
+  };
+
   const gateReviewComplete = detail?.scan.status === "complete";
   const gateReviewFailed = detail?.scan.status === "failed";
 
   // npm scans become decidable once complete; gate scans are decidable while
-  // pending after the review either completes or fails. Failed reviews can only
-  // be rejected because approval releases the held GitHub job.
+  // pending after the review either completes or fails. Human decisions remain
+  // allowed even when automated review fails; the retry action gives a safer
+  // first move when the maintainer wants a fresh automated pass.
   const onDecideClick = isWorkflowGate
     ? gate?.status === "pending" && (gateReviewComplete || gateReviewFailed)
       ? () => (gateDialogOpen.value = true)
@@ -221,7 +226,14 @@ export default function ScanDetailPage() {
 
       {error ? <Alert tone="critical">{error}</Alert> : null}
       {isWorkflowGate && detail ? (
-        <GateContextPanel gate={gate} packageName={detail.scan.packageName} />
+        <GateContextPanel
+          gate={gate}
+          packageName={detail.scan.packageName}
+          canRetry={gate?.status === "pending" && gateReviewFailed && !detail.scan.decision}
+          retryStatus={model.gateRetryStatus.value}
+          retryError={model.gateRetryError.value}
+          onRetry={handleGateRetry}
+        />
       ) : null}
       {isWorkflowGate && detail && gate ? (
         <GatePackagesPanel gate={gate} currentScanId={detail.scan.id} />
@@ -360,7 +372,8 @@ export default function ScanDetailPage() {
               ? detail.scan.decision
               : null
           }
-          canApprove={detail.scan.status === "complete"}
+          canApprove={detail.scan.status === "complete" || detail.scan.status === "failed"}
+          reviewFailed={detail.scan.status === "failed"}
           onSubmit={handleGateDecision}
         />
       ) : null}

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -203,6 +203,9 @@ export default function ScanDetailPage() {
 
   const handleGateRetry = async () => {
     await model.retryGate();
+    if (model.gateRetryStatus.peek() === "idle") {
+      location.route("/dashboard", true);
+    }
   };
 
   const gateReviewComplete = detail?.scan.status === "complete";

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -372,7 +372,10 @@ export default function ScanDetailPage() {
               ? detail.scan.decision
               : null
           }
-          canApprove={detail.scan.status === "complete" || detail.scan.status === "failed"}
+          canApprove={
+            Boolean(gate.scanId) &&
+            (detail.scan.status === "complete" || detail.scan.status === "failed")
+          }
           reviewFailed={detail.scan.status === "failed"}
           onSubmit={handleGateDecision}
         />

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -26,7 +26,7 @@ import {
   VersionPicker,
 } from "../../../components";
 import { DecisionDialog } from "./DecisionDialog";
-import { GateContextPanel, GateDecisionDialog } from "./GateDecisionDialog";
+import { GateContextPanel, GateDecisionDialog, GatePackagesPanel } from "./GateDecisionDialog";
 import { DiffWorkbench } from "./DiffWorkbench";
 import { RiskSignalsSection } from "./FindingsSection";
 import { ReleaseRecommendation } from "./ReleaseRecommendation";
@@ -223,6 +223,9 @@ export default function ScanDetailPage() {
       {isWorkflowGate && detail ? (
         <GateContextPanel gate={gate} packageName={detail.scan.packageName} />
       ) : null}
+      {isWorkflowGate && detail && gate ? (
+        <GatePackagesPanel gate={gate} currentScanId={detail.scan.id} />
+      ) : null}
       {detail?.scan.status === "failed" ? (
         <ScanFailureAlert errorJson={detail.scan.errorJson} />
       ) : null}
@@ -352,6 +355,11 @@ export default function ScanDetailPage() {
           packageName={detail.scan.packageName}
           statusSignal={model.gateDecisionStatus}
           errorSignal={model.gateDecisionError}
+          packageDecision={
+            detail.scan.decision === "publish" || detail.scan.decision === "no_publish"
+              ? detail.scan.decision
+              : null
+          }
           canApprove={detail.scan.status === "complete"}
           onSubmit={handleGateDecision}
         />

--- a/src/pages/Dashboard/Settings/GithubAppSection.tsx
+++ b/src/pages/Dashboard/Settings/GithubAppSection.tsx
@@ -177,11 +177,14 @@ function ReleaseTargetList({
             <div class="flex flex-col gap-1.5 min-w-0">
               <div class="flex items-center gap-2 flex-wrap">
                 <span class="font-mono text-[14px] font-medium">{target.repositoryFullName}</span>
-                <Badge tone="info">{target.ecosystem}</Badge>
+                <Badge tone="info">{target.ecosystem ?? "auto"}</Badge>
               </div>
               <MonoDetail
                 parts={[
                   <span key="env">env {target.environment}</span>,
+                  target.artifactName ? (
+                    <span key="artifact">artifact {target.artifactName}</span>
+                  ) : null,
                   <span key="install">
                     via {installation?.accountLogin ?? "unknown"} ·{" "}
                     {installation?.installationId ?? target.installationRowId}

--- a/src/pages/Dashboard/Settings/ReleaseTargetForm.tsx
+++ b/src/pages/Dashboard/Settings/ReleaseTargetForm.tsx
@@ -164,7 +164,7 @@ function ArtifactNameField({ githubApp }: { githubApp: GithubApp }) {
         id="releaseTargetArtifact"
         type="text"
         value={artifactName}
-        placeholder="e.g. dist"
+        placeholder="e.g. pypi-release-candidate"
         onInput={(e) => (githubApp.formArtifactName.value = (e.target as HTMLInputElement).value)}
         disabled={submitting}
         maxLength={200}
@@ -172,9 +172,8 @@ function ArtifactNameField({ githubApp }: { githubApp: GithubApp }) {
         spellcheck={false}
       />
       <Muted class="text-[12px] mt-1.5">
-        Leave blank to use the default artifact name for the selected mode: release-candidate for
-        auto-detect, or the pinned ecosystem's default. Set a name when your workflow uploads the
-        release candidates under a different artifact.
+        Leave blank to scan every non-expired artifact uploaded by the held workflow run. Set a name
+        only when you want Drydock to inspect one specific upload.
       </Muted>
     </Field>
   );

--- a/src/pages/Dashboard/Settings/ReleaseTargetForm.tsx
+++ b/src/pages/Dashboard/Settings/ReleaseTargetForm.tsx
@@ -1,7 +1,11 @@
 import { useEffect } from "preact/hooks";
 import { useModel } from "@preact/signals";
-import { GithubAppModel, type PublicGithubAppInstallation } from "../../../models/github-app";
-import { Alert, Button, Field, Muted, Select } from "../../../components";
+import {
+  GithubAppModel,
+  type PublicGithubAppInstallation,
+  type SupportedEcosystem,
+} from "../../../models/github-app";
+import { Alert, Button, Field, Input, Muted, Select } from "../../../components";
 
 type GithubApp = ReturnType<typeof useModel<typeof GithubAppModel.prototype>>;
 
@@ -37,6 +41,11 @@ export function ReleaseTargetForm({
       <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
         <RepositorySelector githubApp={githubApp} />
         <EnvironmentSelector githubApp={githubApp} />
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <EcosystemSelector githubApp={githubApp} />
+        <ArtifactNameField githubApp={githubApp} />
       </div>
 
       {formError ? <Alert tone="critical">{formError}</Alert> : null}
@@ -117,6 +126,55 @@ function RepositorySelector({ githubApp }: { githubApp: GithubApp }) {
           and refresh.
         </Muted>
       ) : null}
+    </Field>
+  );
+}
+
+function EcosystemSelector({ githubApp }: { githubApp: GithubApp }) {
+  const ecosystem = githubApp.formEcosystem.value;
+  const submitting = githubApp.formSubmitting.value;
+
+  return (
+    <Field label="Ecosystem" for="releaseTargetEcosystem">
+      <Select
+        id="releaseTargetEcosystem"
+        value={ecosystem}
+        disabled={submitting}
+        onChange={(value) => (githubApp.formEcosystem.value = value as "auto" | SupportedEcosystem)}
+      >
+        <option value="auto">Auto-detect from artifacts</option>
+        <option value="pypi">PyPI</option>
+      </Select>
+      <Muted class="text-[12px] mt-1.5">
+        Auto-detect derives each package's ecosystem from the uploaded artifacts — the right choice
+        for a monorepo publishing several packages from one workflow. Pin an ecosystem only when the
+        release always publishes that one kind.
+      </Muted>
+    </Field>
+  );
+}
+
+function ArtifactNameField({ githubApp }: { githubApp: GithubApp }) {
+  const artifactName = githubApp.formArtifactName.value;
+  const submitting = githubApp.formSubmitting.value;
+
+  return (
+    <Field label="Artifact name (optional)" for="releaseTargetArtifact">
+      <Input
+        id="releaseTargetArtifact"
+        type="text"
+        value={artifactName}
+        placeholder="e.g. dist"
+        onInput={(e) => (githubApp.formArtifactName.value = (e.target as HTMLInputElement).value)}
+        disabled={submitting}
+        maxLength={200}
+        autoComplete="off"
+        spellcheck={false}
+      />
+      <Muted class="text-[12px] mt-1.5">
+        Leave blank to consume every artifact the run uploads. Set this to a single workflow
+        artifact name when only one upload holds the release candidates.
+      </Muted>
     </Field>
   );
 }

--- a/src/pages/Dashboard/Settings/ReleaseTargetForm.tsx
+++ b/src/pages/Dashboard/Settings/ReleaseTargetForm.tsx
@@ -172,8 +172,9 @@ function ArtifactNameField({ githubApp }: { githubApp: GithubApp }) {
         spellcheck={false}
       />
       <Muted class="text-[12px] mt-1.5">
-        Leave blank to consume every artifact the run uploads. Set this to a single workflow
-        artifact name when only one upload holds the release candidates.
+        Leave blank to use the default artifact name for the selected mode: release-candidate for
+        auto-detect, or the pinned ecosystem's default. Set a name when your workflow uploads the
+        release candidates under a different artifact.
       </Muted>
     </Field>
   );

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -203,6 +203,23 @@ export default function DocsPage() {
             </Prose>
           </Subsection>
 
+          <Subsection title="Monorepo releases">
+            <Prose>
+              One workflow run can publish several distinct packages — a monorepo cutting many
+              wheels and sdists at once. Drydock groups the uploaded artifacts by package identity
+              and fans the gate out into one review per package, each diffed against its own
+              previously-published baseline. A release target left without a pinned ecosystem
+              auto-detects each package's ecosystem from its artifacts, so a single gate can cover
+              every package the environment publishes.
+            </Prose>
+            <Prose>
+              The held deployment is released only once every discovered package is individually
+              approved; rejecting any single package blocks the whole release. The review workbench
+              lists the package roster, tracks how many are approved, and links each package to its
+              own diff-first review.
+            </Prose>
+          </Subsection>
+
           <Subsection title="Workflow shape">
             <CodeBlock name=".github/workflows/release.yml">
               {`jobs:
@@ -256,16 +273,18 @@ export default function DocsPage() {
                 </>,
                 <>
                   Drydock derives the release set from the uploaded bundle, recomputes each
-                  artifact's sha256, runs the scan pipeline, and records an advisory recommendation.
-                  The review never posts to GitHub — it leaves the gate <Code>pending</Code> and
-                  hands off to a human.
+                  artifact's sha256, and runs the scan pipeline — one review per discovered package,
+                  each against its own baseline — recording an advisory recommendation. The review
+                  never posts to GitHub — it leaves the gate <Code>pending</Code> and hands off to a
+                  human.
                 </>,
                 <>
                   A maintainer opens the review in the diff-first workbench at{" "}
-                  <Code>/dashboard/scans/:id</Code> and approves or rejects. Only that decision is
-                  posted back to GitHub, releasing or blocking the held publish job. A bundle whose
-                  artifacts can't be verified is auto-rejected fail-closed — no human is needed to
-                  block something Drydock can't identify.
+                  <Code>/dashboard/scans/:id</Code> and approves or rejects each package. The held
+                  publish job is released only once every package is approved, and blocked the
+                  moment any one is rejected — only that final decision is posted back to GitHub. A
+                  bundle whose artifacts can't be verified is auto-rejected fail-closed — no human
+                  is needed to block something Drydock can't identify.
                 </>,
                 <>
                   The decision callback hits{" "}

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -173,9 +173,9 @@ export default function DocsPage() {
                 </>,
                 <>
                   Add the build and publish workflow below. The build job uploads the wheels and
-                  sdists as a <Code>pypi-release-candidate</Code> bundle; the publish job runs in{" "}
-                  <Code>environment: pypi</Code> and stays blocked until a maintainer approves the
-                  review in Drydock.
+                  sdists as a GitHub Actions artifact; the publish job runs in{" "}
+                  <Code>environment: pypi</Code>, downloads the same artifact, and stays blocked
+                  until a maintainer approves the review in Drydock.
                 </>,
               ]}
             />
@@ -189,9 +189,10 @@ export default function DocsPage() {
           <Subsection title="Release-candidate bundle">
             <Prose>
               There is no manifest to write. The boundary between your workflow and Drydock is the
-              uploaded <Code>pypi-release-candidate</Code> bundle: CI builds and uploads{" "}
-              <Code>dist/*</Code>, and Drydock treats every <Code>.whl</Code>, <Code>.tar.gz</Code>,
-              and <Code>.tgz</Code> in it as the release set.
+              workflow run's uploaded artifacts: CI builds and uploads <Code>dist/*</Code>, and
+              Drydock treats every <Code>.whl</Code>, <Code>.tar.gz</Code>, and <Code>.tgz</Code> it
+              finds as the release set. The settings form can narrow discovery to one artifact name,
+              but leaving it blank lets Drydock inspect every non-expired upload from the held run.
             </Prose>
             <Prose>
               The release identity is derived from the artifacts themselves — package name and

--- a/test/notify.test.mjs
+++ b/test/notify.test.mjs
@@ -111,6 +111,15 @@ describe("notifyWorkflowGateReview", () => {
     }
   });
 
+  test("flags a monorepo bundle so the owner knows every package needs approval", async () => {
+    await notifyWorkflowGateReview(gateInput({ packageCount: 3 }));
+
+    const [, message] = emailMock.sendNotificationEmail.mock.calls[0];
+    expect(message.text).toContain(
+      "demo-package@1.2.0 (+2 more in this release; each must be approved)",
+    );
+  });
+
   test("never leaks token, header, or callback material into the email", async () => {
     await notifyWorkflowGateReview(gateInput());
 

--- a/test/workers/github-app-artifacts.test.ts
+++ b/test/workers/github-app-artifacts.test.ts
@@ -178,6 +178,12 @@ async function buildFixture(opts?: {
 
 interface StubOptions {
   bundleZip: Uint8Array | null;
+  artifacts?: Array<{
+    id: number;
+    name: string;
+    bundleZip: Uint8Array | null;
+    expired?: boolean;
+  }>;
   artifactsResponse?: () => Response;
   artifactId?: number;
   artifactName?: string;
@@ -186,16 +192,22 @@ interface StubOptions {
 
 function stubGithubFetch(options: StubOptions) {
   const calls: { url: string; authorization: string | null }[] = [];
+  const artifacts = options.artifacts ?? [
+    {
+      id: options.artifactId ?? ARTIFACT_ID,
+      name: options.artifactName ?? ARTIFACT_NAME,
+      bundleZip: options.bundleZip,
+      expired: false,
+    },
+  ];
   const artifactsBody = JSON.stringify({
-    total_count: 1,
-    artifacts: [
-      {
-        id: options.artifactId ?? ARTIFACT_ID,
-        name: options.artifactName ?? ARTIFACT_NAME,
-        size_in_bytes: options.bundleZip?.length ?? 0,
-        expired: false,
-      },
-    ],
+    total_count: artifacts.length,
+    artifacts: artifacts.map((artifact) => ({
+      id: artifact.id,
+      name: artifact.name,
+      size_in_bytes: artifact.bundleZip?.length ?? 0,
+      expired: artifact.expired === true,
+    })),
   });
   vi.stubGlobal(
     "fetch",
@@ -213,16 +225,19 @@ function stubGithubFetch(options: StubOptions) {
         });
       }
       if (request.url.includes("/actions/artifacts/")) {
-        if (!options.bundleZip) {
+        const match = request.url.match(/\/actions\/artifacts\/(\d+)\/zip$/);
+        const artifactId = match ? Number.parseInt(match[1], 10) : Number.NaN;
+        const artifact = artifacts.find((candidate) => candidate.id === artifactId);
+        if (!artifact?.bundleZip) {
           return new Response("not found", { status: 404 });
         }
         const headers: Record<string, string> = {
           "content-type": "application/zip",
         };
         if (options.contentLength !== null) {
-          headers["content-length"] = String(options.contentLength ?? options.bundleZip.length);
+          headers["content-length"] = String(options.contentLength ?? artifact.bundleZip.length);
         }
-        return new Response(options.bundleZip, { status: 200, headers });
+        return new Response(artifact.bundleZip, { status: 200, headers });
       }
       throw new Error(`unexpected fetch in test: ${request.url}`);
     }),
@@ -230,11 +245,12 @@ function stubGithubFetch(options: StubOptions) {
   return calls;
 }
 
-function source(): WorkflowArtifactSource {
+function source(overrides: Partial<WorkflowArtifactSource> = {}): WorkflowArtifactSource {
   return {
     installationExternalId: "1010",
     repositoryFullName: REPO,
     runId: RUN_ID,
+    ...overrides,
   };
 }
 
@@ -287,6 +303,40 @@ describe("fetchReleaseBundleWithToken", () => {
     expect(sdist?.sha256).toBe(await sha256Hex(sdistBytes));
   });
 
+  test("collects reviewable files across every non-expired workflow artifact", async () => {
+    const first = await buildFixture();
+    const secondWheel = makeWheelBytes("other-package", "2.0.0");
+    const secondZip = makeZip([{ path: secondWheel.path, body: secondWheel.bytes }]);
+    stubGithubFetch({
+      bundleZip: null,
+      artifacts: [
+        {
+          id: ARTIFACT_ID,
+          name: "alpha-upload",
+          bundleZip: first.bundleZip,
+        },
+        {
+          id: ARTIFACT_ID + 1,
+          name: "beta-upload",
+          bundleZip: secondZip,
+        },
+        {
+          id: ARTIFACT_ID + 2,
+          name: "expired-upload",
+          bundleZip: makeZip([{ path: "dist/expired-1.0.0.tar.gz", body: "expired" }]),
+          expired: true,
+        },
+      ],
+    });
+
+    const bundle = await fetchReleaseBundleWithToken(TOKEN, source(), classifyArtifact);
+
+    expect(bundle.artifactName).toBe("all");
+    expect(bundle.artifactSizeBytes).toBe(first.bundleZip.length + secondZip.length);
+    const paths = bundle.artifacts.map((artifact) => artifact.path).sort();
+    expect(paths).toEqual([first.wheel.path, secondWheel.path].sort());
+  });
+
   test("ignores non-artifact files in the bundle", async () => {
     const fixture = await buildFixture({
       extraEntries: [
@@ -332,12 +382,12 @@ describe("fetchReleaseBundleWithToken", () => {
     });
   });
 
-  test("bundle_unavailable when no artifact with that name exists", async () => {
+  test("bundle_unavailable when an explicit artifact name does not exist", async () => {
     const fixture = await buildFixture();
     stubGithubFetch({ bundleZip: fixture.bundleZip, artifactName: "something-else" });
 
     await expect(
-      fetchReleaseBundleWithToken(TOKEN, source(), classifyArtifact),
+      fetchReleaseBundleWithToken(TOKEN, source({ artifactName: ARTIFACT_NAME }), classifyArtifact),
     ).rejects.toMatchObject({
       name: "WorkflowArtifactError",
       code: "bundle_unavailable",

--- a/test/workers/github-app-artifacts.test.ts
+++ b/test/workers/github-app-artifacts.test.ts
@@ -240,11 +240,13 @@ function source(): WorkflowArtifactSource {
 
 // The shared fetcher is ecosystem-agnostic; the workflow-gate adapter supplies
 // this. These tests use a wheel/sdist classifier to exercise the release-set
-// collection without coupling to a specific adapter.
-function classifyArtifact(path: string): string | null {
+// collection without coupling to a specific adapter. The classifier tags each
+// kept entry with its ecosystem so a monorepo bundle can fan out per-ecosystem.
+function classifyArtifact(path: string): { ecosystem: string; kind: string } | null {
   const lower = path.toLowerCase();
-  if (lower.endsWith(".whl")) return "wheel";
-  if (lower.endsWith(".tar.gz") || lower.endsWith(".tgz")) return "sdist";
+  if (lower.endsWith(".whl")) return { ecosystem: "pypi", kind: "wheel" };
+  if (lower.endsWith(".tar.gz") || lower.endsWith(".tgz"))
+    return { ecosystem: "pypi", kind: "sdist" };
   return null;
 }
 
@@ -262,6 +264,7 @@ describe("fetchReleaseBundleWithToken", () => {
     expect(bundle.artifacts).toHaveLength(1);
     expect(bundle.artifacts[0]?.path).toBe(fixture.wheel.path);
     expect(bundle.artifacts[0]?.kind).toBe("wheel");
+    expect(bundle.artifacts[0]?.ecosystem).toBe("pypi");
     expect(bundle.artifacts[0]?.bytes).toEqual(fixture.wheel.bytes);
     expect(bundle.artifacts[0]?.sha256).toBe(fixture.wheelSha);
     expect(calls.every((call) => call.authorization === `Bearer ${TOKEN}`)).toBe(true);

--- a/test/workers/github-app.test.ts
+++ b/test/workers/github-app.test.ts
@@ -1045,6 +1045,20 @@ describe("github-app workflow-gate decision route", () => {
     expect(partialBody.gate.packages).toHaveLength(2);
     expect(decisionCalls).toHaveLength(0);
 
+    // The package decision is final while the gate is pending; a stale second
+    // submit must not overwrite it before the aggregate gate decision happens.
+    const staleOverwrite = await callGithubAppRoute(
+      buildTestApp(userId),
+      "POST",
+      `/api/v1/github-app/workflow-gates/${gateId}/decision`,
+      { decision: "rejected", scanId: scanId! },
+    );
+    expect(staleOverwrite.status).toBe(409);
+    expect(await staleOverwrite.json()).toMatchObject({
+      error: "package has already been decided",
+    });
+    expect(decisionCalls).toHaveLength(0);
+
     // Approving the last package finalizes the gate and posts the release.
     const finalRes = await callGithubAppRoute(
       buildTestApp(userId),

--- a/test/workers/github-app.test.ts
+++ b/test/workers/github-app.test.ts
@@ -987,6 +987,55 @@ describe("github-app workflow-gate decision route", () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
+  test("rejects approval for a partial failed review batch", async () => {
+    const { userId, organizationId } = await seedUser();
+    const { gateId } = await seedGate(organizationId);
+    const completeScanId = await seedGatePackageScan({
+      organizationId,
+      ownerUserId: userId,
+      gateId,
+      packageName: "alpha-pkg",
+      version: "1.0.0",
+    });
+    const failedScanId = `scan_${crypto.randomUUID()}`;
+    await createScanJob(createDb(env.DB), {
+      id: failedScanId,
+      stageId: `workflow-gate:${gateId}:pypi:beta-pkg`,
+      organizationId,
+      ownerUserId: userId,
+      source: "workflow_gate",
+      gateId,
+    });
+    await markScanFailed(createDb(env.DB), failedScanId, organizationId, {
+      code: "review_failed",
+      message: "review failed",
+    });
+    globalThis.fetch = vi.fn();
+
+    const res = await callGithubAppRoute(
+      buildTestApp(userId),
+      "POST",
+      `/api/v1/github-app/workflow-gates/${gateId}/decision`,
+      { decision: "approved", scanId: completeScanId },
+    );
+
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({
+      error: "approval requires a completed workflow-gate review batch",
+      gate: { status: "pending" },
+    });
+    const stored = await getGateForOrganization(createDb(env.DB), organizationId, gateId);
+    expect(stored?.scanId).toBeNull();
+    expect(stored?.status).toBe("pending");
+    const scan = await createDb(env.DB)
+      .select({ decision: schema.scans.decision })
+      .from(schema.scans)
+      .where(eq(schema.scans.id, completeScanId))
+      .limit(1);
+    expect(scan[0]?.decision).toBeNull();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
   test("decides a pending gate once, posts to GitHub, and 409s a double-submit", async () => {
     const { userId, organizationId } = await seedUser();
     const { gateId, scanId } = await seedGate(organizationId, {

--- a/test/workers/github-app.test.ts
+++ b/test/workers/github-app.test.ts
@@ -111,6 +111,7 @@ async function callGithubAppRoute(
   method: string,
   path: string,
   body?: unknown,
+  envOverrides: Partial<Bindings> = {},
 ) {
   const ctx = createExecutionContext();
   const init: RequestInit = { method };
@@ -128,6 +129,7 @@ async function callGithubAppRoute(
     GITHUB_APP_WEBHOOK_SECRET: "webhook-secret-value-1234567890",
     GITHUB_APP_STATE_SECRET: "0123456789abcdef0123456789abcdef",
     BETTER_AUTH_SECRET: "fallback-secret-with-enough-entropy-aaaaaaaa",
+    ...envOverrides,
   };
   const res = await app.fetch(new Request(`http://test.local${path}`, init), routeEnv, ctx);
   await waitOnExecutionContext(ctx);
@@ -921,7 +923,7 @@ describe("github-app workflow-gate decision route", () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
-  test("rejects approval when the package scan has not completed", async () => {
+  test("allows a human to approve a failed package review", async () => {
     const { userId, organizationId } = await seedUser();
     const { gateId, scanId } = await seedGate(organizationId, {
       attachScan: { ownerUserId: userId },
@@ -929,6 +931,45 @@ describe("github-app workflow-gate decision route", () => {
     await markScanFailed(createDb(env.DB), scanId!, organizationId, {
       code: "review_failed",
       message: "review failed",
+    });
+    const decisionCalls: { state: string }[] = [];
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      if (request.url.includes("/access_tokens")) {
+        return Response.json({ token: "ghs_install_token", expires_at: "2099-01-01T00:00:00Z" });
+      }
+      if (request.url.endsWith("/deployment_protection_rule")) {
+        decisionCalls.push((await request.json()) as { state: string });
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`unexpected fetch in decision test: ${request.url}`);
+    });
+
+    const res = await callGithubAppRoute(
+      buildTestApp(userId),
+      "POST",
+      `/api/v1/github-app/workflow-gates/${gateId}/decision`,
+      { decision: "approved", scanId: scanId! },
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      gate: { status: "approved", decision: "approved" },
+    });
+    const scan = await createDb(env.DB)
+      .select({ decision: schema.scans.decision })
+      .from(schema.scans)
+      .where(eq(schema.scans.id, scanId!))
+      .limit(1);
+    expect(scan[0]?.decision).toBe("publish");
+    expect(decisionCalls).toHaveLength(1);
+    expect(decisionCalls[0].state).toBe("approved");
+  });
+
+  test("rejects a decision while the package scan is still pending", async () => {
+    const { userId, organizationId } = await seedUser();
+    const { gateId, scanId } = await seedGate(organizationId, {
+      attachScan: { ownerUserId: userId },
     });
     globalThis.fetch = vi.fn();
 
@@ -1123,6 +1164,36 @@ describe("github-app workflow-gate decision route", () => {
     expect(stored?.status).toBe("rejected");
     expect(decisionCalls).toHaveLength(1);
     expect(decisionCalls[0].state).toBe("rejected");
+  });
+
+  test("retries a failed package review by requeueing the pending gate", async () => {
+    const { userId, organizationId } = await seedUser();
+    const { gateId, scanId } = await seedGate(organizationId, {
+      attachScan: { ownerUserId: userId },
+    });
+    await markScanFailed(createDb(env.DB), scanId!, organizationId, {
+      code: "review_failed",
+      message: "review failed",
+    });
+    const queueSend = vi.fn(async () => undefined);
+
+    const res = await callGithubAppRoute(
+      buildTestApp(userId),
+      "POST",
+      `/api/v1/github-app/workflow-gates/${gateId}/retry`,
+      {},
+      { SCAN_QUEUE: { send: queueSend } as unknown as Queue },
+    );
+
+    expect(res.status).toBe(202);
+    expect(await res.json()).toMatchObject({ queued: true, gate: { status: "pending" } });
+    expect(queueSend).toHaveBeenCalledWith({
+      kind: "workflow_gate",
+      organizationId,
+      gateId,
+    });
+    const gate = await getGateForOrganization(createDb(env.DB), organizationId, gateId);
+    expect(gate?.scanId).toBeNull();
   });
 });
 

--- a/test/workers/github-app.test.ts
+++ b/test/workers/github-app.test.ts
@@ -1,4 +1,5 @@
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
@@ -731,17 +732,9 @@ async function seedGate(
     createdByUserId: null,
   });
   const gateId = crypto.randomUUID();
-  let scanId: string | null = null;
-  if (overrides.attachScan) {
-    scanId = `scan_${crypto.randomUUID()}`;
-    await createScanJob(db, {
-      id: scanId,
-      stageId: `workflow-gate:${gateId}`,
-      organizationId,
-      ownerUserId: overrides.attachScan.ownerUserId,
-      source: "workflow_gate",
-    });
-  }
+  // Insert the gate before any per-package scan: `scans.gate_id` references the
+  // gate, so the gate must exist first (production creates the gate from the
+  // webhook before the runner fans out per-package scans).
   await db.insert(schema.githubWorkflowGates).values({
     id: gateId,
     organizationId,
@@ -757,11 +750,28 @@ async function seedGate(
     eventAction: "requested",
     status: overrides.status ?? "pending",
     decision: overrides.decision ?? null,
-    scanId,
+    scanId: null,
     requestedAt: now,
     createdAt: now,
     updatedAt: now,
   });
+  let scanId: string | null = null;
+  if (overrides.attachScan) {
+    scanId = `scan_${crypto.randomUUID()}`;
+    await createScanJob(db, {
+      id: scanId,
+      stageId: `workflow-gate:${gateId}`,
+      organizationId,
+      ownerUserId: overrides.attachScan.ownerUserId,
+      source: "workflow_gate",
+      gateId,
+    });
+    // Point the gate at its representative scan, mirroring `attachScanToGate`.
+    await db
+      .update(schema.githubWorkflowGates)
+      .set({ scanId })
+      .where(eq(schema.githubWorkflowGates.id, gateId));
+  }
   return { gateId, scanId, installation, releaseTarget, runId };
 }
 
@@ -770,13 +780,15 @@ async function completeWorkflowGateScan(input: {
   ownerUserId: string;
   gateId: string;
   scanId: string;
+  packageName?: string;
+  version?: string;
 }) {
   await persistScan(createDb(env.DB), {
     id: input.scanId,
     stageId: `workflow-gate:${input.gateId}`,
     organizationId: input.organizationId,
     ownerUserId: input.ownerUserId,
-    packageJson: { name: "pkg", version: "1.0.0" },
+    packageJson: { name: input.packageName ?? "pkg", version: input.version ?? "1.0.0" },
     previousPackageJson: null,
     risk: "low",
     status: "complete",
@@ -787,6 +799,37 @@ async function completeWorkflowGateScan(input: {
     diff: [],
     findings: [],
   });
+}
+
+// Seed a second (or further) complete per-package scan linked to an existing
+// gate via `scans.gate_id`. The gate decision aggregates over every such scan,
+// so multi-package tests stack these on top of the gate's first package.
+async function seedGatePackageScan(input: {
+  organizationId: string;
+  ownerUserId: string;
+  gateId: string;
+  packageName: string;
+  version: string;
+}) {
+  const db = createDb(env.DB);
+  const scanId = `scan_${crypto.randomUUID()}`;
+  await createScanJob(db, {
+    id: scanId,
+    stageId: `workflow-gate:${input.gateId}:pypi:${input.packageName}`,
+    organizationId: input.organizationId,
+    ownerUserId: input.ownerUserId,
+    source: "workflow_gate",
+    gateId: input.gateId,
+  });
+  await completeWorkflowGateScan({
+    organizationId: input.organizationId,
+    ownerUserId: input.ownerUserId,
+    gateId: input.gateId,
+    scanId,
+    packageName: input.packageName,
+    version: input.version,
+  });
+  return scanId;
 }
 
 describe("github-app workflow-gate decision route", () => {
@@ -815,12 +858,29 @@ describe("github-app workflow-gate decision route", () => {
       buildTestApp(userId),
       "POST",
       `/api/v1/github-app/workflow-gates/${gateId}/decision`,
-      { decision: "approved", comment: "x".repeat(501) },
+      { decision: "approved", scanId: "scan_x", comment: "x".repeat(501) },
     );
 
     expect(res.status).toBe(400);
     expect(await res.json()).toMatchObject({
       error: "comment must be <= 500 characters",
+    });
+  });
+
+  test("rejects a decision that does not name the package scan", async () => {
+    const { userId, organizationId } = await seedUser();
+    const { gateId } = await seedGate(organizationId);
+
+    const res = await callGithubAppRoute(
+      buildTestApp(userId),
+      "POST",
+      `/api/v1/github-app/workflow-gates/${gateId}/decision`,
+      { decision: "approved" },
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: "scanId of the package being decided is required",
     });
   });
 
@@ -834,7 +894,7 @@ describe("github-app workflow-gate decision route", () => {
       buildTestApp(caller.userId),
       "POST",
       `/api/v1/github-app/workflow-gates/${gateId}/decision`,
-      { decision: "approved" },
+      { decision: "approved", scanId: "scan_x" },
     );
 
     expect(res.status).toBe(404);
@@ -842,7 +902,7 @@ describe("github-app workflow-gate decision route", () => {
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
-  test("rejects approval when the gate has no completed review scan", async () => {
+  test("rejects a scanId that is not a package of this gate", async () => {
     const { userId, organizationId } = await seedUser();
     const { gateId } = await seedGate(organizationId);
     globalThis.fetch = vi.fn();
@@ -851,17 +911,17 @@ describe("github-app workflow-gate decision route", () => {
       buildTestApp(userId),
       "POST",
       `/api/v1/github-app/workflow-gates/${gateId}/decision`,
-      { decision: "approved" },
+      { decision: "approved", scanId: `scan_${crypto.randomUUID()}` },
     );
 
     expect(res.status).toBe(409);
     expect(await res.json()).toMatchObject({
-      error: "approval requires a completed workflow-gate review",
+      error: "scanId is not a reviewable package of this gate",
     });
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
-  test("rejects approval when the linked review scan failed", async () => {
+  test("rejects approval when the package scan has not completed", async () => {
     const { userId, organizationId } = await seedUser();
     const { gateId, scanId } = await seedGate(organizationId, {
       attachScan: { ownerUserId: userId },
@@ -876,12 +936,12 @@ describe("github-app workflow-gate decision route", () => {
       buildTestApp(userId),
       "POST",
       `/api/v1/github-app/workflow-gates/${gateId}/decision`,
-      { decision: "approved" },
+      { decision: "approved", scanId: scanId! },
     );
 
     expect(res.status).toBe(409);
     expect(await res.json()).toMatchObject({
-      error: "approval requires a completed workflow-gate review",
+      error: "scanId is not a reviewable package of this gate",
     });
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
@@ -914,7 +974,7 @@ describe("github-app workflow-gate decision route", () => {
       buildTestApp(userId),
       "POST",
       `/api/v1/github-app/workflow-gates/${gateId}/decision`,
-      { decision: "approved", comment: "ship it" },
+      { decision: "approved", scanId: scanId!, comment: "ship it" },
     );
     expect(first.status).toBe(200);
     expect(await first.json()).toMatchObject({
@@ -930,12 +990,125 @@ describe("github-app workflow-gate decision route", () => {
       buildTestApp(userId),
       "POST",
       `/api/v1/github-app/workflow-gates/${gateId}/decision`,
-      { decision: "rejected" },
+      { decision: "rejected", scanId: scanId! },
     );
     expect(second.status).toBe(409);
     expect(await second.json()).toMatchObject({ error: "gate has already been decided" });
     // The CAS lost the second transition, so no extra callback is posted.
     expect(decisionCalls).toHaveLength(1);
+  });
+
+  test("holds the deployment until every package is approved, then releases", async () => {
+    const { userId, organizationId } = await seedUser();
+    const { gateId, scanId } = await seedGate(organizationId, {
+      attachScan: { ownerUserId: userId },
+    });
+    await completeWorkflowGateScan({
+      organizationId,
+      ownerUserId: userId,
+      gateId,
+      scanId: scanId!,
+      packageName: "alpha-pkg",
+    });
+    const secondScanId = await seedGatePackageScan({
+      organizationId,
+      ownerUserId: userId,
+      gateId,
+      packageName: "beta-pkg",
+      version: "2.0.0",
+    });
+    const decisionCalls: { state: string }[] = [];
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      if (request.url.includes("/access_tokens")) {
+        return Response.json({ token: "ghs_install_token", expires_at: "2099-01-01T00:00:00Z" });
+      }
+      if (request.url.endsWith("/deployment_protection_rule")) {
+        decisionCalls.push((await request.json()) as { state: string });
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`unexpected fetch in decision test: ${request.url}`);
+    });
+
+    // Approving only the first package keeps the gate pending: no callback yet.
+    const partial = await callGithubAppRoute(
+      buildTestApp(userId),
+      "POST",
+      `/api/v1/github-app/workflow-gates/${gateId}/decision`,
+      { decision: "approved", scanId: scanId! },
+    );
+    expect(partial.status).toBe(200);
+    const partialBody = (await partial.json()) as {
+      gate: { status: string; packages: { scanId: string; decision: string | null }[] };
+    };
+    expect(partialBody.gate.status).toBe("pending");
+    expect(partialBody.gate.packages).toHaveLength(2);
+    expect(decisionCalls).toHaveLength(0);
+
+    // Approving the last package finalizes the gate and posts the release.
+    const finalRes = await callGithubAppRoute(
+      buildTestApp(userId),
+      "POST",
+      `/api/v1/github-app/workflow-gates/${gateId}/decision`,
+      { decision: "approved", scanId: secondScanId },
+    );
+    expect(finalRes.status).toBe(200);
+    expect(await finalRes.json()).toMatchObject({
+      gate: { status: "approved", decision: "approved" },
+    });
+    const stored = await getGateForOrganization(createDb(env.DB), organizationId, gateId);
+    expect(stored?.status).toBe("approved");
+    expect(decisionCalls).toHaveLength(1);
+    expect(decisionCalls[0].state).toBe("approved");
+  });
+
+  test("rejecting any single package blocks the whole release immediately", async () => {
+    const { userId, organizationId } = await seedUser();
+    const { gateId, scanId } = await seedGate(organizationId, {
+      attachScan: { ownerUserId: userId },
+    });
+    await completeWorkflowGateScan({
+      organizationId,
+      ownerUserId: userId,
+      gateId,
+      scanId: scanId!,
+      packageName: "alpha-pkg",
+    });
+    // A second, still-undecided package exists, yet one rejection is enough.
+    await seedGatePackageScan({
+      organizationId,
+      ownerUserId: userId,
+      gateId,
+      packageName: "beta-pkg",
+      version: "2.0.0",
+    });
+    const decisionCalls: { state: string }[] = [];
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      if (request.url.includes("/access_tokens")) {
+        return Response.json({ token: "ghs_install_token", expires_at: "2099-01-01T00:00:00Z" });
+      }
+      if (request.url.endsWith("/deployment_protection_rule")) {
+        decisionCalls.push((await request.json()) as { state: string });
+        return new Response(null, { status: 204 });
+      }
+      throw new Error(`unexpected fetch in decision test: ${request.url}`);
+    });
+
+    const res = await callGithubAppRoute(
+      buildTestApp(userId),
+      "POST",
+      `/api/v1/github-app/workflow-gates/${gateId}/decision`,
+      { decision: "rejected", scanId: scanId! },
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      gate: { status: "rejected", decision: "rejected" },
+    });
+    const stored = await getGateForOrganization(createDb(env.DB), organizationId, gateId);
+    expect(stored?.status).toBe("rejected");
+    expect(decisionCalls).toHaveLength(1);
+    expect(decisionCalls[0].state).toBe("rejected");
   });
 });
 

--- a/test/workers/github-gate-two-factor.test.ts
+++ b/test/workers/github-gate-two-factor.test.ts
@@ -1,5 +1,6 @@
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
 import { afterEach, describe, expect, test, vi } from "vitest";
+import { eq } from "drizzle-orm";
 import * as OTPAuth from "otpauth";
 import worker from "../../server/index";
 import { createDb, createScanJob, ensurePersonalOrganization, persistScan } from "../../server/db";
@@ -146,7 +147,7 @@ async function seedDecidableGate(
   organizationId: string,
   ownerUserId: string,
   options: { completeScan?: boolean } = {},
-): Promise<string> {
+): Promise<{ gateId: string; scanId: string }> {
   const completeScan = options.completeScan ?? true;
   const db = createDb(env.DB);
   const now = new Date();
@@ -171,13 +172,10 @@ async function seedDecidableGate(
   });
   const gateId = crypto.randomUUID();
   const scanId = `scan_${crypto.randomUUID()}`;
-  await createScanJob(db, {
-    id: scanId,
-    stageId: `workflow-gate:${gateId}`,
-    organizationId,
-    ownerUserId,
-    source: "workflow_gate",
-  });
+  // scans.gate_id references the gate and the gate's scanId references the scan,
+  // so insert the gate first (scanId null), create the per-package scan linked
+  // via gateId, then point the gate at it (mirroring attachScanToGate) once the
+  // scan is complete — avoiding the circular foreign key.
   await db.insert(schema.githubWorkflowGates).values({
     id: gateId,
     organizationId,
@@ -193,10 +191,18 @@ async function seedDecidableGate(
     eventAction: "requested",
     status: "pending",
     decision: null,
-    scanId,
+    scanId: null,
     requestedAt: now,
     createdAt: now,
     updatedAt: now,
+  });
+  await createScanJob(db, {
+    id: scanId,
+    stageId: `workflow-gate:${gateId}`,
+    organizationId,
+    ownerUserId,
+    source: "workflow_gate",
+    gateId,
   });
   if (completeScan) {
     await persistScan(db, {
@@ -215,8 +221,12 @@ async function seedDecidableGate(
       diff: [],
       findings: [],
     });
+    await db
+      .update(schema.githubWorkflowGates)
+      .set({ scanId })
+      .where(eq(schema.githubWorkflowGates.id, gateId));
   }
-  return gateId;
+  return { gateId, scanId };
 }
 
 // Mocks the two GitHub calls the delivery path makes (install token + callback)
@@ -249,20 +259,22 @@ describe("workflow-gate decision 2FA step-up", () => {
       await enrollTwoFactor(jar);
       const organizationId = personalOrganizationId(userId);
       await ensurePersonalOrganization(createDb(env.DB), { userId });
-      const gateId = await seedDecidableGate(organizationId, userId, { completeScan: false });
+      const { gateId, scanId } = await seedDecidableGate(organizationId, userId, {
+        completeScan: false,
+      });
 
       const decisionCalls: { state: string }[] = [];
       mockGithubDecisionFetch(decisionCalls);
 
       const res = await call("POST", `/api/v1/github-app/workflow-gates/${gateId}/decision`, {
-        body: { decision: "approved" },
+        body: { decision: "approved", scanId },
         jar,
         env: await githubEnv(),
       });
 
       expect(res.res.status).toBe(409);
       expect(res.json).toMatchObject({
-        error: "approval requires a completed workflow-gate review",
+        error: "scanId is not a reviewable package of this gate",
       });
       const stored = await getGateForOrganization(createDb(env.DB), organizationId, gateId);
       expect(stored?.status).toBe("pending");
@@ -279,13 +291,13 @@ describe("workflow-gate decision 2FA step-up", () => {
       await enrollTwoFactor(jar);
       const organizationId = personalOrganizationId(userId);
       await ensurePersonalOrganization(createDb(env.DB), { userId });
-      const gateId = await seedDecidableGate(organizationId, userId);
+      const { gateId, scanId } = await seedDecidableGate(organizationId, userId);
 
       const decisionCalls: { state: string }[] = [];
       mockGithubDecisionFetch(decisionCalls);
 
       const res = await call("POST", `/api/v1/github-app/workflow-gates/${gateId}/decision`, {
-        body: { decision: "approved" },
+        body: { decision: "approved", scanId },
         jar,
         env: await githubEnv(),
       });
@@ -308,13 +320,13 @@ describe("workflow-gate decision 2FA step-up", () => {
       await enrollTwoFactor(jar);
       const organizationId = personalOrganizationId(userId);
       await ensurePersonalOrganization(createDb(env.DB), { userId });
-      const gateId = await seedDecidableGate(organizationId, userId);
+      const { gateId, scanId } = await seedDecidableGate(organizationId, userId);
 
       const decisionCalls: { state: string }[] = [];
       mockGithubDecisionFetch(decisionCalls);
 
       const res = await call("POST", `/api/v1/github-app/workflow-gates/${gateId}/decision`, {
-        body: { decision: "approved", totpCode: "000000" },
+        body: { decision: "approved", totpCode: "000000", scanId },
         jar,
         env: await githubEnv(),
       });
@@ -336,13 +348,13 @@ describe("workflow-gate decision 2FA step-up", () => {
       const totpURI = await enrollTwoFactor(jar);
       const organizationId = personalOrganizationId(userId);
       await ensurePersonalOrganization(createDb(env.DB), { userId });
-      const gateId = await seedDecidableGate(organizationId, userId);
+      const { gateId, scanId } = await seedDecidableGate(organizationId, userId);
 
       const decisionCalls: { state: string }[] = [];
       mockGithubDecisionFetch(decisionCalls);
 
       const res = await call("POST", `/api/v1/github-app/workflow-gates/${gateId}/decision`, {
-        body: { decision: "approved", totpCode: totpFor(totpURI) },
+        body: { decision: "approved", totpCode: totpFor(totpURI), scanId },
         jar,
         env: await githubEnv(),
       });
@@ -361,13 +373,13 @@ describe("workflow-gate decision 2FA step-up", () => {
     const userId = await signUp(jar);
     const organizationId = personalOrganizationId(userId);
     await ensurePersonalOrganization(createDb(env.DB), { userId });
-    const gateId = await seedDecidableGate(organizationId, userId);
+    const { gateId, scanId } = await seedDecidableGate(organizationId, userId);
 
     const decisionCalls: { state: string }[] = [];
     mockGithubDecisionFetch(decisionCalls);
 
     const res = await call("POST", `/api/v1/github-app/workflow-gates/${gateId}/decision`, {
-      body: { decision: "approved" },
+      body: { decision: "approved", scanId },
       jar,
       env: await githubEnv(),
     });

--- a/test/workers/workflow-gate-job.test.ts
+++ b/test/workers/workflow-gate-job.test.ts
@@ -8,6 +8,7 @@ import {
   createReleaseTarget,
   attachScanToGate,
   getGateForOrganization,
+  listGatePackageScans,
   markGateDecided,
   upsertInstallation,
 } from "../../server/lib/github-app";
@@ -661,12 +662,17 @@ describe("executeWorkflowGateJob", () => {
 
     const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
     expect(gate?.status).toBe("pending");
-    expect(gate?.scanId).toBeTruthy();
+    // The representative headline is attached only on a successful batch, so a
+    // failed batch leaves it unset; the failed package scan is still linked to
+    // the gate via `scans.gate_id` for the dashboard.
+    expect(gate?.scanId).toBeNull();
     expect(scenario.decisionCalls).toHaveLength(0);
 
-    const persisted = await getScan(db, gate!.scanId!, seeded.organizationId);
-    expect(persisted?.scan.status).toBe("failed");
-    expect(persisted?.scan.source).toBe("workflow_gate");
+    const failedPackages = await listGatePackageScans(db, seeded.organizationId, seeded.gateId);
+    expect(failedPackages).toHaveLength(1);
+    expect(failedPackages[0].status).toBe("failed");
+    const failedScan = await getScan(db, failedPackages[0].scanId, seeded.organizationId);
+    expect(failedScan?.scan.source).toBe("workflow_gate");
 
     const types = await scanEventTypes(seeded.organizationId, seeded.gateId);
     expect(types).toContain("github_workflow_gate.review_failed");
@@ -682,14 +688,19 @@ describe("executeWorkflowGateJob", () => {
 
     const retriedGate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
     expect(retriedGate?.status).toBe("pending");
+    // The retry discards the failed batch and re-runs it, so a fresh
+    // representative scan attaches on success.
     expect(retriedGate?.scanId).toBeTruthy();
-    expect(retriedGate?.scanId).not.toBe(gate?.scanId);
     expect(loaderMock.calls.length).toBeGreaterThan(loaderCallsAfterFailure);
     expect(scenario.decisionCalls).toHaveLength(0);
 
     const retriedScan = await getScan(db, retriedGate!.scanId!, seeded.organizationId);
     expect(retriedScan?.scan.status).toBe("complete");
     expect(retriedScan?.scan.source).toBe("workflow_gate");
+
+    const retriedPackages = await listGatePackageScans(db, seeded.organizationId, seeded.gateId);
+    expect(retriedPackages).toHaveLength(1);
+    expect(retriedPackages[0].status).toBe("complete");
   });
 
   test("does not re-review a pending gate that already has a scan attached", async () => {
@@ -990,10 +1001,15 @@ describe("executeWorkflowGateJob", () => {
 
     const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
     expect(gate?.status).toBe("rejected");
-    expect(gate?.scanId).toBeTruthy();
+    // The trigger decided the gate on the `reviewed` event, before the runner
+    // attaches the representative headline: the attach CAS (expecting a pending
+    // gate) loses the race, so `scanId` stays null. The reviewed package scan is
+    // still persisted and linked via `scans.gate_id`.
+    expect(gate?.scanId).toBeNull();
 
-    const persisted = await getScan(db, gate!.scanId!, seeded.organizationId);
-    expect(persisted?.scan.status).toBe("complete");
+    const packages = await listGatePackageScans(db, seeded.organizationId, seeded.gateId);
+    expect(packages).toHaveLength(1);
+    expect(packages[0].status).toBe("complete");
 
     const types = await scanEventTypes(seeded.organizationId, seeded.gateId);
     expect(types).not.toContain("github_workflow_gate.notification_sent");

--- a/test/workers/workflow-gate-prepare.test.ts
+++ b/test/workers/workflow-gate-prepare.test.ts
@@ -237,11 +237,20 @@ function buildConfigBindings(): Record<string, string> {
 // The bundle contains only the wheel/sdist files — no `drydock-manifest.json`.
 // The wheel bytes here are opaque: the sandbox is mocked, so identity comes from
 // the loader's returned METADATA rather than these bytes.
-async function buildScenario(runId: number, opts?: { artifactPaths?: string[] }) {
+async function buildScenario(
+  runId: number,
+  opts?: {
+    artifactPaths?: string[];
+    extraArtifacts?: Array<{ id: number; name: string; artifactPaths: string[] }>;
+  },
+) {
   const artifactPaths = opts?.artifactPaths ?? ["dist/demo_package-1.2.0-py3-none-any.whl"];
-  const bundleZip = makeZip(
-    artifactPaths.map((path) => ({ path, body: `opaque bytes for ${path}` })),
-  );
+  const bundles = new Map<number, Uint8Array>();
+  const bundleZip = zipForArtifactPaths(artifactPaths);
+  bundles.set(88888, bundleZip);
+  for (const artifact of opts?.extraArtifacts ?? []) {
+    bundles.set(artifact.id, zipForArtifactPaths(artifact.artifactPaths));
+  }
 
   const fetchSpy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = input instanceof Request ? input : new Request(input, init);
@@ -262,13 +271,23 @@ async function buildScenario(runId: number, opts?: { artifactPaths?: string[] })
               size_in_bytes: bundleZip.length,
               expired: false,
             },
+            ...(opts?.extraArtifacts ?? []).map((artifact) => ({
+              id: artifact.id,
+              name: artifact.name,
+              size_in_bytes: bundles.get(artifact.id)?.length ?? 0,
+              expired: false,
+            })),
           ],
         }),
         { status: 200, headers: { "content-type": "application/json" } },
       );
     }
     if (request.url.includes("/actions/artifacts/")) {
-      return new Response(bundleZip, {
+      const match = request.url.match(/\/actions\/artifacts\/(\d+)\/zip$/);
+      const artifactId = match ? Number.parseInt(match[1], 10) : 88888;
+      const zip = bundles.get(artifactId);
+      if (!zip) return new Response("not found", { status: 404 });
+      return new Response(zip, {
         status: 200,
         headers: { "content-type": "application/zip" },
       });
@@ -277,6 +296,10 @@ async function buildScenario(runId: number, opts?: { artifactPaths?: string[] })
   });
   vi.stubGlobal("fetch", fetchSpy);
   return { fetchSpy, artifactPaths };
+}
+
+function zipForArtifactPaths(artifactPaths: string[]): Uint8Array {
+  return makeZip(artifactPaths.map((path) => ({ path, body: `opaque bytes for ${path}` })));
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -329,6 +352,51 @@ describe("prepareReleaseCandidatesForGate", () => {
 
     const refreshed = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
     expect(refreshed?.status).toBe("pending");
+  });
+
+  test("uses the PyPI default artifact for pinned targets without an override", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9106",
+      repositoryId: 71005,
+      runId: 10101,
+    });
+    const scenario = await buildScenario(10101, {
+      extraArtifacts: [
+        {
+          id: 99999,
+          name: "unrelated-build-output",
+          artifactPaths: ["dist/unrelated_package-9.9.9-py3-none-any.whl"],
+        },
+      ],
+    });
+    const loaderMock = buildLoaderMock([[metadataFile("demo-package", "1.2.0")]]);
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const config = readGithubAppConfig({
+      ...bindings,
+      BETTER_AUTH_SECRET: bindings.BETTER_AUTH_SECRET,
+    });
+    const sandboxEnv = {
+      ...env,
+      ...bindings,
+      LOADER: loaderMock.binding as unknown as WorkerLoader,
+    } as Cloudflare.Env;
+
+    const db = createDb(env.DB);
+    const result = await prepareReleaseCandidatesForGate(sandboxEnv, ctx, db, {
+      config,
+      organizationId: seeded.organizationId,
+      gateId: seeded.gateId,
+    });
+
+    expect(result.packages).toHaveLength(1);
+    expect(result.packages[0].candidate.package.name).toBe("demo-package");
+    expect(loaderMock.calls).toHaveLength(1);
+    const downloadedArtifactIds = scenario.fetchSpy.mock.calls
+      .map(([input]) => (input instanceof Request ? input.url : String(input)))
+      .filter((url) => url.includes("/actions/artifacts/"))
+      .map((url) => url.match(/\/actions\/artifacts\/(\d+)\/zip$/)?.[1]);
+    expect(downloadedArtifactIds).toEqual(["88888"]);
   });
 
   test("fans a monorepo bundle out into one candidate per distinct package", async () => {

--- a/test/workers/workflow-gate-prepare.test.ts
+++ b/test/workers/workflow-gate-prepare.test.ts
@@ -10,7 +10,7 @@ import {
   upsertInstallation,
 } from "../../server/lib/github-app";
 import type { PyPiAdapterInput } from "../../server/lib/adapters/pypi/index";
-import { prepareReleaseCandidateForGate } from "../../server/lib/workflow-gates";
+import { prepareReleaseCandidatesForGate } from "../../server/lib/workflow-gates";
 
 const WEBHOOK_SECRET = "webhook-secret-value-1234567890";
 
@@ -281,7 +281,7 @@ async function buildScenario(runId: number, opts?: { artifactPaths?: string[] })
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 
-describe("prepareReleaseCandidateForGate", () => {
+describe("prepareReleaseCandidatesForGate", () => {
   test("derives the release identity from the artifacts for a matching gate", async () => {
     const seeded = await seedGateForTest({
       installationExternalId: "9100",
@@ -303,17 +303,20 @@ describe("prepareReleaseCandidateForGate", () => {
     } as Cloudflare.Env;
 
     const db = createDb(env.DB);
-    const result = await prepareReleaseCandidateForGate(sandboxEnv, ctx, db, {
+    const result = await prepareReleaseCandidatesForGate(sandboxEnv, ctx, db, {
       config,
       organizationId: seeded.organizationId,
       gateId: seeded.gateId,
     });
 
     expect(result.gate.id).toBe(seeded.gateId);
-    expect(result.adapter.ecosystem).toBe("pypi");
-    expect(result.candidate.package).toEqual({ name: "demo-package", version: "1.2.0" });
+    expect(result.packages).toHaveLength(1);
+    const [prepared] = result.packages;
+    expect(prepared.candidate.ecosystem).toBe("pypi");
+    expect(prepared.packageAdapter.id).toBe("pypi");
+    expect(prepared.candidate.package).toEqual({ name: "demo-package", version: "1.2.0" });
 
-    const pipelineInput = result.candidate.pipelineInput as unknown as PyPiAdapterInput;
+    const pipelineInput = prepared.candidate.pipelineInput as unknown as PyPiAdapterInput;
     expect(pipelineInput.manifest.package).toBe("demo-package");
     expect(pipelineInput.manifest.version).toBe("1.2.0");
     expect(pipelineInput.manifest.artifacts).toHaveLength(1);
@@ -323,6 +326,56 @@ describe("prepareReleaseCandidateForGate", () => {
     expect(pipelineInput.artifacts[0].files).toHaveLength(1);
     expect(loaderMock.calls).toHaveLength(1);
     expect(loaderMock.calls[0].format).toBe("zip");
+
+    const refreshed = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(refreshed?.status).toBe("pending");
+  });
+
+  test("fans a monorepo bundle out into one candidate per distinct package", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9105",
+      repositoryId: 71006,
+      runId: 12121,
+    });
+    // Two distinct packages publish from one release: each wheel carries its own
+    // identity and must become its own candidate (its own scan + baseline).
+    const scenario = await buildScenario(12121, {
+      artifactPaths: [
+        "dist/alpha_pkg-1.0.0-py3-none-any.whl",
+        "dist/beta_pkg-2.0.0-py3-none-any.whl",
+      ],
+    });
+    const loaderMock = buildLoaderMock([
+      [metadataFile("alpha-pkg", "1.0.0")],
+      [metadataFile("beta-pkg", "2.0.0")],
+    ]);
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const config = readGithubAppConfig({
+      ...bindings,
+      BETTER_AUTH_SECRET: bindings.BETTER_AUTH_SECRET,
+    });
+    const sandboxEnv = {
+      ...env,
+      ...bindings,
+      LOADER: loaderMock.binding as unknown as WorkerLoader,
+    } as Cloudflare.Env;
+
+    const db = createDb(env.DB);
+    const result = await prepareReleaseCandidatesForGate(sandboxEnv, ctx, db, {
+      config,
+      organizationId: seeded.organizationId,
+      gateId: seeded.gateId,
+    });
+
+    expect(result.packages).toHaveLength(2);
+    const names = result.packages.map((pkg) => pkg.candidate.package.name).sort();
+    expect(names).toEqual(["alpha-pkg", "beta-pkg"]);
+    for (const pkg of result.packages) {
+      expect(pkg.candidate.ecosystem).toBe("pypi");
+      expect(pkg.packageAdapter.id).toBe("pypi");
+    }
+    expect(scenario.artifactPaths).toHaveLength(2);
 
     const refreshed = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
     expect(refreshed?.status).toBe("pending");
@@ -353,7 +406,7 @@ describe("prepareReleaseCandidateForGate", () => {
 
     const db = createDb(env.DB);
     await expect(
-      prepareReleaseCandidateForGate(sandboxEnv, ctx, db, {
+      prepareReleaseCandidatesForGate(sandboxEnv, ctx, db, {
         config,
         organizationId: seeded.organizationId,
         gateId: seeded.gateId,
@@ -394,7 +447,7 @@ describe("prepareReleaseCandidateForGate", () => {
 
     const db = createDb(env.DB);
     await expect(
-      prepareReleaseCandidateForGate(sandboxEnv, ctx, db, {
+      prepareReleaseCandidatesForGate(sandboxEnv, ctx, db, {
         config,
         organizationId: seeded.organizationId,
         gateId: seeded.gateId,
@@ -426,7 +479,7 @@ describe("prepareReleaseCandidateForGate", () => {
     } as Cloudflare.Env;
     const db = createDb(env.DB);
     await expect(
-      prepareReleaseCandidateForGate(sandboxEnv, ctx, db, {
+      prepareReleaseCandidatesForGate(sandboxEnv, ctx, db, {
         config,
         organizationId: "other-org",
         gateId: seeded.gateId,

--- a/test/workers/workflow-gate-registry.test.ts
+++ b/test/workers/workflow-gate-registry.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../../server/lib/github-app";
 import {
   getWorkflowGateAdapter,
-  prepareReleaseCandidateForGate,
+  prepareReleaseCandidatesForGate,
   pypiWorkflowGateAdapter,
   supportedWorkflowGateEcosystems,
   UnsupportedEcosystemError,
@@ -120,7 +120,7 @@ async function seedUnsupportedEcosystemGate(ecosystem: string) {
   return { organizationId, gateId };
 }
 
-describe("prepareReleaseCandidateForGate adapter dispatch", () => {
+describe("prepareReleaseCandidatesForGate adapter dispatch", () => {
   test("marks the gate errored and rethrows when the ecosystem has no adapter", async () => {
     const { organizationId, gateId } = await seedUnsupportedEcosystemGate("cargo");
     const ctx = createExecutionContext();
@@ -128,7 +128,7 @@ describe("prepareReleaseCandidateForGate adapter dispatch", () => {
     const db = createDb(env.DB);
 
     await expect(
-      prepareReleaseCandidateForGate(env, ctx, db, { config, organizationId, gateId }),
+      prepareReleaseCandidatesForGate(env, ctx, db, { config, organizationId, gateId }),
     ).rejects.toBeInstanceOf(UnsupportedEcosystemError);
 
     // A configuration/data problem leaves the gate pending (never auto-approved)


### PR DESCRIPTION
## Summary

Implements [#164](https://github.com/JoviDeCroock/staged-publish-sandbox-prototype/issues/164): a single workflow gate can now cover every package a monorepo publishes from one repo/environment.

- **Per-package fan-out** — the release-candidate bundle is grouped by normalized (PEP 503) package name into one scan per distinct package, each run against its own baseline and linked to the gate via the `scans.gate_id` column (no separate review table). A monorepo release produces N scans; the gate's `scanId` points at the worst-risk representative.
- **Every package must be approved** — the held GitHub deployment releases only when every discovered package is individually approved. The decision route names one package's `scanId` per call and aggregates: any rejection blocks the whole release immediately; all-approved releases the job; otherwise the gate stays pending with the roster.
- **Ecosystem auto-detect** — release targets may leave `ecosystem` unpinned (`null`/`""`/`"auto"`), classifying artifacts across all registered ecosystems, with an optional `artifactName` override. PyPI remains the only wired ecosystem (npm/vsix gate adapters belong to #143).
- **UI** — the decision dialog, by-scan lookup, public gate shape, and review workbench surface the per-package roster ("N of M approved") and cross-link each package's scan.
- Single folded D1 migration; docs in `docs/pypi-workflow-gate.md` updated end-to-end for the per-package/monorepo model.

## Test plan

- [x] `pnpm run verify` — lint, format, typecheck, tests (283 node + 163 worker pass)
- [x] `pnpm run test:e2e` — 10 passed against the fake-registry harness
- [ ] Reviewer: confirm the every-package-approval gating and the auto-detect/pinned ecosystem split read correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)