### PR TITLE
Add CSP to statically-served assets

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,19 @@
+# Security headers for Cloudflare-served static assets.
+#
+# The SPA HTML document, JS and CSS are served by Cloudflare's edge BEFORE the
+# Worker runs (only run_worker_first paths — /api, /api/*, /webhooks/* — reach
+# the Worker), so the Worker's applySecurityHeaders() never touches them. This
+# file is how those static responses get a Content-Security-Policy and the rest
+# of the security headers. Worker-served JSON responses keep their own policy.
+#
+# Vite copies public/ to the asset root at build time, so this lands at /_headers
+# where Cloudflare consumes it as config rather than serving it.
+#
+# Keep in sync with server/lib/security-headers.ts (DOCUMENT_CSP +
+# SECURITY_HEADERS); test/security-headers.test.ts fails if they drift.
+/*
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: DENY
+  Referrer-Policy: strict-origin-when-cross-origin
+  Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,7 @@ import {
 import { createAuth, getAuthSession } from "./lib/auth";
 import { rateLimitResponse } from "./lib/http";
 import { allowInsecureLocalRegistry } from "./lib/npm-connection";
+import { API_CSP, DOCUMENT_CSP, SECURITY_HEADERS } from "./lib/security-headers";
 import {
   describeOperationalError,
   durationMsSince,
@@ -47,28 +48,12 @@ const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
 function applySecurityHeaders(c: { res: Response; req: { path: string } }) {
   const headers = new Headers(c.res.headers);
-  const apiResponse = c.req.path.startsWith("/api/");
-  headers.set("X-Content-Type-Options", "nosniff");
-  headers.set("X-Frame-Options", "DENY");
-  headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
-  headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=(), payment=()");
-  headers.set(
-    "Content-Security-Policy",
-    apiResponse
-      ? "default-src 'none'; frame-ancestors 'none'; base-uri 'none'"
-      : [
-          "default-src 'self'",
-          "base-uri 'self'",
-          "object-src 'none'",
-          "frame-ancestors 'none'",
-          "form-action 'self'",
-          "script-src 'self'",
-          "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-          "font-src 'self' https://fonts.gstatic.com",
-          "img-src 'self' data:",
-          "connect-src 'self'",
-        ].join("; "),
-  );
+  for (const [name, value] of Object.entries(SECURITY_HEADERS)) headers.set(name, value);
+  // Static assets (the HTML document, JS, CSS) are served by Cloudflare's edge
+  // before the Worker runs, so only run_worker_first paths reach here; those are
+  // all JSON API/webhook responses and take the locked-down policy. The static
+  // document CSP lives in public/_headers — see server/lib/security-headers.ts.
+  headers.set("Content-Security-Policy", c.req.path.startsWith("/api/") ? API_CSP : DOCUMENT_CSP);
 
   c.res = new Response(c.res.body, {
     status: c.res.status,

--- a/server/lib/security-headers.ts
+++ b/server/lib/security-headers.ts
@@ -1,0 +1,48 @@
+// Single source of truth for Drydock's security response headers.
+//
+// These headers reach the browser by two independent delivery paths that must
+// carry the same policy:
+//   1. Worker responses — paths listed under `run_worker_first` in
+//      wrangler.jsonc (/api, /api/*, /webhooks/*) flow through the Worker, where
+//      applySecurityHeaders() in server/index.ts stamps these on every response.
+//   2. Static assets — the SPA HTML document, JS, CSS and everything else are
+//      served by Cloudflare's edge BEFORE the Worker runs, so they never hit
+//      path (1). Those responses get their headers from the static
+//      `public/_headers` file instead.
+// Because `_headers` is plain text consumed at build time it cannot import this
+// module, so the values are duplicated there by hand. The drift guard in
+// test/security-headers.test.ts fails if the two ever diverge — update both.
+
+// Non-CSP headers; identical for every response regardless of content type.
+export const SECURITY_HEADERS: Readonly<Record<string, string>> = {
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=(), payment=()",
+};
+
+// API/webhook responses are JSON and never load any subresource, so the policy
+// denies everything. frame-ancestors/base-uri are still pinned in case a
+// response is ever rendered directly in a browser tab.
+export const API_CSP = ["default-src 'none'", "frame-ancestors 'none'", "base-uri 'none'"].join(
+  "; ",
+);
+
+// The HTML UI loads same-origin scripts/styles/images plus the Geist webfont
+// from Google Fonts: the stylesheet from fonts.googleapis.com (style-src) pulls
+// font files from fonts.gstatic.com (font-src). 'unsafe-inline' on style-src
+// covers Tailwind's injected styles and the prerendered critical CSS; img-src
+// data: covers inline data-URI images. connect-src stays 'self' — the UI only
+// calls the same-origin /api surface.
+export const DOCUMENT_CSP = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "frame-ancestors 'none'",
+  "form-action 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "font-src 'self' https://fonts.gstatic.com",
+  "img-src 'self' data:",
+  "connect-src 'self'",
+].join("; ");

--- a/test/security-headers.test.ts
+++ b/test/security-headers.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+import { API_CSP, DOCUMENT_CSP, SECURITY_HEADERS } from "../server/lib/security-headers.ts";
+
+// The HTML document the browser (and external scanners like Aikido) load is a
+// static asset served by Cloudflare's edge, bypassing the Worker. Its security
+// headers come from public/_headers, which can't import the shared module — so
+// this guard asserts the hand-copied values still match the source of truth.
+const headersFile = readFileSync(
+  fileURLToPath(new URL("../public/_headers", import.meta.url)),
+  "utf8",
+);
+
+// Minimal parser for the Cloudflare _headers format: an unindented path pattern
+// followed by indented `Name: value` lines, `#` comments ignored.
+function parseHeaders(source: string): Map<string, Record<string, string>> {
+  const rules = new Map<string, Record<string, string>>();
+  let current: Record<string, string> | null = null;
+  for (const raw of source.split("\n")) {
+    const line = raw.replace(/\r$/, "");
+    if (!line.trim() || line.trimStart().startsWith("#")) continue;
+    if (!/^\s/.test(line)) {
+      current = {};
+      rules.set(line.trim(), current);
+      continue;
+    }
+    const idx = line.indexOf(":");
+    if (current && idx !== -1) {
+      current[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+    }
+  }
+  return rules;
+}
+
+describe("public/_headers static-asset security headers", () => {
+  const rules = parseHeaders(headersFile);
+  const catchAll = rules.get("/*");
+
+  test("applies a policy to every static path", () => {
+    expect(catchAll).toBeDefined();
+  });
+
+  test("CSP matches the shared document policy", () => {
+    expect(catchAll?.["Content-Security-Policy"]).toBe(DOCUMENT_CSP);
+  });
+
+  test("carries the same non-CSP security headers as the Worker", () => {
+    for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
+      expect(catchAll?.[name]).toBe(value);
+    }
+  });
+
+  // The static document must never receive the API's deny-all CSP: that would
+  // block its own scripts, styles and webfont and white-screen the app.
+  test("does not ship the locked-down API CSP to the document", () => {
+    expect(catchAll?.["Content-Security-Policy"]).not.toBe(API_CSP);
+  });
+});


### PR DESCRIPTION
## What

Aikido flagged the Drydock site (`drydock.resynapse.dev`) for a missing **Content-Security-Policy** header on the document a browser actually loads.

The Worker already sets a full CSP + security-header set in `applySecurityHeaders` — but Cloudflare serves static assets (the SPA HTML, JS, CSS) **from its edge before the Worker runs**. Only `run_worker_first` paths (`/api`, `/api/*`, `/webhooks/*`) reach the Worker, so the HTML document — the one surface a scanner loads — went out with no CSP. That's the gap.

## Fix

- **`public/_headers`** — Cloudflare Workers static assets honor a `_headers` file at the asset root (Vite copies `public/` there at build time). This stamps the document CSP + `X-Content-Type-Options` / `X-Frame-Options` / `Referrer-Policy` / `Permissions-Policy` onto every statically-served response. Worker-served JSON keeps its own locked-down policy.
- **`server/lib/security-headers.ts`** — extracted the policy strings into one module so the Worker path and the static path share a single source of truth. The Worker now consumes it; the `_headers` file (plain text, can't import TS) duplicates it by hand.
- **`test/security-headers.test.ts`** — parses `public/_headers` and asserts its CSP + security headers match the shared module, so the two delivery paths can't silently drift.

The static document CSP mirrors the Worker's existing document policy, which already accounts for the UI's only cross-origin loads (Google Fonts: `fonts.googleapis.com` stylesheet → `fonts.gstatic.com` font files). The GitHub URLs in the UI are links, not subresource loads, so they need no allowance.

## Notes

- `resynapse.dev` is co-flagged in the same Aikido alert but lives in a separate repo — out of scope for this change.
- Verified with `pnpm run verify` (lint + format + typecheck + tests all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)