### PR TITLE
Relabel installed GitHub App button to "Modify installation"

### DIFF
--- a/src/pages/Dashboard/Settings/GithubAppSection.tsx
+++ b/src/pages/Dashboard/Settings/GithubAppSection.tsx
@@ -100,12 +100,9 @@ export function GithubAppSection({
             {status === "starting"
               ? "Redirecting…"
               : installations.length
-                ? "Install on another organization"
+                ? "Modify installation"
                 : "Install GitHub App"}
           </Button>
-          <Muted class="text-[12px] m-0">
-            You'll be sent to GitHub to pick which account to install on, then returned here.
-          </Muted>
         </div>
       </div>
 


### PR DESCRIPTION
Once the Drydock GitHub App is already installed, the action button now reads "Modify installation" instead of "Install on another organization", better reflecting that GitHub lets you adjust the existing installation. The redundant "You'll be sent to GitHub…" helper line beneath the button is removed. First-install and redirecting states are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)