### PR TITLE
Add npm workflow-gate mode for non-staged publishes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - `server/` — Hono Worker. `index.ts` mounts routes under `/api/*`. The Worker is the deploy target (`main` in `wrangler.jsonc`).
   - `routes/scan.ts` — `POST /api/v1/scan { stageId }`. Runs the full pipeline.
   - `routes/scans.ts` — `GET /api/v1/scans` (list), `GET /api/v1/scans/:id` (persisted detail).
-  - `routes/github-webhooks.ts` — `POST /webhooks/github`. Public, signed by the GitHub App webhook secret; bypasses Better Auth. Persists `deployment_protection_rule` deliveries into `github_workflow_gates` and updates installation status on lifecycle events. See `docs/workflow-gates.md`.
+  - `routes/github-webhooks.ts` — `POST /webhooks/github`. Public, signed by the GitHub App webhook secret; bypasses Better Auth. Persists `deployment_protection_rule` deliveries into `github_workflow_gates` and updates installation status on lifecycle events. See `docs/workflow-gates.md` and `docs/npm-workflow-gate.md` (the gate machinery is ecosystem-neutral; npm vs PyPI is content-detected in `lib/workflow-gates/`).
   - `lib/sandbox.ts` — Dynamic Worker that downloads + parses a tarball; `NpmStageGateway` is the only allowed egress.
   - `lib/review.ts` — Deterministic findings, package diff, package.json diff, risk computation. Types are shared with the UI.
   - `lib/ai-review.ts` — Workers AI reviewer, wired via `scan-pipeline.ts` (`maybeRunAiReview`) but off by default (see trust boundary below).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -306,7 +306,7 @@ Keep `POST /api/v1/scan` only as a compatibility shim during migration.
 
 ## Workflow-gate foundation
 
-Workflow gates are a separate product mode from npm staged publishing, for ecosystems with no staged-publish review primitive. The pipeline is ecosystem-neutral — everything GitHub-shaped (install, webhook, artifact fetch, digest recomputation, decision callback, persistence) is shared, and only an ecosystem's artifact semantics are pluggable behind a `WorkflowGateAdapter`. PyPI is the first (and currently only) ecosystem. The implementation is mounted through the GitHub App routes and the public `POST /webhooks/github` deployment-protection webhook, and reviews are persisted as ordinary scans with `source: "workflow_gate"` and a synthetic `stageId: "workflow-gate:<gateId>:<ecosystem>:<package>"`.
+Workflow gates are a separate product mode from npm staged publishing, for releases where the registry is not holding a staged candidate for Drydock to review. The pipeline is ecosystem-neutral — everything GitHub-shaped (install, webhook, artifact fetch, digest recomputation, decision callback, persistence) is shared, and only an ecosystem's artifact semantics are pluggable behind a `WorkflowGateAdapter`. PyPI and npm are supported today. The implementation is mounted through the GitHub App routes and the public `POST /webhooks/github` deployment-protection webhook, and reviews are persisted as ordinary scans with `source: "workflow_gate"` and a synthetic `stageId: "workflow-gate:<gateId>:<ecosystem>:<package>"`.
 
 Implemented pieces:
 

--- a/docs/npm-workflow-gate.md
+++ b/docs/npm-workflow-gate.md
@@ -7,7 +7,7 @@ publish npm packages without staged publishing.
 It only describes what is npm-specific. The webhook ingestion, gate persistence,
 artifact download + SHA-256 recomputation, approve/reject callback, 2FA step-up,
 monorepo fan-out, notifications, and timeout handling are all **shared with the
-PyPI gate** and documented in [`pypi-workflow-gate.md`](./pypi-workflow-gate.md).
+PyPI gate** and documented in [`workflow-gates.md`](./workflow-gates.md).
 Read that first for the end-to-end gate lifecycle.
 
 ## When to use it
@@ -54,15 +54,26 @@ by **content** after parsing the archive in the credentials-free sandbox:
 
 - an npm tarball carries a root `package.json` (the sandbox surfaces
   `package/package.json` with the `package/` prefix stripped) → **npm**;
-- a PyPI sdist carries a `PKG-INFO` → **pypi**.
+- a PyPI sdist carries a `PKG-INFO` at the root of its single top-level directory
+  → **pypi**.
 
 This lives in the shared router (`server/lib/workflow-gates/resolve.ts`): every
 artifact is parsed once, and entries the path classifier could not disambiguate
 (tagged with the `AMBIGUOUS_ARCHIVE_ECOSYSTEM` sentinel) are routed by
-`detectArchiveEcosystem`. A single auto-detect gate therefore reviews npm, PyPI,
+`detectArchiveEcosystems`. A single auto-detect gate therefore reviews npm, PyPI,
 or a mixed monorepo that publishes both — no one has to tell Drydock what they're
 shipping. Pinning `ecosystem: "npm"` on the release target is supported but
 optional.
+
+**Ambiguity fails closed.** Package contents are untrusted, and an npm tarball
+can ship arbitrary files — including a decoy root `PKG-INFO`. The router collects
+_every_ ecosystem's content claim rather than taking the first match, so an
+archive that presents as more than one ecosystem is rejected
+(`artifact_identity_inconsistent`) instead of being silently routed to one and
+skipping the other's findings. A maintainer resolves a genuine collision by
+pinning the release target's ecosystem, which bypasses content detection. PyPI's
+`PKG-INFO` match is scoped to the sdist root location so a file vendored deep
+inside an npm tarball does not look like a sdist.
 
 ## Monorepo
 

--- a/docs/npm-workflow-gate.md
+++ b/docs/npm-workflow-gate.md
@@ -1,0 +1,172 @@
+# npm workflow-gate mode
+
+This document covers npm review through a **GitHub deployment-protection workflow
+gate** — the alternative to npm staged-publish review for repositories that
+publish npm packages without staged publishing.
+
+It only describes what is npm-specific. The webhook ingestion, gate persistence,
+artifact download + SHA-256 recomputation, approve/reject callback, 2FA step-up,
+monorepo fan-out, notifications, and timeout handling are all **shared with the
+PyPI gate** and documented in [`pypi-workflow-gate.md`](./pypi-workflow-gate.md).
+Read that first for the end-to-end gate lifecycle.
+
+## When to use it
+
+Two ways an npm package reaches Drydock review:
+
+| Mode                           | Boundary                                                                                         | Doc                                    |
+| ------------------------------ | ------------------------------------------------------------------------------------------------ | -------------------------------------- |
+| **Staged publish** (preferred) | npm holds the staged tarball; Drydock fetches it by `stageId`                                    | [`architecture.md`](./architecture.md) |
+| **Workflow gate** (this doc)   | the publish job is held on a GitHub Environment; Drydock reviews the uploaded `npm pack` tarball | here                                   |
+
+Workflow-gate mode is **not** a replacement for staged-publish review. Use
+staged publishing when the registry supports it; reach for a workflow gate when a
+repository publishes npm packages without staging them, and wants the same
+review-before-publish guarantee.
+
+## The release candidate
+
+There is **no manifest file and no checksum file** to write. The boundary is the
+workflow run's uploaded artifacts: CI runs `npm pack` (one tarball per
+publishable workspace) and uploads `dist/*.tgz` as a GitHub Actions artifact.
+Drydock treats every `.tgz` / `.tar.gz` it finds as the release set.
+
+Integrity rests on **GitHub artifact immutability**, exactly like the PyPI gate:
+
+- Drydock downloads the artifact bytes in the control plane and recomputes each
+  tarball's SHA-256 (`fetchReleaseBundleWithToken`). That digest is the reviewed
+  tarball's digest, surfaced in the report and shown in the UI.
+- The publish job downloads the **same immutable artifact** and runs
+  `npm publish <tarball>` — it never re-packs. The bytes Drydock reviewed are the
+  bytes that get published.
+
+Drydock synthesizes an internal release manifest
+(`drydock.release-artifacts.v1`, `ecosystem: "npm"`) from the parsed
+`package.json` identity plus the recomputed digest. The manifest is what the
+report and UI render uniformly across ecosystems; maintainers never author it.
+
+## Auto-detection (no declared ecosystem)
+
+An npm `.tgz` is byte- and filename-indistinguishable from a PyPI sdist
+`.tar.gz`/`.tgz`, so a release target left on **auto-detect** (no pinned
+ecosystem) cannot decide the ecosystem from the path alone. The gate resolves it
+by **content** after parsing the archive in the credentials-free sandbox:
+
+- an npm tarball carries a root `package.json` (the sandbox surfaces
+  `package/package.json` with the `package/` prefix stripped) → **npm**;
+- a PyPI sdist carries a `PKG-INFO` → **pypi**.
+
+This lives in the shared router (`server/lib/workflow-gates/resolve.ts`): every
+artifact is parsed once, and entries the path classifier could not disambiguate
+(tagged with the `AMBIGUOUS_ARCHIVE_ECOSYSTEM` sentinel) are routed by
+`detectArchiveEcosystem`. A single auto-detect gate therefore reviews npm, PyPI,
+or a mixed monorepo that publishes both — no one has to tell Drydock what they're
+shipping. Pinning `ecosystem: "npm"` on the release target is supported but
+optional.
+
+## Monorepo
+
+`npm run pack:all` → `dist/*.tgz` (one tarball per workspace) fans out into one
+review per package: tarballs are grouped by their `package.json` name and each
+group is scanned against its own previously-published baseline. The held
+deployment releases only once every package is individually approved; rejecting
+any one package blocks the whole release.
+
+A single npm package version is exactly one tarball, so two tarballs that claim
+the same name (whether the versions agree or not) is treated as inconsistent and
+fails the gate closed (`artifact_identity_inconsistent`). A tarball with no
+`package.json` name/version fails closed too (`artifact_identity_missing`).
+
+## Baseline (currently-published version)
+
+The baseline is the currently-published npm version, selected and fetched through
+the **organization's npm connection** — the same path the staged-publish adapter
+uses (`acquireBaselineNpm`, `pickBaselineVersion`). Private packages resolve
+because the org token is attached, and the token never enters the sandbox: the
+published tarball is fetched by the trusted parent worker and parsed
+credentials-free. If no npm connection is configured (or it is invalid), the
+review runs without a baseline (full-tree review).
+
+## Code sharing
+
+The npm review behaves identically whether a package arrives via staged publish
+or workflow gate, because both share the deterministic findings, package diff,
+risk model, and baseline selection:
+
+- `server/lib/adapters/npm/gate.ts` — `npmGateAdapter`, the `PackageAdapter` the
+  shared pipeline runs for a gated npm publish. It reassembles the already-parsed
+  tarball (no broker, no sandbox call for the staged side) and delegates baseline
+  (`acquireBaselineNpm`), findings (`buildNpmFindings`), and the broker
+  (`createNpmBroker`) to the shared npm adapter code. The only npm-gate-specific
+  bits are input parsing and surfacing the reviewed digest in the report.
+- `server/lib/adapters/npm/manifest.ts` — the synthesized release-manifest type +
+  validator.
+- `server/lib/workflow-gates/npm.ts` — `npmWorkflowGateAdapter`, the
+  `WorkflowGateAdapter`: `classifyArtifact` (`.tgz`/`.tar.gz`), `detectArtifact`
+  (root `package.json`), and `prepareReleaseCandidates` (group parsed tarballs by
+  package identity → one candidate per package).
+
+The staged-publish `npmAdapter` (`server/lib/adapters/npm/index.ts`) is
+unchanged: staged scans keep their existing behavior and routes.
+
+## Workflow shape
+
+A worked monorepo example lives at
+[`JoviDeCroock/drydock-npm-monorepo-ci-example`](https://github.com/JoviDeCroock/drydock-npm-monorepo-ci-example/blob/main/.github/workflows/release.yml).
+The shape:
+
+```yaml
+jobs:
+  build-release-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: "22", registry-url: "https://registry.npmjs.org" }
+      - run: npm run pack:all # npm pack each publishable workspace into dist/*.tgz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: npm-release-candidates # or leave blank in the release target to auto-detect
+          path: dist/*.tgz
+          if-no-files-found: error
+
+  publish:
+    needs: build-release-artifacts
+    runs-on: ubuntu-latest
+    environment: npm # the gate: Drydock's deployment protection rule lives here
+    permissions:
+      id-token: write # OIDC for npm provenance / Trusted Publishing
+      contents: read
+    steps:
+      - uses: actions/setup-node@v4
+        with: { node-version: "22", registry-url: "https://registry.npmjs.org" }
+      # No checkout, no re-pack: GitHub artifact storage is immutable, so the
+      # bytes the gate approved are the bytes we download and publish here.
+      - uses: actions/download-artifact@v4
+        with: { name: npm-release-candidates, path: dist }
+      - run: |
+          shopt -s nullglob
+          for tgz in dist/*.tgz; do
+            npm publish "$tgz" --access public --provenance
+          done
+```
+
+The `environment: npm` line is the gate. Map the repository + environment on
+`Organization settings → GitHub App` so the webhook can resolve a delivery to
+your organization, then attach Drydock as a custom deployment protection rule on
+that environment. The publish job stays blocked until a maintainer approves every
+package's review in Drydock.
+
+## Acceptance mapping (issue #144)
+
+- _A deployment-protection request for an npm target produces a stored review and
+  approve/reject callback_ — shared gate machinery; the npm bundle resolves to
+  `npmGateAdapter` scans linked to the gate.
+- _The report shows the reviewed tarball digest and npm package/version_ —
+  `npmGateAdapter.summarizeDetails` persists the recomputed digest + synthesized
+  manifest.
+- _Existing npm staged-publish scans keep their current behavior and routes_ —
+  `npmAdapter` is untouched; the gate uses a separate adapter.
+- _Tarball/identity verification before review_ — the reviewed digest is bound to
+  the immutable artifact bytes; a tarball with missing/inconsistent
+  `package.json` identity fails the gate closed before any scan runs.

--- a/docs/workflow-gates.md
+++ b/docs/workflow-gates.md
@@ -7,7 +7,7 @@ Workflow gates are a Drydock **product mode distinct from npm staged publishing*
 
 The gate pipeline is **ecosystem-neutral**: everything GitHub-shaped (App installation, webhook verification, artifact fetch, digest recomputation, decision callback, persistence, audit) is shared, and only an ecosystem's artifact semantics are pluggable behind a `WorkflowGateAdapter`. See [Multi-ecosystem workflow gates](#multi-ecosystem-workflow-gates) and [Adding a new ecosystem](#adding-a-new-ecosystem).
 
-**PyPI is the first — and currently only — workflow-gate ecosystem.** The rest of this document uses PyPI as the reference ecosystem: the GitHub plumbing it describes is shared by every future ecosystem (npm, VSIX, …), and only the wheel/sdist-specific parts are PyPI's adapter. For PyPI there is no `drydock-manifest.json` to write — the release set is whatever wheels/sdists the workflow uploads, and package identity is derived from the artifacts themselves.
+**PyPI and npm are the supported workflow-gate ecosystems.** The rest of this document uses PyPI as the reference ecosystem: the GitHub plumbing it describes is shared by every ecosystem (npm, VSIX, …), and only the artifact-specific parts live in each adapter. For PyPI there is no `drydock-manifest.json` to write — the release set is whatever wheels/sdists the workflow uploads, and package identity is derived from the artifacts themselves. npm workflow-gate specifics are documented separately in [`npm-workflow-gate.md`](./npm-workflow-gate.md).
 
 Official references:
 
@@ -304,16 +304,16 @@ the operator can retry once the underlying issue is fixed.
 - Signatures are required. There is no "trust the header" fallback.
 - Callback URLs are pinned to `api.github.com` and the deployment-protection
   path; spoofed URLs are rejected even when the signature is valid.
-- The decision API uses a fresh installation access token; no long-lived
-  PyPI credential ever touches Drydock.
+- The decision API uses a fresh installation access token; registry publish
+  credentials stay in the GitHub workflow and never touch Drydock.
 - `markGateDecided` is a CAS on the pending status, so a race between
   webhook retries and the review pipeline cannot double-approve.
 
 ### Trust boundary
 
-The mapping never holds PyPI credentials or OIDC tokens. The publish job on
-GitHub Actions exchanges its OIDC token with PyPI directly; Drydock only
-controls whether the deployment protection gate releases that job.
+The mapping never holds registry publish credentials or OIDC tokens. The publish
+job on GitHub Actions exchanges its own identity with the registry directly;
+Drydock only controls whether the deployment protection gate releases that job.
 
 ### Env bindings
 
@@ -552,10 +552,10 @@ therefore covers a **set** of packages, not just one:
 
 ## Multi-ecosystem workflow gates
 
-PyPI is the first workflow-gate ecosystem, not the only intended one. The gate
-pipeline is split so that everything GitHub-shaped is shared and only the
-ecosystem's artifact semantics are pluggable. Two distinct adapter layers are
-involved — do not conflate them:
+PyPI and npm are the first workflow-gate ecosystems. The gate pipeline is split
+so that everything GitHub-shaped is shared and only the ecosystem's artifact
+semantics are pluggable. Two distinct adapter layers are involved — do not
+conflate them:
 
 - **`WorkflowGateAdapter`** (`server/lib/workflow-gates/types.ts`) — gate-time
   artifact semantics: which uploaded files are reviewable, and how to derive the

--- a/server/lib/adapters/npm/acquire.ts
+++ b/server/lib/adapters/npm/acquire.ts
@@ -44,9 +44,16 @@ export async function acquireStagedNpm(
   };
 }
 
+/**
+ * Resolve + fetch the currently-published npm version to diff against. Shared by
+ * the staged-publish adapter and the workflow-gate adapter: both select the
+ * baseline through the organization's npm connection (so private packages
+ * resolve) and parse it in the credentials-free sandbox. Only the download
+ * limits are read here, so the gate adapter passes its limits without a stageId.
+ */
 export async function acquireBaselineNpm(
   _ctx: AdapterContext,
-  input: NpmAdapterInput,
+  input: { maxFiles?: number; maxBytesPerFile?: number },
   broker: NpmBroker,
   staged: { artifact: AcquiredArtifact; details: StagedDetails },
 ): Promise<{ artifact: AcquiredArtifact | null; baseline: BaselineInfo }> {

--- a/server/lib/adapters/npm/gate.ts
+++ b/server/lib/adapters/npm/gate.ts
@@ -1,0 +1,176 @@
+import type { FileRecord, PackageJsonSummary } from "../../review";
+import type { TarSuspiciousEntry } from "../../tar-parser.js";
+import type { AcquiredArtifact, AdapterContext, PackageAdapter, StagedDetails } from "../types";
+import { acquireBaselineNpm } from "./acquire";
+import { createNpmBroker, type NpmBroker } from "./broker";
+import { buildNpmFindings } from "./findings";
+import {
+  buildNpmReleaseManifest,
+  isRecord,
+  parseNpmReleaseManifest,
+  type NpmReleaseManifest,
+} from "./manifest";
+
+/**
+ * One npm tarball that the shared workflow-gate router already downloaded,
+ * digested, and parsed in the credentials-free sandbox. `files`/`packageJson`
+ * are the parsed contents; `sha256` is the reviewed tarball digest.
+ */
+export interface NpmGateArtifactInput {
+  path: string;
+  sha256: string;
+  files: FileRecord[];
+  packageJson: PackageJsonSummary | null;
+  suspiciousEntries?: TarSuspiciousEntry[];
+}
+
+export interface NpmGateAdapterInput {
+  manifest: NpmReleaseManifest;
+  artifact: NpmGateArtifactInput;
+  maxFiles?: number;
+  maxBytesPerFile?: number;
+}
+
+/** Persisted, opaque snapshot of the reviewed artifact for the report/UI. */
+export interface NpmGateDetails {
+  mode: "workflow_gate";
+  manifest: NpmReleaseManifest;
+  /** SHA-256 of the reviewed `.tgz`, recomputed from the immutable artifact. */
+  digest: string;
+}
+
+/**
+ * npm workflow-gate review adapter.
+ *
+ * Distinct from the staged-publish `npmAdapter` (which downloads from the npm
+ * staging registry by `stageId`), this adapter reviews a tarball that arrived as
+ * an immutable GitHub Actions artifact: the bytes are already parsed, so
+ * `acquireStaged` is a synchronous reassembly with no broker or sandbox call.
+ * Everything downstream is shared with the staged adapter — baseline selection
+ * (`acquireBaselineNpm`, through the org npm connection), deterministic findings
+ * (`buildNpmFindings`), the package diff, and the risk model — so npm review
+ * behaves identically whether it arrives via staged publish or workflow gate.
+ */
+export const npmGateAdapter: PackageAdapter<NpmGateAdapterInput, NpmBroker> = {
+  id: "npm",
+
+  parseInput(raw: unknown): NpmGateAdapterInput {
+    if (!isRecord(raw)) throw new Error("npm gate adapter input must be an object");
+    const manifest = parseNpmReleaseManifest(raw.manifest);
+    const artifact = parseGateArtifact(raw.artifact);
+    return {
+      manifest,
+      artifact,
+      ...(typeof raw.maxFiles === "number" ? { maxFiles: raw.maxFiles } : {}),
+      ...(typeof raw.maxBytesPerFile === "number" ? { maxBytesPerFile: raw.maxBytesPerFile } : {}),
+    };
+  },
+
+  createBroker(ctx, ref) {
+    return createNpmBroker(ctx, ref);
+  },
+
+  acquireStaged(
+    _ctx: AdapterContext,
+    input: NpmGateAdapterInput,
+    _broker: NpmBroker,
+  ): Promise<{ artifact: AcquiredArtifact; details: StagedDetails }> {
+    // The bytes were already parsed by the shared router; the manifest carries
+    // the reviewed digest. There is no staged-registry metadata to merge.
+    return Promise.resolve({
+      artifact: {
+        files: input.artifact.files,
+        manifest: input.artifact.packageJson,
+        ...(input.artifact.suspiciousEntries
+          ? { suspiciousTarEntries: input.artifact.suspiciousEntries }
+          : {}),
+      },
+      details: {
+        mode: "workflow_gate",
+        manifest: input.manifest,
+        digest: input.artifact.sha256,
+      } satisfies NpmGateDetails,
+    });
+  },
+
+  async acquireBaseline(ctx, input, broker, staged) {
+    try {
+      return await acquireBaselineNpm(
+        ctx,
+        { maxFiles: input.maxFiles, maxBytesPerFile: input.maxBytesPerFile },
+        broker,
+        staged,
+      );
+    } catch {
+      // The baseline is a best-effort diff aid, not a security control. Unlike a
+      // staged publish, a workflow gate does not require an org npm token, so a
+      // missing/invalid connection (or a transient registry error) must degrade
+      // to a full-tree review — every file reads as added, which is the more
+      // conservative outcome — rather than fail the gate closed.
+      return {
+        artifact: null,
+        baseline: {
+          version: null,
+          tag: null,
+          source: "none",
+          distTagVersion: null,
+          reason: "baseline-unavailable",
+        },
+      };
+    }
+  },
+
+  runFindings(args) {
+    // No staged-registry metadata exists for a gated publish, so there is no
+    // metadata-vs-tarball mismatch rule to run; `details: null` skips it.
+    return buildNpmFindings({
+      staged: args.staged,
+      details: null,
+      fileDiff: args.fileDiff,
+      manifestDiff: args.manifestDiff,
+      stagedManifestText: args.stagedManifestText,
+    });
+  },
+
+  describe({ staged, details, previous }) {
+    const d = details as NpmGateDetails;
+    return {
+      name: staged.manifest?.name ?? d.manifest.package,
+      stagedVersion: staged.manifest?.version ?? d.manifest.version,
+      stagedTag: null,
+      previousVersion: previous?.manifest?.version ?? null,
+    };
+  },
+
+  summarizeDetails(details) {
+    const d = details as NpmGateDetails;
+    return {
+      mode: d.mode,
+      ecosystem: "npm",
+      digest: d.digest,
+      manifest: d.manifest,
+    };
+  },
+};
+
+function parseGateArtifact(raw: unknown): NpmGateArtifactInput {
+  if (!isRecord(raw)) throw new Error("npm gate adapter input must include an artifact");
+  const path = typeof raw.path === "string" ? raw.path : "";
+  if (!path) throw new Error("npm gate artifact path is required");
+  const sha256 = typeof raw.sha256 === "string" ? raw.sha256 : "";
+  if (!/^[a-f0-9]{64}$/i.test(sha256)) throw new Error("npm gate artifact sha256 is invalid");
+  if (!Array.isArray(raw.files)) throw new Error("npm gate artifact files must be an array");
+  const packageJson = isRecord(raw.packageJson) ? (raw.packageJson as PackageJsonSummary) : null;
+  return {
+    path,
+    sha256: sha256.toLowerCase(),
+    files: raw.files as FileRecord[],
+    packageJson,
+    ...(Array.isArray(raw.suspiciousEntries)
+      ? { suspiciousEntries: raw.suspiciousEntries as TarSuspiciousEntry[] }
+      : {}),
+  };
+}
+
+export type { NpmReleaseManifest };
+export { buildNpmReleaseManifest };

--- a/server/lib/adapters/npm/manifest.ts
+++ b/server/lib/adapters/npm/manifest.ts
@@ -1,5 +1,3 @@
-import { isValidNpmPackageName } from "../../registry";
-
 /**
  * npm workflow-gate release manifest.
  *
@@ -18,6 +16,12 @@ export const NPM_RELEASE_MANIFEST_SCHEMA = "drydock.release-artifacts.v1";
 // npm versions are semver; keep the charset tight so a hostile version string
 // cannot smuggle path or control characters into report/UI surfaces.
 const SAFE_VERSION_RE = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$/;
+// npm only enforces lowercase for *new* names; legacy packages (e.g. `JSONStream`)
+// keep uppercase names and still publish, so the registration-time validator
+// (`isValidNpmPackageName`) would fail their gate closed. Accept any name the
+// registry still serves while blocking the path/control characters that could
+// poison report/UI surfaces — the same concern the version charset guards against.
+const SAFE_PACKAGE_NAME_RE = /^(?:@[A-Za-z0-9][A-Za-z0-9._~-]*\/)?[A-Za-z0-9][A-Za-z0-9._~-]*$/;
 const SHA256_RE = /^[a-f0-9]{64}$/i;
 // A single npm package version is exactly one tarball; keep a small bound to
 // guard against a degenerate group somehow accumulating many artifacts.
@@ -59,7 +63,7 @@ export function parseNpmReleaseManifest(value: unknown): NpmReleaseManifest {
   if (value.ecosystem !== "npm") throw new Error("manifest ecosystem must be npm");
   const packageName = String(value.package || "");
   const version = String(value.version || "");
-  if (!isValidNpmPackageName(packageName)) {
+  if (!isSafeManifestPackageName(packageName)) {
     throw new Error("manifest package is not a valid npm package name");
   }
   if (!SAFE_VERSION_RE.test(version)) {
@@ -94,6 +98,10 @@ export function parseNpmReleaseManifest(value: unknown): NpmReleaseManifest {
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSafeManifestPackageName(name: string): boolean {
+  return name.length >= 1 && name.length <= 214 && SAFE_PACKAGE_NAME_RE.test(name);
 }
 
 function isSafeManifestPath(path: string): boolean {

--- a/server/lib/adapters/npm/manifest.ts
+++ b/server/lib/adapters/npm/manifest.ts
@@ -1,0 +1,104 @@
+import { isValidNpmPackageName } from "../../registry";
+
+/**
+ * npm workflow-gate release manifest.
+ *
+ * Like the PyPI gate, the manifest is **synthesized server-side** from the
+ * parsed `package.json` plus the SHA-256 the control plane recomputed from the
+ * immutable GitHub Actions artifact bytes — maintainers do not upload a manifest
+ * or checksum file (see the example workflow in `docs/npm-workflow-gate.md`).
+ * Integrity rests on GitHub artifact immutability: the bytes Drydock reviews are
+ * the bytes the publish job downloads and runs `npm publish` on.
+ *
+ * The shape is shared with PyPI (`drydock.release-artifacts.v1`) so the report
+ * and UI can render a digest + package/version uniformly across ecosystems.
+ */
+export const NPM_RELEASE_MANIFEST_SCHEMA = "drydock.release-artifacts.v1";
+
+// npm versions are semver; keep the charset tight so a hostile version string
+// cannot smuggle path or control characters into report/UI surfaces.
+const SAFE_VERSION_RE = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$/;
+const SHA256_RE = /^[a-f0-9]{64}$/i;
+// A single npm package version is exactly one tarball; keep a small bound to
+// guard against a degenerate group somehow accumulating many artifacts.
+const NPM_ARTIFACT_LIMIT = 4;
+
+export interface NpmReleaseManifestArtifact {
+  path: string;
+  sha256: string;
+}
+
+export interface NpmReleaseManifest {
+  schema: typeof NPM_RELEASE_MANIFEST_SCHEMA;
+  ecosystem: "npm";
+  package: string;
+  version: string;
+  artifacts: NpmReleaseManifestArtifact[];
+}
+
+/** Synthesize + validate a manifest from a package's resolved identity + artifacts. */
+export function buildNpmReleaseManifest(
+  name: string,
+  version: string,
+  artifacts: NpmReleaseManifestArtifact[],
+): NpmReleaseManifest {
+  return parseNpmReleaseManifest({
+    schema: NPM_RELEASE_MANIFEST_SCHEMA,
+    ecosystem: "npm",
+    package: name,
+    version,
+    artifacts,
+  });
+}
+
+export function parseNpmReleaseManifest(value: unknown): NpmReleaseManifest {
+  if (!isRecord(value)) throw new Error("manifest must be an object");
+  if (value.schema !== NPM_RELEASE_MANIFEST_SCHEMA) {
+    throw new Error(`manifest schema must be ${NPM_RELEASE_MANIFEST_SCHEMA}`);
+  }
+  if (value.ecosystem !== "npm") throw new Error("manifest ecosystem must be npm");
+  const packageName = String(value.package || "");
+  const version = String(value.version || "");
+  if (!isValidNpmPackageName(packageName)) {
+    throw new Error("manifest package is not a valid npm package name");
+  }
+  if (!SAFE_VERSION_RE.test(version)) {
+    throw new Error("manifest version is not a safe npm version string");
+  }
+  if (!Array.isArray(value.artifacts) || !value.artifacts.length) {
+    throw new Error("manifest must include at least one artifact");
+  }
+  if (value.artifacts.length > NPM_ARTIFACT_LIMIT) {
+    throw new Error(`manifest must include no more than ${NPM_ARTIFACT_LIMIT} artifacts`);
+  }
+
+  const artifacts = value.artifacts.map((artifact, index) => {
+    if (!isRecord(artifact)) throw new Error(`artifact ${index + 1} must be an object`);
+    const path = String(artifact.path || "");
+    if (!isSafeManifestPath(path)) throw new Error(`artifact ${index + 1} path is not safe`);
+    const sha256 = String(artifact.sha256 || "");
+    if (!SHA256_RE.test(sha256)) {
+      throw new Error(`artifact ${index + 1} sha256 must be a hex SHA-256 digest`);
+    }
+    return { path, sha256: sha256.toLowerCase() };
+  });
+
+  return {
+    schema: NPM_RELEASE_MANIFEST_SCHEMA,
+    ecosystem: "npm",
+    package: packageName,
+    version,
+    artifacts,
+  };
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSafeManifestPath(path: string): boolean {
+  if (!path || path.length > 512 || path.includes("\0") || path.includes("\\")) return false;
+  if (path.startsWith("/") || path.startsWith("../") || path.includes("/../")) return false;
+  if (/^[A-Za-z]:/.test(path)) return false;
+  return path.split("/").every((part) => part && part !== "." && part !== "..");
+}

--- a/server/lib/github-app/config.ts
+++ b/server/lib/github-app/config.ts
@@ -9,7 +9,7 @@ export interface GithubAppEnv {
   BETTER_AUTH_SECRET: string;
 }
 
-export const SUPPORTED_ECOSYSTEMS = ["pypi"] as const;
+export const SUPPORTED_ECOSYSTEMS = ["pypi", "npm"] as const;
 export type SupportedEcosystem = (typeof SUPPORTED_ECOSYSTEMS)[number];
 
 export const INSTALLATION_STATUSES = ["active", "suspended", "uninstalled"] as const;

--- a/server/lib/workflow-gates/index.ts
+++ b/server/lib/workflow-gates/index.ts
@@ -1,4 +1,6 @@
 export * from "./types";
 export * from "./registry";
 export * from "./prepare";
+export { resolveBundleArtifacts } from "./resolve";
 export { pypiWorkflowGateAdapter } from "./pypi";
+export { npmWorkflowGateAdapter } from "./npm";

--- a/server/lib/workflow-gates/npm.ts
+++ b/server/lib/workflow-gates/npm.ts
@@ -1,0 +1,130 @@
+import { buildNpmReleaseManifest, npmGateAdapter } from "../adapters/npm/gate";
+import type { AdapterBroker, PackageAdapter } from "../adapters/types";
+import { WorkflowArtifactError } from "../github-app";
+import type {
+  ArchiveContents,
+  ParsedGateArtifact,
+  PreparedReleaseCandidate,
+  WorkflowArtifactKind,
+  WorkflowGateAdapter,
+} from "./types";
+
+/**
+ * npm workflow-gate adapter.
+ *
+ * The release set is whatever `.tgz` tarballs the workflow uploaded (`npm pack`
+ * output) — no maintainer-declared manifest. Identity (`package`/`version`) is
+ * read from each tarball's `package.json` after the bytes are parsed in the
+ * shared sandbox router, and the manifest is synthesized server-side with the
+ * recomputed digest. Because an npm `.tgz` is indistinguishable from a PyPI
+ * sdist by name, auto-detect targets route here by content (`detectArtifact`):
+ * an archive that carries a root `package.json` is npm's.
+ *
+ * The deterministic review, baseline selection (through the org npm connection),
+ * findings, and risk model are shared with the staged-publish path via
+ * `npmGateAdapter` (`server/lib/adapters/npm/gate`).
+ */
+export const npmWorkflowGateAdapter: WorkflowGateAdapter = {
+  ecosystem: "npm",
+  // Matches the `actions/upload-artifact` name in the documented release flow,
+  // but discovery does not require it — auto-detect inspects every upload.
+  artifactName: "npm-release-candidates",
+  packageAdapter: npmGateAdapter as unknown as PackageAdapter<unknown, AdapterBroker>,
+
+  classifyArtifact(path: string): WorkflowArtifactKind | null {
+    const lower = path.toLowerCase();
+    return lower.endsWith(".tgz") || lower.endsWith(".tar.gz") ? "tarball" : null;
+  },
+
+  detectArtifact(contents: ArchiveContents): WorkflowArtifactKind | null {
+    // `package.json` is surfaced from the npm `package/` root by the sandbox
+    // parser; a PyPI sdist never carries a root `package.json`.
+    return contents.packageJson?.name ? "tarball" : null;
+  },
+
+  prepareReleaseCandidates(artifacts: ParsedGateArtifact[]): PreparedReleaseCandidate[] {
+    return deriveNpmReleaseCandidates(artifacts);
+  },
+};
+
+interface NpmGroup {
+  name: string;
+  version: string;
+  artifacts: ParsedGateArtifact[];
+}
+
+/**
+ * Split the bundle's npm tarballs into one candidate per distinct package.
+ *
+ * A monorepo publishes several packages from one release (e.g. `npm run
+ * pack:all` → `dist/*.tgz`), so tarballs are grouped by their `package.json`
+ * name and each group becomes its own candidate → its own scan against its own
+ * baseline. Every tarball must expose a `name`/`version`; tarballs sharing a
+ * name must agree on the version (and a single npm package version is exactly
+ * one tarball), so a smuggled or version-skewed tarball is rejected rather than
+ * silently shipped.
+ */
+function deriveNpmReleaseCandidates(artifacts: ParsedGateArtifact[]): PreparedReleaseCandidate[] {
+  const groups = new Map<string, NpmGroup>();
+  for (const artifact of artifacts) {
+    const name = artifact.packageJson?.name;
+    const version = artifact.packageJson?.version;
+    if (!name || !version) {
+      throw new WorkflowArtifactError(
+        "artifact_identity_missing",
+        `${artifact.path} does not expose a package.json name/version`,
+      );
+    }
+    const group = groups.get(name);
+    if (!group) {
+      groups.set(name, { name, version, artifacts: [artifact] });
+      continue;
+    }
+    if (version !== group.version) {
+      throw new WorkflowArtifactError(
+        "artifact_identity_inconsistent",
+        `${artifact.path} version ${version} disagrees with ${group.version} for ${name}`,
+      );
+    }
+    // A single published npm version maps to exactly one tarball; two tarballs
+    // claiming the same name+version is ambiguous and must not ship.
+    throw new WorkflowArtifactError(
+      "artifact_identity_inconsistent",
+      `package ${name} has more than one tarball in this release`,
+    );
+  }
+
+  // `artifacts` is non-empty: the resolver throws `bundle_empty` for a bundle
+  // with no reviewable artifacts, so `groups` always has at least one package.
+  return [...groups.values()].map((group) => {
+    const artifact = group.artifacts[0];
+    const manifest = buildManifest(group.name, group.version, artifact);
+    return {
+      ecosystem: "npm",
+      pipelineInput: {
+        manifest,
+        artifact: {
+          path: artifact.path,
+          sha256: artifact.sha256,
+          files: artifact.files,
+          packageJson: artifact.packageJson,
+          ...(artifact.suspiciousEntries ? { suspiciousEntries: artifact.suspiciousEntries } : {}),
+        },
+      },
+      package: { name: manifest.package, version: manifest.version },
+    };
+  });
+}
+
+function buildManifest(name: string, version: string, artifact: ParsedGateArtifact) {
+  try {
+    return buildNpmReleaseManifest(name, version, [
+      { path: artifact.path, sha256: artifact.sha256 },
+    ]);
+  } catch (err) {
+    throw new WorkflowArtifactError(
+      "artifact_identity_missing",
+      err instanceof Error ? err.message : "derived release identity is not valid",
+    );
+  }
+}

--- a/server/lib/workflow-gates/prepare.ts
+++ b/server/lib/workflow-gates/prepare.ts
@@ -9,7 +9,6 @@ import {
   type GithubAppConfig,
   markGateErrored,
   type ResolvedReleaseBundle,
-  type ResolvedReleaseFile,
   WorkflowArtifactError,
   type WorkflowGateRecord,
 } from "../github-app";
@@ -19,7 +18,8 @@ import {
   getWorkflowGateAdapter,
   UnsupportedEcosystemError,
 } from "./registry";
-import type { PreparedReleaseCandidate, WorkflowGateAdapter } from "./types";
+import { resolveBundleArtifacts } from "./resolve";
+import type { ParsedGateArtifact, PreparedReleaseCandidate, WorkflowGateAdapter } from "./types";
 
 export interface PrepareForGateInput {
   config: GithubAppConfig;
@@ -207,27 +207,29 @@ function resolveBundleClassifier(
 }
 
 /**
- * Group the verified artifacts by ecosystem and let each ecosystem's adapter
- * split its slice into one prepared candidate per distinct package.
+ * Parse every verified artifact once in the shared sandbox router, group the
+ * parsed artifacts by their (possibly content-resolved) ecosystem, and let each
+ * ecosystem's adapter split its slice into one prepared candidate per distinct
+ * package.
  */
 async function prepareBundlePackages(
   env: Cloudflare.Env,
   ctx: ExecutionContext,
   bundle: ResolvedReleaseBundle,
 ): Promise<PreparedGatePackage[]> {
-  const byEcosystem = new Map<string, ResolvedReleaseFile[]>();
-  for (const file of bundle.artifacts) {
-    const slice = byEcosystem.get(file.ecosystem);
-    if (slice) slice.push(file);
-    else byEcosystem.set(file.ecosystem, [file]);
+  const resolved = await resolveBundleArtifacts(env, ctx, bundle);
+
+  const byEcosystem = new Map<string, ParsedGateArtifact[]>();
+  for (const artifact of resolved) {
+    const slice = byEcosystem.get(artifact.ecosystem);
+    if (slice) slice.push(artifact);
+    else byEcosystem.set(artifact.ecosystem, [artifact]);
   }
 
   const packages: PreparedGatePackage[] = [];
   for (const [ecosystem, artifacts] of byEcosystem) {
     const adapter = getWorkflowGateAdapter(ecosystem);
-    const candidates = await adapter.prepareReleaseCandidates(env, ctx, {
-      bundle: { ...bundle, artifacts },
-    });
+    const candidates = adapter.prepareReleaseCandidates(artifacts);
     for (const candidate of candidates) {
       packages.push({ candidate, packageAdapter: adapter.packageAdapter });
     }

--- a/server/lib/workflow-gates/pypi.ts
+++ b/server/lib/workflow-gates/pypi.ts
@@ -6,18 +6,18 @@ import {
   pypiAdapter,
   PYPI_RELEASE_MANIFEST_SCHEMA,
   type PyPiArtifactInput,
-  type PyPiArtifactKind,
   type PyPiPreparedArtifact,
   type PyPiReleaseManifest,
 } from "../adapters/pypi/index";
 import type { AdapterBroker, PackageAdapter } from "../adapters/types";
-import {
-  type ResolvedReleaseBundle,
-  type ResolvedReleaseFile,
-  WorkflowArtifactError,
-} from "../github-app";
-import { downloadInSandboxInline, type DownloadResult } from "../sandbox";
-import type { PreparedReleaseCandidate, WorkflowArtifactKind, WorkflowGateAdapter } from "./types";
+import { WorkflowArtifactError } from "../github-app";
+import type {
+  ArchiveContents,
+  ParsedGateArtifact,
+  PreparedReleaseCandidate,
+  WorkflowArtifactKind,
+  WorkflowGateAdapter,
+} from "./types";
 
 /**
  * PyPI workflow-gate adapter.
@@ -25,7 +25,7 @@ import type { PreparedReleaseCandidate, WorkflowArtifactKind, WorkflowGateAdapte
  * There is no maintainer-declared manifest: the release set is whatever
  * wheel/sdist files the bundle contains, and identity (`package`/`version`) is
  * derived from each wheel's `METADATA` / sdist's `PKG-INFO` after the bytes are
- * parsed in the credentials-free sandbox. The deterministic review + baseline
+ * parsed in the shared sandbox router. The deterministic review + baseline
  * selection live in the shared `pypiAdapter` (`server/lib/adapters/pypi`); this
  * adapter only owns the gate-time artifact semantics.
  */
@@ -38,23 +38,24 @@ export const pypiWorkflowGateAdapter: WorkflowGateAdapter = {
     return inferPyPiArtifactKind(path);
   },
 
-  async prepareReleaseCandidates(
-    env: Cloudflare.Env,
-    ctx: ExecutionContext,
-    { bundle }: { bundle: ResolvedReleaseBundle },
-  ): Promise<PreparedReleaseCandidate[]> {
-    const entries: PreparedArtifactEntry[] = [];
-    for (const file of bundle.artifacts) {
-      const files = await parseArtifactBytes(env, ctx, file);
-      const input: PyPiArtifactInput = { path: file.path, files };
-      entries.push({ file, input, prepared: preparePyPiArtifact(input) });
-    }
+  detectArtifact(contents: ArchiveContents): WorkflowArtifactKind | null {
+    // A PyPI sdist carries `PKG-INFO` at the archive root, usually under the
+    // single project-version directory. Nested egg-info metadata can appear in
+    // vendored files inside npm tarballs, so it must not claim the archive.
+    return contents.files.some((file) => isSdistRootMetadataPath(file.path)) ? "sdist" : null;
+  },
+
+  prepareReleaseCandidates(artifacts: ParsedGateArtifact[]): PreparedReleaseCandidate[] {
+    const entries: PreparedArtifactEntry[] = artifacts.map((artifact) => {
+      const input: PyPiArtifactInput = { path: artifact.path, files: artifact.files };
+      return { artifact, input, prepared: preparePyPiArtifact(input) };
+    });
     return deriveReleaseCandidates(entries);
   },
 };
 
 interface PreparedArtifactEntry {
-  file: ResolvedReleaseFile;
+  artifact: ParsedGateArtifact;
   input: PyPiArtifactInput;
   prepared: PyPiPreparedArtifact;
 }
@@ -84,7 +85,7 @@ function deriveReleaseCandidates(entries: PreparedArtifactEntry[]): PreparedRele
     if (!summary.name || !summary.version) {
       throw new WorkflowArtifactError(
         "artifact_identity_missing",
-        `${entry.file.path} does not expose a PyPI Name/Version in its metadata`,
+        `${entry.artifact.path} does not expose a PyPI Name/Version in its metadata`,
       );
     }
     const normalized = normalizePyPiProjectName(summary.name);
@@ -96,7 +97,7 @@ function deriveReleaseCandidates(entries: PreparedArtifactEntry[]): PreparedRele
     if (summary.version !== group.version) {
       throw new WorkflowArtifactError(
         "artifact_identity_inconsistent",
-        `${entry.file.path} version ${summary.version} disagrees with ${group.version} for ${group.name}`,
+        `${entry.artifact.path} version ${summary.version} disagrees with ${group.version} for ${group.name}`,
       );
     }
     group.entries.push(entry);
@@ -108,7 +109,7 @@ function deriveReleaseCandidates(entries: PreparedArtifactEntry[]): PreparedRele
     const manifest = buildReleaseManifest(
       group.name,
       group.version,
-      group.entries.map((entry) => entry.file),
+      group.entries.map((entry) => entry.artifact),
     );
     return {
       ecosystem: "pypi",
@@ -121,7 +122,7 @@ function deriveReleaseCandidates(entries: PreparedArtifactEntry[]): PreparedRele
 function buildReleaseManifest(
   name: string,
   version: string,
-  files: ResolvedReleaseFile[],
+  files: ParsedGateArtifact[],
 ): PyPiReleaseManifest {
   const candidate = {
     schema: PYPI_RELEASE_MANIFEST_SCHEMA,
@@ -140,19 +141,8 @@ function buildReleaseManifest(
   }
 }
 
-async function parseArtifactBytes(
-  env: Cloudflare.Env,
-  ctx: ExecutionContext,
-  artifact: ResolvedReleaseFile,
-): Promise<DownloadResult["files"]> {
-  const format = inlineFormatForKind(artifact.kind as PyPiArtifactKind);
-  const result = await downloadInSandboxInline(env, ctx, {
-    bytes: artifact.bytes,
-    format,
-  });
-  return result.files;
-}
-
-function inlineFormatForKind(kind: PyPiArtifactKind): "zip" | "tgz" {
-  return kind === "wheel" ? "zip" : "tgz";
+function isSdistRootMetadataPath(path: string): boolean {
+  if (path === "PKG-INFO") return true;
+  const parts = path.split("/");
+  return parts.length === 2 && parts[1] === "PKG-INFO";
 }

--- a/server/lib/workflow-gates/registry.ts
+++ b/server/lib/workflow-gates/registry.ts
@@ -45,7 +45,7 @@ export function getWorkflowGateAdapter(ecosystem: string): WorkflowGateAdapter {
  * name-indistinguishable from a PyPI sdist `.tar.gz` — the entry is kept but
  * tagged with the `AMBIGUOUS_ARCHIVE_ECOSYSTEM` sentinel. The shared router then
  * parses the bytes and resolves the real ecosystem by content
- * (`detectArchiveEcosystem`), so we never have to make people declare which
+ * (`detectArchiveEcosystems`), so we never have to make people declare which
  * ecosystem they are publishing.
  */
 export function classifyBundleArtifact(path: string): { ecosystem: string; kind: string } | null {
@@ -60,19 +60,28 @@ export function classifyBundleArtifact(path: string): { ecosystem: string; kind:
 }
 
 /**
- * Resolve an ambiguous archive's ecosystem from its parsed contents. The first
- * adapter whose `detectArtifact` claims the contents wins; npm claims an archive
- * with a root `package.json`, PyPI an sdist with a `PKG-INFO`. Returns `null`
- * when no ecosystem recognizes the archive (the runner fail-closes the gate).
+ * Collect every ecosystem whose content detector claims a parsed archive: npm
+ * claims an archive with a root `package.json`, PyPI an sdist with a root
+ * `PKG-INFO`.
+ *
+ * A clean release artifact belongs to exactly one ecosystem, but npm tarballs
+ * can ship arbitrary files — including a decoy `PKG-INFO` at the package root —
+ * so an archive can present as more than one ecosystem. We must not resolve that
+ * by registration order (it would silently route the npm publish through the
+ * PyPI adapter and skip every npm lifecycle/`package.json` finding). The caller
+ * therefore inspects the full claim set and fail-closes a multi-ecosystem match;
+ * a maintainer resolves it by pinning the release target's ecosystem, which
+ * bypasses content detection entirely.
  */
-export function detectArchiveEcosystem(
+export function detectArchiveEcosystems(
   contents: ArchiveContents,
-): { ecosystem: string; kind: string } | null {
+): { ecosystem: string; kind: string }[] {
+  const claims: { ecosystem: string; kind: string }[] = [];
   for (const adapter of Object.values(WORKFLOW_GATE_ADAPTERS)) {
     const kind = adapter.detectArtifact(contents);
-    if (kind) return { ecosystem: adapter.ecosystem, kind };
+    if (kind) claims.push({ ecosystem: adapter.ecosystem, kind });
   }
-  return null;
+  return claims;
 }
 
 /** Ecosystems that currently have a registered workflow-gate adapter. */

--- a/server/lib/workflow-gates/registry.ts
+++ b/server/lib/workflow-gates/registry.ts
@@ -1,5 +1,14 @@
+import { npmWorkflowGateAdapter } from "./npm";
 import { pypiWorkflowGateAdapter } from "./pypi";
-import type { WorkflowGateAdapter } from "./types";
+import type { ArchiveContents, WorkflowGateAdapter } from "./types";
+
+/**
+ * Sentinel ecosystem assigned to a kept bundle entry whose extension more than
+ * one ecosystem claims (an npm `.tgz` vs a PyPI sdist `.tar.gz`). The shared
+ * router resolves the real ecosystem by parsing the bytes and asking each
+ * adapter's `detectArtifact`; the sentinel never reaches an adapter.
+ */
+export const AMBIGUOUS_ARCHIVE_ECOSYSTEM = "archive";
 
 /**
  * Thrown when a release target names an ecosystem that has no registered
@@ -16,6 +25,7 @@ export class UnsupportedEcosystemError extends Error {
 
 const WORKFLOW_GATE_ADAPTERS: Record<string, WorkflowGateAdapter> = {
   [pypiWorkflowGateAdapter.ecosystem]: pypiWorkflowGateAdapter,
+  [npmWorkflowGateAdapter.ecosystem]: npmWorkflowGateAdapter,
 };
 
 /** Resolve the workflow-gate adapter for a release target's ecosystem. */
@@ -27,17 +37,39 @@ export function getWorkflowGateAdapter(ecosystem: string): WorkflowGateAdapter {
 
 /**
  * Classify a bundle entry across every registered ecosystem for an auto-detect
- * release target (one that does not pin an ecosystem). The first adapter whose
- * `classifyArtifact` claims the path wins; entries no adapter claims are dropped.
+ * release target (one that does not pin an ecosystem). Entries no adapter claims
+ * are dropped; an entry exactly one adapter claims is tagged with that
+ * ecosystem.
  *
- * A path can in principle look like two ecosystems' artifacts, but in practice
- * the suffixes are disjoint (`.whl`/`.tar.gz` vs other ecosystems'), so order
- * only matters for genuinely ambiguous names — which we treat as the first
- * registered match deterministically rather than erroring.
+ * When more than one ecosystem claims the same path — an npm `.tgz` is byte- and
+ * name-indistinguishable from a PyPI sdist `.tar.gz` — the entry is kept but
+ * tagged with the `AMBIGUOUS_ARCHIVE_ECOSYSTEM` sentinel. The shared router then
+ * parses the bytes and resolves the real ecosystem by content
+ * (`detectArchiveEcosystem`), so we never have to make people declare which
+ * ecosystem they are publishing.
  */
 export function classifyBundleArtifact(path: string): { ecosystem: string; kind: string } | null {
+  const claims: { ecosystem: string; kind: string }[] = [];
   for (const adapter of Object.values(WORKFLOW_GATE_ADAPTERS)) {
     const kind = adapter.classifyArtifact(path);
+    if (kind) claims.push({ ecosystem: adapter.ecosystem, kind });
+  }
+  if (claims.length === 0) return null;
+  if (claims.length === 1) return claims[0];
+  return { ecosystem: AMBIGUOUS_ARCHIVE_ECOSYSTEM, kind: "archive" };
+}
+
+/**
+ * Resolve an ambiguous archive's ecosystem from its parsed contents. The first
+ * adapter whose `detectArtifact` claims the contents wins; npm claims an archive
+ * with a root `package.json`, PyPI an sdist with a `PKG-INFO`. Returns `null`
+ * when no ecosystem recognizes the archive (the runner fail-closes the gate).
+ */
+export function detectArchiveEcosystem(
+  contents: ArchiveContents,
+): { ecosystem: string; kind: string } | null {
+  for (const adapter of Object.values(WORKFLOW_GATE_ADAPTERS)) {
+    const kind = adapter.detectArtifact(contents);
     if (kind) return { ecosystem: adapter.ecosystem, kind };
   }
   return null;

--- a/server/lib/workflow-gates/resolve.ts
+++ b/server/lib/workflow-gates/resolve.ts
@@ -1,0 +1,58 @@
+import { type ResolvedReleaseBundle, WorkflowArtifactError } from "../github-app";
+import { downloadInSandboxInline } from "../sandbox";
+import { AMBIGUOUS_ARCHIVE_ECOSYSTEM, detectArchiveEcosystem } from "./registry";
+import type { ParsedGateArtifact } from "./types";
+
+/**
+ * Parse every verified bundle artifact once in the credentials-free sandbox and
+ * resolve each one's ecosystem.
+ *
+ * Parsing is shared across ecosystems: npm tarballs and PyPI sdists are both
+ * gzip-compressed tarballs, wheels are zips, and the same tar/zip reader handles
+ * all of them. An entry the auto-detect classifier could not disambiguate by
+ * extension (tagged `AMBIGUOUS_ARCHIVE_ECOSYSTEM`) is routed by content here —
+ * npm if the archive carries a root `package.json`, PyPI if it carries a
+ * `PKG-INFO`. An archive no ecosystem recognizes fails the gate closed.
+ *
+ * Trust boundary: the installation token is already gone. `bundle` holds only
+ * artifact bytes whose SHA-256 the control plane recomputed; the sandbox is
+ * constructed with no credentials, so even a compromised parser cannot exfil a
+ * token (there is none in scope).
+ */
+export async function resolveBundleArtifacts(
+  env: Cloudflare.Env,
+  ctx: ExecutionContext,
+  bundle: ResolvedReleaseBundle,
+): Promise<ParsedGateArtifact[]> {
+  const resolved: ParsedGateArtifact[] = [];
+  for (const file of bundle.artifacts) {
+    const format = file.path.toLowerCase().endsWith(".whl") ? "zip" : "tgz";
+    const parsed = await downloadInSandboxInline(env, ctx, { bytes: file.bytes, format });
+    const contents = { files: parsed.files, packageJson: parsed.packageJson ?? null };
+
+    let ecosystem = file.ecosystem;
+    let kind = file.kind;
+    if (ecosystem === AMBIGUOUS_ARCHIVE_ECOSYSTEM) {
+      const detected = detectArchiveEcosystem(contents);
+      if (!detected) {
+        throw new WorkflowArtifactError(
+          "artifact_identity_missing",
+          `${file.path} is not a recognizable npm or PyPI release artifact`,
+        );
+      }
+      ecosystem = detected.ecosystem;
+      kind = detected.kind;
+    }
+
+    resolved.push({
+      path: file.path,
+      sha256: file.sha256,
+      ecosystem,
+      kind,
+      files: parsed.files,
+      packageJson: parsed.packageJson ?? null,
+      ...(parsed.suspiciousEntries ? { suspiciousEntries: parsed.suspiciousEntries } : {}),
+    });
+  }
+  return resolved;
+}

--- a/server/lib/workflow-gates/resolve.ts
+++ b/server/lib/workflow-gates/resolve.ts
@@ -1,6 +1,6 @@
 import { type ResolvedReleaseBundle, WorkflowArtifactError } from "../github-app";
 import { downloadInSandboxInline } from "../sandbox";
-import { AMBIGUOUS_ARCHIVE_ECOSYSTEM, detectArchiveEcosystem } from "./registry";
+import { AMBIGUOUS_ARCHIVE_ECOSYSTEM, detectArchiveEcosystems } from "./registry";
 import type { ParsedGateArtifact } from "./types";
 
 /**
@@ -33,15 +33,26 @@ export async function resolveBundleArtifacts(
     let ecosystem = file.ecosystem;
     let kind = file.kind;
     if (ecosystem === AMBIGUOUS_ARCHIVE_ECOSYSTEM) {
-      const detected = detectArchiveEcosystem(contents);
-      if (!detected) {
+      const claims = detectArchiveEcosystems(contents);
+      if (claims.length === 0) {
         throw new WorkflowArtifactError(
           "artifact_identity_missing",
           `${file.path} is not a recognizable npm or PyPI release artifact`,
         );
       }
-      ecosystem = detected.ecosystem;
-      kind = detected.kind;
+      if (claims.length > 1) {
+        // The archive presents as several ecosystems (e.g. an npm tarball that
+        // also ships a root PKG-INFO). Routing it to one would skip the other's
+        // findings, so fail closed and let the maintainer pin the ecosystem.
+        throw new WorkflowArtifactError(
+          "artifact_identity_inconsistent",
+          `${file.path} matches more than one ecosystem (${claims
+            .map((claim) => claim.ecosystem)
+            .join(", ")}); pin the release target's ecosystem to review it`,
+        );
+      }
+      ecosystem = claims[0].ecosystem;
+      kind = claims[0].kind;
     }
 
     resolved.push({

--- a/server/lib/workflow-gates/types.ts
+++ b/server/lib/workflow-gates/types.ts
@@ -1,13 +1,41 @@
-import type { ResolvedReleaseBundle } from "../github-app";
 import type { AdapterBroker, PackageAdapter } from "../adapters/types";
+import type { FileRecord, PackageJsonSummary } from "../review";
+import type { TarSuspiciousEntry } from "../tar-parser.js";
 
 /**
  * Ecosystem-defined classification of a bundle entry. PyPI uses
- * `"wheel" | "sdist"`; other ecosystems pick their own opaque kinds. The shared
- * fetch layer only cares whether `classifyArtifact` returns a kind (the entry is
- * reviewable) or `null` (ignored).
+ * `"wheel" | "sdist"`; npm uses `"tarball"`; other ecosystems pick their own
+ * opaque kinds. The shared fetch layer only cares whether `classifyArtifact`
+ * returns a kind (the entry is reviewable) or `null` (ignored).
  */
 export type WorkflowArtifactKind = string;
+
+/**
+ * A reviewable bundle entry after the shared router has parsed its bytes in the
+ * credentials-free sandbox and resolved its ecosystem.
+ *
+ * Parsing is shared (every ecosystem's archive is read by the same tar/zip
+ * sandbox), so the adapter receives the already-parsed `files`/`packageJson`
+ * instead of raw bytes. The `sha256` is the digest the control plane recomputed
+ * from the downloaded artifact bytes — it is the reviewed tarball's digest,
+ * bound to the immutable GitHub Actions artifact.
+ */
+export interface ParsedGateArtifact {
+  path: string;
+  sha256: string;
+  ecosystem: string;
+  kind: WorkflowArtifactKind;
+  files: FileRecord[];
+  /** npm tarballs surface their `package.json`; PyPI artifacts are `null`. */
+  packageJson: PackageJsonSummary | null;
+  suspiciousEntries?: TarSuspiciousEntry[];
+}
+
+/** The parsed contents an adapter inspects to content-detect an ambiguous archive. */
+export interface ArchiveContents {
+  files: FileRecord[];
+  packageJson: PackageJsonSummary | null;
+}
 
 /**
  * Result of turning one package's slice of a verified artifact bundle into the
@@ -39,11 +67,15 @@ export interface PreparedReleaseCandidate {
  * review wiring:
  *
  *  - `classifyArtifact` — which bundle entries are this ecosystem's reviewable
- *    artifacts.
- *  - `prepareReleaseCandidates` — split the ecosystem's slice of the verified
- *    bundle into one candidate per distinct package (grouping the bundle's
- *    artifacts by package identity), rejecting a group whose artifacts disagree
- *    on the identity they carry.
+ *    artifacts, by path (used to keep/drop entries and to pick the adapter for a
+ *    pinned target).
+ *  - `detectArtifact` — content-based ecosystem detection for an archive whose
+ *    extension is ambiguous across ecosystems (an npm `.tgz` is byte- and
+ *    name-indistinguishable from a PyPI sdist `.tar.gz`). Auto-detect targets
+ *    use this on the parsed contents instead of the path.
+ *  - `prepareReleaseCandidates` — split the ecosystem's already-parsed artifacts
+ *    into one candidate per distinct package (grouping by package identity),
+ *    rejecting a group whose artifacts disagree on the identity they carry.
  *  - `packageAdapter` — the deterministic review/baseline/findings adapter the
  *    shared pipeline runs (see `server/lib/adapters/types.ts`); risk-to-decision
  *    mapping stays shared in `recommendationForReleaseRisk`.
@@ -59,28 +91,37 @@ export interface WorkflowGateAdapter {
   readonly packageAdapter: PackageAdapter<unknown, AdapterBroker>;
 
   /**
-   * Decide whether a bundle entry is a reviewable artifact. Returning a kind
-   * keeps the entry (the kind is opaque to the shared fetcher); returning `null`
-   * ignores it (checksums, READMEs, …) so it never reaches the review.
+   * Decide whether a bundle entry is a reviewable artifact by path. Returning a
+   * kind keeps the entry (the kind is opaque to the shared fetcher); returning
+   * `null` ignores it (checksums, READMEs, …) so it never reaches the review.
+   *
+   * A path can be claimed by more than one ecosystem (npm and PyPI both produce
+   * `.tgz`); the auto-detect classifier resolves that ambiguity by content via
+   * `detectArtifact` once the bytes are parsed.
    */
   classifyArtifact(path: string): WorkflowArtifactKind | null;
 
   /**
-   * Split this ecosystem's slice of the verified bundle into one prepared
-   * candidate per distinct package. `bundle.artifacts` has already been narrowed
-   * to entries this adapter's `classifyArtifact` kept, so the adapter only needs
-   * to group them by package identity and synthesize each group's pipeline input.
-   *
-   * Trust boundary: the installation token is already gone — `bundle` holds only
-   * artifact bytes whose SHA-256 was recomputed in the control plane. The
-   * adapter parses those bytes through the credentials-free sandbox. It must
-   * throw `WorkflowArtifactError` when a group cannot be trusted (missing or
-   * inconsistent artifact identity) so the shared runner fail-closes the
-   * deployment.
+   * Content-based detection for an archive whose extension alone cannot decide
+   * the ecosystem. Returning a kind claims the parsed archive for this
+   * ecosystem; returning `null` defers to another adapter. npm claims an archive
+   * that contains a root `package.json`; PyPI claims an sdist that contains a
+   * `PKG-INFO`.
    */
-  prepareReleaseCandidates(
-    env: Cloudflare.Env,
-    ctx: ExecutionContext,
-    args: { bundle: ResolvedReleaseBundle },
-  ): Promise<PreparedReleaseCandidate[]>;
+  detectArtifact(contents: ArchiveContents): WorkflowArtifactKind | null;
+
+  /**
+   * Split this ecosystem's already-parsed artifacts into one prepared candidate
+   * per distinct package. `artifacts` has already been narrowed to this
+   * ecosystem and parsed in the credentials-free sandbox by the shared router,
+   * so the adapter only groups them by package identity and synthesizes each
+   * group's pipeline input.
+   *
+   * Trust boundary: the installation token is already gone — each artifact holds
+   * only parsed file records plus the SHA-256 the control plane recomputed from
+   * the downloaded bytes. The adapter must throw `WorkflowArtifactError` when a
+   * group cannot be trusted (missing or inconsistent artifact identity) so the
+   * shared runner fail-closes the deployment.
+   */
+  prepareReleaseCandidates(artifacts: ParsedGateArtifact[]): PreparedReleaseCandidate[];
 }

--- a/src/models/github-app.ts
+++ b/src/models/github-app.ts
@@ -16,7 +16,7 @@ export interface PublicGithubAppInstallation {
   updatedAt: string;
 }
 
-export type SupportedEcosystem = "pypi";
+export type SupportedEcosystem = "pypi" | "npm";
 
 export interface PublicReleaseTarget {
   id: string;

--- a/src/pages/Dashboard/Settings/ReleaseTargetForm.tsx
+++ b/src/pages/Dashboard/Settings/ReleaseTargetForm.tsx
@@ -144,11 +144,13 @@ function EcosystemSelector({ githubApp }: { githubApp: GithubApp }) {
       >
         <option value="auto">Auto-detect from artifacts</option>
         <option value="pypi">PyPI</option>
+        <option value="npm">npm</option>
       </Select>
       <Muted class="text-[12px] mt-1.5">
-        Auto-detect derives each package's ecosystem from the uploaded artifacts — the right choice
-        for a monorepo publishing several packages from one workflow. Pin an ecosystem only when the
-        release always publishes that one kind.
+        Auto-detect derives each package's ecosystem from the uploaded artifacts (npm by its
+        package.json, PyPI by its wheel/sdist) — the right choice for a monorepo publishing several
+        packages from one workflow. Pin an ecosystem only when the release always publishes that one
+        kind.
       </Muted>
     </Field>
   );

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -19,17 +19,16 @@ export default function DocsPage() {
           </h1>
           <p class="text-[17px] text-ink-muted max-w-[620px] leading-[1.6] m-0">
             Drydock reviews what a release ships before it goes public, and never holds your publish
-            credential. How it hooks in depends on the registry: npm hands Drydock a staged tarball
-            to inspect; registries without a staged artifact (PyPI today) use a workflow gate, where
-            a GitHub Actions deployment-protection rule holds the publish until the build is
-            reviewed.
+            credential. How it hooks in depends on the release: npm hands Drydock a staged tarball
+            to inspect; when there's no staged artifact — PyPI, or an npm publish that skips staging
+            — a GitHub Actions gate holds the publish until the build is reviewed.
           </p>
           <nav class="flex flex-wrap gap-x-5 gap-y-2 mt-1 font-mono text-[11px] uppercase tracking-[0.1em]">
             <a class="text-accent hover:text-accent-hover" href="#staged-publishing">
               → Staged publishing (npm)
             </a>
             <a class="text-accent hover:text-accent-hover" href="#workflow-gating">
-              → Workflow gating
+              → Workflow gating (PyPI &amp; npm)
             </a>
           </nav>
         </header>
@@ -129,24 +128,31 @@ export default function DocsPage() {
         <section id="workflow-gating" class="flex flex-col gap-8 scroll-mt-6">
           <div class="flex flex-col gap-3">
             <SectionLabel>
-              Workflow gating — GitHub Actions <Badge tone="info">Preview</Badge>
+              Workflow gating — PyPI &amp; npm on GitHub Actions <Badge tone="info">Preview</Badge>
             </SectionLabel>
             <h2 class="text-2xl font-semibold tracking-[-0.015em] m-0 max-w-[680px]">
               When the registry can't hold the candidate, the workflow does.
             </h2>
             <Prose>
-              Some registries don't expose a staged candidate. For those, the publish job itself
-              becomes the boundary: CI builds the release artifacts, uploads them as a release
-              candidate, and a GitHub Environment with a Drydock-owned deployment protection rule
-              holds the publish job. Drydock reviews the candidate and records a recommendation, but
-              never approves on its own — a maintainer approves or rejects from the review
-              workbench, and only then is the held job released or blocked. The publish runs on the
-              workflow's own credential (e.g. Trusted Publishing via OIDC); Drydock never holds it.
+              PyPI does not expose a staged tarball, and not every npm publish goes through staged
+              publishing. For those, the publish job itself becomes the boundary: CI builds the
+              release artifacts — wheels and sdists for PyPI, <Code>npm pack</Code> tarballs for npm
+              — uploads them as a release candidate, and a GitHub Environment with a Drydock-owned
+              deployment protection rule holds the publish job. Drydock reviews the candidate and
+              records a recommendation, but never approves on its own — a maintainer approves or
+              rejects from the review workbench, and only then is the held job released or blocked.
+              The publish runs on the workflow's own credential (PyPI Trusted Publishing, or npm via
+              OIDC); Drydock never holds it.
             </Prose>
             <Prose>
-              PyPI is the first supported ecosystem. The GitHub plumbing below — install, gate,
-              fetch, review, decide — is shared, so future ecosystems plug in behind the same gate;
-              this walkthrough uses PyPI as the example.
+              PyPI and npm are both supported. The GitHub plumbing — install, gate, fetch, review,
+              decide — is shared, and Drydock auto-detects each package's ecosystem from the uploaded
+              artifacts, so future ecosystems plug in behind the same gate. This walkthrough uses
+              PyPI as the example; for npm, a workflow gate is an alternative to{" "}
+              <a class="underline" href="#staged-publishing">
+                staged-publish review
+              </a>{" "}
+              for repositories that publish without staging.
             </Prose>
             <Alert tone="info">
               The full gate runs in production today: Drydock fetches the release candidate, reviews
@@ -202,10 +208,17 @@ export default function DocsPage() {
             </Prose>
             <Prose>
               The release identity is derived from the artifacts themselves — package name and
-              version from each wheel's <Code>METADATA</Code> and each sdist's <Code>PKG-INFO</Code>
-              , with every sha256 recomputed server-side from the uploaded bytes. The reviewed wheel
-              or sdist must be the exact file published: the publish job only downloads the reviewed
-              bundle and never rebuilds, so the reviewed bytes are the published bytes.
+              version from each wheel's <Code>METADATA</Code>, each sdist's <Code>PKG-INFO</Code>,
+              and each npm tarball's <Code>package.json</Code> — with every sha256 recomputed
+              server-side from the uploaded bytes. The reviewed artifact must be the exact file
+              published: the publish job only downloads the reviewed bundle and never rebuilds, so
+              the reviewed bytes are the published bytes.
+            </Prose>
+            <Prose>
+              You never declare which ecosystem you're publishing. Drydock tells an npm tarball from
+              a PyPI sdist by content — an npm <Code>.tgz</Code> carries a <Code>package.json</Code>
+              , a PyPI sdist a <Code>PKG-INFO</Code> — so the same auto-detect target reviews
+              either, or both at once for a mixed monorepo.
             </Prose>
           </Subsection>
 
@@ -259,6 +272,41 @@ export default function DocsPage() {
               approves the review in Drydock, then publishes the downloaded bundle with whatever
               tool you prefer.
             </Prose>
+            <Prose>
+              npm looks the same — <Code>npm pack</Code> the workspaces, upload{" "}
+              <Code>dist/*.tgz</Code>, and gate the publish job on a GitHub Environment. The publish
+              job downloads the reviewed tarballs and runs <Code>npm publish &lt;tarball&gt;</Code>{" "}
+              with <Code>--provenance</Code>; it never re-packs.
+            </Prose>
+            <CodeBlock name=".github/workflows/release.yml (npm)">
+              {`jobs:
+  build-release-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm run pack:all   # npm pack each workspace into dist/*.tgz
+      - uses: actions/upload-artifact@v4
+        with:
+          name: npm-release-candidates
+          path: dist/*.tgz
+
+  publish:
+    needs: build-release-artifacts
+    environment: npm
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: npm-release-candidates
+          path: dist
+      # no checkout, no re-pack: publish exactly the reviewed bytes
+      - run: |
+          for tgz in dist/*.tgz; do
+            npm publish "$tgz" --access public --provenance
+          done`}
+            </CodeBlock>
           </Subsection>
 
           <Subsection title="Decision flow">

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -146,9 +146,9 @@ export default function DocsPage() {
             </Prose>
             <Prose>
               PyPI and npm are both supported. The GitHub plumbing — install, gate, fetch, review,
-              decide — is shared, and Drydock auto-detects each package's ecosystem from the uploaded
-              artifacts, so future ecosystems plug in behind the same gate. This walkthrough uses
-              PyPI as the example; for npm, a workflow gate is an alternative to{" "}
+              decide — is shared, and Drydock auto-detects each package's ecosystem from the
+              uploaded artifacts, so future ecosystems plug in behind the same gate. This
+              walkthrough uses PyPI as the example; for npm, a workflow gate is an alternative to{" "}
               <a class="underline" href="#staged-publishing">
                 staged-publish review
               </a>{" "}

--- a/test/npm-release-manifest.test.mjs
+++ b/test/npm-release-manifest.test.mjs
@@ -47,9 +47,24 @@ describe("npm release manifest", () => {
     ).toThrow(/ecosystem must be npm/);
   });
 
+  test("accepts a legacy uppercase package name", () => {
+    // npm enforces lowercase only for new names; legacy packages like JSONStream
+    // still publish, so the gate must not reject them at manifest synthesis.
+    expect(() =>
+      buildNpmReleaseManifest("JSONStream", "1.0.0", [{ path: "p.tgz", sha256: SHA }]),
+    ).not.toThrow();
+    expect(() =>
+      buildNpmReleaseManifest("@MyScope/Pkg", "1.0.0", [{ path: "p.tgz", sha256: SHA }]),
+    ).not.toThrow();
+  });
+
   test("rejects an invalid package name", () => {
     expect(() =>
       buildNpmReleaseManifest("Invalid Name", "1.0.0", [{ path: "p.tgz", sha256: SHA }]),
+    ).toThrow(/valid npm package name/);
+    // A name that smuggles a path separator or control character must still fail.
+    expect(() =>
+      buildNpmReleaseManifest("../evil", "1.0.0", [{ path: "p.tgz", sha256: SHA }]),
     ).toThrow(/valid npm package name/);
   });
 

--- a/test/npm-release-manifest.test.mjs
+++ b/test/npm-release-manifest.test.mjs
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildNpmReleaseManifest,
+  NPM_RELEASE_MANIFEST_SCHEMA,
+  parseNpmReleaseManifest,
+} from "../server/lib/adapters/npm/manifest.ts";
+
+const SHA = "a".repeat(64);
+
+describe("npm release manifest", () => {
+  test("builds + round-trips a valid manifest", () => {
+    const manifest = buildNpmReleaseManifest("@scope/pkg", "1.2.3", [
+      { path: "dist/scope-pkg-1.2.3.tgz", sha256: SHA },
+    ]);
+    expect(manifest).toEqual({
+      schema: NPM_RELEASE_MANIFEST_SCHEMA,
+      ecosystem: "npm",
+      package: "@scope/pkg",
+      version: "1.2.3",
+      artifacts: [{ path: "dist/scope-pkg-1.2.3.tgz", sha256: SHA }],
+    });
+    expect(parseNpmReleaseManifest(manifest)).toEqual(manifest);
+  });
+
+  test("lowercases the declared sha256", () => {
+    const manifest = buildNpmReleaseManifest("pkg", "1.0.0", [
+      { path: "pkg.tgz", sha256: SHA.toUpperCase() },
+    ]);
+    expect(manifest.artifacts[0].sha256).toBe(SHA);
+  });
+
+  test("accepts a semver prerelease + build version", () => {
+    expect(() =>
+      buildNpmReleaseManifest("pkg", "2.0.0-beta.1+build.5", [{ path: "pkg.tgz", sha256: SHA }]),
+    ).not.toThrow();
+  });
+
+  test("rejects a non-npm ecosystem", () => {
+    expect(() =>
+      parseNpmReleaseManifest({
+        schema: NPM_RELEASE_MANIFEST_SCHEMA,
+        ecosystem: "pypi",
+        package: "pkg",
+        version: "1.0.0",
+        artifacts: [{ path: "pkg.tgz", sha256: SHA }],
+      }),
+    ).toThrow(/ecosystem must be npm/);
+  });
+
+  test("rejects an invalid package name", () => {
+    expect(() =>
+      buildNpmReleaseManifest("Invalid Name", "1.0.0", [{ path: "p.tgz", sha256: SHA }]),
+    ).toThrow(/valid npm package name/);
+  });
+
+  test("rejects an unsafe version string", () => {
+    expect(() =>
+      buildNpmReleaseManifest("pkg", "../../etc", [{ path: "p.tgz", sha256: SHA }]),
+    ).toThrow(/safe npm version/);
+  });
+
+  test("rejects a non-hex sha256", () => {
+    expect(() =>
+      buildNpmReleaseManifest("pkg", "1.0.0", [{ path: "p.tgz", sha256: "nope" }]),
+    ).toThrow(/sha256/);
+  });
+
+  test("rejects a path-traversing artifact path", () => {
+    expect(() =>
+      buildNpmReleaseManifest("pkg", "1.0.0", [{ path: "../escape.tgz", sha256: SHA }]),
+    ).toThrow(/path is not safe/);
+  });
+
+  test("rejects an empty artifact list", () => {
+    expect(() => buildNpmReleaseManifest("pkg", "1.0.0", [])).toThrow(/at least one artifact/);
+  });
+});

--- a/test/workers/workflow-gate-npm.test.ts
+++ b/test/workers/workflow-gate-npm.test.ts
@@ -12,7 +12,7 @@ import {
 import {
   AMBIGUOUS_ARCHIVE_ECOSYSTEM,
   classifyBundleArtifact,
-  detectArchiveEcosystem,
+  detectArchiveEcosystems,
   getWorkflowGateAdapter,
   npmWorkflowGateAdapter,
   prepareReleaseCandidatesForGate,
@@ -72,34 +72,46 @@ describe("workflow-gate registry with npm registered", () => {
     expect(classifyBundleArtifact("dist/SHASUMS.txt")).toBeNull();
   });
 
-  test("content-detects npm via a root package.json and pypi via PKG-INFO", () => {
+  test("content-detects npm via a root package.json and pypi via a root PKG-INFO", () => {
     expect(
-      detectArchiveEcosystem({ files: [], packageJson: { name: "left-pad", version: "1.0.0" } }),
-    ).toEqual({ ecosystem: "npm", kind: "tarball" });
+      detectArchiveEcosystems({ files: [], packageJson: { name: "left-pad", version: "1.0.0" } }),
+    ).toEqual([{ ecosystem: "npm", kind: "tarball" }]);
     expect(
-      detectArchiveEcosystem({
+      detectArchiveEcosystems({
         files: [{ path: "left_pad-1.0.0/PKG-INFO", size: 1, sha256: "x", flags: [] }],
         packageJson: null,
       }),
-    ).toEqual({ ecosystem: "pypi", kind: "sdist" });
+    ).toEqual([{ ecosystem: "pypi", kind: "sdist" }]);
     expect(
-      detectArchiveEcosystem({
+      detectArchiveEcosystems({
         files: [{ path: "a.txt", size: 1, sha256: "x", flags: [] }],
         packageJson: null,
       }),
-    ).toBeNull();
+    ).toEqual([]);
   });
 
   test("keeps npm routing when a tarball contains nested PyPI metadata", () => {
+    // Only a *root* PKG-INFO is a sdist signal; a deeply-vendored one is ignored,
+    // so a tarball with a root package.json is unambiguously npm.
     expect(
-      detectArchiveEcosystem({
+      detectArchiveEcosystems({
         files: [
           { path: "package.json", size: 1, sha256: "x", flags: [] },
           { path: "vendor/foo.egg-info/PKG-INFO", size: 1, sha256: "x", flags: [] },
         ],
         packageJson: { name: "left-pad", version: "1.0.0" },
       }),
-    ).toEqual({ ecosystem: "npm", kind: "tarball" });
+    ).toEqual([{ ecosystem: "npm", kind: "tarball" }]);
+  });
+
+  test("reports an archive that claims both ecosystems (root decoy PKG-INFO)", () => {
+    // An npm tarball with a root PKG-INFO claims both ecosystems; the resolver
+    // must refuse to guess rather than route by registration order.
+    const claims = detectArchiveEcosystems({
+      files: [{ path: "PKG-INFO", size: 1, sha256: "x", flags: [] }],
+      packageJson: { name: "evil", version: "1.0.0" },
+    });
+    expect(claims.map((claim) => claim.ecosystem).sort()).toEqual(["npm", "pypi"]);
   });
 });
 
@@ -598,6 +610,54 @@ describe("prepareReleaseCandidatesForGate · npm auto-detect", () => {
     const refreshed = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
     expect(refreshed?.status).toBe("pending");
     expect(refreshed?.failureReason).toBe("artifact_identity_missing");
+    vi.unstubAllGlobals();
+  });
+
+  test("fails the gate closed when a tarball looks like both npm and PyPI", async () => {
+    const seeded = await seedAutoDetectGate({
+      installationExternalId: "9303",
+      repositoryId: 73004,
+      runId: 6004,
+    });
+    stubGithubFetch(6004, ["dist/evil-1.0.0.tgz"]);
+    // An npm tarball carrying a decoy root PKG-INFO would otherwise be routed to
+    // the PyPI adapter by registration order, skipping every npm finding.
+    const loader = buildLoaderMock([
+      {
+        files: [
+          {
+            path: "package.json",
+            size: 20,
+            sha256: "00",
+            flags: [],
+            textSample: '{"name":"evil","version":"1.0.0"}',
+          },
+          { path: "PKG-INFO", size: 5, sha256: "00", flags: [] },
+        ],
+        packageJson: { name: "evil", version: "1.0.0" },
+      },
+    ]);
+    const ctx = buildCtxWithGateway();
+    const bindings = configBindings();
+    const config = readGithubAppConfig(bindings);
+    const sandboxEnv = {
+      ...env,
+      ...bindings,
+      LOADER: loader.binding as unknown as WorkerLoader,
+    } as Cloudflare.Env;
+    const db = createDb(env.DB);
+
+    await expect(
+      prepareReleaseCandidatesForGate(sandboxEnv, ctx, db, {
+        config,
+        organizationId: seeded.organizationId,
+        gateId: seeded.gateId,
+      }),
+    ).rejects.toMatchObject({ code: "artifact_identity_inconsistent" });
+
+    const refreshed = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(refreshed?.status).toBe("pending");
+    expect(refreshed?.failureReason).toBe("artifact_identity_inconsistent");
     vi.unstubAllGlobals();
   });
 });

--- a/test/workers/workflow-gate-npm.test.ts
+++ b/test/workers/workflow-gate-npm.test.ts
@@ -1,0 +1,603 @@
+import { createExecutionContext, env } from "cloudflare:test";
+import { generateKeyPairSync } from "node:crypto";
+import { describe, expect, test, vi } from "vitest";
+import { createDb, ensurePersonalOrganization } from "../../server/db";
+import * as schema from "../../server/db/schema";
+import {
+  createReleaseTarget,
+  getGateForOrganization,
+  readGithubAppConfig,
+  upsertInstallation,
+} from "../../server/lib/github-app";
+import {
+  AMBIGUOUS_ARCHIVE_ECOSYSTEM,
+  classifyBundleArtifact,
+  detectArchiveEcosystem,
+  getWorkflowGateAdapter,
+  npmWorkflowGateAdapter,
+  prepareReleaseCandidatesForGate,
+  supportedWorkflowGateEcosystems,
+} from "../../server/lib/workflow-gates";
+import type { ParsedGateArtifact } from "../../server/lib/workflow-gates";
+import { npmGateAdapter } from "../../server/lib/adapters/npm/gate";
+import type { NpmGateDetails } from "../../server/lib/adapters/npm/gate";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+function npmArtifact(
+  path: string,
+  name: string,
+  version: string,
+  sha = "ab".repeat(32),
+): ParsedGateArtifact {
+  return {
+    path,
+    sha256: sha,
+    ecosystem: "npm",
+    kind: "tarball",
+    files: [
+      {
+        path: "package.json",
+        size: 20,
+        sha256: "00",
+        flags: [],
+        textSample: JSON.stringify({ name, version }),
+      },
+    ],
+    packageJson: { name, version },
+  };
+}
+
+// ── Registry: classification + content detection ─────────────────────────────
+
+describe("workflow-gate registry with npm registered", () => {
+  test("resolves the npm adapter by ecosystem and lists it", () => {
+    expect(getWorkflowGateAdapter("npm")).toBe(npmWorkflowGateAdapter);
+    expect(supportedWorkflowGateEcosystems()).toEqual(expect.arrayContaining(["pypi", "npm"]));
+  });
+
+  test("tags an ambiguous .tgz with the archive sentinel, a .whl with pypi", () => {
+    expect(classifyBundleArtifact("dist/pkg-1.0.0.tgz")).toEqual({
+      ecosystem: AMBIGUOUS_ARCHIVE_ECOSYSTEM,
+      kind: "archive",
+    });
+    expect(classifyBundleArtifact("dist/pkg-1.0.0.tar.gz")).toEqual({
+      ecosystem: AMBIGUOUS_ARCHIVE_ECOSYSTEM,
+      kind: "archive",
+    });
+    expect(classifyBundleArtifact("dist/pkg-1.0.0-py3-none-any.whl")).toEqual({
+      ecosystem: "pypi",
+      kind: "wheel",
+    });
+    expect(classifyBundleArtifact("dist/SHASUMS.txt")).toBeNull();
+  });
+
+  test("content-detects npm via a root package.json and pypi via PKG-INFO", () => {
+    expect(
+      detectArchiveEcosystem({ files: [], packageJson: { name: "left-pad", version: "1.0.0" } }),
+    ).toEqual({ ecosystem: "npm", kind: "tarball" });
+    expect(
+      detectArchiveEcosystem({
+        files: [{ path: "left_pad-1.0.0/PKG-INFO", size: 1, sha256: "x", flags: [] }],
+        packageJson: null,
+      }),
+    ).toEqual({ ecosystem: "pypi", kind: "sdist" });
+    expect(
+      detectArchiveEcosystem({
+        files: [{ path: "a.txt", size: 1, sha256: "x", flags: [] }],
+        packageJson: null,
+      }),
+    ).toBeNull();
+  });
+
+  test("keeps npm routing when a tarball contains nested PyPI metadata", () => {
+    expect(
+      detectArchiveEcosystem({
+        files: [
+          { path: "package.json", size: 1, sha256: "x", flags: [] },
+          { path: "vendor/foo.egg-info/PKG-INFO", size: 1, sha256: "x", flags: [] },
+        ],
+        packageJson: { name: "left-pad", version: "1.0.0" },
+      }),
+    ).toEqual({ ecosystem: "npm", kind: "tarball" });
+  });
+});
+
+// ── npm workflow-gate adapter (pure) ─────────────────────────────────────────
+
+describe("npmWorkflowGateAdapter", () => {
+  test("classifies tarballs by extension and detects by package.json", () => {
+    expect(npmWorkflowGateAdapter.classifyArtifact("a/b/pkg-1.0.0.tgz")).toBe("tarball");
+    expect(npmWorkflowGateAdapter.classifyArtifact("a/b/pkg.tar.gz")).toBe("tarball");
+    expect(npmWorkflowGateAdapter.classifyArtifact("a/b/pkg.whl")).toBeNull();
+    expect(npmWorkflowGateAdapter.detectArtifact({ files: [], packageJson: { name: "x" } })).toBe(
+      "tarball",
+    );
+    expect(npmWorkflowGateAdapter.detectArtifact({ files: [], packageJson: null })).toBeNull();
+  });
+
+  test("derives one candidate per distinct package (monorepo fan-out)", () => {
+    const candidates = npmWorkflowGateAdapter.prepareReleaseCandidates([
+      npmArtifact("dist/alpha-1.0.0.tgz", "@scope/alpha", "1.0.0", "11".repeat(32)),
+      npmArtifact("dist/beta-2.0.0.tgz", "@scope/beta", "2.0.0", "22".repeat(32)),
+    ]);
+    expect(candidates).toHaveLength(2);
+    const byName = Object.fromEntries(candidates.map((c) => [c.package.name, c]));
+    expect(byName["@scope/alpha"].package.version).toBe("1.0.0");
+    const input = byName["@scope/alpha"].pipelineInput as {
+      manifest: { artifacts: { sha256: string }[] };
+      artifact: { sha256: string };
+    };
+    expect(input.manifest.artifacts[0].sha256).toBe("11".repeat(32));
+    expect(input.artifact.sha256).toBe("11".repeat(32));
+  });
+
+  test("rejects a tarball with no package.json identity", () => {
+    const artifact = { ...npmArtifact("dist/x.tgz", "x", "1.0.0"), packageJson: null };
+    expect(() => npmWorkflowGateAdapter.prepareReleaseCandidates([artifact])).toThrow(
+      /does not expose a package.json/,
+    );
+  });
+
+  test("rejects two tarballs of the same package (version skew or duplicate)", () => {
+    expect(() =>
+      npmWorkflowGateAdapter.prepareReleaseCandidates([
+        npmArtifact("dist/a.tgz", "pkg", "1.0.0"),
+        npmArtifact("dist/b.tgz", "pkg", "1.0.1"),
+      ]),
+    ).toThrow(/version 1.0.1 disagrees with 1.0.0/);
+    expect(() =>
+      npmWorkflowGateAdapter.prepareReleaseCandidates([
+        npmArtifact("dist/a.tgz", "pkg", "1.0.0"),
+        npmArtifact("dist/b.tgz", "pkg", "1.0.0"),
+      ]),
+    ).toThrow(/more than one tarball/);
+  });
+});
+
+// ── npm gate package adapter (pure) ──────────────────────────────────────────
+
+describe("npmGateAdapter", () => {
+  function gateInput() {
+    const [candidate] = npmWorkflowGateAdapter.prepareReleaseCandidates([
+      npmArtifact("dist/pkg-1.2.3.tgz", "pkg", "1.2.3", "cd".repeat(32)),
+    ]);
+    return { scanId: "s", stageId: "g", organizationId: "o", ...candidate.pipelineInput };
+  }
+
+  test("parseInput validates the synthesized manifest + artifact", () => {
+    const input = npmGateAdapter.parseInput(gateInput());
+    expect(input.manifest.package).toBe("pkg");
+    expect(input.artifact.sha256).toBe("cd".repeat(32));
+    expect(() => npmGateAdapter.parseInput({})).toThrow();
+  });
+
+  test("acquireStaged reassembles parsed files without a broker, carrying the digest", async () => {
+    const input = npmGateAdapter.parseInput(gateInput());
+    const ctx = {
+      env,
+      executionCtx: createExecutionContext(),
+      db: createDb(env.DB),
+      session: { userId: "u" },
+    };
+    const staged = await npmGateAdapter.acquireStaged(ctx, input, {} as never);
+    expect(staged.artifact.manifest).toEqual({ name: "pkg", version: "1.2.3" });
+    expect((staged.details as NpmGateDetails).digest).toBe("cd".repeat(32));
+    expect((staged.details as NpmGateDetails).mode).toBe("workflow_gate");
+  });
+
+  test("describe + summarizeDetails surface identity and the reviewed digest", () => {
+    const input = npmGateAdapter.parseInput(gateInput());
+    const details: NpmGateDetails = {
+      mode: "workflow_gate",
+      manifest: input.manifest,
+      digest: input.artifact.sha256,
+    };
+    const summary = npmGateAdapter.describe({
+      input,
+      staged: { files: input.artifact.files, manifest: input.artifact.packageJson },
+      details,
+      baseline: { version: null, tag: null, source: "none", distTagVersion: null, reason: "x" },
+      previous: null,
+    });
+    expect(summary).toEqual({
+      name: "pkg",
+      stagedVersion: "1.2.3",
+      stagedTag: null,
+      previousVersion: null,
+    });
+    expect(npmGateAdapter.summarizeDetails(details)).toEqual({
+      mode: "workflow_gate",
+      ecosystem: "npm",
+      digest: "cd".repeat(32),
+      manifest: input.manifest,
+    });
+  });
+
+  test("degrades to a full-tree review when the baseline cannot be fetched", async () => {
+    const input = npmGateAdapter.parseInput(gateInput());
+    const ctx = {
+      env,
+      executionCtx: createExecutionContext(),
+      db: createDb(env.DB),
+      session: { userId: "u" },
+    };
+    // A workflow gate does not require an org npm token; a broker that throws on
+    // credential resolution must not fail the gate closed.
+    const throwingBroker = {
+      dispose() {},
+      fetchPackageMetadata() {
+        throw new Error("Connect an organization npm token before scanning.");
+      },
+      fetchStagedDetails: async () => null,
+      downloadStaged: async () => {
+        throw new Error("unused");
+      },
+      downloadPublished: async () => {
+        throw new Error("unused");
+      },
+    };
+    const staged = await npmGateAdapter.acquireStaged(ctx, input, throwingBroker as never);
+    const result = await npmGateAdapter.acquireBaseline(
+      ctx,
+      input,
+      throwingBroker as never,
+      staged,
+    );
+    expect(result.artifact).toBeNull();
+    expect(result.baseline.source).toBe("none");
+    expect(result.baseline.reason).toBe("baseline-unavailable");
+  });
+});
+
+// ── Integration: auto-detect npm bundle through the shared runner ─────────────
+
+interface ZipEntry {
+  path: string;
+  body: string;
+}
+
+function makeZip(entries: ZipEntry[]): Uint8Array {
+  const encoder = new TextEncoder();
+  const records: Uint8Array[] = [];
+  const central: Uint8Array[] = [];
+  let offset = 0;
+  for (const entry of entries) {
+    const body = encoder.encode(entry.body);
+    const nameBytes = encoder.encode(entry.path);
+    const crc = crc32(body);
+    const local = new Uint8Array(30 + nameBytes.length + body.length);
+    const lv = new DataView(local.buffer);
+    lv.setUint32(0, 0x04034b50, true);
+    lv.setUint16(4, 20, true);
+    lv.setUint32(14, crc, true);
+    lv.setUint32(18, body.length, true);
+    lv.setUint32(22, body.length, true);
+    lv.setUint16(26, nameBytes.length, true);
+    local.set(nameBytes, 30);
+    local.set(body, 30 + nameBytes.length);
+    records.push(local);
+
+    const c = new Uint8Array(46 + nameBytes.length);
+    const cv = new DataView(c.buffer);
+    cv.setUint32(0, 0x02014b50, true);
+    cv.setUint16(4, 20, true);
+    cv.setUint16(6, 20, true);
+    cv.setUint32(16, crc, true);
+    cv.setUint32(20, body.length, true);
+    cv.setUint32(24, body.length, true);
+    cv.setUint16(28, nameBytes.length, true);
+    cv.setUint32(42, offset, true);
+    c.set(nameBytes, 46);
+    central.push(c);
+    offset += local.length;
+  }
+  const centralBytes = concat(central);
+  const eocd = new Uint8Array(22);
+  const ev = new DataView(eocd.buffer);
+  ev.setUint32(0, 0x06054b50, true);
+  ev.setUint16(8, entries.length, true);
+  ev.setUint16(10, entries.length, true);
+  ev.setUint32(12, centralBytes.length, true);
+  ev.setUint32(16, offset, true);
+  return concat([...records, centralBytes, eocd]);
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, p) => sum + p.length, 0);
+  const out = new Uint8Array(total);
+  let i = 0;
+  for (const part of parts) {
+    out.set(part, i);
+    i += part.length;
+  }
+  return out;
+}
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let i = 0; i < 8; i += 1) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+interface SandboxResult {
+  files: { path: string; size: number; sha256: string; flags: string[]; textSample?: string }[];
+  packageJson: { name?: string; version?: string } | null;
+}
+
+// Returns one parsed result per artifact the router parses, in bundle order.
+function buildLoaderMock(results: SandboxResult[]) {
+  const calls: { format: string | null }[] = [];
+  let index = 0;
+  return {
+    calls,
+    binding: {
+      load: vi.fn(() => ({
+        getEntrypoint: () => ({
+          fetch: vi.fn(async (request: Request) => {
+            calls.push({ format: request.headers.get("x-archive-format") });
+            const result = results[Math.min(index, results.length - 1)];
+            index += 1;
+            return new Response(JSON.stringify(result), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            });
+          }),
+        }),
+      })),
+    },
+  };
+}
+
+function buildCtxWithGateway() {
+  const ctx = createExecutionContext() as ExecutionContext & {
+    exports: { NpmStageGateway(options: { props: unknown }): Fetcher };
+  };
+  ctx.exports = { NpmStageGateway: vi.fn(() => ({ fetch: vi.fn() }) as unknown as Fetcher) };
+  return ctx;
+}
+
+function configBindings(): Record<string, string> {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const privateKeyPem = privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+  return {
+    GITHUB_APP_ID: "12345",
+    GITHUB_APP_SLUG: "drydock-test",
+    GITHUB_APP_CLIENT_ID: "client-id",
+    GITHUB_APP_CLIENT_SECRET: "client-secret",
+    GITHUB_APP_PRIVATE_KEY: privateKeyPem,
+    GITHUB_APP_WEBHOOK_SECRET: "webhook-secret-value-1234567890",
+    GITHUB_APP_STATE_SECRET: "0123456789abcdef0123456789abcdef",
+    BETTER_AUTH_SECRET: "fallback-secret-with-enough-entropy-aaaaaaaa",
+  };
+}
+
+// Auto-detect release target (ecosystem null): npm `.tgz` must route by content.
+async function seedAutoDetectGate(opts: {
+  installationExternalId: string;
+  repositoryId: number;
+  runId: number;
+}) {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  const installation = await upsertInstallation(db, {
+    organizationId,
+    installationId: opts.installationExternalId,
+    accountLogin: "octo",
+    accountType: "Organization",
+    targetType: "Organization",
+    status: "active",
+    createdByUserId: null,
+  });
+  const releaseTarget = await createReleaseTarget(db, {
+    organizationId,
+    installationRowId: installation.id,
+    ecosystem: null,
+    repositoryId: opts.repositoryId,
+    repositoryFullName: "octo/example",
+    environment: "npm",
+    createdByUserId: null,
+  });
+  const gateId = crypto.randomUUID();
+  await db.insert(schema.githubWorkflowGates).values({
+    id: gateId,
+    organizationId,
+    installationRowId: installation.id,
+    releaseTargetId: releaseTarget.id,
+    deliveryId: crypto.randomUUID(),
+    repositoryId: opts.repositoryId,
+    repositoryFullName: "octo/example",
+    environment: "npm",
+    runId: opts.runId,
+    deploymentId: 909,
+    deploymentCallbackUrl: `https://api.github.com/repos/octo/example/actions/runs/${opts.runId}/deployment_protection_rule`,
+    eventAction: "requested",
+    status: "pending",
+    requestedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  });
+  return { organizationId, gateId };
+}
+
+function stubGithubFetch(runId: number, artifactPaths: string[]) {
+  const bundleZip = makeZip(artifactPaths.map((path) => ({ path, body: `bytes for ${path}` })));
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      if (request.url.includes("/access_tokens")) {
+        return Response.json({ token: "ghs_install_token", expires_at: "2099-01-01T00:00:00Z" });
+      }
+      if (request.url.includes(`/actions/runs/${runId}/artifacts`)) {
+        return Response.json({
+          total_count: 1,
+          artifacts: [
+            {
+              id: 4242,
+              name: "npm-release-candidates",
+              size_in_bytes: bundleZip.length,
+              expired: false,
+            },
+          ],
+        });
+      }
+      if (request.url.includes("/actions/artifacts/")) {
+        return new Response(bundleZip, {
+          status: 200,
+          headers: { "content-type": "application/zip" },
+        });
+      }
+      throw new Error(`unexpected fetch: ${request.url}`);
+    }),
+  );
+}
+
+describe("prepareReleaseCandidatesForGate · npm auto-detect", () => {
+  test("routes a .tgz with a package.json to the npm adapter", async () => {
+    const seeded = await seedAutoDetectGate({
+      installationExternalId: "9300",
+      repositoryId: 73001,
+      runId: 6001,
+    });
+    stubGithubFetch(6001, ["dist/left-pad-1.3.0.tgz"]);
+    const loader = buildLoaderMock([
+      {
+        files: [
+          {
+            path: "package.json",
+            size: 20,
+            sha256: "00",
+            flags: [],
+            textSample: '{"name":"left-pad","version":"1.3.0"}',
+          },
+        ],
+        packageJson: { name: "left-pad", version: "1.3.0" },
+      },
+    ]);
+    const ctx = buildCtxWithGateway();
+    const bindings = configBindings();
+    const config = readGithubAppConfig(bindings);
+    const sandboxEnv = {
+      ...env,
+      ...bindings,
+      LOADER: loader.binding as unknown as WorkerLoader,
+    } as Cloudflare.Env;
+    const db = createDb(env.DB);
+
+    const result = await prepareReleaseCandidatesForGate(sandboxEnv, ctx, db, {
+      config,
+      organizationId: seeded.organizationId,
+      gateId: seeded.gateId,
+    });
+
+    expect(result.packages).toHaveLength(1);
+    expect(result.packages[0].candidate.ecosystem).toBe("npm");
+    expect(result.packages[0].packageAdapter.id).toBe("npm");
+    expect(result.packages[0].candidate.package).toEqual({ name: "left-pad", version: "1.3.0" });
+    expect(loader.calls).toEqual([{ format: "tgz" }]);
+    vi.unstubAllGlobals();
+  });
+
+  test("fans a monorepo of npm tarballs into one candidate per package", async () => {
+    const seeded = await seedAutoDetectGate({
+      installationExternalId: "9301",
+      repositoryId: 73002,
+      runId: 6002,
+    });
+    stubGithubFetch(6002, ["dist/alpha-1.0.0.tgz", "dist/beta-2.0.0.tgz"]);
+    const loader = buildLoaderMock([
+      {
+        files: [
+          {
+            path: "package.json",
+            size: 20,
+            sha256: "00",
+            flags: [],
+            textSample: '{"name":"@scope/alpha","version":"1.0.0"}',
+          },
+        ],
+        packageJson: { name: "@scope/alpha", version: "1.0.0" },
+      },
+      {
+        files: [
+          {
+            path: "package.json",
+            size: 20,
+            sha256: "00",
+            flags: [],
+            textSample: '{"name":"@scope/beta","version":"2.0.0"}',
+          },
+        ],
+        packageJson: { name: "@scope/beta", version: "2.0.0" },
+      },
+    ]);
+    const ctx = buildCtxWithGateway();
+    const bindings = configBindings();
+    const config = readGithubAppConfig(bindings);
+    const sandboxEnv = {
+      ...env,
+      ...bindings,
+      LOADER: loader.binding as unknown as WorkerLoader,
+    } as Cloudflare.Env;
+    const db = createDb(env.DB);
+
+    const result = await prepareReleaseCandidatesForGate(sandboxEnv, ctx, db, {
+      config,
+      organizationId: seeded.organizationId,
+      gateId: seeded.gateId,
+    });
+
+    const names = result.packages.map((p) => p.candidate.package.name).sort();
+    expect(names).toEqual(["@scope/alpha", "@scope/beta"]);
+    for (const pkg of result.packages) expect(pkg.candidate.ecosystem).toBe("npm");
+    vi.unstubAllGlobals();
+  });
+
+  test("fails the gate closed when a tarball carries no package.json", async () => {
+    const seeded = await seedAutoDetectGate({
+      installationExternalId: "9302",
+      repositoryId: 73003,
+      runId: 6003,
+    });
+    stubGithubFetch(6003, ["dist/mystery-1.0.0.tgz"]);
+    const loader = buildLoaderMock([
+      { files: [{ path: "lib/index.js", size: 5, sha256: "00", flags: [] }], packageJson: null },
+    ]);
+    const ctx = buildCtxWithGateway();
+    const bindings = configBindings();
+    const config = readGithubAppConfig(bindings);
+    const sandboxEnv = {
+      ...env,
+      ...bindings,
+      LOADER: loader.binding as unknown as WorkerLoader,
+    } as Cloudflare.Env;
+    const db = createDb(env.DB);
+
+    await expect(
+      prepareReleaseCandidatesForGate(sandboxEnv, ctx, db, {
+        config,
+        organizationId: seeded.organizationId,
+        gateId: seeded.gateId,
+      }),
+    ).rejects.toMatchObject({ code: "artifact_identity_missing" });
+
+    const refreshed = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(refreshed?.status).toBe("pending");
+    expect(refreshed?.failureReason).toBe("artifact_identity_missing");
+    vi.unstubAllGlobals();
+  });
+});


### PR DESCRIPTION
Adds npm as a workflow-gate ecosystem alongside PyPI (issue #144): CI uploads `npm pack` tarballs, the publish job is held on a GitHub Environment, and Drydock reviews the exact reviewed bytes before a maintainer approves — integrity resting on GitHub artifact immutability plus the recomputed SHA-256, with no manifest or checksum file to author. The ecosystem is auto-detected by archive content (npm = root `package.json`, PyPI = root `PKG-INFO`) so nobody declares it, monorepos fan out into one review per package against its own baseline, and an archive that presents as more than one ecosystem (e.g. an npm tarball with a decoy root `PKG-INFO`) fails the gate closed rather than being misrouted. A new `npmGateAdapter` reuses the staged-publish npm baseline/findings/diff/risk code via a shared parse router, leaving the existing staged npm adapter and routes untouched. Also adds an npm option to the release-target form, in-app + `docs/npm-workflow-gate.md` coverage, and unit/worker tests.

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)