### PR TITLE
Add discovery-cron integration test and cross-corpus rule-parity test

### DIFF
--- a/test/fixtures/security-corpus/README.md
+++ b/test/fixtures/security-corpus/README.md
@@ -13,4 +13,26 @@ This directory contains Drydock's synthetic golden corpus for deterministic stag
 
 PyPI `expectedFindings[].file` uses two namespacing schemes: `pypi.*` findings use the literal manifest artifact path joined to the in-archive file path (sdists root-stripped); shared `file.*`/`code.*`/`diff.*` findings use the diff namespace (`sdist/…` or `wheel/<sorted WHEEL tags>/…`, with `.dist-info` collapsed). See `docs/security-detection-corpus.md` for the full cheat-sheet.
 
+## Cross-corpus parity
+
+`test/security-corpus-parity.test.mjs` pairs conceptually-equivalent npm and PyPI
+fixtures so that an edit to a shared rule (`file.*`/`code.*`/`diff.*`) can't be
+applied to one corpus and silently forgotten in the other.
+
+- Pair fixtures by adding the same `"parityGroup"` slug to exactly one fixture in
+  `cases/` and one in `cases-pypi/`. Each group must have exactly one npm member
+  and one pypi member; an unpaired or triple-membered group fails the test.
+- The test runs the real detection engines on both members and asserts the sorted
+  multiset of `${ruleId}:${severity}` is identical across the pair. The diff-namespace
+  `file` differs by ecosystem, so it is intentionally excluded from the comparison.
+- When one ecosystem legitimately emits an extra rule the other can't (e.g. npm's
+  `install-script.preinstall` lifecycle hook has no PyPI equivalent), list those rule
+  IDs in that fixture's `"parityIgnoreRuleIds"` array so they're dropped before the
+  multiset comparison. Keep this list as small as possible — it documents an allowed
+  divergence, not a way to mute genuine drift.
+
+Current groups: `benign-version-bump` (clean bump raises nothing on both),
+`credential-file-added` (a `.env`/`.npmrc` appears between versions), and
+`code-sink-exfil` (process + network + credential sinks chained in module code).
+
 Do not vendor live malicious packages, encrypted malware archives, real credentials, or raw customer package bytes here. Use synthetic `example.invalid` endpoints and obviously fake secrets only.

--- a/test/fixtures/security-corpus/cases-pypi/01-benign-control.json
+++ b/test/fixtures/security-corpus/cases-pypi/01-benign-control.json
@@ -1,5 +1,6 @@
 {
   "id": "pypi-benign-control",
+  "parityGroup": "benign-version-bump",
   "title": "clean wheel + sdist version bump raises nothing",
   "category": "control",
   "intent": "a well-formed release with matching metadata, complete RECORD, and no active code must stay low risk",

--- a/test/fixtures/security-corpus/cases-pypi/11-python-sink-exfil.json
+++ b/test/fixtures/security-corpus/cases-pypi/11-python-sink-exfil.json
@@ -1,5 +1,6 @@
 {
   "id": "pypi-python-sink-exfil",
+  "parityGroup": "code-sink-exfil",
   "title": "wheel module chains Python process, network, and credential sinks",
   "category": "code-capability",
   "intent": "ratifies the Python-aware shared code.* rules on a non-setup module: subprocess + requests + os.environ",

--- a/test/fixtures/security-corpus/cases-pypi/12-wheel-baseline-credential-added.json
+++ b/test/fixtures/security-corpus/cases-pypi/12-wheel-baseline-credential-added.json
@@ -1,5 +1,6 @@
 {
   "id": "pypi-wheel-baseline-credential-added",
+  "parityGroup": "credential-file-added",
   "title": "new wheel version adds a credential-looking file vs the previous release",
   "category": "diff",
   "intent": "baseline-backed fixture: a .env added between versions must raise the shared diff credential rule alongside secret-content",

--- a/test/fixtures/security-corpus/cases/benign-minimal.json
+++ b/test/fixtures/security-corpus/cases/benign-minimal.json
@@ -1,5 +1,6 @@
 {
   "id": "benign-minimal",
+  "parityGroup": "benign-version-bump",
   "title": "Small version bump with unchanged runtime code",
   "category": "benign-control",
   "intent": "Keep a low-risk control case in the corpus so broad rules cannot silently start flagging ordinary package changes.",

--- a/test/fixtures/security-corpus/cases/preinstall-env-exfil.json
+++ b/test/fixtures/security-corpus/cases/preinstall-env-exfil.json
@@ -1,5 +1,7 @@
 {
   "id": "preinstall-env-exfil",
+  "parityGroup": "code-sink-exfil",
+  "parityIgnoreRuleIds": ["install-script.preinstall"],
   "title": "Preinstall hook reads environment data and sends it over the network",
   "category": "lifecycle-credential-exfiltration",
   "intent": "Model the common install-time collect-and-exfiltrate chain without embedding a working endpoint or real secret.",

--- a/test/fixtures/security-corpus/cases/secret-file-added.json
+++ b/test/fixtures/security-corpus/cases/secret-file-added.json
@@ -1,5 +1,6 @@
 {
   "id": "secret-file-added",
+  "parityGroup": "credential-file-added",
   "title": "Package accidentally includes an .npmrc-looking credential file",
   "category": "secret-retention",
   "intent": "Ensure secret-looking files remain critical findings. The token string is synthetic and non-functional.",

--- a/test/security-corpus-parity.test.mjs
+++ b/test/security-corpus-parity.test.mjs
@@ -1,0 +1,110 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  createPackageDiff,
+  deterministicFindings,
+  packageJsonDiffFindings,
+  summarizePackageJsonDiff,
+} from "../server/lib/review.ts";
+import {
+  createPyPiReleaseCandidateReview,
+  parsePyPiReleaseManifest,
+} from "../server/lib/adapters/pypi/index.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const corpusDir = join(__dirname, "fixtures/security-corpus");
+
+function loadCorpus(relativeDir, ecosystem) {
+  const dir = join(corpusDir, relativeDir);
+  return readdirSync(dir)
+    .filter((file) => file.endsWith(".json"))
+    .sort()
+    .map((file) => ({
+      ecosystem,
+      file: `${relativeDir}/${file}`,
+      fixture: JSON.parse(readFileSync(join(dir, file), "utf8")),
+    }));
+}
+
+const npmFixtures = loadCorpus("cases", "npm");
+const pypiFixtures = loadCorpus("cases-pypi", "pypi");
+const allFixtures = [...npmFixtures, ...pypiFixtures];
+
+function runNpm(fixture) {
+  const previousFiles = fixture.previousFiles ?? [];
+  const stagedFiles = fixture.stagedFiles ?? [];
+  const diff = createPackageDiff(previousFiles, stagedFiles);
+  const packageJsonDiff = summarizePackageJsonDiff(
+    fixture.previousPackageJson,
+    fixture.stagedPackageJson,
+  );
+  return [
+    ...deterministicFindings(stagedFiles, diff, fixture.stagedPackageJson),
+    ...packageJsonDiffFindings(packageJsonDiff),
+  ];
+}
+
+function runPyPi(fixture) {
+  const review = createPyPiReleaseCandidateReview({
+    manifest: parsePyPiReleaseManifest(fixture.manifest),
+    artifacts: fixture.artifacts,
+    previousArtifacts: fixture.previousArtifacts,
+  });
+  return review.ruleFindings;
+}
+
+function runEngine(entry) {
+  return entry.ecosystem === "npm" ? runNpm(entry.fixture) : runPyPi(entry.fixture);
+}
+
+// Reduce a finding set to a sorted multiset of `${ruleId}:${severity}` strings,
+// dropping the rule IDs this fixture documents as legitimately ecosystem-specific.
+function ruleSeverityMultiset(findings, ignoreRuleIds) {
+  const ignore = new Set(ignoreRuleIds ?? []);
+  return findings
+    .filter((finding) => !ignore.has(finding.ruleId))
+    .map((finding) => `${finding.ruleId}:${finding.severity}`)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+const groups = new Map();
+for (const entry of allFixtures) {
+  const group = entry.fixture.parityGroup;
+  if (!group) continue;
+  if (!groups.has(group)) groups.set(group, []);
+  groups.get(group).push(entry);
+}
+
+describe("cross-corpus npm<->pypi rule-ID parity", () => {
+  test("at least one parity group is declared", () => {
+    expect(groups.size).toBeGreaterThan(0);
+  });
+
+  for (const [group, entries] of groups) {
+    describe(`parity group: ${group}`, () => {
+      test("has exactly one npm fixture and one pypi fixture", () => {
+        const ecosystems = entries.map((entry) => entry.ecosystem).sort();
+        expect(ecosystems).toEqual(["npm", "pypi"]);
+      });
+
+      test("npm and pypi findings agree on rule IDs and severities", () => {
+        const npm = entries.find((entry) => entry.ecosystem === "npm");
+        const pypi = entries.find((entry) => entry.ecosystem === "pypi");
+        // Skip silently is wrong here: a malformed group is a real failure
+        // surfaced by the membership test above, so guard with a hard assertion.
+        expect(npm, `parity group "${group}" is missing an npm fixture`).toBeTruthy();
+        expect(pypi, `parity group "${group}" is missing a pypi fixture`).toBeTruthy();
+
+        const npmMultiset = ruleSeverityMultiset(runEngine(npm), npm.fixture.parityIgnoreRuleIds);
+        const pypiMultiset = ruleSeverityMultiset(
+          runEngine(pypi),
+          pypi.fixture.parityIgnoreRuleIds,
+        );
+
+        expect(npmMultiset, `npm fixture: ${npm.file}`).toEqual(pypiMultiset);
+      });
+    });
+  }
+});

--- a/test/workers/discovery-cron.test.ts
+++ b/test/workers/discovery-cron.test.ts
@@ -1,0 +1,222 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  createDb,
+  ensurePersonalOrganization,
+  updateNpmConnectionValidation,
+  upsertNpmConnection,
+} from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { encryptNpmToken } from "../../server/lib/npm-connection";
+import worker from "../../server/index";
+
+const REGISTRY_URL = "https://registry.npmjs.org";
+const STAGE_ID = "stage-aaaaaa";
+
+type ValidationStatus = "valid" | "invalid" | "unvalidated";
+
+interface SeededOrg {
+  organizationId: string;
+  userId: string;
+  email: string;
+  token: string;
+}
+
+async function seedOrg(input: {
+  index: number;
+  token: string;
+  validationStatus: ValidationStatus;
+}): Promise<SeededOrg> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  const email = `${userId}@example.com`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: `Tester ${input.index}`,
+    email,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  const encrypted = await encryptNpmToken(env, input.token);
+  await upsertNpmConnection(db, {
+    organizationId,
+    registryUrl: REGISTRY_URL,
+    label: "npm registry",
+    createdByUserId: userId,
+    ...encrypted,
+  });
+  await updateNpmConnectionValidation(db, {
+    organizationId,
+    validationStatus: input.validationStatus,
+    validatedAt: input.validationStatus === "valid" ? now : null,
+  });
+  return { organizationId, userId, email, token: input.token };
+}
+
+function scheduledController(): ScheduledController {
+  return {
+    scheduledTime: Date.now(),
+    cron: "*/15 * * * *",
+    noRetry() {},
+  } as unknown as ScheduledController;
+}
+
+function authHeader(input: Request | string | URL, init?: RequestInit): string | null {
+  const headers =
+    input instanceof Request ? input.headers : new Headers(init?.headers ?? undefined);
+  return headers.get("authorization");
+}
+
+describe("staged publishes discovery cron", () => {
+  // The cron sweeps every eligible connection in the database, so a prior
+  // test's seeded connections would otherwise be picked up here. Clear them so
+  // each test's assertions reflect only the orgs it seeds.
+  beforeEach(async () => {
+    await createDb(env.DB).delete(schema.npmConnections);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  test("queues the valid org, records a per-org failure for the expired org, and skips the disabled org", async () => {
+    // (a) live token + discovery on, (b) token that now 401s + discovery on,
+    // (c) discovery off. There is no separate auto-discovery flag: the sweep
+    // queries connections whose validationStatus is valid/unvalidated, so a
+    // disabled connection is modelled as `invalid` and never appears.
+    const orgA = await seedOrg({
+      index: 0,
+      token: "npm_valid_aaaaaaaaaaaa",
+      validationStatus: "valid",
+    });
+    const orgB = await seedOrg({
+      index: 1,
+      token: "npm_expired_bbbbbbbbbb",
+      validationStatus: "valid",
+    });
+    const orgC = await seedOrg({
+      index: 2,
+      token: "npm_disabled_cccccccc",
+      validationStatus: "invalid",
+    });
+
+    const fetchMock = vi.fn(async (input: Request | string | URL, init?: RequestInit) => {
+      const url = String(input instanceof Request ? input.url : input);
+      expect(url).toContain("/-/stage");
+      const auth = authHeader(input, init);
+      if (auth === `Bearer ${orgA.token}`) {
+        return Response.json({
+          items: [{ id: STAGE_ID, name: "demo-package", version: "1.0.0" }],
+          total: 1,
+          perPage: 50,
+          page: 0,
+        });
+      }
+      if (auth === `Bearer ${orgB.token}`) {
+        return new Response("token expired", { status: 401 });
+      }
+      // The disabled org must never reach the registry; surface it loudly.
+      throw new Error(`unexpected staged-list fetch for token ${auth}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const queue = { send: vi.fn(async () => undefined) };
+    const ctx = createExecutionContext();
+    await worker.scheduled(
+      scheduledController(),
+      { ...env, SCAN_QUEUE: queue } as unknown as Cloudflare.Env,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    // (c) excluded entirely: only (a) and (b) are swept, so only two fetches.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // (a) only: exactly one scan enqueued, scoped to org A.
+    expect(queue.send).toHaveBeenCalledTimes(1);
+    expect(queue.send.mock.calls[0]![0]).toMatchObject({
+      organizationId: orgA.organizationId,
+      stageId: STAGE_ID,
+      source: "auto_discovery",
+    });
+
+    // (b) expired token: structured per-org failure event, no crash.
+    const failureCall = errorSpy.mock.calls.find(
+      (call) => call[0] === "staged publishes cron sweep failed for organization",
+    );
+    expect(failureCall).toBeDefined();
+    expect(failureCall![1]).toMatchObject({
+      organizationId: orgB.organizationId,
+      error: { status: 401 },
+    });
+
+    // (c) never queued nor errored.
+    for (const call of queue.send.mock.calls) {
+      expect(call[0]).not.toMatchObject({ organizationId: orgC.organizationId });
+    }
+    for (const call of errorSpy.mock.calls) {
+      expect(call[1]).not.toMatchObject({ organizationId: orgC.organizationId });
+    }
+
+    // Sweep finished cleanly over the two eligible orgs.
+    const sweptCall = logSpy.mock.calls.find((call) => call[0] === "staged_publishes.cron.swept");
+    expect(sweptCall).toBeDefined();
+    expect(sweptCall![1]).toMatchObject({ orgsProcessed: 2 });
+  });
+
+  test("dispatches an auto-discovery email for the valid org", async () => {
+    // Email only fires downstream in executeScanJob, which the cron runs inline
+    // (via waitUntil) when SCAN_QUEUE is absent. The inline scan fails fast
+    // because the sandbox LOADER binding is not bound in tests; an
+    // auto_discovery scan failure (not a staged_tarball_unavailable skip) sends
+    // a completion email, so the SEND_EMAIL fake receives one message.
+    const orgA = await seedOrg({
+      index: 0,
+      token: "npm_valid_aaaaaaaaaaaa",
+      validationStatus: "valid",
+    });
+
+    const fetchMock = vi.fn(async (input: Request | string | URL) => {
+      const url = String(input instanceof Request ? input.url : input);
+      expect(url).toContain("/-/stage");
+      return Response.json({
+        items: [{ id: STAGE_ID, name: "demo-package", version: "1.0.0" }],
+        total: 1,
+        perPage: 50,
+        page: 0,
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const send = vi.fn(async () => undefined);
+    const ctx = createExecutionContext();
+    await worker.scheduled(
+      scheduledController(),
+      { ...env, SEND_EMAIL: { send } } as unknown as Cloudflare.Env,
+      ctx,
+    );
+    // Draining the context also settles the inline scan's waitUntil, which
+    // rejects with the expected sandbox-LOADER error (no LOADER binding in
+    // tests). The failure-notification email is dispatched before that
+    // rejection, so swallow it and assert the email below.
+    try {
+      await waitOnExecutionContext(ctx);
+    } catch {
+      // expected: inline scan job rejects because the sandbox is unavailable.
+    }
+
+    await vi.waitFor(() => {
+      expect(send).toHaveBeenCalledTimes(1);
+    });
+    expect(orgA.email).toContain("@example.com");
+  });
+});


### PR DESCRIPTION
## Summary
- **Issue #180**: adds a worker-runtime integration test for `runStagedPublishesDiscoveryCron` that seeds three orgs (valid token, expired/401 token, disabled connection) and asserts the valid org is queued, the expired org records a structured per-org failure event without crashing the sweep, the disabled org is skipped entirely, and an auto-discovery email is dispatched via the `SEND_EMAIL` fake.
- **Issue #179**: adds a cross-corpus parity test that pairs conceptually-equivalent npm and PyPI fixtures by a shared `parityGroup` slug, runs the real detection engines on each pair, and asserts identical `{ruleId, severity}` multisets so a shared-rule edit can't be applied to one ecosystem and forgotten in the other.
- Tags the paired corpus fixtures with `parityGroup` (plus `parityIgnoreRuleIds` for npm's PyPI-less `install-script.preinstall`) and documents the pairing convention in the corpus README.

## Test plan
- [x] `pnpm run verify` (lint, format check, typecheck, node + worker tests) passes