### PR TITLE
Require fresh 2FA step-up to decide a workflow approval gate

### DIFF
--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -149,8 +149,8 @@ organization (`x-organization-id` header to scope writes).
   controls. Returns the public gate shape (no `deployment_callback_url`); 404
   when the scan is not a gate review or belongs to another org.
 - `POST /workflow-gates/:gateId/decision` — records a maintainer's
-  `{ decision: "approved" | "rejected", comment? }` and releases/blocks the held
-  GitHub job. `markGateDecided` is the single CAS out of `pending`, so a
+  `{ decision: "approved" | "rejected", comment?, totpCode? }` and releases/blocks
+  the held GitHub job. `markGateDecided` is the single CAS out of `pending`, so a
   double-submit (or a race with the fail-closed artifact reject) returns 409.
   Approval requires the gate to be linked to a completed `workflow_gate` scan;
   rejection is allowed without one so maintainers can still fail closed.
@@ -160,6 +160,21 @@ organization (`x-organization-id` header to scope writes).
   also mirrored onto the underlying scan as `publish` for approved gates or
   `no_publish` for rejected gates when that write succeeds. Rate-limited to
   60/min per org.
+  - **2FA step-up (issue #162):** releasing or blocking a held deployment is
+    irreversible (approval immediately releases the job and publishing proceeds
+    over Trusted Publishing/OIDC), so when the deciding maintainer has two-factor
+    auth enabled they must include a **fresh** `totpCode` from their authenticator
+    app. A missing code returns `401 { code: "two_factor_required" }` and a wrong
+    code `401 { code: "two_factor_invalid" }`; both leave the gate `pending` and
+    never post to GitHub. The code is verified against the request's own session
+    via Better Auth's `verifyTOTP` (`server/lib/auth.ts`), so a stale session is
+    not enough. Step-up attempts are rate-limited to 10 per 15 min per user, and
+    the verified method is recorded on the `github_workflow_gate.approved` /
+    `.rejected` scan event (`twoFactor`, `twoFactorMethod`). Maintainers without
+    2FA decide as before. This requirement is specific to the **approval gate**;
+    the staged-publish decision (`POST /api/v1/scans/:id/decision`) is an audit
+    record only — it never publishes or cancels anything — and deliberately does
+    not require a step-up.
 
 `POST /release-targets` enforces every validation listed in issue #114:
 

--- a/docs/two-factor-auth.md
+++ b/docs/two-factor-auth.md
@@ -48,6 +48,37 @@ Enrolled users can regenerate backup codes
 (`POST /api/auth/two-factor/generate-backup-codes`, password-gated) or disable 2FA
 (`POST /api/auth/two-factor/disable`, password-gated) from Settings → General.
 
+### Step-up: deciding a workflow gate (issue #162)
+
+Two-factor is also a **step-up** factor for the highest-trust action in the product:
+releasing or blocking a held GitHub deployment gate (`POST
+/api/v1/github-app/workflow-gates/:gateId/decision`). Approving a gate immediately
+releases the held Actions job and publishing proceeds over Trusted Publishing/OIDC,
+which cannot be reversed — so an existing session alone is not enough.
+
+When the deciding maintainer has 2FA enabled, the request must carry a **fresh**
+`totpCode`. The route checks enrollment with `userHasTwoFactor` and verifies the code
+with `verifyTotpStepUp` (both in `server/lib/auth.ts`), which delegates to Better
+Auth's own `verifyTOTP` so the code is checked against the request's session user and
+the encrypted secret is never decrypted in app code. Outcomes:
+
+- no code → `401 { code: "two_factor_required" }`
+- wrong code → `401 { code: "two_factor_invalid" }`
+- valid code → the decision proceeds and the verified method is stamped on the
+  `github_workflow_gate.approved` / `.rejected` scan event (`twoFactor`,
+  `twoFactorMethod: "totp"`).
+
+A failed/missing step-up never mutates the gate (it stays `pending`) and never posts
+to GitHub. Step-up attempts have their own rate-limit bucket
+(`github-app:gate-decision-2fa:<userId>`, 10 per 15 min) on top of the route's
+60/min-per-org limit. The dialog (`GateDecisionDialog`) only shows the code field when
+the signed-in user has `twoFactorEnabled`.
+
+This is scoped to the approval gate. The **staged-publish** decision (`POST
+/api/v1/scans/:id/decision`) is an audit record only — it never publishes or cancels a
+release on npm — and intentionally does **not** require a step-up. Maintainers without
+2FA enabled decide gates without a code, as before.
+
 ## Endpoints
 
 All under the Better Auth base path `/api/auth` and handled by `auth.handler`:
@@ -97,3 +128,8 @@ already covers these POSTs.
   flow runs several scrypt hashes, so the test sets a 30s timeout.)
 - `test/e2e/two-factor.spec.ts` — Playwright flow: register → enable 2FA in Settings (reads the
   secret, computes a TOTP with `otpauth`) → sign out → sign in through the challenge step.
+- `test/workers/github-gate-two-factor.test.ts` — drives the real worker for the gate-decision
+  step-up: an enrolled maintainer is rejected without a code (`two_factor_required`) and with a
+  wrong code (`two_factor_invalid`) — the gate stays `pending` and nothing is posted to GitHub — a
+  fresh TOTP releases the gate and posts the decision exactly once, and a maintainer without 2FA
+  decides without a code.

--- a/server/lib/auth.ts
+++ b/server/lib/auth.ts
@@ -1,7 +1,8 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { twoFactor } from "better-auth/plugins";
-import { createDb } from "../db";
+import { eq } from "drizzle-orm";
+import { createDb, type AppDb } from "../db";
 import * as schema from "../db/schema";
 import { sendAccountVerificationEmail } from "./account-email";
 
@@ -85,6 +86,47 @@ export async function getAuthSession(auth: Auth, request: Request): Promise<Auth
 
 export async function isAuthenticated(auth: Auth, request: Request) {
   return Boolean(await getAuthSession(auth, request));
+}
+
+/**
+ * Whether the user has completed two-factor enrollment. Drives the step-up
+ * requirement on high-trust actions: a member who turned on 2FA must prove a
+ * fresh second factor before releasing or blocking a held deployment gate.
+ */
+export async function userHasTwoFactor(db: AppDb, userId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ enabled: schema.user.twoFactorEnabled })
+    .from(schema.user)
+    .where(eq(schema.user.id, userId))
+    .limit(1);
+  return Boolean(row?.enabled);
+}
+
+/**
+ * Verify a *fresh* TOTP step-up for the request's authenticated session.
+ *
+ * Delegates to Better Auth's own `verifyTOTP` so the code is checked against the
+ * session user's encrypted secret (never decrypted here) and is bound to the
+ * very session making the request — a member cannot step up on another's behalf.
+ * Returns `false` on any invalid code rather than throwing, so callers map it to
+ * a 401. No session side effects: for an already-authenticated, already-verified
+ * user the plugin only validates the code.
+ */
+export async function verifyTotpStepUp(
+  auth: Auth,
+  request: Request,
+  code: string,
+): Promise<boolean> {
+  try {
+    await (
+      auth.api as {
+        verifyTOTP(args: { body: { code: string }; headers: Headers }): Promise<unknown>;
+      }
+    ).verifyTOTP({ body: { code }, headers: request.headers });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function normalizeSession(data: unknown): AuthSession | null {

--- a/server/routes/github-app.ts
+++ b/server/routes/github-app.ts
@@ -429,6 +429,19 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
     throw err;
   }
 
+  const gateId = c.req.param("gateId");
+  const existing = await getGateForOrganization(db, organizationId, gateId);
+  if (!existing) return c.json({ error: "not found" }, 404);
+  if (decision === "approved") {
+    if (!existing.scanId) {
+      return c.json({ error: "approval requires a completed workflow-gate review" }, 409);
+    }
+    const scan = await getScan(db, existing.scanId, organizationId);
+    if (!scan || scan.scan.source !== "workflow_gate" || scan.scan.status !== "complete") {
+      return c.json({ error: "approval requires a completed workflow-gate review" }, 409);
+    }
+  }
+
   // 2FA step-up. Releasing or blocking a held deployment is a high-trust action
   // — approval immediately releases the GitHub job and publishing proceeds via
   // Trusted Publishing/OIDC, which can't be reversed. So a maintainer who has
@@ -461,19 +474,6 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
       return c.json({ error: "invalid two-factor code", code: "two_factor_invalid" }, 401);
     }
     twoFactorVerified = true;
-  }
-
-  const gateId = c.req.param("gateId");
-  const existing = await getGateForOrganization(db, organizationId, gateId);
-  if (!existing) return c.json({ error: "not found" }, 404);
-  if (decision === "approved") {
-    if (!existing.scanId) {
-      return c.json({ error: "approval requires a completed workflow-gate review" }, 409);
-    }
-    const scan = await getScan(db, existing.scanId, organizationId);
-    if (!scan || scan.scan.source !== "workflow_gate" || scan.scan.status !== "complete") {
-      return c.json({ error: "approval requires a completed workflow-gate review" }, 409);
-    }
   }
 
   const reportUrl = buildReportUrl(c.env, existing.scanId);

--- a/server/routes/github-app.ts
+++ b/server/routes/github-app.ts
@@ -11,6 +11,7 @@ import {
   requireActiveOrganization,
   requireActiveOrganizationContext,
 } from "../lib/active-organization";
+import { userHasTwoFactor, verifyTotpStepUp } from "../lib/auth";
 import { roleCanManageIntegrations } from "../lib/roles";
 import { rateLimitResponse } from "../lib/http";
 import { describeOperationalError, emitOperationalEvent } from "../lib/observability";
@@ -401,6 +402,7 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
   const body = (await c.req.json().catch(() => ({}))) as Partial<{
     decision: string;
     comment: string;
+    totpCode: string;
   }>;
   if (!GATE_DECISION_SET.has(body.decision as GateDecision)) {
     return c.json({ error: "decision must be 'approved' or 'rejected'" }, 400);
@@ -425,6 +427,40 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
       return rateLimitResponse(c, "gate decision rate limit exceeded", err);
     }
     throw err;
+  }
+
+  // 2FA step-up. Releasing or blocking a held deployment is a high-trust action
+  // — approval immediately releases the GitHub job and publishing proceeds via
+  // Trusted Publishing/OIDC, which can't be reversed. So a maintainer who has
+  // enrolled in two-factor auth must prove a *fresh* second factor here; an
+  // existing session is not enough. Members without 2FA decide as before. (The
+  // staged-publish decision in scans.ts is an audit record only — it never
+  // publishes or cancels anything — and deliberately never requires this.)
+  let twoFactorVerified = false;
+  if (await userHasTwoFactor(db, session.userId)) {
+    try {
+      await enforceRateLimit(db, {
+        key: `github-app:gate-decision-2fa:${session.userId}`,
+        limit: 10,
+        windowMs: 15 * 60 * 1000,
+      });
+    } catch (err) {
+      if (err instanceof RateLimitError) {
+        return rateLimitResponse(c, "too many two-factor attempts", err);
+      }
+      throw err;
+    }
+    const totpCode = typeof body.totpCode === "string" ? body.totpCode.trim() : "";
+    if (!totpCode) {
+      return c.json(
+        { error: "two-factor verification required", code: "two_factor_required" },
+        401,
+      );
+    }
+    if (!(await verifyTotpStepUp(c.get("auth"), c.req.raw, totpCode))) {
+      return c.json({ error: "invalid two-factor code", code: "two_factor_invalid" }, 401);
+    }
+    twoFactorVerified = true;
   }
 
   const gateId = c.req.param("gateId");
@@ -477,7 +513,13 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
       scanId: decided.scanId,
       type:
         decision === "approved" ? "github_workflow_gate.approved" : "github_workflow_gate.rejected",
-      metadata: { gateId, decidedBy: "human", reportUrl },
+      metadata: {
+        gateId,
+        decidedBy: "human",
+        reportUrl,
+        twoFactor: twoFactorVerified,
+        twoFactorMethod: twoFactorVerified ? "totp" : null,
+      },
     });
   } catch (err) {
     emitOperationalEvent("warn", "github_workflow_gate.decision_bookkeeping_failed", {

--- a/src/models/github-app.ts
+++ b/src/models/github-app.ts
@@ -68,10 +68,16 @@ export function decideWorkflowGate(
   gateId: string,
   decision: WorkflowGateDecision,
   comment: string | null,
+  totpCode?: string | null,
 ): Promise<{ gate: PublicWorkflowGate }> {
+  const payload: { decision: WorkflowGateDecision; comment?: string; totpCode?: string } = {
+    decision,
+  };
+  if (comment) payload.comment = comment;
+  if (totpCode) payload.totpCode = totpCode;
   return apiJson<{ gate: PublicWorkflowGate }>(
     `/api/v1/github-app/workflow-gates/${encodeURIComponent(gateId)}/decision`,
-    comment ? { decision, comment } : { decision },
+    payload,
   );
 }
 

--- a/src/models/github-app.ts
+++ b/src/models/github-app.ts
@@ -78,7 +78,22 @@ export function decideWorkflowGate(
   return apiJson<{ gate: PublicWorkflowGate }>(
     `/api/v1/github-app/workflow-gates/${encodeURIComponent(gateId)}/decision`,
     payload,
-  );
+  ).catch((err) => {
+    if (err instanceof ApiError && err.status === 401) {
+      if (err.code === "two_factor_required") {
+        throw new ApiError(
+          "Enter your authentication code to decide this gate.",
+          401,
+          err.detail,
+          err.code,
+        );
+      }
+      if (err.code === "two_factor_invalid") {
+        throw new ApiError("That authentication code is invalid.", 401, err.detail, err.code);
+      }
+    }
+    throw err;
+  });
 }
 
 export interface InstallationRepository {

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -415,13 +415,17 @@ export const ScanDetailModel = createModel((id: string) => {
       }
     },
 
-    async decideGate(decision: WorkflowGateDecision, comment: string | null): Promise<void> {
+    async decideGate(
+      decision: WorkflowGateDecision,
+      comment: string | null,
+      totpCode: string | null = null,
+    ): Promise<void> {
       const current = this.gate.peek();
       if (!current) return;
       this.gateDecisionStatus.value = "saving";
       this.gateDecisionError.value = null;
       try {
-        const { gate: updated } = await decideWorkflowGate(current.id, decision, comment);
+        const { gate: updated } = await decideWorkflowGate(current.id, decision, comment, totpCode);
         this.gate.value = updated;
         this.gateDecisionStatus.value = "idle";
         // The decision also writes the scan's publish/no_publish decision and an

--- a/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
@@ -94,6 +94,7 @@ export function GateDecisionDialog({
   status,
   error,
   canApprove,
+  requireTwoFactor,
   onSubmit,
 }: {
   open: boolean;
@@ -103,20 +104,32 @@ export function GateDecisionDialog({
   status: DecisionStatus;
   error: string | null;
   canApprove: boolean;
-  onSubmit: (decision: WorkflowGateDecision, comment: string | null) => void | Promise<void>;
+  requireTwoFactor: boolean;
+  onSubmit: (
+    decision: WorkflowGateDecision,
+    comment: string | null,
+    totpCode: string | null,
+  ) => void | Promise<void>;
 }) {
   const commentDraft = useSignal("");
+  const codeDraft = useSignal("");
   const saving = status === "saving";
   const decided = gate.status === "approved" || gate.status === "rejected";
+  const needsCode = requireTwoFactor && !decided;
+  const code = codeDraft.value.trim();
+  const blockedOnCode = needsCode && code.length === 0;
 
   useEffect(() => {
-    if (open) commentDraft.value = "";
+    if (open) {
+      commentDraft.value = "";
+      codeDraft.value = "";
+    }
   }, [open]);
 
   const submit = (next: WorkflowGateDecision) => {
-    if (saving || decided) return;
+    if (saving || decided || blockedOnCode) return;
     const trimmed = commentDraft.value.trim();
-    void onSubmit(next, trimmed.length ? trimmed : null);
+    void onSubmit(next, trimmed.length ? trimmed : null, needsCode ? code : null);
   };
 
   const handleClose = () => {
@@ -159,6 +172,26 @@ export function GateDecisionDialog({
         />
       </Field>
 
+      {needsCode ? (
+        <Field label="Authentication code" for="gateTotp">
+          <Input
+            id="gateTotp"
+            type="text"
+            value={codeDraft.value}
+            placeholder="6-digit code"
+            inputmode="numeric"
+            autocomplete="one-time-code"
+            maxLength={8}
+            spellcheck={false}
+            disabled={saving}
+            onInput={(e) => (codeDraft.value = (e.target as HTMLInputElement).value)}
+          />
+          <Muted class="m-0 mt-1 text-[12px]">
+            Confirm with the code from your authenticator app to release or block this deployment.
+          </Muted>
+        </Field>
+      ) : null}
+
       {decided ? (
         <Muted class="m-0 text-[13px]">
           This gate has already been decided. The decision is final — GitHub has been notified.
@@ -166,11 +199,15 @@ export function GateDecisionDialog({
       ) : (
         <div class="flex flex-wrap gap-2">
           {canApprove ? (
-            <Button onClick={() => submit("approved")} disabled={saving}>
+            <Button onClick={() => submit("approved")} disabled={saving || blockedOnCode}>
               {saving ? "Submitting…" : "Approve & release"}
             </Button>
           ) : null}
-          <Button variant="danger" onClick={() => submit("rejected")} disabled={saving}>
+          <Button
+            variant="danger"
+            onClick={() => submit("rejected")}
+            disabled={saving || blockedOnCode}
+          >
             {saving ? "Submitting…" : "Reject & block"}
           </Button>
         </div>

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -190,8 +190,12 @@ export default function ScanDetailPage() {
     }
   };
 
-  const handleGateDecision = async (decision: WorkflowGateDecision, comment: string | null) => {
-    await model.decideGate(decision, comment);
+  const handleGateDecision = async (
+    decision: WorkflowGateDecision,
+    comment: string | null,
+    totpCode: string | null,
+  ) => {
+    await model.decideGate(decision, comment, totpCode);
     if (model.gateDecisionStatus.peek() === "idle") {
       gateDialogOpen.value = false;
     }
@@ -388,16 +392,24 @@ function GateDialogHost({
   statusSignal,
   errorSignal,
   ...props
-}: Omit<ComponentProps<typeof GateDecisionDialog>, "open" | "status" | "error"> & {
+}: Omit<
+  ComponentProps<typeof GateDecisionDialog>,
+  "open" | "status" | "error" | "requireTwoFactor"
+> & {
   openSignal: ReadonlySignal<boolean>;
   statusSignal: ReadonlySignal<DecisionStatus>;
   errorSignal: ReadonlySignal<string | null>;
 }) {
+  // Read the session here so a step-up prompt only appears for members who
+  // enrolled in 2FA. Reading it inside the host keeps the subscription off the
+  // page body (which renders the per-finding risk list).
+  const requireTwoFactor = Boolean(sessionModel.session.value?.user.twoFactorEnabled);
   return (
     <GateDecisionDialog
       open={openSignal.value}
       status={statusSignal.value}
       error={errorSignal.value}
+      requireTwoFactor={requireTwoFactor}
       {...props}
     />
   );

--- a/test/workers/github-gate-two-factor.test.ts
+++ b/test/workers/github-gate-two-factor.test.ts
@@ -142,7 +142,12 @@ async function enrollTwoFactor(jar: Jar): Promise<string> {
 
 // Seed an installation + release target + a pending gate whose linked review
 // scan is already complete, so the gate is decidable (approval requires it).
-async function seedDecidableGate(organizationId: string, ownerUserId: string): Promise<string> {
+async function seedDecidableGate(
+  organizationId: string,
+  ownerUserId: string,
+  options: { completeScan?: boolean } = {},
+): Promise<string> {
+  const completeScan = options.completeScan ?? true;
   const db = createDb(env.DB);
   const now = new Date();
   const installation = await upsertInstallation(db, {
@@ -193,22 +198,24 @@ async function seedDecidableGate(organizationId: string, ownerUserId: string): P
     createdAt: now,
     updatedAt: now,
   });
-  await persistScan(db, {
-    id: scanId,
-    stageId: `workflow-gate:${gateId}`,
-    organizationId,
-    ownerUserId,
-    packageJson: { name: "pkg", version: "1.0.0" },
-    previousPackageJson: null,
-    risk: "low",
-    status: "complete",
-    summary: { diff: [] },
-    ai: null,
-    files: [],
-    previousFiles: [],
-    diff: [],
-    findings: [],
-  });
+  if (completeScan) {
+    await persistScan(db, {
+      id: scanId,
+      stageId: `workflow-gate:${gateId}`,
+      organizationId,
+      ownerUserId,
+      packageJson: { name: "pkg", version: "1.0.0" },
+      previousPackageJson: null,
+      risk: "low",
+      status: "complete",
+      summary: { diff: [] },
+      ai: null,
+      files: [],
+      previousFiles: [],
+      diff: [],
+      findings: [],
+    });
+  }
   return gateId;
 }
 
@@ -233,6 +240,36 @@ afterEach(() => {
 });
 
 describe("workflow-gate decision 2FA step-up", () => {
+  test(
+    "an enrolled maintainer is not prompted for 2FA when approval is not yet allowed",
+    { timeout: 30_000 },
+    async () => {
+      const jar: Jar = new Map();
+      const userId = await signUp(jar);
+      await enrollTwoFactor(jar);
+      const organizationId = personalOrganizationId(userId);
+      await ensurePersonalOrganization(createDb(env.DB), { userId });
+      const gateId = await seedDecidableGate(organizationId, userId, { completeScan: false });
+
+      const decisionCalls: { state: string }[] = [];
+      mockGithubDecisionFetch(decisionCalls);
+
+      const res = await call("POST", `/api/v1/github-app/workflow-gates/${gateId}/decision`, {
+        body: { decision: "approved" },
+        jar,
+        env: await githubEnv(),
+      });
+
+      expect(res.res.status).toBe(409);
+      expect(res.json).toMatchObject({
+        error: "approval requires a completed workflow-gate review",
+      });
+      const stored = await getGateForOrganization(createDb(env.DB), organizationId, gateId);
+      expect(stored?.status).toBe("pending");
+      expect(decisionCalls).toHaveLength(0);
+    },
+  );
+
   test(
     "an enrolled maintainer cannot decide a gate without a fresh code",
     { timeout: 30_000 },

--- a/test/workers/github-gate-two-factor.test.ts
+++ b/test/workers/github-gate-two-factor.test.ts
@@ -1,0 +1,342 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import * as OTPAuth from "otpauth";
+import worker from "../../server/index";
+import { createDb, createScanJob, ensurePersonalOrganization, persistScan } from "../../server/db";
+import * as schema from "../../server/db/schema";
+import {
+  createReleaseTarget,
+  getGateForOrganization,
+  upsertInstallation,
+} from "../../server/lib/github-app";
+import { personalOrganizationId } from "../../server/lib/ownership";
+
+// 2FA gate-decision step-up is the trust boundary in issue #162: a maintainer
+// who enrolled in two-factor auth must prove a *fresh* second factor before a
+// held GitHub deployment is released or blocked. These specs drive the real
+// worker end to end (real session cookies + Better Auth TOTP enrollment) so the
+// step-up is exercised exactly as the browser hits it. The staged-publish
+// decision (`/api/v1/scans/:id/decision`) intentionally never requires this and
+// is covered separately.
+
+const ORIGIN = "http://example.com";
+const PASSWORD = "correct horse battery staple";
+const originalFetch = globalThis.fetch;
+
+type Jar = Map<string, string>;
+
+function mergeSetCookies(jar: Jar, res: Response) {
+  const cookies = res.headers.getSetCookie?.() ?? [];
+  for (const raw of cookies) {
+    const [pair] = raw.split(";");
+    const idx = pair.indexOf("=");
+    if (idx === -1) continue;
+    jar.set(pair.slice(0, idx).trim(), pair.slice(idx + 1).trim());
+  }
+}
+
+function cookieHeader(jar: Jar): string {
+  return [...jar.entries()].map(([k, v]) => `${k}=${v}`).join("; ");
+}
+
+interface CallOptions {
+  body?: unknown;
+  jar?: Jar;
+  env?: typeof env;
+}
+
+async function call(method: string, path: string, opts: CallOptions = {}) {
+  const ctx = createExecutionContext();
+  const headers = new Headers();
+  if (opts.body !== undefined) headers.set("content-type", "application/json");
+  if (!["GET", "HEAD", "OPTIONS"].includes(method)) headers.set("origin", ORIGIN);
+  if (opts.jar && opts.jar.size) headers.set("cookie", cookieHeader(opts.jar));
+  const init: RequestInit = { method, headers };
+  if (opts.body !== undefined) init.body = JSON.stringify(opts.body);
+  const res = await worker.fetch(new Request(`${ORIGIN}${path}`, init), opts.env ?? env, ctx);
+  await waitOnExecutionContext(ctx);
+  if (opts.jar) mergeSetCookies(opts.jar, res);
+  const text = await res.text();
+  let json: unknown = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = null;
+  }
+  return { res, json: json as Record<string, unknown> | null, text };
+}
+
+let testPrivateKeyPem: string | null = null;
+async function getTestPrivateKeyPem(): Promise<string> {
+  if (testPrivateKeyPem) return testPrivateKeyPem;
+  const keyPair = (await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256",
+    },
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  const pkcs8 = await crypto.subtle.exportKey("pkcs8", keyPair.privateKey);
+  let binary = "";
+  for (const byte of new Uint8Array(pkcs8)) binary += String.fromCharCode(byte);
+  const base64 = btoa(binary);
+  const lines = base64.match(/.{1,64}/g)?.join("\n") ?? base64;
+  testPrivateKeyPem = `-----BEGIN PRIVATE KEY-----\n${lines}\n-----END PRIVATE KEY-----`;
+  return testPrivateKeyPem;
+}
+
+// The GitHub App env the decision-delivery path needs to mint an installation
+// token and POST the deployment callback. Shares BETTER_AUTH_SECRET/URL with the
+// base test env so session cookies minted during sign-up stay valid.
+async function githubEnv(): Promise<typeof env> {
+  return {
+    ...env,
+    GITHUB_APP_ID: "12345",
+    GITHUB_APP_SLUG: "drydock-test",
+    GITHUB_APP_CLIENT_ID: "client-id",
+    GITHUB_APP_CLIENT_SECRET: "client-secret",
+    GITHUB_APP_PRIVATE_KEY: await getTestPrivateKeyPem(),
+    GITHUB_APP_WEBHOOK_SECRET: "webhook-secret-value-1234567890",
+    GITHUB_APP_STATE_SECRET: "0123456789abcdef0123456789abcdef",
+  } as typeof env;
+}
+
+function totpFor(totpURI: string): string {
+  const parsed = OTPAuth.URI.parse(totpURI) as OTPAuth.TOTP;
+  return parsed.generate();
+}
+
+async function signUp(jar: Jar): Promise<string> {
+  const email = `gate2fa-${crypto.randomUUID()}@example.test`;
+  const up = await call("POST", "/api/auth/sign-up/email", {
+    body: { name: "Gate Tester", email, password: PASSWORD },
+    jar,
+  });
+  expect(up.res.status).toBe(200);
+  const session = await call("GET", "/api/auth/get-session", { jar });
+  const userId = (session.json?.user as { id?: string } | undefined)?.id;
+  expect(typeof userId).toBe("string");
+  return userId as string;
+}
+
+// Enroll the signed-in user in TOTP 2FA and return the otpauth URI so the spec
+// can mint fresh codes at decision time.
+async function enrollTwoFactor(jar: Jar): Promise<string> {
+  const enable = await call("POST", "/api/auth/two-factor/enable", {
+    body: { password: PASSWORD },
+    jar,
+  });
+  expect(enable.res.status).toBe(200);
+  const totpURI = enable.json?.totpURI as string;
+  expect(typeof totpURI).toBe("string");
+  const verify = await call("POST", "/api/auth/two-factor/verify-totp", {
+    body: { code: totpFor(totpURI) },
+    jar,
+  });
+  expect(verify.res.status).toBe(200);
+  return totpURI;
+}
+
+// Seed an installation + release target + a pending gate whose linked review
+// scan is already complete, so the gate is decidable (approval requires it).
+async function seedDecidableGate(organizationId: string, ownerUserId: string): Promise<string> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const installation = await upsertInstallation(db, {
+    organizationId,
+    installationId: `${Math.floor(Math.random() * 1e9)}`,
+    accountLogin: "octo",
+    accountType: "Organization",
+    targetType: "Organization",
+    status: "active",
+    createdByUserId: null,
+  });
+  const runId = Math.floor(Math.random() * 1e6) + 1;
+  const releaseTarget = await createReleaseTarget(db, {
+    organizationId,
+    installationRowId: installation.id,
+    ecosystem: "pypi",
+    repositoryId: Math.floor(Math.random() * 1e6) + 1,
+    repositoryFullName: "octo/example",
+    environment: "pypi",
+    createdByUserId: null,
+  });
+  const gateId = crypto.randomUUID();
+  const scanId = `scan_${crypto.randomUUID()}`;
+  await createScanJob(db, {
+    id: scanId,
+    stageId: `workflow-gate:${gateId}`,
+    organizationId,
+    ownerUserId,
+    source: "workflow_gate",
+  });
+  await db.insert(schema.githubWorkflowGates).values({
+    id: gateId,
+    organizationId,
+    installationRowId: installation.id,
+    releaseTargetId: releaseTarget.id,
+    deliveryId: crypto.randomUUID(),
+    repositoryId: releaseTarget.repositoryId,
+    repositoryFullName: "octo/example",
+    environment: "pypi",
+    runId,
+    deploymentId: 909,
+    deploymentCallbackUrl: `https://api.github.com/repos/octo/example/actions/runs/${runId}/deployment_protection_rule`,
+    eventAction: "requested",
+    status: "pending",
+    decision: null,
+    scanId,
+    requestedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  });
+  await persistScan(db, {
+    id: scanId,
+    stageId: `workflow-gate:${gateId}`,
+    organizationId,
+    ownerUserId,
+    packageJson: { name: "pkg", version: "1.0.0" },
+    previousPackageJson: null,
+    risk: "low",
+    status: "complete",
+    summary: { diff: [] },
+    ai: null,
+    files: [],
+    previousFiles: [],
+    diff: [],
+    findings: [],
+  });
+  return gateId;
+}
+
+// Mocks the two GitHub calls the delivery path makes (install token + callback)
+// and records each posted decision state.
+function mockGithubDecisionFetch(decisionCalls: { state: string }[]) {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    if (request.url.includes("/access_tokens")) {
+      return Response.json({ token: "ghs_install_token", expires_at: "2099-01-01T00:00:00Z" });
+    }
+    if (request.url.endsWith("/deployment_protection_rule")) {
+      decisionCalls.push((await request.json()) as { state: string });
+      return new Response(null, { status: 204 });
+    }
+    throw new Error(`unexpected fetch in gate 2FA test: ${request.url}`);
+  });
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("workflow-gate decision 2FA step-up", () => {
+  test(
+    "an enrolled maintainer cannot decide a gate without a fresh code",
+    { timeout: 30_000 },
+    async () => {
+      const jar: Jar = new Map();
+      const userId = await signUp(jar);
+      await enrollTwoFactor(jar);
+      const organizationId = personalOrganizationId(userId);
+      await ensurePersonalOrganization(createDb(env.DB), { userId });
+      const gateId = await seedDecidableGate(organizationId, userId);
+
+      const decisionCalls: { state: string }[] = [];
+      mockGithubDecisionFetch(decisionCalls);
+
+      const res = await call("POST", `/api/v1/github-app/workflow-gates/${gateId}/decision`, {
+        body: { decision: "approved" },
+        jar,
+        env: await githubEnv(),
+      });
+
+      expect(res.res.status).toBe(401);
+      expect(res.json).toMatchObject({ code: "two_factor_required" });
+      // The gate is untouched and GitHub was never told to release the job.
+      const stored = await getGateForOrganization(createDb(env.DB), organizationId, gateId);
+      expect(stored?.status).toBe("pending");
+      expect(decisionCalls).toHaveLength(0);
+    },
+  );
+
+  test(
+    "an enrolled maintainer cannot decide a gate with an invalid code",
+    { timeout: 30_000 },
+    async () => {
+      const jar: Jar = new Map();
+      const userId = await signUp(jar);
+      await enrollTwoFactor(jar);
+      const organizationId = personalOrganizationId(userId);
+      await ensurePersonalOrganization(createDb(env.DB), { userId });
+      const gateId = await seedDecidableGate(organizationId, userId);
+
+      const decisionCalls: { state: string }[] = [];
+      mockGithubDecisionFetch(decisionCalls);
+
+      const res = await call("POST", `/api/v1/github-app/workflow-gates/${gateId}/decision`, {
+        body: { decision: "approved", totpCode: "000000" },
+        jar,
+        env: await githubEnv(),
+      });
+
+      expect(res.res.status).toBe(401);
+      expect(res.json).toMatchObject({ code: "two_factor_invalid" });
+      const stored = await getGateForOrganization(createDb(env.DB), organizationId, gateId);
+      expect(stored?.status).toBe("pending");
+      expect(decisionCalls).toHaveLength(0);
+    },
+  );
+
+  test(
+    "a fresh TOTP step-up releases the gate and posts to GitHub once",
+    { timeout: 30_000 },
+    async () => {
+      const jar: Jar = new Map();
+      const userId = await signUp(jar);
+      const totpURI = await enrollTwoFactor(jar);
+      const organizationId = personalOrganizationId(userId);
+      await ensurePersonalOrganization(createDb(env.DB), { userId });
+      const gateId = await seedDecidableGate(organizationId, userId);
+
+      const decisionCalls: { state: string }[] = [];
+      mockGithubDecisionFetch(decisionCalls);
+
+      const res = await call("POST", `/api/v1/github-app/workflow-gates/${gateId}/decision`, {
+        body: { decision: "approved", totpCode: totpFor(totpURI) },
+        jar,
+        env: await githubEnv(),
+      });
+
+      expect(res.res.status).toBe(200);
+      expect(res.json).toMatchObject({ gate: { status: "approved", decision: "approved" } });
+      const stored = await getGateForOrganization(createDb(env.DB), organizationId, gateId);
+      expect(stored?.status).toBe("approved");
+      expect(decisionCalls).toHaveLength(1);
+      expect(decisionCalls[0].state).toBe("approved");
+    },
+  );
+
+  test("a maintainer without 2FA decides a gate without a code", { timeout: 30_000 }, async () => {
+    const jar: Jar = new Map();
+    const userId = await signUp(jar);
+    const organizationId = personalOrganizationId(userId);
+    await ensurePersonalOrganization(createDb(env.DB), { userId });
+    const gateId = await seedDecidableGate(organizationId, userId);
+
+    const decisionCalls: { state: string }[] = [];
+    mockGithubDecisionFetch(decisionCalls);
+
+    const res = await call("POST", `/api/v1/github-app/workflow-gates/${gateId}/decision`, {
+      body: { decision: "approved" },
+      jar,
+      env: await githubEnv(),
+    });
+
+    expect(res.res.status).toBe(200);
+    expect(res.json).toMatchObject({ gate: { status: "approved", decision: "approved" } });
+    expect(decisionCalls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Releasing or blocking a held GitHub deployment gate is irreversible — approval immediately releases the job and publishing proceeds over Trusted Publishing/OIDC — so a maintainer who has 2FA enabled must now prove a *fresh* TOTP at decision time on `POST /workflow-gates/:gateId/decision`; a missing code returns `two_factor_required` and a wrong code `two_factor_invalid`, both leaving the gate `pending` and never posting to GitHub. Verification delegates to Better Auth's `verifyTOTP` (bound to the request's own session, so a stale session is not enough), is rate-limited per user, and stamps the verified method onto the gate decision event. The UI shows an authenticator-code field on the release dialog only when the signed-in user has 2FA enabled. The staged-publish decision (`POST /api/v1/scans/:id/decision`) is an audit-only record that never publishes or cancels anything and deliberately requires no step-up, so it is untouched. Adds a real-worker integration test (enroll → decide without/with valid TOTP, exactly-once GitHub post, plus a non-2FA maintainer) and updates the 2FA and workflow-gate docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)