### PR TITLE
Fix .d.ts diffs and exclude declarations from content scanning

### DIFF
--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -15,6 +15,7 @@ The fixture taxonomy is based on the current Drydock rule surface plus public np
 - The same benchmark highlights the central detection trade-off: benign and malicious packages often call the same APIs. A single `process.env` or `https` use is capability evidence, while chains such as collect → serialize → exfiltrate are stronger intent evidence.
 - Network-only code follows that trade-off: unchanged network-only files are suppressed as package context, added network-only files remain medium-severity contextual evidence, and added network access escalates to high when it is tied to lifecycle scripts, process execution, dynamic evaluation, or credential access.
 - Documentation and prose files remain available as package evidence, but deterministic `code.*` rules do not treat them as executable capability evidence. Secret checks in documentation use only high-confidence token formats; generic key/value examples such as `token = localStorage.getItem("token")` are not `file.secret-content` findings.
+- TypeScript declaration files (`.d.ts`/`.d.cts`/`.d.mts`) keep a diffable text sample but are excluded from `code.*` and `file.secret-content` content scanning (`isTypeDeclarationPath`). Declarations are never executed and carry only type signatures, so scanning large bundled declarations is pure perf/memory cost and a signature like `fetch(url: string)` would only produce false positives. Cheap path-based checks (credential filenames, the files-allowlist) still apply.
 
 ## Safety policy
 

--- a/server/lib/review-rules/file-types.ts
+++ b/server/lib/review-rules/file-types.ts
@@ -23,3 +23,15 @@ export function isDocumentationPath(path: string): boolean {
   if (dot > 0) return false;
   return DOCUMENTATION_BASENAMES.has(basename);
 }
+
+// TypeScript declaration files (.d.ts/.d.cts/.d.mts) carry only type
+// information: they are never executed by Node and are stripped by bundlers, so
+// a payload would ship as .js, not .d.ts. We keep their text sample so the
+// public API surface stays diffable, but exclude them from the content-scanning
+// rules — running the normalizer and capability/secret regexes over large
+// bundled declaration files is pure cost (perf/memory) with no detection value,
+// and type signatures like `fetch(...)` would only yield false positives.
+export function isTypeDeclarationPath(path: string): boolean {
+  const basename = path.replaceAll("\\", "/").split("/").at(-1)?.toLowerCase() ?? "";
+  return /\.d\.(?:c|m)?ts$/.test(basename);
+}

--- a/server/lib/review-rules/metadata.ts
+++ b/server/lib/review-rules/metadata.ts
@@ -2,7 +2,7 @@ import { isOutsidePackageFilesAllowlist } from "../review-package-files";
 import type { Finding } from "../review";
 import { containsSecretLikeText, firstSecretLine, tag } from "./helpers";
 import { changedPrefix, type RuleContext } from "./context";
-import { isDocumentationPath } from "./file-types";
+import { isDocumentationPath, isTypeDeclarationPath } from "./file-types";
 
 // Manifest integrity and secret-exposure rules: parse failures, secret-looking
 // files, files outside the declared allowlist, and credential files added to
@@ -30,10 +30,13 @@ export function metadataFindings(ctx: RuleContext): Finding[] {
     const prefix = changedPrefix(ctx, file.path);
     const changed = ctx.diffByPath.get(file.path)?.status;
     const secretOptions = { highConfidenceOnly: isDocumentationPath(file.path) };
+    // Type declarations keep a diffable sample but are excluded from content
+    // scanning (perf/memory); the cheap path-based checks below still apply.
+    const scanContent = !isTypeDeclarationPath(file.path);
 
     if (
       /\.npmrc|\.env|id_rsa|id_ed25519/i.test(file.path) ||
-      containsSecretLikeText(sample, secretOptions)
+      (scanContent && containsSecretLikeText(sample, secretOptions))
     ) {
       findings.push(
         tag("fileSecretContent", {

--- a/server/lib/review-rules/scripts.ts
+++ b/server/lib/review-rules/scripts.ts
@@ -4,7 +4,7 @@ import type { Finding } from "../review";
 import { LIFECYCLE_SCRIPTS } from "./patterns";
 import { firstJsonPropertyLine, tag } from "./helpers";
 import { changedPrefix, type RuleContext } from "./context";
-import { isDocumentationPath } from "./file-types";
+import { isDocumentationPath, isTypeDeclarationPath } from "./file-types";
 import { normalizeCodeForScanning } from "./normalize";
 
 // Install lifecycle hooks and in-file code-execution capability: the scripts and
@@ -45,7 +45,7 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
   }
 
   for (const file of ctx.files) {
-    if (isDocumentationPath(file.path)) continue;
+    if (isDocumentationPath(file.path) || isTypeDeclarationPath(file.path)) continue;
 
     const sample = file.textSample || "";
     // Constant-fold runtime-assembled identifiers (`'chi'+'ld_process'`,

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -218,6 +218,36 @@ describe("review", () => {
     expect(findings.some((finding) => finding.ruleId === "file.secret-content")).toBe(false);
   });
 
+  test("excludes type declaration files from content scanning", () => {
+    // .d.ts files keep a diffable sample but must not drive deterministic
+    // findings: declaration syntax like `fetch(...)` is a type signature, and
+    // scanning large bundled declarations is pure perf/memory cost.
+    const staged = [
+      {
+        path: "dist/index.d.ts",
+        size: 200,
+        sha256: "decl",
+        flags: [],
+        textSample:
+          "export declare function run(): void;\n" +
+          "export declare const fetch: (url: string) => Promise<Response>;\n" +
+          "export declare const child_process: typeof import('child_process');\n" +
+          "export declare const token: 'npm_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';\n",
+      },
+      {
+        path: "dist/index.d.mts",
+        size: 80,
+        sha256: "decl-mts",
+        flags: [],
+        textSample: "export declare const exec: (cmd: string) => void;\n",
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged));
+
+    expect(findings.some((finding) => finding.ruleId?.startsWith("code."))).toBe(false);
+    expect(findings.some((finding) => finding.ruleId === "file.secret-content")).toBe(false);
+  });
+
   test("still flags high-confidence token leaks in documentation", () => {
     const staged = [
       {


### PR DESCRIPTION
## Why

Diffing a `.d.ts` file in the scan detail UI showed **"No text samples available to diff."** Commit `1112088` ("Filter low-value tarball text samples") had grouped TypeScript declaration files together with source maps and minified bundles and skipped their text samples — but unlike `.map`/`.min.*` artifacts, `.d.ts` files are small, human-readable, and describe a package's **public API surface**, which is exactly what supply-chain review wants to diff.

## What

**1. Keep diffable text samples for `.d.ts` files**
- `server/lib/tar-parser.js` — `shouldSkipTextSample` no longer skips `.d.ts`/`.d.cts`/`.d.mts`. Source maps and minified bundles remain skipped. The highlighter already maps `.d.ts` → typescript, so highlighting works automatically.

**2. Exclude `.d.ts` from deterministic content scanning (perf/memory)**
- Now that declarations retain a sample, they'd otherwise flow into the expensive content-scanning loops. Added `isTypeDeclarationPath` (`server/lib/review-rules/file-types.ts`) and skip `.d.ts` in:
  - `scripts.ts` — skips `normalizeCodeForScanning` + the four capability-regex passes.
  - `metadata.ts` — skips the `file.secret-content` regex over the body.
- Cheap path-based checks (credential filenames, files-allowlist provenance) still apply.

### Why this is safe for detection
`.d.ts` files are never executed by Node and are stripped by bundlers — a real payload ships as `.js`. A declaration like `export declare const fetch: (url: string) => Promise<Response>` is a type signature, not a call, so scanning it only yields false positives. Pure cost reduction, no detection loss.

## Tests & docs
- `test/tar-parser.test.mjs` — asserts `.d.ts`/`.d.mts`/`.d.cts` retain samples (maps/minified still skipped).
- `test/review.test.mjs` — asserts a `.d.ts` with `fetch`/`child_process`/secret-looking content produces no `code.*` or `file.secret-content` findings.
- Updated `docs/cost-model.md`, `docs/security-model.md`, `docs/security-detection-corpus.md`.

`pnpm run verify` (lint, format, typecheck, tests) passes.

> Note: only affects scans run *after* this change — previously-persisted scans stored no sample for their `.d.ts` files.

https://claude.ai/code/session_012LvVsnosEcgh8f71Z45n8M

---
_Generated by [Claude Code](https://claude.ai/code/session_012LvVsnosEcgh8f71Z45n8M)_