### PR TITLE
Add regression test for root-level package files glob matching

### DIFF
--- a/test/review-package-files.test.ts
+++ b/test/review-package-files.test.ts
@@ -15,6 +15,13 @@ describe("isOutsidePackageFilesAllowlist", () => {
     ).toBe(false);
   });
 
+  test("treats root-level files covered by package.json glob entries as declared", () => {
+    const packageJson = { files: ["**/*.js", "**/*.md"] };
+
+    expect(isOutsidePackageFilesAllowlist("version.js", packageJson)).toBe(false);
+    expect(isOutsidePackageFilesAllowlist("CHANGELOG.md", packageJson)).toBe(false);
+  });
+
   test("still flags files that are not covered by package.json entries", () => {
     const packageJson = { files: ["dist", "**/*.d.ts"] };
 


### PR DESCRIPTION
## Summary
- Adds a regression assertion to `test/review-package-files.test.ts` pinning the **root-level, zero-slash** case (`version.js` / `CHANGELOG.md` against `**/*.js` / `**/*.md`).
- This was the most distinctive symptom of the glob-matcher bug fixed in `e1389e0`: the old chained-replace pipeline compiled `**/*.js` to a regex requiring *exactly one* slash, so root files (zero slashes) and deeply-nested files (2+ slashes) were false-flagged as outside the `package.json` `files` allowlist. The fix handles it; this test guards against a regression.

## Context
Surfaced from an AI-reviewer pass on `@apollo/client` 4.2.0 → 4.2.1, where the reviewer correctly identified the `fileOutsideFilesList` findings (`version.js`, `CHANGELOG.md`, nested `.js`/`.cjs`/`.map`) as false positives. For *added* files this rule emits `high` severity, so the bug could manufacture high-severity noise.

## Test plan
- [x] `npx vitest run test/review-package-files.test.ts` — 3 pass, 0 fail
- [x] pre-commit `verify` (lint + format + typecheck + tests) passed