### PR TITLE
Add backoff and a stop cap to scan detail polling

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,7 +120,7 @@ Current async-capable flow:
 4. Pipeline stores derived/redacted report data and marks the scan `complete`.
 5. Terminal failures are persisted as `failed` with structured `error_json`; transient npm/sandbox failures are retried before they are marked failed.
 6. Exhausted retryable Queue jobs are sent to the configured dead-letter queue for operator review.
-7. UI polls `GET /api/v1/scans/:id` until terminal state.
+7. UI polls `GET /api/v1/scans/:id` until terminal state. The scan detail model polls every 2.5s, doubling the delay on consecutive failures (capped at 30s, reset on success), and stops outright after ~10 minutes without a terminal status — the page then surfaces a warn alert whose "Resume refresh" action (`ScanDetailModel.resumePolling`) refetches immediately and restarts a fresh backoff chain.
 
 `POST /api/v1/scan` remains a synchronous compatibility route while the product moves to the persisted report surface.
 

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -239,11 +239,21 @@ export const ScanListModel = createModel(() => {
 
 export type DecisionStatus = "idle" | "saving" | "error";
 
+// Polling cadence for scans still in pending/running. The base delay doubles
+// per consecutive poll failure (so an unreachable API isn't hammered at a
+// fixed rate) up to the max, and resets on success. A scan that never reaches
+// a terminal status stops polling entirely after the stall window; the UI
+// offers a manual resume via `resumePolling()`.
+export const SCAN_POLL_BASE_DELAY_MS = 2_500;
+export const SCAN_POLL_MAX_DELAY_MS = 30_000;
+export const SCAN_POLL_STALL_AFTER_MS = 10 * 60_000;
+
 export const ScanDetailModel = createModel((id: string) => {
   const scanId = signal(id);
   const detail = signal<PersistedScanDetail | null>(null);
   const selectedPath = signal<string | null>(null);
   const error = signal<string | null>(null);
+  const pollingStalled = signal(false);
   const versions = signal<ScanVersionsResponse | null>(null);
   const selectedVersion = signal<string | null>(null);
   const compareCache = signal<Record<string, ScanCompareResponse>>({});
@@ -278,13 +288,38 @@ export const ScanDetailModel = createModel((id: string) => {
     return v ? (cache[v] ?? null) : null;
   });
 
-  // Background polling while the scan is still running.
+  // Background polling while the scan is still running. A self-scheduling
+  // timeout chain (not setInterval) lets the cadence adapt: consecutive
+  // failures back off exponentially, and a scan stuck non-terminal past the
+  // stall window latches `pollingStalled` instead of polling forever. Both
+  // signals are read unconditionally so the effect tracks them on every run.
   effect(() => {
-    if (!isPolling.value) return;
-    const timer = window.setInterval(() => {
-      void pollDetail();
-    }, 2500);
-    return () => window.clearInterval(timer);
+    const polling = isPolling.value;
+    const stalled = pollingStalled.value;
+    if (!polling || stalled) return;
+
+    let disposed = false;
+    let delay = SCAN_POLL_BASE_DELAY_MS;
+    const startedAt = Date.now();
+
+    const tick = async () => {
+      if (Date.now() - startedAt >= SCAN_POLL_STALL_AFTER_MS) {
+        pollingStalled.value = true;
+        return;
+      }
+      const ok = await pollDetail();
+      // The poll itself can flip isPolling (terminal status) and re-run the
+      // effect; the disposed flag keeps the stale chain from rescheduling.
+      if (disposed) return;
+      delay = ok ? SCAN_POLL_BASE_DELAY_MS : Math.min(delay * 2, SCAN_POLL_MAX_DELAY_MS);
+      timer = setTimeout(() => void tick(), delay);
+    };
+
+    let timer = setTimeout(() => void tick(), delay);
+    return () => {
+      disposed = true;
+      clearTimeout(timer);
+    };
   });
 
   // Auto-load comparison data when the user picks a version.
@@ -296,7 +331,7 @@ export const ScanDetailModel = createModel((id: string) => {
     void loadCompare(version);
   });
 
-  async function pollDetail() {
+  async function pollDetail(): Promise<boolean> {
     const id = scanId.peek();
     try {
       const data = await getScan(id, { poll: true });
@@ -305,8 +340,10 @@ export const ScanDetailModel = createModel((id: string) => {
       if (selectedPath.peek() === null) {
         selectedPath.value = pickInitialPath(data);
       }
+      return true;
     } catch (err) {
       error.value = errorMessage(err);
+      return false;
     }
   }
 
@@ -329,6 +366,7 @@ export const ScanDetailModel = createModel((id: string) => {
     detail,
     selectedPath,
     error,
+    pollingStalled,
     versions,
     selectedVersion,
     compareCache,
@@ -383,6 +421,13 @@ export const ScanDetailModel = createModel((id: string) => {
 
     selectPath(path: string | null) {
       this.selectedPath.value = path;
+    },
+
+    // Manual recovery from the stalled state: refetch right away and clear
+    // the latch so the polling effect restarts a fresh backoff chain.
+    resumePolling(): void {
+      this.pollingStalled.value = false;
+      void pollDetail();
     },
 
     selectVersion(version: string | null) {

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -17,6 +17,7 @@ import { displayedAiResult, type AiReview } from "../../../../server/lib/ai-revi
 import { createPackageDiff, type DiffEntry } from "../../../../server/lib/review";
 import {
   Alert,
+  Button,
   Card,
   FileTree,
   Input,
@@ -190,6 +191,7 @@ export default function ScanDetailPage() {
   const detail = model.detail.value;
   const versions = versionsSignal.value;
   const error = model.error.value;
+  const pollingStalled = model.pollingStalled.value;
   const compareLoading = model.compareLoading.value;
   const compareError = model.compareError.value;
   const selectedVersion = model.selectedVersion.value;
@@ -245,6 +247,16 @@ export default function ScanDetailPage() {
       <ScanDetailHeader detail={detail} onDecideClick={onDecideClick} />
 
       {error ? <Alert tone="critical">{error}</Alert> : null}
+      {pollingStalled ? (
+        <Alert tone="warn">
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <span>Automatic refresh stopped after 10 minutes without the review finishing.</span>
+            <Button variant="secondary" size="sm" onClick={() => model.resumePolling()}>
+              Resume refresh
+            </Button>
+          </div>
+        </Alert>
+      ) : null}
       {isWorkflowGate && detail ? (
         <GateContextPanel
           gate={gate}
@@ -364,10 +376,14 @@ export default function ScanDetailPage() {
             <PersistedReportSections summary={summary.value} ai={ai.value} />
           </>
         ) : detail.scan.status === "pending" || detail.scan.status === "running" ? (
-          <LoadingState
-            title={detail.scan.status === "pending" ? "Review queued" : "Reviewing release"}
-            detail="auto-refreshes when the report is ready"
-          />
+          // While stalled the pulsing line would falsely promise an
+          // auto-refresh; the warn Alert above carries the state instead.
+          pollingStalled ? null : (
+            <LoadingState
+              title={detail.scan.status === "pending" ? "Review queued" : "Reviewing release"}
+              detail="auto-refreshes when the report is ready"
+            />
+          )
         ) : null
       ) : null}
 

--- a/test/scan-detail-polling-model.test.ts
+++ b/test/scan-detail-polling-model.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  SCAN_POLL_BASE_DELAY_MS,
+  SCAN_POLL_MAX_DELAY_MS,
+  SCAN_POLL_STALL_AFTER_MS,
+  ScanDetailModel,
+  type PersistedScanDetail,
+} from "../src/models/scan";
+
+function runningDetail(): PersistedScanDetail {
+  return {
+    scan: {
+      id: "scan-1",
+      stageId: "stage-1",
+      packageName: "left-pad",
+      stagedVersion: "1.0.1",
+      previousVersion: "1.0.0",
+      risk: "none",
+      status: "running",
+      createdAt: "2026-06-09T00:00:00.000Z",
+      updatedAt: "2026-06-09T00:00:00.000Z",
+    },
+    files: [],
+    findings: [],
+    events: [],
+  };
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function failedResponse(): Response {
+  return new Response(JSON.stringify({ error: "boom" }), {
+    status: 500,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+type ScanDetailModelInstance = InstanceType<typeof ScanDetailModel>;
+
+// Flips the model into the polling state (status running) without going
+// through the network, so the fetch mock only ever sees poll requests.
+function startPolling(model: ScanDetailModelInstance): void {
+  model.detail.value = runningDetail();
+}
+
+describe("ScanDetailModel polling", () => {
+  let model: ScanDetailModelInstance | null = null;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    model?.[Symbol.dispose]();
+    model = null;
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  test("backs off exponentially on consecutive failures, capped at the max delay", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(failedResponse()));
+    vi.stubGlobal("fetch", fetchMock);
+
+    model = new ScanDetailModel("scan-1");
+    startPolling(model);
+
+    // First poll fires at the base delay.
+    await vi.advanceTimersByTimeAsync(SCAN_POLL_BASE_DELAY_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(model.error.value).not.toBeNull();
+
+    // One failure doubles the delay: nothing at 4999ms, the poll at 5000ms.
+    await vi.advanceTimersByTimeAsync(2 * SCAN_POLL_BASE_DELAY_MS - 1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    // Keeps doubling: 10s, 20s, then clamps to the 30s cap.
+    await vi.advanceTimersByTimeAsync(4 * SCAN_POLL_BASE_DELAY_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    await vi.advanceTimersByTimeAsync(8 * SCAN_POLL_BASE_DELAY_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    await vi.advanceTimersByTimeAsync(SCAN_POLL_MAX_DELAY_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    await vi.advanceTimersByTimeAsync(SCAN_POLL_MAX_DELAY_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+
+    // Disposal clears the pending timer; no further polls leak.
+    model[Symbol.dispose]();
+    model = null;
+    await vi.advanceTimersByTimeAsync(10 * SCAN_POLL_MAX_DELAY_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+  });
+
+  test("resets to the base delay after a successful poll", async () => {
+    let fail = true;
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(fail ? failedResponse() : jsonResponse(runningDetail())),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    model = new ScanDetailModel("scan-1");
+    startPolling(model);
+
+    // First poll fails → the chain backs off to 2× base.
+    await vi.advanceTimersByTimeAsync(SCAN_POLL_BASE_DELAY_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    fail = false;
+    await vi.advanceTimersByTimeAsync(2 * SCAN_POLL_BASE_DELAY_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(model.error.value).toBeNull();
+
+    // Success resets the cadence: the next poll fires at the base delay again.
+    await vi.advanceTimersByTimeAsync(SCAN_POLL_BASE_DELAY_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  test("stops polling and raises pollingStalled after the stall window", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse(runningDetail())));
+    vi.stubGlobal("fetch", fetchMock);
+
+    model = new ScanDetailModel("scan-1");
+    startPolling(model);
+
+    await vi.advanceTimersByTimeAsync(SCAN_POLL_STALL_AFTER_MS);
+    expect(model.pollingStalled.value).toBe(true);
+
+    const callsAtStall = fetchMock.mock.calls.length;
+    expect(callsAtStall).toBeGreaterThan(0);
+    await vi.advanceTimersByTimeAsync(10 * SCAN_POLL_MAX_DELAY_MS);
+    expect(fetchMock.mock.calls.length).toBe(callsAtStall);
+  });
+
+  test("resumePolling refetches immediately and restarts the chain", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse(runningDetail())));
+    vi.stubGlobal("fetch", fetchMock);
+
+    model = new ScanDetailModel("scan-1");
+    startPolling(model);
+
+    await vi.advanceTimersByTimeAsync(SCAN_POLL_STALL_AFTER_MS);
+    expect(model.pollingStalled.value).toBe(true);
+    const callsAtStall = fetchMock.mock.calls.length;
+
+    model.resumePolling();
+    expect(model.pollingStalled.value).toBe(false);
+    // The manual refresh fires without waiting for the next scheduled tick.
+    expect(fetchMock.mock.calls.length).toBe(callsAtStall + 1);
+
+    // The restarted chain polls at the base delay again.
+    await vi.advanceTimersByTimeAsync(SCAN_POLL_BASE_DELAY_MS);
+    expect(fetchMock.mock.calls.length).toBe(callsAtStall + 2);
+  });
+});


### PR DESCRIPTION
## Failure modes fixed

The scan detail page polled `GET /api/v1/scans/:id` from a fixed `setInterval(2500)` inside the `ScanDetailModel` effect. Two failure modes:

1. **Failures kept polling at full rate forever.** Poll errors were caught into the `error` signal, but the next poll still fired 2.5s later — an unreachable or erroring API got hammered indefinitely at a fixed cadence.
2. **A scan stuck non-terminal polled forever.** If a scan never left `pending`/`running` (lost queue job, dead worker), the tab kept polling with no cap and no signal to the user.

## What changed

- The interval is replaced with a **self-scheduling timeout chain**, so each poll picks the next delay. Effect cleanup sets a `disposed` flag and clears the pending timer, so no chain survives `isPolling` flips or model disposal.
- **Exponential backoff on consecutive failures:** base 2.5s, doubled per consecutive failure, capped at 30s, reset to base on the first success.
- **Stop cap:** after ~10 minutes without reaching a terminal status, polling stops entirely and a new `pollingStalled` signal latches. The page hides the "auto-refreshes when the report is ready" loading line (it would be a lie) and shows an `Alert tone="warn"` with a **Resume refresh** button.
- `resumePolling()` clears the latch, refetches immediately, and the polling effect restarts a fresh backoff chain with a new 10-minute window.

## Chosen constants

| Constant | Value | Rationale |
| --- | --- | --- |
| `SCAN_POLL_BASE_DELAY_MS` | 2.5s | Unchanged from the previous fixed interval |
| `SCAN_POLL_MAX_DELAY_MS` | 30s | Slow enough to stop hammering a failing API, fast enough to recover promptly |
| `SCAN_POLL_STALL_AFTER_MS` | 10min | Well past any healthy scan duration; queue retries that take longer surface through the manual resume |

## Tests

`test/scan-detail-polling-model.test.ts` (fake timers + stubbed `fetch`, same pattern as the existing model tests): backoff growth at exact tick boundaries, cap at 30s, reset on success, stall latch with no further polls, immediate refetch + chain restart via `resumePolling()`, and no timer leak after model dispose.

`pnpm run verify` passes (lint, format check, typecheck, tests). Also updated the polling step in `docs/architecture.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)