### PR TITLE
feat(landing): show Dashboard link in header when signed in

### DIFF
--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -33,9 +33,16 @@ export default function LandingPage() {
     <PageShell
       class="gap-12"
       headerActions={
-        <LinkButton href="/docs" variant="ghost" size="sm">
-          Docs
-        </LinkButton>
+        <>
+          <Show when={authed}>
+            <LinkButton href="/dashboard" variant="ghost" size="sm">
+              Dashboard
+            </LinkButton>
+          </Show>
+          <LinkButton href="/docs" variant="ghost" size="sm">
+            Docs
+          </LinkButton>
+        </>
       }
     >
       <section class="py-8 md:py-12 border-y border-border flex flex-col gap-5">


### PR DESCRIPTION
Adds a **Dashboard** entry to the home page's top-right header, rendered only for authenticated visitors via the existing `authed` session signal. It sits alongside Docs and reuses the ghost `LinkButton` styling used by the Dashboard page's own nav. Anonymous visitors still see just Feedback + Docs, and the hero "Open dashboard" button is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)