### PR TITLE
Add production deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,83 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# One production deploy at a time. Never cancel an in-flight run: killing it
+# between "migrations applied" and "worker deployed" would leave the schema
+# ahead of the live code. Queued runs wait their turn instead.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    name: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify (lint · format · typecheck · test)
+        run: pnpm run verify
+
+  deploy:
+    name: deploy
+    needs: verify
+    runs-on: ubuntu-latest
+    # Repo-level protection rules on the "production" environment (required
+    # reviewers, branch restrictions) gate this job and hold the secrets.
+    environment:
+      name: production
+      url: https://drydock.resynapse.dev
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Migrations apply before the new Worker goes live, so Worker code must
+      # stay backward compatible with a schema one migration ahead. This step
+      # also runs before the build on purpose: `vite build` emits a redirected
+      # Wrangler config (.wrangler/deploy/config.json -> dist/**/wrangler.json)
+      # that later wrangler invocations resolve instead of the checked-in
+      # wrangler.jsonc, and migrations need the source config's
+      # `migrations_dir: "drizzle"`.
+      - name: Apply D1 migrations
+        run: pnpm run db:migrate:remote
+
+      # The Cloudflare Vite plugin bundles the Worker + prerendered UI assets
+      # into dist/ and writes the redirected Wrangler config the deploy step
+      # consumes. A bare `wrangler deploy` against wrangler.jsonc cannot work:
+      # its `assets` block has no `directory` — only the build output provides
+      # one.
+      - name: Build
+        run: pnpm run build
+
+      - name: Deploy Worker
+        run: pnpm run deploy

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -57,6 +57,58 @@ them out of the worker boot graph.
 
 Run `pnpm run verify` before every commit, so each commit passes lint + format + typecheck + tests. There is no git hook enforcing this — it is run explicitly. CI (`.github/workflows/ci.yml`) runs the same core checks and then installs Chromium and runs `pnpm run test:e2e`.
 
+## Production deploys
+
+`.github/workflows/deploy.yml` deploys the Worker to production. It runs on
+every push to `main` and on demand via `workflow_dispatch` (Actions → Deploy →
+"Run workflow", or `gh workflow run deploy.yml`). A `deploy-production`
+concurrency group serializes runs without cancelling an in-flight deploy, so a
+deploy is never killed between applying migrations and uploading the Worker.
+
+Two jobs:
+
+1. **verify** — same setup as CI, runs `pnpm run verify`.
+2. **deploy** — `needs: verify` and runs in the `production` GitHub
+   Environment, so repo-level environment protection rules (required
+   reviewers, branch restrictions) can gate it. Steps, in order:
+   1. `pnpm run db:migrate:remote` — applies pending D1 migrations to the
+      remote `staged-publish-review` database **before** the new Worker code
+      goes live. Worker code must therefore stay backward compatible with a
+      schema one migration ahead. This step also deliberately runs before the
+      build: `vite build` writes a redirected Wrangler config
+      (`.wrangler/deploy/config.json` → `dist/**/wrangler.json`) that later
+      wrangler invocations resolve instead of the checked-in `wrangler.jsonc`,
+      and migrations need the source config's `migrations_dir: "drizzle"`.
+   2. `pnpm run build` — the Cloudflare Vite plugin bundles the Worker and the
+      prerendered UI assets into `dist/` and emits the redirected Wrangler
+      config. A bare `wrangler deploy` against `wrangler.jsonc` cannot work:
+      its `assets` block has no `directory`; only the build output provides
+      one.
+   3. `pnpm run deploy` — `wrangler deploy`, which picks up the redirected
+      config and uploads the built Worker, assets, cron triggers, queue
+      consumers, and routes.
+
+### Required repo secrets
+
+Configure these as repository (or `production` environment) secrets before the
+first run — the workflow cannot be exercised without them:
+
+- `CLOUDFLARE_API_TOKEN` — minimum permissions:
+  - Account → **Workers Scripts: Edit** (upload Worker + assets, crons,
+    bindings)
+  - Account → **D1: Edit** (apply migrations)
+  - Account → **Queues: Edit** (register the `staged-publish-review-scans`
+    consumer)
+  - Zone `resynapse.dev` → **Workers Routes: Edit** (the
+    `drydock.resynapse.dev` custom-domain routes)
+
+  If a deploy fails with a permissions error, Cloudflare's "Edit Cloudflare
+  Workers" token template plus D1 Edit and Queues Edit is the known-good
+  superset.
+
+- `CLOUDFLARE_ACCOUNT_ID` — the Cloudflare account id. Required in
+  non-interactive CI whenever the token can see more than one account.
+
 ## Banned hooks
 
 `useState` and `useReducer` are forbidden via oxlint's `no-restricted-imports` from `preact/hooks` (and `react`, defensively). The codebase is migrating component-local state to:


### PR DESCRIPTION
## What

Adds `.github/workflows/deploy.yml` so production deploys stop being manual `wrangler deploy` runs, plus a "Production deploys" section in `docs/tooling.md`.

## Trigger model

- **`push` to `main`** — every merged change deploys automatically (after the gates below).
- **`workflow_dispatch`** — manual deploys from the Actions tab or `gh workflow run deploy.yml`.
- **Concurrency**: a `deploy-production` group with `cancel-in-progress: false` serializes deploys. An in-flight deploy is never cancelled (killing one between "migrations applied" and "worker uploaded" would leave schema ahead of live code); superseded queued runs collapse to the latest.

## Gates

1. **`verify` job** — same pnpm/Node 22 setup as `ci.yml`, runs `pnpm run verify` (lint + format check + typecheck + tests).
2. **`environment: production`** on the deploy job — once you add protection rules to the `production` environment in repo settings (required reviewers, branch restriction to `main`), every deploy pauses for approval there. The environment is also where the secrets can live.

## Deploy steps and why this order

1. **`pnpm run db:migrate:remote`** (`wrangler d1 migrations apply staged-publish-review --remote`) — migrations land **before** the new Worker goes live, so Worker code must stay backward compatible with a schema one migration ahead. It also deliberately runs **before the build**: the build emits a redirected Wrangler config and migrations need the checked-in `wrangler.jsonc` (`migrations_dir: "drizzle"`).
2. **`pnpm run build`** (`vite build`) — required, not optional. This project uses `@cloudflare/vite-plugin`, which bundles the Worker + prerendered UI into `dist/` and writes Wrangler's redirected configuration (`.wrangler/deploy/config.json` → `dist/**/wrangler.json`). A bare `wrangler deploy` against the checked-in `wrangler.jsonc` **cannot work**: its `assets` block has no `directory` — only the Vite build output provides one. (Verified against the plugin bundle, which emits `.wrangler/deploy/config.json`.)
3. **`pnpm run deploy`** (`wrangler deploy`) — picks up the redirected config and uploads the built Worker, assets, crons, queue consumers, and routes. Both scripts already existed in `package.json`; the workflow just sequences them.

## ⚠️ REQUIRED SETUP before the first run

The workflow **cannot be tested in CI until these exist**. Configure as repository secrets (or secrets on the `production` environment):

- **`CLOUDFLARE_API_TOKEN`** — minimum permissions:
  - Account → Workers Scripts: **Edit**
  - Account → D1: **Edit**
  - Account → Queues: **Edit** (registers the `staged-publish-review-scans` consumer)
  - Zone `resynapse.dev` → Workers Routes: **Edit** (the `drydock.resynapse.dev` custom-domain routes)
- **`CLOUDFLARE_ACCOUNT_ID`** — needed in non-interactive CI whenever the token can see more than one account.

Optionally create the `production` environment in repo settings and add required reviewers to make deploys approval-gated.

No other secrets are used or invented. No deploy was run from this change — first real run happens in Actions after the secrets are configured.

## Validation

- `pnpm run verify` passes (untouched by this change).
- `actionlint` not available locally; YAML parse-validated and self-reviewed (trigger/concurrency/environment syntax, `needs` reference, pnpm-before-node-cache step order mirroring `ci.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)