### PR TITLE
Add no-signal-conditional-jsx lint rule, skill, and docs

### DIFF
--- a/.claude/skills/preact-signals-no-eager-unwrap/SKILL.md
+++ b/.claude/skills/preact-signals-no-eager-unwrap/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: preact-signals-no-eager-unwrap
+description: Use when writing or reviewing Preact components that render signals — to avoid eagerly unwrapping `signal.value` in the component body for conditional rendering, text nodes, or attributes. Covers Show/Show-fallback, direct signal rendering, useComputed for derivations, the DOM-attribute vs plain-prop distinction, and the local `signals-local/no-signal-conditional-jsx` lint rule.
+---
+
+# Preact Signals: don't eagerly unwrap
+
+## Core idea
+
+Reading `signal.value` in a component body subscribes the **whole component**, so any
+change re-renders everything — even parts that didn't change. Unbox as late as possible:
+push the read down to a `<Show>` boundary, a `useComputed`, or a direct DOM/text binding so
+only the affected subtree updates. See [`preact-signals-preact-integration`] for the
+underlying "unbox late" model.
+
+"Eager unwrapping" is any `signal.value` read in the render body used only to feed JSX:
+a conditional, a text node, or an attribute. Each one has a tighter replacement.
+
+## The four anti-patterns and their fixes
+
+| You wrote | Replace with | Why |
+| --- | --- | --- |
+| `{cond.value ? <A/> : <B/>}` / `{cond.value && <A/>}` | `<Show when={cond} fallback={<B/>}>…</Show>` | conditional rendering → boundary component |
+| `{cond.value ? "Saving…" : "Save"}` (text) | `<Show when={cond} fallback="Save">Saving…</Show>` | a two-way toggle is still conditional rendering |
+| `{count}` where `count` is `count.value` only as a text child | `{count}` (pass the signal) | Preact owns the text-node subscription |
+| `{format(size.value)}` / `{trigger(open.value)}` (a derivation) | `const text = useComputed(() => format(size.value)); {text}` | a single derivation → computed, rendered directly |
+| `<input value={name.value} />` (DOM / `Input` / `Button`) | `<input value={name} />` | direct DOM binding, no component re-render |
+| `disabled={busy.value ? a : b}` (attribute, can't host `<Show>`) | `const d = useComputed(() => busy.value ? a : b); disabled={d}` | attribute-position derivation → computed |
+
+The headline mistake is the first row. There's a lint rule for it (below).
+
+## Conditional rendering → `<Show>`
+
+```tsx
+import { Show } from "@preact/signals/utils";
+
+// ❌ eager: the component re-renders whenever `error` changes
+{error.value ? <Alert tone="critical">{error.value}</Alert> : null}
+
+// ✅ only the <Show> boundary re-renders; the child fn receives the unwrapped value
+<Show when={error}>{(message) => <Alert tone="critical">{message}</Alert>}</Show>
+
+// ✅ two-way / else branch via fallback
+<Show when={loading} fallback="Save">Saving…</Show>
+
+// ✅ derived condition → thunk (NOT `when={derivedBoolean.value}`)
+<Show when={() => items.value.length > 0}>{() => <List items={items.value} />}</Show>
+```
+
+Rules of thumb:
+
+- `when={signal}` when the condition is exactly a signal's truthiness. `when={() => …}` for a
+  derived/compound/negated condition. Never `when={signal.value}` — that unwraps in the parent.
+- **Move every signal read that was inside the branch into the boundary** — use a function child
+  `{(v) => …}`, a `useComputed`, or pass the signal directly. If you leave `{x.value}` in plain
+  (non-function) children, it reads in the *parent* render and the read goes stale once the parent
+  stops re-rendering. `<Show>` only re-runs children when `when` re-runs.
+- `Show`'s child function receives `NonNullable<T>` of the `when` value, so
+  `when={user}` (a `Signal<User | null>`) gives you `(user: User) => …`.
+
+## A single derivation → `useComputed` (not `<Show>`)
+
+A `<Show>` is for *choosing what to render*. A value you compute from a signal and render once
+is a derivation — lift it into a `useComputed` and render the computed directly:
+
+```tsx
+// ❌ reads open.value in the body
+{trigger(open.value)}
+
+// ✅ the computed reads it inside its own boundary
+const triggerContent = useComputed(() => trigger(open.value));
+{triggerContent}
+```
+
+This also covers attribute-position derivations, which can't host a `<Show>`:
+
+```tsx
+const inputMode = useComputed(() => (useBackup.value ? "text" : "numeric"));
+<Input inputmode={inputMode} />
+```
+
+⚠️ Don't wrap a derivation that closes over a **plain prop** in `useComputed` — the computed only
+recomputes when its tracked *signals* change, so a changed prop goes stale. Either read the prop
+in the body (accept the re-render) or make it reactive with `useLiveSignal`.
+
+## Text and attribute nodes → pass the signal
+
+When a signal is only displayed/bound, pass the box, not the value:
+
+```tsx
+<p>{name}</p>                  // not {name.value}
+<input value={name} />         // not value={name.value}
+<button disabled={busy} />     // not disabled={busy.value}
+<button aria-expanded={open} />
+```
+
+**This only works for DOM elements and components that spread to a DOM node** (in this repo:
+`Input`, `Button` — both spread `...props` onto a real element, and `@preact/signals` augments
+JSX so DOM attributes accept `Signal<T>`).
+
+It does **not** work for components with plain-typed props that read the value themselves:
+
+- `Select` (`value: string`), `Dialog` (`open: boolean`) — passing a signal is a type error and
+  wouldn't be reactive. Leave these as `.value` reads.
+- If a primitive *should* take a signal, widen its prop to `ComponentChildren` / `Signal<T>`
+  rather than unwrapping at every call site (e.g. `Field`'s `label` was widened to
+  `ComponentChildren` so it can take a computed).
+
+## Gotchas
+
+- **`Show` generic inference** fails through a thunk `when` + a typed function child (you get
+  `Object`). Drive those `Show`s from a `useComputed` instead — the `Signal<T>` form infers
+  cleanly: `const at = useComputed(() => …number|null…); <Show when={at}>{(at) => …}</Show>`.
+  Or annotate explicitly: `<Show<Foo | null> when={() => …}>`.
+- **`no-conditional-value-read`** fires if a `useComputed` reads `signal.value` behind a guard
+  that doesn't itself read a signal (e.g. `if (!localVar) … signal.value`). Read every signal
+  **unconditionally at the top** of the computed, then branch on the locals.
+- **`&&` with a numeric signal**: `{count.value && <X/>}` renders `0` when count is 0;
+  `<Show when={count}>` correctly renders the fallback instead. Converting fixes the footgun.
+- **Models / member-access signals** (`model.count.value`) are caught by these same patterns, but
+  the lint rule below can't *detect* them (no type info under oxlint) — apply by hand.
+
+## Lint rule
+
+`signals-local/no-signal-conditional-jsx` (local plugin in
+`tooling/oxlint/signals-local/`, wired through `jsPlugins` in `.oxlintrc.json`) flags conditional
+rendering — ternary or `&&`/`||`/`??` in JSX child position — whose condition reads a **local**
+signal's `.value`. It does not flag attribute positions (no `<Show>` there) or single derivations.
+Run `pnpm run lint`. Fixture + test: `test/fixtures/oxlint-signals/` and
+`test/oxlint-signal-conditional-jsx.test.mjs`.
+
+## References
+
+- [`preact-signals-preact-integration`] — unboxing boundaries, `Show`/`For`, DOM optimization.
+- [`preact-signals-models-utils`] — `createModel`/`useModel`, passing signals without unwrapping.
+- [`preact-signals-eslint-plugin`] — the upstream correctness rules these conventions complement.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,7 +1,10 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": ["typescript", "unicorn", "oxc", "import", "react", "promise"],
-  "jsPlugins": ["@preact/eslint-plugin-signals"],
+  "jsPlugins": [
+    "@preact/eslint-plugin-signals",
+    { "name": "signals-local", "specifier": "./tooling/oxlint/signals-local/index.mjs" }
+  ],
   "categories": {
     "correctness": "error"
   },
@@ -42,6 +45,7 @@
     "@preact/signals/no-signal-truthiness": "warn",
     "@preact/signals/no-signal-in-component-body": "error",
     "@preact/signals/no-conditional-value-read": "error",
+    "signals-local/no-signal-conditional-jsx": "error",
     "react-hooks/exhaustive-deps": "off"
   },
   "ignorePatterns": [
@@ -50,6 +54,7 @@
     "drizzle/**",
     "node_modules/**",
     "worker-configuration.d.ts",
-    "**/*.d.ts"
+    "**/*.d.ts",
+    "test/fixtures/oxlint-signals/**"
   ]
 }

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -91,6 +91,42 @@ The following rules from `@preact/eslint-plugin-signals` are enforced (see [`pre
 - `no-conditional-value-read` (error)
 - `no-signal-truthiness` (warn)
 
+### Local rule: `signals-local/no-signal-conditional-jsx`
+
+A project-specific oxlint JS plugin lives in `tooling/oxlint/signals-local/` and is loaded
+through `jsPlugins` in `.oxlintrc.json` under the `signals-local` alias. Its one rule
+(`no-signal-conditional-jsx`, error) flags conditional rendering — a ternary or
+`&&`/`||`/`??` in JSX **child** position — whose condition reads (or derives from) a
+signal's `.value`, and points you at `<Show>`:
+
+```tsx
+{
+  error.value ? <Alert>{error.value}</Alert> : null;
+} // ❌ flagged
+<Show when={error}>{(msg) => <Alert>{msg}</Alert>}</Show>; // ✅
+
+{
+  loading.value ? "Saving…" : "Save";
+} // ❌ flagged (text counts too)
+<Show when={loading} fallback="Save">
+  Saving…
+</Show>; // ✅
+```
+
+It deliberately does not flag attribute positions (a `<Show>` can't live there — use a
+`useComputed`) or single derivations like `{format(size.value)}`. Detection is scope-based,
+so it catches local signals (`useSignal`/`useComputed`) and `Signal<T>`-typed props but not
+member-access signals (`model.count.value`) — fix those by hand. See the
+[`preact-signals-no-eager-unwrap`](../.claude/skills/preact-signals-no-eager-unwrap/SKILL.md)
+skill for the full set of eager-unwrap anti-patterns and fixes. Fixture and test:
+`test/fixtures/oxlint-signals/` and `test/oxlint-signal-conditional-jsx.test.mjs`.
+
+The rule ships as `error`, but the pre-existing call sites are grandfathered in a baseline
+at `tooling/oxlint/signals-local/suppressions.json` (repo-relative path → 1-based lines), so
+only **new** infractions fail lint. Burn the baseline down as sites migrate to `<Show>`, then
+regenerate it with `node tooling/oxlint/signals-local/regenerate-suppressions.mjs` (it runs
+oxlint with `SIGNALS_NO_SUPPRESS=1` to see through the baseline). The list should only shrink.
+
 ## Client API helpers
 
 Use `apiFetch` from `src/models/api.ts` for same-origin JSON requests so active organization headers and `ApiError` handling stay consistent. Use `apiJson` for JSON request bodies instead of repeating `content-type` and `JSON.stringify` at call sites. Use `errorMessage(err)` when model actions need to surface caught errors into a signal.
@@ -107,4 +143,5 @@ The `.claude/skills/` directory ships the canonical signals/models reference set
 - `preact-signals-preact-integration` — `useSignal`, JSX rendering choices, `Show`/`For`, `useLiveSignal`.
 - `preact-signals-models-utils` — `createModel`/`useModel` patterns and state shape.
 - `preact-signals-eslint-plugin` — what the rules catch.
+- `preact-signals-no-eager-unwrap` — eager-unwrap anti-patterns (conditional render → `Show`, text/attr → direct signal, derivations → `useComputed`) and the local lint rule.
 - `preact-signals-debugging` — triage map for stale renders, missing updates, SSR issues.

--- a/test/fixtures/oxlint-signals/conditional-jsx.tsx
+++ b/test/fixtures/oxlint-signals/conditional-jsx.tsx
@@ -1,0 +1,71 @@
+import { useSignal, useComputed } from "@preact/signals";
+import type { Signal } from "@preact/signals";
+
+// --- Should be flagged: conditional rendering driven by a signal ----------
+
+export function TernaryNull() {
+  const error = useSignal<string | null>(null);
+  return <div>{error.value ? <span>{error.value}</span> : null}</div>;
+}
+
+export function TernaryBothJsx() {
+  const authed = useSignal(false);
+  return <div>{authed.value ? <a>dash</a> : <a>login</a>}</div>;
+}
+
+export function LogicalAnd() {
+  const open = useSignal(false);
+  return <div>{open.value && <section>panel</section>}</div>;
+}
+
+export function DerivedNegation() {
+  const loading = useSignal(false);
+  return <div>{!loading.value ? <span>ready</span> : null}</div>;
+}
+
+export function DerivedComparison() {
+  const items = useSignal<number[]>([]);
+  return <div>{items.value.length > 0 && <ul>list</ul>}</div>;
+}
+
+export function ComputedDriven() {
+  const count = useSignal(0);
+  const hasItems = useComputed(() => count.value > 0);
+  return <div>{hasItems.value ? <ul>list</ul> : null}</div>;
+}
+
+export function SignalProp({ flag }: { flag: Signal<boolean> }) {
+  return <div>{flag.value ? <b>on</b> : null}</div>;
+}
+
+// Conditional *text* is flagged too — the fix is the same `<Show fallback>`.
+export function ConditionalText() {
+  const loading = useSignal(false);
+  return <button>{loading.value ? "Saving…" : "Save"}</button>;
+}
+
+// --- Should NOT be flagged -------------------------------------------------
+
+// Plain (non-signal) condition.
+export function PlainBoolean({ folder }: { folder: boolean }) {
+  return <div>{folder ? <span>dir</span> : null}</div>;
+}
+
+// The *test* is non-reactive; a branch merely selects a signal value. This is a
+// value selection, not signal-driven conditional rendering.
+export function ValueSelection({ useError }: { useError: boolean }) {
+  const error = useSignal("");
+  return <div>{useError ? error.value : "ok"}</div>;
+}
+
+// Signal condition but in an attribute position (cannot host a <Show>).
+export function AttributeTernary() {
+  const loading = useSignal(false);
+  return <input disabled={loading.value ? true : false} />;
+}
+
+// Signal rendered directly — the good pattern.
+export function DirectSignal() {
+  const name = useSignal("Ada");
+  return <div>{name}</div>;
+}

--- a/test/fixtures/oxlint-signals/oxlintrc.json
+++ b/test/fixtures/oxlint-signals/oxlintrc.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "../../../node_modules/oxlint/configuration_schema.json",
+  "categories": { "correctness": "off" },
+  "jsPlugins": [
+    { "name": "signals-local", "specifier": "../../../tooling/oxlint/signals-local/index.mjs" }
+  ],
+  "rules": {
+    "signals-local/no-signal-conditional-jsx": "error"
+  }
+}

--- a/test/oxlint-signal-conditional-jsx.test.mjs
+++ b/test/oxlint-signal-conditional-jsx.test.mjs
@@ -1,0 +1,80 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+
+// Drive the local oxlint plugin through the real oxlint runtime against a
+// fixture, so the test exercises the same path production lint does. JS plugins
+// are alpha, so an end-to-end check is more trustworthy than a mocked context.
+
+const fixtureDir = fileURLToPath(new URL("./fixtures/oxlint-signals/", import.meta.url));
+const fixtureFile = "conditional-jsx.tsx";
+const oxlintBin = fileURLToPath(new URL("../node_modules/.bin/oxlint", import.meta.url));
+
+const RULE_CODE = "signals-local(no-signal-conditional-jsx)";
+
+function runRule() {
+  let stdout;
+  try {
+    stdout = execFileSync(oxlintBin, ["-c", "oxlintrc.json", "--format=json", fixtureFile], {
+      cwd: fixtureDir,
+      encoding: "utf8",
+    });
+  } catch (err) {
+    // oxlint exits non-zero when it reports errors; the JSON is on stdout.
+    stdout = err.stdout?.toString() ?? "";
+  }
+  const report = JSON.parse(stdout);
+  // oxlint span offsets/lengths are UTF-8 byte offsets, so slice the raw bytes
+  // (not a JS UTF-16 string) — otherwise multibyte chars like "…" misalign.
+  const source = readFileSync(join(fixtureDir, fixtureFile));
+  return (report.diagnostics ?? [])
+    .filter((d) => d.code === RULE_CODE)
+    .map((d) => {
+      const span = d.labels?.[0]?.span;
+      return span ? source.subarray(span.offset, span.offset + span.length).toString("utf8") : "";
+    });
+}
+
+describe("signals-local/no-signal-conditional-jsx", () => {
+  const flagged = runRule();
+
+  it("flags exactly the signal-driven conditional-render cases", () => {
+    // Eight positive cases: ternary→null, ternary→both-JSX, logical &&, derived
+    // negation, derived comparison, computed-driven, a destructured `Signal<T>`
+    // prop, and a conditional *text* ternary.
+    assert.equal(
+      flagged.length,
+      8,
+      `expected 8 violations, got ${flagged.length}:\n${flagged.join("\n")}`,
+    );
+  });
+
+  it("flags direct and derived signal conditions, element and text branches", () => {
+    const joined = flagged.join("\n");
+    for (const needle of [
+      "error.value ?",
+      "authed.value ?",
+      "open.value &&",
+      "!loading.value ?",
+      "items.value.length > 0 &&",
+      "hasItems.value ?",
+      "flag.value ?",
+      'loading.value ? "Saving', // conditional text
+    ]) {
+      assert.ok(joined.includes(needle), `expected a violation containing \`${needle}\``);
+    }
+  });
+
+  it("does not flag non-signal tests, value selection, or attribute positions", () => {
+    const joined = flagged.join("\n");
+    // Plain boolean condition, a non-reactive test that merely selects a signal
+    // value, an attribute-position ternary, and a directly-rendered signal must
+    // all stay clean.
+    assert.ok(!joined.includes("folder ?"), "plain boolean condition should not be flagged");
+    assert.ok(!joined.includes("useError ?"), "non-reactive test should not be flagged");
+    assert.ok(!joined.includes("disabled="), "attribute-position ternary should not be flagged");
+  });
+});

--- a/tooling/oxlint/signals-local/index.mjs
+++ b/tooling/oxlint/signals-local/index.mjs
@@ -1,0 +1,21 @@
+/**
+ * Local oxlint JS plugin for project-specific signal conventions.
+ *
+ * Loaded via `jsPlugins` in `.oxlintrc.json` under the `signals-local` alias.
+ * Rules:
+ *   - signals-local/no-signal-conditional-jsx
+ */
+
+import noSignalConditionalJsx from "./no-signal-conditional-jsx.mjs";
+
+const plugin = {
+  meta: {
+    name: "signals-local",
+    version: "0.1.0",
+  },
+  rules: {
+    "no-signal-conditional-jsx": noSignalConditionalJsx,
+  },
+};
+
+export default plugin;

--- a/tooling/oxlint/signals-local/no-signal-conditional-jsx.mjs
+++ b/tooling/oxlint/signals-local/no-signal-conditional-jsx.mjs
@@ -1,0 +1,162 @@
+/**
+ * Flag conditional rendering whose condition reads (or derives from) a signal's
+ * `.value`, expressed as a ternary or `&&`/`||`/`??` in JSX child position
+ * instead of `<Show>`.
+ *
+ * Eagerly unwrapping a signal to branch in the component body subscribes the
+ * whole component, so any change re-renders everything — even the parts that
+ * didn't change. `<Show when={signal}>` (or `when={() => derived}` for a derived
+ * condition) moves the subscription into a tiny boundary component, so only the
+ * conditional subtree re-renders.
+ *
+ *   {error.value ? <Alert>{error.value}</Alert> : null}        // flagged
+ *   {open.value && <Panel />}                                  // flagged
+ *   {loading.value ? "Saving…" : "Save"}                       // flagged (text too)
+ *   <Show when={error}>{(msg) => <Alert>{msg}</Alert>}</Show>  // preferred
+ *   <Show when={loading} fallback="Save">Saving…</Show>        // preferred
+ *
+ * Both element and text branches are reported, because the fix is the same
+ * `<Show>` either way. A single derivation that is not a two-way conditional —
+ * e.g. `{trigger(open.value)}` or `{format(size.value)}` — is NOT reported;
+ * lift those into a `useComputed` and render the computed directly.
+ *
+ * Only child position is reported. Attribute values like
+ * `disabled={loading.value ? a : b}` cannot host a `<Show>`, so they are left
+ * for a `useComputed` and not flagged.
+ *
+ * Limitation: detection is scope-based, so it catches signals declared as
+ * locals (`useSignal`/`useComputed`/`signal`/`computed`) or typed
+ * `Signal`/`ReadonlySignal`. Signals reached only through member access
+ * (e.g. `model.count.value`) are missed unless type information is available,
+ * which oxlint generally does not provide today.
+ */
+
+import { readFileSync } from "node:fs";
+import { isAbsolute, relative, sep } from "node:path";
+import { isKnownSignal, isSignalByTypeChecker } from "./signals-scope.mjs";
+
+const SKIP_KEYS = new Set(["parent", "loc", "range", "start", "end", "type"]);
+
+// Baseline of pre-existing infractions, grandfathered so the rule can ship as
+// `error` without first migrating every call site to `<Show>`. Keyed by
+// repo-relative path → 1-based line numbers; anything NOT listed still errors,
+// so the baseline only shrinks. Burn it down as sites migrate, then regenerate:
+//   node tooling/oxlint/signals-local/regenerate-suppressions.mjs
+// (SIGNALS_NO_SUPPRESS=1 bypasses the baseline — the regenerator sets it.)
+const SUPPRESSIONS =
+  process.env.SIGNALS_NO_SUPPRESS === "1"
+    ? {}
+    : (() => {
+        try {
+          return JSON.parse(readFileSync(new URL("./suppressions.json", import.meta.url), "utf8"));
+        } catch {
+          return {};
+        }
+      })();
+
+/** Repo-relative, forward-slashed path so lookups match suppressions.json keys. */
+function toRepoRelative(filename) {
+  if (!filename) return "";
+  const rel = isAbsolute(filename) ? relative(process.cwd(), filename) : filename;
+  return rel.split(sep).join("/");
+}
+
+/** @type {import("eslint").Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description:
+        "Render conditional JSX driven by a signal through `<Show>` instead of an eagerly-unwrapped ternary or `&&`",
+      recommended: true,
+    },
+    messages: {
+      ternary:
+        "Conditional JSX driven by a signal. Reading `.value` here subscribes the whole component, so any change re-renders everything. Use `<Show when={signal}>` (or `when={() => derived}` for a derived condition) so only this subtree re-renders.",
+      logical:
+        "Conditional JSX driven by a signal. Reading `.value` here subscribes the whole component, so any change re-renders everything. Use `<Show when={signal}>` (or `when={() => derived}` for a derived condition) so only this subtree re-renders.",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode();
+    const parserServices = context.parserServices ?? sourceCode?.parserServices;
+
+    // Skip infractions grandfathered in the baseline (see SUPPRESSIONS above).
+    const suppressedLines = new Set(
+      SUPPRESSIONS[toRepoRelative(context.filename ?? context.getFilename?.() ?? "")] ?? [],
+    );
+    function reportConditional(node, messageId) {
+      if (suppressedLines.has(node.loc?.start?.line)) return;
+      context.report({ node, messageId });
+    }
+
+    function isSignal(node) {
+      return isKnownSignal(sourceCode, node) || isSignalByTypeChecker(parserServices, node);
+    }
+
+    /** A `<signal>.value` member read, where `<signal>` is a known signal. */
+    function isSignalValueRead(node) {
+      return (
+        node?.type === "MemberExpression" &&
+        !node.computed &&
+        node.property.type === "Identifier" &&
+        node.property.name === "value" &&
+        isSignal(node.object)
+      );
+    }
+
+    /**
+     * Walk an expression subtree looking for any `<signal>.value` read. This is
+     * what makes a condition count as "derived from a signal" — `!a.value`,
+     * `a.value > 3`, `a.value && b.value`, `fn(a.value)` all qualify.
+     */
+    function containsSignalValueRead(node) {
+      if (!node || typeof node.type !== "string") return false;
+      if (isSignalValueRead(node)) return true;
+      for (const key in node) {
+        if (SKIP_KEYS.has(key)) continue;
+        const child = node[key];
+        if (Array.isArray(child)) {
+          for (const item of child) {
+            if (item && typeof item.type === "string" && containsSignalValueRead(item)) {
+              return true;
+            }
+          }
+        } else if (child && typeof child.type === "string") {
+          if (containsSignalValueRead(child)) return true;
+        }
+      }
+      return false;
+    }
+
+    return {
+      JSXExpressionContainer(node) {
+        // Only conditional rendering in child position is fixable with `<Show>`;
+        // attribute values (`<X disabled={a.value ? …} />`) cannot host one and
+        // are left for a `useComputed`.
+        const parentType = node.parent?.type;
+        if (parentType !== "JSXElement" && parentType !== "JSXFragment") return;
+
+        const expr = node.expression;
+        if (!expr) return;
+
+        if (expr.type === "ConditionalExpression") {
+          if (containsSignalValueRead(expr.test)) {
+            reportConditional(expr, "ternary");
+          }
+        } else if (
+          expr.type === "LogicalExpression" &&
+          (expr.operator === "&&" || expr.operator === "||" || expr.operator === "??")
+        ) {
+          if (containsSignalValueRead(expr.left)) {
+            reportConditional(expr, "logical");
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/tooling/oxlint/signals-local/regenerate-suppressions.mjs
+++ b/tooling/oxlint/signals-local/regenerate-suppressions.mjs
@@ -1,0 +1,47 @@
+// Regenerate the no-signal-conditional-jsx baseline (suppressions.json) from the
+// current tree. Runs oxlint with the rule's baseline bypassed (SIGNALS_NO_SUPPRESS=1)
+// so it reports every infraction, then records each by repo-relative path →
+// 1-based line. Run from the repo root:
+//   node tooling/oxlint/signals-local/regenerate-suppressions.mjs
+import { execFileSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const RULE_CODE = "signals-local(no-signal-conditional-jsx)";
+const oxlintBin = fileURLToPath(new URL("../../../node_modules/.bin/oxlint", import.meta.url));
+const oxfmtBin = fileURLToPath(new URL("../../../node_modules/.bin/oxfmt", import.meta.url));
+const outPath = fileURLToPath(new URL("./suppressions.json", import.meta.url));
+
+let stdout;
+try {
+  stdout = execFileSync(oxlintBin, ["--format=json"], {
+    encoding: "utf8",
+    env: { ...process.env, SIGNALS_NO_SUPPRESS: "1" },
+    maxBuffer: 64 * 1024 * 1024,
+  });
+} catch (err) {
+  // oxlint exits non-zero whenever it reports errors; the JSON is still on stdout.
+  stdout = err.stdout?.toString() ?? "";
+}
+
+const { diagnostics = [] } = JSON.parse(stdout);
+const byFile = {};
+for (const d of diagnostics) {
+  if (d.code !== RULE_CODE) continue;
+  const line = d.labels?.[0]?.span?.line;
+  if (line == null) continue;
+  (byFile[d.filename] ??= new Set()).add(line);
+}
+
+const baseline = {};
+for (const file of Object.keys(byFile).sort()) {
+  baseline[file] = [...byFile[file]].sort((a, b) => a - b);
+}
+
+writeFileSync(outPath, `${JSON.stringify(baseline, null, 2)}\n`);
+// Match the repo's formatter so a regenerated baseline stays format-check clean.
+execFileSync(oxfmtBin, [outPath], { stdio: "ignore" });
+const total = Object.values(baseline).reduce((n, lines) => n + lines.length, 0);
+console.log(
+  `Wrote ${Object.keys(baseline).length} file(s) / ${total} infraction(s) to suppressions.json`,
+);

--- a/tooling/oxlint/signals-local/signals-scope.mjs
+++ b/tooling/oxlint/signals-local/signals-scope.mjs
@@ -1,0 +1,238 @@
+/**
+ * Scope analysis utilities for resolving signal-related imports and types.
+ *
+ * Adapted from `@preact/eslint-plugin-signals` (its `signals-scope.mjs` is not a
+ * public export, so the pieces this plugin needs are vendored here). Uses scope
+ * analysis to trace identifiers to their declarations, confirming they originate
+ * from `@preact/signals-*` — either via a creator call (signal(), useSignal(),
+ * computed(), useComputed()) or a Signal/ReadonlySignal type annotation.
+ */
+
+const SIGNAL_PACKAGES = new Set([
+  "@preact/signals-core",
+  "@preact/signals",
+  "@preact/signals-react",
+  "@preact/signals-react/runtime",
+]);
+
+const SIGNAL_CREATORS = new Set(["signal", "useSignal"]);
+const COMPUTED_CREATORS = new Set(["computed", "useComputed"]);
+const ALL_SIGNAL_CREATORS = new Set([...SIGNAL_CREATORS, ...COMPUTED_CREATORS]);
+
+/** Type names that represent signal instances. */
+const SIGNAL_TYPE_NAMES = new Set(["Signal", "ReadonlySignal"]);
+
+/**
+ * Resolve an Identifier to its import source and original exported name.
+ * Returns null if the identifier isn't an import binding.
+ */
+function resolveImport(sourceCode, node) {
+  let scope;
+  try {
+    scope = sourceCode.getScope(node);
+  } catch {
+    return null;
+  }
+
+  while (scope) {
+    const variable = scope.variables.find((v) => v.name === node.name);
+    if (variable) {
+      for (const def of variable.defs) {
+        if (def.type === "ImportBinding" && def.parent?.type === "ImportDeclaration") {
+          return {
+            source: def.parent.source.value,
+            importedName:
+              def.node.type === "ImportSpecifier" ? def.node.imported.name : def.node.local.name,
+          };
+        }
+      }
+      return null;
+    }
+    scope = scope.upper;
+  }
+  return null;
+}
+
+/**
+ * Check whether an Identifier resolves to an import from a signals package
+ * with the given exported name set.
+ */
+function isSignalsImport(sourceCode, node, nameSet) {
+  if (node.type !== "Identifier") return false;
+  const resolved = resolveImport(sourceCode, node);
+  if (!resolved) return false;
+  return SIGNAL_PACKAGES.has(resolved.source) && nameSet.has(resolved.importedName);
+}
+
+/**
+ * Check a CallExpression callee against a name set from signal packages.
+ * Returns the matched imported name or null.
+ */
+function getSignalsCallName(sourceCode, callNode, nameSet) {
+  const callee = callNode.callee;
+
+  if (callee.type === "Identifier") {
+    if (isSignalsImport(sourceCode, callee, nameSet)) {
+      const resolved = resolveImport(sourceCode, callee);
+      return resolved ? resolved.importedName : null;
+    }
+  }
+
+  // Namespace import: core.computed(...)
+  if (
+    callee.type === "MemberExpression" &&
+    !callee.computed &&
+    callee.property.type === "Identifier" &&
+    nameSet.has(callee.property.name) &&
+    callee.object.type === "Identifier"
+  ) {
+    const resolved = resolveImport(sourceCode, callee.object);
+    if (resolved && SIGNAL_PACKAGES.has(resolved.source)) {
+      return callee.property.name;
+    }
+  }
+
+  return null;
+}
+
+/** Check whether a VariableDeclarator is initialised with a signals creator. */
+function isSignalCreatorInit(sourceCode, declarator, nameSet = ALL_SIGNAL_CREATORS) {
+  const init = declarator.init;
+  if (!init || init.type !== "CallExpression") return false;
+  return getSignalsCallName(sourceCode, init, nameSet) !== null;
+}
+
+/**
+ * Check whether a TSTypeReference node refers to Signal or ReadonlySignal
+ * imported from a signals package.
+ */
+function isSignalTypeRef(sourceCode, typeRef) {
+  if (!typeRef || typeRef.type !== "TSTypeReference") return false;
+  const typeName = typeRef.typeName;
+
+  if (typeName.type === "Identifier" && SIGNAL_TYPE_NAMES.has(typeName.name)) {
+    const resolved = resolveImport(sourceCode, typeName);
+    // Accept if imported from a signals package, or if we can't resolve it
+    // (type-only imports may not always have scope bindings).
+    return !resolved || SIGNAL_PACKAGES.has(resolved.source);
+  }
+
+  // Qualified: e.g. signals.Signal
+  if (
+    typeName.type === "TSQualifiedName" &&
+    typeName.right.type === "Identifier" &&
+    SIGNAL_TYPE_NAMES.has(typeName.right.name)
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Check whether a node has a Signal/ReadonlySignal type annotation.
+ * Works on VariableDeclarators, function params, and property definitions.
+ */
+function hasSignalTypeAnnotation(sourceCode, node) {
+  const annotation = node.typeAnnotation || node.id?.typeAnnotation;
+  if (!annotation) return false;
+
+  const typeNode = annotation.type === "TSTypeAnnotation" ? annotation.typeAnnotation : annotation;
+
+  return isSignalTypeRef(sourceCode, typeNode);
+}
+
+/** Find the type node for `key` inside an object-type-literal annotation. */
+function objectPatternMemberType(objectPattern, keyName) {
+  const annotation = objectPattern.typeAnnotation;
+  if (!annotation || annotation.type !== "TSTypeAnnotation") return null;
+  const typeNode = annotation.typeAnnotation;
+  if (typeNode?.type !== "TSTypeLiteral") return null;
+  for (const member of typeNode.members ?? []) {
+    if (
+      member.type === "TSPropertySignature" &&
+      !member.computed &&
+      member.key?.type === "Identifier" &&
+      member.key.name === keyName &&
+      member.typeAnnotation?.type === "TSTypeAnnotation"
+    ) {
+      return member.typeAnnotation.typeAnnotation;
+    }
+  }
+  return null;
+}
+
+/**
+ * Handle the canonical signal-prop pattern where the binding is destructured
+ * from a param typed with an inline object literal, e.g.
+ * `function Toolbar({ disabled }: { disabled: Signal<boolean> })`. The type
+ * annotation lives on the ObjectPattern, not on the binding identifier, so
+ * `hasSignalTypeAnnotation` alone misses it.
+ */
+function isDestructuredSignalBinding(sourceCode, bindingIdent) {
+  const prop = bindingIdent?.parent;
+  if (!prop || prop.type !== "Property") return false;
+  const pattern = prop.parent;
+  if (!pattern || pattern.type !== "ObjectPattern") return false;
+  const keyName = prop.key?.type === "Identifier" ? prop.key.name : null;
+  if (!keyName) return false;
+  const typeNode = objectPatternMemberType(pattern, keyName);
+  return typeNode ? isSignalTypeRef(sourceCode, typeNode) : false;
+}
+
+/**
+ * Determine whether an Identifier resolves to a known signal — either via a
+ * creator call or a Signal/ReadonlySignal type annotation on its declaration
+ * (variable, parameter, import).
+ */
+function isKnownSignal(sourceCode, node) {
+  if (node.type !== "Identifier") return false;
+
+  let scope;
+  try {
+    scope = sourceCode.getScope(node);
+  } catch {
+    return false;
+  }
+
+  while (scope) {
+    const variable = scope.variables.find((v) => v.name === node.name);
+    if (variable) {
+      for (const def of variable.defs) {
+        if (def.type === "Variable" && def.node.type === "VariableDeclarator") {
+          if (isSignalCreatorInit(sourceCode, def.node)) return true;
+        }
+        if (def.name && hasSignalTypeAnnotation(sourceCode, def.name)) return true;
+        if (def.name && isDestructuredSignalBinding(sourceCode, def.name)) return true;
+      }
+      return false;
+    }
+    scope = scope.upper;
+  }
+  return false;
+}
+
+/**
+ * Use TypeScript's type checker (via parser services, when available) to decide
+ * whether a node's type is Signal or ReadonlySignal. Catches signals reached
+ * through member access (e.g. `model.count`). Returns false when type
+ * information is unavailable — which is the common case under oxlint today.
+ */
+function isSignalByTypeChecker(parserServices, node) {
+  if (!parserServices?.program || !parserServices?.esTreeNodeToTSNodeMap) {
+    return false;
+  }
+
+  try {
+    const checker = parserServices.program.getTypeChecker();
+    const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node);
+    if (!tsNode) return false;
+    const type = checker.getTypeAtLocation(tsNode);
+    const symbol = type.getSymbol?.() ?? type.aliasSymbol;
+    return Boolean(symbol && SIGNAL_TYPE_NAMES.has(symbol.getName()));
+  } catch {
+    return false;
+  }
+}
+
+export { isKnownSignal, isSignalByTypeChecker };

--- a/tooling/oxlint/signals-local/suppressions.json
+++ b/tooling/oxlint/signals-local/suppressions.json
@@ -1,0 +1,9 @@
+{
+  "src/components/Menu.tsx": [69],
+  "src/pages/Auth/Login.tsx": [113, 114, 117, 137, 159, 162, 176, 214, 217],
+  "src/pages/Auth/Register.tsx": [88, 89, 92, 145, 148],
+  "src/pages/Auth/VerifyEmail.tsx": [114, 115, 120],
+  "src/pages/Dashboard/Account/DeleteAccountSection.tsx": [86, 114],
+  "src/pages/Dashboard/GithubAppCallback.tsx": [88, 100, 113, 135],
+  "src/pages/Dashboard/Invite/index.tsx": [72]
+}


### PR DESCRIPTION
Adds the local oxlint JS plugin **`signals-local/no-signal-conditional-jsx`** (in `tooling/oxlint/signals-local/`, wired via `jsPlugins` in `.oxlintrc.json`), which flags signal-driven conditional rendering in JSX **child** position (`{x.value ? … : …}`, `{x.value && …}`) and points at `<Show>`. Ships with the `preact-signals-no-eager-unwrap` skill and `docs/tooling.md` updates.

**No UI changes.** This PR was rescoped to just the tooling — the rule lands as `error`, and the pre-existing call sites are grandfathered in a baseline at `tooling/oxlint/signals-local/suppressions.json` (repo-relative path → 1-based lines, 25 infractions across 7 files). Only **new** infractions fail lint.

- Burn the baseline down as sites migrate to `<Show>`; it should only shrink.
- Regenerate with `node tooling/oxlint/signals-local/regenerate-suppressions.mjs` (runs oxlint with `SIGNALS_NO_SUPPRESS=1` to see through the baseline, then formats the output).
- Rule unit test + fixture: `test/oxlint-signal-conditional-jsx.test.mjs`, `test/fixtures/oxlint-signals/`.

`pnpm run verify` is green (lint, format, typecheck, test).