### PR TITLE
[codex] Route API callbacks before SPA fallback

### DIFF
--- a/docs/slack-notifications.md
+++ b/docs/slack-notifications.md
@@ -131,6 +131,11 @@ a redirect URL registered in the Slack app. Until both client credentials are
 set, `GET /api/v1/slack` reports `configured: false` and the UI explains that
 Slack is not configured on this instance.
 
+Because the Worker also serves the Preact app with static-asset SPA fallback,
+`wrangler.jsonc` must keep `/api` and `/api/*` in `assets.run_worker_first`.
+Otherwise Slack's top-level browser redirect can be claimed by `index.html` and
+shown as the client 404 instead of reaching `GET /api/v1/slack/callback`.
+
 ## Front end
 
 `src/models/slack-connection.ts` (`SlackConnectionModel`) handles

--- a/test/e2e/dev-server.mjs
+++ b/test/e2e/dev-server.mjs
@@ -91,6 +91,7 @@ async function writeWranglerConfig() {
     compatibility_flags: ["nodejs_compat"],
     assets: {
       not_found_handling: "single-page-application",
+      run_worker_first: ["/api", "/api/*", "/webhooks/*"],
     },
     worker_loaders: [{ binding: "LOADER" }],
     d1_databases: [

--- a/test/wrangler-config.test.mjs
+++ b/test/wrangler-config.test.mjs
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, test } from "vitest";
+
+describe("Wrangler static asset routing", () => {
+  test("runs the Worker before the SPA fallback for server-owned paths", () => {
+    const config = readFileSync(new URL("../wrangler.jsonc", import.meta.url), "utf8");
+    const assetsBlock = config.match(/"assets"\s*:\s*\{(?<body>[\s\S]*?)\n\t\}/)?.groups?.body;
+
+    expect(assetsBlock).toContain('"not_found_handling": "single-page-application"');
+    expect(assetsBlock).toContain('"run_worker_first"');
+    for (const route of ["/api", "/api/*", "/webhooks/*"]) {
+      expect(assetsBlock).toContain(`"${route}"`);
+    }
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -14,7 +14,15 @@
 		}
 	},
 	"assets": {
-		"not_found_handling": "single-page-application"
+		"not_found_handling": "single-page-application",
+		// Keep server-owned paths out of the SPA fallback. Without this, OAuth
+		// callbacks such as /api/v1/slack/callback can render the client 404
+		// before the Hono route sees the request.
+		"run_worker_first": [
+			"/api",
+			"/api/*",
+			"/webhooks/*"
+		]
 	},
 	"ai": {
 		"binding": "AI"


### PR DESCRIPTION
This prevents Cloudflare static assets from handing /api and /webhooks requests to the SPA fallback before Hono routes run. It adds run_worker_first for server-owned paths, mirrors that in the e2e Wrangler config, and adds a regression test plus Slack docs. Validation: pnpm run verify; pnpm run build.