### PR TITLE
Flag newly added bin executables (diff.bin-added)

### DIFF
--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -66,14 +66,14 @@ The first corpus slice covers:
 - large opaque binary addition;
 - files that appear in the tarball outside a declared `package.json.files` allowlist;
 - malformed `package.json` parse failure;
-- dependency and entrypoint package-json diff changes; unusual non-registry dependency specs now raise deterministic findings while entrypoint changes remain a documented coverage gap.
+- dependency and entrypoint package-json diff changes; unusual non-registry dependency specs raise deterministic findings, and a newly added `bin` command raises `diff.bin-added` because npm links it onto the consumer's install path;
 
 ## Known coverage gaps
 
 The corpus deliberately records some product gaps instead of hiding them:
 
 - Plain dependency additions are visible in `packageJsonDiff`, but they do not yet raise deterministic findings unless they use unusual specs such as `github:`, `git+ssh:`, `http(s):`, `file:`, or `npm:` aliases. Newly added optional dependencies also raise deterministic findings because they can fail softly while still running install-time lifecycle hooks.
-- Entrypoint changes are visible in `packageJsonDiff`, but they do not yet raise deterministic findings or risk.
+- A newly added `bin` command raises `diff.bin-added` (medium), but `main`/`module`/`types`/`exports` retargets are intentionally not flagged: they change on almost every build (`index.js` → `dist/index.js`) and would be noise. They remain visible as the `entrypointsChanged` diff flag.
 - Maintainer/package transfer signals, new publisher signals, package reputation, and OpenSSF/package intelligence integrations are not implemented.
 - Behavior-chain detection is regex-based and does not yet prove source-to-sink intent. The one modeled chain is a heuristic: credential access co-located with a network egress path in the same file escalates to high (the collect-and-exfiltrate shape), without proving the value actually flows from the read to the send.
 - Anti-analysis and environment-detection patterns are not deeply modeled because Drydock intentionally avoids package execution.

--- a/server/lib/review-rules/entrypoints.ts
+++ b/server/lib/review-rules/entrypoints.ts
@@ -1,0 +1,29 @@
+import type { Finding, PackageJsonDiff } from "../review";
+import { firstJsonPropertyLine, tag } from "./helpers";
+
+// Entrypoint-surface rules derived from the package.json diff. The high-signal
+// case is a newly added `bin` command: npm symlinks every bin entry into the
+// consumer's node_modules/.bin, so a release that adds one puts a new command on
+// the install path even when no install script or code pattern fires. Plain
+// `main`/`exports` retargets are intentionally not flagged here: they change on
+// almost every build (e.g. `index.js` -> `dist/index.js`) and would be noise.
+export function entrypointDiffFindings(
+  packageJsonDiff: PackageJsonDiff,
+  stagedPackageJsonText?: string | null,
+): Finding[] {
+  const findings: Finding[] = [];
+  for (const entry of packageJsonDiff.bin) {
+    if (entry.status !== "added") continue;
+    findings.push(
+      tag("diffBinAdded", {
+        severity: "medium",
+        file: "package.json",
+        line: firstJsonPropertyLine(stagedPackageJsonText, "bin", entry.staged),
+        evidence: `bin ${entry.key}: ${entry.staged}`,
+        reason:
+          "npm links package bin entries into the consumer's node_modules/.bin, so a newly published executable puts a new command on the install path and should be reviewed before approving the release",
+      }),
+    );
+  }
+  return findings;
+}

--- a/server/lib/review-rules/index.ts
+++ b/server/lib/review-rules/index.ts
@@ -10,12 +10,13 @@ import { metadataFindings } from "./metadata";
 import { scriptFindings } from "./scripts";
 import { binaryFindings } from "./binaries";
 import { dependencyDiffFindings } from "./deps";
+import { entrypointDiffFindings } from "./entrypoints";
 
 // Bump when deterministic rule semantics, severities, or coverage change in a
 // way that should invalidate cached scan reports. Stored alongside each finding
 // so historical reports can be traced back to the ruleset that produced them.
 // Lives here (not in a family module) because versioning spans every family.
-export const DETERMINISTIC_RULES_VERSION = "1.9.0";
+export const DETERMINISTIC_RULES_VERSION = "1.10.0";
 
 export { DETERMINISTIC_RULE_IDS } from "./rule-ids";
 export {
@@ -50,5 +51,8 @@ export function packageJsonDiffFindings(
   packageJsonDiff: PackageJsonDiff,
   stagedPackageJsonText?: string | null,
 ): Finding[] {
-  return stampVersion(dependencyDiffFindings(packageJsonDiff, stagedPackageJsonText));
+  return stampVersion([
+    ...dependencyDiffFindings(packageJsonDiff, stagedPackageJsonText),
+    ...entrypointDiffFindings(packageJsonDiff, stagedPackageJsonText),
+  ]);
 }

--- a/server/lib/review-rules/rule-ids.ts
+++ b/server/lib/review-rules/rule-ids.ts
@@ -14,6 +14,7 @@ export const DETERMINISTIC_RULE_IDS = {
   packageJsonParseFailed: "package-json.parse-failed",
   diffCredentialFileAdded: "diff.credential-file-added",
   diffLargeNewFile: "diff.large-new-file",
+  diffBinAdded: "diff.bin-added",
   dependencyUnusualSpec: "dependency.unusual-spec",
   dependencyOptionalAdded: "dependency.optional-added",
   stageMetadataMismatch: "stage.metadata-mismatch",

--- a/server/lib/review-serialize.ts
+++ b/server/lib/review-serialize.ts
@@ -32,6 +32,10 @@ export interface PackageJsonDiff {
   stagedVersion: string | null;
   scripts: PackageJsonDiffEntry[];
   dependencies: PackageJsonDiffEntry[];
+  // Per-command diff of the `bin` map: npm links each entry into the consumer's
+  // node_modules/.bin, so a newly added command is an install-path behavior
+  // change that release review should surface (see diff.bin-added).
+  bin: PackageJsonDiffEntry[];
   entrypointsChanged: boolean;
 }
 
@@ -47,6 +51,7 @@ export function summarizePackageJsonDiff(
     stagedVersion: stagedPkg?.version || null,
     scripts: changedScripts,
     dependencies: changedDependencies,
+    bin: diffObject(normalizeBin(previousPkg), normalizeBin(stagedPkg)),
     entrypointsChanged:
       JSON.stringify([
         previousPkg?.bin,
@@ -80,6 +85,30 @@ function diffDependencySections(
     ...sectionEntries("optionalDependencies"),
     ...sectionEntries("peerDependencies"),
   ].sort((a, b) => a.key.localeCompare(b.key) || a.section.localeCompare(b.section));
+}
+
+// Normalize the two npm `bin` shapes to a command -> target map. A string `bin`
+// installs one command named after the package (the unscoped part for scoped
+// names), matching how npm derives the command. Non-string targets are dropped
+// so a malformed manifest cannot crash the diff.
+function normalizeBin(pkg: PackageJsonSummary | null | undefined): Record<string, string> {
+  const bin = pkg?.bin;
+  if (!bin) return {};
+  if (typeof bin === "string") {
+    const command = unscopedName(pkg?.name) ?? "(package)";
+    return { [command]: bin };
+  }
+  const out: Record<string, string> = {};
+  for (const [command, target] of Object.entries(bin)) {
+    if (typeof target === "string") out[command] = target;
+  }
+  return out;
+}
+
+function unscopedName(name: string | undefined): string | undefined {
+  if (!name) return undefined;
+  const slash = name.lastIndexOf("/");
+  return slash >= 0 ? name.slice(slash + 1) : name;
 }
 
 function diffObject(

--- a/src/pages/Dashboard/ScanDetail/ReportSections.tsx
+++ b/src/pages/Dashboard/ScanDetail/ReportSections.tsx
@@ -115,6 +115,10 @@ function PackageJsonDiffView({ diff }: { diff: PackageJsonDiff }) {
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
         <ChangeList title="scripts" rows={diff.scripts} />
         <ChangeList title="dependencies" rows={diff.dependencies} />
+        {/* Only surfaced when present: most releases change no bin, and a new
+            bin command is the install-path change flagged by diff.bin-added.
+            Optional-chained for reports persisted before bin was diffed. */}
+        {diff.bin?.length ? <ChangeList title="bin" rows={diff.bin} /> : null}
       </div>
     </div>
   );

--- a/test/fixtures/security-corpus/cases/bin-added.json
+++ b/test/fixtures/security-corpus/cases/bin-added.json
@@ -1,0 +1,73 @@
+{
+  "id": "bin-added",
+  "title": "Release newly exposes an executable on the consumer PATH",
+  "category": "entrypoint-surface-change",
+  "intent": "A package that shipped no bin in the previous version adds one. npm symlinks bin entries into the consumer's node_modules/.bin, so the release puts a new command on the install path even though no install script or risky code pattern fires. The diff.bin-added rule surfaces this install-path behavior change for review. The added cli.js is inert (a plain console log).",
+  "previousPackageJson": {
+    "name": "tool",
+    "version": "1.0.0",
+    "main": "index.js"
+  },
+  "stagedPackageJson": {
+    "name": "tool",
+    "version": "1.0.1",
+    "main": "index.js",
+    "bin": { "tool": "cli.js" }
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 60,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"tool\",\"version\":\"1.0.0\",\"main\":\"index.js\"}"
+    },
+    {
+      "path": "index.js",
+      "size": 26,
+      "sha256": "index-v1",
+      "flags": [],
+      "textSample": "export const answer = 42;\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 88,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"tool\",\"version\":\"1.0.1\",\"main\":\"index.js\",\"bin\":{\"tool\":\"cli.js\"}}"
+    },
+    {
+      "path": "index.js",
+      "size": 26,
+      "sha256": "index-v1",
+      "flags": [],
+      "textSample": "export const answer = 42;\n"
+    },
+    {
+      "path": "cli.js",
+      "size": 40,
+      "sha256": "cli-v1",
+      "flags": [],
+      "textSample": "#!/usr/bin/env node\nconsole.log('tool');\n"
+    }
+  ],
+  "expectedRisk": "medium",
+  "expectedFindings": [
+    {
+      "ruleId": "diff.bin-added",
+      "severity": "medium",
+      "file": "package.json"
+    }
+  ],
+  "expectedPackageJsonDiff": {
+    "bin": [
+      {
+        "key": "tool",
+        "status": "added",
+        "staged": "cli.js"
+      }
+    ]
+  }
+}

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -669,6 +669,47 @@ describe("review", () => {
     expect(summary.entrypointsChanged).toBe(true);
   });
 
+  test("diffs bin commands and flags newly added executables", () => {
+    const objectForm = summarizePackageJsonDiff(
+      { name: "tool", version: "1.0.0" },
+      { name: "tool", version: "1.0.1", bin: { tool: "cli.js", helper: "helper.js" } },
+    );
+    expect(objectForm.bin).toEqual([
+      { key: "helper", status: "added", staged: "helper.js" },
+      { key: "tool", status: "added", staged: "cli.js" },
+    ]);
+
+    // A string bin installs one command named after the package (unscoped part).
+    const stringForm = summarizePackageJsonDiff(
+      { name: "@scope/tool", version: "1.0.0" },
+      { name: "@scope/tool", version: "1.0.1", bin: "cli.js" },
+    );
+    expect(stringForm.bin).toEqual([{ key: "tool", status: "added", staged: "cli.js" }]);
+
+    expect(packageJsonDiffFindings(objectForm)).toEqual([
+      expect.objectContaining({
+        ruleId: "diff.bin-added",
+        severity: "medium",
+        evidence: "bin helper: helper.js",
+      }),
+      expect.objectContaining({
+        ruleId: "diff.bin-added",
+        severity: "medium",
+        evidence: "bin tool: cli.js",
+      }),
+    ]);
+
+    // A bin command whose target only moves (build-path churn) is not flagged.
+    const retarget = summarizePackageJsonDiff(
+      { name: "tool", version: "1.0.0", bin: { tool: "cli.js" } },
+      { name: "tool", version: "1.0.1", bin: { tool: "dist/cli.js" } },
+    );
+    expect(retarget.bin).toEqual([
+      { key: "tool", status: "modified", previous: "cli.js", staged: "dist/cli.js" },
+    ]);
+    expect(packageJsonDiffFindings(retarget)).toEqual([]);
+  });
+
   test("flags unusual dependency specs in package json diffs", () => {
     const diff = summarizePackageJsonDiff(
       { name: "pkg", version: "1.0.0", dependencies: { safe: "^1.0.0" } },


### PR DESCRIPTION
> **Stacked on #287.** Review/merge that first; this PR's base auto-retargets to `main` afterward. Diff below is only this change.

## What

A package that ships a new `bin` between versions puts a command on the consumer's PATH — npm symlinks every `bin` entry into `node_modules/.bin`. Today that install-path behavior change is invisible unless an install script or risky code pattern also fires. This closes that documented entrypoint-coverage gap with the **high-signal subset**: newly added bin commands.

- **Structured `bin` diff.** `summarizePackageJsonDiff` now emits a per-command `bin` diff (`PackageJsonDiff.bin`), normalizing both npm shapes: a string `bin` → one command named after the package (unscoped part for scoped names, matching npm); an object `bin` → as-is.
- **`diff.bin-added` rule (medium).** Fires for each newly added bin command. `main`/`module`/`types`/`exports` retargets are **intentionally not flagged** — they churn on almost every build (`index.js` → `dist/index.js`) and would be noise. They stay visible via the existing `entrypointsChanged` flag.
- **UI.** Surfaces bin changes in the manifest-diff section, reusing the existing `ChangeList` primitive, rendered only when a bin change is present (keeps the common case clean).

## Why medium, why this scope

Putting a new command on the install path is a genuine, reviewable behavior change, but it's frequently legitimate (a library grows a CLI). `medium` surfaces it for human review without the alert fatigue of `high`; it's deliberately more conservative than the existing `dependency.optional-added: high`. Restricting to *added* commands (not retargets) keeps the false-positive surface minimal.

## Trust boundary

Deterministic-only; manifest-derived; no AI involvement; rules can only add findings. Bumps `DETERMINISTIC_RULES_VERSION` → `1.10.0`.

## Tests / docs

- Golden regression case `cases/bin-added.json`.
- Unit test in `review.test.mjs` covering string + object `bin` forms and asserting a bin *retarget* is not flagged.
- `docs/security-detection-corpus.md` updated (gap closed for bin; retargets documented as deliberate non-flags).
- Detection eval: malicious regression recall **100% (23/23)**, benign control FPs **0/2**.
- `pnpm run verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)