### PR TITLE
Weight code.process-execution by install-reachability and diff novelty

### DIFF
--- a/docs/detection-eval.md
+++ b/docs/detection-eval.md
@@ -119,16 +119,17 @@ Recall is measured per class so blind spots are visible. Malicious:
 
 ## Gated thresholds (and the ratchet)
 
-Only regression metrics are gated today (`detection-eval.test.mjs`):
+Gated today (`detection-eval.test.mjs`):
 
 - malicious recall ≥ 90%
 - every `expectMinRisk: critical` case caught (100%)
 - zero false positives on benign controls
+- benign hard-negative FP rate < 10% (newly gated: install-reachability weighting
+  cleared `legit-build-childprocess`, the only standing hard-negative FP)
 
-Frontier recall, benign hard-negative FP rate, and evasion robustness are
-reported, not gated, so they can start red. Ratchet plan as the corpus and
-detector improve: gate benign FP rate < 10%, then gate frontier recall, then
-gate `pushPastWindow` survival once full-bytes scanning lands.
+Frontier recall and evasion robustness are reported, not gated, so they can start
+red. Remaining ratchet plan as the corpus and detector improve: gate frontier
+recall, then gate `pushPastWindow` survival once full-bytes scanning lands.
 
 ## Corpus expansion
 

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -14,6 +14,7 @@ The fixture taxonomy is based on the current Drydock rule surface plus public np
 - Recent npm detection benchmark research reports a curated dataset of 6,420 malicious and 7,288 benign npm packages, with 11 behavior categories and 8 evasion categories. The most common behaviors were command execution, data collection, and data exfiltration; install scripts were used by about 72% of malicious packages in that study, and preinstall hooks were the dominant install-time entry point.
 - The same benchmark highlights the central detection trade-off: benign and malicious packages often call the same APIs. A single `process.env` or `https` use is capability evidence, while chains such as collect → serialize → exfiltrate are stronger intent evidence.
 - Network-only code follows that trade-off: unchanged network-only files are suppressed as package context, added network-only files remain medium-severity contextual evidence, and added network access escalates to high when it is tied to lifecycle scripts, process execution, dynamic evaluation, or credential access.
+- Process/shell execution is weighted by **install-reachability** and **diff novelty**, not flagged uniformly. A file the manifest runs on install (an explicit `preinstall`/`install`/`postinstall`/`prepare` hook) or exposes as an entrypoint (`bin`, `main`/`module`/`types`/`exports`, plus the default `index.js` package-root entry unless `main`/`exports` override it) keeps `code.process-execution` at high. A file no manifest field references — typically local maintainer build tooling — is recorded at low when newly added/changed and at info when pre-existing, so a build helper that legitimately shells out (`legit-build-childprocess`) is no longer a significant false positive. Co-occurring network/credential/eval capability still escalates through its own rule, so a real install-time dropper stays high. The reachability map is derived from the npm manifest; PyPI install reachability is modeled by the adapter's `setup.py`/startup-hook rules, so Python evidence keeps the historical high severity.
 - Documentation and prose files remain available as package evidence, but deterministic `code.*` rules do not treat them as executable capability evidence. Secret checks in documentation use only high-confidence token formats; generic key/value examples such as `token = localStorage.getItem("token")` are not `file.secret-content` findings.
 
 ## Safety policy
@@ -96,7 +97,7 @@ A PyPI review runs two rule families over the staged artifacts:
 
 - `pypi.*` findings come from `pyPiReleaseFindings` and carry `PYPI_RULES_VERSION` (currently `0.2.0`).
 - shared `file.*` / `code.*` / `diff.*` findings come from `deterministicFindings` and carry
-  `DETERMINISTIC_RULES_VERSION` (currently `1.7.0`).
+  `DETERMINISTIC_RULES_VERSION` (currently `1.8.0`).
 
 The harness asserts this per family: every `pypi.*` finding must equal `PYPI_RULES_VERSION` and every
 other finding must equal `DETERMINISTIC_RULES_VERSION`. Bump the relevant constant **and** update the
@@ -113,7 +114,10 @@ JavaScript `code.*` rules also see runtime-assembled identifiers: string-concate
 (`'chi' + 'ld_process'`), `[...].join('')` array assembly, and literal-keyed computed member access
 (`globalThis['re' + 'quire']`) are folded back to their literal form before the regex set runs. A
 tokenizer keeps folding out of comments, string bodies, template literals, and regex literals, and both
-the raw and folded text are scanned so folding can only add detections, never drop one. `pypi.*` grew
+the raw and folded text are scanned so folding can only add detections, never drop one. `1.8.0` weights
+`code.process-execution` on npm files by install-reachability and diff novelty (high for install
+hooks/entrypoints, low/info for unreferenced build files); PyPI keeps the historical high severity
+because its install reachability is modeled by the `setup.py`/startup-hook rules. `pypi.*` grew
 `startup-hook`,
 `record-mismatch`, and `unusual-dependency` in `0.2.0`, and
 `setup-install-command` was upgraded to fire on the top-level sdist `setup.py` install-time code, not

--- a/server/lib/review-rules/context.ts
+++ b/server/lib/review-rules/context.ts
@@ -1,11 +1,24 @@
 import { isRootGypPath, normalizeStringRecord } from "../tar-parser.js";
 import type { CodePatternSet, DiffEntry, FileRecord, PackageJsonSummary } from "../review";
-import { codePatternsFor, type JS_PATTERN_SET } from "./patterns";
+import { codePatternsFor, LIFECYCLE_SCRIPTS, type JS_PATTERN_SET } from "./patterns";
 import { safeJson } from "./helpers";
 
 export interface DeterministicFindingOptions {
   codePatternSet?: CodePatternSet;
 }
+
+// How a file is reached from the package manifest. Capability weighting keys off
+// this: code that runs automatically on install, or that the consumer invokes
+// through a declared entrypoint, is materially riskier than a build/source file
+// the manifest never references.
+//   - install    — referenced by an explicit pre/post/install/prepare hook
+//                   command; runs automatically on `npm install`.
+//   - runtime     — the package's `bin`, `main`/`module`/`types`/`exports`
+//                   entry (or the default `index.js` when none is declared);
+//                   runs when the consumer imports or invokes the package.
+//   - unreferenced — no manifest field references it; typically local maintainer
+//                   build/source tooling the consumer never executes.
+export type FileReachability = "install" | "runtime" | "unreferenced";
 
 // Resolved inputs shared by every rule family for a single deterministic pass.
 // Built once so the manifest parse, script normalization, and lookup maps are
@@ -21,7 +34,15 @@ export interface RuleContext {
   implicitScripts: Record<string, string>;
   rootGypFile: FileRecord | undefined;
   patterns: typeof JS_PATTERN_SET;
-  codePatternSet: CodePatternSet | undefined;
+  // Defaults to "javascript" so npm callers (which omit the option) read a
+  // concrete value; the PyPI adapter passes "python". Main's constant-folding
+  // pre-pass and this module's process-execution weighting both gate on it.
+  codePatternSet: CodePatternSet;
+  // Path tokens (normalized basenames/relative paths) that a lifecycle hook or
+  // an entrypoint field points at. Precomputed once; consumed by fileReachability.
+  installReferenceTokens: Set<string>;
+  runtimeReferenceTokens: Set<string>;
+  hasPackageRootEntryOverride: boolean;
 }
 
 export function buildRuleContext(
@@ -37,6 +58,8 @@ export function buildRuleContext(
     : null;
   const packageJsonParseFailed = Boolean(packageJsonFile?.textSample) && rawPackageJson === null;
   const packageJson = packageJsonSummary ?? rawPackageJson;
+  const scripts = normalizeStringRecord(packageJson?.scripts);
+  const implicitScripts = normalizeStringRecord(packageJson?.implicitScripts);
   return {
     files,
     diff,
@@ -44,11 +67,14 @@ export function buildRuleContext(
     packageJson,
     packageJsonFile,
     packageJsonParseFailed,
-    scripts: normalizeStringRecord(packageJson?.scripts),
-    implicitScripts: normalizeStringRecord(packageJson?.implicitScripts),
+    scripts,
+    implicitScripts,
     rootGypFile: files.find((file) => isRootGypPath(file.path)),
     patterns: codePatternsFor(options.codePatternSet),
-    codePatternSet: options.codePatternSet,
+    codePatternSet: options.codePatternSet ?? "javascript",
+    installReferenceTokens: collectInstallReferenceTokens(scripts, implicitScripts),
+    runtimeReferenceTokens: collectRuntimeReferenceTokens(packageJson),
+    hasPackageRootEntryOverride: packageJsonHasPackageRootEntryOverride(packageJson),
   };
 }
 
@@ -57,4 +83,148 @@ export function buildRuleContext(
 export function changedPrefix(ctx: RuleContext, path: string): string {
   const changed = ctx.diffByPath.get(path)?.status;
   return changed && changed !== "unchanged" ? `new/changed ${changed} file: ` : "";
+}
+
+// Resolve a file to its reachability tier from the manifest reference maps.
+// Install reachability wins over runtime (a file both run on install and listed
+// as an entrypoint is treated by its strongest, install-time, exposure).
+export function fileReachability(ctx: RuleContext, path: string): FileReachability {
+  if (setsIntersect(scriptPathCandidates(path), ctx.installReferenceTokens)) return "install";
+  if (setsIntersect(runtimePathCandidates(path), ctx.runtimeReferenceTokens)) return "runtime";
+  if (!ctx.hasPackageRootEntryOverride && isDefaultEntryFile(path)) return "runtime";
+  return "unreferenced";
+}
+
+// npm resolves the package root entry to `index.js` (or its `.cjs`/`.mjs`
+// siblings) unless package-root resolution is overridden by `main` or `exports`.
+const DEFAULT_ENTRY_PATHS = new Set(["index.js", "index.cjs", "index.mjs"]);
+
+function isDefaultEntryFile(path: string): boolean {
+  const normalized = path.replaceAll("\\", "/").replace(/^\.\//, "");
+  const withoutPackage = normalized.startsWith("package/")
+    ? normalized.slice("package/".length)
+    : normalized;
+  return DEFAULT_ENTRY_PATHS.has(withoutPackage);
+}
+
+// Lifecycle hooks run automatically on `npm install`; any file their command
+// references is install-reachable. Implicit defaults (e.g. npm's own
+// `node-gyp rebuild`) are skipped so only maintainer-declared hooks count.
+function collectInstallReferenceTokens(
+  scripts: Record<string, string>,
+  implicitScripts: Record<string, string>,
+): Set<string> {
+  const tokens = new Set<string>();
+  for (const script of LIFECYCLE_SCRIPTS) {
+    const command = scripts[script];
+    if (!command || implicitScripts[script] === command) continue;
+    for (const token of scriptCommandTokens(command)) tokens.add(token);
+  }
+  return tokens;
+}
+
+// `bin` (CLI), `main`/`module`/`types`, and `exports` string leaves are the
+// surface a consumer invokes or imports when they use the package.
+function collectRuntimeReferenceTokens(packageJson: PackageJsonSummary | null): Set<string> {
+  const tokens = new Set<string>();
+  if (!packageJson) return tokens;
+  const bin = packageJson.bin;
+  if (typeof bin === "string") addReferenceTokens(tokens, bin);
+  else if (bin && typeof bin === "object") {
+    for (const value of Object.values(bin)) {
+      if (typeof value === "string") addReferenceTokens(tokens, value);
+    }
+  }
+  for (const entry of [packageJson.main, packageJson.module, packageJson.types]) {
+    if (typeof entry === "string") addReferenceTokens(tokens, entry);
+  }
+  collectExportStringLeaves(packageJson.exports, tokens);
+  return tokens;
+}
+
+function addReferenceTokens(tokens: Set<string>, value: string): void {
+  for (const token of entryReferenceTokens(value)) tokens.add(token);
+}
+
+// `exports` may be a string, a nested conditions/subpath object, or arrays of
+// those; collect every string leaf as a referenced path.
+function collectExportStringLeaves(node: unknown, tokens: Set<string>): void {
+  if (typeof node === "string") {
+    addReferenceTokens(tokens, node);
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const item of node) collectExportStringLeaves(item, tokens);
+    return;
+  }
+  if (node && typeof node === "object") {
+    for (const value of Object.values(node)) collectExportStringLeaves(value, tokens);
+  }
+}
+
+function packageJsonHasPackageRootEntryOverride(packageJson: PackageJsonSummary | null): boolean {
+  if (!packageJson) return false;
+  return typeof packageJson.main === "string" || packageJson.exports != null;
+}
+
+// Normalize a file path to the set of forms a script command might use to name
+// it: the full relative path, the `package/`-stripped path, the basename, and
+// each of those with the extension dropped.
+function scriptPathCandidates(path: string): Set<string> {
+  const normalized = path.replaceAll("\\", "/").replace(/^\.\//, "");
+  const withoutPackage = normalized.startsWith("package/")
+    ? normalized.slice("package/".length)
+    : normalized;
+  const basename = withoutPackage.split("/").at(-1) ?? withoutPackage;
+  const baseValues = [normalized, withoutPackage, basename];
+  const values = [...baseValues];
+  for (const value of baseValues) {
+    values.push(value.replace(/\.[^/.]+$/, ""));
+  }
+  return new Set(values.filter(Boolean));
+}
+
+// Runtime entrypoints are manifest paths, not shell commands. Keep matching
+// path-scoped so `main: "index.js"` does not make `src/index.js` reachable just
+// because the basenames match.
+function runtimePathCandidates(path: string): Set<string> {
+  const normalized = path.replaceAll("\\", "/").replace(/^\.\//, "");
+  const withoutPackage = normalized.startsWith("package/")
+    ? normalized.slice("package/".length)
+    : normalized;
+  const baseValues = [normalized, withoutPackage];
+  const values = [...baseValues];
+  for (const value of baseValues) {
+    values.push(value.replace(/\.[^/.]+$/, ""));
+  }
+  return new Set(values.filter(Boolean));
+}
+
+function entryReferenceTokens(value: string): string[] {
+  const normalized = value.replaceAll("\\", "/").replace(/^\.\//, "");
+  const withoutPackage = normalized.startsWith("package/")
+    ? normalized.slice("package/".length)
+    : normalized;
+  const baseValues = [normalized, withoutPackage];
+  const values = [...baseValues];
+  for (const item of baseValues) {
+    values.push(item.replace(/\.[^/.]+$/, ""));
+  }
+  return [...new Set(values.filter(Boolean))];
+}
+
+// Pull path-shaped tokens out of a script command, dropping any leading `./` so
+// they line up with scriptPathCandidates output.
+function scriptCommandTokens(command: string): string[] {
+  return [...command.matchAll(/(?:\.\/)?[\w@./-]+(?:\.[\w-]+)?\b/g)].map((match) =>
+    match[0].replace(/^\.\//, ""),
+  );
+}
+
+function setsIntersect(a: Set<string>, b: Set<string>): boolean {
+  if (!b.size) return false;
+  for (const value of a) {
+    if (b.has(value)) return true;
+  }
+  return false;
 }

--- a/server/lib/review-rules/index.ts
+++ b/server/lib/review-rules/index.ts
@@ -15,7 +15,7 @@ import { dependencyDiffFindings } from "./deps";
 // way that should invalidate cached scan reports. Stored alongside each finding
 // so historical reports can be traced back to the ruleset that produced them.
 // Lives here (not in a family module) because versioning spans every family.
-export const DETERMINISTIC_RULES_VERSION = "1.7.0";
+export const DETERMINISTIC_RULES_VERSION = "1.8.0";
 
 export { DETERMINISTIC_RULE_IDS } from "./rule-ids";
 export {

--- a/server/lib/review-rules/scripts.ts
+++ b/server/lib/review-rules/scripts.ts
@@ -3,7 +3,12 @@ import { firstMatchingLine } from "../text-utils";
 import type { Finding } from "../review";
 import { LIFECYCLE_SCRIPTS } from "./patterns";
 import { firstJsonPropertyLine, tag } from "./helpers";
-import { changedPrefix, type RuleContext } from "./context";
+import {
+  changedPrefix,
+  fileReachability,
+  type FileReachability,
+  type RuleContext,
+} from "./context";
 import { isDocumentationPath } from "./file-types";
 import { normalizeCodeForScanning } from "./normalize";
 
@@ -56,7 +61,8 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
     const normalized = ctx.codePatternSet === "python" ? sample : normalizeCodeForScanning(sample);
     const prefix = changedPrefix(ctx, file.path);
     const changed = ctx.diffByPath.get(file.path)?.status;
-    const lifecycleScriptFile = isLifecycleScriptFile(ctx, file.path);
+    const reachability = fileReachability(ctx, file.path);
+    const lifecycleScriptFile = reachability === "install";
 
     const processExecution = matchCategory(ctx.patterns.processExecution, sample, normalized);
     const networkAccess = matchCategory(ctx.patterns.networkAccess, sample, normalized);
@@ -66,13 +72,17 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
       processExecution.matched || dynamicEvaluation.matched || credentialAccess.matched;
 
     if (processExecution.matched) {
+      const severity = processExecutionSeverity(ctx, reachability, changed);
       findings.push(
         tag("codeProcessExecution", {
-          severity: "high",
+          severity,
           file: file.path,
           line: processExecution.line,
           evidence: `${prefix}process or shell execution`,
-          reason: "package may execute arbitrary commands",
+          reason:
+            severity === "high"
+              ? "package may execute arbitrary commands"
+              : "process or shell execution in a file the manifest neither runs on install nor exposes as an entrypoint; commonly local build tooling, so weighted below release significance",
         }),
       );
     }
@@ -144,31 +154,23 @@ function networkAccessSeverity(
   return changed === "added" && (lifecycleScriptFile || adjacentExecutionRisk) ? "high" : "medium";
 }
 
-function isLifecycleScriptFile(ctx: RuleContext, path: string): boolean {
-  const candidates = scriptPathCandidates(path);
-  return LIFECYCLE_SCRIPTS.some((script) => {
-    const command = ctx.scripts[script];
-    if (!command || ctx.implicitScripts[script] === command) return false;
-    return scriptCommandTokens(command).some((token) => candidates.has(token));
-  });
-}
-
-function scriptPathCandidates(path: string): Set<string> {
-  const normalized = path.replaceAll("\\", "/").replace(/^\.\//, "");
-  const withoutPackage = normalized.startsWith("package/")
-    ? normalized.slice("package/".length)
-    : normalized;
-  const basename = withoutPackage.split("/").at(-1) ?? withoutPackage;
-  const baseValues = [normalized, withoutPackage, basename];
-  const values = [...baseValues];
-  for (const value of baseValues) {
-    values.push(value.replace(/\.[^/.]+$/, ""));
-  }
-  return new Set(values.filter(Boolean));
-}
-
-function scriptCommandTokens(command: string): string[] {
-  return [...command.matchAll(/(?:\.\/)?[\w@./-]+(?:\.[\w-]+)?\b/g)].map((match) =>
-    match[0].replace(/^\.\//, ""),
-  );
+// Weight process/shell execution by where the code sits in the package, so a
+// local build helper that legitimately shells out is not scored the same as an
+// install hook. Install hooks (auto-run on `npm install`) and declared
+// entrypoints (run when the consumer imports/invokes the package) keep full
+// weight; an unreferenced build/source file is recorded but weighted below
+// release significance, with diff novelty splitting newly-introduced from
+// pre-existing capability. Co-occurring network/credential/eval capability still
+// escalates through its own rule, so a real dropper does not slip through.
+function processExecutionSeverity(
+  ctx: RuleContext,
+  reachability: FileReachability,
+  changed: RuleContext["diff"][number]["status"] | undefined,
+): Finding["severity"] {
+  // PyPI install reachability is modeled by the adapter's setup.py / startup-hook
+  // rules rather than the npm manifest map, so the reachability tiers above do
+  // not apply; keep the historical high severity for Python evidence.
+  if (ctx.codePatternSet === "python") return "high";
+  if (reachability !== "unreferenced") return "high";
+  return changed === "unchanged" ? "info" : "low";
 }

--- a/test/eval/detection-eval.test.mjs
+++ b/test/eval/detection-eval.test.mjs
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "vitest";
 import { runEval, writeReport } from "./harness.mjs";
 
-// Gated metrics only. Frontier recall, benign hard-negative FP rate, and
-// evasion robustness are deliberately *reported* (written to the report), not
-// asserted here — they start red and ratchet as detection improves. See
-// docs/detection-eval.md for the threshold ladder.
+// Gated metrics only. Frontier recall and evasion robustness are deliberately
+// *reported* (written to the report), not asserted here — they start red and
+// ratchet as detection improves. The benign hard-negative FP rate is the first
+// ratchet step and is now gated (< 10%) since install-reachability weighting
+// drove it to zero. See docs/detection-eval.md for the threshold ladder.
 const result = runEval();
 writeReport(result);
 
@@ -19,5 +20,9 @@ describe("detection eval (gated thresholds)", () => {
 
   test("no false positives on benign regression controls", () => {
     expect(result.regression.benign.falsePositives).toBe(0);
+  });
+
+  test("benign hard-negative false-positive rate stays under 10%", () => {
+    expect(result.benignHardNegatives.fpRate).toBeLessThan(0.1);
   });
 });

--- a/test/fixtures/security-corpus/cases-benign/legit-build-childprocess.json
+++ b/test/fixtures/security-corpus/cases-benign/legit-build-childprocess.json
@@ -5,7 +5,7 @@
   "verdict": "benign",
   "threatClass": "legit-childprocess",
   "source": "benign-popular",
-  "intent": "A real-world-shaped local build script that legitimately uses child_process. The deterministic rules flag code.process-execution, but the truth is benign. This case measures false-positive precision; it is expected to be a reported false positive until the detector gains context (e.g. not an install hook, well-known build pattern).",
+  "intent": "A real-world-shaped local build script that legitimately uses child_process. build.js is not reachable from any install hook or declared entrypoint, so install-reachability weighting records code.process-execution at low severity instead of high. This case measures false-positive precision: it must stay below the significant-finding threshold (no longer a benign hard-negative false positive).",
   "expectMinRisk": "low",
   "expectAnyRule": [],
   "previousPackageJson": { "name": "buildtool", "version": "2.0.0" },

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -79,6 +79,190 @@ describe("review", () => {
     );
   });
 
+  test("weights process execution down on an unreferenced build file", () => {
+    const staged = [
+      {
+        path: "package.json",
+        size: 41,
+        sha256: "pkg",
+        flags: [],
+        textSample: JSON.stringify({ name: "buildtool", version: "2.1.0" }),
+      },
+      {
+        path: "build.js",
+        size: 120,
+        sha256: "build",
+        flags: [],
+        textSample:
+          "const { execSync } = require('child_process');\n// local build, not an install hook\nexecSync('cc -O2 -o out/app src/app.c');\n",
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged), {
+      name: "buildtool",
+      version: "2.1.0",
+    });
+    const processFinding = findings.find((finding) => finding.ruleId === "code.process-execution");
+
+    expect(processFinding).toBeDefined();
+    expect(processFinding.severity).toBe("low");
+    // A lone build helper that shells out must not inflate release risk.
+    expect(computeRisk(findings)).toBe("low");
+  });
+
+  test("treats pre-existing unreferenced process execution as informational", () => {
+    const file = {
+      path: "scripts/compile.js",
+      size: 90,
+      sha256: "compile",
+      flags: [],
+      textSample: "require('child_process').execSync('make');\n",
+    };
+    const pkg = {
+      path: "package.json",
+      size: 41,
+      sha256: "pkg",
+      flags: [],
+      textSample: JSON.stringify({ name: "buildtool", version: "2.1.0" }),
+    };
+    const previous = [pkg, file];
+    const staged = [pkg, file];
+    const findings = deterministicFindings(staged, createPackageDiff(previous, staged), {
+      name: "buildtool",
+      version: "2.1.0",
+    });
+    const processFinding = findings.find((finding) => finding.ruleId === "code.process-execution");
+
+    expect(processFinding?.severity).toBe("info");
+  });
+
+  test("keeps process execution high when an install hook reaches the file", () => {
+    const staged = [
+      {
+        path: "package.json",
+        size: 90,
+        sha256: "pkg",
+        flags: [],
+        textSample: JSON.stringify({ scripts: { postinstall: "node tools/setup.js" } }),
+      },
+      {
+        path: "tools/setup.js",
+        size: 60,
+        sha256: "setup",
+        flags: [],
+        textSample: "require('child_process').execSync('cc -o out src.c');\n",
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged));
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: "code.process-execution",
+          severity: "high",
+          file: "tools/setup.js",
+        }),
+      ]),
+    );
+  });
+
+  test("keeps process execution high on a declared bin and the default entry", () => {
+    const binStaged = [
+      {
+        path: "package.json",
+        size: 90,
+        sha256: "pkg",
+        flags: [],
+        textSample: JSON.stringify({ name: "cli", version: "1.0.0", bin: { cli: "./bin/run.js" } }),
+      },
+      {
+        path: "bin/run.js",
+        size: 60,
+        sha256: "run",
+        flags: [],
+        textSample: "require('child_process').execSync('git status');\n",
+      },
+    ];
+    const binFindings = deterministicFindings(binStaged, createPackageDiff([], binStaged));
+    expect(
+      binFindings.find((finding) => finding.ruleId === "code.process-execution")?.severity,
+    ).toBe("high");
+
+    const entryStaged = [
+      {
+        path: "package.json",
+        size: 41,
+        sha256: "pkg2",
+        flags: [],
+        textSample: JSON.stringify({ name: "lib", version: "1.0.0" }),
+      },
+      {
+        path: "index.js",
+        size: 60,
+        sha256: "index",
+        flags: [],
+        textSample: "require('child_process').execSync('uname -a');\n",
+      },
+    ];
+    const entryFindings = deterministicFindings(entryStaged, createPackageDiff([], entryStaged));
+    expect(
+      entryFindings.find((finding) => finding.ruleId === "code.process-execution")?.severity,
+    ).toBe("high");
+
+    const metadataOnlyStaged = [
+      {
+        path: "package.json",
+        size: 120,
+        sha256: "pkg3",
+        flags: [],
+        textSample: JSON.stringify({
+          name: "cli-lib",
+          version: "1.0.0",
+          bin: { cli: "./bin/run.js" },
+          module: "./dist/module.js",
+          types: "./dist/index.d.ts",
+        }),
+      },
+      {
+        path: "index.js",
+        size: 60,
+        sha256: "index2",
+        flags: [],
+        textSample: "require('child_process').execSync('whoami');\n",
+      },
+    ];
+    const metadataOnlyFindings = deterministicFindings(
+      metadataOnlyStaged,
+      createPackageDiff([], metadataOnlyStaged),
+    );
+    expect(
+      metadataOnlyFindings.find((finding) => finding.ruleId === "code.process-execution")?.severity,
+    ).toBe("high");
+  });
+
+  test("does not treat a nested file with the entrypoint basename as runtime reachable", () => {
+    const staged = [
+      {
+        path: "package.json",
+        size: 62,
+        sha256: "pkg",
+        flags: [],
+        textSample: JSON.stringify({ name: "lib", version: "1.0.0", main: "index.js" }),
+      },
+      {
+        path: "src/index.js",
+        size: 60,
+        sha256: "src-index",
+        flags: [],
+        textSample: "require('child_process').execSync('make');\n",
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged));
+
+    expect(findings.find((finding) => finding.ruleId === "code.process-execution")?.severity).toBe(
+      "low",
+    );
+  });
+
   test("does not apply Python capability patterns to JavaScript packages", () => {
     const staged = [
       {


### PR DESCRIPTION
Closes #194. `code.process-execution` previously fired `high` regardless of whether the code was reachable from an install hook or sat in a plain local build script, so the benign `legit-build-childprocess` fixture tripped a false positive. This adds a manifest→file reachability map (`scripts`/`bin`/`main`/`module`/`exports`/default-`index.js`) to `RuleContext` and weights the rule by it: install hooks and declared entrypoints keep `high`, while an unreferenced build/source file drops to `low` (newly added/changed) or `info` (pre-existing) — with co-occurring network/credential/eval capability still escalating through its own rule so a real install-time dropper stays `high`. PyPI keeps the historical `high` severity because its install reachability is modeled by the adapter's `setup.py`/startup-hook rules, which preserves the npm↔PyPI parity group. The eval's benign hard-negative false-positive rate went 1 → 0 with malicious/critical recall unchanged at 100%, so that metric (`< 10%`) is now a gated threshold; `DETERMINISTIC_RULES_VERSION` bumps to `1.7.0`, with new unit tests and updated detection docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)