### PR TITLE
Show prominent processing state while diff comparison loads

### DIFF
--- a/src/pages/Dashboard/ScanDetail/DiffWorkbench.tsx
+++ b/src/pages/Dashboard/ScanDetail/DiffWorkbench.tsx
@@ -1,6 +1,7 @@
 import type { DiffEntry, FileRecord } from "../../../../server/lib/review";
 import type { PersistedScanDetail } from "../../../models/scan";
-import { DiffView, EmptyLine, LoadingLine } from "../../../components";
+import { DiffView, EmptyLine, IndeterminateBar, LoadingLine } from "../../../components";
+import { selectDiffWorkbenchState } from "./diff-helpers";
 
 export function DiffWorkbench({
   entry,
@@ -8,6 +9,7 @@ export function DiffWorkbench({
   previousMeta,
   previousContent,
   compareReady,
+  compareLoading,
   selectedVersion,
   stagedVersion,
 }: {
@@ -16,26 +18,31 @@ export function DiffWorkbench({
   previousMeta: FileRecord | null;
   previousContent: FileRecord | null;
   compareReady: boolean;
+  compareLoading: boolean;
   selectedVersion: string | null;
   stagedVersion: string | null | undefined;
 }) {
   if (!entry) {
-    return <EmptyLine>Select a file from the tree to diff.</EmptyLine>;
+    return <DiffPanelMessage>Select a file from the tree to diff.</DiffPanelMessage>;
   }
 
-  const needsPrevious = entry.status !== "added";
-  const isBinaryPrev = Boolean(previousMeta?.flags?.includes("binary"));
+  const state = selectDiffWorkbenchState({
+    hasEntry: true,
+    entryStatus: entry.status,
+    hasStaged: Boolean(staged),
+    hasPreviousMeta: Boolean(previousMeta),
+    hasPreviousContent: Boolean(previousContent),
+    previousIsBinary: Boolean(previousMeta?.flags?.includes("binary")),
+    compareReady,
+    compareLoading,
+  });
 
-  if (needsPrevious && !compareReady && entry.status !== "unchanged") {
-    return <LoadingLine size="inline">Loading comparison</LoadingLine>;
+  if (state.kind === "empty") {
+    return <DiffPanelMessage>{state.message}</DiffPanelMessage>;
   }
 
-  if (needsPrevious && previousMeta && !isBinaryPrev && !previousContent) {
-    return <LoadingLine size="inline">Loading file content</LoadingLine>;
-  }
-
-  if (!staged && !previousContent && !previousMeta) {
-    return <EmptyLine>No file content available.</EmptyLine>;
+  if (state.kind === "processing") {
+    return <DiffProcessing title={state.title} detail={state.detail} />;
   }
 
   return (
@@ -53,6 +60,28 @@ export function DiffWorkbench({
       }
       after={staged ? scanFileToDiffSide(staged) : null}
     />
+  );
+}
+
+// A centered processing block that fills the diff panel so the "still working"
+// signal is unmistakable while the previous version streams in — the file tree
+// renders first, and the sandbox fetch of the previous tarball can take a
+// minute. No spinner (DESIGN.md): mono line plus an indeterminate bar.
+function DiffProcessing({ title, detail }: { title: string; detail: string }) {
+  return (
+    <div class="flex flex-1 flex-col items-center justify-center gap-3 text-center min-h-0">
+      <LoadingLine>{title}</LoadingLine>
+      <IndeterminateBar class="w-48 max-w-full" />
+      <p class="font-mono text-[11px] tracking-[0.02em] text-ink-subtle m-0">{detail}</p>
+    </div>
+  );
+}
+
+function DiffPanelMessage({ children }: { children: string }) {
+  return (
+    <div class="flex flex-1 flex-col items-center justify-center min-h-0">
+      <EmptyLine>{children}</EmptyLine>
+    </div>
   );
 }
 

--- a/src/pages/Dashboard/ScanDetail/diff-helpers.ts
+++ b/src/pages/Dashboard/ScanDetail/diff-helpers.ts
@@ -15,6 +15,69 @@ const DIFF_STATUS_RANK: Record<DiffEntry["status"], number> = {
   unchanged: 3,
 };
 
+export type DiffWorkbenchState =
+  | { kind: "empty"; message: string }
+  | { kind: "processing"; title: string; detail: string }
+  | { kind: "diff" };
+
+// Decides what the diff panel should show for the selected file. Extracted so
+// the loading/empty/diff guards are testable: the previous version is fetched
+// through the sandbox after the file tree already renders, and during that
+// window we must show an explicit processing state instead of letting DiffView
+// render a one-sided (all added/removed) view of a file that is actually
+// modified.
+export function selectDiffWorkbenchState(input: {
+  hasEntry: boolean;
+  entryStatus: DiffEntry["status"] | null;
+  hasStaged: boolean;
+  hasPreviousMeta: boolean;
+  hasPreviousContent: boolean;
+  previousIsBinary: boolean;
+  compareReady: boolean;
+  compareLoading: boolean;
+}): DiffWorkbenchState {
+  if (!input.hasEntry) {
+    return { kind: "empty", message: "Select a file from the tree to diff." };
+  }
+
+  const needsPrevious = input.entryStatus !== "added";
+
+  // Previous version still being fetched via the sandbox. Keyed off
+  // compareLoading too (not just compareReady) so a stale cache entry from a
+  // prior version can't flash a wrong diff while the new fetch is in flight.
+  if (
+    needsPrevious &&
+    input.entryStatus !== "unchanged" &&
+    (input.compareLoading || !input.compareReady)
+  ) {
+    return {
+      kind: "processing",
+      title: "Loading comparison",
+      detail: "fetching previous version via sandbox · this can take a minute",
+    };
+  }
+
+  // Comparison resolved; the previous file body is still loading.
+  if (
+    needsPrevious &&
+    input.hasPreviousMeta &&
+    !input.previousIsBinary &&
+    !input.hasPreviousContent
+  ) {
+    return {
+      kind: "processing",
+      title: "Loading file diff",
+      detail: "fetching file contents",
+    };
+  }
+
+  if (!input.hasStaged && !input.hasPreviousContent && !input.hasPreviousMeta) {
+    return { kind: "empty", message: "No file content available." };
+  }
+
+  return { kind: "diff" };
+}
+
 export function filterDiffEntries(
   entries: DiffEntry[],
   rawFilter: string,

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -299,6 +299,7 @@ export default function ScanDetailPage() {
                   previousMeta={previousFileMeta.value}
                   previousContent={previousFile.value}
                   compareReady={Boolean(compare)}
+                  compareLoading={compareLoading}
                   selectedVersion={selectedVersion}
                   stagedVersion={detail.scan.stagedVersion}
                 />

--- a/test/scan-detail-diff-helpers.test.mjs
+++ b/test/scan-detail-diff-helpers.test.mjs
@@ -3,6 +3,7 @@ import {
   annotatePersistedFindings,
   filterDiffEntries,
   scanFilesToFileRecords,
+  selectDiffWorkbenchState,
 } from "../src/pages/Dashboard/ScanDetail/diff-helpers.ts";
 
 describe("filterDiffEntries", () => {
@@ -64,6 +65,93 @@ describe("scanFilesToFileRecords", () => {
       textSample: undefined,
       flags: [],
     });
+  });
+});
+
+describe("selectDiffWorkbenchState", () => {
+  const base = {
+    hasEntry: true,
+    entryStatus: "modified",
+    hasStaged: true,
+    hasPreviousMeta: true,
+    hasPreviousContent: true,
+    previousIsBinary: false,
+    compareReady: true,
+    compareLoading: false,
+  };
+
+  test("prompts to pick a file when nothing is selected", () => {
+    const state = selectDiffWorkbenchState({ ...base, hasEntry: false });
+    expect(state).toEqual({ kind: "empty", message: "Select a file from the tree to diff." });
+  });
+
+  test("shows processing while the previous version is still fetching", () => {
+    const state = selectDiffWorkbenchState({
+      ...base,
+      compareReady: false,
+      hasPreviousMeta: false,
+      hasPreviousContent: false,
+    });
+    expect(state.kind).toBe("processing");
+    expect(state.title).toBe("Loading comparison");
+  });
+
+  test("stays in processing when a newer compare fetch is in flight over a stale cache", () => {
+    const state = selectDiffWorkbenchState({ ...base, compareLoading: true });
+    expect(state.kind).toBe("processing");
+    expect(state.title).toBe("Loading comparison");
+  });
+
+  test("shows processing once the compare resolves but the file body is loading", () => {
+    const state = selectDiffWorkbenchState({ ...base, hasPreviousContent: false });
+    expect(state.kind).toBe("processing");
+    expect(state.title).toBe("Loading file diff");
+  });
+
+  test("renders the diff for an added file without waiting on a previous version", () => {
+    const state = selectDiffWorkbenchState({
+      ...base,
+      entryStatus: "added",
+      compareReady: false,
+      hasPreviousMeta: false,
+      hasPreviousContent: false,
+    });
+    expect(state).toEqual({ kind: "diff" });
+  });
+
+  test("renders the diff for a binary previous file instead of waiting on its body", () => {
+    const state = selectDiffWorkbenchState({
+      ...base,
+      previousIsBinary: true,
+      hasPreviousContent: false,
+    });
+    expect(state).toEqual({ kind: "diff" });
+  });
+
+  test("renders an unchanged file without a comparison fetch", () => {
+    const state = selectDiffWorkbenchState({
+      ...base,
+      entryStatus: "unchanged",
+      compareReady: false,
+      hasPreviousMeta: false,
+      hasPreviousContent: false,
+    });
+    expect(state).toEqual({ kind: "diff" });
+  });
+
+  test("reports no content when neither side has anything to show", () => {
+    const state = selectDiffWorkbenchState({
+      ...base,
+      entryStatus: "unchanged",
+      hasStaged: false,
+      hasPreviousMeta: false,
+      hasPreviousContent: false,
+    });
+    expect(state).toEqual({ kind: "empty", message: "No file content available." });
+  });
+
+  test("renders the diff once both sides are ready", () => {
+    expect(selectDiffWorkbenchState(base)).toEqual({ kind: "diff" });
   });
 });
 


### PR DESCRIPTION
## Summary
The scan-detail file tree renders from the persisted scan instantly, but each file's previous version streams in via a sandbox tarball fetch that can take a minute, and the old `size="inline"` loading line was easy to miss in the tall diff panel — so the diff read as a broken one-sided (all-red) view until the comparison resolved. This extracts the panel's loading/empty/diff guards into a pure, tested `selectDiffWorkbenchState` selector keyed off `compareLoading` (not just `compareReady`, so a stale cached compare can't flash a wrong diff mid-fetch) and renders a centered processing block (mono line + indeterminate bar, no spinner per DESIGN.md). Added unit tests in `test/scan-detail-diff-helpers.test.mjs` covering the loading, empty, and short-circuit (added/binary/unchanged) cases.

## Test plan
- [x] `pnpm run verify` (lint + format + typecheck + tests) passes
- [ ] Open a scan detail and confirm the diff panel shows a clear centered "Loading comparison" state while the previous version fetches, then the real diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)