### PR TITLE
Add canonical report JSON export

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ curl http://localhost:5173/api/v1/scans
 # Read status/report detail for a persisted scan
 curl http://localhost:5173/api/v1/scans/<scan-id>
 
+# Export a completed scan's report as canonical, stable-ordered JSON (download)
+curl http://localhost:5173/api/v1/scans/<scan-id>/report.json
+
 # List published versions that can be compared against the staged release
 curl http://localhost:5173/api/v1/scans/<scan-id>/versions
 

--- a/docs/production-roadmap.md
+++ b/docs/production-roadmap.md
@@ -54,7 +54,7 @@ Tasks:
 
 - Surface report digest, report schema version, deterministic rules version, and generated timestamp in scan detail.
 - Add a provenance section: package name, staged version, selected baseline, stage ID or workflow gate ID, artifact digests, review limitations, and AI availability/model metadata when applicable.
-- Add canonical report JSON export.
+- Canonical report JSON export shipped: `GET /api/v1/scans/:id/report.json` serves a stable-ordered document (provenance metadata, package/baseline, risk summary, manifest/file diffs, deterministic findings) and is downloadable from scan detail. Re-exports are byte-identical; reproducing the stored digest from the database is still future work.
 - Add digest tests for stable canonical ordering and evidence changes.
 - Add human-readable report export, initially HTML.
 - Keep public signed report URLs deferred until access controls, revocation semantics, and report payload stability are ready.

--- a/server/lib/report-export.ts
+++ b/server/lib/report-export.ts
@@ -1,0 +1,100 @@
+import type { getScan } from "../db/scans";
+
+// A persisted scan detail, as returned by getScan (never null at the call site).
+type ScanDetail = NonNullable<Awaited<ReturnType<typeof getScan>>>;
+
+// Schema tag for the exported report document. Bump the suffix when the export
+// shape changes in a way consumers must branch on.
+export const REPORT_EXPORT_SCHEMA = "drydock.report.v1";
+
+// Build a self-contained, archivable view of a completed review from the data
+// already persisted for it: provenance metadata, package/baseline identity, the
+// risk summary, the manifest and file diffs, and the deterministic findings.
+//
+// This is the persisted *record*, not a re-derivation of the digested payload —
+// the stored report digest is carried through for reference, but reproducing it
+// byte-for-byte from the database is deliberately out of scope here.
+export function buildReportExport(detail: ScanDetail) {
+  const { scan } = detail;
+  const summary = isRecord(scan.summaryJson) ? scan.summaryJson : {};
+  return {
+    schema: REPORT_EXPORT_SCHEMA,
+    report: summary.report ?? null,
+    scan: {
+      id: scan.id,
+      stageId: scan.stageId,
+      status: scan.status,
+      source: scan.source,
+      risk: scan.risk,
+      decision: scan.decision ?? null,
+      createdAt: toIso(scan.createdAt),
+      completedAt: toIso(scan.completedAt),
+    },
+    package: {
+      name: scan.packageName ?? null,
+      stagedVersion: scan.stagedVersion ?? null,
+      previousVersion: scan.previousVersion ?? null,
+    },
+    baseline: summary.baseline ?? null,
+    safety: summary.safety ?? null,
+    riskSummary: detail.riskSummary ?? null,
+    packageJsonDiff: summary.packageJsonDiff ?? null,
+    diff: summary.diff ?? null,
+    findings: [...detail.findings].sort(compareFindings).map((finding) => ({
+      severity: finding.severity,
+      file: finding.file,
+      line: finding.line ?? null,
+      ruleId: finding.ruleId ?? null,
+      ruleVersion: finding.ruleVersion ?? null,
+      source: finding.source,
+      diffStatus: finding.diffStatus ?? null,
+      releaseDelta: finding.releaseDelta ?? null,
+      evidence: finding.evidence,
+      reason: finding.reason,
+    })),
+  };
+}
+
+// Serialize the export with stable key ordering so the same evidence always
+// produces byte-identical output — the property two report artifacts need to be
+// comparable, and a prerequisite for signing later.
+export function serializeReportExport(detail: ScanDetail): string {
+  return stableStringify(buildReportExport(detail));
+}
+
+function compareFindings(
+  a: ScanDetail["findings"][number],
+  b: ScanDetail["findings"][number],
+): number {
+  return (
+    cmp(a.file, b.file) ||
+    cmp(a.ruleId ?? "", b.ruleId ?? "") ||
+    (a.line ?? 0) - (b.line ?? 0) ||
+    cmp(a.severity, b.severity)
+  );
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, item]) => item !== undefined)
+    .sort(([a], [b]) => cmp(a, b));
+  return `{${entries.map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`).join(",")}}`;
+}
+
+function cmp(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function toIso(value: unknown): string | null {
+  if (value == null) return null;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "number") return new Date(value).toISOString();
+  if (typeof value === "string") return value;
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -25,6 +25,7 @@ import { compareSemver, fetchPackageMetadata, pickPreviousVersion } from "../lib
 import { annotateFindingsWithDiffStatus, createPackageDiff, type FileRecord } from "../lib/review";
 import { describeOperationalError, emitOperationalEvent } from "../lib/observability";
 import { parseScanInput } from "../lib/scan-input";
+import { serializeReportExport } from "../lib/report-export";
 import { executeScanJob, type ScanQueueMessage } from "../lib/scan-job";
 import type { Bindings, ScanInput, Variables } from "../types";
 
@@ -195,6 +196,27 @@ scansRoutes.get("/:id", async (c) => {
     });
   }
   return c.json(scan);
+});
+
+scansRoutes.get("/:id/report.json", async (c) => {
+  const db = createDb(c.env.DB);
+  const organizationId = await requireActiveOrganization(c, db);
+  const detail = await getScan(db, c.req.param("id"), organizationId);
+  if (!detail) return c.json({ error: "not found" }, 404);
+  if (detail.scan.status !== "complete") {
+    return c.json({ error: "report export is only available for completed scans" }, 409);
+  }
+  // Canonical, stable-ordered serialization so re-exports are byte-identical and
+  // two artifacts describing the same evidence compare equal. Served as a
+  // download; no scan.viewed event is recorded for a pure export.
+  return new Response(serializeReportExport(detail), {
+    status: 200,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "content-disposition": `attachment; filename="drydock-report-${detail.scan.id}.json"`,
+      "cache-control": "private, no-store",
+    },
+  });
 });
 
 scansRoutes.get("/:id/versions", async (c) => {

--- a/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
+++ b/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
@@ -1,7 +1,15 @@
 import { getDashboardReturnUrl } from "../../../lib/query-state";
 import { formatDateTime } from "../../../lib/format";
 import type { PersistedScanDetail } from "../../../models/scan";
-import { Alert, Badge, Button, LoadingLine, MonoDetail, severityTone } from "../../../components";
+import {
+  Alert,
+  Badge,
+  Button,
+  LinkButton,
+  LoadingLine,
+  MonoDetail,
+  severityTone,
+} from "../../../components";
 
 export function ScanDetailHeader({
   detail,
@@ -42,7 +50,7 @@ export function ScanDetailHeader({
           <LoadingLine size="inline">Loading saved review</LoadingLine>
         )}
       </div>
-      {decision || onDecideClick ? (
+      {decision || onDecideClick || (detail && isComplete) ? (
         <div class="flex flex-wrap items-start gap-3">
           {decision ? (
             <div class="flex flex-col items-end gap-1">
@@ -55,6 +63,16 @@ export function ScanDetailHeader({
                 </span>
               ) : null}
             </div>
+          ) : null}
+          {detail && isComplete ? (
+            <LinkButton
+              variant="ghost"
+              size="sm"
+              href={`/api/v1/scans/${detail.scan.id}/report.json`}
+              download={`drydock-report-${detail.scan.id}.json`}
+            >
+              Export JSON
+            </LinkButton>
           ) : null}
           {onDecideClick ? (
             <Button variant={decision ? "secondary" : "primary"} onClick={onDecideClick}>

--- a/test/workers/scan-report-export.test.ts
+++ b/test/workers/scan-report-export.test.ts
@@ -1,0 +1,173 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { describe, expect, test } from "vitest";
+import { createDb, createScanJob, ensurePersonalOrganization, persistScan } from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { scansRoutes } from "../../server/routes/scans";
+import type { Bindings, Variables } from "../../server/types";
+
+interface SeededUser {
+  userId: string;
+  organizationId: string;
+}
+
+async function seedUser(): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+function buildTestApp(session: { userId: string }) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.use("*", async (c, next) => {
+    c.set("authSession", { userId: session.userId });
+    await next();
+  });
+  app.route("/api/v1/scans", scansRoutes);
+  return app;
+}
+
+async function getReport(app: Hono<{ Bindings: Bindings; Variables: Variables }>, scanId: string) {
+  const ctx = createExecutionContext();
+  const res = await app.fetch(
+    new Request(`http://test.local/api/v1/scans/${scanId}/report.json`, { method: "GET" }),
+    env,
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+async function seedCompletedScan(owner: SeededUser): Promise<string> {
+  const db = createDb(env.DB);
+  const scanId = `scan_${crypto.randomUUID()}`;
+  const stageId = `stage-${scanId.slice(-12)}`;
+  await createScanJob(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+  });
+  await persistScan(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+    packageJson: { name: "@org/pkg", version: "1.1.0" },
+    risk: "high",
+    status: "complete",
+    summary: {
+      report: {
+        version: 1,
+        digest: "abc123",
+        digestAlgorithm: "sha256",
+        generatedAt: "2026-01-01T00:00:00.000Z",
+        rulesVersion: "1.8.0",
+      },
+      baseline: { kind: "registry", version: "1.0.0" },
+      safety: { outboundPolicy: "gateway-only" },
+      packageJsonDiff: {
+        name: "@org/pkg",
+        previousVersion: "1.0.0",
+        stagedVersion: "1.1.0",
+        scripts: [{ key: "postinstall", status: "added", staged: "node install.js" }],
+        dependencies: [],
+        entrypointsChanged: false,
+      },
+      diff: [{ path: "package.json", status: "modified" }],
+    },
+    ai: null,
+    files: [{ path: "package.json", size: 10, sha256: "a", flags: [], textSample: "{}" }],
+    diff: [{ path: "package.json", status: "modified", flags: [] }],
+    findings: [
+      {
+        severity: "high",
+        file: "package.json",
+        evidence: "postinstall: node install.js",
+        reason: "install lifecycle hooks execute on consumer machines",
+        ruleId: "install-script.lifecycle",
+        ruleVersion: "1.8.0",
+      },
+    ],
+    report: { version: 1, digest: "abc123" },
+  });
+  return scanId;
+}
+
+describe("scan report JSON export", () => {
+  test("exports a canonical, downloadable report for a completed scan", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+
+    const res = await getReport(buildTestApp(owner), scanId);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    expect(res.headers.get("content-disposition")).toBe(
+      `attachment; filename="drydock-report-${scanId}.json"`,
+    );
+
+    const text = await res.text();
+    const body = JSON.parse(text) as {
+      schema: string;
+      report: { digest: string; rulesVersion: string } | null;
+      scan: { id: string; status: string };
+      package: { name: string | null; stagedVersion: string | null };
+      packageJsonDiff: unknown;
+      findings: Array<{ ruleId: string | null; severity: string }>;
+    };
+    expect(body.schema).toBe("drydock.report.v1");
+    expect(body.report?.digest).toBe("abc123");
+    expect(body.report?.rulesVersion).toBe("1.8.0");
+    expect(body.scan.id).toBe(scanId);
+    expect(body.package.name).toBe("@org/pkg");
+    expect(body.package.stagedVersion).toBe("1.1.0");
+    expect(body.packageJsonDiff).toBeTruthy();
+    expect(body.findings).toEqual([
+      expect.objectContaining({ ruleId: "install-script.lifecycle", severity: "high" }),
+    ]);
+
+    // Stable serialization: a re-export of the same evidence is byte-identical.
+    const again = await getReport(buildTestApp(owner), scanId);
+    expect(await again.text()).toBe(text);
+  });
+
+  test("does not leak another organization's report", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const outsider = await seedUser();
+
+    const res = await getReport(buildTestApp(outsider), scanId);
+    expect(res.status).toBe(404);
+  });
+
+  test("refuses export for a scan that has not completed", async () => {
+    const owner = await seedUser();
+    const db = createDb(env.DB);
+    const scanId = `scan_${crypto.randomUUID()}`;
+    await createScanJob(db, {
+      id: scanId,
+      stageId: `stage-${scanId.slice(-12)}`,
+      organizationId: owner.organizationId,
+      ownerUserId: owner.userId,
+    });
+
+    const res = await getReport(buildTestApp(owner), scanId);
+    expect(res.status).toBe(409);
+  });
+
+  test("returns 404 for an unknown scan id", async () => {
+    const owner = await seedUser();
+    const res = await getReport(buildTestApp(owner), "scan_does_not_exist");
+    expect(res.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## What

Phase 1 (report provenance & export) work: make completed reviews durable, archivable, and comparable. A new endpoint serves a self-contained report document built entirely from data already persisted for the scan.

`GET /api/v1/scans/:id/report.json` returns:
- **provenance** — report version, digest, digest algorithm, generated timestamp, deterministic rules version;
- **identity** — package name/versions, selected baseline, stage/source;
- **verdict** — risk + risk summary (release vs. context split);
- **evidence** — manifest diff, file diff, and the deterministic findings;
- **safety posture**.

A "**Export JSON**" download link appears in the scan-detail header for completed scans (uses the existing `LinkButton`; same-origin authenticated GET).

## Canonical & deterministic

Serialization uses stable key ordering and a deterministic finding sort, so a re-export of the same evidence is **byte-identical** — the property two report artifacts need to compare equal, and a prerequisite for signed reports later.

## Scope / honesty

This is the persisted **record**, not a re-derivation of the originally digested payload. The stored report digest is carried through for reference, but reproducing it byte-for-byte from the database is deliberately out of scope (the digested payload includes redacted intermediates not fully reconstructable from persisted columns). Noted as future work in `docs/production-roadmap.md`.

## Security

- Org-scoped via `requireActiveOrganization`; cross-tenant and unknown ids return **404**.
- Gated to completed scans (**409** otherwise).
- Read-only; served as a download with `no-store`; records no `scan.viewed` event.

## Tests / docs

- Worker-route test (`test/workers/scan-report-export.test.ts`): format + headers, byte-identical re-export, **tenant isolation**, not-completed (409), unknown id (404).
- README API list + roadmap Phase 1 updated.
- `pnpm run verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)