### PR TITLE
Stop duplicating scan detail into D1 for R2-backed scans

### DIFF
--- a/docs/artifact-storage.md
+++ b/docs/artifact-storage.md
@@ -24,7 +24,7 @@ Completed scans can be artifact-backed when these `scans` columns are set:
 - `file_samples_artifact_key`
 - `diff_artifact_key`
 
-D1 still keeps scan status/lifecycle fields, ownership, package/version metadata, decisions, compact list summaries, report digest/version, file metadata, and findings. Artifact-backed new scans write `scan_files` rows with `text_sample = NULL`; the redacted samples live in R2. Existing rows keep their historical `scan_files.text_sample` values until a later explicit compaction step.
+D1 still keeps scan status/lifecycle fields, ownership, package/version metadata, decisions, compact list summaries (including `risk_summary_json` and the summary-embedded diff), and report digest/version. The per-row detail — `scan_files` and `scan_findings` — is **no longer duplicated into D1 for artifact-backed scans**: once the R2 write succeeds, `persistScan` skips those inserts entirely and the detail (file metadata, redacted samples, diff, deterministic findings) is read back from `files.json` / `diff.json` / `report.json`. The detail rows are written only on the degraded path (no `ARTIFACTS` binding, so the R2 write was skipped and the scan falls back to D1). Legacy rows written before this change keep their historical `scan_files` / `scan_findings` content; the read path prefers R2 for any scan that carries artifact metadata.
 
 ## Object Layout
 
@@ -45,21 +45,22 @@ User-initiated report downloads serve the same canonical `report.json` bytes wit
 
 ## Write And Read Flow
 
-New completed scans try to write `report.json`, `files.json`, `diff.json`, and `manifest.json` to R2 before `persistScan` marks the D1 row artifact-backed. Each object is read back and verified against its expected size and SHA-256 digest before D1 metadata is saved. Transient write or verification failures are retried; exhausted failures log `scan.artifacts.write_failed` and fail closed so the scan can retry instead of persisting new file samples into D1. When the R2 write succeeds, D1 stores compact file metadata only and leaves `scan_files.text_sample` null.
+New completed scans try to write `report.json`, `files.json`, `diff.json`, and `manifest.json` to R2 before `persistScan` marks the D1 row artifact-backed. Each object is read back and verified against its expected size and SHA-256 digest before D1 metadata is saved. Transient write or verification failures are retried; exhausted failures log `scan.artifacts.write_failed` and fail closed so the scan can retry instead of persisting detail into D1. When the R2 write succeeds, D1 stores the scan metadata row only — no `scan_files` or `scan_findings` rows are written, so the redacted samples, file metadata, diff, and findings live exclusively in R2.
 
-`GET /api/v1/scans/:id` returns D1-backed scan metadata, findings, events, and file metadata without loading staged file bodies. The dashboard fetches a selected staged body through:
+`GET /api/v1/scans/:id` returns scan metadata, deterministic findings, events, and file metadata without staged file bodies. For artifact-backed scans the findings, diff, and file metadata come from R2 (`report.json` / `diff.json` / `files.json`); legacy and degraded scans read them from the D1 `scan_findings` / `scan_files` rows. The dashboard fetches a selected staged body on demand through:
 
 ```http
 GET /api/v1/scans/:id/file?path=package.json
 ```
 
-The file-body route shadow-reads R2 when all artifact metadata exists. The artifact read path verifies:
+Both the detail read and the file-body read shadow-read R2 when all artifact metadata exists. The artifact read path verifies:
 
 - manifest key, size, and digest;
 - manifest scan/org identity and object-key references;
-- file/diff payload shape.
+- on the detail read, the `report.json` digest against `scans.report_digest` (the findings are parsed from that verified report);
+- each object's size + digest against the manifest descriptor, and the file/diff payload shape.
 
-Any mismatch, missing object, invalid payload, or R2 read failure logs `scan.artifacts.fallback_read` and returns the existing D1-backed metadata instead. For artifact-backed scans created after this rollout, that fallback keeps file metadata and findings readable but does not include redacted file text samples because new samples are not duplicated into D1.
+Any mismatch, missing object, invalid payload, or R2 read failure logs `scan.artifacts.fallback_read` and returns the D1-backed detail instead. For scans created before D1 detail compaction (or written on the degraded path), that fallback still returns the D1 `scan_files` / `scan_findings` rows. For compacted artifact-backed scans the detail rows do not exist in D1, so a fallback read returns the scan metadata, risk summary, and the summary-embedded diff but no file samples or findings — the read degrades gracefully rather than failing. This is the single-source-of-truth tradeoff the compaction accepts; `SCAN_ARTIFACT_READS_DISABLED` is not a recovery path for these rows because the data is no longer in D1.
 
 ## Backfill
 
@@ -95,6 +96,8 @@ The script defaults to the production `staged-publish-review` D1 database and `s
 
 ## Rollback
 
-Set `SCAN_ARTIFACT_READS_DISABLED=true` (or `1`) to force scan-detail reads back to D1 while leaving R2 artifacts untouched. Do not delete R2 objects during rollback. This restores historical D1-backed samples for old rows; new artifact-backed rows continue to show compact file metadata without samples until R2 reads are re-enabled.
+Set `SCAN_ARTIFACT_READS_DISABLED=true` (or `1`) to force scan-detail reads back to D1 while leaving R2 artifacts untouched. Do not delete R2 objects during rollback. This restores D1-backed detail for legacy/degraded rows that still have `scan_files` / `scan_findings` content. It does **not** recover detail for compacted artifact-backed scans (the rows were never written), so disabling reads for those rows shows metadata only — keep R2 reads enabled for them. The safe operational lever for a suspect R2 read remains the per-object digest/size verification, which already fails closed to the metadata view.
 
-D1 compaction is a later explicit step after backfill and shadow-read confidence. Compaction must not run until operators are comfortable with fallback/read metrics and have a separate rollback plan for any compacted rows.
+## D1 Detail Compaction
+
+New artifact-backed scans are compacted at write time: `persistScan` no longer duplicates `scan_files` / `scan_findings` into D1 once the R2 write is verified (see `server/db/scans.ts`). R2 is therefore the single source of truth for file samples, file metadata, the diff, and deterministic findings on those scans. The degraded path (no `ARTIFACTS` binding) still writes the detail to D1 so a scan that cannot reach R2 stays fully readable. Legacy rows written before this change are unaffected until an explicit one-time D1 cleanup of their now-redundant detail rows — that cleanup is still a separate, deliberate step and must only target rows that already carry verified artifact metadata.

--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -175,6 +175,9 @@ export async function discardGateScans(db: AppDb, gateId: string, organizationId
 export async function persistScan(db: AppDb, input: PersistedScanInput) {
   const now = new Date();
   const artifactFileRows = scanFileRowsForArtifacts(input.files, input.diff);
+  // These rows are only persisted on the degraded path (no R2 artifacts), so
+  // they carry the full redacted sample — R2-backed scans skip the insert
+  // entirely below and serve samples from files.json instead.
   const fileRows = artifactFileRows.map((file) => {
     return {
       id: crypto.randomUUID(),
@@ -184,7 +187,7 @@ export async function persistScan(db: AppDb, input: PersistedScanInput) {
       size: file.size,
       sha256: file.sha256,
       flagsJson: file.flagsJson,
-      textSample: input.artifacts ? null : file.textSample,
+      textSample: file.textSample,
     };
   });
   const findingRows = input.findings.map((finding) => ({
@@ -294,19 +297,29 @@ export async function persistScan(db: AppDb, input: PersistedScanInput) {
     await db.insert(scans).values(scanValues).onConflictDoNothing({ target: scans.id });
   }
 
+  // Always clear prior detail rows first so a retry — including one that flips a
+  // scan from D1-backed to R2-backed — never leaves stale rows behind.
   await Promise.all([
     db.delete(scanFiles).where(eq(scanFiles.scanId, input.id)),
     db.delete(scanFindings).where(eq(scanFindings.scanId, input.id)),
   ]);
 
-  // D1 caps bound parameters at 100 per query, so insert in chunks sized to
-  // each row's column count. Without this, packages with more than ~12 files
-  // silently drop their scan_files rows and the scan-detail view renders as
-  // "No file content available." for every entry.
-  await Promise.all([
-    ...chunkForD1(fileRows, 8).map((chunk) => db.insert(scanFiles).values(chunk)),
-    ...chunkForD1(findingRows, 10).map((chunk) => db.insert(scanFindings).values(chunk)),
-  ]);
+  // When the scan is R2-artifact-backed, its redacted file samples, file
+  // metadata, diff, and findings already live in R2 (files.json / diff.json /
+  // report.json) and are read back from there, so persisting the same rows into
+  // D1 would be a pure duplicate. Only the degraded path — the R2 write was
+  // skipped (no bucket) and `artifacts` is null — falls back to storing the
+  // detail in D1 so the scan stays readable.
+  if (!input.artifacts) {
+    // D1 caps bound parameters at 100 per query, so insert in chunks sized to
+    // each row's column count. Without this, packages with more than ~12 files
+    // silently drop their scan_files rows and the scan-detail view renders as
+    // "No file content available." for every entry.
+    await Promise.all([
+      ...chunkForD1(fileRows, 8).map((chunk) => db.insert(scanFiles).values(chunk)),
+      ...chunkForD1(findingRows, 10).map((chunk) => db.insert(scanFindings).values(chunk)),
+    ]);
+  }
 
   return { persisted: true as const };
 }
@@ -687,8 +700,15 @@ export async function getScan(
   const responseFiles =
     (options.includeFileSamples ?? true) ? detailFiles : detailFiles.map(stripFileSampleForList);
   const diff = artifactDetail?.diff ?? diffForFindingAnnotations(scan.summaryJson, detailFiles);
-  const annotatedFindings = annotateFindingsWithDiffStatus(findings, diff, {
-    persistedAnnotations: readFindingAnnotations(scan.summaryJson),
+  // Artifact-backed scans no longer duplicate their findings into `scan_findings`
+  // (see persistScan); read them, with annotations, from the digest-verified
+  // report.json. The D1 rows + summary-embedded annotations stay the source for
+  // legacy/degraded scans that were never R2-backed.
+  const findingRows = artifactDetail ? artifactDetail.findings : findings;
+  const annotatedFindings = annotateFindingsWithDiffStatus(findingRows, diff, {
+    persistedAnnotations: artifactDetail
+      ? artifactDetail.findingAnnotations
+      : readFindingAnnotations(scan.summaryJson),
   });
   return {
     scan,
@@ -744,7 +764,12 @@ export async function getScanStatus(db: AppDb, id: string, organizationId: strin
   return scan ?? null;
 }
 
-export async function getScanCompareData(db: AppDb, id: string, organizationId: string) {
+export async function getScanCompareData(
+  db: AppDb,
+  id: string,
+  organizationId: string,
+  artifactBucket?: R2Bucket,
+) {
   const [scanRows, files, findings] = await Promise.all([
     db
       .select()
@@ -756,7 +781,13 @@ export async function getScanCompareData(db: AppDb, id: string, organizationId: 
   ]);
   const scan = scanRows[0];
   if (!scan) return null;
-  return { scan, files: files.map(stripFileSampleForList), findings };
+  // Compare annotations need this scan's file metadata + findings. For
+  // artifact-backed scans those no longer live in D1, so source them from R2
+  // (samples are stripped either way — compare diffs at file granularity).
+  const artifactDetail = await loadScanArtifacts(artifactBucket, scan);
+  const detailFiles = artifactDetail ? mergeArtifactFiles(files, artifactDetail.files, id) : files;
+  const findingRows = artifactDetail ? artifactDetail.findings : findings;
+  return { scan, files: detailFiles.map(stripFileSampleForList), findings: findingRows };
 }
 
 function stripFileSampleForList<T extends { textSample: string | null }>(file: T): T {

--- a/server/lib/scan-artifacts.ts
+++ b/server/lib/scan-artifacts.ts
@@ -1,4 +1,10 @@
-import type { DiffEntry, FileRecord } from "./review";
+import {
+  normalizeFindingDiffStatus,
+  type DiffEntry,
+  type FileRecord,
+  type Finding,
+  type FindingDiffAnnotation,
+} from "./review";
 import { describeOperationalError, emitOperationalEvent } from "./observability";
 import { sha256Hex, stableJson, utf8Size } from "./stable-json";
 
@@ -32,6 +38,23 @@ export interface ScanArtifactFileRow {
   textSample: string | null;
 }
 
+// Mirrors `scan_findings.$inferSelect` so an R2-sourced finding is a drop-in
+// replacement for a D1 row on the read path. The id is derived from the finding
+// index (`artifactFindingId`) rather than a persisted UUID, so it stays stable
+// across reads without a per-finding D1 row.
+export interface ScanArtifactFindingRow {
+  id: string;
+  scanId: string;
+  severity: string;
+  file: string;
+  evidence: string;
+  reason: string;
+  line: number | null;
+  source: string;
+  ruleId: string | null;
+  ruleVersion: string | null;
+}
+
 export interface ScanArtifactScanRow {
   id: string;
   organizationId: string | null;
@@ -48,6 +71,11 @@ export interface ScanArtifactScanRow {
 export interface ScanArtifactsDetail {
   files: ScanArtifactFileRow[];
   diff: DiffEntry[];
+  // Deterministic findings + their diff annotations, parsed from the canonical
+  // report.json. These let the detail read source findings from R2 once the
+  // duplicate `scan_findings` rows are no longer written to D1.
+  findings: ScanArtifactFindingRow[];
+  findingAnnotations: Map<string, FindingDiffAnnotation>;
 }
 
 export interface ScanArtifactsManifestDetail {
@@ -238,28 +266,52 @@ export async function loadScanArtifacts(
 ): Promise<ScanArtifactsDetail | null> {
   const manifestDetail = await loadScanArtifactsManifest(bucket, scan);
   if (!manifestDetail) return null;
+  const { manifest } = manifestDetail;
+
+  // The detail read also sources findings from report.json (they are no longer
+  // duplicated into D1), so the verified manifest's report descriptor must match
+  // the digest D1 recorded for the scan. readVerifiedJsonText then ties the
+  // report bytes to that digest, making the parsed findings authoritative.
+  if (manifest.artifacts.report.digest !== scan.reportDigest) {
+    emitArtifactFallback("report_digest_mismatch", scan, {
+      expectedDigest: scan.reportDigest,
+      actualDigest: manifest.artifacts.report.digest,
+    });
+    return null;
+  }
 
   try {
-    const [filesText, diffText] = await Promise.all([
+    const [reportText, filesText, diffText] = await Promise.all([
       readVerifiedJsonText(bucket as R2Bucket, {
-        ...manifestDetail.manifest.artifacts.files,
+        ...manifest.artifacts.report,
+        scanId: scan.id,
+        kind: "report",
+      }),
+      readVerifiedJsonText(bucket as R2Bucket, {
+        ...manifest.artifacts.files,
         scanId: scan.id,
         kind: "files",
       }),
       readVerifiedJsonText(bucket as R2Bucket, {
-        ...manifestDetail.manifest.artifacts.diff,
+        ...manifest.artifacts.diff,
         scanId: scan.id,
         kind: "diff",
       }),
     ]);
 
+    const reportFindings = parseReportFindings(reportText, scan.id);
     const files = parseFilesArtifact(filesText, scan.id);
     const diff = parseDiffArtifact(diffText, scan.id);
-    if (!files || !diff) {
+    if (!files || !diff || !reportFindings) {
       emitArtifactFallback("artifact_payload_invalid", scan);
       return null;
     }
-    return { files, diff };
+    return {
+      files,
+      diff,
+      findings: reportFindings.findings,
+      findingAnnotations: reportFindings.annotations,
+    };
   } catch (err) {
     emitArtifactFallback("read_failed", scan, { error: describeOperationalError(err) });
     return null;
@@ -515,6 +567,72 @@ function parseDiffArtifact(text: string, scanId: string): DiffEntry[] | null {
     });
   }
   return diff;
+}
+
+// Stable, content-free id for an R2-sourced finding. The detail read and the
+// compare endpoint both key findings by id (React keys + annotation joins), so
+// the same scan/index must always yield the same id without a persisted UUID.
+function artifactFindingId(scanId: string, index: number): string {
+  return `${scanId}:finding:${index}`;
+}
+
+// Rebuild the deterministic findings and their diff annotations from the
+// digest-verified report.json. `ruleFindings` is the ordered finding list and
+// `findingAnnotations` references each by `findingIndex`; we re-key both by the
+// derived finding id so the annotation join matches the rows we hand back.
+// Returns null only when the findings array is structurally invalid — an empty
+// array (a clean scan) is valid and yields no findings.
+function parseReportFindings(
+  text: string,
+  scanId: string,
+): { findings: ScanArtifactFindingRow[]; annotations: Map<string, FindingDiffAnnotation> } | null {
+  const parsed = parseJsonObject(text);
+  const rawFindings = parsed?.ruleFindings;
+  if (!Array.isArray(rawFindings)) return null;
+
+  const findings: ScanArtifactFindingRow[] = [];
+  for (let index = 0; index < rawFindings.length; index += 1) {
+    const entry = rawFindings[index];
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
+    const item = entry as Partial<Finding>;
+    if (
+      typeof item.severity !== "string" ||
+      typeof item.file !== "string" ||
+      typeof item.evidence !== "string" ||
+      typeof item.reason !== "string"
+    ) {
+      return null;
+    }
+    findings.push({
+      id: artifactFindingId(scanId, index),
+      scanId,
+      severity: item.severity,
+      file: item.file,
+      evidence: item.evidence,
+      reason: item.reason,
+      line: typeof item.line === "number" ? item.line : null,
+      source: "rule",
+      ruleId: typeof item.ruleId === "string" ? item.ruleId : null,
+      ruleVersion: typeof item.ruleVersion === "string" ? item.ruleVersion : null,
+    });
+  }
+
+  const annotations = new Map<string, FindingDiffAnnotation>();
+  const rawAnnotations = parsed?.findingAnnotations;
+  if (Array.isArray(rawAnnotations)) {
+    for (const entry of rawAnnotations) {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+      const index = (entry as { findingIndex?: unknown }).findingIndex;
+      if (typeof index !== "number" || !Number.isInteger(index)) continue;
+      if (index < 0 || index >= findings.length) continue;
+      annotations.set(artifactFindingId(scanId, index), {
+        diffStatus: normalizeFindingDiffStatus((entry as { diffStatus?: unknown }).diffStatus),
+        releaseDelta: Boolean((entry as { releaseDelta?: unknown }).releaseDelta),
+      });
+    }
+  }
+
+  return { findings, annotations };
 }
 
 function parseJsonObject(text: string): Record<string, unknown> | null {

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -294,7 +294,14 @@ scansRoutes.get("/:id/report.json", async (c) => {
   const db = createDb(c.env.DB);
   const organizationId = await resolveReportExportOrganization(c, db);
   if (!organizationId) return c.json({ error: "not found" }, 404);
-  const detail = await getScan(db, c.req.param("id"), organizationId);
+  // Full-detail export: the findings come from R2 for artifact-backed scans, so
+  // load the artifact bucket (unlike the metadata-only reads below).
+  const detail = await getScan(
+    db,
+    c.req.param("id"),
+    organizationId,
+    scanArtifactReadBucket(c.env),
+  );
   if (!detail) return c.json({ error: "not found" }, 404);
   if (detail.scan.status !== "complete") {
     return c.json({ error: "report export is only available for completed scans" }, 409);
@@ -425,7 +432,7 @@ async function resolveCompareContext(
   const db = createDb(c.env.DB);
   const session = c.get("authSession");
   const organizationId = await requireActiveOrganization(c, db);
-  const scan = await getScanCompareData(db, scanId, organizationId);
+  const scan = await getScanCompareData(db, scanId, organizationId, scanArtifactReadBucket(c.env));
   if (!scan) return { error: c.json({ error: "not found" }, 404) } as const;
   if (!scan.scan.packageName)
     return { error: c.json({ error: "scan has no package name" }, 400) } as const;

--- a/test/workers/scan-artifacts-routes.test.ts
+++ b/test/workers/scan-artifacts-routes.test.ts
@@ -348,32 +348,57 @@ describe("scan artifact backfill route", () => {
     expect(fake.putCalls()).toBe(SCAN_ARTIFACT_WRITE_ATTEMPTS);
   });
 
-  test("new artifact-backed scans keep D1 file rows compact", async () => {
+  test("new artifact-backed scans skip D1 detail rows and serve files + findings from R2", async () => {
     const owner = await seedUser();
     const app = buildTestApp(owner);
     const { db, scanId } = await seedDigestMatchedLegacyScan(owner, { artifactBacked: true });
 
-    const d1Rows = await db
-      .select({
-        path: schema.scanFiles.path,
-        textSample: schema.scanFiles.textSample,
-      })
+    // The duplicate per-row detail is no longer written to D1 once the scan is
+    // R2-backed; files.json / report.json hold it instead.
+    const fileRows = await db
+      .select({ path: schema.scanFiles.path })
       .from(schema.scanFiles)
       .where(eq(schema.scanFiles.scanId, scanId));
-    expect(d1Rows.length).toBeGreaterThan(0);
-    expect(d1Rows.every((row) => row.textSample === null)).toBe(true);
+    const findingRows = await db
+      .select({ id: schema.scanFindings.id })
+      .from(schema.scanFindings)
+      .where(eq(schema.scanFindings.scanId, scanId));
+    expect(fileRows.length).toBe(0);
+    expect(findingRows.length).toBe(0);
 
+    // Without the artifact bucket a compacted scan exposes no file/finding detail
+    // (graceful degradation, not a crash).
     const d1Only = await getScan(db, scanId, owner.organizationId);
-    expect(d1Only?.files.find((file) => file.path === "index.js")?.textSample).toBeNull();
+    expect(d1Only?.files.length).toBe(0);
+    expect(d1Only?.findings.length).toBe(0);
 
+    // The detail route loads the bucket, so file metadata and findings come back
+    // from R2 (staged bodies are stripped here and fetched via /file).
     const detailRes = await fetchJsonWithSession(app, `/api/v1/scans/${scanId}`, {
       method: "GET",
     });
     expect(detailRes.status).toBe(200);
     const detail = (await detailRes.json()) as {
       files: Array<{ path: string; textSample: string | null }>;
+      findings: Array<{
+        file: string;
+        ruleId: string | null;
+        severity: string;
+        diffStatus: string;
+        releaseDelta: boolean;
+      }>;
     };
+    // The detail route strips staged bodies (fetched separately via /file), but
+    // findings still come from R2, annotated from the report's findingAnnotations.
     expect(detail.files.find((file) => file.path === "index.js")?.textSample).toBeNull();
+    expect(detail.findings).toHaveLength(1);
+    expect(detail.findings[0]).toMatchObject({
+      file: "index.js",
+      ruleId: "code.credential-access",
+      severity: "high",
+      diffStatus: "added",
+      releaseDelta: true,
+    });
 
     const statusRes = await fetchJsonWithSession(app, `/api/v1/scans/${scanId}/status`, {
       method: "GET",
@@ -383,12 +408,26 @@ describe("scan artifact backfill route", () => {
       scan: { id: scanId, status: "complete" },
     });
 
+    // The staged body has no D1 row, so the file-body route serves it from R2.
     const fileRes = await fetchJsonWithSession(app, `/api/v1/scans/${scanId}/file?path=index.js`, {
       method: "GET",
     });
     expect(fileRes.status).toBe(200);
     const fileDetail = (await fileRes.json()) as { file: { textSample: string | null } };
     expect(fileDetail.file.textSample).toContain("npm_config_user_agent");
+
+    // The report.json export is a full-detail read, so it must also pull findings
+    // from R2 for a compacted scan rather than the (now empty) D1 rows.
+    const exportRes = await fetchJsonWithSession(app, `/api/v1/scans/${scanId}/report.json`, {
+      method: "GET",
+    });
+    expect(exportRes.status).toBe(200);
+    const exported = (await exportRes.json()) as {
+      findings: Array<{ ruleId: string | null; severity: string }>;
+    };
+    expect(exported.findings).toEqual([
+      expect.objectContaining({ ruleId: "code.credential-access", severity: "high" }),
+    ]);
   });
 
   test("backfills legacy scan artifacts and detail reads survive D1 sample compaction", async () => {

--- a/test/workers/workflow-gate-job.test.ts
+++ b/test/workers/workflow-gate-job.test.ts
@@ -589,7 +589,9 @@ describe("executeWorkflowGateJob", () => {
     );
     expect(reviewed?.recommendation).toBe("rejected");
 
-    const persisted = await getScan(db, gate!.scanId!, seeded.organizationId);
+    // The gate scan is R2-artifact-backed, so its findings live in report.json,
+    // not D1 — read with the artifact bucket like the real detail route does.
+    const persisted = await getScan(db, gate!.scanId!, seeded.organizationId, env.ARTIFACTS);
     expect(persisted?.scan.riskSummaryJson).toMatchObject({
       artifactRisk: "high",
       releaseRisk: "high",


### PR DESCRIPTION
Once the R2 artifact write is verified, `persistScan` no longer writes the duplicate `scan_files` / `scan_findings` rows — R2 (`files.json` / `diff.json` / `report.json`) becomes the single source of truth for file samples, metadata, the diff, and deterministic findings. `getScan` now sources findings and their diff annotations from the digest-verified `report.json` (with deterministic finding ids), and the `report.json` export route passes the artifact bucket so compacted scans still export findings. The degraded path (no `ARTIFACTS` binding) still writes detail to D1, so a scan that can't reach R2 stays fully readable. Tests cover that artifact-backed scans write zero detail rows and serve files + findings from R2, and `docs/artifact-storage.md` documents the compaction, the read fallback, and the rollback caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)