### PR TITLE
Show monorepo bundle size in Slack release-gate notification

### DIFF
--- a/server/lib/notify.ts
+++ b/server/lib/notify.ts
@@ -246,9 +246,14 @@ export async function notifyWorkflowGateReview(
   const packageLabel = formatPackageLabel(packageName, version);
   const dashboardUrl = scanUrl(env, scanId);
   const otherPackages = packageCount && packageCount > 1 ? packageCount - 1 : 0;
-  const packageLine = otherPackages
-    ? `Package: ${packageLabel} (+${otherPackages} more in this release; each must be approved)`
-    : `Package: ${packageLabel}`;
+  // A monorepo release fans out into several per-package scans behind one gate;
+  // the gate carries only its headline (highest-risk) package. Surface the bundle
+  // size in every channel so the headline isn't mistaken for the whole release —
+  // each package must be approved before the held deployment can publish.
+  const packageDisplay = otherPackages
+    ? `${packageLabel} (+${otherPackages} more in this release; each must be approved)`
+    : packageLabel;
+  const packageLine = `Package: ${packageDisplay}`;
   const subject = `Release gate needs your review — ${packageLabel}`;
   const lines = [
     "Hi there,",
@@ -270,7 +275,7 @@ export async function notifyWorkflowGateReview(
 
   const slackPayload: SlackNotificationPayload = {
     title: "Release gate needs a decision",
-    packageLabel,
+    packageLabel: packageDisplay,
     source: "GitHub workflow gate",
     risk: releaseRisk,
     repository: repositoryFullName,

--- a/test/notify.test.mjs
+++ b/test/notify.test.mjs
@@ -287,6 +287,27 @@ describe("Slack connection delivery", () => {
     expect(serialized).not.toContain("ciphertext");
   });
 
+  test("flags a monorepo bundle in the Slack payload so the headline isn't read as the whole release", async () => {
+    dbMock.getSlackConnectionSecret.mockResolvedValue(slackConnection());
+
+    await notifyWorkflowGateReview(gateInput({ packageCount: 2 }));
+
+    expect(slackMock.renderSlackMessage).toHaveBeenCalledTimes(1);
+    const [payload] = slackMock.renderSlackMessage.mock.calls[0];
+    expect(payload.packageLabel).toBe(
+      "demo-package@1.2.0 (+1 more in this release; each must be approved)",
+    );
+  });
+
+  test("keeps the Slack package label bare for a single-package gate", async () => {
+    dbMock.getSlackConnectionSecret.mockResolvedValue(slackConnection());
+
+    await notifyWorkflowGateReview(gateInput({ packageCount: 1 }));
+
+    const [payload] = slackMock.renderSlackMessage.mock.calls[0];
+    expect(payload.packageLabel).toBe("demo-package@1.2.0");
+  });
+
   test("records a delivery failure with its reason but no token", async () => {
     dbMock.getSlackConnectionSecret.mockResolvedValue(slackConnection());
     slackMock.postSlackMessage.mockResolvedValue({


### PR DESCRIPTION
A monorepo gate fans one held GitHub deployment out into several per-package scans, but the gate row only carries its headline (highest-risk) package — so the Slack "Release gate needs a decision" message showed a single package while the scan screen correctly listed all of them. `notifyWorkflowGateReview` already annotated the *email* body with `(+N more in this release; each must be approved)` via `packageCount`, but the Slack payload was built separately and dropped the count entirely. This single-sources a `packageDisplay` label and feeds it to both the email and the Slack payload, so the bundle size surfaces in every channel; single-package gates keep the bare label. Added two regression tests asserting the Slack payload reflects the bundle for a 2-package release and stays bare for a single-package gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)