### PR TITLE
Speed up the Vitest worker suite (~46% faster)

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -29,6 +29,30 @@ can express. See [`release-safety.md`](./release-safety.md) for the expected
 Worker-route, sandbox invariant, fake-registry e2e, security-corpus, and
 observability coverage by change type.
 
+## Worker-suite performance
+
+The `workers` Vitest project runs every test file in its own Miniflare isolate,
+so anything paid per file is paid ~24×. Two deliberate choices keep it fast:
+
+- **`wrangler.test.jsonc` has no `main`.** The worker tests don't use `SELF` —
+  they `import worker from "../../server/index"` and call `worker.fetch(req, env, ctx)`
+  directly. Setting `main` makes Miniflare eagerly evaluate the whole app graph
+  in _every_ isolate at boot (~5s/file → most of the suite's wall time). Leaving
+  it unset drops per-file boot to ~0.3s; the files that need the app still import
+  it themselves. **Do not add `main` back** unless a test genuinely needs `SELF`
+  or a Durable Object binding — and if one does, scope it to a separate project
+  rather than taxing all 24 files.
+- **Native scrypt for password hashing.** `server/lib/auth.ts` overrides Better
+  Auth's KDF with `node:crypto`'s native scrypt (same params, byte-identical
+  output — see `test/workers/auth-password-hash.test.ts`). On `workerd` the
+  default falls back to a pure-JS scrypt that runs synchronously in the isolate;
+  native scrypt is ~10× faster, which matters for production logins and for the
+  auth-heavy worker tests that sign up / sign in / enroll TOTP.
+
+Heavy, conditionally-used modules (e.g. the Vercel AI SDK behind the off-by-default
+AI reviewer) are loaded with `await import(...)` past their feature gate, to keep
+them out of the worker boot graph.
+
 ## Pre-commit verification
 
 Run `pnpm run verify` before every commit, so each commit passes lint + format + typecheck + tests. There is no git hook enforcing this — it is run explicitly. CI (`.github/workflows/ci.yml`) runs the same core checks and then installs Chromium and runs `pnpm run test:e2e`.

--- a/docs/two-factor-auth.md
+++ b/docs/two-factor-auth.md
@@ -125,7 +125,8 @@ already covers these POSTs.
 - `test/workers/two-factor-routes.test.ts` — drives the real Better Auth handler via
   `worker.fetch`: enroll → verify TOTP → assert `twoFactorEnabled`, sign-in challenge
   (`twoFactorRedirect`), backup-code sign-in, disable, and the rate-limit bucket. (The full TOTP
-  flow runs several scrypt hashes, so the test sets a 30s timeout.)
+  flow runs several scrypt hashes; the test keeps a generous 30s timeout even though
+  `auth.ts` now uses native scrypt — see [`tooling.md`](./tooling.md#worker-suite-performance).)
 - `test/e2e/two-factor.spec.ts` — Playwright flow: register → enable 2FA in Settings (reads the
   secret, computes a TOTP with `otpauth`) → sign out → sign in through the challenge step.
 - `test/workers/github-gate-two-factor.test.ts` — drives the real worker for the gate-decision

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "^1.33.2",
-    "@cloudflare/vitest-pool-workers": "^0.16.7",
+    "@cloudflare/vitest-pool-workers": "^0.16.13",
     "@cloudflare/workers-types": "^4.20260520.0",
     "@playwright/test": "^1.60.0",
     "@preact/eslint-plugin-signals": "^0.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: ^1.33.2
         version: 1.37.2(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))(workerd@1.20260518.1)(wrangler@4.93.0(@cloudflare/workers-types@4.20260520.1))
       '@cloudflare/vitest-pool-workers':
-        specifier: ^0.16.7
-        version: 0.16.7(@cloudflare/workers-types@4.20260520.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)))
+        specifier: ^0.16.13
+        version: 0.16.13(@cloudflare/workers-types@4.20260520.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)))
       '@cloudflare/workers-types':
         specifier: ^4.20260520.0
         version: 4.20260520.1
@@ -311,8 +311,8 @@ packages:
       vite: ^6.1.0 || ^7.0.0 || ^8.0.0
       wrangler: ^4.93.0
 
-  '@cloudflare/vitest-pool-workers@0.16.7':
-    resolution: {integrity: sha512-CRGUVBDXEfeKY+GMTy7P9ikn12lYIZgmmSwr4tLhLRiN0lDoQxkRZvSkEUouRu/AQYesj5z+BV33Lg4TQC2IWg==}
+  '@cloudflare/vitest-pool-workers@0.16.13':
+    resolution: {integrity: sha512-nTuEiuLv+YoLrGfftdlBJB3nJJELT/9VVuBlF2JDpnv3uAOCXaZcniP+K5C9Mcg0xSopvFLAL45Q7Hco1hHOLQ==}
     peerDependencies:
       '@vitest/runner': ^4.1.0
       '@vitest/snapshot': ^4.1.0
@@ -324,8 +324,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@cloudflare/workerd-darwin-64@1.20260603.1':
+    resolution: {integrity: sha512-cEXDWu6V3ZrpmwWkM4OJE9AeXjdAgOY5rh8EHhcBVCuP5rxnzUbPzLtrVOHx0UUUAcCrFq0Xsa6mZKL1VUZsKQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
   '@cloudflare/workerd-darwin-arm64@1.20260518.1':
     resolution: {integrity: sha512-uqlNP1psd8SWfN1Lg5p8ePv8/piOOXt+ycvb8+NQopXECGeh9+PQ/yr/IQjpurxBhYpvSaMC+vEeihejahjkJg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260603.1':
+    resolution: {integrity: sha512-uBPK4LaWJNbbCYwPnUAehlHbbVulhVZPZsdcAhBPfZhHb3QAuAEPAQepO/P67R3V6Cni4YGx1fLbL8A5wwoaNA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -336,14 +348,32 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-64@1.20260603.1':
+    resolution: {integrity: sha512-ht9l6/8Tk7Rp6kA4S9oFZ4X8u0VjnnFdmU/6B3fnABYKREYTKh2RdOqXqXxcp5eNJseireKnWik/hQOPK1CutQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
   '@cloudflare/workerd-linux-arm64@1.20260518.1':
     resolution: {integrity: sha512-+vNRkuOp9E/uRKHgQXVDUBPF5cwtTeXK6+ucLK50QUFzMYycqVl8kTFN2b//BX2H5BI4bjMRhXoBpe/zAlGRWQ==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-arm64@1.20260603.1':
+    resolution: {integrity: sha512-LJZ6x00rAjSrobV4m0ZW0TpH5ilBbKcWBzlH+y+KOUsIE/CpTuhAzKV43TbSnFLRX5+jrWKiz2v0hO91lPXy6A==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
   '@cloudflare/workerd-windows-64@1.20260518.1':
     resolution: {integrity: sha512-tnqofUq+ZvKliQHhboygbH7iy/Zm/MaCCotIlrqVj5a988+tPtndxyLM0r4vaAIC10iy/2LWCkwnE67VFTFiUA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workerd-windows-64@1.20260603.1':
+    resolution: {integrity: sha512-DvwqkXMAJRPoDN4PxapAwhlz/6ouD+6R1ttbAEK3cWD/QBvFF5STx7Ds/9Irf+rBly3np3uHWkeX+wZnNFEuzA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -1908,8 +1938,8 @@ packages:
   character-entities-legacy@3.0.0:
     resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
-  cjs-module-lexer@1.4.3:
-    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+  cjs-module-lexer@1.2.3:
+    resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
 
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
@@ -2338,6 +2368,11 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
+  miniflare@4.20260603.0:
+    resolution: {integrity: sha512-+kMQYB82gC8MPOuojHur3icQsUeZUEJ+Sphuo5rVC3Ri9txBLAW/mH33b9OVrpmkogQeaaqPS4tPtugJZhk5Kw==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2745,6 +2780,11 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  workerd@1.20260603.1:
+    resolution: {integrity: sha512-NPcbhI1++CS+fnELyXtsIR52en+5kwr/OrKeiQeYXGy10HxmPdsQBv9N+DU7hJIOOmBHhOGAAsoGDjyiQ2YCaA==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   workers-ai-provider@3.1.14:
     resolution: {integrity: sha512-/umrajFP6OkZVbDAxwkrO9NPdNFG4c+i0fiVqdf4PGsLN+CiDsLJCI6xW0WXDLDR1ZZyjE4T6Xp6O/IKBIWGHQ==}
     peerDependencies:
@@ -2761,12 +2801,34 @@ packages:
       '@cloudflare/workers-types':
         optional: true
 
+  wrangler@4.98.0:
+    resolution: {integrity: sha512-cXfFUuF4rMIvE0hiMnXjEAB27ERryaCgquBJdUoPIjFzYYE1rbRdMUkEdQ18qDPUtsPvhJdqxLntixT9OfSzQw==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260603.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
 
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3022,6 +3084,12 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260518.1
 
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260603.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260603.1
+
   '@cloudflare/vite-plugin@1.37.2(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))(workerd@1.20260518.1)(wrangler@4.93.0(@cloudflare/workers-types@4.20260520.1))':
     dependencies:
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260518.1)
@@ -3035,15 +3103,15 @@ snapshots:
       - utf-8-validate
       - workerd
 
-  '@cloudflare/vitest-pool-workers@0.16.7(@cloudflare/workers-types@4.20260520.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)))':
+  '@cloudflare/vitest-pool-workers@0.16.13(@cloudflare/workers-types@4.20260520.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)))':
     dependencies:
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
-      cjs-module-lexer: 1.4.3
+      cjs-module-lexer: 1.2.3
       esbuild: 0.27.3
-      miniflare: 4.20260518.0
+      miniflare: 4.20260603.0
       vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(vite@8.0.13(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3))
-      wrangler: 4.93.0(@cloudflare/workers-types@4.20260520.1)
+      wrangler: 4.98.0(@cloudflare/workers-types@4.20260520.1)
       zod: 3.25.76
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -3053,16 +3121,31 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20260518.1':
     optional: true
 
+  '@cloudflare/workerd-darwin-64@1.20260603.1':
+    optional: true
+
   '@cloudflare/workerd-darwin-arm64@1.20260518.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260603.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20260518.1':
     optional: true
 
+  '@cloudflare/workerd-linux-64@1.20260603.1':
+    optional: true
+
   '@cloudflare/workerd-linux-arm64@1.20260518.1':
     optional: true
 
+  '@cloudflare/workerd-linux-arm64@1.20260603.1':
+    optional: true
+
   '@cloudflare/workerd-windows-64@1.20260518.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260603.1':
     optional: true
 
   '@cloudflare/workers-types@4.20260520.1': {}
@@ -4053,7 +4136,7 @@ snapshots:
 
   character-entities-legacy@3.0.0: {}
 
-  cjs-module-lexer@1.4.3: {}
+  cjs-module-lexer@1.2.3: {}
 
   cliui@6.0.0:
     dependencies:
@@ -4439,6 +4522,18 @@ snapshots:
       undici: 7.24.8
       workerd: 1.20260518.1
       ws: 8.18.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  miniflare@4.20260603.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.24.8
+      workerd: 1.20260603.1
+      ws: 8.20.1
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
       - bufferutil
@@ -4853,6 +4948,14 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260518.1
       '@cloudflare/workerd-windows-64': 1.20260518.1
 
+  workerd@1.20260603.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260603.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260603.1
+      '@cloudflare/workerd-linux-64': 1.20260603.1
+      '@cloudflare/workerd-linux-arm64': 1.20260603.1
+      '@cloudflare/workerd-windows-64': 1.20260603.1
+
   workers-ai-provider@3.1.14(@ai-sdk/provider@3.0.10)(ai@6.0.191(zod@4.4.3)):
     dependencies:
       '@ai-sdk/provider': 3.0.10
@@ -4875,6 +4978,23 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  wrangler@4.98.0(@cloudflare/workers-types@4.20260520.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260603.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260603.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260603.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260520.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -4882,6 +5002,8 @@ snapshots:
       strip-ansi: 6.0.1
 
   ws@8.18.0: {}
+
+  ws@8.20.1: {}
 
   y18n@4.0.3: {}
 

--- a/server/lib/auth.ts
+++ b/server/lib/auth.ts
@@ -1,3 +1,4 @@
+import { scrypt as nodeScrypt, scryptSync } from "node:crypto";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { twoFactor } from "better-auth/plugins";
@@ -13,6 +14,66 @@ export interface AuthSession {
 }
 
 const VERIFICATION_TOKEN_TTL_SECONDS = 60 * 60 * 24; // 24 hours
+
+function toHex(bytes: Uint8Array): string {
+  let out = "";
+  for (const byte of bytes) out += byte.toString(16).padStart(2, "0");
+  return out;
+}
+
+// Better Auth's password KDF is scrypt with these parameters. On the Workers
+// runtime it resolves to the pure-JS `@noble/hashes` scrypt, which runs
+// synchronously in the isolate and costs ~hundreds of ms per hash — slow for
+// every production login and the dominant cost of the auth-heavy Worker test
+// suite. node:crypto's native scrypt (libuv thread pool, C implementation) is an
+// order of magnitude faster and, for identical parameters/salt, produces
+// byte-identical output. We keep the exact format Better Auth uses — salt is the
+// lowercase hex of 16 random bytes, stored as `salt:hex(key)` — so hashes are
+// compatible in both directions (a hash written by either implementation
+// verifies under the other). The parity invariant is locked by
+// test/workers/auth-password-hash.test.ts; mirrors better-auth#8456.
+const SCRYPT_N = 16384;
+const SCRYPT_R = 16;
+const SCRYPT_P = 1;
+const SCRYPT_DKLEN = 64;
+const SCRYPT_MAXMEM = 128 * SCRYPT_N * SCRYPT_R * 2;
+
+export function scryptKeyHex(password: string, salt: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    nodeScrypt(
+      password.normalize("NFKC"),
+      salt,
+      SCRYPT_DKLEN,
+      { N: SCRYPT_N, r: SCRYPT_R, p: SCRYPT_P, maxmem: SCRYPT_MAXMEM },
+      (err, key) => (err ? reject(err) : resolve(key.toString("hex"))),
+    );
+  });
+}
+
+export const nativeScryptPassword = {
+  hash: async (password: string): Promise<string> => {
+    const salt = toHex(crypto.getRandomValues(new Uint8Array(16)));
+    return `${salt}:${await scryptKeyHex(password, salt)}`;
+  },
+  verify: async ({ hash, password }: { hash: string; password: string }): Promise<boolean> => {
+    const [salt, key] = hash.split(":");
+    if (!salt || !key) return false;
+    return (await scryptKeyHex(password, salt)) === key;
+  },
+};
+
+// Use native scrypt when the runtime supports it (all of prod/test/dev run with
+// `nodejs_compat`), otherwise leave Better Auth on its own scrypt default — never
+// a silent downgrade. Probed once with tiny work-factor params so import stays
+// cheap; the real work factor above is exercised on every hash/verify.
+const nativeScryptAvailable = (() => {
+  try {
+    scryptSync("probe", "probe", SCRYPT_DKLEN, { N: 2, r: 1, p: 1, maxmem: SCRYPT_MAXMEM });
+    return true;
+  } catch {
+    return false;
+  }
+})();
 
 export function createAuth(env: Cloudflare.Env) {
   if (!env.DB) throw new Error("DB binding is required for Better Auth");
@@ -52,6 +113,7 @@ export function createAuth(env: Cloudflare.Env) {
       requireEmailVerification: emailVerificationEnabled,
       minPasswordLength: 12,
       maxPasswordLength: 256,
+      ...(nativeScryptAvailable ? { password: nativeScryptPassword } : {}),
     },
     plugins: [twoFactor({ issuer: "Drydock" })],
     advanced: {

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -1,5 +1,5 @@
 import { type AppDb, type WorkspaceSession } from "../db";
-import { AI_MODEL, runSelectiveAiReview, type AiReview } from "./ai-review";
+import type { AiReview } from "./ai-review-types";
 import type {
   AdapterBroker,
   AdapterConnectionRef,
@@ -136,6 +136,13 @@ async function maybeRunAiReview(args: AiReviewArgs): Promise<AiReview> {
       })
     : false;
   if (!aiReviewEnabled) return disabled;
+
+  // Loaded lazily so the Vercel AI SDK + workers-ai-provider stay out of the
+  // Worker's boot graph: AI review is off by default, so pulling these heavy
+  // modules eagerly would tax every cold start (and every per-file test isolate)
+  // for a path most scans never take. AI_MODEL rides along — it lives in the same
+  // module, so importing it statically would defeat the point.
+  const { runSelectiveAiReview, AI_MODEL } = await import("./ai-review");
 
   const startedAtMs = Date.now();
   try {

--- a/test/workers/auth-password-hash.test.ts
+++ b/test/workers/auth-password-hash.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+import { nativeScryptPassword, scryptKeyHex } from "../../server/lib/auth";
+
+// Golden vectors produced by Better Auth's @noble/hashes scrypt
+// (N=16384, r=16, p=1, dkLen=64) — the implementation the Workers runtime would
+// otherwise fall back to. auth.ts swaps in node:crypto's native scrypt for speed;
+// these lock the migration-safety invariant that the native KDF produces
+// byte-identical output, so password hashes written before the swap (or by any
+// runtime still on @noble) keep verifying. If this fails, the swap is NOT a
+// transparent drop-in and would lock existing users out. See better-auth#8456.
+const NOBLE_VECTORS = [
+  {
+    password: "correct horse battery staple",
+    salt: "00112233445566778899aabbccddeeff",
+    key: "f5b22309b28fe412c82a4b2cab57498b8f8a42c849af16cb908974048f61c13933421858db3a8f111430bdc493c7cef90f61f904061c77206e3820a2e8b11bc2",
+  },
+  {
+    // Non-ASCII to pin NFKC normalization behavior across implementations.
+    password: "córrect-horse é password",
+    salt: "deadbeefdeadbeefdeadbeefdeadbeef",
+    key: "7e3afce44a95375a525c1f543efe272c4ae032a6610018c49def22a929eb2e328c76851090a08279e02c27aa97e08afa4f2f4d8f78a883f9d2b431ef461f8c72",
+  },
+];
+
+describe("native scrypt password hashing", () => {
+  test("derives the same key as @noble/hashes scrypt for fixed inputs", async () => {
+    for (const v of NOBLE_VECTORS) {
+      expect(await scryptKeyHex(v.password, v.salt)).toBe(v.key);
+    }
+  });
+
+  test("verifies hashes in the Better Auth `salt:hex` format written by @noble", async () => {
+    for (const v of NOBLE_VECTORS) {
+      const stored = `${v.salt}:${v.key}`;
+      expect(await nativeScryptPassword.verify({ hash: stored, password: v.password })).toBe(true);
+      expect(await nativeScryptPassword.verify({ hash: stored, password: `${v.password}!` })).toBe(
+        false,
+      );
+    }
+  });
+
+  test("hash() output round-trips through verify() and uses a random salt", async () => {
+    const a = await nativeScryptPassword.hash("a-sufficiently-long-password");
+    const b = await nativeScryptPassword.hash("a-sufficiently-long-password");
+    expect(a).not.toBe(b); // distinct random salts
+    expect(
+      await nativeScryptPassword.verify({ hash: a, password: "a-sufficiently-long-password" }),
+    ).toBe(true);
+    expect(
+      await nativeScryptPassword.verify({ hash: a, password: "wrong-password-entirely" }),
+    ).toBe(false);
+  });
+
+  test("verify() rejects malformed hashes instead of throwing", async () => {
+    expect(await nativeScryptPassword.verify({ hash: "", password: "x" })).toBe(false);
+    expect(await nativeScryptPassword.verify({ hash: "no-colon", password: "x" })).toBe(false);
+  });
+});

--- a/wrangler.test.jsonc
+++ b/wrangler.test.jsonc
@@ -1,7 +1,6 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "staged-publish-review-test",
-  "main": "server/index.ts",
   "compatibility_date": "2026-05-20",
   "compatibility_flags": ["nodejs_compat"],
   "vars": {


### PR DESCRIPTION
## What

The `workers` Vitest project dominated suite wall time. I profiled before changing anything; the `node` project was already fast (~1.5s) and everything else was per-isolate overhead in the Cloudflare Workers pool. Three causes, fixed in order of impact:

1. **`wrangler.test.jsonc` set `main: server/index.ts`** — this makes Miniflare eagerly evaluate the *entire app graph in every test isolate at boot* (a no-op test file cost ~5s). But **no worker test uses `SELF`** — they `import worker from "../../server/index"` and call `worker.fetch(req, env, ctx)` directly — so `main` was pure dead weight. Removing it drops per-file boot from **~5.0s → ~0.34s**. (Documented in `tooling.md` with a warning not to re-add it; if a future test needs `SELF`/a DO binding, scope it to its own project instead of taxing all 24 files.)

2. **Password hashing.** On `workerd`, Better Auth falls back to a pure-JS `@noble` scrypt (`N=16384, r=16`) that runs synchronously in the isolate — ~30s of cumulative CPU concentrated in the auth/2FA tests, and slow for every production login. This overrides the KDF with `node:crypto`'s native scrypt (libuv thread pool), which is ~10× faster and, for the same params/salt, produces **byte-identical output** — so existing stored hashes keep verifying. Falls back to Better Auth's own default when native scrypt is unavailable (never a silent downgrade). Mirrors [better-auth#8456](https://github.com/better-auth/better-auth/issues/8456).

3. **Bumped `@cloudflare/vitest-pool-workers` 0.16.7 → 0.16.13** for a faster miniflare/workerd boot (~4s).

Also lazy-`import()` the Vercel AI SDK past the off-by-default AI-review feature gate, keeping it out of the worker boot graph (helps prod cold start too).

## Results (warm)

| | Before | After |
|---|---|---|
| Full `vitest run` | 35.99s | **19.49s** |
| `workers` project | 37.7s | **~18–20s** |
| `pnpm run verify` (the gate) | ~37s+ | **21.6s** |

## Safety

- `test/workers/auth-password-hash.test.ts` (new) locks the migration-safety invariant: native scrypt produces byte-identical output to `@noble` for fixed golden vectors (incl. NFKC/unicode), verifies hashes written in Better Auth's `salt:hex` format, and round-trips. If native scrypt ever stops matching, CI fails before deploy rather than locking users out.
- All 585 unit/worker tests pass; all 11 fake-registry e2e tests pass; `pnpm run verify` is green.

## Review note

Items 1 and 3 are test-only. **Item 2 touches the production password KDF** — it's proven byte-compatible and fallback-guarded, but it's an auth-path change worth a deliberate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)