### PR TITLE
Emit HSTS header on all Worker responses

### DIFF
--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -202,6 +202,10 @@ Before SaaS launch:
 
 RBAC is not required for the first launch slice, but the schema and route boundaries should not assume resources are global or user-only.
 
+## Browser response headers
+
+Security response headers reach the browser by two delivery paths that must carry the same policy: Worker-served responses (the `run_worker_first` paths — `/api`, `/api/*`, `/webhooks/*`) get them from `applySecurityHeaders()` in `server/index.ts`, while static assets and the SPA document are served by Cloudflare's edge and get them from `public/_headers`. `server/lib/security-headers.ts` is the single source of truth; `test/security-headers.test.ts` fails if the hand-copied `_headers` values drift. HSTS (`Strict-Transport-Security`) lives in both so every response — API, webhook, page, and bundled asset — pins clients to HTTPS and a stripped/downgraded request can't reach the origin in cleartext.
+
 ## Signed reports later
 
 Signed reports are not launching yet. Prepare by making report payloads canonical and digestible.

--- a/public/_headers
+++ b/public/_headers
@@ -12,6 +12,7 @@
 # Keep in sync with server/lib/security-headers.ts (DOCUMENT_CSP +
 # SECURITY_HEADERS); test/security-headers.test.ts fails if they drift.
 /*
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin

--- a/server/lib/security-headers.ts
+++ b/server/lib/security-headers.ts
@@ -15,6 +15,12 @@
 
 // Non-CSP headers; identical for every response regardless of content type.
 export const SECURITY_HEADERS: Readonly<Record<string, string>> = {
+  // Pin clients to HTTPS for a year so a stripped/downgraded request can't reach
+  // the origin in cleartext. Drydock is only ever served over TLS at the edge,
+  // and browsers ignore this header on plaintext responses, so it's safe to emit
+  // unconditionally. includeSubDomains + preload satisfy the HSTS preload-list
+  // requirements that surface scanners (Aikido) check for.
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
   "X-Content-Type-Options": "nosniff",
   "X-Frame-Options": "DENY",
   "Referrer-Policy": "strict-origin-when-cross-origin",

--- a/test/workers/security-headers.test.ts
+++ b/test/workers/security-headers.test.ts
@@ -1,0 +1,29 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { describe, expect, test } from "vitest";
+import worker from "../../server/index";
+
+const HSTS_VALUE = "max-age=31536000; includeSubDomains; preload";
+
+// HSTS guards against protocol-downgrade / SSL-stripping man-in-the-middle
+// attacks by forcing clients onto HTTPS. It must ride on every response the
+// Worker emits, including error responses, so a single missed path can't be the
+// one a downgrade attack lands on. The static-asset delivery path is covered
+// separately by test/security-headers.test.ts (public/_headers drift guard).
+describe("worker security headers", () => {
+  async function fetchHeaders(path: string, method = "GET"): Promise<Headers> {
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request(`http://example.com${path}`, { method }), env, ctx);
+    await waitOnExecutionContext(ctx);
+    return res.headers;
+  }
+
+  test("sets a one-year HSTS policy with includeSubDomains and preload", async () => {
+    const headers = await fetchHeaders("/api/health");
+    expect(headers.get("Strict-Transport-Security")).toBe(HSTS_VALUE);
+  });
+
+  test("applies HSTS to non-API responses too", async () => {
+    const headers = await fetchHeaders("/does-not-exist");
+    expect(headers.get("Strict-Transport-Security")).toBe(HSTS_VALUE);
+  });
+});


### PR DESCRIPTION
## What

Aikido surface monitoring flagged `drydock.resynapse.dev` for a missing **Strict-Transport-Security** (HSTS) header. The Worker already centralizes its security headers in `applySecurityHeaders` (`server/index.ts`) — CSP, `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Permissions-Policy` — but never set HSTS, so a downgraded / SSL-stripped request could reach the origin in cleartext.

## Change

- Add `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload` to the existing security-headers middleware, so it rides on **every** response the Worker emits (API, static, and error responses alike).
  - The Worker is only ever served over TLS at the edge, and browsers ignore HSTS on plaintext responses, so it's safe to emit unconditionally.
  - `includeSubDomains` + `preload` satisfy the HSTS preload-list requirements that scanners (and Aikido) check for. Note: actual preload-list enrollment is a separate manual submission for the registrable domain — this header alone changes nothing irreversibly.
- Add `test/workers/security-headers.test.ts` asserting the header is present on both an API route and a non-API (404) response.

## Verification

- `pnpm run typecheck` — clean
- `oxlint` / `oxfmt --check` — clean
- `pnpm vitest run test/workers/security-headers.test.ts` — 2 passing

Ref: https://app.aikido.dev/issues/31578341/detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)