### PR TITLE
fix(settings): drop internal divider rules from notification + Slack cards

### DIFF
--- a/src/pages/Dashboard/Settings/NotificationRecipientsSection.tsx
+++ b/src/pages/Dashboard/Settings/NotificationRecipientsSection.tsx
@@ -53,9 +53,9 @@ export function NotificationRecipientsSection({
         </Muted>
 
         {!loaded ? (
-          <LoadingLine class="border-y border-border py-3">loading recipients</LoadingLine>
+          <LoadingLine>loading recipients</LoadingLine>
         ) : list.length > 0 ? (
-          <ul class="flex flex-col gap-2 m-0 p-0 list-none border-y border-border py-3">
+          <ul class="flex flex-col gap-2 m-0 p-0 list-none">
             {list.map((recipient: NotificationRecipient) => (
               <li key={recipient.id} class="flex items-center justify-between gap-3">
                 <code class="text-[13px] text-ink-muted break-all">{recipient.email}</code>
@@ -76,7 +76,7 @@ export function NotificationRecipientsSection({
             ))}
           </ul>
         ) : (
-          <Muted class="text-[13px] m-0 border-y border-border py-3">
+          <Muted class="text-[13px] m-0">
             No recipients configured — notifications go to{" "}
             {fallbackEmail ?? "the organization owner"}.
           </Muted>

--- a/src/pages/Dashboard/Settings/SlackConnectionSection.tsx
+++ b/src/pages/Dashboard/Settings/SlackConnectionSection.tsx
@@ -59,14 +59,14 @@ export function SlackConnectionSection({
         ) : null}
 
         {!loaded ? (
-          <LoadingLine class="border-y border-border py-3">loading Slack connection</LoadingLine>
+          <LoadingLine>loading Slack connection</LoadingLine>
         ) : !configured ? (
-          <Muted class="text-[13px] m-0 border-y border-border py-3">
+          <Muted class="text-[13px] m-0">
             Slack is not configured on this Drydock instance. Ask the operator to add the Slack app
             credentials.
           </Muted>
         ) : connected ? (
-          <div class="flex flex-col gap-4 border-y border-border py-4">
+          <div class="flex flex-col gap-4">
             <div class="flex items-center justify-between gap-3">
               <div class="flex items-center gap-2 min-w-0">
                 <span class="text-[13px] text-ink break-all">
@@ -159,7 +159,7 @@ export function SlackConnectionSection({
             ) : null}
           </div>
         ) : (
-          <div class="flex flex-col gap-3 border-y border-border py-4">
+          <div class="flex flex-col gap-3">
             <Muted class="text-[13px] m-0">No Slack workspace connected.</Muted>
             {canManage ? (
               <Button onClick={() => void slack.connect()} disabled={busy} class="self-start">


### PR DESCRIPTION
The notification-recipients and Slack settings cards wrapped each state block (loading / empty / list / connection) in `border-y border-border`, drawing a hairline rule above *and* below every block — which, stacked with the card's `flex gap-5` rhythm, sliced each card into thin stripes (worst in the empty/loading states, where two rules merely bracketed a single line of muted text). This removes those internal dividers and relies on the existing `gap-5` spacing instead. The outer card border and collapsible header divider already supply all the structure these panels need, matching DESIGN.md's intent that rules belong on section labels and genuine data tables, not bracketing prose. No logic or type changes — purely the removal of Tailwind utility classes; lint and format pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)