### PR TITLE
Increase sandbox archive limits to 2,500 files and 128 KiB per-file sample

### DIFF
--- a/docs/cost-model.md
+++ b/docs/cost-model.md
@@ -1,6 +1,6 @@
 # Cost model (napkin math)
 
-Order-of-magnitude estimates for running Drydock on Cloudflare. Numbers are based on Cloudflare's published rates for the Workers Paid plan and assume a typical scan profile (≤250 files, ≤64 KB per file textSample). Treat this as a sanity check, not a quote.
+Order-of-magnitude estimates for running Drydock on Cloudflare. Numbers are based on Cloudflare's published rates for the Workers Paid plan and assume a typical scan profile (≤2,500 files, ≤128 KB per file textSample). Treat this as a sanity check, not a quote.
 
 > **AI review is Flagship-gated and off by default**. The Workers-AI lines below describe what scans cost for organizations where the per-organization `ai-review` flag is enabled; until then, the dominant per-scan cost is the sandbox + D1 path. The cost-model scenarios already reflect AI as the dominant variable cost for the paid-tier rollout.
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -217,7 +217,7 @@ Do not expose signed report URLs until access controls, report canonicalization,
 - Per-organization encrypted npm connections exist. `validateNpmCredential` checks registry auth (`/-/whoami`), staged-list access (`validateStagedListAccess`), and — when supplied a real stage ID — staged-view (`validateStagedViewAccess`) and staged-tarball (`validateStagedTarballAccess`) access. A read-only granular token reaches all of these endpoints, so the previous list/view capability gap is resolved.
 - Queue-backed scan retry/dead-letter behavior exists in code and Wrangler config, and scan/queue paths now emit structured secret-redacted operational events. Production queue resources, DLQ visibility, metrics dashboards, and alerts still need deployment validation.
 - Persisted detail UI now renders recommendations, package diffs, manifest changes, reviewer notes, and release/context risk signals; report provenance/digest display and lifecycle timelines still need polish.
-- Tar parsing now rejects traversal paths, skips symlinks/hardlinks, handles long-name/PAX paths, caps expanded size, and fails closed when the safe file-count limit is exceeded, but it still needs deeper archive-bomb fuzzing before broad public launch.
+- Tar/ZIP parsing now rejects traversal paths, skips symlinks/hardlinks, handles long-name/PAX paths, caps expanded size, keeps at most 2,500 file records with 128 KiB text samples per file, and fails closed when the safe file-count limit is exceeded, but it still needs deeper archive-bomb fuzzing before broad public launch.
 - Basic D1-backed rate limits exist for scans and credential operations; production should add metrics, alerts, and edge/IP-based abuse controls.
 - Team RBAC is deferred.
 - Public signed reports are deferred.

--- a/server/lib/sandbox.ts
+++ b/server/lib/sandbox.ts
@@ -5,8 +5,10 @@ import { STAGE_ID_PATTERN } from "./stage-id";
 import * as tarParser from "./tar-parser.js";
 import type { TarSuspiciousEntry } from "./tar-parser.js";
 
-const MAX_FILES = 250;
-const MAX_BYTES_PER_FILE = 64 * 1024;
+export const SANDBOX_MAX_FILES = 2_500;
+export const SANDBOX_MAX_BYTES_PER_FILE = 128 * 1024;
+const MAX_FILES = SANDBOX_MAX_FILES;
+const MAX_BYTES_PER_FILE = SANDBOX_MAX_BYTES_PER_FILE;
 const MAX_TAR_BYTES = 25 * 1024 * 1024;
 
 // Functions whose source text is concatenated into the sandbox worker module.
@@ -344,7 +346,7 @@ export default {
       }
       let files;
       try {
-        files = await readZipArchive(zip, env.MAX_FILES || 250, env.MAX_BYTES_PER_FILE || 65536, maxTarBytes);
+        files = await readZipArchive(zip, env.MAX_FILES || 2_500, env.MAX_BYTES_PER_FILE || 131072, maxTarBytes);
       } catch (err) {
         const reason = err && err.message === "archive contains too many files"
           ? "archive contains too many files"
@@ -373,7 +375,7 @@ export default {
     let files;
     let suspiciousEntries;
     try {
-      const parsed = await readTar(tar, env.MAX_FILES || 250, env.MAX_BYTES_PER_FILE || 65536, maxTarBytes);
+      const parsed = await readTar(tar, env.MAX_FILES || 2_500, env.MAX_BYTES_PER_FILE || 131072, maxTarBytes);
       files = parsed.files;
       suspiciousEntries = parsed.suspicious;
     } catch (err) {

--- a/test/sandbox-gateway.test.mjs
+++ b/test/sandbox-gateway.test.mjs
@@ -4,7 +4,8 @@ vi.mock("cloudflare:workers", () => ({
   WorkerEntrypoint: class {},
 }));
 
-const { evaluateNpmStageGatewayRequest } = await import("../server/lib/sandbox.ts");
+const { SANDBOX_MAX_BYTES_PER_FILE, SANDBOX_MAX_FILES, evaluateNpmStageGatewayRequest } =
+  await import("../server/lib/sandbox.ts");
 
 describe("npm stage gateway policy", () => {
   const registry = "https://registry.npmjs.org";
@@ -86,5 +87,12 @@ describe("npm stage gateway policy", () => {
       credentialed: false,
       kind: "blocked",
     });
+  });
+});
+
+describe("sandbox archive limits", () => {
+  test("defaults allow 2,500 files and 128 KiB text samples", () => {
+    expect(SANDBOX_MAX_FILES).toBe(2_500);
+    expect(SANDBOX_MAX_BYTES_PER_FILE).toBe(128 * 1024);
   });
 });

--- a/test/tar-parser.test.mjs
+++ b/test/tar-parser.test.mjs
@@ -80,7 +80,11 @@ function buildTar(entries) {
   return out;
 }
 
-const PARSE_LIMITS = { maxFiles: 250, maxBytesPerFile: 64 * 1024, maxTarBytes: 25 * 1024 * 1024 };
+const PARSE_LIMITS = {
+  maxFiles: 2_500,
+  maxBytesPerFile: 128 * 1024,
+  maxTarBytes: 25 * 1024 * 1024,
+};
 
 async function parse(tar, limits = PARSE_LIMITS) {
   const result = await readTar(

--- a/test/zip-parser.test.mjs
+++ b/test/zip-parser.test.mjs
@@ -82,8 +82,8 @@ function buildZip(entries) {
 }
 
 const LIMITS = {
-  maxFiles: 250,
-  maxBytesPerFile: 64 * 1024,
+  maxFiles: 2_500,
+  maxBytesPerFile: 128 * 1024,
   maxArchiveBytes: 25 * 1024 * 1024,
 };
 


### PR DESCRIPTION
### Motivation

- Increase the sandbox parser capacity to handle larger staged publishes without hitting `too_many_files` for large repos. 
- Capture larger per-file text samples for better deterministic detection and AI evidence when needed.

### Description

- Raised the sandbox defaults from 250 files → 2,500 files and from 64 KiB → 128 KiB per-file text sample in `server/lib/sandbox.ts` and exported them as `SANDBOX_MAX_FILES` / `SANDBOX_MAX_BYTES_PER_FILE`.
- Applied the new caps to both inline and fetched sandbox parsing paths so both `downloadInSandbox` and `downloadInSandboxInline` use the increased limits.
- Updated parser test defaults in `test/tar-parser.test.mjs` and `test/zip-parser.test.mjs` to use `maxFiles: 2_500` and `maxBytesPerFile: 128 * 1024`.
- Added a regression test verifying the exported sandbox defaults in `test/sandbox-gateway.test.mjs` and updated docs (`docs/cost-model.md`, `docs/security-model.md`) to reflect the new profile.

### Testing

- Ran targeted unit tests with `pnpm exec vitest run test/sandbox-gateway.test.mjs test/tar-parser.test.mjs test/zip-parser.test.mjs`, which passed.
- Ran formatting with `pnpm run format` and the repo formatter completed successfully.
- Ran full verification with `pnpm run verify` (lint, format check, typecheck, and test suites); automated tests passed (all relevant test files and worker tests ran; test run showed 316 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1efab6264c832f8cc46e5c2eb61bfc)