### PR TITLE
Trim AI review initial payload to cut input tokens

### DIFF
--- a/server/lib/ai-review-contract.ts
+++ b/server/lib/ai-review-contract.ts
@@ -103,7 +103,6 @@ export const MAX_AGENT_STEPS = 20;
 // cap it would truncate mid-JSON, fail schema validation, and silently degrade
 // to an `invalid` review — so loosening the schema bounds means raising this.
 export const MAX_REVIEW_OUTPUT_TOKENS = 8_000;
-export const MAX_INITIAL_PACKAGE_JSON_CHARS = 6_000;
 export const MAX_CHANGED_FILE_MANIFEST = 300;
 export const MAX_TOOL_RESPONSE_CHARS = 16_000;
 export const MAX_TOTAL_TOOL_RESPONSE_CHARS = 48_000;

--- a/server/lib/ai-review-evidence.ts
+++ b/server/lib/ai-review-evidence.ts
@@ -5,7 +5,6 @@ import {
   LARGE_FILE_BYTES,
   ListFilesFilter,
   MAX_CHANGED_FILE_MANIFEST,
-  MAX_INITIAL_PACKAGE_JSON_CHARS,
   MAX_TOOL_RESPONSE_CHARS,
   MAX_TOTAL_TOOL_RESPONSE_CHARS,
   normalizeAiReviewEcosystem,
@@ -39,19 +38,15 @@ export function buildAiReviewPayload(options: SelectiveAiReviewOptions) {
       index.previousByPath.get(index.packageJsonPath) ??
       null)
     : null;
-  const changedFileDiff = options.diff
+  const changedPaths = options.diff
     .filter((entry) => entry.status !== "unchanged")
-    .slice(0, MAX_CHANGED_FILE_MANIFEST);
+    .slice(0, MAX_CHANGED_FILE_MANIFEST)
+    .map((entry) => entry.path);
 
   return {
     ecosystem,
     task: reviewTaskFor(ecosystem),
     toolPolicy: {
-      toolsMayRead:
-        "redacted package text samples and text diffs for changed files, package manifest-referenced script/entrypoint files where applicable, deterministic-finding files, and package manifests where present",
-      toolsMaySearch: "literal search over the same redacted tool-readable package text",
-      toolsMayNot:
-        "fetch external URLs, install dependencies, execute package code, import package modules, or read unbounded/raw tarball contents",
       maxToolResponseChars: MAX_TOOL_RESPONSE_CHARS,
       maxTotalToolResponseChars: MAX_TOTAL_TOOL_RESPONSE_CHARS,
     },
@@ -61,14 +56,11 @@ export function buildAiReviewPayload(options: SelectiveAiReviewOptions) {
       ? {
           path: packageJsonFile.path,
           size: packageJsonFile.size,
-          sha256: packageJsonFile.sha256,
           flags: packageJsonFile.flags,
-          textSample: packageJsonFile.textSample?.slice(0, MAX_INITIAL_PACKAGE_JSON_CHARS),
         }
       : null,
     previousVersionAvailable: options.previousVersionAvailable,
-    changedFileDiff,
-    changedFileManifest: changedFileDiff.map((entry) => manifestEntry(entry.path, index)),
+    changedFileManifest: changedPaths.map((path) => manifestEntry(path, index)),
   };
 }
 
@@ -411,9 +403,8 @@ function manifestEntry(path: string, index: EvidenceIndex) {
   return {
     path,
     status: diff?.status ?? "unchanged",
-    size: staged?.size ?? previous?.size ?? diff?.stagedSize ?? diff?.previousSize ?? null,
-    sha256:
-      staged?.sha256 ?? previous?.sha256 ?? diff?.stagedSha256 ?? diff?.previousSha256 ?? null,
+    previousSize: previous?.size ?? diff?.previousSize,
+    stagedSize: staged?.size ?? diff?.stagedSize,
     flags: file?.flags ?? diff?.flags ?? [],
     signals: fileSignals(path, index),
   };

--- a/test/ai-review-evidence.test.mjs
+++ b/test/ai-review-evidence.test.mjs
@@ -172,13 +172,32 @@ describe("AI review evidence tools", () => {
     }
   });
 
-  test("describes package-json-referenced evidence in the initial payload policy", () => {
+  test("trims the initial payload to drop dead input tokens", () => {
     const payload = buildAiReviewPayload(reviewOptions());
 
-    expect(payload.toolPolicy.toolsMayRead).toContain(
-      "manifest-referenced script/entrypoint files",
-    );
+    // Tool policy carries only the numeric budgets; the prose duplicated the
+    // system prompt and tool descriptions.
+    expect(payload.toolPolicy).toEqual({
+      maxToolResponseChars: expect.any(Number),
+      maxTotalToolResponseChars: expect.any(Number),
+    });
+
+    // One file list, not two: the diff list is gone and the manifest subsumes it.
+    expect(payload).not.toHaveProperty("changedFileDiff");
     expect(payload.changedFileManifest.map((entry) => entry.path)).toEqual(["package.json"]);
+
+    const entry = payload.changedFileManifest[0];
+    // SHA256 is input-token noise an LLM can't reason over.
+    expect(entry).not.toHaveProperty("sha256");
+    // The byte-size delta the diff list carried lives on the manifest entry.
+    expect(typeof entry.previousSize).toBe("number");
+    expect(typeof entry.stagedSize).toBe("number");
+    expect(entry.signals).toContain("diff:modified");
+
+    // The package.json pointer no longer inlines a multi-KB text sample or hash;
+    // the model reads it on demand.
+    expect(payload.packageJson).not.toHaveProperty("textSample");
+    expect(payload.packageJson).not.toHaveProperty("sha256");
   });
 
   test("labels PyPI review payloads with the ecosystem-specific task", () => {
@@ -215,5 +234,12 @@ describe("AI review evidence tools", () => {
     expect(payload.task).toContain("PyPI release candidate");
     expect(payload.task).toContain("workflow gate");
     expect(payload.packageJson).toBeNull();
+
+    // An added file has no previous side, so previousSize is omitted from the
+    // serialized payload the model actually receives.
+    const added = JSON.parse(JSON.stringify(payload)).changedFileManifest[0];
+    expect(added.status).toBe("added");
+    expect(added).not.toHaveProperty("previousSize");
+    expect(added.stagedSize).toBe(53);
   });
 });


### PR DESCRIPTION
## Summary

Implements the Tier 1 token-trim from #203, removing data the reviewer model can't use from the payload serialized by `buildAiReviewPayload`. Drops the 64-char sha256 hashes (an LLM can't reason over a hash), the redundant `changedFileDiff` list (the changed-file manifest's `signals` array already subsumes it), the 6KB inline `package.json` text sample (the model reads it on demand), and the verbose `toolPolicy` prose (duplicated the system prompt and tool descriptions). The manifest entry now carries the previous/staged size delta the diff list provided, so no signal is lost.

## Test plan
- [x] `npm run verify` (lint, format, typecheck, tests) passes
- [x] `test/ai-review-evidence.test.mjs` updated to lock in the trimmed payload shape
- [ ] Measure input/cached-input/output tokens before/after via the `usage` block on `scan.ai_review.completed` (needs a live Flagship-enabled scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)