### PR TITLE
Fix light mode, dark contrast, footer, and auth centering

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -72,16 +72,20 @@ The system has three small-text sizes (10/11/12px). They are not interchangeable
 
 ### Dark mode
 
-| Token             | Hex       | Usage              |
-| ----------------- | --------- | ------------------ |
-| `--bg`            | `#0a0a0a` | Page background    |
-| `--bg-elev`       | `#141414` | Cards              |
-| `--bg-elev-2`     | `#1c1c1c` | Secondary surfaces |
-| `--border`        | `#27272a` | Default borders    |
-| `--border-strong` | `#3f3f46` | Hover borders      |
-| `--fg`            | `#fafafa` | Primary text       |
-| `--fg-muted`      | `#a1a1aa` | Secondary text     |
-| `--fg-subtle`     | `#71717a` | Tertiary text      |
+| Token             | Hex       | Usage                                            |
+| ----------------- | --------- | ------------------------------------------------ |
+| `--bg`            | `#0a0a0a` | Page background                                  |
+| `--bg-elev`       | `#141414` | Cards                                            |
+| `--bg-elev-2`     | `#1c1c1c` | Secondary surfaces                               |
+| `--border`        | `#27272a` | Default borders                                  |
+| `--border-strong` | `#3f3f46` | Hover borders                                    |
+| `--fg`            | `#fafafa` | Primary text                                     |
+| `--fg-muted`      | `#a1a1aa` | Secondary text                                   |
+| `--fg-subtle`     | `#8b8b94` | Tertiary text, mono labels (AA on dark surfaces) |
+
+`--fg-subtle` in dark is `#8b8b94` — it clears WCAG AA (≥5:1) on `--bg`, `--surface`, _and_ `--surface-2` for the 11px mono labels and the mono detail line. The earlier `#71717a` was only 3.8:1 on cards (the dark-mode counterpart to the light-mode floor codified 2026-06-03). Don't lower it back toward `#71717a`.
+
+**Theme application (Tailwind v4):** the dark tokens are set on a plain `:root` inside `@media (prefers-color-scheme: dark)` in `src/style.css`, **never** inside a nested `@theme`. Tailwind v4 hoists every `@theme` block to one unconditional top-level `:root` and discards the surrounding `@media` — a nested dark `@theme` overrides light for everyone and strands the site in dark mode. Keep new dark overrides on the media-scoped `:root`.
 
 ### Accent (brand action)
 
@@ -136,6 +140,10 @@ Don't naively invert. Surfaces darken (true neutrals, no warm tint), accent + se
   - `8px` — Cards, alerts, larger surfaces.
   - `10px` — Mockup/window shells.
   - `999px` — Reserved for true circle elements (avatars, toggle handles). Avoid for badges.
+
+### Page structure (`PageShell`)
+
+Every page is a min-height flex column: header → content (`main`, grows) → site footer pinned to the bottom. The footer matches the page's content width and carries the brand mark, a mono `11px / --fg-subtle` line (`Pre-publish review for npm and PyPI · © Drydock`), and `Docs` / `Feedback` / `Security` links — the only trust/legal surface, so it stays on every route (marketing _and_ app). `width="narrow"` pages (auth, 404, invite) are single short cards: they vertically center in the space between header and footer (via `my-auto`, which never clips over-tall content) rather than pinning to the top.
 
 ## Marketing surfaces
 
@@ -360,3 +368,4 @@ The canonical "labeled control with metadata" row pattern. Re-use this compositi
 | 2026-06-03 | Light-mode contrast pass: `--fg-subtle` darkened, accent shifted to orange-700, severity text split into `*-text` variants, small-text size floor codified.           | The system's signature treatment (mono detail line, mono labels) was rendered in `--fg-subtle` `#a8a29e` — 2.4:1 contrast, well below WCAG AA. White text on `--accent` `#ea580c` and `text-accent` body both failed AA (3.5–3.6:1). Light-mode `text-warn` and `text-ok` failed AA on white. The pass darkens `--fg-subtle` to `#6b6660` (5.9:1), unifies the accent at orange-700 `#c2410c` (4.97:1 in both surface and text roles), adds `--*-text` severity variants for text-on-bg use, and codifies the 10/11/12px role split so future contributors keep load-bearing labels at the 11px floor.                                                                                                                                                                                                                                                                                                                                 |
 | 2026-06-05 | Information-hierarchy pass: findings pinned inline on diff hunks; Recommendation elevated as the one primary section; landing brought to npm + PyPI parity.           | Holistic review found the marketed interaction (findings on the hunk that triggered them) absent from the real workbench — findings lived in a separate card grid — and every report section sharing one flat `SectionLabel` altitude so the verdict didn't out-rank supplements. DiffView now pins deterministic findings to their staged line (banner fallback for unpinned/truncated); the Risk-signals list becomes a clickable index into the diff. The Recommendation is the only carded/headline-scale section. The landing eyebrow/copy and a new "how it hooks in" two-registry section now cover PyPI workflow gating (was npm-only), replacing the redundant three-pillar feature grid that duplicated the status strip. Also: workbench panels go `lg:`-only fixed-height to avoid nested scroll on mobile; dashboard Status renders as a Badge to match Decision; freshness shows readable mono text instead of a bare ✓. |
 | 2026-06-10 | What/why pass on landing + docs: problem-first copy, "Why review a publish" prose section, three-step "How it works", closing CTA; docs gain a two-card mode chooser. | Both pages led with mechanism (staged tarballs, hunks, CI gates) before stating the problem, so first-time visitors couldn't tell what the product was for or why it matters. The landing now runs problem → proof (sample review) → mechanism → trust; the docs header states the problem and trust posture in two paragraphs and a card-shaped mode chooser replaces the bare anchor nav. The "why" section is deliberately prose (document-shaped, security-advisory mood), not another card grid, to avoid card fatigue next to the status strip and registry cards. Also fixed a latent step-list spacing bug: `last:pb-0` sat on a div that is always its `li`'s last child, zeroing inter-step padding in both step components.                                                                                                                                                                                                 |
+| 2026-06-10 | Design-review fixes: light mode un-stranded, dark subtle text bumped to AA, site footer added, narrow pages centered.                                                 | A design pass found the site permanently dark for everyone: the dark tokens lived in an `@theme` nested inside `@media (prefers-color-scheme: dark)`, which Tailwind v4 hoists to an unconditional `:root`, so dark overrode the light default for all users (light mode — the documented default surface — was unreachable). Moved the dark tokens to a media-scoped plain `:root`. Same pass: dark `--fg-subtle` `#71717a` was 3.8:1 on cards (fails AA for the signature mono detail line) → `#8b8b94` (≥5:1); added the always-present site footer (first trust/legal link surface, was none); `width="narrow"` card pages now vertically center instead of floating high with a void below. Landing sample-review mockup: version label dropped the `v` prefix to match the app's `4.2.0 → 4.3.0` convention, file-tree column widened `200px → 220px` so `package.json` stops truncating.                                        |

--- a/src/components/PageShell.tsx
+++ b/src/components/PageShell.tsx
@@ -6,6 +6,15 @@ import { LinkButton } from "./Button";
 const FEEDBACK_MAILTO =
   "mailto:drydock@resynapse.dev?subject=Drydock%20feedback&body=Tell%20us%20what%27s%20broken%2C%20confusing%2C%20or%20missing%3A%0A%0A";
 
+const SECURITY_MAILTO =
+  "mailto:drydock@resynapse.dev?subject=Drydock%20security%20report&body=Describe%20the%20issue%20and%20how%20to%20reproduce%20it%3A%0A%0A";
+
+const WIDTH_CLASS = {
+  narrow: "max-w-[640px]",
+  doc: "max-w-[880px]",
+  wide: "max-w-[1160px]",
+} as const;
+
 export function PageShell({
   class: className,
   children,
@@ -19,27 +28,72 @@ export function PageShell({
   brand?: boolean;
   headerActions?: ComponentChildren;
 }) {
-  const maxWidth =
-    width === "narrow" ? "max-w-[640px]" : width === "doc" ? "max-w-[880px]" : "max-w-[1160px]";
+  const maxWidth = WIDTH_CLASS[width];
+  // Narrow pages are single short cards (auth, 404, invite). Center them in the
+  // viewport instead of pinning them to the top with a large void below.
+  const centered = width === "narrow";
   return (
-    <main class={cn("mx-auto w-full px-6 pt-6 pb-24 flex flex-col gap-6", maxWidth, className)}>
-      {brand ? (
-        <div class="flex flex-wrap items-center justify-between gap-3">
-          <BrandMark href="/" size="sm" />
-          <div class="flex items-center gap-2">
-            <LinkButton
-              href={FEEDBACK_MAILTO}
-              variant="ghost"
-              size="sm"
-              title="Email drydock@resynapse.dev with any issues"
-            >
-              Feedback
-            </LinkButton>
-            {headerActions}
+    <div class="flex min-h-[100svh] flex-col">
+      <main
+        class={cn("mx-auto w-full grow px-6 pt-6 pb-16 flex flex-col gap-6", maxWidth, className)}
+      >
+        {brand ? (
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <BrandMark href="/" size="sm" />
+            <div class="flex items-center gap-2">
+              <LinkButton
+                href={FEEDBACK_MAILTO}
+                variant="ghost"
+                size="sm"
+                title="Email drydock@resynapse.dev with any issues"
+              >
+                Feedback
+              </LinkButton>
+              {headerActions}
+            </div>
           </div>
+        ) : null}
+        {centered ? (
+          // `my-auto` (not justify-center) so over-tall content never clips off-screen.
+          <div class="my-auto flex w-full flex-col gap-6">{children}</div>
+        ) : (
+          children
+        )}
+      </main>
+      <SiteFooter maxWidth={maxWidth} />
+    </div>
+  );
+}
+
+function SiteFooter({ maxWidth }: { maxWidth: string }) {
+  const linkClass =
+    "text-ink-muted no-underline transition-colors hover:text-ink focus-visible:text-ink";
+  return (
+    <footer class="border-t border-border">
+      <div
+        class={cn(
+          "mx-auto flex w-full flex-col gap-4 px-6 py-8 sm:flex-row sm:items-center sm:justify-between",
+          maxWidth,
+        )}
+      >
+        <div class="flex flex-col gap-1">
+          <BrandMark href="/" size="sm" />
+          <p class="m-0 font-mono text-[11px] text-ink-subtle">
+            Pre-publish review for npm and PyPI · © 2026 Drydock
+          </p>
         </div>
-      ) : null}
-      {children}
-    </main>
+        <nav class="flex flex-wrap items-center gap-x-5 gap-y-2 text-[13px]" aria-label="Footer">
+          <a href="/docs" class={linkClass}>
+            Docs
+          </a>
+          <a href={FEEDBACK_MAILTO} class={linkClass}>
+            Feedback
+          </a>
+          <a href={SECURITY_MAILTO} class={linkClass}>
+            Security
+          </a>
+        </nav>
+      </div>
+    </footer>
   );
 }

--- a/src/pages/Auth/VerifyEmail.tsx
+++ b/src/pages/Auth/VerifyEmail.tsx
@@ -82,7 +82,7 @@ export default function VerifyEmailPage() {
         <Card class="flex flex-col gap-4">
           <Eyebrow>Email verified</Eyebrow>
           <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">You're all set</h1>
-          <Alert tone="ok">Your email is verified. You can sign in now.</Alert>
+          <Alert tone="ok">Your email is verified — you can sign in now.</Alert>
           <Button onClick={() => location.route("/login", true)}>Go to sign in</Button>
         </Card>
       </PageShell>

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -275,7 +275,7 @@ function ScanPreview() {
           <SeverityBar counts={{ critical: 1, medium: 1 }} class="max-w-[420px]" />
         </header>
 
-        <div class="grid grid-cols-1 md:grid-cols-[200px_minmax(0,1fr)] divide-y md:divide-y-0 md:divide-x divide-border">
+        <div class="grid grid-cols-1 md:grid-cols-[220px_minmax(0,1fr)] divide-y md:divide-y-0 md:divide-x divide-border">
           <aside class="p-4 flex flex-col gap-2 bg-bg/40">
             <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">
               Release tree
@@ -297,7 +297,7 @@ function ScanPreview() {
                 <code class="font-mono text-xs text-ink-muted truncate">package.json</code>
               </div>
               <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">
-                v4.2.0 → v4.3.0
+                4.2.0 → 4.3.0
               </span>
             </div>
 

--- a/src/style.css
+++ b/src/style.css
@@ -48,8 +48,16 @@
   }
 }
 
+/* Dark-mode overrides MUST live on a plain `:root` inside this media query, not
+   inside `@theme`. Tailwind v4 hoists every `@theme` block to one unconditional
+   top-level `:root` and discards the surrounding `@media` — so a nested dark
+   `@theme` overwrote the light tokens for everyone, leaving the whole site stuck
+   in dark mode. The light tokens above still register the namespaces, so utilities
+   keep emitting `var(--color-*)`; re-binding those variables here flips the theme
+   only when the user actually prefers dark. (The `--sh-token-*` block below has
+   always used this pattern correctly.) */
 @media (prefers-color-scheme: dark) {
-  @theme {
+  :root {
     --color-bg: #0a0a0a;
     --color-surface: #141414;
     --color-surface-2: #1c1c1c;
@@ -57,7 +65,10 @@
     --color-border-strong: #3f3f46;
     --color-ink: #fafafa;
     --color-ink-muted: #a1a1aa;
-    --color-ink-subtle: #71717a;
+    /* #71717a was only 3.8:1 on cards — failing AA for the mono detail line and
+       11px labels. #8b8b94 clears AA (≥5:1) on bg, surface, and surface-2 while
+       staying clearly below --color-ink-muted in the hierarchy. */
+    --color-ink-subtle: #8b8b94;
 
     --color-accent: #fb923c;
     --color-accent-hover: #fdba74;
@@ -79,9 +90,7 @@
 
     --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
     --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.5);
-  }
 
-  :root {
     --sh-token-string: #4db6a4;
     --sh-token-string-expression: #4db6a4;
     --sh-token-link: #4db6a4;

--- a/test/style-theme.test.mjs
+++ b/test/style-theme.test.mjs
@@ -1,0 +1,81 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+// Guards the theming invariants from the 2026-06-10 design-review pass. The
+// light-mode bug these protect against was invisible in normal development
+// (the site renders fine in dark mode), so it needs a source-level guard.
+const css = readFileSync(fileURLToPath(new URL("../src/style.css", import.meta.url)), "utf8");
+
+/** Return the body of the first `@media (prefers-color-scheme: dark)` block. */
+function darkMediaBlock(source) {
+  const marker = source.match(/@media[^{]*prefers-color-scheme:\s*dark[^{]*\{/);
+  if (!marker) return null;
+  let depth = 0;
+  const start = marker.index + marker[0].length;
+  for (let i = start; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      if (depth === 0) return source.slice(start, i);
+      depth--;
+    }
+  }
+  return null;
+}
+
+/** WCAG relative luminance for a #rrggbb string. */
+function luminance(hex) {
+  const channels = [1, 3, 5].map((i) => {
+    const c = parseInt(hex.slice(i, i + 2), 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+}
+
+function contrast(a, b) {
+  const la = luminance(a);
+  const lb = luminance(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+
+function tokenInBlock(block, name) {
+  const match = block.match(new RegExp(`${name}:\\s*(#[0-9a-fA-F]{6})`));
+  return match ? match[1] : null;
+}
+
+describe("theme tokens", () => {
+  const dark = darkMediaBlock(css);
+
+  test("a prefers-color-scheme: dark media block exists", () => {
+    expect(dark).not.toBeNull();
+  });
+
+  test("dark tokens are NOT inside a nested @theme", () => {
+    // Tailwind v4 hoists every `@theme` to one unconditional top-level `:root`
+    // and drops the surrounding @media. A dark `@theme` therefore overrides the
+    // light default for everyone and strands the site in dark mode.
+    expect(dark).not.toContain("@theme");
+  });
+
+  test("light and dark define distinct --color-bg (both modes reachable)", () => {
+    // Light value lives in the top-level @theme; dark value lives in the media block.
+    const lightBg = css.match(/--color-bg:\s*(#[0-9a-fA-F]{6})/)?.[1];
+    const darkBg = tokenInBlock(dark, "--color-bg");
+    expect(lightBg?.toLowerCase()).toBe("#fafaf9");
+    expect(darkBg?.toLowerCase()).toBe("#0a0a0a");
+  });
+
+  test("dark --color-ink-subtle passes WCAG AA on every dark surface", () => {
+    const subtle = tokenInBlock(dark, "--color-ink-subtle");
+    const surfaces = ["--color-bg", "--color-surface", "--color-surface-2"]
+      .map((name) => tokenInBlock(dark, name))
+      .filter(Boolean);
+    expect(subtle).toBeTruthy();
+    expect(surfaces.length).toBe(3);
+    for (const surface of surfaces) {
+      // 4.5:1 is the AA floor for the 11px mono labels / detail line.
+      expect(contrast(subtle, surface)).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+});


### PR DESCRIPTION
A design review of the live site surfaced one **critical** bug and several polish gaps. All findings the review flagged as defects are fixed here.

## 🔴 Critical — light mode was unreachable
The dark tokens lived in an `@theme` **nested inside** `@media (prefers-color-scheme: dark)`. Tailwind v4 hoists every `@theme` to one unconditional top-level `:root` and **discards the surrounding `@media`** — so the dark values overrode the light default for everyone. The site rendered dark regardless of OS preference, and light mode (the documented *default* surface) never shipped.

**Fix:** moved the dark tokens to a media-scoped plain `:root` — the exact pattern the adjacent `--sh-token-*` block already used correctly. Verified in-browser: under a light OS preference `--color-bg` now resolves to `#fafaf9` (light); dark stays `#0a0a0a`.

| | before | after |
|---|---|---|
| light OS preference | renders **dark** (#0a0a0a) | renders **light** (#fafaf9) ✅ |
| compiled `--color-bg` | only `#0a0a0a`, unconditional | `#fafaf9` flat + `#0a0a0a` media-scoped ✅ |

## 🟠 Medium — dark subtle text failed WCAG AA
Dark `--color-ink-subtle` `#71717a` was **3.8:1** on cards — failing AA for the signature mono detail line and 11px labels (the dark-mode counterpart to the light-mode floor codified 2026-06-03). Bumped to `#8b8b94` → **5.07–5.89:1** across bg/surface/surface-2, still clearly below `--color-ink-muted` in the hierarchy.

## 🟡 Polish
- **Site footer** (new): brand + `Docs` / `Feedback` / `Security` links + copyright, on every route via `PageShell`. First trust/legal link surface — pages previously just ended in empty space.
- **Auth/404/invite cards** now vertically center between header and footer (via `my-auto`, which never clips over-tall content) instead of floating high with a large void below.
- **Landing sample-review mockup:** dropped the `v` version prefix (`v4.2.0` → `4.2.0 → 4.3.0`) to match the app's convention; widened the file-tree column `200→220px` so `package.json` stops truncating.
- **verify-email** success Alert reduced to one sentence (DESIGN.md state-copy rule).

## Tests / docs
- New `test/style-theme.test.mjs` guards the *otherwise-invisible* theming invariants: no `@theme` nested in the dark media query, both `--color-bg` values defined, dark subtle text ≥4.5:1 on every dark surface.
- DESIGN.md updated (dark `--fg-subtle` token, the Tailwind-v4 theming rule, the footer/page-structure spec, and a Decisions Log entry).
- `pnpm run verify` (lint + format + typecheck + node/worker tests) passes. Verified in-browser across light + dark and desktop + mobile (375px), no horizontal overflow.

## Deliberately NOT changed (documented design choices)
- **Hero desktop "dead space"** — the ~440px empty gutter beside the 760px headline is the *deliberate single-column hero* per DESIGN.md ("hero is type + brand mark + Cards"). Left as-is to avoid deviating from the source of truth.
- **No manual theme toggle** — DESIGN.md's default is auto-follow `prefers-color-scheme`. Now that the bug above is fixed, auto-follow works in both directions. A persistent override toggle is a feature (placement/persistence/glyph decisions) for a separate change — happy to add it if wanted.

## Not reviewed (coverage gap)
The authenticated product (dashboard, the scan-detail **diff workbench**, settings, account) is gated and auth is `503 "not configured"` in local dev, so those surfaces — where DESIGN.md invests the most detail — were not part of this review or PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)