### PR TITLE
Fix package files glob allowlist matching

### DIFF
--- a/server/lib/review-package-files.ts
+++ b/server/lib/review-package-files.ts
@@ -43,11 +43,7 @@ function globLikePackageFilesEntryMatches(entry: string, path: string): boolean 
     return pattern.test(path);
   }
 
-  const escaped = entry
-    .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
-    .replace(/\*\*/g, ".*")
-    .replace(/\*/g, "[^/]*");
-  pattern = new RegExp(`^${escaped}$`);
+  pattern = new RegExp(`^${packageFilesGlobToRegexSource(entry)}$`);
 
   if (globPatternCache.size >= GLOB_PATTERN_CACHE_LIMIT) {
     const oldestEntry = globPatternCache.keys().next().value;
@@ -56,4 +52,37 @@ function globLikePackageFilesEntryMatches(entry: string, path: string): boolean 
   globPatternCache.set(entry, pattern);
 
   return pattern.test(path);
+}
+
+function packageFilesGlobToRegexSource(entry: string): string {
+  let source = "";
+  for (let index = 0; index < entry.length; ) {
+    const char = entry[index];
+    const next = entry[index + 1];
+    const afterNext = entry[index + 2];
+
+    if (char === "*" && next === "*" && afterNext === "/") {
+      source += "(?:.*/)?";
+      index += 3;
+      continue;
+    }
+    if (char === "*" && next === "*") {
+      source += ".*";
+      index += 2;
+      continue;
+    }
+    if (char === "*") {
+      source += "[^/]*";
+      index += 1;
+      continue;
+    }
+
+    source += escapeRegexChar(char);
+    index += 1;
+  }
+  return source;
+}
+
+function escapeRegexChar(char: string): string {
+  return /[\\^$.*+?()[\]{}|]/.test(char) ? `\\${char}` : char;
 }

--- a/test/review-package-files.test.ts
+++ b/test/review-package-files.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+import { isOutsidePackageFilesAllowlist } from "../server/lib/review-package-files";
+
+describe("isOutsidePackageFilesAllowlist", () => {
+  test("treats nested files covered by package.json glob entries as declared", () => {
+    const packageJson = {
+      files: ["**/*.js", "**/*.cjs", "**/*.d.ts", "**/*.d.cts", "**/*.map"],
+    };
+
+    expect(
+      isOutsidePackageFilesAllowlist("__cjs/link/http/createSignalIfSupported.d.cts", packageJson),
+    ).toBe(false);
+    expect(
+      isOutsidePackageFilesAllowlist("link/http/createSignalIfSupported.js", packageJson),
+    ).toBe(false);
+  });
+
+  test("still flags files that are not covered by package.json entries", () => {
+    const packageJson = { files: ["dist", "**/*.d.ts"] };
+
+    expect(isOutsidePackageFilesAllowlist("router_init.js", packageJson)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- fix package.json `files` glob matching so `**/*.d.cts` covers nested declaration files like `__cjs/link/http/createSignalIfSupported.d.cts`
- keep flagging genuinely undeclared files outside the allowlist
- add regression coverage for the Apollo-style nested CJS/declaration paths

## Verification
- `pnpm exec vitest run --config vitest.config.ts test/review-package-files.test.ts`
- Apollo tarball check: @apollo/client@4.2.0 => 1811 files, 0 outside package files allowlist, Apollo example outside=false
- `pnpm run verify`