### PR TITLE
docs: remove stale and redundant info from docs/

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -181,7 +181,7 @@ Raw tarballs should not be retained by default in SaaS. If needed later, make ra
 
 ### Workers AI (Flagship-gated)
 
-Workers AI review is wired into the scan pipeline through `maybeRunAiReview`, but it is **gated by the per-organization Cloudflare Flagship `ai-review` flag and off by default**. The reviewer module - `server/lib/ai-review.ts`, its model policy, the prompt-injection-resistant system prompt, the AI SDK evidence-tool loop, and the test suite - stays in the active contract for the planned paid-tier feature. The code currently declares `AI_MODEL = "@cf/moonshotai/kimi-k2.5"`; Cloudflare scheduled that model to alias to Kimi K2.6 on May 30, 2026, so treat K2.6 as the effective model and pricing target unless the constant is migrated.
+Workers AI review is wired into the scan pipeline through `maybeRunAiReview`, but it is **gated by the per-organization Cloudflare Flagship `ai-review` flag and off by default**. The reviewer module - `server/lib/ai-review.ts`, its model policy, the prompt-injection-resistant system prompt, the AI SDK evidence-tool loop, and the test suite - stays in the active contract for the planned paid-tier feature. The code currently declares `AI_MODEL = "@cf/moonshotai/kimi-k2.5"`; Cloudflare aliases that model to Kimi K2.6 (effective May 30, 2026), so treat K2.6 as the effective model and pricing target unless the constant is migrated.
 
 When Flagship does not return `true` for the scanning organization, the pipeline records an `unavailable` AI review. If enabled AI review fails, the pipeline emits `scan.ai_review.failed`, records AI review as unavailable, and still persists the deterministic report. Risk is computed from deterministic findings unless a complete, schema-valid AI review returns additional evidence or an explicit manual-review flag.
 
@@ -218,7 +218,7 @@ Organization-owned resources scope by the active org:
 
 Team membership, invitations, and RBAC ship today — see [`organization-members.md`](./organization-members.md). Each membership row carries one of three roles (`owner`, `admin`, `member`) defined in `server/lib/roles.ts`. Owners and admins manage members, invitations, npm connections, and GitHub release targets; members get read access to org-scoped resources and can act on releases. The owner is the `organizations.ownerUserId` and cannot be removed or demoted through the API. Route guards still verify membership through `organization_members` via `requireActiveOrganization`; sensitive mutations additionally resolve the caller's role with `requireActiveOrganizationContext` and gate on `roleCanManageMembers` / `roleCanManageIntegrations` rather than trusting client-supplied org ids.
 
-Deletion, audit-log UI, billing, and quotas remain deferred (see Phase 12 in `docs/production-roadmap.md`).
+Deletion, audit-log UI, billing, and quotas remain deferred (see Phase 7 in `docs/production-roadmap.md`).
 
 ## Account email verification
 

--- a/docs/cost-model.md
+++ b/docs/cost-model.md
@@ -46,7 +46,7 @@ Workers AI is ~90% of the variable cost at every scale above the smallest tier.
 - **D1**: 50M writes + 25B reads/mo included on the paid plan, $1/M writes and $0.001/1k reads beyond. Storage $0.75/GB-mo.
 - **KV**: $0.50/M reads, $5/M writes, $0.50/GB-mo storage. ~5 MB per cached `package@version` entry.
 - **Queues**: $0.40/M operations.
-- **Workers AI (Kimi)**: `server/lib/ai-review.ts` still declares `AI_MODEL = "@cf/moonshotai/kimi-k2.5"`, but Cloudflare scheduled Kimi K2.5 requests to auto-alias to Kimi K2.6 on May 30, 2026. Treat K2.6 pricing ($0.95/M input + $0.16/M cached input + $4.00/M output) as the effective current margin model until the constant is migrated; K2.5's listed legacy price was $0.60/M input + $0.10/M cached input + $3.00/M output. Confirm against current Cloudflare AI pricing before sizing margins.
+- **Workers AI (Kimi)**: `server/lib/ai-review.ts` still declares `AI_MODEL = "@cf/moonshotai/kimi-k2.5"`, but Cloudflare aliases Kimi K2.5 requests to Kimi K2.6 (effective May 30, 2026). Treat K2.6 pricing ($0.95/M input + $0.16/M cached input + $4.00/M output) as the effective current margin model until the constant is migrated; K2.5's listed legacy price was $0.60/M input + $0.10/M cached input + $3.00/M output. Confirm against current Cloudflare AI pricing before sizing margins.
 - **Dynamic Workers / Worker Loader**: treated as regular Worker billing; Cloudflare hasn't published a separate model at the time of writing.
 
 ## Where the money goes
@@ -63,7 +63,7 @@ AI review is wired into the pipeline through `maybeRunAiReview`, but the per-org
 The scanner's actual security boundary is deterministic analysis plus human npm approval; AI is advisory triage. The intended production posture, implemented in [`server/lib/ai-review.ts`](../server/lib/ai-review.ts), is:
 
 1. run deterministic rules first;
-2. send the resulting evidence to Kimi for AI review. The code currently points at `AI_MODEL = "@cf/moonshotai/kimi-k2.5"`, but Cloudflare aliases that model to Kimi K2.6 as of May 30, 2026; migrate the constant before enabling paid AI review.
+2. send the resulting evidence to Kimi for AI review (migrate the `AI_MODEL` constant to the effective K2.6 model before enabling paid AI review — see the pricing-inputs note above).
 
 The reviewer in [`server/lib/ai-review.ts`](../server/lib/ai-review.ts) uses the Vercel AI SDK with the Workers AI provider. The first prompt contains deterministic findings, a normalized manifest diff, ecosystem id, and a changed-file manifest. The model can then call app-owned tools to read bounded redacted file evidence — the `read` tool batches up to 10 paths per call (dividing the per-call character budget fairly across them so later paths are not starved) and auto-returns a unified text diff for changed files (or the staged sample otherwise), `search_files` batches up to 5 literal queries, `list_files` filters file subsets — and finally submit the review through a schema-validated `submit_review` tool. The controller enforces max steps, per-tool character caps, a total evidence budget, an output-token cap, and scan-ID-suffixed cache affinity; the model never gets raw tarballs, arbitrary filesystem access, network access, or package execution. The submission schema is sized to fit the output-token cap, and the persisted review keeps only the top critical/high findings (most severe first); medium and lower observations live in the summary, while overall risk still derives from the model's risk plus its manual-review flag.
 

--- a/docs/detection-eval.md
+++ b/docs/detection-eval.md
@@ -149,7 +149,7 @@ Three tracks, in priority order:
      how it was defanged).
 
 This is the corpus that proves Drydock would catch the real thing rather than a
-mock of its own rules. It is the ongoing Phase 13 track in the roadmap.
+mock of its own rules. It is the ongoing Phase 6 (detection defensibility) track in the roadmap.
 
 The first real-sanitized batch lives in `cases-frontier/` and is truth-labeled,
 so frontier recall now reflects real technique coverage rather than synthetic

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -205,7 +205,3 @@ Exit criteria:
 - Deep native/binary malware analysis.
 - Automated publish approval. This remains intentionally out of scope.
 - Additional ecosystems beyond npm/PyPI until one private-beta path is polished and the workflow-gate byte-continuity contract is proven.
-
-## Suggested next implementation slice
-
-Report/workbench polish plus PyPI digest persistence: render scan-event timeline and report provenance, persist reviewed PyPI artifact digests, and tighten finding grouping around the release decision.


### PR DESCRIPTION
Cleans up stale, redundant, and superfluous content in `docs/` after cross-checking each claim against the codebase. Repoints two dangling roadmap cross-references that were left behind when the roadmap was compacted to seven phases (`Phase 12` → `Phase 7` in `architecture.md`, `Phase 13` → `Phase 6` in `detection-eval.md`). Rewords the Kimi `K2.5`→`K2.6` alias note out of its now-past future tense in `architecture.md` and `cost-model.md`, and drops the duplicate restatement of it within `cost-model.md`. Removes the trailing "Suggested next implementation slice" section in `production-roadmap.md`, which merely restated the existing "Current cut line" section. No code or behavior changes — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)