### PR TITLE
feat(gates): enforce org-wide 2FA for release-gate decisions

### DIFF
--- a/docs/two-factor-auth.md
+++ b/docs/two-factor-auth.md
@@ -99,6 +99,25 @@ submits, matching what the route enforces. The decision audit event records
 `twoFactorRequiredByOrg` alongside `twoFactor`/`twoFactorMethod`. Only the owner can change
 the policy — an admin cannot weaken a gate the owner hardened.
 
+**Changing the policy is itself 2FA-guarded** (it mirrors the gate decision it governs, so
+an owner cannot mandate a control they have not adopted, nor silently relax it from a
+hijacked session). The `PUT /api/v1/organizations/:id/release-two-factor` route, after the
+owner check, applies:
+
+- the owner must have **enrolled** in 2FA, regardless of direction → otherwise
+  `403 { code: "two_factor_enrollment_required" }` (you cannot enforce a control you have not
+  adopted, and it would otherwise lock the owner out of their own release decisions);
+- **enabling** then needs nothing more — hardening the gate is allowed with enrollment alone;
+- **disabling** (relaxing the control) additionally requires a fresh `totpCode` →
+  `401 { code: "two_factor_required" }` when absent, `401 { code: "two_factor_invalid" }` when
+  wrong. A failed step-up leaves the policy untouched.
+
+The `organization.release_two_factor_changed` audit event records `enabled` plus
+`twoFactor`/`twoFactorMethod` (the step-up is recorded only on a relax, the
+security-weakening direction). `ReleaseSecuritySection` mirrors this: it blocks an unenrolled
+owner with a link to enroll, and asks for an authenticator code before letting them stop
+requiring 2FA.
+
 ## Endpoints
 
 All under the Better Auth base path `/api/auth` and handled by `auth.handler`:
@@ -159,5 +178,12 @@ already covers these POSTs.
   decides without a code. The org-enforced policy adds: an unenrolled member is blocked
   (`two_factor_enrollment_required`), and an enrolled member still needs a fresh code.
 - `test/workers/organizations-routes.test.ts` — covers the owner-only
-  `PUT /api/v1/organizations/:id/release-two-factor` toggle (reflected in `GET /`, rejected for
-  admins/strangers, body validated).
+  `PUT /api/v1/organizations/:id/release-two-factor` toggle that needs no real authenticator:
+  rejected for admins/strangers (404) and a non-boolean body (400); an unenrolled owner is
+  blocked from enabling (`two_factor_enrollment_required`) while an enrolled owner enables with
+  no code; and relaxing without a code stops at `two_factor_required` with the policy left on.
+- `test/workers/organizations-release-two-factor.test.ts` — drives the real worker for the
+  toggle's step-up: an enrolled owner enables without a code and relaxes with a fresh code, but
+  cannot relax without one (`two_factor_required`) or with a wrong one (`two_factor_invalid`),
+  and an owner without 2FA cannot enable (`two_factor_enrollment_required`) — a failed step-up
+  never changes the stored policy.

--- a/docs/two-factor-auth.md
+++ b/docs/two-factor-auth.md
@@ -79,6 +79,26 @@ This is scoped to the approval gate. The **staged-publish** decision (`POST
 release on npm — and intentionally does **not** require a step-up. Maintainers without
 2FA enabled decide gates without a code, as before.
 
+### Org-enforced step-up (organization policy)
+
+By default the step-up is per-user: enrolled maintainers step up, others decide without a
+code. An organization owner can make it mandatory for **every** member via
+`organizations.require_two_factor_for_release_decisions` (Settings → General → "Release
+security", `PUT /api/v1/organizations/:id/release-two-factor`, owner-only). When the policy
+is on, the gate decision route (`organizationRequiresTwoFactorForReleaseDecisions` in
+`server/db/organizations.ts`) layers two extra rules on top of the per-user check:
+
+- a member who has **not** enrolled in 2FA is blocked outright →
+  `403 { code: "two_factor_enrollment_required" }` (they must enroll first; the gate is
+  untouched and nothing is posted to GitHub),
+- an enrolled member must still present a fresh `totpCode`, exactly as above.
+
+The gate's public shape carries `organizationRequiresTwoFactor` so `GateDecisionDialog`
+prompts for a code (or shows the "enable 2FA in Settings" blocker) before the member
+submits, matching what the route enforces. The decision audit event records
+`twoFactorRequiredByOrg` alongside `twoFactor`/`twoFactorMethod`. Only the owner can change
+the policy — an admin cannot weaken a gate the owner hardened.
+
 ## Endpoints
 
 All under the Better Auth base path `/api/auth` and handled by `auth.handler`:
@@ -97,6 +117,9 @@ All under the Better Auth base path `/api/auth` and handled by `auth.handler`:
 
 - `user.two_factor_enabled` (`integer`, boolean mode, nullable) — set `true` once TOTP enrollment
   is verified.
+- `organizations.require_two_factor_for_release_decisions` (`integer`, boolean mode, not null,
+  default `false`) — the org-level policy that forces a step-up for every member on release-gate
+  decisions (see the org-enforced step-up section above).
 - `two_factor` table — one row per enrolled user:
   - `id` (text, PK)
   - `secret` (text) — symmetrically encrypted by Better Auth, never the raw base32
@@ -133,4 +156,8 @@ already covers these POSTs.
   step-up: an enrolled maintainer is rejected without a code (`two_factor_required`) and with a
   wrong code (`two_factor_invalid`) — the gate stays `pending` and nothing is posted to GitHub — a
   fresh TOTP releases the gate and posts the decision exactly once, and a maintainer without 2FA
-  decides without a code.
+  decides without a code. The org-enforced policy adds: an unenrolled member is blocked
+  (`two_factor_enrollment_required`), and an enrolled member still needs a fresh code.
+- `test/workers/organizations-routes.test.ts` — covers the owner-only
+  `PUT /api/v1/organizations/:id/release-two-factor` toggle (reflected in `GET /`, rejected for
+  admins/strangers, body validated).

--- a/docs/workflow-gates.md
+++ b/docs/workflow-gates.md
@@ -202,6 +202,16 @@ releaseRisk, decision }]` array (one entry per distinct package).
     the staged-publish decision (`POST /api/v1/scans/:id/decision`) is an audit
     record only — it never publishes or cancels anything — and deliberately does
     not require a step-up.
+  - **Org-enforced 2FA:** an organization owner can make the step-up mandatory
+    for every member via `organizations.require_two_factor_for_release_decisions`
+    (owner-only `PUT /api/v1/organizations/:id/release-two-factor`; Settings →
+    General → "Release security"). With the policy on, an **unenrolled** member is
+    blocked outright — `403 { code: "two_factor_enrollment_required" }`, gate left
+    `pending`, nothing posted to GitHub — and enrolled members still present a
+    fresh `totpCode`. The public gate shape carries `organizationRequiresTwoFactor`
+    so the decision dialog prompts (or blocks) before submit, and the scan event
+    records `twoFactorRequiredByOrg`. See
+    [`two-factor-auth.md`](./two-factor-auth.md#org-enforced-step-up-organization-policy).
 
 - `POST /workflow-gates/:gateId/retry` — requeues a failed package-review batch
   while the gate is still pending. It is only accepted when at least one package

--- a/docs/workflow-gates.md
+++ b/docs/workflow-gates.md
@@ -210,7 +210,9 @@ releaseRisk, decision }]` array (one entry per distinct package).
     `pending`, nothing posted to GitHub — and enrolled members still present a
     fresh `totpCode`. The public gate shape carries `organizationRequiresTwoFactor`
     so the decision dialog prompts (or blocks) before submit, and the scan event
-    records `twoFactorRequiredByOrg`. See
+    records `twoFactorRequiredByOrg`. Flipping the policy is itself 2FA-guarded: the
+    owner must be enrolled to enable it, and must present a fresh `totpCode` to
+    relax it (a failed step-up leaves the policy on). See
     [`two-factor-auth.md`](./two-factor-auth.md#org-enforced-step-up-organization-policy).
 
 - `POST /workflow-gates/:gateId/retry` — requeues a failed package-review batch

--- a/drizzle/0021_magical_exiles.sql
+++ b/drizzle/0021_magical_exiles.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `organizations` ADD `require_two_factor_for_release_decisions` integer DEFAULT false NOT NULL;

--- a/drizzle/meta/0021_snapshot.json
+++ b/drizzle/meta/0021_snapshot.json
@@ -1,0 +1,2389 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d381d227-a90a-4475-8065-4d87f9902fea",
+  "prevId": "344597f7-1ae0-4c54-936d-3494de781fd0",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_app_installations": {
+      "name": "github_app_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Organization'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uninstalled_at": {
+          "name": "uninstalled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_app_installations_installation_unique_idx": {
+          "name": "github_app_installations_installation_unique_idx",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        },
+        "github_app_installations_org_idx": {
+          "name": "github_app_installations_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installations_created_by_user_id_user_id_fk": {
+          "name": "github_app_installations_created_by_user_id_user_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_release_targets": {
+      "name": "github_release_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ecosystem": {
+          "name": "ecosystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_release_targets_org_repo_env_unique_idx": {
+          "name": "github_release_targets_org_repo_env_unique_idx",
+          "columns": [
+            "organization_id",
+            "repository_id",
+            "environment"
+          ],
+          "isUnique": true
+        },
+        "github_release_targets_installation_idx": {
+          "name": "github_release_targets_installation_idx",
+          "columns": [
+            "installation_row_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_release_targets_organization_id_organizations_id_fk": {
+          "name": "github_release_targets_organization_id_organizations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_release_targets_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_created_by_user_id_user_id_fk": {
+          "name": "github_release_targets_created_by_user_id_user_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_workflow_gates": {
+      "name": "github_workflow_gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_target_id": {
+          "name": "release_target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deployment_callback_url": {
+          "name": "deployment_callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_comment": {
+          "name": "decision_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_url": {
+          "name": "report_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_started_at": {
+          "name": "review_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_workflow_gates_delivery_unique_idx": {
+          "name": "github_workflow_gates_delivery_unique_idx",
+          "columns": [
+            "delivery_id"
+          ],
+          "isUnique": true
+        },
+        "github_workflow_gates_org_status_idx": {
+          "name": "github_workflow_gates_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_release_target_idx": {
+          "name": "github_workflow_gates_release_target_idx",
+          "columns": [
+            "release_target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_workflow_gates_organization_id_organizations_id_fk": {
+          "name": "github_workflow_gates_organization_id_organizations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_workflow_gates_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_release_target_id_github_release_targets_id_fk": {
+          "name": "github_workflow_gates_release_target_id_github_release_targets_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_release_targets",
+          "columnsFrom": [
+            "release_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_scan_id_scans_id_fk": {
+          "name": "github_workflow_gates_scan_id_scans_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_unique_idx": {
+          "name": "npm_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_invitations": {
+      "name": "organization_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_invitations_token_hash_unique_idx": {
+          "name": "organization_invitations_token_hash_unique_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "organization_invitations_org_status_idx": {
+          "name": "organization_invitations_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "organization_invitations_org_email_idx": {
+          "name": "organization_invitations_org_email_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_invitations_organization_id_organizations_id_fk": {
+          "name": "organization_invitations_organization_id_organizations_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_invited_by_user_id_user_id_fk": {
+          "name": "organization_invitations_invited_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_accepted_by_user_id_user_id_fk": {
+          "name": "organization_invitations_accepted_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_notification_recipients": {
+      "name": "organization_notification_recipients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_notification_recipients_org_email_unique_idx": {
+          "name": "organization_notification_recipients_org_email_unique_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_notification_recipients_organization_id_organizations_id_fk": {
+          "name": "organization_notification_recipients_organization_id_organizations_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_notification_recipients_created_by_user_id_user_id_fk": {
+          "name": "organization_notification_recipients_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_slack_connections": {
+      "name": "organization_slack_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_token_ciphertext": {
+          "name": "bot_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bot_token_nonce": {
+          "name": "bot_token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slack_connections_org_unique_idx": {
+          "name": "organization_slack_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_slack_connections_organization_id_organizations_id_fk": {
+          "name": "organization_slack_connections_organization_id_organizations_id_fk",
+          "tableFrom": "organization_slack_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_slack_connections_created_by_user_id_user_id_fk": {
+          "name": "organization_slack_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_slack_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "require_two_factor_for_release_decisions": {
+          "name": "require_two_factor_for_release_decisions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_findings_scan_severity_idx": {
+          "name": "scan_findings_scan_severity_idx",
+          "columns": [
+            "scan_id",
+            "severity"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changed_file_count": {
+          "name": "changed_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_summary_json": {
+          "name": "risk_summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_storage_version": {
+          "name": "artifact_storage_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_key": {
+          "name": "artifact_manifest_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_digest": {
+          "name": "artifact_manifest_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_size": {
+          "name": "artifact_manifest_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_artifact_key": {
+          "name": "report_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_samples_artifact_key": {
+          "name": "file_samples_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "diff_artifact_key": {
+          "name": "diff_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        },
+        "scans_gate_org_idx": {
+          "name": "scans_gate_org_idx",
+          "columns": [
+            "gate_id",
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_artifact_backfill_idx": {
+          "name": "scans_artifact_backfill_idx",
+          "columns": [
+            "organization_id",
+            "status",
+            "artifact_storage_version",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "scans_org_decision_created_idx": {
+          "name": "scans_org_decision_created_idx",
+          "columns": [
+            "organization_id",
+            "decision",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scans_org_created_idx": {
+          "name": "scans_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_gate_id_github_workflow_gates_id_fk": {
+          "name": "scans_gate_id_github_workflow_gates_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "github_workflow_gates",
+          "columnsFrom": [
+            "gate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_decided_by_user_id_user_id_fk": {
+          "name": "scans_decided_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "two_factor": {
+      "name": "two_factor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1781543124536,
       "tag": "0020_gifted_leo",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "6",
+      "when": 1781546985955,
+      "tag": "0021_magical_exiles",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/organizations.ts
+++ b/server/db/organizations.ts
@@ -96,6 +96,7 @@ export interface OrganizationListEntry {
   role: string;
   isPersonal: boolean;
   npmConnectionConfigured: boolean;
+  requireTwoFactorForReleaseDecisions: boolean;
   createdAt: Date | string | number;
   updatedAt: Date | string | number;
 }
@@ -111,6 +112,7 @@ export async function listUserOrganizations(
       name: organizations.name,
       ownerUserId: organizations.ownerUserId,
       role: organizationMembers.role,
+      requireTwoFactorForReleaseDecisions: organizations.requireTwoFactorForReleaseDecisions,
       createdAt: organizations.createdAt,
       updatedAt: organizations.updatedAt,
       npmConnectionConfigured: sql<boolean>`exists (
@@ -131,6 +133,7 @@ export async function listUserOrganizations(
       role: row.role,
       isPersonal: row.id === personalId,
       npmConnectionConfigured: Boolean(row.npmConnectionConfigured),
+      requireTwoFactorForReleaseDecisions: Boolean(row.requireTwoFactorForReleaseDecisions),
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
     }))
@@ -185,6 +188,36 @@ export async function renameOrganization(db: AppDb, organizationId: string, name
   await db
     .update(organizations)
     .set({ name, updatedAt: new Date() })
+    .where(eq(organizations.id, organizationId));
+}
+
+/**
+ * Whether this org enforces a two-factor step-up on release-gate decisions for
+ * every member. Read at decision time as an authoritative org-level policy on
+ * top of the per-user enrollment check — fail closed: a missing org row reads as
+ * "not required" only because such a row cannot reach the decision path (the
+ * gate is scoped to a real org the caller belongs to).
+ */
+export async function organizationRequiresTwoFactorForReleaseDecisions(
+  db: AppDb,
+  organizationId: string,
+): Promise<boolean> {
+  const [row] = await db
+    .select({ enabled: organizations.requireTwoFactorForReleaseDecisions })
+    .from(organizations)
+    .where(eq(organizations.id, organizationId))
+    .limit(1);
+  return Boolean(row?.enabled);
+}
+
+export async function setRequireTwoFactorForReleaseDecisions(
+  db: AppDb,
+  organizationId: string,
+  enabled: boolean,
+) {
+  await db
+    .update(organizations)
+    .set({ requireTwoFactorForReleaseDecisions: enabled, updatedAt: new Date() })
     .where(eq(organizations.id, organizationId));
 }
 

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -26,6 +26,15 @@ export const organizations = sqliteTable(
     ownerUserId: text("owner_user_id")
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
+    // When true, every member must prove a fresh second factor before deciding a
+    // release gate — and a member who has not enrolled in 2FA cannot decide one
+    // at all. Off by default so existing orgs keep today's per-user step-up
+    // behavior (enrolled members step up; others decide without a code).
+    requireTwoFactorForReleaseDecisions: integer("require_two_factor_for_release_decisions", {
+      mode: "boolean",
+    })
+      .notNull()
+      .default(false),
     createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
     updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
   },

--- a/server/routes/github-app.ts
+++ b/server/routes/github-app.ts
@@ -4,6 +4,7 @@ import {
   createDb,
   enforceRateLimit,
   getScan,
+  organizationRequiresTwoFactorForReleaseDecisions,
   recordGatePackageDecision,
   recordScanEvent,
 } from "../db";
@@ -405,7 +406,11 @@ githubAppRoutes.get("/workflow-gates/by-scan/:scanId", async (c) => {
   const gate = await getGateByScanId(db, organizationId, scanId);
   if (!gate) return c.json({ error: "not found" }, 404);
   const packages = await listGatePackageScans(db, organizationId, gate.id);
-  return c.json({ gate: publicWorkflowGate(gate, packages) });
+  const orgRequiresTwoFactor = await organizationRequiresTwoFactorForReleaseDecisions(
+    db,
+    organizationId,
+  );
+  return c.json({ gate: publicWorkflowGate(gate, packages, orgRequiresTwoFactor) });
 });
 
 // Record a maintainer's decision on one package of a gate and, once the whole
@@ -458,6 +463,14 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
     throw err;
   }
 
+  // Org-wide policy: when on, the step-up below is mandatory for every member
+  // and an unenrolled member cannot decide at all. Looked up once so every gate
+  // returned from this handler carries a consistent flag for the dialog.
+  const orgRequiresTwoFactor = await organizationRequiresTwoFactorForReleaseDecisions(
+    db,
+    organizationId,
+  );
+
   const gateId = c.req.param("gateId");
   const existing = await getGateForOrganization(db, organizationId, gateId);
   if (!existing) return c.json({ error: "not found" }, 404);
@@ -486,7 +499,7 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
     const packages = await listGatePackageScans(db, organizationId, gateId);
     return c.json(
       {
-        gate: publicWorkflowGate(existing, packages),
+        gate: publicWorkflowGate(existing, packages, orgRequiresTwoFactor),
         error: "approval requires a completed workflow-gate review batch",
       },
       409,
@@ -497,13 +510,28 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
   // — approval immediately releases the GitHub job and publishing proceeds via
   // Trusted Publishing/OIDC, which can't be reversed. So a maintainer who has
   // enrolled in two-factor auth must prove a *fresh* second factor here; an
-  // existing session is not enough. Members without 2FA decide as before. This
-  // runs only after the decision is confirmed actionable above, so an enrolled
-  // maintainer is never prompted for a code on a decision that would 409 anyway.
-  // (The staged-publish decision in scans.ts is an audit record only — it never
-  // publishes or cancels anything — and deliberately never requires this.)
+  // existing session is not enough. On top of that, an org can require 2FA for
+  // every release decision: then an unenrolled member is blocked outright (must
+  // enroll first) and enrolled members still step up. With the policy off, only
+  // enrolled members step up and others decide as before. This runs only after
+  // the decision is confirmed actionable above, so a maintainer is never
+  // prompted for a code (or blocked for enrollment) on a decision that would 409
+  // anyway. (The staged-publish decision in scans.ts is an audit record only —
+  // it never publishes or cancels anything — and deliberately never requires
+  // this.)
   let twoFactorVerified = false;
-  if (await userHasTwoFactor(db, session.userId)) {
+  const userEnrolledInTwoFactor = await userHasTwoFactor(db, session.userId);
+  if (orgRequiresTwoFactor && !userEnrolledInTwoFactor) {
+    return c.json(
+      {
+        error:
+          "your organization requires two-factor authentication to decide release gates — enable it in Settings, then try again",
+        code: "two_factor_enrollment_required",
+      },
+      403,
+    );
+  }
+  if (orgRequiresTwoFactor || userEnrolledInTwoFactor) {
     try {
       await enforceRateLimit(db, {
         key: `github-app:gate-decision-2fa:${session.userId}`,
@@ -550,7 +578,7 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
     const currentPackages = await listGatePackageScans(db, organizationId, gateId);
     return c.json(
       {
-        gate: current ? publicWorkflowGate(current, currentPackages) : null,
+        gate: current ? publicWorkflowGate(current, currentPackages, orgRequiresTwoFactor) : null,
         error:
           current?.status === "pending"
             ? "package has already been decided"
@@ -567,12 +595,12 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
   const allApproved = packages.length > 0 && packages.every((pkg) => pkg.decision === "publish");
   if (!anyRejected && !allApproved) {
     // Other packages still need a decision; keep the deployment held.
-    return c.json({ gate: publicWorkflowGate(existing, packages) });
+    return c.json({ gate: publicWorkflowGate(existing, packages, orgRequiresTwoFactor) });
   }
   if (allApproved && !existing.scanId) {
     return c.json(
       {
-        gate: publicWorkflowGate(existing, packages),
+        gate: publicWorkflowGate(existing, packages, orgRequiresTwoFactor),
         error: "approval requires a completed workflow-gate review batch",
       },
       409,
@@ -593,7 +621,7 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
     const current = await getGateForOrganization(db, organizationId, gateId);
     return c.json(
       {
-        gate: current ? publicWorkflowGate(current, packages) : null,
+        gate: current ? publicWorkflowGate(current, packages, orgRequiresTwoFactor) : null,
         error: "gate has already been decided",
       },
       409,
@@ -622,6 +650,7 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
         packageCount: packages.length,
         twoFactor: twoFactorVerified,
         twoFactorMethod: twoFactorVerified ? "totp" : null,
+        twoFactorRequiredByOrg: orgRequiresTwoFactor,
       },
     });
   } catch (err) {
@@ -633,7 +662,7 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
     });
   }
 
-  return c.json({ gate: publicWorkflowGate(decided, packages) });
+  return c.json({ gate: publicWorkflowGate(decided, packages, orgRequiresTwoFactor) });
 });
 
 // Re-run a failed workflow-gate review batch. The retry is intentionally scoped
@@ -665,10 +694,14 @@ githubAppRoutes.post("/workflow-gates/:gateId/retry", async (c) => {
 
   const reset = await resetGateReviewForRetry(db, { gateId, organizationId });
   const packages = await listGatePackageScans(db, organizationId, gateId);
+  const orgRequiresTwoFactor = await organizationRequiresTwoFactorForReleaseDecisions(
+    db,
+    organizationId,
+  );
   if (!reset) {
     return c.json(
       {
-        gate: publicWorkflowGate(existing, packages),
+        gate: publicWorkflowGate(existing, packages, orgRequiresTwoFactor),
         error: "gate review is not retryable",
       },
       409,
@@ -688,7 +721,10 @@ githubAppRoutes.post("/workflow-gates/:gateId/retry", async (c) => {
 
   const gate = await getGateForOrganization(db, organizationId, gateId);
   return c.json(
-    { gate: publicWorkflowGate(gate ?? existing, packages), queued: Boolean(c.env.SCAN_QUEUE) },
+    {
+      gate: publicWorkflowGate(gate ?? existing, packages, orgRequiresTwoFactor),
+      queued: Boolean(c.env.SCAN_QUEUE),
+    },
     202,
   );
 });
@@ -775,7 +811,14 @@ function publicReleaseTarget(record: ReleaseTargetRecord) {
 // so the credentialed egress target is never exposed to the browser. `packages`
 // is one entry per distinct package the release publishes (a monorepo fans out
 // into several); the gate releases only once every package is approved.
-function publicWorkflowGate(record: WorkflowGateRecord, packages: GatePackageScan[] = []) {
+// `organizationRequiresTwoFactor` surfaces the org policy so the decision dialog
+// can prompt for a code (or block an unenrolled member) before submitting,
+// matching what the route enforces server-side.
+function publicWorkflowGate(
+  record: WorkflowGateRecord,
+  packages: GatePackageScan[] = [],
+  organizationRequiresTwoFactor = false,
+) {
   return {
     id: record.id,
     organizationId: record.organizationId,
@@ -789,6 +832,7 @@ function publicWorkflowGate(record: WorkflowGateRecord, packages: GatePackageSca
     reportUrl: record.reportUrl,
     scanId: record.scanId,
     failureReason: record.failureReason,
+    organizationRequiresTwoFactor,
     packages: packages.map((pkg) => ({
       scanId: pkg.scanId,
       packageName: pkg.packageName,

--- a/server/routes/organizations.ts
+++ b/server/routes/organizations.ts
@@ -17,6 +17,7 @@ import {
   setRequireTwoFactorForReleaseDecisions,
   type NotificationRecipient,
 } from "../db";
+import { userHasTwoFactor, verifyTotpStepUp } from "../lib/auth";
 import { sanitizeAddress } from "../lib/email";
 import { rateLimitResponse } from "../lib/http";
 import { describeOperationalError, emitOperationalEvent } from "../lib/observability";
@@ -97,8 +98,20 @@ organizationsRoutes.patch("/:id", async (c) => {
 // decisions. Owner-only — this is a security policy that binds every member, so
 // it sits alongside rename/delete rather than the admin-level integration
 // controls; an admin must not be able to weaken a gate the owner hardened.
+//
+// Changing this policy is itself a 2FA-guarded action, mirroring the gate
+// decision it governs: the owner must have enrolled in 2FA before they can
+// mandate it for everyone (you cannot enforce a control you have not adopted,
+// and it would otherwise lock the owner out of their own release decisions), and
+// *relaxing* the policy weakens a security control — so, like deciding a gate, it
+// demands a fresh second factor rather than just a live session. Enabling only
+// hardens, so enrollment alone is enough there; disabling additionally needs a
+// fresh `totpCode`.
 organizationsRoutes.put("/:id/release-two-factor", async (c) => {
-  const body = (await c.req.json().catch(() => ({}))) as { enabled?: unknown };
+  const body = (await c.req.json().catch(() => ({}))) as {
+    enabled?: unknown;
+    totpCode?: unknown;
+  };
   if (typeof body.enabled !== "boolean") {
     return c.json({ error: "enabled must be a boolean" }, 400);
   }
@@ -123,12 +136,44 @@ organizationsRoutes.put("/:id/release-two-factor", async (c) => {
     throw err;
   }
 
+  const ownerEnrolledInTwoFactor = await userHasTwoFactor(db, session.userId);
+  if (!ownerEnrolledInTwoFactor) {
+    return c.json(
+      {
+        error:
+          "enable two-factor authentication on your account before changing the release two-factor policy",
+        code: "two_factor_enrollment_required",
+      },
+      403,
+    );
+  }
+  let twoFactorVerified = false;
+  if (!enabled) {
+    const totpCode = typeof body.totpCode === "string" ? body.totpCode.trim() : "";
+    if (!totpCode) {
+      return c.json(
+        { error: "two-factor verification required", code: "two_factor_required" },
+        401,
+      );
+    }
+    if (!(await verifyTotpStepUp(c.get("auth"), c.req.raw, totpCode))) {
+      return c.json({ error: "invalid two-factor code", code: "two_factor_invalid" }, 401);
+    }
+    twoFactorVerified = true;
+  }
+
   await setRequireTwoFactorForReleaseDecisions(db, organizationId, enabled);
   await recordScanEvent(db, {
     organizationId,
     actorUserId: session.userId,
     type: "organization.release_two_factor_changed",
-    metadata: { enabled },
+    metadata: {
+      enabled,
+      // Records whether a fresh step-up gated the change — true only on a relax,
+      // which is the security-weakening direction worth auditing precisely.
+      twoFactor: twoFactorVerified,
+      twoFactorMethod: twoFactorVerified ? "totp" : null,
+    },
   });
   return c.json({ requireTwoFactorForReleaseDecisions: enabled });
 });

--- a/server/routes/organizations.ts
+++ b/server/routes/organizations.ts
@@ -14,6 +14,7 @@ import {
   listUserOrganizations,
   recordScanEvent,
   renameOrganization,
+  setRequireTwoFactorForReleaseDecisions,
   type NotificationRecipient,
 } from "../db";
 import { sanitizeAddress } from "../lib/email";
@@ -90,6 +91,46 @@ organizationsRoutes.patch("/:id", async (c) => {
     metadata: { name },
   });
   return c.json({ organization: { id: organizationId, name } });
+});
+
+// Enforce (or relax) the org-wide two-factor requirement for release-gate
+// decisions. Owner-only — this is a security policy that binds every member, so
+// it sits alongside rename/delete rather than the admin-level integration
+// controls; an admin must not be able to weaken a gate the owner hardened.
+organizationsRoutes.put("/:id/release-two-factor", async (c) => {
+  const body = (await c.req.json().catch(() => ({}))) as { enabled?: unknown };
+  if (typeof body.enabled !== "boolean") {
+    return c.json({ error: "enabled must be a boolean" }, 400);
+  }
+  const enabled = body.enabled;
+
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const organizationId = c.req.param("id");
+  const owner = await isOrganizationOwner(db, organizationId, session.userId);
+  if (!owner) return c.json({ error: "not found" }, 404);
+
+  try {
+    await enforceRateLimit(db, {
+      key: `organizations:release-two-factor:${session.userId}`,
+      limit: 30,
+      windowMs: 60 * 60 * 1000,
+    });
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      return rateLimitResponse(c, "release two-factor rate limit exceeded", err);
+    }
+    throw err;
+  }
+
+  await setRequireTwoFactorForReleaseDecisions(db, organizationId, enabled);
+  await recordScanEvent(db, {
+    organizationId,
+    actorUserId: session.userId,
+    type: "organization.release_two_factor_changed",
+    metadata: { enabled },
+  });
+  return c.json({ requireTwoFactorForReleaseDecisions: enabled });
 });
 
 organizationsRoutes.delete("/:id", async (c) => {

--- a/src/models/github-app.ts
+++ b/src/models/github-app.ts
@@ -63,6 +63,9 @@ export interface PublicWorkflowGate {
   reportUrl: string | null;
   scanId: string | null;
   failureReason: string | null;
+  // Org policy: every member must step up with a fresh code to decide this gate,
+  // and a member who has not enrolled in 2FA cannot decide it at all.
+  organizationRequiresTwoFactor: boolean;
   packages: GatePackageScan[];
   requestedAt: string;
   decidedAt: string | null;
@@ -118,6 +121,18 @@ export function decideWorkflowGate(
       if (err.code === "two_factor_invalid") {
         throw new ApiError("That authentication code is invalid.", 401, err.detail, err.code);
       }
+    }
+    if (
+      err instanceof ApiError &&
+      err.status === 403 &&
+      err.code === "two_factor_enrollment_required"
+    ) {
+      throw new ApiError(
+        "Your organization requires two-factor authentication to decide releases. Enable it in Settings, then try again.",
+        403,
+        err.detail,
+        err.code,
+      );
     }
     throw err;
   });

--- a/src/models/organization.ts
+++ b/src/models/organization.ts
@@ -9,6 +9,7 @@ export interface Organization {
   role: string;
   isPersonal: boolean;
   npmConnectionConfigured: boolean;
+  requireTwoFactorForReleaseDecisions: boolean;
   createdAt: string | number | Date;
   updatedAt: string | number | Date;
 }
@@ -17,7 +18,13 @@ interface ListResponse {
   organizations: Organization[];
 }
 
-export type OrganizationStatus = "idle" | "loading" | "creating" | "renaming" | "deleting";
+export type OrganizationStatus =
+  | "idle"
+  | "loading"
+  | "creating"
+  | "renaming"
+  | "deleting"
+  | "updating";
 
 export const OrganizationModel = createModel(() => {
   const organizations = signal<Organization[]>([]);
@@ -133,6 +140,27 @@ export const OrganizationModel = createModel(() => {
             method: "PATCH",
           },
         );
+        await this.load();
+        return true;
+      } catch (err) {
+        this.error.value = errorMessage(err);
+        return false;
+      } finally {
+        this.status.value = "idle";
+      }
+    },
+
+    async setReleaseTwoFactor(organizationId: string, enabled: boolean): Promise<boolean> {
+      this.status.value = "updating";
+      this.error.value = null;
+      try {
+        await apiJson<{ requireTwoFactorForReleaseDecisions: boolean }>(
+          `/api/v1/organizations/${encodeURIComponent(organizationId)}/release-two-factor`,
+          { enabled },
+          { method: "PUT" },
+        );
+        // Reload so `active.requireTwoFactorForReleaseDecisions` reflects the new
+        // policy everywhere that reads the org list.
         await this.load();
         return true;
       } catch (err) {

--- a/src/models/organization.ts
+++ b/src/models/organization.ts
@@ -1,6 +1,6 @@
 import { computed, createModel, signal } from "@preact/signals";
 import { activeOrganizationId, setActiveOrganizationId } from "./active-organization";
-import { apiFetch, apiJson, errorMessage } from "./api";
+import { ApiError, apiFetch, apiJson, errorMessage } from "./api";
 
 export interface Organization {
   id: string;
@@ -25,6 +25,24 @@ export type OrganizationStatus =
   | "renaming"
   | "deleting"
   | "updating";
+
+// The release-two-factor route answers with stable codes; map them to copy that
+// matches what the owner must do. `apiFetch` rewrites the generic 401 message but
+// preserves `code`, so we key off the code rather than the message text.
+function releaseTwoFactorErrorMessage(err: unknown): string {
+  if (err instanceof ApiError) {
+    if (err.code === "two_factor_enrollment_required") {
+      return "Enable two-factor authentication on your own account first, then change this policy.";
+    }
+    if (err.code === "two_factor_required") {
+      return "Enter the code from your authenticator app to stop requiring two-factor.";
+    }
+    if (err.code === "two_factor_invalid") {
+      return "That authentication code is invalid or expired — enter the current code.";
+    }
+  }
+  return errorMessage(err);
+}
 
 export const OrganizationModel = createModel(() => {
   const organizations = signal<Organization[]>([]);
@@ -150,13 +168,20 @@ export const OrganizationModel = createModel(() => {
       }
     },
 
-    async setReleaseTwoFactor(organizationId: string, enabled: boolean): Promise<boolean> {
+    // Changing the policy is 2FA-guarded server-side: enabling requires the owner
+    // be enrolled, and disabling requires a fresh `totpCode` (passed only on the
+    // relax path). Codes are surfaced as friendly copy below.
+    async setReleaseTwoFactor(
+      organizationId: string,
+      enabled: boolean,
+      totpCode?: string | null,
+    ): Promise<boolean> {
       this.status.value = "updating";
       this.error.value = null;
       try {
         await apiJson<{ requireTwoFactorForReleaseDecisions: boolean }>(
           `/api/v1/organizations/${encodeURIComponent(organizationId)}/release-two-factor`,
-          { enabled },
+          { enabled, totpCode: totpCode?.trim() || undefined },
           { method: "PUT" },
         );
         // Reload so `active.requireTwoFactorForReleaseDecisions` reflects the new
@@ -164,7 +189,7 @@ export const OrganizationModel = createModel(() => {
         await this.load();
         return true;
       } catch (err) {
-        this.error.value = errorMessage(err);
+        this.error.value = releaseTwoFactorErrorMessage(err);
         return false;
       } finally {
         this.status.value = "idle";

--- a/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
@@ -260,6 +260,16 @@ export function GateDecisionDialog({
   const needsCode = requireTwoFactor && !gateDecided;
   const code = codeDraft.value.trim();
   const blockedOnCode = needsCode && code.length === 0;
+  // The org requires a second factor to decide releases but this member hasn't
+  // enrolled — they're blocked until they do. `requireTwoFactor` is the member's
+  // own enrollment, so this is exactly the case the route answers with 403
+  // `two_factor_enrollment_required`. Decided gates/packages are read-only, so
+  // there's nothing to block there.
+  const mustEnroll =
+    gate.organizationRequiresTwoFactor &&
+    !requireTwoFactor &&
+    !gateDecided &&
+    !packageAlreadyDecided;
 
   useEffect(() => {
     if (open) {
@@ -269,7 +279,7 @@ export function GateDecisionDialog({
   }, [open]);
 
   const submit = (next: WorkflowGateDecision) => {
-    if (saving || gateDecided || packageAlreadyDecided || blockedOnCode) return;
+    if (saving || gateDecided || packageAlreadyDecided || blockedOnCode || mustEnroll) return;
     const trimmed = commentDraft.value.trim();
     void onSubmit(next, trimmed.length ? trimmed : null, needsCode ? code : null);
   };
@@ -322,6 +332,17 @@ export function GateDecisionDialog({
         </Alert>
       ) : null}
 
+      {mustEnroll ? (
+        <Alert tone="warn">
+          Your organization requires two-factor authentication to approve or block releases. Enable
+          it in{" "}
+          <a class="underline text-accent" href="/dashboard/settings">
+            Settings → General
+          </a>
+          , then reopen this decision.
+        </Alert>
+      ) : null}
+
       <Field label="Comment (optional, shown in the GitHub run log)" for="gateComment">
         <Input
           id="gateComment"
@@ -329,7 +350,7 @@ export function GateDecisionDialog({
           value={commentDraft.value}
           placeholder="e.g. reviewed changed files, no risk signals"
           onInput={(e) => (commentDraft.value = (e.target as HTMLInputElement).value)}
-          disabled={saving || gateDecided || packageAlreadyDecided}
+          disabled={saving || gateDecided || packageAlreadyDecided || mustEnroll}
           maxLength={500}
           autoComplete="off"
           spellcheck={false}
@@ -368,7 +389,10 @@ export function GateDecisionDialog({
       ) : (
         <div class="flex flex-wrap gap-2">
           {canApprove ? (
-            <Button onClick={() => submit("approved")} disabled={saving || blockedOnCode}>
+            <Button
+              onClick={() => submit("approved")}
+              disabled={saving || blockedOnCode || mustEnroll}
+            >
               {saving
                 ? "Submitting…"
                 : reviewFailed
@@ -383,7 +407,7 @@ export function GateDecisionDialog({
           <Button
             variant="danger"
             onClick={() => submit("rejected")}
-            disabled={saving || blockedOnCode}
+            disabled={saving || blockedOnCode || mustEnroll}
           >
             {saving ? "Submitting…" : "Reject & block release"}
           </Button>

--- a/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
@@ -336,8 +336,8 @@ export function GateDecisionDialog({
         <Alert tone="warn">
           Your organization requires two-factor authentication to approve or block releases. Enable
           it in{" "}
-          <a class="underline text-accent" href="/dashboard/settings">
-            Settings → General
+          <a class="underline text-accent" href="/dashboard/account">
+            Account
           </a>
           , then reopen this decision.
         </Alert>

--- a/src/pages/Dashboard/Settings/ReleaseSecuritySection.tsx
+++ b/src/pages/Dashboard/Settings/ReleaseSecuritySection.tsx
@@ -1,0 +1,81 @@
+import { useModel } from "@preact/signals";
+import type { OrganizationRole } from "../../../../server/lib/roles";
+import { OrganizationModel } from "../../../models/organization";
+import { Alert, Badge, Button, Card, Muted, SectionLabel } from "../../../components";
+
+/**
+ * Owner-only control for the org-wide policy that forces a fresh two-factor
+ * step-up on every release-gate decision (and blocks members who have not
+ * enrolled in 2FA from deciding at all). The route enforces this authoritatively
+ * — this section only flips the policy; the gate decision dialog reflects it.
+ */
+export function ReleaseSecuritySection({
+  organizations,
+  currentUserRole,
+}: {
+  organizations: ReturnType<typeof useModel<typeof OrganizationModel.prototype>>;
+  currentUserRole: OrganizationRole | null;
+}) {
+  const active = organizations.active.value;
+  const status = organizations.status.value;
+  const error = organizations.error.value;
+  const saving = status === "updating";
+  const isOwner = currentUserRole === "owner";
+  const enabled = active?.requireTwoFactorForReleaseDecisions ?? false;
+
+  const toggle = () => {
+    if (!active || !isOwner || saving) return;
+    void organizations.setReleaseTwoFactor(active.id, !enabled);
+  };
+
+  return (
+    <Card class="flex flex-col gap-5">
+      <div class="flex items-center justify-between gap-2 flex-wrap">
+        <SectionLabel>Release security</SectionLabel>
+        <Badge tone={enabled ? "ok" : "neutral"}>{enabled ? "required" : "not required"}</Badge>
+      </div>
+
+      <Muted class="text-[13px] m-0 max-w-[760px]">
+        Require two-factor authentication to approve or block a release gate. Approving a gate
+        releases the held GitHub Actions job and publishing proceeds over Trusted Publishing/OIDC,
+        which cannot be undone — so when this is on, every member must confirm with a fresh
+        authenticator code, and a member who has not enabled 2FA cannot decide a release until they
+        do.
+      </Muted>
+
+      {active ? (
+        isOwner ? (
+          <div class="flex flex-col gap-2">
+            <Button
+              variant={enabled ? "secondary" : "primary"}
+              size="sm"
+              onClick={toggle}
+              disabled={saving}
+              class="self-start"
+            >
+              {saving
+                ? "Saving…"
+                : enabled
+                  ? "Stop requiring two-factor"
+                  : "Require two-factor for releases"}
+            </Button>
+            {active.isPersonal ? (
+              <Muted class="text-[12px] m-0">
+                This is your personal workspace, so the policy only affects you. It matters most for
+                organizations with multiple members.
+              </Muted>
+            ) : null}
+          </div>
+        ) : (
+          <Muted class="text-[13px] m-0">
+            Only the organization owner can change the release two-factor policy.
+          </Muted>
+        )
+      ) : (
+        <Muted class="text-[13px] m-0">No organization selected.</Muted>
+      )}
+
+      {error ? <Alert tone="critical">{error}</Alert> : null}
+    </Card>
+  );
+}

--- a/src/pages/Dashboard/Settings/ReleaseSecuritySection.tsx
+++ b/src/pages/Dashboard/Settings/ReleaseSecuritySection.tsx
@@ -1,13 +1,17 @@
-import { useModel } from "@preact/signals";
+import { useModel, useSignal } from "@preact/signals";
 import type { OrganizationRole } from "../../../../server/lib/roles";
+import { sessionModel } from "../../../models/auth";
 import { OrganizationModel } from "../../../models/organization";
-import { Alert, Badge, Button, Card, Muted, SectionLabel } from "../../../components";
+import { Alert, Badge, Button, Card, Field, Input, Muted, SectionLabel } from "../../../components";
 
 /**
  * Owner-only control for the org-wide policy that forces a fresh two-factor
  * step-up on every release-gate decision (and blocks members who have not
  * enrolled in 2FA from deciding at all). The route enforces this authoritatively
- * — this section only flips the policy; the gate decision dialog reflects it.
+ * — this section flips the policy and mirrors the same 2FA guard the route puts
+ * on the change itself: the owner must have enrolled in 2FA before they can
+ * require it for everyone, and *relaxing* it asks for a fresh authenticator code
+ * (an existing session is not enough) exactly like deciding a gate.
  */
 export function ReleaseSecuritySection({
   organizations,
@@ -16,16 +20,29 @@ export function ReleaseSecuritySection({
   organizations: ReturnType<typeof useModel<typeof OrganizationModel.prototype>>;
   currentUserRole: OrganizationRole | null;
 }) {
+  const codeDraft = useSignal("");
   const active = organizations.active.value;
   const status = organizations.status.value;
   const error = organizations.error.value;
   const saving = status === "updating";
   const isOwner = currentUserRole === "owner";
   const enabled = active?.requireTwoFactorForReleaseDecisions ?? false;
+  // Whether *this owner* has 2FA on their own account. The route rejects an
+  // unenrolled owner with `two_factor_enrollment_required`, so we gate the action
+  // on the same fact instead of letting them submit into a guaranteed error.
+  const enrolled = sessionModel.user.value?.twoFactorEnabled === true;
+  const code = codeDraft.value.trim();
+  // Relaxing the policy needs a fresh code; enabling only hardens, so it doesn't.
+  const blockedOnCode = enabled && code.length === 0;
 
-  const toggle = () => {
-    if (!active || !isOwner || saving) return;
-    void organizations.setReleaseTwoFactor(active.id, !enabled);
+  const enable = () => {
+    if (!active || !isOwner || saving || !enrolled) return;
+    void organizations.setReleaseTwoFactor(active.id, true);
+  };
+  const disable = async () => {
+    if (!active || !isOwner || saving || !enrolled || blockedOnCode) return;
+    const ok = await organizations.setReleaseTwoFactor(active.id, false, code);
+    if (ok) codeDraft.value = "";
   };
 
   return (
@@ -45,27 +62,66 @@ export function ReleaseSecuritySection({
 
       {active ? (
         isOwner ? (
-          <div class="flex flex-col gap-2">
-            <Button
-              variant={enabled ? "secondary" : "primary"}
-              size="sm"
-              onClick={toggle}
-              disabled={saving}
-              class="self-start"
-            >
-              {saving
-                ? "Saving…"
-                : enabled
-                  ? "Stop requiring two-factor"
-                  : "Require two-factor for releases"}
-            </Button>
-            {active.isPersonal ? (
-              <Muted class="text-[12px] m-0">
-                This is your personal workspace, so the policy only affects you. It matters most for
-                organizations with multiple members.
-              </Muted>
-            ) : null}
-          </div>
+          !enrolled ? (
+            <Alert tone="warn">
+              Turn on two-factor authentication for your own account in{" "}
+              <a class="underline text-accent" href="/dashboard/account">
+                Account
+              </a>{" "}
+              before you can require it for releases.
+            </Alert>
+          ) : enabled ? (
+            // Relaxing the policy weakens a security control, so confirm with a
+            // fresh authenticator code before submitting — same step-up the gate
+            // decision asks for.
+            <div class="flex flex-col gap-3">
+              <Field label="Authentication code" for="releaseTotp">
+                <Input
+                  id="releaseTotp"
+                  type="text"
+                  value={codeDraft.value}
+                  placeholder="6-digit code"
+                  inputmode="numeric"
+                  autocomplete="one-time-code"
+                  maxLength={8}
+                  spellcheck={false}
+                  disabled={saving}
+                  onInput={(e) => (codeDraft.value = (e.target as HTMLInputElement).value)}
+                />
+                <Muted class="m-0 mt-1 text-[12px]">
+                  Enter the code from your authenticator app to stop requiring two-factor for
+                  releases.
+                </Muted>
+              </Field>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={disable}
+                disabled={saving || blockedOnCode}
+                class="self-start"
+              >
+                {saving ? "Saving…" : "Stop requiring two-factor"}
+              </Button>
+            </div>
+          ) : (
+            <div class="flex flex-col gap-2">
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={enable}
+                disabled={saving}
+                class="self-start"
+              >
+                {saving ? "Saving…" : "Require two-factor for releases"}
+              </Button>
+              {active.isPersonal ? (
+                <Muted class="text-[12px] m-0">
+                  This is your personal workspace, so the policy only affects you. It matters most
+                  for organizations with multiple members.
+                </Muted>
+              ) : null}
+            </div>
+          )
         ) : (
           <Muted class="text-[13px] m-0">
             Only the organization owner can change the release two-factor policy.

--- a/src/pages/Dashboard/Settings/index.tsx
+++ b/src/pages/Dashboard/Settings/index.tsx
@@ -28,6 +28,7 @@ import {
   UserMenu,
 } from "../../../components";
 import { GeneralSection } from "./GeneralSection";
+import { ReleaseSecuritySection } from "./ReleaseSecuritySection";
 import { GithubAppSection } from "./GithubAppSection";
 import { NotificationRecipientsSection } from "./NotificationRecipientsSection";
 import { SlackConnectionSection } from "./SlackConnectionSection";
@@ -158,11 +159,17 @@ export default function SettingsPage() {
 
           <div class="min-w-0 flex flex-col gap-6">
             {tab === "general" ? (
-              <GeneralSection
-                organizations={organizations}
-                currentUserRole={activeRole(organizations)}
-                onDeleted={reloadActiveOrgScopedData}
-              />
+              <>
+                <GeneralSection
+                  organizations={organizations}
+                  currentUserRole={activeRole(organizations)}
+                  onDeleted={reloadActiveOrgScopedData}
+                />
+                <ReleaseSecuritySection
+                  organizations={organizations}
+                  currentUserRole={activeRole(organizations)}
+                />
+              </>
             ) : null}
             {tab === "members" ? (
               <OrganizationMembersSection

--- a/test/workers/github-gate-two-factor.test.ts
+++ b/test/workers/github-gate-two-factor.test.ts
@@ -3,7 +3,13 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { eq } from "drizzle-orm";
 import * as OTPAuth from "otpauth";
 import worker from "../../server/index";
-import { createDb, createScanJob, ensurePersonalOrganization, persistScan } from "../../server/db";
+import {
+  createDb,
+  createScanJob,
+  ensurePersonalOrganization,
+  persistScan,
+  setRequireTwoFactorForReleaseDecisions,
+} from "../../server/db";
 import * as schema from "../../server/db/schema";
 import {
   createReleaseTarget,
@@ -388,4 +394,101 @@ describe("workflow-gate decision 2FA step-up", () => {
     expect(res.json).toMatchObject({ gate: { status: "approved", decision: "approved" } });
     expect(decisionCalls).toHaveLength(1);
   });
+});
+
+// When the org turns on `requireTwoFactorForReleaseDecisions`, the per-user
+// step-up becomes a hard requirement for *every* member: an unenrolled member is
+// blocked outright (must enroll first) and enrolled members must still present a
+// fresh code. This is the org-level policy on top of the per-user check above.
+describe("workflow-gate decision org-enforced 2FA", () => {
+  test(
+    "an unenrolled member is blocked when the org requires 2FA",
+    { timeout: 30_000 },
+    async () => {
+      const jar: Jar = new Map();
+      const userId = await signUp(jar);
+      const organizationId = personalOrganizationId(userId);
+      await ensurePersonalOrganization(createDb(env.DB), { userId });
+      await setRequireTwoFactorForReleaseDecisions(createDb(env.DB), organizationId, true);
+      const { gateId, scanId } = await seedDecidableGate(organizationId, userId);
+
+      const decisionCalls: { state: string }[] = [];
+      mockGithubDecisionFetch(decisionCalls);
+
+      const res = await call("POST", `/api/v1/github-app/workflow-gates/${gateId}/decision`, {
+        body: { decision: "approved", scanId },
+        jar,
+        env: await githubEnv(),
+      });
+
+      expect(res.res.status).toBe(403);
+      expect(res.json).toMatchObject({ code: "two_factor_enrollment_required" });
+      // No enrollment, no code, no release: the gate stays held and GitHub is
+      // never told to release the job.
+      const stored = await getGateForOrganization(createDb(env.DB), organizationId, gateId);
+      expect(stored?.status).toBe("pending");
+      expect(decisionCalls).toHaveLength(0);
+    },
+  );
+
+  test(
+    "an enrolled member still needs a fresh code when the org requires 2FA",
+    { timeout: 30_000 },
+    async () => {
+      const jar: Jar = new Map();
+      const userId = await signUp(jar);
+      await enrollTwoFactor(jar);
+      const organizationId = personalOrganizationId(userId);
+      await ensurePersonalOrganization(createDb(env.DB), { userId });
+      await setRequireTwoFactorForReleaseDecisions(createDb(env.DB), organizationId, true);
+      const { gateId, scanId } = await seedDecidableGate(organizationId, userId);
+
+      const decisionCalls: { state: string }[] = [];
+      mockGithubDecisionFetch(decisionCalls);
+
+      const res = await call("POST", `/api/v1/github-app/workflow-gates/${gateId}/decision`, {
+        body: { decision: "approved", scanId },
+        jar,
+        env: await githubEnv(),
+      });
+
+      expect(res.res.status).toBe(401);
+      expect(res.json).toMatchObject({ code: "two_factor_required" });
+      const stored = await getGateForOrganization(createDb(env.DB), organizationId, gateId);
+      expect(stored?.status).toBe("pending");
+      expect(decisionCalls).toHaveLength(0);
+    },
+  );
+
+  test(
+    "an enrolled member with a fresh code decides under the org policy",
+    { timeout: 30_000 },
+    async () => {
+      const jar: Jar = new Map();
+      const userId = await signUp(jar);
+      const totpURI = await enrollTwoFactor(jar);
+      const organizationId = personalOrganizationId(userId);
+      await ensurePersonalOrganization(createDb(env.DB), { userId });
+      await setRequireTwoFactorForReleaseDecisions(createDb(env.DB), organizationId, true);
+      const { gateId, scanId } = await seedDecidableGate(organizationId, userId);
+
+      const decisionCalls: { state: string }[] = [];
+      mockGithubDecisionFetch(decisionCalls);
+
+      const res = await call("POST", `/api/v1/github-app/workflow-gates/${gateId}/decision`, {
+        body: { decision: "approved", totpCode: totpFor(totpURI), scanId },
+        jar,
+        env: await githubEnv(),
+      });
+
+      expect(res.res.status).toBe(200);
+      expect(res.json).toMatchObject({
+        gate: { status: "approved", decision: "approved", organizationRequiresTwoFactor: true },
+      });
+      const stored = await getGateForOrganization(createDb(env.DB), organizationId, gateId);
+      expect(stored?.status).toBe("approved");
+      expect(decisionCalls).toHaveLength(1);
+      expect(decisionCalls[0].state).toBe("approved");
+    },
+  );
 });

--- a/test/workers/organizations-release-two-factor.test.ts
+++ b/test/workers/organizations-release-two-factor.test.ts
@@ -1,0 +1,190 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { describe, expect, test } from "vitest";
+import * as OTPAuth from "otpauth";
+import worker from "../../server/index";
+import {
+  createDb,
+  ensurePersonalOrganization,
+  organizationRequiresTwoFactorForReleaseDecisions,
+  setRequireTwoFactorForReleaseDecisions,
+} from "../../server/db";
+import { personalOrganizationId } from "../../server/lib/ownership";
+
+// The owner-only release-two-factor toggle is itself 2FA-guarded, mirroring the
+// gate decision it governs: enabling requires the owner be enrolled (you cannot
+// mandate a control you have not adopted), and *relaxing* it — the
+// security-weakening direction — demands a fresh TOTP step-up, not just a live
+// session. These specs drive the real worker end to end (real session cookies +
+// Better Auth TOTP enrollment) so the step-up is exercised exactly as the
+// browser hits it; the stub-harness specs in organizations-routes.test.ts cover
+// the enrollment gate and the no-code path that need no real authenticator.
+
+const ORIGIN = "http://example.com";
+const PASSWORD = "correct horse battery staple";
+
+type Jar = Map<string, string>;
+
+function mergeSetCookies(jar: Jar, res: Response) {
+  const cookies = res.headers.getSetCookie?.() ?? [];
+  for (const raw of cookies) {
+    const [pair] = raw.split(";");
+    const idx = pair.indexOf("=");
+    if (idx === -1) continue;
+    jar.set(pair.slice(0, idx).trim(), pair.slice(idx + 1).trim());
+  }
+}
+
+function cookieHeader(jar: Jar): string {
+  return [...jar.entries()].map(([k, v]) => `${k}=${v}`).join("; ");
+}
+
+async function call(method: string, path: string, opts: { body?: unknown; jar?: Jar } = {}) {
+  const ctx = createExecutionContext();
+  const headers = new Headers();
+  if (opts.body !== undefined) headers.set("content-type", "application/json");
+  // Non-GET requests are CSRF-checked against the request origin.
+  if (!["GET", "HEAD", "OPTIONS"].includes(method)) headers.set("origin", ORIGIN);
+  if (opts.jar && opts.jar.size) headers.set("cookie", cookieHeader(opts.jar));
+  const init: RequestInit = { method, headers };
+  if (opts.body !== undefined) init.body = JSON.stringify(opts.body);
+  const res = await worker.fetch(new Request(`${ORIGIN}${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  if (opts.jar) mergeSetCookies(opts.jar, res);
+  const text = await res.text();
+  let json: unknown = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = null;
+  }
+  return { res, json: json as Record<string, unknown> | null };
+}
+
+function totpFor(totpURI: string): string {
+  const parsed = OTPAuth.URI.parse(totpURI) as OTPAuth.TOTP;
+  return parsed.generate();
+}
+
+async function signUp(jar: Jar): Promise<string> {
+  const email = `release2fa-${crypto.randomUUID()}@example.test`;
+  const up = await call("POST", "/api/auth/sign-up/email", {
+    body: { name: "Release Tester", email, password: PASSWORD },
+    jar,
+  });
+  expect(up.res.status).toBe(200);
+  const session = await call("GET", "/api/auth/get-session", { jar });
+  const userId = (session.json?.user as { id?: string } | undefined)?.id;
+  expect(typeof userId).toBe("string");
+  return userId as string;
+}
+
+async function enrollTwoFactor(jar: Jar): Promise<string> {
+  const enable = await call("POST", "/api/auth/two-factor/enable", {
+    body: { password: PASSWORD },
+    jar,
+  });
+  expect(enable.res.status).toBe(200);
+  const totpURI = enable.json?.totpURI as string;
+  expect(typeof totpURI).toBe("string");
+  const verify = await call("POST", "/api/auth/two-factor/verify-totp", {
+    body: { code: totpFor(totpURI) },
+    jar,
+  });
+  expect(verify.res.status).toBe(200);
+  return totpURI;
+}
+
+async function setUpOwner(): Promise<{ jar: Jar; userId: string; organizationId: string }> {
+  const jar: Jar = new Map();
+  const userId = await signUp(jar);
+  const organizationId = personalOrganizationId(userId);
+  await ensurePersonalOrganization(createDb(env.DB), { userId });
+  return { jar, userId, organizationId };
+}
+
+const releasePath = (organizationId: string) =>
+  `/api/v1/organizations/${organizationId}/release-two-factor`;
+
+describe("release-two-factor toggle 2FA guard", () => {
+  test("an enrolled owner enables the policy without a code", { timeout: 30_000 }, async () => {
+    const { jar, organizationId } = await setUpOwner();
+    await enrollTwoFactor(jar);
+
+    const res = await call("PUT", releasePath(organizationId), { body: { enabled: true }, jar });
+
+    expect(res.res.status).toBe(200);
+    expect(res.json).toMatchObject({ requireTwoFactorForReleaseDecisions: true });
+    expect(
+      await organizationRequiresTwoFactorForReleaseDecisions(createDb(env.DB), organizationId),
+    ).toBe(true);
+  });
+
+  test("an enrolled owner relaxes the policy with a fresh code", { timeout: 30_000 }, async () => {
+    const { jar, organizationId } = await setUpOwner();
+    const totpURI = await enrollTwoFactor(jar);
+    await setRequireTwoFactorForReleaseDecisions(createDb(env.DB), organizationId, true);
+
+    const res = await call("PUT", releasePath(organizationId), {
+      body: { enabled: false, totpCode: totpFor(totpURI) },
+      jar,
+    });
+
+    expect(res.res.status).toBe(200);
+    expect(res.json).toMatchObject({ requireTwoFactorForReleaseDecisions: false });
+    expect(
+      await organizationRequiresTwoFactorForReleaseDecisions(createDb(env.DB), organizationId),
+    ).toBe(false);
+  });
+
+  test(
+    "an enrolled owner cannot relax the policy without a code",
+    { timeout: 30_000 },
+    async () => {
+      const { jar, organizationId } = await setUpOwner();
+      await enrollTwoFactor(jar);
+      await setRequireTwoFactorForReleaseDecisions(createDb(env.DB), organizationId, true);
+
+      const res = await call("PUT", releasePath(organizationId), { body: { enabled: false }, jar });
+
+      expect(res.res.status).toBe(401);
+      expect(res.json).toMatchObject({ code: "two_factor_required" });
+      // The hardened policy is left in place — a failed step-up never weakens it.
+      expect(
+        await organizationRequiresTwoFactorForReleaseDecisions(createDb(env.DB), organizationId),
+      ).toBe(true);
+    },
+  );
+
+  test(
+    "an enrolled owner cannot relax the policy with an invalid code",
+    { timeout: 30_000 },
+    async () => {
+      const { jar, organizationId } = await setUpOwner();
+      await enrollTwoFactor(jar);
+      await setRequireTwoFactorForReleaseDecisions(createDb(env.DB), organizationId, true);
+
+      const res = await call("PUT", releasePath(organizationId), {
+        body: { enabled: false, totpCode: "000000" },
+        jar,
+      });
+
+      expect(res.res.status).toBe(401);
+      expect(res.json).toMatchObject({ code: "two_factor_invalid" });
+      expect(
+        await organizationRequiresTwoFactorForReleaseDecisions(createDb(env.DB), organizationId),
+      ).toBe(true);
+    },
+  );
+
+  test("an owner without 2FA cannot enable the policy", { timeout: 30_000 }, async () => {
+    const { jar, organizationId } = await setUpOwner();
+
+    const res = await call("PUT", releasePath(organizationId), { body: { enabled: true }, jar });
+
+    expect(res.res.status).toBe(403);
+    expect(res.json).toMatchObject({ code: "two_factor_enrollment_required" });
+    expect(
+      await organizationRequiresTwoFactorForReleaseDecisions(createDb(env.DB), organizationId),
+    ).toBe(false);
+  });
+});

--- a/test/workers/organizations-routes.test.ts
+++ b/test/workers/organizations-routes.test.ts
@@ -162,6 +162,110 @@ describe("organizations routes", () => {
     expect(intruder.status).toBe(404);
   });
 
+  test("PUT /:id/release-two-factor toggles the policy and reflects it in GET /", async () => {
+    const owner = await seedUser();
+    const create = await call(buildTestApp(owner), "POST", "/api/v1/organizations", {
+      body: { name: "secure-org" },
+    });
+    const orgId = ((await create.json()) as { organization: { id: string } }).organization.id;
+
+    const beforeList = await call(buildTestApp(owner), "GET", "/api/v1/organizations");
+    const beforeOrg = (
+      (await beforeList.json()) as {
+        organizations: Array<{ id: string; requireTwoFactorForReleaseDecisions: boolean }>;
+      }
+    ).organizations.find((o) => o.id === orgId);
+    expect(beforeOrg?.requireTwoFactorForReleaseDecisions).toBe(false);
+
+    const enable = await call(
+      buildTestApp(owner),
+      "PUT",
+      `/api/v1/organizations/${orgId}/release-two-factor`,
+      { body: { enabled: true } },
+    );
+    expect(enable.status).toBe(200);
+    expect((await enable.json()) as unknown).toMatchObject({
+      requireTwoFactorForReleaseDecisions: true,
+    });
+
+    const afterList = await call(buildTestApp(owner), "GET", "/api/v1/organizations");
+    const afterOrg = (
+      (await afterList.json()) as {
+        organizations: Array<{ id: string; requireTwoFactorForReleaseDecisions: boolean }>;
+      }
+    ).organizations.find((o) => o.id === orgId);
+    expect(afterOrg?.requireTwoFactorForReleaseDecisions).toBe(true);
+
+    const disable = await call(
+      buildTestApp(owner),
+      "PUT",
+      `/api/v1/organizations/${orgId}/release-two-factor`,
+      { body: { enabled: false } },
+    );
+    expect(disable.status).toBe(200);
+    const finalList = await call(buildTestApp(owner), "GET", "/api/v1/organizations");
+    const finalOrg = (
+      (await finalList.json()) as {
+        organizations: Array<{ id: string; requireTwoFactorForReleaseDecisions: boolean }>;
+      }
+    ).organizations.find((o) => o.id === orgId);
+    expect(finalOrg?.requireTwoFactorForReleaseDecisions).toBe(false);
+  });
+
+  test("PUT /:id/release-two-factor is owner-only (admins and strangers get 404)", async () => {
+    const owner = await seedUser();
+    const admin = await seedUser();
+    const stranger = await seedUser();
+    const db = createDb(env.DB);
+
+    const create = await call(buildTestApp(owner), "POST", "/api/v1/organizations", {
+      body: { name: "owner-only-org" },
+    });
+    const orgId = ((await create.json()) as { organization: { id: string } }).organization.id;
+    await addOrganizationMember(db, { organizationId: orgId, userId: admin.userId, role: "admin" });
+
+    const asAdmin = await call(
+      buildTestApp(admin),
+      "PUT",
+      `/api/v1/organizations/${orgId}/release-two-factor`,
+      { body: { enabled: true } },
+    );
+    expect(asAdmin.status).toBe(404);
+
+    const asStranger = await call(
+      buildTestApp(stranger),
+      "PUT",
+      `/api/v1/organizations/${orgId}/release-two-factor`,
+      { body: { enabled: true } },
+    );
+    expect(asStranger.status).toBe(404);
+
+    // The policy was never flipped by the rejected callers.
+    const list = await call(buildTestApp(owner), "GET", "/api/v1/organizations");
+    const org = (
+      (await list.json()) as {
+        organizations: Array<{ id: string; requireTwoFactorForReleaseDecisions: boolean }>;
+      }
+    ).organizations.find((o) => o.id === orgId);
+    expect(org?.requireTwoFactorForReleaseDecisions).toBe(false);
+  });
+
+  test("PUT /:id/release-two-factor rejects a non-boolean body", async () => {
+    const owner = await seedUser();
+    const create = await call(buildTestApp(owner), "POST", "/api/v1/organizations", {
+      body: { name: "validate-org" },
+    });
+    const orgId = ((await create.json()) as { organization: { id: string } }).organization.id;
+
+    const res = await call(
+      buildTestApp(owner),
+      "PUT",
+      `/api/v1/organizations/${orgId}/release-two-factor`,
+      { body: { enabled: "yes" } },
+    );
+    expect(res.status).toBe(400);
+  });
+
   test("x-organization-id header scopes npm-connection writes to that org", async () => {
     const owner = await seedUser();
     const db = createDb(env.DB);

--- a/test/workers/organizations-routes.test.ts
+++ b/test/workers/organizations-routes.test.ts
@@ -71,6 +71,28 @@ async function call(
   return res;
 }
 
+async function readReleasePolicy(
+  session: { userId: string },
+  orgId: string,
+): Promise<boolean | undefined> {
+  const list = await call(buildTestApp(session), "GET", "/api/v1/organizations");
+  return (
+    (await list.json()) as {
+      organizations: Array<{ id: string; requireTwoFactorForReleaseDecisions: boolean }>;
+    }
+  ).organizations.find((o) => o.id === orgId)?.requireTwoFactorForReleaseDecisions;
+}
+
+// Flip Better Auth's enrollment flag directly. The stub harness has no real
+// `auth` to run TOTP enrollment through, but enabling the policy only checks
+// enrollment (no fresh code), so the column is all these specs need.
+async function setEnrolledInTwoFactor(userId: string, enabled: boolean): Promise<void> {
+  await createDb(env.DB)
+    .update(schema.user)
+    .set({ twoFactorEnabled: enabled })
+    .where(eq(schema.user.id, userId));
+}
+
 const originalFetch = globalThis.fetch;
 
 afterEach(() => {
@@ -162,21 +184,29 @@ describe("organizations routes", () => {
     expect(intruder.status).toBe(404);
   });
 
-  test("PUT /:id/release-two-factor toggles the policy and reflects it in GET /", async () => {
+  test("PUT /:id/release-two-factor requires the owner to be enrolled before enabling", async () => {
     const owner = await seedUser();
     const create = await call(buildTestApp(owner), "POST", "/api/v1/organizations", {
       body: { name: "secure-org" },
     });
     const orgId = ((await create.json()) as { organization: { id: string } }).organization.id;
+    expect(await readReleasePolicy(owner, orgId)).toBe(false);
 
-    const beforeList = await call(buildTestApp(owner), "GET", "/api/v1/organizations");
-    const beforeOrg = (
-      (await beforeList.json()) as {
-        organizations: Array<{ id: string; requireTwoFactorForReleaseDecisions: boolean }>;
-      }
-    ).organizations.find((o) => o.id === orgId);
-    expect(beforeOrg?.requireTwoFactorForReleaseDecisions).toBe(false);
+    // An owner who has not turned on 2FA themselves cannot mandate it for everyone.
+    const blocked = await call(
+      buildTestApp(owner),
+      "PUT",
+      `/api/v1/organizations/${orgId}/release-two-factor`,
+      { body: { enabled: true } },
+    );
+    expect(blocked.status).toBe(403);
+    expect((await blocked.json()) as unknown).toMatchObject({
+      code: "two_factor_enrollment_required",
+    });
+    expect(await readReleasePolicy(owner, orgId)).toBe(false);
 
+    // Once enrolled, enabling only hardens the gate, so it needs no fresh code.
+    await setEnrolledInTwoFactor(owner.userId, true);
     const enable = await call(
       buildTestApp(owner),
       "PUT",
@@ -187,29 +217,38 @@ describe("organizations routes", () => {
     expect((await enable.json()) as unknown).toMatchObject({
       requireTwoFactorForReleaseDecisions: true,
     });
+    expect(await readReleasePolicy(owner, orgId)).toBe(true);
+  });
 
-    const afterList = await call(buildTestApp(owner), "GET", "/api/v1/organizations");
-    const afterOrg = (
-      (await afterList.json()) as {
-        organizations: Array<{ id: string; requireTwoFactorForReleaseDecisions: boolean }>;
-      }
-    ).organizations.find((o) => o.id === orgId);
-    expect(afterOrg?.requireTwoFactorForReleaseDecisions).toBe(true);
+  test("PUT /:id/release-two-factor refuses to relax the policy without a fresh code", async () => {
+    const owner = await seedUser();
+    await setEnrolledInTwoFactor(owner.userId, true);
+    const create = await call(buildTestApp(owner), "POST", "/api/v1/organizations", {
+      body: { name: "hardened-org" },
+    });
+    const orgId = ((await create.json()) as { organization: { id: string } }).organization.id;
 
+    const enable = await call(
+      buildTestApp(owner),
+      "PUT",
+      `/api/v1/organizations/${orgId}/release-two-factor`,
+      { body: { enabled: true } },
+    );
+    expect(enable.status).toBe(200);
+
+    // Relaxing the policy is the security-weakening direction: a live session is
+    // not enough, the route demands a fresh second factor (verified for real in
+    // the worker e2e specs). Without a code it stops at `two_factor_required` and
+    // the policy stays on.
     const disable = await call(
       buildTestApp(owner),
       "PUT",
       `/api/v1/organizations/${orgId}/release-two-factor`,
       { body: { enabled: false } },
     );
-    expect(disable.status).toBe(200);
-    const finalList = await call(buildTestApp(owner), "GET", "/api/v1/organizations");
-    const finalOrg = (
-      (await finalList.json()) as {
-        organizations: Array<{ id: string; requireTwoFactorForReleaseDecisions: boolean }>;
-      }
-    ).organizations.find((o) => o.id === orgId);
-    expect(finalOrg?.requireTwoFactorForReleaseDecisions).toBe(false);
+    expect(disable.status).toBe(401);
+    expect((await disable.json()) as unknown).toMatchObject({ code: "two_factor_required" });
+    expect(await readReleasePolicy(owner, orgId)).toBe(true);
   });
 
   test("PUT /:id/release-two-factor is owner-only (admins and strangers get 404)", async () => {


### PR DESCRIPTION
Adds an owner-only organization policy (`organizations.require_two_factor_for_release_decisions`, off by default) that makes a fresh two-factor step-up mandatory for **every** member when deciding a CI release gate — closing the gap where an un-enrolled member could approve an irreversible release with no second factor. When the policy is on, an un-enrolled member is blocked outright (`403 two_factor_enrollment_required`, gate left `pending`, nothing posted to GitHub) and enrolled members must still present a fresh TOTP code; with it off, today's per-user behavior is preserved. Owners toggle it via the new `PUT /api/v1/organizations/:id/release-two-factor` endpoint and a "Release security" control in Settings → General, and the gate decision dialog pre-empts un-enrolled members instead of letting them submit a decision that would 403. Includes the schema migration (`0019`), `organizationRequiresTwoFactor` on the public gate shape, worker tests for the enforcement and the new endpoint, and updated docs.

⚠️ Schema change: the new column needs a migration applied (`pnpm db:migrate:remote`) on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)