### PR TITLE
fix(settings): remove "Back to dashboard" link from npm access tab

### DIFF
--- a/src/pages/Dashboard/Settings/NpmConnectionSection.tsx
+++ b/src/pages/Dashboard/Settings/NpmConnectionSection.tsx
@@ -8,7 +8,6 @@ import {
   CollapsibleCard,
   Field,
   Input,
-  LinkButton,
   Muted,
 } from "../../../components";
 
@@ -133,10 +132,7 @@ export function NpmConnectionSection({
         {error ? <Alert tone="critical">{error}</Alert> : null}
 
         {connection ? (
-          <div class="flex items-center justify-between border-t border-border pt-4 gap-3">
-            <LinkButton variant="ghost" size="sm" href="/dashboard">
-              Back to dashboard
-            </LinkButton>
+          <div class="flex items-center justify-end border-t border-border pt-4 gap-3">
             <Button variant="danger" size="sm" onClick={() => void npm.remove()} disabled={busy}>
               {status === "deleting" ? "Removing…" : "Disconnect npm"}
             </Button>

--- a/src/pages/Dashboard/Settings/NpmConnectionSection.tsx
+++ b/src/pages/Dashboard/Settings/NpmConnectionSection.tsx
@@ -1,15 +1,7 @@
 import { useModel } from "@preact/signals";
 import { formatTimestamp } from "../../../lib/format";
 import { NpmConnectionModel } from "../../../models/npm-connection";
-import {
-  Alert,
-  Badge,
-  Button,
-  CollapsibleCard,
-  Field,
-  Input,
-  Muted,
-} from "../../../components";
+import { Alert, Badge, Button, CollapsibleCard, Field, Input, Muted } from "../../../components";
 
 export function NpmConnectionSection({
   npm,


### PR DESCRIPTION
Removes the "Back to dashboard" link from the npm access settings tab, leaving the **Disconnect npm** button right-aligned in the footer via `justify-end`. The now-unused `LinkButton` import is dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)