### PR TITLE
Require verified email before accepting organization invites

### DIFF
--- a/docs/organization-members.md
+++ b/docs/organization-members.md
@@ -77,14 +77,16 @@ The raw token exists only in the invite email and the accept request; it is
 3. **Accept** (`POST /invitations/accept`, authenticated invitee): this route is
    deliberately **not** scoped by the `x-organization-id` header — an invitee is
    not a member yet, so the org is determined solely by the token (matched by
-   hash). The caller's account email must equal the invited address, so a leaked
-   link cannot enroll a third party. The transition out of `pending` is a
-   compare-and-swap (`markInvitationAccepted`), so concurrent accepts race and
-   only one wins. On success it adds the member, records
+   hash). The caller's account email must equal the invited address **and** the
+   account's `emailVerified` flag must be true, so a leaked link cannot be
+   redeemed by registering an unverified account with the invitee's address. The
+   transition out of `pending` is a compare-and-swap (`markInvitationAccepted`),
+   so concurrent accepts race and only one wins. On success it adds the member, records
    `organization.member_joined`, and returns `{ organizationId, role }`.
 
 Accept failure codes: `404` unknown token, `409` already used/revoked (or lost
-the CAS race), `410` expired, `403` the caller's email does not match the invite.
+the CAS race), `410` expired, `403` the caller's email does not match the invite
+or has not been verified.
 
 ### Front end
 
@@ -112,5 +114,5 @@ All recorded via `recordScanEvent` into `scan_events`:
 
 `test/workers/organization-members-routes.test.ts` covers invite creation,
 token-never-leaked, role enforcement (member 403, admin allowed), accept →
-membership, leaked-link rejection, expiry, revoke-then-accept, owner-removal
-guard, and roster ordering.
+membership, leaked-link rejection, unverified-email rejection, expiry,
+revoke-then-accept, owner-removal guard, and roster ordering.

--- a/server/db/organizations.ts
+++ b/server/db/organizations.ts
@@ -36,7 +36,7 @@ export async function ensurePersonalOrganization(db: AppDb, session: WorkspaceSe
 
 export async function getUserContact(db: AppDb, userId: string) {
   const [row] = await db
-    .select({ id: user.id, email: user.email, name: user.name })
+    .select({ id: user.id, email: user.email, emailVerified: user.emailVerified, name: user.name })
     .from(user)
     .where(eq(user.id, userId))
     .limit(1);

--- a/server/routes/organization-members.ts
+++ b/server/routes/organization-members.ts
@@ -158,8 +158,9 @@ organizationMembersRoutes.delete("/invitations/:invitationId", async (c) => {
 
 // The accept path is deliberately NOT scoped by the active-organization header:
 // an invitee is not a member yet, so the invitation token alone determines which
-// org they join. The token is matched by hash and the caller's account email
-// must equal the invited address, so a leaked link cannot enroll a third party.
+// org they join. The token is matched by hash and the caller must have verified
+// ownership of the invited email address, so a leaked link cannot enroll a third
+// party.
 organizationMembersRoutes.post("/invitations/accept", async (c) => {
   const body = (await c.req.json().catch(() => ({}))) as { token?: unknown };
   const token = typeof body.token === "string" ? body.token.trim() : "";
@@ -180,6 +181,9 @@ organizationMembersRoutes.post("/invitations/accept", async (c) => {
   const contact = await getUserContact(db, session.userId);
   if (!contact?.email || normalizeEmail(contact.email) !== invitation.email) {
     return c.json({ error: "this invitation was sent to a different email address" }, 403);
+  }
+  if (!contact.emailVerified) {
+    return c.json({ error: "verify your email address before accepting this invitation" }, 403);
   }
 
   const accepted = await markInvitationAccepted(db, {

--- a/test/workers/organization-members-routes.test.ts
+++ b/test/workers/organization-members-routes.test.ts
@@ -23,7 +23,7 @@ interface SeededUser {
   personalOrganizationId: string;
 }
 
-async function seedUser(): Promise<SeededUser> {
+async function seedUser(options: { emailVerified?: boolean } = {}): Promise<SeededUser> {
   const db = createDb(env.DB);
   const now = new Date();
   const userId = `user_${crypto.randomUUID()}`;
@@ -32,7 +32,7 @@ async function seedUser(): Promise<SeededUser> {
     id: userId,
     name: "Tester",
     email,
-    emailVerified: true,
+    emailVerified: options.emailVerified ?? true,
     createdAt: now,
     updatedAt: now,
   });
@@ -230,6 +230,32 @@ describe("organization member routes", () => {
 
     const db = createDb(env.DB);
     expect(await getOrganizationRole(db, organizationId, stranger.userId)).toBeNull();
+  });
+
+  test("an unverified account cannot accept an invitation for its email", async () => {
+    const owner = await seedUser();
+    const invitee = await seedUser({ emailVerified: false });
+    const organizationId = await createOrganization(owner, "verify-first");
+    const { token } = await seedInvitation({
+      owner,
+      organizationId,
+      email: invitee.email,
+      role: "admin",
+    });
+
+    const accept = await call(
+      buildTestApp(invitee),
+      "POST",
+      "/api/v1/organizations/invitations/accept",
+      { body: { token } },
+    );
+    expect(accept.status).toBe(403);
+    await expect(accept.json()).resolves.toEqual({
+      error: "verify your email address before accepting this invitation",
+    });
+
+    const db = createDb(env.DB);
+    expect(await getOrganizationRole(db, organizationId, invitee.userId)).toBeNull();
   });
 
   test("an expired invitation cannot be accepted", async () => {


### PR DESCRIPTION
### Motivation

- The invite accept flow previously authorized a caller solely by comparing the account email string to the invited address, allowing newly-registered unverified accounts to redeem leaked invitation links. 
- The change closes this authz gap by ensuring the accepting account actually controls the invited address via the `emailVerified` flag.

### Description

- Include `emailVerified` in the user contact lookup returned by `getUserContact` so callers can check verification state (`server/db/organizations.ts`).
- Enforce verification in the accept route by returning `403` with a clear error when `contact.emailVerified` is false (`server/routes/organization-members.ts`).
- Add a worker-route regression test that an unverified account cannot accept an invitation (`test/workers/organization-members-routes.test.ts`).
- Update `docs/organization-members.md` to document that invite acceptance requires both email equality and `emailVerified = true`.

### Testing

- Ran the organization-members worker tests with `pnpm exec vitest run --config vitest.workers.config.ts test/workers/organization-members-routes.test.ts --reporter=verbose`, and the suite passed.
- Ran the full verification pipeline with `pnpm run verify` (lint, format check, typecheck, unit + worker tests) and it completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dc07cd164832f848acb462cdfd679)