### PR TITLE
Weighted multi-signal risk scoring (replace max-severity roll-up)

### DIFF
--- a/docs/detection-eval.md
+++ b/docs/detection-eval.md
@@ -78,7 +78,7 @@ Recall is measured per class so blind spots are visible. Malicious:
 `network-exfil`, `native-artifact-smuggle`, `files-allowlist-escape`,
 `typosquat-metadata`, `protestware`, `dependency-confusion`,
 `wheel-integrity` (PyPI), `pth-injection` (PyPI). Benign hard-negatives:
-`legit-native`, `legit-childprocess`, `legit-env-read`.
+`legit-native`, `legit-childprocess`, `legit-env-read`, `legit-network`.
 
 ## Metrics
 
@@ -88,9 +88,14 @@ Recall is measured per class so blind spots are visible. Malicious:
 - **Frontier recall (reported).** Recall over `cases-frontier/`, which are
   labeled by _truth_ and intentionally hard. These are where real detection gaps
   show up. Starts low; that is the point.
-- **Benign false-positive rate (reported).** Over `cases-benign/`. Popular
+- **Benign false-positive rate (gated < 10%).** Over `cases-benign/`. Popular
   packages that legitimately use scary capabilities (native binaries, build-time
-  `child_process`, reading `process.env`). This is where precision is lost.
+  `child_process`, reading `process.env`). A benign case counts as a false
+  positive when the **risk roll-up** (`computeRisk`) treats it as risky (medium
+  or higher) — not merely when a finding fires. Deterministic findings stay
+  authoritative evidence; the weighted roll-up decides whether that evidence adds
+  up to risk. This keeps the benign-FP metric symmetric with malicious recall,
+  which is also risk-based. This is where precision is lost.
 - **Evasion robustness (reported).** For each transform, over npm malicious cases
   we currently catch:
   - `blockedRate` — would the product still treat it as risky? (often high,
@@ -103,9 +108,14 @@ Recall is measured per class so blind spots are visible. Malicious:
 - `splitStringLiterals` — `'child_process'` → `'chi'+'ld_process'`; defeats
   literal-based matches like `require('https')`.
 - `bracketifyMemberAccess` — `process.env` → `process['e'+'nv']`.
-- `base64Wrap` — wrap the payload in `eval(atob("…"))`. Note this _trips_ the
-  dynamic-evaluation rule, so the file stays "blocked" while the specific
-  network/process/credential rules are lost — the report shows that split.
+- `base64Wrap` — wrap the payload in `eval(atob("…"))`. This _trips_ the
+  dynamic-evaluation rule but loses the specific network/process/credential
+  rules (they are now inside the base64 string). Under the weighted roll-up an
+  isolated capability is not risk, so a wrapped payload whose only surviving
+  signal is the lone dynamic-evaluation no longer blocks unless a manifest signal
+  (e.g. `preinstall`) survives — the report shows that split. This is the same
+  gap as the assembled-identifier frontier case: it needs an AST/de-obfuscation
+  detector, not a regex.
 - `pushPastWindow` — prepend >64KB of filler, then truncate to the sandbox
   sample limit so the payload falls off the end. `codeRetention` goes to 0 and
   any case without a surviving manifest signal stops being blocked. This is the
@@ -114,16 +124,42 @@ Recall is measured per class so blind spots are visible. Malicious:
 
 ## Gated thresholds (and the ratchet)
 
-Only regression metrics are gated today (`detection-eval.test.mjs`):
+Gated metrics today (`detection-eval.test.mjs`):
 
 - malicious recall ≥ 90%
 - every `expectMinRisk: critical` case caught (100%)
 - zero false positives on benign controls
+- benign hard-negative FP rate < 10%
 
-Frontier recall, benign hard-negative FP rate, and evasion robustness are
-reported, not gated, so they can start red. Ratchet plan as the corpus and
-detector improve: gate benign FP rate < 10%, then gate frontier recall, then
+The benign hard-negative gate was turned on once the weighted multi-signal risk
+roll-up landed (see "Risk roll-up" below) — it dropped the FP rate from 100% (a
+lone build-time `child_process` landed high) to 0%.
+
+Frontier recall and evasion robustness are reported, not gated, so they can start
+red. Ratchet plan as the corpus and detector improve: gate frontier recall, then
 gate `pushPastWindow` survival once full-bytes scanning lands.
+
+## Risk roll-up (weighted multi-signal)
+
+The npm/PyPI risk roll-up (`computeRisk`, `server/lib/review.ts`) is not the max
+single-finding severity. Structural findings (install hooks, secrets,
+files-allowlist escapes, native artifacts, dependency specs, metadata) stay
+authoritative and floor the risk at their own severity. The noisy `code.*`
+capability findings — process execution, network, dynamic evaluation, credential
+access — are instead scored by **co-occurrence**, because benign build tooling and
+application code use each of them constantly:
+
+- an isolated capability is not risk on its own (the over-detection fix);
+- two capabilities escalate to high when a high-confidence primitive (process
+  execution or code evaluation) is involved, otherwise to medium;
+- three or more co-occurring capabilities is the full collect→exfiltrate shape →
+  high.
+
+This changes only the risk **roll-up**; deterministic findings are emitted
+unchanged, so they remain authoritative evidence on the diff. Install-context and
+diff-weighting refinements (e.g. distinguishing a build-time `child_process` from
+an install-hook one, or escalating an exfil chain inside a lifecycle script) are
+tracked separately.
 
 ## Corpus expansion
 

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -105,7 +105,7 @@ A PyPI review runs two rule families over the staged artifacts:
 
 - `pypi.*` findings come from `pyPiReleaseFindings` and carry `PYPI_RULES_VERSION` (currently `0.2.0`).
 - shared `file.*` / `code.*` / `diff.*` findings come from `deterministicFindings` and carry
-  `DETERMINISTIC_RULES_VERSION` (currently `1.6.2`).
+  `DETERMINISTIC_RULES_VERSION` (currently `1.6.3`).
 
 The harness asserts this per family: every `pypi.*` finding must equal `PYPI_RULES_VERSION` and every
 other finding must equal `DETERMINISTIC_RULES_VERSION`. Bump the relevant constant **and** update the
@@ -117,6 +117,8 @@ the same Python matcher must be used when annotating modified-file findings so r
 classification stays consistent for extensionless Python files. `1.6.2` excludes documentation from
 shared `code.*` capability findings, narrows JavaScript `fetch` matching to calls rather than class
 method declarations, and limits documentation secret-content matches to high-confidence token formats.
+`1.6.3` changes the visible risk roll-up so structural findings still floor risk by severity while
+`code.*` capability findings escalate by co-occurrence.
 `pypi.*` grew `startup-hook`,
 `record-mismatch`, and `unusual-dependency` in `0.2.0`, and
 `setup-install-command` was upgraded to fire on the top-level sdist `setup.py` install-time code, not

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -12,7 +12,7 @@ The fixture taxonomy is based on the current Drydock rule surface plus public np
 - [OpenSSF Package Analysis](https://github.com/ossf/package-analysis) tracks package behavior by asking what files packages access, what addresses they connect to, and what commands they run. Its public case studies are useful for behavior taxonomy, but Drydock should not execute packages.
 - [Datadog's malicious-software-packages-dataset](https://github.com/DataDog/malicious-software-packages-dataset/) is human-triaged and useful for taxonomy validation, but its samples are actively malicious and distributed as encrypted `infected` archives. Do not copy those samples into this repository.
 - Recent npm detection benchmark research reports a curated dataset of 6,420 malicious and 7,288 benign npm packages, with 11 behavior categories and 8 evasion categories. The most common behaviors were command execution, data collection, and data exfiltration; install scripts were used by about 72% of malicious packages in that study, and preinstall hooks were the dominant install-time entry point.
-- The same benchmark highlights the central detection trade-off: benign and malicious packages often call the same APIs. A single `process.env` or `https` use is capability evidence, while chains such as collect → serialize → exfiltrate are stronger intent evidence.
+- The same benchmark highlights the central detection trade-off: benign and malicious packages often call the same APIs. A single `process.env` or `https` use is capability evidence, while chains such as collect → serialize → exfiltrate are stronger intent evidence. The risk roll-up encodes exactly this: an isolated `code.*` capability is not risk on its own, while co-occurring capabilities escalate (see "Risk roll-up" below).
 - Network-only code follows that trade-off: unchanged network-only files are suppressed as package context, added network-only files remain medium-severity contextual evidence, and added network access escalates to high when it is tied to lifecycle scripts, process execution, dynamic evaluation, or credential access.
 - Documentation and prose files remain available as package evidence, but deterministic `code.*` rules do not treat them as executable capability evidence. Secret checks in documentation use only high-confidence token formats; generic key/value examples such as `token = localStorage.getItem("token")` are not `file.secret-content` findings.
 
@@ -37,7 +37,7 @@ Required fields:
 - `category` — taxonomy bucket.
 - `intent` — what behavior the fixture is meant to protect.
 - `stagedFiles` — sandbox-shaped `FileRecord[]` for the staged package.
-- `expectedRisk` — expected deterministic risk from `computeRisk()`.
+- `expectedRisk` — expected deterministic risk from the weighted `computeRisk()` roll-up (see "Risk roll-up" below).
 - `expectedFindings` — exact expected `{ ruleId, severity, file }` entries.
 
 Optional fields:
@@ -64,6 +64,15 @@ The first corpus slice covers:
 - files that appear in the tarball outside a declared `package.json.files` allowlist;
 - malformed `package.json` parse failure;
 - dependency and entrypoint package-json diff changes; unusual non-registry dependency specs now raise deterministic findings while entrypoint changes remain a documented coverage gap.
+
+## Risk roll-up
+
+`computeRisk()` is a weighted multi-signal roll-up, not the max single-finding severity. Findings split into two groups:
+
+- **Structural findings** (install hooks, secrets, files-allowlist escapes, native artifacts, dependency specs, metadata, tar anomalies) are authoritative on their own and floor the risk at their declared severity — exactly as before. Two high structural findings stay high (they do not stack into critical); a critical structural finding is critical.
+- **`code.*` capability findings** (process execution, network, dynamic evaluation, credential access) are scored by **co-occurrence**, because benign code uses each of them constantly. An isolated capability is low; two capabilities are high when a high-confidence primitive (process execution or code evaluation) is involved, otherwise medium; three or more is high.
+
+The final risk is the maximum of the structural floor and the co-occurrence score. This is a roll-up change only: the deterministic findings themselves are emitted unchanged, so a fixture's `expectedFindings` still asserts the raw evidence while `expectedRisk` asserts the weighted verdict. See `docs/detection-eval.md` for the eval that gates the resulting benign false-positive rate.
 
 ## Known coverage gaps
 
@@ -122,7 +131,7 @@ Required fields:
   `pypi`, `package`, `version`, and `artifacts[{path, sha256 (64 hex), url?}]`.
 - `artifacts` — `[{path, files: FileRecord[]}]`. Artifact paths must **exactly** match the manifest's
   artifact paths or `assertManifestArtifactSet` throws.
-- `expectedRisk` — expected risk from `computeRisk()`.
+- `expectedRisk` — expected risk from the weighted `computeRisk()` roll-up (shared with npm; see "Risk roll-up").
 - `expectedFindings` — exact `{ruleId, severity, file}` entries.
 
 Optional fields:

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -79,7 +79,7 @@ Persist by default:
 - package.json summary and diff;
 - deterministic findings;
 - AI findings (Flagship-gated and unavailable by default);
-- risk summary split into release, artifact, and context risk so `scans.risk` reflects the full artifact while unchanged hazards remain separated from the package-to-package release verdict;
+- risk summary split into release, artifact, and context risk so `scans.risk` reflects the full artifact while unchanged hazards remain separated from the package-to-package release verdict; each is a weighted multi-signal roll-up (structural findings floor the risk, `code.*` capabilities escalate by co-occurrence — see `docs/detection-eval.md`), not a max single-finding severity;
 - safety posture;
 - audit events;
 - future canonical report JSON.

--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -479,7 +479,12 @@ function countChangedFileEntries(diff: Array<{ status?: unknown }>): number {
  */
 function computeRiskSummary(
   persistedRisk: string,
-  findings: Array<{ severity?: string | null; releaseDelta: boolean; diffStatus: string }>,
+  findings: Array<{
+    severity?: string | null;
+    ruleId?: string | null;
+    releaseDelta: boolean;
+    diffStatus: string;
+  }>,
   persistedBreakdown?: Partial<ScanRiskBreakdown> | null,
 ): ScanRiskBreakdown {
   const releaseFindings = findings.filter((finding) => finding.releaseDelta);

--- a/server/lib/review-rules/index.ts
+++ b/server/lib/review-rules/index.ts
@@ -15,7 +15,7 @@ import { dependencyDiffFindings } from "./deps";
 // way that should invalidate cached scan reports. Stored alongside each finding
 // so historical reports can be traced back to the ruleset that produced them.
 // Lives here (not in a family module) because versioning spans every family.
-export const DETERMINISTIC_RULES_VERSION = "1.6.2";
+export const DETERMINISTIC_RULES_VERSION = "1.6.3";
 
 export { DETERMINISTIC_RULE_IDS } from "./rule-ids";
 export {

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -99,11 +99,82 @@ function tarSuspiciousReason(entry: TarSuspiciousEntry): string {
   }
 }
 
-export function computeRisk(findings: Array<{ severity?: string | null }>): RiskLevel {
-  if (findings.some((f) => f.severity === "critical")) return "critical";
-  if (findings.some((f) => f.severity === "high")) return "high";
-  if (findings.some((f) => f.severity === "medium")) return "medium";
-  return "low";
+// The four `code.*` rules detect runtime *capabilities*: the package can spawn
+// processes, reach the network, evaluate code at runtime, or read credentials.
+// Individually these are weak signals — benign build tooling and application code
+// use them constantly — so the literal max-severity roll-up both over-detected
+// (a lone `child_process` in a build helper landed high) and under-detected (a
+// chain of individually-medium capabilities never escalated). Risk roll-up scores
+// these by co-occurrence instead: an isolated capability is not risk on its own,
+// while a combination (read-env + network, or any code-evaluation primitive
+// paired with another capability) is the collect→exfiltrate / dropper shape.
+type CodeCapability = "process-execution" | "network" | "dynamic-evaluation" | "credential-access";
+
+const CODE_CAPABILITY_BY_RULE: Record<string, CodeCapability> = {
+  [DETERMINISTIC_RULE_IDS.codeProcessExecution]: "process-execution",
+  [DETERMINISTIC_RULE_IDS.codeNetworkAccess]: "network",
+  [DETERMINISTIC_RULE_IDS.codeDynamicEvaluation]: "dynamic-evaluation",
+  [DETERMINISTIC_RULE_IDS.codeCredentialAccess]: "credential-access",
+};
+
+// High-confidence malware primitives: arbitrary command execution and runtime
+// code evaluation/obfuscation are rare in benign *package* runtime code, so one
+// of them alongside any other capability is enough to escalate to high. Network
+// and credential reads are common in benign code, so two of those alone only
+// reach medium.
+const STRONG_CODE_CAPABILITIES = new Set<CodeCapability>([
+  "process-execution",
+  "dynamic-evaluation",
+]);
+
+function severityToRisk(severity: string | null | undefined): RiskLevel {
+  switch (severity) {
+    case "critical":
+      return "critical";
+    case "high":
+      return "high";
+    case "medium":
+      return "medium";
+    default:
+      return "low"; // "info" | "low" | unknown
+  }
+}
+
+function scoreCodeCapabilities(capabilities: Set<CodeCapability>): RiskLevel {
+  // An isolated capability is not risk by itself (the over-detection fix).
+  if (capabilities.size <= 1) return "low";
+  // Two capabilities only escalate to high when a high-confidence primitive is
+  // involved; two common reads (network + credential) stay medium.
+  if (capabilities.size === 2) {
+    return [...capabilities].some((capability) => STRONG_CODE_CAPABILITIES.has(capability))
+      ? "high"
+      : "medium";
+  }
+  // Three or more co-occurring capabilities is the full collect→exfiltrate shape.
+  return "high";
+}
+
+// Weighted multi-signal risk roll-up. Structural findings (install hooks, secrets,
+// files-allowlist escapes, native artifacts, dependency specs, metadata, …) stay
+// authoritative and floor the risk at their own severity, exactly as before. The
+// noisy `code.*` capability findings are instead scored by co-occurrence. This
+// changes only the risk *roll-up*; deterministic findings are emitted unchanged.
+export function computeRisk(
+  findings: Array<{ severity?: string | null; ruleId?: string | null }>,
+): RiskLevel {
+  let structuralFloor: RiskLevel = "low";
+  const codeCapabilities = new Set<CodeCapability>();
+  for (const finding of findings) {
+    const capability = finding.ruleId ? CODE_CAPABILITY_BY_RULE[finding.ruleId] : undefined;
+    // A code capability finding that is itself critical (not expected today) is
+    // never downgraded: it floors at critical like any other authoritative signal.
+    if (capability && finding.severity !== "critical") {
+      codeCapabilities.add(capability);
+      continue;
+    }
+    structuralFloor = combineRisk(structuralFloor, severityToRisk(finding.severity));
+  }
+  return combineRisk(structuralFloor, scoreCodeCapabilities(codeCapabilities));
 }
 
 export function combineRisk(...risks: Array<RiskLevel | null | undefined>): RiskLevel {

--- a/test/eval/detection-eval.test.mjs
+++ b/test/eval/detection-eval.test.mjs
@@ -1,9 +1,10 @@
 import { describe, expect, test } from "vitest";
 import { runEval, writeReport } from "./harness.mjs";
 
-// Gated metrics only. Frontier recall, benign hard-negative FP rate, and
-// evasion robustness are deliberately *reported* (written to the report), not
-// asserted here — they start red and ratchet as detection improves. See
+// Gated metrics. Frontier recall and evasion robustness are deliberately
+// *reported* (written to the report), not asserted here — they start red and
+// ratchet as detection improves. The benign hard-negative FP rate is now gated
+// (< 10%) after the weighted multi-signal risk roll-up landed; see
 // docs/detection-eval.md for the threshold ladder.
 const result = runEval();
 writeReport(result);
@@ -19,5 +20,9 @@ describe("detection eval (gated thresholds)", () => {
 
   test("no false positives on benign regression controls", () => {
     expect(result.regression.benign.falsePositives).toBe(0);
+  });
+
+  test("benign hard-negative false-positive rate stays under 10%", () => {
+    expect(result.benignHardNegatives.fpRate).toBeLessThan(0.1);
   });
 });

--- a/test/eval/harness.mjs
+++ b/test/eval/harness.mjs
@@ -115,8 +115,13 @@ function caughtAsMalicious(record, result) {
   return riskOk && ruleOk;
 }
 
-function hasSignificantFinding(result) {
-  return result.findings.some((f) => severityRank(f.severity) >= SIGNIFICANT_SEVERITY);
+// A benign package is a false positive when the *risk roll-up* — the verdict the
+// product surfaces — treats it as risky (medium or higher), not merely when a
+// finding fires. Deterministic findings stay authoritative evidence; the weighted
+// roll-up (computeRisk) decides whether that evidence amounts to risk. This keeps
+// the benign-FP metric symmetric with malicious recall, which is also risk-based.
+function flaggedRisky(result) {
+  return riskRank(result.risk) >= RISK_RANK.medium;
 }
 
 // --- Evasion transforms (npm/JS). Each mutates file text the way an attacker
@@ -189,11 +194,11 @@ export function runEval() {
   const regBenign = regression.filter((r) => r.verdict === "benign");
   const regCritical = regMalicious.filter((r) => r.expectMinRisk === "critical");
 
-  const benignFalsePositives = regBenign.filter((r) => hasSignificantFinding(detect(r)));
+  const benignFalsePositives = regBenign.filter((r) => flaggedRisky(detect(r)));
 
   const frontierMisses = frontier.filter((r) => !caughtAsMalicious(r, detect(r)));
 
-  const hardNegativeHits = benign.filter((r) => hasSignificantFinding(detect(r)));
+  const hardNegativeHits = benign.filter((r) => flaggedRisky(detect(r)));
 
   // Evasion: only mutate npm malicious cases we currently catch and that have a
   // code file to mutate. blockedRate = product still treats it as risky;

--- a/test/fixtures/security-corpus/README.md
+++ b/test/fixtures/security-corpus/README.md
@@ -4,10 +4,11 @@ This directory contains Drydock's synthetic golden corpus for deterministic stag
 
 - `cases/` holds npm fixtures evaluated by `test/security-corpus.test.mjs`.
 - `cases-pypi/` holds PyPI release-artifact fixtures evaluated by `test/security-corpus-pypi.test.mjs`.
+- `cases-frontier/` (truth-labeled hard misses) and `cases-benign/` (hard-negatives the rules may flag) are eval-only; the golden tests never read them. See `docs/detection-eval.md`.
 - Fixtures are intentionally small JSON documents, not tarballs and not real malware.
 - `stagedFiles`/`previousFiles` (npm) and `artifacts`/`previousArtifacts` (PyPI) use the same `FileRecord` shape returned by the sandbox.
 - `expectedFindings` names the exact deterministic rule IDs, severities, and files expected today.
-- `expectedRisk` records the expected deterministic risk from those findings.
+- `expectedRisk` records the expected risk from the weighted `computeRisk()` roll-up (structural findings floor the risk; `code.*` capabilities escalate by co-occurrence). See "Risk roll-up" in `docs/security-detection-corpus.md`.
 - Optional `expectedPackageJsonDiff` assertions cover diff surfaces that may not yet produce findings.
 - `coverageGaps` records intentional blind spots so future rule work can promote them into findings.
 

--- a/test/fixtures/security-corpus/cases-benign/legit-env-read.json
+++ b/test/fixtures/security-corpus/cases-benign/legit-env-read.json
@@ -1,0 +1,38 @@
+{
+  "id": "legit-env-read",
+  "title": "Config module legitimately reads process.env (benign hard-negative)",
+  "ecosystem": "npm",
+  "verdict": "benign",
+  "threatClass": "legit-env-read",
+  "source": "benign-popular",
+  "intent": "Almost every package reads configuration from process.env. The deterministic rules emit code.credential-access (authoritative evidence), but an isolated environment read with no network, process-execution, or code-evaluation capability alongside it is not risk. The weighted risk roll-up must keep this at low risk.",
+  "expectMinRisk": "low",
+  "expectAnyRule": [],
+  "previousPackageJson": { "name": "configlib", "version": "1.4.0" },
+  "stagedPackageJson": { "name": "configlib", "version": "1.5.0" },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 40,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"configlib\",\"version\":\"1.4.0\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 40,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"configlib\",\"version\":\"1.5.0\"}"
+    },
+    {
+      "path": "config.js",
+      "size": 150,
+      "sha256": "config-js",
+      "flags": [],
+      "textSample": "const mode = process.env.NODE_ENV || 'development';\nexport const config = { mode, debug: mode !== 'production' };\n"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-benign/legit-network-client.json
+++ b/test/fixtures/security-corpus/cases-benign/legit-network-client.json
@@ -1,0 +1,38 @@
+{
+  "id": "legit-network-client",
+  "title": "HTTP client wrapper legitimately calls fetch (benign hard-negative)",
+  "ecosystem": "npm",
+  "verdict": "benign",
+  "threatClass": "legit-network",
+  "source": "benign-popular",
+  "intent": "An API-client package whose whole purpose is to make HTTP requests. The deterministic rules emit code.network-access (authoritative evidence), but an isolated network capability with no credential read, process-execution, or code-evaluation capability alongside it is not the exfiltration shape. The weighted risk roll-up must keep this at low risk.",
+  "expectMinRisk": "low",
+  "expectAnyRule": [],
+  "previousPackageJson": { "name": "tiny-http-client", "version": "3.0.0" },
+  "stagedPackageJson": { "name": "tiny-http-client", "version": "3.1.0" },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 48,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"tiny-http-client\",\"version\":\"3.0.0\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 48,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"tiny-http-client\",\"version\":\"3.1.0\"}"
+    },
+    {
+      "path": "client.js",
+      "size": 160,
+      "sha256": "client-js",
+      "flags": [],
+      "textSample": "export async function getJson(url) {\n  const res = await fetch(url);\n  return res.json();\n}\n"
+    }
+  ]
+}

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -935,3 +935,94 @@ describe("review", () => {
     );
   });
 });
+
+describe("computeRisk weighted multi-signal roll-up", () => {
+  const finding = (ruleId, severity) => ({ ruleId, severity, file: "x", evidence: "", reason: "" });
+
+  test("no findings roll up to low", () => {
+    expect(computeRisk([])).toBe("low");
+  });
+
+  test("an isolated code capability is not risk on its own", () => {
+    // The over-detection fix: a lone capability finding (even one the rule emits
+    // at high severity) no longer escalates the risk roll-up.
+    expect(computeRisk([finding("code.process-execution", "high")])).toBe("low");
+    expect(computeRisk([finding("code.network-access", "medium")])).toBe("low");
+    expect(computeRisk([finding("code.credential-access", "high")])).toBe("low");
+    expect(computeRisk([finding("code.dynamic-evaluation", "high")])).toBe("low");
+  });
+
+  test("two co-occurring capabilities escalate by confidence", () => {
+    // A high-confidence primitive (process execution / code evaluation) alongside
+    // any other capability reaches high; two common reads only reach medium.
+    expect(
+      computeRisk([
+        finding("code.process-execution", "high"),
+        finding("code.network-access", "medium"),
+      ]),
+    ).toBe("high");
+    expect(
+      computeRisk([
+        finding("code.dynamic-evaluation", "high"),
+        finding("code.network-access", "high"),
+      ]),
+    ).toBe("high");
+    expect(
+      computeRisk([
+        finding("code.network-access", "medium"),
+        finding("code.credential-access", "medium"),
+      ]),
+    ).toBe("medium");
+  });
+
+  test("three co-occurring capabilities are the full exfiltrate shape", () => {
+    expect(
+      computeRisk([
+        finding("code.process-execution", "high"),
+        finding("code.network-access", "high"),
+        finding("code.credential-access", "high"),
+      ]),
+    ).toBe("high");
+  });
+
+  test("duplicate findings of one capability stay a single isolated signal", () => {
+    expect(
+      computeRisk([
+        finding("code.network-access", "medium"),
+        finding("code.network-access", "medium"),
+      ]),
+    ).toBe("low");
+  });
+
+  test("structural findings stay authoritative and floor the risk", () => {
+    expect(computeRisk([finding("file.outside-files-list", "high")])).toBe("high");
+    expect(computeRisk([finding("package-json.parse-failed", "medium")])).toBe("medium");
+    expect(computeRisk([finding("file.secret-content", "critical")])).toBe("critical");
+  });
+
+  test("multiple high structural findings stay high, not critical", () => {
+    expect(
+      computeRisk([
+        finding("dependency.unusual-spec", "high"),
+        finding("dependency.unusual-spec", "high"),
+      ]),
+    ).toBe("high");
+  });
+
+  test("an install hook plus code capabilities lands high; preinstall stays critical", () => {
+    expect(
+      computeRisk([
+        finding("install-script.lifecycle", "high"),
+        finding("code.process-execution", "high"),
+        finding("code.network-access", "medium"),
+        finding("code.credential-access", "medium"),
+      ]),
+    ).toBe("high");
+    expect(
+      computeRisk([
+        finding("install-script.preinstall", "critical"),
+        finding("code.process-execution", "high"),
+      ]),
+    ).toBe("critical");
+  });
+});

--- a/test/scan-pipeline-phases.test.mjs
+++ b/test/scan-pipeline-phases.test.mjs
@@ -104,7 +104,7 @@ function makeAdapter(overrides = {}) {
         reason: "credential-like content on a changed line",
         line: 2,
         ruleId: "code.credential-access",
-        ruleVersion: "1.6.2",
+        ruleVersion: "1.6.3",
       },
     ]),
     describe: vi.fn(() => ({

--- a/test/scan-pipeline.test.mjs
+++ b/test/scan-pipeline.test.mjs
@@ -624,7 +624,8 @@ describe("scan pipeline baseline selection", () => {
           size: 80,
           sha256: "same-risk",
           flags: [],
-          textSample: "require('child_process').execSync('true');\n",
+          textSample:
+            "require('child_process').execSync('true');\nrequire('https').get('https://example.invalid');\n",
         },
       ],
       packageJson: { name: "pkg", version: "1.0.1" },
@@ -643,7 +644,8 @@ describe("scan pipeline baseline selection", () => {
           size: 80,
           sha256: "same-risk",
           flags: [],
-          textSample: "require('child_process').execSync('true');\n",
+          textSample:
+            "require('child_process').execSync('true');\nrequire('https').get('https://example.invalid');\n",
         },
       ],
       packageJson: { name: "pkg", version: "1.0.0" },
@@ -663,7 +665,7 @@ describe("scan pipeline baseline selection", () => {
       releaseRisk: "low",
       contextRisk: "high",
       releaseFindingCount: 0,
-      contextFindingCount: 1,
+      contextFindingCount: 2,
     });
     expect(result.ruleFindings).toContainEqual(
       expect.objectContaining({


### PR DESCRIPTION
Closes #193. Replaces the max single-finding severity risk roll-up (`computeRisk`) with weighted multi-signal scoring: structural findings (install hooks, secrets, files-allowlist escapes, native artifacts, dependency specs, metadata) stay authoritative and floor the risk at their own severity, while the noisy `code.*` capability findings are scored by co-occurrence — an isolated capability is low, two escalate to high when a high-confidence primitive (process-exec or code-eval) is involved else medium, and three+ is high. Finding emission is unchanged; only the roll-up changes. This drops the benign hard-negative false-positive rate from 100% to 0% (now gated <10% in the detection eval, measured by the risk roll-up rather than raw finding severity) while keeping malicious recall at 100% with every critical case caught. Adds unit tests for the new roll-up, two isolated-capability benign fixtures, updates the affected pipeline test, and documents the model in `docs/detection-eval.md`, `docs/security-detection-corpus.md`, and `docs/security-model.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)