### PR TITLE
Generalize workflow-gate copy and docs beyond PyPI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - `server/` — Hono Worker. `index.ts` mounts routes under `/api/*`. The worker is the deploy target (`main` in `wrangler.jsonc`).
   - `routes/scan.ts` — `POST /api/v1/scan { stageId }`. Runs the full pipeline.
   - `routes/scans.ts` — `GET /api/v1/scans` (list), `GET /api/v1/scans/:id` (persisted detail).
-  - `routes/github-webhooks.ts` — `POST /webhooks/github`. Public, signed by the GitHub App webhook secret; bypasses Better Auth. Persists `deployment_protection_rule` deliveries into `github_workflow_gates` and updates installation status on lifecycle events. See `docs/pypi-workflow-gate.md`.
+  - `routes/github-webhooks.ts` — `POST /webhooks/github`. Public, signed by the GitHub App webhook secret; bypasses Better Auth. Persists `deployment_protection_rule` deliveries into `github_workflow_gates` and updates installation status on lifecycle events. See `docs/workflow-gates.md`.
   - `lib/sandbox.ts` — Dynamic Worker that downloads + parses a tarball; `NpmStageGateway` is the only egress allowed (staged tarball, published tarball, registry metadata).
   - `lib/review.ts` — Deterministic findings, package diff, package.json diff, risk computation. Shared types are imported by both server and UI.
   - `lib/ai-review.ts` — Workers AI JSON-mode reviewer. Wired into `scan-pipeline.ts` via `maybeRunAiReview`, but **gated by the per-organization `ai-review` Flagship flag and off by default** (planned paid-tier feature). It only runs when Flagship returns `true` for the scanning org; otherwise the pipeline records an `unavailable` AI review. Don't change the default-off gating without a feature decision.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository is moving from prototype to real product. The current implementa
 - **SaaS, organization-scoped.** Scans belong to an organization boundary. RBAC is intentionally deferred for the first production slice, but the data model should keep organization ownership explicit.
 - **Per-organization npm credentials.** Production SaaS should not use a deployment-wide npm token. Each organization will connect its own npm credential, scoped as narrowly as npm permits, and the credential will only be used by the gateway that talks to npm.
 - **Manual publish approval.** The product reviews and explains a staged publish. It does not run `npm stage approve`, does not bypass npm 2FA, and does not become the final publisher.
-- **Two operating modes.** npm uses registry-stage mode: Drydock reviews npm-staged bytes before the maintainer approves in npm. PyPI uses workflow-gate mode: a GitHub Environment deployment-protection rule blocks the trusted-publishing job while Drydock reviews the built wheel/sdist artifacts. See [`docs/pypi-workflow-gate.md`](docs/pypi-workflow-gate.md).
+- **Two operating modes.** npm uses registry-stage mode: Drydock reviews npm-staged bytes before the maintainer approves in npm. Ecosystems without a staged artifact use workflow-gate mode: a GitHub Environment deployment-protection rule blocks the publish job while Drydock reviews the built release artifacts. PyPI is the first workflow-gate ecosystem (built wheel/sdist artifacts); the gate plumbing is ecosystem-neutral. See [`docs/workflow-gates.md`](docs/workflow-gates.md).
 - **AI review default-off.** Cloudflare Workers AI review is wired into the pipeline, but it is gated by the per-organization Flagship `ai-review` flag and defaults to unavailable. Deterministic findings are the review authority unless a complete, schema-valid AI review is enabled; AI remains advisory and cannot downgrade deterministic findings.
 - **Safe artifact defaults.** Do not retain raw tarballs by default in SaaS. Persist redacted summaries, manifests, diffs, findings, and report metadata. Raw artifact retention may become an explicit short-TTL organization setting later.
 - **Signed reports later.** Prepare report data to be canonical and signable, but do not launch public signed report generation yet.
@@ -21,7 +21,7 @@ Use the docs by layer:
 - [`docs/architecture.md`](docs/architecture.md) — runtime shape, trust boundaries, adapters, APIs.
 - [`docs/security-model.md`](docs/security-model.md) — non-negotiable security posture and known gaps.
 - [`docs/production-roadmap.md`](docs/production-roadmap.md) — remaining product slices, with closed work collapsed.
-- [`docs/pypi-workflow-gate.md`](docs/pypi-workflow-gate.md) — PyPI GitHub Environment gate contract and implementation notes.
+- [`docs/workflow-gates.md`](docs/workflow-gates.md) — workflow-gate product mode: ecosystem-neutral GitHub Environment gate contract, with PyPI as the first ecosystem.
 - [`docs/release-safety.md`](docs/release-safety.md), [`docs/security-detection-corpus.md`](docs/security-detection-corpus.md), [`docs/detection-eval.md`](docs/detection-eval.md), and [`docs/e2e-test-environment.md`](docs/e2e-test-environment.md) — change safety, detection quality, and local verification.
 
 ## Current capabilities

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -298,19 +298,19 @@ Current API:
 - `POST /api/v1/organizations/invitations` — invite an email at a chosen role (owner/admin; rate-limited; the raw token is emailed, never returned);
 - `DELETE /api/v1/organizations/invitations/:invitationId` — revoke a pending invitation (owner/admin);
 - `POST /api/v1/organizations/invitations/accept` — accept an invitation by token (authenticated invitee; **not** org-header scoped — the org is resolved from the token and the caller's account email must equal the invited address);
-- `GET /api/v1/github-app/config`, `POST /api/v1/github-app/install`, `POST /api/v1/github-app/install/callback`, installation/repository/environment proxy reads, release-target CRUD, and workflow-gate decision endpoints — see [`pypi-workflow-gate.md`](./pypi-workflow-gate.md) for the full GitHub App surface.
+- `GET /api/v1/github-app/config`, `POST /api/v1/github-app/install`, `POST /api/v1/github-app/install/callback`, installation/repository/environment proxy reads, release-target CRUD, and workflow-gate decision endpoints — see [`workflow-gates.md`](./workflow-gates.md) for the full GitHub App surface.
 
 All other `/api/v1/*` endpoints honor the `x-organization-id` request header to pick the active org; absent or non-member ids silently fall back to the caller's personal org.
 
 Keep `POST /api/v1/scan` only as a compatibility shim during migration.
 
-## PyPI workflow-gate foundation
+## Workflow-gate foundation
 
-PyPI support is intentionally modeled as a separate workflow-gate mode because PyPI does not have npm's staged-publish review primitive. The implementation is mounted through the GitHub App routes and the public `POST /webhooks/github` deployment-protection webhook, and reviews are persisted as ordinary scans with `source: "workflow_gate"` and a synthetic `stageId: "workflow-gate:<gateId>"`.
+Workflow gates are a separate product mode from npm staged publishing, for ecosystems with no staged-publish review primitive. The pipeline is ecosystem-neutral — everything GitHub-shaped (install, webhook, artifact fetch, digest recomputation, decision callback, persistence) is shared, and only an ecosystem's artifact semantics are pluggable behind a `WorkflowGateAdapter`. PyPI is the first (and currently only) ecosystem. The implementation is mounted through the GitHub App routes and the public `POST /webhooks/github` deployment-protection webhook, and reviews are persisted as ordinary scans with `source: "workflow_gate"` and a synthetic `stageId: "workflow-gate:<gateId>:<ecosystem>:<package>"`.
 
 Implemented pieces:
 
-- GitHub App install/callback, installation listing, repository/environment proxy reads, and PyPI release-target CRUD in `server/routes/github-app.ts`;
+- GitHub App install/callback, installation listing, repository/environment proxy reads, and ecosystem-neutral release-target CRUD in `server/routes/github-app.ts`;
 - `deployment_protection_rule` webhook handling in `server/routes/github-webhooks.ts`, backed by `github_workflow_gates`;
 - queue-driven gate review in `server/lib/workflow-gate-job.ts`, including fail-closed rejection for unverifiable artifact bundles and human approve/reject delivery back to GitHub;
 - release-candidate derivation from the held workflow run's uploaded GitHub Actions artifacts: every wheel/sdist SHA-256 is recomputed from upload bytes, package identity is derived from wheel `METADATA` / sdist `PKG-INFO`, and no maintainer-declared manifest is required;
@@ -320,4 +320,4 @@ Implemented pieces:
 - PyPI project JSON metadata helpers for baseline release selection and wheel/sdist download metadata;
 - settings UI for GitHub App installation/release-target mapping and workbench controls for pending gate decisions.
 
-The target gate is a GitHub custom deployment protection rule on the same GitHub Environment configured in PyPI Trusted Publishers. CI must build artifacts before the gate and the publish job must download the reviewed artifact bundle rather than rebuilding. There is no publish-side digest manifest check in the current contract, so byte continuity rests on GitHub artifact immutability plus workflow discipline. Remaining work is to persist the reviewed artifact digests in the report payload for audit/provenance. See [`pypi-workflow-gate.md`](./pypi-workflow-gate.md).
+The target gate is a GitHub custom deployment protection rule on the same GitHub Environment configured in PyPI Trusted Publishers. CI must build artifacts before the gate and the publish job must download the reviewed artifact bundle rather than rebuilding. There is no publish-side digest manifest check in the current contract, so byte continuity rests on GitHub artifact immutability plus workflow discipline. Remaining work is to persist the reviewed artifact digests in the report payload for audit/provenance. See [`workflow-gates.md`](./workflow-gates.md).

--- a/docs/workflow-gates.md
+++ b/docs/workflow-gates.md
@@ -1,8 +1,13 @@
-# PyPI Workflow-Gate Support
+# Workflow Gates
 
-PyPI support uses a different product shape from npm staged publishing.
+Workflow gates are a Drydock **product mode distinct from npm staged publishing**.
 
-npm owns a pending staged tarball, so Drydock can fetch `/-/stage/<stage-id>/tarball` and leave final approval in npm. PyPI does not expose an equivalent registry-staged artifact. The PyPI path is therefore **workflow gate mode**: CI builds wheels/sdists first, uploads them as GitHub Actions artifacts for review, and a GitHub Environment blocks the publish job until the reviewed release is approved. There is no `drydock-manifest.json` to write — the release set is whatever wheels/sdists the workflow uploads, and the package identity is derived from the artifacts themselves.
+- **npm staged publishing** works because npm owns a pending staged tarball: Drydock fetches `/-/stage/<stage-id>/tarball`, reviews it, and leaves final approval in npm.
+- **Workflow gates** cover ecosystems with no registry-staged artifact. CI builds the release artifacts first, uploads them as GitHub Actions artifacts, and a GitHub Environment custom deployment-protection rule holds the publish job until the reviewed release is approved or rejected.
+
+The gate pipeline is **ecosystem-neutral**: everything GitHub-shaped (App installation, webhook verification, artifact fetch, digest recomputation, decision callback, persistence, audit) is shared, and only an ecosystem's artifact semantics are pluggable behind a `WorkflowGateAdapter`. See [Multi-ecosystem workflow gates](#multi-ecosystem-workflow-gates) and [Adding a new ecosystem](#adding-a-new-ecosystem).
+
+**PyPI is the first — and currently only — workflow-gate ecosystem.** The rest of this document uses PyPI as the reference ecosystem: the GitHub plumbing it describes is shared by every future ecosystem (npm, VSIX, …), and only the wheel/sdist-specific parts are PyPI's adapter. For PyPI there is no `drydock-manifest.json` to write — the release set is whatever wheels/sdists the workflow uploads, and package identity is derived from the artifacts themselves.
 
 Official references:
 

--- a/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
@@ -274,8 +274,8 @@ export function GateDecisionDialog({
       title={multi ? "Package decision" : "Release decision"}
       description={
         multi
-          ? "Decide this package. The held GitHub Actions job releases only once every package in the release is approved; rejecting any one blocks the whole release. Publishing then proceeds through PyPI Trusted Publishing (OIDC) — Drydock never holds PyPI credentials."
-          : "Approve to release the held GitHub Actions job — publishing then proceeds through PyPI Trusted Publishing (OIDC). Reject to block the job. Drydock never holds PyPI credentials or uploads the package."
+          ? "Decide this package. The held GitHub Actions job releases only once every package in the release is approved; rejecting any one blocks the whole release. Publishing then proceeds through your release workflow's own publish step (e.g. Trusted Publishing / OIDC) — Drydock never holds your registry credentials."
+          : "Approve to release the held GitHub Actions job — publishing then proceeds through your release workflow's own publish step (e.g. Trusted Publishing / OIDC). Reject to block the job. Drydock never holds your registry credentials or uploads the package."
       }
     >
       <div class="flex flex-col gap-2 border border-border rounded-md p-3">

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -20,15 +20,16 @@ export default function DocsPage() {
           <p class="text-[17px] text-ink-muted max-w-[620px] leading-[1.6] m-0">
             Drydock reviews what a release ships before it goes public, and never holds your publish
             credential. How it hooks in depends on the registry: npm hands Drydock a staged tarball
-            to inspect; PyPI has no staged artifact, so a GitHub Actions gate holds the publish
-            until the build is reviewed.
+            to inspect; registries without a staged artifact (PyPI today) use a workflow gate, where
+            a GitHub Actions deployment-protection rule holds the publish until the build is
+            reviewed.
           </p>
           <nav class="flex flex-wrap gap-x-5 gap-y-2 mt-1 font-mono text-[11px] uppercase tracking-[0.1em]">
             <a class="text-accent hover:text-accent-hover" href="#staged-publishing">
               → Staged publishing (npm)
             </a>
             <a class="text-accent hover:text-accent-hover" href="#workflow-gating">
-              → Workflow gating (PyPI)
+              → Workflow gating
             </a>
           </nav>
         </header>
@@ -128,19 +129,24 @@ export default function DocsPage() {
         <section id="workflow-gating" class="flex flex-col gap-8 scroll-mt-6">
           <div class="flex flex-col gap-3">
             <SectionLabel>
-              Workflow gating — PyPI &amp; GitHub Actions <Badge tone="info">Preview</Badge>
+              Workflow gating — GitHub Actions <Badge tone="info">Preview</Badge>
             </SectionLabel>
             <h2 class="text-2xl font-semibold tracking-[-0.015em] m-0 max-w-[680px]">
               When the registry can't hold the candidate, the workflow does.
             </h2>
             <Prose>
-              PyPI does not expose a staged tarball. The publish job itself becomes the boundary: CI
-              builds the wheels and sdists, uploads them as a release candidate, and a GitHub
-              Environment with a Drydock-owned deployment protection rule holds the publish job.
-              Drydock reviews the candidate and records a recommendation, but never approves on its
-              own — a maintainer approves or rejects from the review workbench, and only then is the
-              held job released or blocked. The publish runs on the workflow's own PyPI Trusted
-              Publishing credential via OIDC; Drydock never holds it.
+              Some registries don't expose a staged candidate. For those, the publish job itself
+              becomes the boundary: CI builds the release artifacts, uploads them as a release
+              candidate, and a GitHub Environment with a Drydock-owned deployment protection rule
+              holds the publish job. Drydock reviews the candidate and records a recommendation, but
+              never approves on its own — a maintainer approves or rejects from the review
+              workbench, and only then is the held job released or blocked. The publish runs on the
+              workflow's own credential (e.g. Trusted Publishing via OIDC); Drydock never holds it.
+            </Prose>
+            <Prose>
+              PyPI is the first supported ecosystem. The GitHub plumbing below — install, gate,
+              fetch, review, decide — is shared, so future ecosystems plug in behind the same gate;
+              this walkthrough uses PyPI as the example.
             </Prose>
             <Alert tone="info">
               The full gate runs in production today: Drydock fetches the release candidate, reviews


### PR DESCRIPTION
Closes the remaining acceptance-#3 gap of [#143](https://github.com/JoviDeCroock/drydock/issues/143): the generalized workflow-gate architecture (adapter boundary, registry dispatch, ecosystem-neutral GitHub plumbing, auto-detect) already landed, so this PR removes the last PyPI assumptions in shared dashboard copy and docs. The shared gate decision dialog (`GateDecisionDialog.tsx`) no longer hardcodes "PyPI Trusted Publishing"/"PyPI credentials" and now uses ecosystem-neutral approve/reject copy. `docs/pypi-workflow-gate.md` is renamed to `docs/workflow-gates.md` and reframed as a product mode distinct from npm staged publishing, with PyPI as the first/reference ecosystem; references in README, AGENTS, and architecture docs are updated. The in-app Docs page workflow-gating section is reframed as a general GitHub Actions mode (PyPI as the example), copy-only with no visual/structural change. Remaining PyPI mentions live only inside the PyPI-specific setup flow, which the issue allows; `pnpm verify` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)