### PR TITLE
Add scan comments with @-mentions and mention emails

### DIFF
--- a/docs/scan-comments.md
+++ b/docs/scan-comments.md
@@ -1,0 +1,56 @@
+# Scan comments and mentions
+
+Completed scans carry a team discussion: general comments, comments anchored to
+a staged line in the diff, and comments anchored to a finding. Members can
+@-mention teammates, and mentioned users get a best-effort email (opt-out per
+user).
+
+## Data model
+
+- `scan_comments` — one row per comment, scoped by `scan_id` and
+  `organization_id`. Anchors: `anchor_type` of `general`, `line`
+  (`file_path` + `line`, with the staged file's `sha256` captured at write time
+  — scans are immutable, so anchors never go stale), or `finding`
+  (`finding_id`, which also denormalizes the finding's file/line for inline
+  rendering). `parent_id` supports replies. Deletes are soft (`deleted_at`);
+  the API serializes tombstones with the body and author redacted.
+- `scan_comment_mentions` — one row per (comment, mentioned user), unique.
+  `notified_at` records successful email delivery, making notification
+  idempotent: editing a comment only notifies _newly added_ mentions.
+- `user_notification_settings` — per-user preferences keyed by `user_id`.
+  `mention_emails` defaults to true; absence of a row means defaults.
+
+Organization deletion and account deletion clean these tables up explicitly
+(D1 does not enforce foreign keys); comments by a deleted account survive with
+`author_user_id` nulled, rendered as "former member".
+
+## API
+
+- `GET/POST /api/v1/scans/:scanId/comments` — list / create. Creation
+  validates the anchor against the scan's files/findings, caps bodies at 4000
+  chars, and is rate-limited per user per organization (30/h).
+- `PATCH/DELETE /api/v1/scans/:scanId/comments/:commentId` — author-only edit;
+  delete by the author or an owner/admin.
+- `GET/PATCH /api/v1/account/notification-settings` — the per-user mention
+  email toggle (surfaced on the Account page).
+
+All routes resolve the scan through the active organization
+(`x-organization-id`), so cross-org access yields 404.
+
+## Mentions
+
+Mentions are stored as structured `@[userId]` tokens in the body, never display
+names. The server resolves tokens to organization members and silently drops
+non-members (prevents user-id enumeration); the UI's composer autocomplete
+(type `@`) inserts tokens and renders them as highlighted `@Name` resolved from
+the live member list. Mention emails (`server/lib/notify.ts`
+`notifyCommentMention`) are dispatched on `waitUntil`, carry only the comment
+text and a `path:line` label — never scan evidence — and record
+`scan.comment_mention_sent` / `_failed` audit events.
+
+## UI
+
+The scan detail page shows a Discussion card under the report sections.
+Line-anchored comments also render inline in the diff beneath their staged
+line; hovering a staged line's number shows a `+` affordance that pre-fills the
+composer's anchor chip.

--- a/drizzle/0020_melodic_lilandra.sql
+++ b/drizzle/0020_melodic_lilandra.sql
@@ -1,0 +1,43 @@
+CREATE TABLE `scan_comment_mentions` (
+	`id` text PRIMARY KEY NOT NULL,
+	`comment_id` text NOT NULL,
+	`mentioned_user_id` text NOT NULL,
+	`notified_at` integer,
+	`created_at` integer NOT NULL,
+	FOREIGN KEY (`comment_id`) REFERENCES `scan_comments`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`mentioned_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `scan_comment_mentions_comment_user_unique_idx` ON `scan_comment_mentions` (`comment_id`,`mentioned_user_id`);--> statement-breakpoint
+CREATE INDEX `scan_comment_mentions_user_idx` ON `scan_comment_mentions` (`mentioned_user_id`);--> statement-breakpoint
+CREATE TABLE `scan_comments` (
+	`id` text PRIMARY KEY NOT NULL,
+	`scan_id` text NOT NULL,
+	`organization_id` text NOT NULL,
+	`author_user_id` text,
+	`parent_id` text,
+	`body` text NOT NULL,
+	`anchor_type` text DEFAULT 'general' NOT NULL,
+	`file_path` text,
+	`line` integer,
+	`file_sha256` text,
+	`finding_id` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	`deleted_at` integer,
+	FOREIGN KEY (`scan_id`) REFERENCES `scans`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`author_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null,
+	FOREIGN KEY (`parent_id`) REFERENCES `scan_comments`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`finding_id`) REFERENCES `scan_findings`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE INDEX `scan_comments_scan_created_idx` ON `scan_comments` (`scan_id`,`created_at`);--> statement-breakpoint
+CREATE INDEX `scan_comments_org_idx` ON `scan_comments` (`organization_id`);--> statement-breakpoint
+CREATE TABLE `user_notification_settings` (
+	`user_id` text PRIMARY KEY NOT NULL,
+	`mention_emails` integer DEFAULT true NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE cascade
+);

--- a/drizzle/meta/0020_snapshot.json
+++ b/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,2704 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "83b22535-a2e5-4b20-9adf-5753d39cb079",
+  "prevId": "be683958-6507-4fe0-a22f-258e3726906d",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_app_installations": {
+      "name": "github_app_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Organization'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uninstalled_at": {
+          "name": "uninstalled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_app_installations_installation_unique_idx": {
+          "name": "github_app_installations_installation_unique_idx",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        },
+        "github_app_installations_org_idx": {
+          "name": "github_app_installations_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installations_created_by_user_id_user_id_fk": {
+          "name": "github_app_installations_created_by_user_id_user_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_release_targets": {
+      "name": "github_release_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ecosystem": {
+          "name": "ecosystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_release_targets_org_repo_env_unique_idx": {
+          "name": "github_release_targets_org_repo_env_unique_idx",
+          "columns": [
+            "organization_id",
+            "repository_id",
+            "environment"
+          ],
+          "isUnique": true
+        },
+        "github_release_targets_installation_idx": {
+          "name": "github_release_targets_installation_idx",
+          "columns": [
+            "installation_row_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_release_targets_organization_id_organizations_id_fk": {
+          "name": "github_release_targets_organization_id_organizations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_release_targets_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_created_by_user_id_user_id_fk": {
+          "name": "github_release_targets_created_by_user_id_user_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_workflow_gates": {
+      "name": "github_workflow_gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_target_id": {
+          "name": "release_target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deployment_callback_url": {
+          "name": "deployment_callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_comment": {
+          "name": "decision_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_url": {
+          "name": "report_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_started_at": {
+          "name": "review_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_workflow_gates_delivery_unique_idx": {
+          "name": "github_workflow_gates_delivery_unique_idx",
+          "columns": [
+            "delivery_id"
+          ],
+          "isUnique": true
+        },
+        "github_workflow_gates_org_status_idx": {
+          "name": "github_workflow_gates_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_release_target_idx": {
+          "name": "github_workflow_gates_release_target_idx",
+          "columns": [
+            "release_target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_workflow_gates_organization_id_organizations_id_fk": {
+          "name": "github_workflow_gates_organization_id_organizations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_workflow_gates_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_release_target_id_github_release_targets_id_fk": {
+          "name": "github_workflow_gates_release_target_id_github_release_targets_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_release_targets",
+          "columnsFrom": [
+            "release_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_scan_id_scans_id_fk": {
+          "name": "github_workflow_gates_scan_id_scans_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_unique_idx": {
+          "name": "npm_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_invitations": {
+      "name": "organization_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_invitations_token_hash_unique_idx": {
+          "name": "organization_invitations_token_hash_unique_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "organization_invitations_org_status_idx": {
+          "name": "organization_invitations_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "organization_invitations_org_email_idx": {
+          "name": "organization_invitations_org_email_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_invitations_organization_id_organizations_id_fk": {
+          "name": "organization_invitations_organization_id_organizations_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_invited_by_user_id_user_id_fk": {
+          "name": "organization_invitations_invited_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_accepted_by_user_id_user_id_fk": {
+          "name": "organization_invitations_accepted_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_notification_recipients": {
+      "name": "organization_notification_recipients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_notification_recipients_org_email_unique_idx": {
+          "name": "organization_notification_recipients_org_email_unique_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_notification_recipients_organization_id_organizations_id_fk": {
+          "name": "organization_notification_recipients_organization_id_organizations_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_notification_recipients_created_by_user_id_user_id_fk": {
+          "name": "organization_notification_recipients_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_slack_connections": {
+      "name": "organization_slack_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_token_ciphertext": {
+          "name": "bot_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bot_token_nonce": {
+          "name": "bot_token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slack_connections_org_unique_idx": {
+          "name": "organization_slack_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_slack_connections_organization_id_organizations_id_fk": {
+          "name": "organization_slack_connections_organization_id_organizations_id_fk",
+          "tableFrom": "organization_slack_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_slack_connections_created_by_user_id_user_id_fk": {
+          "name": "organization_slack_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_slack_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_comment_mentions": {
+      "name": "scan_comment_mentions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mentioned_user_id": {
+          "name": "mentioned_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_comment_mentions_comment_user_unique_idx": {
+          "name": "scan_comment_mentions_comment_user_unique_idx",
+          "columns": [
+            "comment_id",
+            "mentioned_user_id"
+          ],
+          "isUnique": true
+        },
+        "scan_comment_mentions_user_idx": {
+          "name": "scan_comment_mentions_user_idx",
+          "columns": [
+            "mentioned_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_comment_mentions_comment_id_scan_comments_id_fk": {
+          "name": "scan_comment_mentions_comment_id_scan_comments_id_fk",
+          "tableFrom": "scan_comment_mentions",
+          "tableTo": "scan_comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_comment_mentions_mentioned_user_id_user_id_fk": {
+          "name": "scan_comment_mentions_mentioned_user_id_user_id_fk",
+          "tableFrom": "scan_comment_mentions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "mentioned_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_comments": {
+      "name": "scan_comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "anchor_type": {
+          "name": "anchor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'general'"
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_sha256": {
+          "name": "file_sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finding_id": {
+          "name": "finding_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_comments_scan_created_idx": {
+          "name": "scan_comments_scan_created_idx",
+          "columns": [
+            "scan_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_comments_org_idx": {
+          "name": "scan_comments_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_comments_scan_id_scans_id_fk": {
+          "name": "scan_comments_scan_id_scans_id_fk",
+          "tableFrom": "scan_comments",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_comments_organization_id_organizations_id_fk": {
+          "name": "scan_comments_organization_id_organizations_id_fk",
+          "tableFrom": "scan_comments",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_comments_author_user_id_user_id_fk": {
+          "name": "scan_comments_author_user_id_user_id_fk",
+          "tableFrom": "scan_comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_comments_parent_id_scan_comments_id_fk": {
+          "name": "scan_comments_parent_id_scan_comments_id_fk",
+          "tableFrom": "scan_comments",
+          "tableTo": "scan_comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_comments_finding_id_scan_findings_id_fk": {
+          "name": "scan_comments_finding_id_scan_findings_id_fk",
+          "tableFrom": "scan_comments",
+          "tableTo": "scan_findings",
+          "columnsFrom": [
+            "finding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_findings_scan_severity_idx": {
+          "name": "scan_findings_scan_severity_idx",
+          "columns": [
+            "scan_id",
+            "severity"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changed_file_count": {
+          "name": "changed_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_summary_json": {
+          "name": "risk_summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_storage_version": {
+          "name": "artifact_storage_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_key": {
+          "name": "artifact_manifest_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_digest": {
+          "name": "artifact_manifest_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_size": {
+          "name": "artifact_manifest_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_artifact_key": {
+          "name": "report_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_samples_artifact_key": {
+          "name": "file_samples_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "diff_artifact_key": {
+          "name": "diff_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        },
+        "scans_gate_org_idx": {
+          "name": "scans_gate_org_idx",
+          "columns": [
+            "gate_id",
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_artifact_backfill_idx": {
+          "name": "scans_artifact_backfill_idx",
+          "columns": [
+            "organization_id",
+            "status",
+            "artifact_storage_version",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "scans_org_decision_created_idx": {
+          "name": "scans_org_decision_created_idx",
+          "columns": [
+            "organization_id",
+            "decision",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_gate_id_github_workflow_gates_id_fk": {
+          "name": "scans_gate_id_github_workflow_gates_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "github_workflow_gates",
+          "columnsFrom": [
+            "gate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_decided_by_user_id_user_id_fk": {
+          "name": "scans_decided_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "two_factor": {
+      "name": "two_factor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_notification_settings": {
+      "name": "user_notification_settings",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mention_emails": {
+          "name": "mention_emails",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_settings_user_id_user_id_fk": {
+          "name": "user_notification_settings_user_id_user_id_fk",
+          "tableFrom": "user_notification_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1780937563979,
       "tag": "0019_serious_aaron_stack",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1781192632524,
+      "tag": "0020_melodic_lilandra",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -6,3 +6,4 @@ export * from "./slack-connection";
 export * from "./invitations";
 export * from "./npm-connections";
 export * from "./scans";
+export * from "./scan-comments";

--- a/server/db/organizations.ts
+++ b/server/db/organizations.ts
@@ -11,12 +11,15 @@ import {
   organizationNotificationRecipients,
   organizationSlackConnections,
   organizations,
+  scanCommentMentions,
+  scanComments,
   scanEvents,
   scanFiles,
   scanFindings,
   scans,
   twoFactor,
   user,
+  userNotificationSettings,
 } from "./schema";
 
 export async function ensurePersonalOrganization(db: AppDb, session: WorkspaceSession) {
@@ -187,7 +190,14 @@ export async function deleteOrganization(db: AppDb, organizationId: string): Pro
     .from(scans)
     .where(eq(scans.organizationId, organizationId));
 
+  const orgComments = db
+    .select({ id: scanComments.id })
+    .from(scanComments)
+    .where(eq(scanComments.organizationId, organizationId));
+
   await db.batch([
+    db.delete(scanCommentMentions).where(inArray(scanCommentMentions.commentId, orgComments)),
+    db.delete(scanComments).where(eq(scanComments.organizationId, organizationId)),
     db.delete(scanFindings).where(inArray(scanFindings.scanId, orgScans)),
     db.delete(scanFiles).where(inArray(scanFiles.scanId, orgScans)),
     db.delete(scanEvents).where(eq(scanEvents.organizationId, organizationId)),
@@ -317,6 +327,12 @@ export async function deleteUserAccount(db: AppDb, userId: string): Promise<void
       .update(organizationInvitations)
       .set({ acceptedByUserId: null })
       .where(eq(organizationInvitations.acceptedByUserId, userId)),
+    db
+      .update(scanComments)
+      .set({ authorUserId: null })
+      .where(eq(scanComments.authorUserId, userId)),
+    db.delete(scanCommentMentions).where(eq(scanCommentMentions.mentionedUserId, userId)),
+    db.delete(userNotificationSettings).where(eq(userNotificationSettings.userId, userId)),
     db.delete(organizationMembers).where(eq(organizationMembers.userId, userId)),
     db.delete(twoFactor).where(eq(twoFactor.userId, userId)),
   ]);

--- a/server/db/scan-comments.ts
+++ b/server/db/scan-comments.ts
@@ -1,0 +1,261 @@
+import { and, asc, eq, inArray, isNull } from "drizzle-orm";
+import type { AppDb } from "./client";
+import {
+  organizationMembers,
+  scanCommentMentions,
+  scanComments,
+  user,
+  userNotificationSettings,
+} from "./schema";
+
+export interface ScanCommentRecord {
+  id: string;
+  scanId: string;
+  organizationId: string;
+  authorUserId: string | null;
+  parentId: string | null;
+  body: string;
+  anchorType: string;
+  filePath: string | null;
+  line: number | null;
+  fileSha256: string | null;
+  findingId: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}
+
+export interface ScanCommentEntry extends ScanCommentRecord {
+  authorName: string | null;
+  authorEmail: string | null;
+  mentionedUserIds: string[];
+}
+
+export interface CreateScanCommentInput {
+  scanId: string;
+  organizationId: string;
+  authorUserId: string;
+  parentId?: string | null;
+  body: string;
+  anchorType: string;
+  filePath?: string | null;
+  line?: number | null;
+  fileSha256?: string | null;
+  findingId?: string | null;
+}
+
+export async function createScanComment(
+  db: AppDb,
+  input: CreateScanCommentInput,
+): Promise<ScanCommentRecord> {
+  const now = new Date();
+  const [row] = await db
+    .insert(scanComments)
+    .values({
+      id: crypto.randomUUID(),
+      scanId: input.scanId,
+      organizationId: input.organizationId,
+      authorUserId: input.authorUserId,
+      parentId: input.parentId ?? null,
+      body: input.body,
+      anchorType: input.anchorType,
+      filePath: input.filePath ?? null,
+      line: input.line ?? null,
+      fileSha256: input.fileSha256 ?? null,
+      findingId: input.findingId ?? null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+  return row;
+}
+
+export async function getScanComment(
+  db: AppDb,
+  commentId: string,
+  scanId: string,
+  organizationId: string,
+): Promise<ScanCommentRecord | null> {
+  const [row] = await db
+    .select()
+    .from(scanComments)
+    .where(
+      and(
+        eq(scanComments.id, commentId),
+        eq(scanComments.scanId, scanId),
+        eq(scanComments.organizationId, organizationId),
+      ),
+    )
+    .limit(1);
+  return row ?? null;
+}
+
+export async function listScanComments(
+  db: AppDb,
+  scanId: string,
+  organizationId: string,
+): Promise<ScanCommentEntry[]> {
+  const rows = await db
+    .select({
+      comment: scanComments,
+      authorName: user.name,
+      authorEmail: user.email,
+    })
+    .from(scanComments)
+    .leftJoin(user, eq(user.id, scanComments.authorUserId))
+    .where(and(eq(scanComments.scanId, scanId), eq(scanComments.organizationId, organizationId)))
+    .orderBy(asc(scanComments.createdAt));
+
+  const commentIds = rows.map((row) => row.comment.id);
+  const mentionRows = commentIds.length
+    ? await db
+        .select({
+          commentId: scanCommentMentions.commentId,
+          mentionedUserId: scanCommentMentions.mentionedUserId,
+        })
+        .from(scanCommentMentions)
+        .where(inArray(scanCommentMentions.commentId, commentIds))
+    : [];
+  const mentionsByComment = new Map<string, string[]>();
+  for (const row of mentionRows) {
+    const bucket = mentionsByComment.get(row.commentId);
+    if (bucket) bucket.push(row.mentionedUserId);
+    else mentionsByComment.set(row.commentId, [row.mentionedUserId]);
+  }
+
+  return rows.map((row) => ({
+    ...row.comment,
+    authorName: row.authorName,
+    authorEmail: row.authorEmail,
+    mentionedUserIds: mentionsByComment.get(row.comment.id) ?? [],
+  }));
+}
+
+export async function updateScanCommentBody(
+  db: AppDb,
+  commentId: string,
+  body: string,
+): Promise<ScanCommentRecord | null> {
+  const [row] = await db
+    .update(scanComments)
+    .set({ body, updatedAt: new Date() })
+    .where(and(eq(scanComments.id, commentId), isNull(scanComments.deletedAt)))
+    .returning();
+  return row ?? null;
+}
+
+export async function softDeleteScanComment(db: AppDb, commentId: string): Promise<boolean> {
+  const now = new Date();
+  const rows = await db
+    .update(scanComments)
+    .set({ deletedAt: now, updatedAt: now })
+    .where(and(eq(scanComments.id, commentId), isNull(scanComments.deletedAt)))
+    .returning({ id: scanComments.id });
+  return rows.length > 0;
+}
+
+/**
+ * Restrict candidate mention targets to current members of the organization.
+ * Anything else (ex-members, users from other orgs, fabricated ids) is silently
+ * dropped so a comment body can never be used to probe which user ids exist.
+ */
+export async function filterOrganizationMemberIds(
+  db: AppDb,
+  organizationId: string,
+  userIds: readonly string[],
+): Promise<string[]> {
+  if (userIds.length === 0) return [];
+  const rows = await db
+    .select({ userId: organizationMembers.userId })
+    .from(organizationMembers)
+    .where(
+      and(
+        eq(organizationMembers.organizationId, organizationId),
+        inArray(organizationMembers.userId, [...userIds]),
+      ),
+    );
+  return rows.map((row) => row.userId);
+}
+
+/**
+ * Record mention rows for a comment and return only the user ids that were
+ * newly added — an edit that keeps an existing mention must not re-notify it.
+ */
+export async function addCommentMentions(
+  db: AppDb,
+  commentId: string,
+  userIds: readonly string[],
+): Promise<string[]> {
+  if (userIds.length === 0) return [];
+  const existing = await db
+    .select({ mentionedUserId: scanCommentMentions.mentionedUserId })
+    .from(scanCommentMentions)
+    .where(eq(scanCommentMentions.commentId, commentId));
+  const known = new Set(existing.map((row) => row.mentionedUserId));
+  const added = userIds.filter((userId) => !known.has(userId));
+  if (added.length === 0) return [];
+  const now = new Date();
+  await db.insert(scanCommentMentions).values(
+    added.map((mentionedUserId) => ({
+      id: crypto.randomUUID(),
+      commentId,
+      mentionedUserId,
+      createdAt: now,
+    })),
+  );
+  return added;
+}
+
+export async function markMentionNotified(
+  db: AppDb,
+  commentId: string,
+  mentionedUserId: string,
+): Promise<void> {
+  await db
+    .update(scanCommentMentions)
+    .set({ notifiedAt: new Date() })
+    .where(
+      and(
+        eq(scanCommentMentions.commentId, commentId),
+        eq(scanCommentMentions.mentionedUserId, mentionedUserId),
+      ),
+    );
+}
+
+export interface UserNotificationSettings {
+  mentionEmails: boolean;
+}
+
+export async function getUserNotificationSettings(
+  db: AppDb,
+  userId: string,
+): Promise<UserNotificationSettings> {
+  const [row] = await db
+    .select({ mentionEmails: userNotificationSettings.mentionEmails })
+    .from(userNotificationSettings)
+    .where(eq(userNotificationSettings.userId, userId))
+    .limit(1);
+  // No row means the user never touched the setting: defaults apply.
+  return { mentionEmails: row?.mentionEmails ?? true };
+}
+
+export async function setUserNotificationSettings(
+  db: AppDb,
+  userId: string,
+  settings: UserNotificationSettings,
+): Promise<UserNotificationSettings> {
+  const now = new Date();
+  await db
+    .insert(userNotificationSettings)
+    .values({
+      userId,
+      mentionEmails: settings.mentionEmails,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: userNotificationSettings.userId,
+      set: { mentionEmails: settings.mentionEmails, updatedAt: now },
+    });
+  return settings;
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -220,6 +220,81 @@ export const scanFindings = sqliteTable(
   }),
 );
 
+// Team discussion on a scan. Comments are either general (anchorType
+// "general") or pinned to a spot in the immutable scan report: a staged diff
+// line (anchorType "line": filePath + line, with the staged file's sha256
+// captured for tamper detection) or a deterministic finding (anchorType
+// "finding"). Scans never change after completion, so anchors are stable —
+// there is no re-anchoring problem. Soft delete (deletedAt) preserves thread
+// shape and the audit trail.
+export const scanComments = sqliteTable(
+  "scan_comments",
+  {
+    id: text("id").primaryKey(),
+    scanId: text("scan_id")
+      .notNull()
+      .references(() => scans.id, { onDelete: "cascade" }),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    authorUserId: text("author_user_id").references(() => user.id, { onDelete: "set null" }),
+    parentId: text("parent_id").references((): AnySQLiteColumn => scanComments.id, {
+      onDelete: "cascade",
+    }),
+    body: text("body").notNull(),
+    anchorType: text("anchor_type").notNull().default("general"),
+    filePath: text("file_path"),
+    line: integer("line"),
+    fileSha256: text("file_sha256"),
+    findingId: text("finding_id").references(() => scanFindings.id, { onDelete: "set null" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+    deletedAt: integer("deleted_at", { mode: "timestamp_ms" }),
+  },
+  (table) => ({
+    scanCreatedIdx: index("scan_comments_scan_created_idx").on(table.scanId, table.createdAt),
+    orgIdx: index("scan_comments_org_idx").on(table.organizationId),
+  }),
+);
+
+// One row per user @-mentioned in a comment. `notifiedAt` is set only after the
+// mention email is actually dispatched, so edits that add mentions notify just
+// the newly mentioned users and webhook/queue retries never double-send.
+export const scanCommentMentions = sqliteTable(
+  "scan_comment_mentions",
+  {
+    id: text("id").primaryKey(),
+    commentId: text("comment_id")
+      .notNull()
+      .references(() => scanComments.id, { onDelete: "cascade" }),
+    mentionedUserId: text("mentioned_user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    notifiedAt: integer("notified_at", { mode: "timestamp_ms" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+  },
+  (table) => ({
+    commentUserUniqueIdx: uniqueIndex("scan_comment_mentions_comment_user_unique_idx").on(
+      table.commentId,
+      table.mentionedUserId,
+    ),
+    userIdx: index("scan_comment_mentions_user_idx").on(table.mentionedUserId),
+  }),
+);
+
+// Per-user notification preferences. Distinct from the org-level recipient list
+// (organization_notification_recipients), which routes release alerts to
+// addresses the org configures; this governs emails addressed to the user
+// personally. Absence of a row means every preference is at its default (on).
+export const userNotificationSettings = sqliteTable("user_notification_settings", {
+  userId: text("user_id")
+    .primaryKey()
+    .references(() => user.id, { onDelete: "cascade" }),
+  mentionEmails: integer("mention_emails", { mode: "boolean" }).notNull().default(true),
+  createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+});
+
 export const scanEvents = sqliteTable(
   "scan_events",
   {

--- a/server/index.ts
+++ b/server/index.ts
@@ -38,6 +38,8 @@ import { organizationMembersRoutes } from "./routes/organization-members";
 import { organizationsRoutes } from "./routes/organizations";
 import { slackRoutes } from "./routes/slack";
 import { scansRoutes } from "./routes/scans";
+import { scanCommentsRoutes } from "./routes/scan-comments";
+import { accountRoutes } from "./routes/account";
 import { stagedPublishesRoutes } from "./routes/staged-publishes";
 import type { Bindings, Variables } from "./types";
 
@@ -185,6 +187,9 @@ app.get("/api", (c) =>
       createScan: "POST /api/v1/scans { stageId }",
       scans: "GET /api/v1/scans",
       scanDetail: "GET /api/v1/scans/:id",
+      scanComments:
+        "GET/POST /api/v1/scans/:scanId/comments; PATCH/DELETE /api/v1/scans/:scanId/comments/:commentId",
+      accountNotificationSettings: "GET/PATCH /api/v1/account/notification-settings",
       stagedPublishes: "POST /api/v1/staged-publishes/scan",
       npmConnection: "GET/POST/DELETE /api/v1/npm-connection; POST /api/v1/npm-connection/validate",
       organizations:
@@ -215,6 +220,8 @@ app.route("/api/v1/organizations", organizationMembersRoutes);
 // directly. Running the full pipeline inline in a request handler is a Workers
 // CPU-timeout risk, so no synchronous submit route exists.
 app.route("/api/v1/scans", scansRoutes);
+app.route("/api/v1/scans", scanCommentsRoutes);
+app.route("/api/v1/account", accountRoutes);
 app.route("/api/v1/slack", slackRoutes);
 app.route("/api/v1/staged-publishes", stagedPublishesRoutes);
 

--- a/server/lib/comment-mentions.ts
+++ b/server/lib/comment-mentions.ts
@@ -1,0 +1,26 @@
+// Mention handling for scan comments. Mentions travel inside the comment body
+// as structured `@[userId]` tokens — the UI resolves them to display names at
+// render time, so a member rename never goes stale and the server never has to
+// parse free-form display names out of text.
+
+export const COMMENT_BODY_MAX = 4000;
+
+export const COMMENT_ANCHOR_TYPES = ["general", "line", "finding"] as const;
+export type CommentAnchorType = (typeof COMMENT_ANCHOR_TYPES)[number];
+
+// User ids are opaque (Better Auth ids, `user_<uuid>` in fixtures); the charset
+// is restricted so a crafted body can't smuggle markup through a token.
+const MENTION_TOKEN_RE = /@\[([A-Za-z0-9_.:-]{1,128})\]/g;
+
+export function extractMentionUserIds(body: string): string[] {
+  const seen = new Set<string>();
+  for (const match of body.matchAll(MENTION_TOKEN_RE)) {
+    const userId = match[1];
+    if (userId) seen.add(userId);
+  }
+  return [...seen];
+}
+
+export function isCommentAnchorType(value: unknown): value is CommentAnchorType {
+  return COMMENT_ANCHOR_TYPES.includes(value as CommentAnchorType);
+}

--- a/server/lib/notify.ts
+++ b/server/lib/notify.ts
@@ -2,6 +2,9 @@ import {
   getOrganizationOwnerUserId,
   getScan,
   getSlackConnectionSecret,
+  getUserContact,
+  getUserNotificationSettings,
+  markMentionNotified,
   recordScanEvent,
   resolveNotificationEmails,
   type AppDb,
@@ -575,6 +578,94 @@ function inviteAcceptUrl(env: Cloudflare.Env, token: string): string | null {
     return url.toString();
   } catch {
     return null;
+  }
+}
+
+export interface NotifyCommentMentionInput {
+  env: Cloudflare.Env;
+  db: AppDb;
+  organizationId: string;
+  scanId: string;
+  commentId: string;
+  authorUserId: string;
+  authorName: string | null;
+  packageName: string | null;
+  stagedVersion: string | null;
+  anchor: { filePath: string | null; line: number | null } | null;
+  body: string;
+  mentionedUserIds: readonly string[];
+}
+
+const MENTION_BODY_PREVIEW_MAX = 300;
+
+/**
+ * Email each newly mentioned user about a scan comment, honoring their
+ * per-user mention preference. Best-effort: each delivery records a
+ * `scan.comment_mention_sent` / `_failed` audit event, and only a successful
+ * send marks the mention row notified (so a retried edit can re-attempt failed
+ * sends without double-mailing successes). The body carries only the comment
+ * text and a path:line anchor label — never scan evidence or file contents.
+ */
+export async function notifyCommentMention(input: NotifyCommentMentionInput): Promise<void> {
+  const { env, db, organizationId, scanId, commentId, mentionedUserIds } = input;
+  const packageLabel = formatPackageLabel(input.packageName, input.stagedVersion);
+  const authorLabel = input.authorName || "A teammate";
+  const dashboardUrl = scanUrl(env, scanId);
+  const commentUrl = dashboardUrl ? `${dashboardUrl}#comment-${commentId}` : null;
+  const anchorLabel =
+    input.anchor?.filePath != null
+      ? input.anchor.line != null
+        ? `${input.anchor.filePath}:${input.anchor.line}`
+        : input.anchor.filePath
+      : null;
+  const preview =
+    input.body.length > MENTION_BODY_PREVIEW_MAX
+      ? `${input.body.slice(0, MENTION_BODY_PREVIEW_MAX)}…`
+      : input.body;
+
+  for (const mentionedUserId of mentionedUserIds) {
+    if (mentionedUserId === input.authorUserId) continue;
+    const settings = await getUserNotificationSettings(db, mentionedUserId);
+    if (!settings.mentionEmails) continue;
+    const contact = await getUserContact(db, mentionedUserId);
+    if (!contact?.email) continue;
+
+    const result = await sendNotificationEmail(env, {
+      to: contact.email,
+      subject: `${authorLabel} mentioned you on a scan — ${packageLabel}`,
+      text: [
+        "Hi there,",
+        "",
+        `${authorLabel} mentioned you in a comment on the scan for ${packageLabel}.`,
+        anchorLabel ? `Location: ${anchorLabel}` : null,
+        "",
+        preview,
+        "",
+        commentUrl ? `View the discussion: ${commentUrl}` : null,
+        commentUrl ? "" : null,
+        "You can turn these emails off in your account settings.",
+        "",
+        "— Drydock",
+      ]
+        .filter((line): line is string => line !== null)
+        .join("\n"),
+    });
+
+    if (result.ok) {
+      await markMentionNotified(db, commentId, mentionedUserId);
+    }
+    await recordScanEvent(db, {
+      organizationId,
+      actorUserId: input.authorUserId,
+      scanId,
+      type: result.ok ? "scan.comment_mention_sent" : "scan.comment_mention_failed",
+      metadata: {
+        commentId,
+        mentionedUserId,
+        channel: "email",
+        ...(result.ok ? {} : { reason: result.reason }),
+      },
+    });
   }
 }
 

--- a/server/routes/account.ts
+++ b/server/routes/account.ts
@@ -1,0 +1,28 @@
+import { Hono } from "hono";
+import { createDb, getUserNotificationSettings, setUserNotificationSettings } from "../db";
+import type { Bindings, Variables } from "../types";
+
+// Personal (cross-organization) account settings. Notification preferences
+// here govern emails addressed to the signed-in user, unlike the org-level
+// recipient list which routes release alerts for an organization.
+export const accountRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+accountRoutes.get("/notification-settings", async (c) => {
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const settings = await getUserNotificationSettings(db, session.userId);
+  return c.json({ settings });
+});
+
+accountRoutes.patch("/notification-settings", async (c) => {
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const body = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+  if (typeof body.mentionEmails !== "boolean") {
+    return c.json({ error: "mentionEmails must be a boolean" }, 400);
+  }
+  const settings = await setUserNotificationSettings(db, session.userId, {
+    mentionEmails: body.mentionEmails,
+  });
+  return c.json({ settings });
+});

--- a/server/routes/scan-comments.ts
+++ b/server/routes/scan-comments.ts
@@ -1,0 +1,358 @@
+import { Hono, type Context } from "hono";
+import { and, eq } from "drizzle-orm";
+import {
+  RateLimitError,
+  addCommentMentions,
+  createDb,
+  createScanComment,
+  enforceRateLimit,
+  filterOrganizationMemberIds,
+  getScanComment,
+  getUserContact,
+  listScanComments,
+  recordScanEvent,
+  softDeleteScanComment,
+  updateScanCommentBody,
+  type AppDb,
+  type ScanCommentEntry,
+  type ScanCommentRecord,
+} from "../db";
+import { scanFiles, scanFindings, scans } from "../db/schema";
+import { requireActiveOrganizationContext } from "../lib/active-organization";
+import {
+  COMMENT_BODY_MAX,
+  extractMentionUserIds,
+  isCommentAnchorType,
+  type CommentAnchorType,
+} from "../lib/comment-mentions";
+import { rateLimitResponse } from "../lib/http";
+import { notifyCommentMention } from "../lib/notify";
+import { roleCanManageMembers } from "../lib/roles";
+import type { Bindings, Variables } from "../types";
+
+export const scanCommentsRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+export interface PublicScanComment {
+  id: string;
+  scanId: string;
+  parentId: string | null;
+  authorUserId: string | null;
+  authorName: string | null;
+  body: string;
+  anchorType: string;
+  filePath: string | null;
+  line: number | null;
+  findingId: string | null;
+  mentionedUserIds: string[];
+  deleted: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// Deleted comments keep their place in the thread but surface no content or
+// author, so a soft delete actually removes the text from API responses.
+function serializeComment(
+  comment: ScanCommentRecord & Partial<Pick<ScanCommentEntry, "authorName" | "mentionedUserIds">>,
+): PublicScanComment {
+  const deleted = comment.deletedAt !== null;
+  return {
+    id: comment.id,
+    scanId: comment.scanId,
+    parentId: comment.parentId,
+    authorUserId: deleted ? null : comment.authorUserId,
+    authorName: deleted ? null : (comment.authorName ?? null),
+    body: deleted ? "" : comment.body,
+    anchorType: comment.anchorType,
+    filePath: comment.filePath,
+    line: comment.line,
+    findingId: comment.findingId,
+    mentionedUserIds: deleted ? [] : (comment.mentionedUserIds ?? []),
+    deleted,
+    createdAt: comment.createdAt,
+    updatedAt: comment.updatedAt,
+  };
+}
+
+async function getOrgScan(db: AppDb, scanId: string, organizationId: string) {
+  const [scan] = await db
+    .select({
+      id: scans.id,
+      packageName: scans.packageName,
+      stagedVersion: scans.stagedVersion,
+    })
+    .from(scans)
+    .where(and(eq(scans.id, scanId), eq(scans.organizationId, organizationId)))
+    .limit(1);
+  return scan ?? null;
+}
+
+interface ParsedAnchor {
+  anchorType: CommentAnchorType;
+  filePath: string | null;
+  line: number | null;
+  fileSha256: string | null;
+  findingId: string | null;
+}
+
+async function parseAnchor(
+  db: AppDb,
+  scanId: string,
+  body: Record<string, unknown>,
+): Promise<{ ok: true; anchor: ParsedAnchor } | { ok: false; error: string }> {
+  const anchorType = body.anchorType ?? "general";
+  if (!isCommentAnchorType(anchorType)) {
+    return { ok: false, error: "anchorType must be one of: general, line, finding" };
+  }
+  if (anchorType === "general") {
+    return {
+      ok: true,
+      anchor: { anchorType, filePath: null, line: null, fileSha256: null, findingId: null },
+    };
+  }
+  if (anchorType === "line") {
+    const filePath = typeof body.filePath === "string" ? body.filePath : "";
+    const line = body.line;
+    if (!filePath || typeof line !== "number" || !Number.isInteger(line) || line < 1) {
+      return { ok: false, error: "line comments require filePath and a positive integer line" };
+    }
+    const [file] = await db
+      .select({ path: scanFiles.path, sha256: scanFiles.sha256 })
+      .from(scanFiles)
+      .where(and(eq(scanFiles.scanId, scanId), eq(scanFiles.path, filePath)))
+      .limit(1);
+    if (!file) return { ok: false, error: "filePath does not exist in this scan" };
+    return {
+      ok: true,
+      anchor: { anchorType, filePath, line, fileSha256: file.sha256, findingId: null },
+    };
+  }
+  const findingId = typeof body.findingId === "string" ? body.findingId : "";
+  if (!findingId) return { ok: false, error: "finding comments require findingId" };
+  const [finding] = await db
+    .select({ id: scanFindings.id, file: scanFindings.file, line: scanFindings.line })
+    .from(scanFindings)
+    .where(and(eq(scanFindings.scanId, scanId), eq(scanFindings.id, findingId)))
+    .limit(1);
+  if (!finding) return { ok: false, error: "findingId does not exist in this scan" };
+  return {
+    ok: true,
+    anchor: {
+      anchorType,
+      filePath: finding.file,
+      line: finding.line ?? null,
+      fileSha256: null,
+      findingId,
+    },
+  };
+}
+
+function parseBody(raw: unknown): { ok: true; body: string } | { ok: false; error: string } {
+  if (typeof raw !== "string") return { ok: false, error: "body is required" };
+  const body = raw.trim();
+  if (!body) return { ok: false, error: "body is required" };
+  if (body.length > COMMENT_BODY_MAX) {
+    return { ok: false, error: `body must be at most ${COMMENT_BODY_MAX} characters` };
+  }
+  return { ok: true, body };
+}
+
+// Resolve mentions, persist the new ones, and queue best-effort emails on
+// waitUntil so delivery never blocks the comment response.
+async function dispatchMentions(options: {
+  c: Context<{ Bindings: Bindings; Variables: Variables }>;
+  db: AppDb;
+  organizationId: string;
+  scan: { id: string; packageName: string | null; stagedVersion: string | null };
+  comment: ScanCommentRecord;
+  authorUserId: string;
+}): Promise<string[]> {
+  const { c, db, organizationId, scan, comment, authorUserId } = options;
+  const candidates = extractMentionUserIds(comment.body);
+  const memberIds = await filterOrganizationMemberIds(db, organizationId, candidates);
+  const mentioned = memberIds.filter((id) => id !== authorUserId);
+  const added = await addCommentMentions(db, comment.id, mentioned);
+  if (added.length > 0) {
+    const author = await getUserContact(db, authorUserId);
+    c.executionCtx.waitUntil(
+      notifyCommentMention({
+        env: c.env,
+        db,
+        organizationId,
+        scanId: scan.id,
+        commentId: comment.id,
+        authorUserId,
+        authorName: author?.name ?? null,
+        packageName: scan.packageName,
+        stagedVersion: scan.stagedVersion,
+        anchor: comment.filePath ? { filePath: comment.filePath, line: comment.line } : null,
+        body: comment.body,
+        mentionedUserIds: added,
+      }),
+    );
+  }
+  return mentioned;
+}
+
+scanCommentsRoutes.get("/:scanId/comments", async (c) => {
+  const db = createDb(c.env.DB);
+  const { organizationId } = await requireActiveOrganizationContext(c, db);
+  const scanId = c.req.param("scanId");
+  const scan = await getOrgScan(db, scanId, organizationId);
+  if (!scan) return c.json({ error: "scan not found" }, 404);
+  const comments = await listScanComments(db, scanId, organizationId);
+  return c.json({ comments: comments.map(serializeComment) });
+});
+
+scanCommentsRoutes.post("/:scanId/comments", async (c) => {
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const { organizationId } = await requireActiveOrganizationContext(c, db);
+  const scanId = c.req.param("scanId");
+  const scan = await getOrgScan(db, scanId, organizationId);
+  if (!scan) return c.json({ error: "scan not found" }, 404);
+
+  const payload = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+  const parsedBody = parseBody(payload.body);
+  if (!parsedBody.ok) return c.json({ error: parsedBody.error }, 400);
+  const parsedAnchor = await parseAnchor(db, scanId, payload);
+  if (!parsedAnchor.ok) return c.json({ error: parsedAnchor.error }, 400);
+
+  let parentId: string | null = null;
+  if (payload.parentId !== undefined && payload.parentId !== null) {
+    if (typeof payload.parentId !== "string") {
+      return c.json({ error: "parentId must be a comment id" }, 400);
+    }
+    const parent = await getScanComment(db, payload.parentId, scanId, organizationId);
+    if (!parent || parent.deletedAt) {
+      return c.json({ error: "parentId does not reference a comment on this scan" }, 400);
+    }
+    parentId = parent.id;
+  }
+
+  try {
+    await enforceRateLimit(db, {
+      key: `scan-comment:${organizationId}:${session.userId}`,
+      limit: 30,
+      windowMs: 60 * 60 * 1000,
+    });
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      return rateLimitResponse(c, "comment rate limit exceeded", err);
+    }
+    throw err;
+  }
+
+  const comment = await createScanComment(db, {
+    scanId,
+    organizationId,
+    authorUserId: session.userId,
+    parentId,
+    body: parsedBody.body,
+    anchorType: parsedAnchor.anchor.anchorType,
+    filePath: parsedAnchor.anchor.filePath,
+    line: parsedAnchor.anchor.line,
+    fileSha256: parsedAnchor.anchor.fileSha256,
+    findingId: parsedAnchor.anchor.findingId,
+  });
+
+  const mentioned = await dispatchMentions({
+    c,
+    db,
+    organizationId,
+    scan,
+    comment,
+    authorUserId: session.userId,
+  });
+
+  await recordScanEvent(db, {
+    organizationId,
+    actorUserId: session.userId,
+    scanId,
+    type: "scan.comment_created",
+    metadata: {
+      commentId: comment.id,
+      anchorType: comment.anchorType,
+      ...(comment.filePath ? { filePath: comment.filePath, line: comment.line } : {}),
+      ...(mentioned.length ? { mentionCount: mentioned.length } : {}),
+    },
+  });
+
+  const author = await getUserContact(db, session.userId);
+  return c.json(
+    {
+      comment: serializeComment({
+        ...comment,
+        authorName: author?.name ?? null,
+        mentionedUserIds: mentioned,
+      }),
+    },
+    201,
+  );
+});
+
+scanCommentsRoutes.patch("/:scanId/comments/:commentId", async (c) => {
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const { organizationId } = await requireActiveOrganizationContext(c, db);
+  const scanId = c.req.param("scanId");
+  const scan = await getOrgScan(db, scanId, organizationId);
+  if (!scan) return c.json({ error: "scan not found" }, 404);
+
+  const existing = await getScanComment(db, c.req.param("commentId"), scanId, organizationId);
+  if (!existing || existing.deletedAt) return c.json({ error: "comment not found" }, 404);
+  if (existing.authorUserId !== session.userId) {
+    return c.json({ error: "only the author can edit a comment" }, 403);
+  }
+
+  const payload = (await c.req.json().catch(() => ({}))) as Record<string, unknown>;
+  const parsedBody = parseBody(payload.body);
+  if (!parsedBody.ok) return c.json({ error: parsedBody.error }, 400);
+
+  const updated = await updateScanCommentBody(db, existing.id, parsedBody.body);
+  if (!updated) return c.json({ error: "comment not found" }, 404);
+
+  const mentioned = await dispatchMentions({
+    c,
+    db,
+    organizationId,
+    scan,
+    comment: updated,
+    authorUserId: session.userId,
+  });
+
+  const author = await getUserContact(db, session.userId);
+  return c.json({
+    comment: serializeComment({
+      ...updated,
+      authorName: author?.name ?? null,
+      mentionedUserIds: mentioned,
+    }),
+  });
+});
+
+scanCommentsRoutes.delete("/:scanId/comments/:commentId", async (c) => {
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const { organizationId, role } = await requireActiveOrganizationContext(c, db);
+  const scanId = c.req.param("scanId");
+  const scan = await getOrgScan(db, scanId, organizationId);
+  if (!scan) return c.json({ error: "scan not found" }, 404);
+
+  const existing = await getScanComment(db, c.req.param("commentId"), scanId, organizationId);
+  if (!existing || existing.deletedAt) return c.json({ error: "comment not found" }, 404);
+
+  const isAuthor = existing.authorUserId === session.userId;
+  if (!isAuthor && !roleCanManageMembers(role)) {
+    return c.json({ error: "only the author or an organization admin can delete a comment" }, 403);
+  }
+
+  await softDeleteScanComment(db, existing.id);
+  await recordScanEvent(db, {
+    organizationId,
+    actorUserId: session.userId,
+    scanId,
+    type: "scan.comment_deleted",
+    metadata: { commentId: existing.id, byAuthor: isAuthor },
+  });
+  return c.json({ ok: true });
+});

--- a/src/components/DiffView.tsx
+++ b/src/components/DiffView.tsx
@@ -21,6 +21,16 @@ import { cn } from "./cn";
 
 export type { DiffFinding } from "./diff-annotations";
 
+// A scan comment pinned to a staged (after-side) line, already resolved to
+// display strings by the caller so DiffView stays decoupled from member data.
+export interface DiffComment {
+  id: string;
+  line?: number | null;
+  authorLabel: string;
+  timeLabel: string;
+  segments: Array<{ type: "text"; text: string } | { type: "mention"; label: string }>;
+}
+
 interface DiffSide {
   textSample?: string | null;
   size?: number | null;
@@ -39,6 +49,11 @@ export interface DiffViewProps {
   // reference. Findings without a matching line surface in a banner above the
   // diff so a truncated sample can't hide a signal.
   findings?: DiffFinding[];
+  // Team comments anchored to staged lines of this file, pinned the same way.
+  comments?: DiffComment[];
+  // When provided, every staged line gets a hover "+" affordance that starts
+  // a comment on that line.
+  onLineComment?: (line: number) => void;
 }
 
 interface Row {
@@ -133,6 +148,8 @@ export function DiffView({
   beforeLabel,
   afterLabel,
   findings = [],
+  comments = [],
+  onLineComment,
 }: DiffViewProps) {
   const beforeSample = before?.textSample ?? "";
   const afterSample = after?.textSample ?? "";
@@ -165,6 +182,8 @@ export function DiffView({
         beforeLabel={beforeLabel}
         afterLabel={afterLabel}
         findings={findings}
+        comments={comments}
+        onLineComment={onLineComment}
       />
     </div>
   );
@@ -179,6 +198,8 @@ function DiffBody({
   beforeLabel,
   afterLabel,
   findings,
+  comments,
+  onLineComment,
 }: {
   path: string;
   status: string;
@@ -188,6 +209,8 @@ function DiffBody({
   beforeLabel: string;
   afterLabel: string;
   findings: DiffFinding[];
+  comments: DiffComment[];
+  onLineComment?: (line: number) => void;
 }) {
   const lang = langForPath(path);
   if (lang && !binary) ensureHighlighter();
@@ -209,6 +232,8 @@ function DiffBody({
         text={afterSample}
         tokens={afterTokens}
         findings={findings}
+        comments={comments}
+        onLineComment={onLineComment}
       />
     );
   }
@@ -225,6 +250,7 @@ function DiffBody({
         text={beforeSample}
         tokens={beforeTokens}
         findings={findings}
+        comments={comments}
       />
     );
   }
@@ -239,6 +265,8 @@ function DiffBody({
         text={afterSample || beforeSample}
         tokens={afterSample ? afterTokens : beforeTokens}
         findings={findings}
+        comments={comments}
+        onLineComment={afterSample ? onLineComment : undefined}
       />
     );
   }
@@ -253,6 +281,8 @@ function DiffBody({
         text={afterSample}
         tokens={afterTokens}
         findings={findings}
+        comments={comments}
+        onLineComment={onLineComment}
       />
     );
   }
@@ -264,6 +294,7 @@ function DiffBody({
         text={beforeSample}
         tokens={beforeTokens}
         findings={findings}
+        comments={comments}
       />
     );
   }
@@ -272,6 +303,10 @@ function DiffBody({
   const presentLines = new Set<number>();
   for (const row of rows) if (row.afterLine !== null) presentLines.add(row.afterLine);
   const { pinned, unpinned } = partitionFindingsByLine(findings, presentLines);
+  const { pinned: pinnedComments, unpinned: unpinnedComments } = partitionFindingsByLine(
+    comments,
+    presentLines,
+  );
   return (
     <div class="border border-border rounded-md overflow-hidden">
       <div class="bg-surface-2 px-3 py-2 font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle flex justify-between">
@@ -279,15 +314,19 @@ function DiffBody({
         <span>{afterLabel}</span>
       </div>
       {unpinned.length ? <AnnotationBanner findings={unpinned} /> : null}
+      {unpinnedComments.length ? <CommentBanner comments={unpinnedComments} /> : null}
       <div class="overflow-auto h-[560px]">
         <table class="w-full border-collapse font-mono text-[12px] leading-[1.55]">
           <tbody>
             {rows.map((row, index) => {
               const pins = row.afterLine !== null ? pinned.get(row.afterLine) : undefined;
+              const commentPins =
+                row.afterLine !== null ? pinnedComments.get(row.afterLine) : undefined;
               return (
                 <Fragment key={index}>
-                  <DiffRow row={row} />
+                  <DiffRow row={row} onLineComment={onLineComment} />
                   {pins ? <AnnotationRows findings={pins} colSpan={4} /> : null}
+                  {commentPins ? <CommentRows comments={commentPins} colSpan={4} /> : null}
                 </Fragment>
               );
             })}
@@ -298,16 +337,21 @@ function DiffBody({
   );
 }
 
-function DiffRow({ row }: { row: Row }) {
+function DiffRow({ row, onLineComment }: { row: Row; onLineComment?: (line: number) => void }) {
   const bg = row.tone === "added" ? "bg-ok-soft" : row.tone === "removed" ? "bg-danger-soft" : "";
   const sign = row.tone === "added" ? "+" : row.tone === "removed" ? "-" : " ";
+  const afterLine = row.afterLine;
   return (
-    <tr class={cn(bg)}>
+    <tr class={cn(bg, "group")}>
       <td class="px-2 py-[2px] text-ink-subtle select-none w-[44px] text-right border-r border-border align-top">
         {row.beforeLine ?? ""}
       </td>
       <td class="px-2 py-[2px] text-ink-subtle select-none w-[44px] text-right border-r border-border align-top">
-        {row.afterLine ?? ""}
+        {afterLine !== null && onLineComment ? (
+          <LineCommentTrigger line={afterLine} onLineComment={onLineComment} />
+        ) : (
+          (afterLine ?? "")
+        )}
       </td>
       <td class="px-2 py-[2px] select-none w-[20px] text-ink-subtle align-top">{sign}</td>
       <td class="px-2 py-[2px] whitespace-pre-wrap break-words align-top">
@@ -317,18 +361,44 @@ function DiffRow({ row }: { row: Row }) {
   );
 }
 
+// The staged line number doubles as the "start a comment here" affordance: a
+// text "+" replaces it on row hover (text glyphs only, per DESIGN.md).
+function LineCommentTrigger({
+  line,
+  onLineComment,
+}: {
+  line: number;
+  onLineComment: (line: number) => void;
+}) {
+  return (
+    <button
+      type="button"
+      class="w-full text-right cursor-pointer text-ink-subtle hover:text-accent focus-visible:text-accent outline-none bg-transparent border-0 p-0 font-mono text-inherit"
+      title={`Comment on line ${line}`}
+      onClick={() => onLineComment(line)}
+    >
+      <span class="group-hover:hidden">{line}</span>
+      <span class="hidden group-hover:inline">+</span>
+    </button>
+  );
+}
+
 function SingleSidedView({
   label,
   tone,
   text,
   tokens,
   findings,
+  comments = [],
+  onLineComment,
 }: {
   label: string;
   tone: "added" | "removed" | "unchanged";
   text: string;
   tokens: TokenLine[] | null;
   findings: DiffFinding[];
+  comments?: DiffComment[];
+  onLineComment?: (line: number) => void;
 }) {
   const headerBg =
     tone === "added" ? "bg-ok-soft" : tone === "removed" ? "bg-danger-soft" : "bg-surface-2";
@@ -337,6 +407,10 @@ function SingleSidedView({
   if (lines.length && lines[lines.length - 1] === "") lines.pop();
   const presentLines = new Set<number>(lines.map((_, index) => index + 1));
   const { pinned, unpinned } = partitionFindingsByLine(findings, presentLines);
+  const { pinned: pinnedComments, unpinned: unpinnedComments } = partitionFindingsByLine(
+    comments,
+    presentLines,
+  );
   return (
     <div class="border border-border rounded-md overflow-hidden">
       <div
@@ -348,22 +422,29 @@ function SingleSidedView({
         {label}
       </div>
       {unpinned.length ? <AnnotationBanner findings={unpinned} /> : null}
+      {unpinnedComments.length ? <CommentBanner comments={unpinnedComments} /> : null}
       <div class="overflow-auto h-[560px]">
         <table class="w-full border-collapse font-mono text-[12px] leading-[1.55]">
           <tbody>
             {lines.map((line, index) => {
               const pins = pinned.get(index + 1);
+              const commentPins = pinnedComments.get(index + 1);
               return (
                 <Fragment key={index}>
-                  <tr class={cn(rowBg)}>
+                  <tr class={cn(rowBg, "group")}>
                     <td class="px-2 py-[2px] text-ink-subtle select-none w-[44px] text-right border-r border-border align-top">
-                      {index + 1}
+                      {onLineComment ? (
+                        <LineCommentTrigger line={index + 1} onLineComment={onLineComment} />
+                      ) : (
+                        index + 1
+                      )}
                     </td>
                     <td class="px-2 py-[2px] whitespace-pre-wrap break-words align-top">
                       <LineContent text={line} tokens={tokens?.[index] ?? null} />
                     </td>
                   </tr>
                   {pins ? <AnnotationRows findings={pins} colSpan={2} /> : null}
+                  {commentPins ? <CommentRows comments={commentPins} colSpan={2} /> : null}
                 </Fragment>
               );
             })}
@@ -440,6 +521,56 @@ function AnnotationRows({ findings, colSpan }: { findings: DiffFinding[]; colSpa
         </tr>
       ))}
     </>
+  );
+}
+
+// A team comment pinned beneath its staged line. Accent-neutral (no severity
+// tint) so human discussion reads distinctly from machine findings.
+function CommentAnnotationBody({ comment }: { comment: DiffComment }) {
+  return (
+    <div class="border-l-2 border-accent bg-surface-2 px-3 py-2.5 flex flex-col gap-1 font-sans">
+      <div class="flex flex-wrap items-baseline gap-2">
+        <span class="text-[12px] font-medium text-ink">{comment.authorLabel}</span>
+        <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">
+          {comment.timeLabel}
+        </span>
+      </div>
+      <p class="m-0 text-[13px] leading-[1.55] text-ink whitespace-pre-wrap break-words">
+        {comment.segments.map((segment, index) =>
+          segment.type === "mention" ? (
+            <span key={index} class="text-accent font-medium">
+              @{segment.label}
+            </span>
+          ) : (
+            <Fragment key={index}>{segment.text}</Fragment>
+          ),
+        )}
+      </p>
+    </div>
+  );
+}
+
+function CommentRows({ comments, colSpan }: { comments: DiffComment[]; colSpan: number }) {
+  return (
+    <>
+      {comments.map((comment) => (
+        <tr key={comment.id}>
+          <td colSpan={colSpan} class="p-0">
+            <CommentAnnotationBody comment={comment} />
+          </td>
+        </tr>
+      ))}
+    </>
+  );
+}
+
+function CommentBanner({ comments }: { comments: DiffComment[] }) {
+  return (
+    <div class="flex flex-col divide-y divide-border border-b border-border">
+      {comments.map((comment) => (
+        <CommentAnnotationBody key={comment.id} comment={comment} />
+      ))}
+    </div>
   );
 }
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -27,7 +27,7 @@ export {
 export { IndeterminateBar, LoadingState } from "./Loading";
 export { FileTree } from "./FileTree";
 export { DiffView } from "./DiffView";
-export type { DiffViewProps, DiffFinding } from "./DiffView";
+export type { DiffViewProps, DiffFinding, DiffComment } from "./DiffView";
 export { VersionPicker } from "./VersionPicker";
 export { SeverityBar } from "./SeverityBar";
 export type { SeverityCounts, SeverityKey } from "./SeverityBar";

--- a/src/lib/mentions.ts
+++ b/src/lib/mentions.ts
@@ -1,0 +1,57 @@
+// Comment bodies carry mentions as structured `@[userId]` tokens (see
+// server/lib/comment-mentions.ts). These helpers split a body into renderable
+// segments and handle composer-side token insertion, so display names are
+// always resolved at render time from the current member list.
+
+export type MentionSegment = { type: "text"; text: string } | { type: "mention"; userId: string };
+
+const MENTION_TOKEN_RE = /@\[([A-Za-z0-9_.:-]{1,128})\]/g;
+
+export function splitMentionSegments(body: string): MentionSegment[] {
+  const segments: MentionSegment[] = [];
+  let last = 0;
+  for (const match of body.matchAll(MENTION_TOKEN_RE)) {
+    const index = match.index ?? 0;
+    if (index > last) segments.push({ type: "text", text: body.slice(last, index) });
+    segments.push({ type: "mention", userId: match[1] });
+    last = index + match[0].length;
+  }
+  if (last < body.length) segments.push({ type: "text", text: body.slice(last) });
+  return segments;
+}
+
+export interface MentionQuery {
+  // index of the "@" that opened the query, in the composer text
+  start: number;
+  // the partial name typed after the "@", up to the caret
+  query: string;
+}
+
+/**
+ * Find an in-progress @-mention immediately before the caret: an "@" at the
+ * start of a word followed only by name-ish characters. Returns null when the
+ * caret isn't completing a mention (e.g. inside an email address or after a
+ * finished `@[id]` token).
+ */
+export function activeMentionQuery(text: string, caret: number): MentionQuery | null {
+  const upToCaret = text.slice(0, caret);
+  const at = upToCaret.lastIndexOf("@");
+  if (at === -1) return null;
+  if (at > 0 && !/[\s([{]/.test(upToCaret[at - 1])) return null;
+  const query = upToCaret.slice(at + 1);
+  if (query.startsWith("[")) return null;
+  if (!/^[^\s@]{0,64}$/.test(query)) return null;
+  return { start: at, query };
+}
+
+/** Replace the active "@partial" with a `@[userId]` token plus trailing space. */
+export function insertMentionToken(
+  text: string,
+  caret: number,
+  start: number,
+  userId: string,
+): { text: string; caret: number } {
+  const token = `@[${userId}] `;
+  const next = text.slice(0, start) + token + text.slice(caret);
+  return { text: next, caret: start + token.length };
+}

--- a/src/models/account-settings.ts
+++ b/src/models/account-settings.ts
@@ -1,0 +1,55 @@
+import { createModel, signal } from "@preact/signals";
+import { apiFetch, apiJson, errorMessage } from "./api";
+
+export interface NotificationSettings {
+  mentionEmails: boolean;
+}
+
+type SettingsStatus = "idle" | "loading" | "saving";
+
+export const NotificationSettingsModel = createModel(() => {
+  const settings = signal<NotificationSettings | null>(null);
+  const status = signal<SettingsStatus>("idle");
+  const error = signal<string | null>(null);
+
+  return {
+    settings,
+    status,
+    error,
+
+    async load(): Promise<void> {
+      status.value = "loading";
+      try {
+        const data = await apiFetch<{ settings: NotificationSettings }>(
+          "/api/v1/account/notification-settings",
+        );
+        settings.value = data.settings;
+        error.value = null;
+      } catch (err) {
+        error.value = errorMessage(err);
+      } finally {
+        status.value = "idle";
+      }
+    },
+
+    async setMentionEmails(enabled: boolean): Promise<void> {
+      const previous = settings.peek();
+      settings.value = { mentionEmails: enabled };
+      status.value = "saving";
+      error.value = null;
+      try {
+        const data = await apiJson<{ settings: NotificationSettings }>(
+          "/api/v1/account/notification-settings",
+          { mentionEmails: enabled },
+          { method: "PATCH" },
+        );
+        settings.value = data.settings;
+      } catch (err) {
+        settings.value = previous;
+        error.value = errorMessage(err);
+      } finally {
+        status.value = "idle";
+      }
+    },
+  };
+});

--- a/src/models/scan-comments.ts
+++ b/src/models/scan-comments.ts
@@ -1,0 +1,104 @@
+import { computed, createModel, signal } from "@preact/signals";
+import { apiFetch, apiJson, errorMessage } from "./api";
+
+export interface ScanComment {
+  id: string;
+  scanId: string;
+  parentId: string | null;
+  authorUserId: string | null;
+  authorName: string | null;
+  body: string;
+  anchorType: "general" | "line" | "finding" | string;
+  filePath: string | null;
+  line: number | null;
+  findingId: string | null;
+  mentionedUserIds: string[];
+  deleted: boolean;
+  createdAt: string | number | Date;
+  updatedAt: string | number | Date;
+}
+
+export interface CommentAnchorInput {
+  anchorType: "general" | "line" | "finding";
+  filePath?: string;
+  line?: number;
+  findingId?: string;
+}
+
+// A line the user clicked "comment" on in the diff; the Discussion composer
+// picks it up as the pending anchor.
+export interface PendingLineAnchor {
+  filePath: string;
+  line: number;
+}
+
+type CommentsStatus = "idle" | "loading" | "posting" | "deleting";
+
+export const ScanCommentsModel = createModel((scanId: string) => {
+  const comments = signal<ScanComment[]>([]);
+  const loaded = signal(false);
+  const status = signal<CommentsStatus>("idle");
+  const error = signal<string | null>(null);
+  const pendingAnchor = signal<PendingLineAnchor | null>(null);
+  const visibleComments = computed(() => comments.value.filter((comment) => !comment.deleted));
+
+  const base = `/api/v1/scans/${encodeURIComponent(scanId)}/comments`;
+
+  return {
+    comments,
+    visibleComments,
+    loaded,
+    status,
+    error,
+    pendingAnchor,
+
+    async load(): Promise<void> {
+      status.value = "loading";
+      try {
+        const data = await apiFetch<{ comments: ScanComment[] }>(base);
+        comments.value = data.comments;
+        error.value = null;
+      } catch (err) {
+        error.value = errorMessage(err);
+      } finally {
+        loaded.value = true;
+        status.value = "idle";
+      }
+    },
+
+    async post(body: string, anchor: CommentAnchorInput): Promise<boolean> {
+      status.value = "posting";
+      error.value = null;
+      try {
+        const data = await apiJson<{ comment: ScanComment }>(base, { body, ...anchor });
+        comments.value = [...comments.peek(), data.comment];
+        pendingAnchor.value = null;
+        return true;
+      } catch (err) {
+        error.value = errorMessage(err);
+        return false;
+      } finally {
+        status.value = "idle";
+      }
+    },
+
+    async remove(commentId: string): Promise<void> {
+      status.value = "deleting";
+      error.value = null;
+      try {
+        await apiFetch(`${base}/${encodeURIComponent(commentId)}`, { method: "DELETE" });
+        comments.value = comments.peek().filter((comment) => comment.id !== commentId);
+      } catch (err) {
+        error.value = errorMessage(err);
+      } finally {
+        status.value = "idle";
+      }
+    },
+
+    setPendingAnchor(anchor: PendingLineAnchor | null): void {
+      pendingAnchor.value = anchor;
+    },
+  };
+});
+
+export type ScanCommentsModelInstance = InstanceType<typeof ScanCommentsModel>;

--- a/src/pages/Dashboard/Account/NotificationsSection.tsx
+++ b/src/pages/Dashboard/Account/NotificationsSection.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from "preact/hooks";
+import { useModel } from "@preact/signals";
+import { NotificationSettingsModel } from "../../../models/account-settings";
+import { Alert, Card, LoadingLine, Muted, SectionLabel } from "../../../components";
+
+export function NotificationsSection() {
+  const model = useModel(NotificationSettingsModel);
+
+  useEffect(() => {
+    void model.load();
+  }, []);
+
+  const settings = model.settings.value;
+  const error = model.error.value;
+  const saving = model.status.value === "saving";
+
+  return (
+    <Card class="p-5 flex flex-col gap-3">
+      <SectionLabel>Notifications</SectionLabel>
+      {error ? <Alert tone="critical">{error}</Alert> : null}
+      {settings ? (
+        <label class="flex items-start gap-2 text-[13px] text-ink cursor-pointer">
+          <input
+            type="checkbox"
+            class="mt-[2px]"
+            checked={settings.mentionEmails}
+            disabled={saving}
+            onChange={(e) => void model.setMentionEmails((e.target as HTMLInputElement).checked)}
+          />
+          <span class="flex flex-col gap-0.5">
+            Email me when I'm mentioned
+            <Muted class="text-[12px]">
+              Sends an email when a teammate @-mentions you in a scan comment.
+            </Muted>
+          </span>
+        </label>
+      ) : (
+        <LoadingLine size="inline">Loading notification settings</LoadingLine>
+      )}
+    </Card>
+  );
+}

--- a/src/pages/Dashboard/Account/index.tsx
+++ b/src/pages/Dashboard/Account/index.tsx
@@ -15,6 +15,7 @@ import {
   Card,
 } from "../../../components";
 import { TwoFactorSection } from "./TwoFactorSection";
+import { NotificationsSection } from "./NotificationsSection";
 import { DeleteAccountSection } from "./DeleteAccountSection";
 
 export default function AccountPage() {
@@ -79,6 +80,8 @@ export default function AccountPage() {
         </Card>
 
         <TwoFactorSection />
+
+        <NotificationsSection />
 
         <DeleteAccountSection onDeleted={() => location.route("/", true)} />
       </div>

--- a/src/pages/Dashboard/ScanDetail/DiffWorkbench.tsx
+++ b/src/pages/Dashboard/ScanDetail/DiffWorkbench.tsx
@@ -5,6 +5,7 @@ import {
   EmptyLine,
   IndeterminateBar,
   LoadingLine,
+  type DiffComment,
   type DiffFinding,
 } from "../../../components";
 import { selectDiffWorkbenchState } from "./diff-helpers";
@@ -19,6 +20,8 @@ export function DiffWorkbench({
   selectedVersion,
   stagedVersion,
   findings,
+  comments,
+  onLineComment,
 }: {
   entry: DiffEntry | null;
   staged: PersistedScanDetail["files"][number] | null;
@@ -29,6 +32,8 @@ export function DiffWorkbench({
   selectedVersion: string | null;
   stagedVersion: string | null | undefined;
   findings: DiffFinding[];
+  comments?: DiffComment[];
+  onLineComment?: (line: number) => void;
 }) {
   if (!entry) {
     return <DiffPanelMessage>Select a file from the tree to diff.</DiffPanelMessage>;
@@ -68,6 +73,8 @@ export function DiffWorkbench({
       }
       after={staged ? scanFileToDiffSide(staged) : null}
       findings={findings}
+      comments={comments}
+      onLineComment={onLineComment}
     />
   );
 }

--- a/src/pages/Dashboard/ScanDetail/DiscussionSection.tsx
+++ b/src/pages/Dashboard/ScanDetail/DiscussionSection.tsx
@@ -1,0 +1,254 @@
+import { Fragment } from "preact";
+import { useComputed, useSignal, type ReadonlySignal } from "@preact/signals";
+import { Show } from "@preact/signals/utils";
+import {
+  activeMentionQuery,
+  insertMentionToken,
+  splitMentionSegments,
+} from "../../../lib/mentions";
+import type { OrganizationMember } from "../../../models/organization-members";
+import type { ScanComment, ScanCommentsModelInstance } from "../../../models/scan-comments";
+import { Alert, Button, Card, Muted, SectionLabel } from "../../../components";
+
+// Team discussion on a scan: a chronological comment list plus a composer with
+// @-mention autocomplete. Line comments started from the diff ("+" on a staged
+// line) land here as a pending anchor chip on the composer.
+export function DiscussionSection({
+  model,
+  members,
+  currentUserId,
+  canModerate,
+  onSelectPath,
+}: {
+  model: ScanCommentsModelInstance;
+  members: ReadonlySignal<OrganizationMember[]>;
+  currentUserId: string | null;
+  canModerate: boolean;
+  onSelectPath: (path: string) => void;
+}) {
+  const comments = model.visibleComments.value;
+  const error = model.error.value;
+  const nameFor = (userId: string | null, fallback: string | null) => {
+    if (!userId) return fallback ?? "former member";
+    const member = members.value.find((entry) => entry.userId === userId);
+    return member?.name || member?.email || fallback || "former member";
+  };
+
+  return (
+    <div id="discussion">
+      <Card class="p-5 flex flex-col gap-4">
+        <SectionLabel>Discussion</SectionLabel>
+        {error ? <Alert tone="critical">{error}</Alert> : null}
+        {comments.length === 0 ? (
+          <Muted class="text-[13px]">
+            No comments yet. Start the discussion — mention teammates with @ to loop them in.
+          </Muted>
+        ) : (
+          <ol class="m-0 p-0 list-none flex flex-col divide-y divide-border">
+            {comments.map((comment) => (
+              <CommentItem
+                key={comment.id}
+                comment={comment}
+                authorLabel={nameFor(comment.authorUserId, comment.authorName)}
+                nameFor={nameFor}
+                canDelete={canModerate || comment.authorUserId === currentUserId}
+                busy={model.status.value === "deleting"}
+                onDelete={() => void model.remove(comment.id)}
+                onSelectPath={onSelectPath}
+              />
+            ))}
+          </ol>
+        )}
+        <CommentComposer model={model} members={members} />
+      </Card>
+    </div>
+  );
+}
+
+export function commentAnchorLabel(comment: Pick<ScanComment, "filePath" | "line">): string | null {
+  if (!comment.filePath) return null;
+  return comment.line != null ? `${comment.filePath}:${comment.line}` : comment.filePath;
+}
+
+function CommentItem({
+  comment,
+  authorLabel,
+  nameFor,
+  canDelete,
+  busy,
+  onDelete,
+  onSelectPath,
+}: {
+  comment: ScanComment;
+  authorLabel: string;
+  nameFor: (userId: string | null, fallback: string | null) => string;
+  canDelete: boolean;
+  busy: boolean;
+  onDelete: () => void;
+  onSelectPath: (path: string) => void;
+}) {
+  const anchorLabel = commentAnchorLabel(comment);
+  return (
+    <li class="py-3 flex flex-col gap-1" id={`comment-${comment.id}`}>
+      <div class="flex flex-wrap items-baseline gap-2">
+        <span class="text-[13px] font-medium text-ink">{authorLabel}</span>
+        <span class="font-mono text-[11px] text-ink-subtle">
+          {formatCommentTime(comment.createdAt)}
+        </span>
+        {anchorLabel && comment.filePath ? (
+          <button
+            type="button"
+            class="font-mono text-[11px] text-accent bg-transparent border-0 p-0 cursor-pointer hover:underline"
+            onClick={() => onSelectPath(comment.filePath as string)}
+          >
+            {anchorLabel}
+          </button>
+        ) : null}
+        {canDelete ? (
+          <button
+            type="button"
+            class="ml-auto font-mono text-[11px] text-ink-subtle bg-transparent border-0 p-0 cursor-pointer hover:text-danger disabled:opacity-60"
+            disabled={busy}
+            onClick={onDelete}
+          >
+            delete
+          </button>
+        ) : null}
+      </div>
+      <p class="m-0 text-[13px] leading-[1.55] text-ink whitespace-pre-wrap break-words">
+        {splitMentionSegments(comment.body).map((segment, index) =>
+          segment.type === "mention" ? (
+            <span key={index} class="text-accent font-medium">
+              @{nameFor(segment.userId, null)}
+            </span>
+          ) : (
+            <Fragment key={index}>{segment.text}</Fragment>
+          ),
+        )}
+      </p>
+    </li>
+  );
+}
+
+function CommentComposer({
+  model,
+  members,
+}: {
+  model: ScanCommentsModelInstance;
+  members: ReadonlySignal<OrganizationMember[]>;
+}) {
+  const text = useSignal("");
+  const caret = useSignal(0);
+  const mention = useComputed(() => activeMentionQuery(text.value, caret.value));
+  const suggestions = useComputed(() => {
+    const active = mention.value;
+    const memberList = members.value;
+    if (!active) return [];
+    const query = active.query.toLowerCase();
+    return memberList
+      .filter((member) => {
+        const label = `${member.name ?? ""} ${member.email ?? ""}`.toLowerCase();
+        return query === "" || label.includes(query);
+      })
+      .slice(0, 6);
+  });
+
+  const pendingAnchor = model.pendingAnchor.value;
+  const posting = model.status.value === "posting";
+
+  const syncFromTextarea = (target: HTMLTextAreaElement) => {
+    text.value = target.value;
+    caret.value = target.selectionStart ?? target.value.length;
+  };
+
+  const pickSuggestion = (member: OrganizationMember) => {
+    const active = mention.peek();
+    if (!active) return;
+    const next = insertMentionToken(text.peek(), caret.peek(), active.start, member.userId);
+    text.value = next.text;
+    caret.value = next.caret;
+  };
+
+  const submit = async () => {
+    const body = text.peek().trim();
+    if (!body) return;
+    const anchor = model.pendingAnchor.peek();
+    const ok = await model.post(
+      body,
+      anchor
+        ? { anchorType: "line", filePath: anchor.filePath, line: anchor.line }
+        : { anchorType: "general" },
+    );
+    if (ok) {
+      text.value = "";
+      caret.value = 0;
+    }
+  };
+
+  return (
+    <div class="flex flex-col gap-2 border-t border-border pt-3">
+      {pendingAnchor ? (
+        <div class="flex items-center gap-2">
+          <span class="font-mono text-[11px] text-accent">
+            commenting on {pendingAnchor.filePath}:{pendingAnchor.line}
+          </span>
+          <button
+            type="button"
+            class="font-mono text-[11px] text-ink-subtle bg-transparent border-0 p-0 cursor-pointer hover:text-ink"
+            onClick={() => model.setPendingAnchor(null)}
+          >
+            × clear
+          </button>
+        </div>
+      ) : null}
+      <div class="relative">
+        <textarea
+          class="w-full bg-bg border border-border rounded-md text-[13px] text-ink px-3 py-2 outline-none transition-[border-color,box-shadow] duration-150 ease-out placeholder:text-ink-subtle focus:border-accent focus:shadow-[0_0_0_3px_var(--color-accent-soft)] min-h-[72px] resize-y"
+          placeholder="Leave a comment — type @ to mention a teammate"
+          value={text.value}
+          disabled={posting}
+          onInput={(e) => syncFromTextarea(e.target as HTMLTextAreaElement)}
+          onClick={(e) => syncFromTextarea(e.target as HTMLTextAreaElement)}
+          onKeyUp={(e) => syncFromTextarea(e.target as HTMLTextAreaElement)}
+        />
+        <Show when={() => Boolean(mention.value && suggestions.value.length)}>
+          {() => (
+            <ul class="absolute left-0 top-full z-10 mt-1 m-0 p-1 list-none min-w-[220px] bg-bg border border-border rounded-md shadow-md flex flex-col">
+              {suggestions.value.map((member) => (
+                <li key={member.userId}>
+                  <button
+                    type="button"
+                    class="w-full text-left px-2 py-1.5 rounded text-[13px] text-ink bg-transparent border-0 cursor-pointer hover:bg-surface-2 flex items-baseline gap-2"
+                    onClick={() => pickSuggestion(member)}
+                  >
+                    <span class="font-medium">{member.name || member.email || member.userId}</span>
+                    {member.name && member.email ? (
+                      <span class="font-mono text-[11px] text-ink-subtle">{member.email}</span>
+                    ) : null}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Show>
+      </div>
+      <div class="flex justify-end">
+        <Button size="sm" disabled={posting || !text.value.trim()} onClick={() => void submit()}>
+          {posting ? "Posting…" : "Comment"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function formatCommentTime(value: string | number | Date): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -12,6 +12,10 @@ import { useQuerySignal } from "../../../lib/query-state";
 import { sortFindingsBySeverity } from "../../../lib/findings";
 import { sessionModel } from "../../../models/auth";
 import { ScanDetailModel, type DecisionStatus, type ScanDecision } from "../../../models/scan";
+import { MembersModel } from "../../../models/organization-members";
+import { ScanCommentsModel } from "../../../models/scan-comments";
+import { splitMentionSegments } from "../../../lib/mentions";
+import { roleCanManageMembers, type OrganizationRole } from "../../../../server/lib/roles";
 import type { WorkflowGateDecision } from "../../../models/github-app";
 import { displayedAiResult, type AiReview } from "../../../../server/lib/ai-review-types";
 import { createPackageDiff, type DiffEntry } from "../../../../server/lib/review";
@@ -26,10 +30,12 @@ import {
   PageShell,
   SectionLabel,
   VersionPicker,
+  type DiffComment,
 } from "../../../components";
 import { DecisionDialog } from "./DecisionDialog";
 import { GateContextPanel, GateDecisionDialog, GatePackagesPanel } from "./GateDecisionDialog";
 import { DiffWorkbench } from "./DiffWorkbench";
+import { DiscussionSection } from "./DiscussionSection";
 import { RiskSignalsSection } from "./FindingsSection";
 import { ReleaseRecommendation } from "./ReleaseRecommendation";
 import { PersistedReportSections } from "./ReportSections";
@@ -45,6 +51,8 @@ export default function ScanDetailPage() {
   const route = useRoute();
   const id = route.params.id;
   const model = useModel(() => new ScanDetailModel(id));
+  const commentsModel = useModel(() => new ScanCommentsModel(id));
+  const membersModel = useModel(() => new MembersModel());
   const sessionChecked = useSignal(false);
   const fileFilter = useSignal("");
   const changedFilesOnly = useSignal(true);
@@ -85,6 +93,7 @@ export default function ScanDetailPage() {
         return;
       }
       sessionChecked.value = true;
+      void membersModel.load(false);
       await model.load();
     })();
     return () => {
@@ -93,6 +102,13 @@ export default function ScanDetailPage() {
   }, [id]);
 
   const versionsSignal = useScanVersions(model);
+
+  // Comments only apply to finished reviews; load them once the scan settles.
+  useSignalEffect(() => {
+    if (model.status.value !== "complete") return;
+    if (commentsModel.loaded.peek()) return;
+    void commentsModel.load();
+  });
 
   // Load the workflow gate once the review reaches a terminal state. Completed
   // and failed scans may both be linked to the pending gate so the workbench can
@@ -165,6 +181,33 @@ export default function ScanDetailPage() {
   // Per-file finding counts for the tree, built once from the same finding set
   // that feeds the inline annotations and the risk-signals index.
   const findingCounts = useComputed(() => findingCountsByPath(findingsWithDiffStatus.value));
+
+  // Line-anchored comments for the file open in the workbench, resolved to
+  // display strings here so DiffView stays decoupled from member data.
+  const selectedDiffComments = useComputed<DiffComment[]>(() => {
+    const path = model.selectedPath.value;
+    const memberList = membersModel.members.value;
+    const allComments = commentsModel.visibleComments.value;
+    if (!path) return [];
+    const labelFor = (userId: string | null, fallback: string | null) => {
+      if (!userId) return fallback ?? "former member";
+      const member = memberList.find((entry) => entry.userId === userId);
+      return member?.name || member?.email || fallback || "former member";
+    };
+    return allComments
+      .filter((comment) => comment.filePath === path && comment.line != null)
+      .map((comment) => ({
+        id: comment.id,
+        line: comment.line,
+        authorLabel: labelFor(comment.authorUserId, comment.authorName),
+        timeLabel: new Date(comment.createdAt).toLocaleString(),
+        segments: splitMentionSegments(comment.body).map((segment) =>
+          segment.type === "mention"
+            ? { type: "mention" as const, label: labelFor(segment.userId, segment.userId) }
+            : segment,
+        ),
+      }));
+  });
 
   const stagedFile = useComputed(() => {
     const path = model.selectedPath.value;
@@ -362,6 +405,15 @@ export default function ScanDetailPage() {
                   selectedVersion={selectedVersion}
                   stagedVersion={detail.scan.stagedVersion}
                   findings={selectedFindings.value}
+                  comments={selectedDiffComments.value}
+                  onLineComment={(line) => {
+                    const path = model.selectedPath.peek();
+                    if (!path) return;
+                    commentsModel.setPendingAnchor({ filePath: path, line });
+                    document
+                      .getElementById("discussion")
+                      ?.scrollIntoView({ behavior: "smooth", block: "start" });
+                  }}
                 />
               </Card>
             </section>
@@ -374,6 +426,18 @@ export default function ScanDetailPage() {
             ) : null}
 
             <PersistedReportSections summary={summary.value} ai={ai.value} />
+
+            <DiscussionSection
+              model={commentsModel}
+              members={membersModel.members}
+              currentUserId={sessionModel.session.value?.user.id ?? null}
+              canModerate={roleCanManageMembers(
+                (membersModel.members.value.find(
+                  (member) => member.userId === sessionModel.session.value?.user.id,
+                )?.role ?? "member") as OrganizationRole,
+              )}
+              onSelectPath={(file) => model.selectPath(file)}
+            />
           </>
         ) : detail.scan.status === "pending" || detail.scan.status === "running" ? (
           // While stalled the pulsing line would falsely promise an

--- a/test/comment-mentions.test.ts
+++ b/test/comment-mentions.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "vitest";
+import {
+  COMMENT_BODY_MAX,
+  extractMentionUserIds,
+  isCommentAnchorType,
+} from "../server/lib/comment-mentions";
+import { activeMentionQuery, insertMentionToken, splitMentionSegments } from "../src/lib/mentions";
+
+describe("extractMentionUserIds", () => {
+  test("extracts unique user ids from @[id] tokens", () => {
+    expect(extractMentionUserIds("hi @[user_a] and @[user_b] and @[user_a]")).toEqual([
+      "user_a",
+      "user_b",
+    ]);
+  });
+
+  test("ignores plain @names, emails, and malformed tokens", () => {
+    expect(extractMentionUserIds("hi @alice, mail me at bob@example.com, @[]")).toEqual([]);
+  });
+
+  test("accepts ids with dots, colons, and dashes", () => {
+    expect(extractMentionUserIds("@[user:abc-1.2_x]")).toEqual(["user:abc-1.2_x"]);
+  });
+});
+
+describe("isCommentAnchorType", () => {
+  test("accepts the three anchor kinds and rejects others", () => {
+    expect(isCommentAnchorType("general")).toBe(true);
+    expect(isCommentAnchorType("line")).toBe(true);
+    expect(isCommentAnchorType("finding")).toBe(true);
+    expect(isCommentAnchorType("inline")).toBe(false);
+    expect(isCommentAnchorType(42)).toBe(false);
+  });
+
+  test("body cap is sane", () => {
+    expect(COMMENT_BODY_MAX).toBe(4000);
+  });
+});
+
+describe("splitMentionSegments", () => {
+  test("splits text around mention tokens", () => {
+    expect(splitMentionSegments("hi @[u1], meet @[u2]")).toEqual([
+      { type: "text", text: "hi " },
+      { type: "mention", userId: "u1" },
+      { type: "text", text: ", meet " },
+      { type: "mention", userId: "u2" },
+    ]);
+  });
+
+  test("returns a single text segment when there are no mentions", () => {
+    expect(splitMentionSegments("plain text")).toEqual([{ type: "text", text: "plain text" }]);
+  });
+});
+
+describe("activeMentionQuery", () => {
+  test("detects an in-progress mention at the caret", () => {
+    expect(activeMentionQuery("hello @al", 9)).toEqual({ start: 6, query: "al" });
+  });
+
+  test("ignores mid-word @ such as emails", () => {
+    expect(activeMentionQuery("bob@example", 11)).toBeNull();
+  });
+
+  test("ignores completed tokens", () => {
+    const text = "hi @[user_a";
+    expect(activeMentionQuery(text, text.length)).toBeNull();
+  });
+});
+
+describe("insertMentionToken", () => {
+  test("replaces the partial query with a token and moves the caret", () => {
+    const result = insertMentionToken("hello @al there", 9, 6, "user_a");
+    expect(result.text).toBe("hello @[user_a]  there");
+    expect(result.caret).toBe("hello @[user_a] ".length);
+  });
+});

--- a/test/workers/scan-comments-routes.test.ts
+++ b/test/workers/scan-comments-routes.test.ts
@@ -1,0 +1,478 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { describe, expect, test } from "vitest";
+import { and, eq } from "drizzle-orm";
+import {
+  addOrganizationMember,
+  createDb,
+  ensurePersonalOrganization,
+  getUserNotificationSettings,
+  setUserNotificationSettings,
+} from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { ACTIVE_ORG_HEADER } from "../../server/lib/active-organization";
+import { accountRoutes } from "../../server/routes/account";
+import { scanCommentsRoutes } from "../../server/routes/scan-comments";
+import { organizationsRoutes } from "../../server/routes/organizations";
+import type { Bindings, Variables } from "../../server/types";
+
+interface SeededUser {
+  userId: string;
+  email: string;
+  personalOrganizationId: string;
+}
+
+async function seedUser(): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  const email = `${userId}@example.com`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const personalOrganizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, email, personalOrganizationId };
+}
+
+async function seedScan(organizationId: string, ownerUserId: string): Promise<string> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const scanId = crypto.randomUUID();
+  await db.insert(schema.scans).values({
+    id: scanId,
+    stageId: `stage_${scanId}`,
+    organizationId,
+    ownerUserId,
+    packageName: "left-pad",
+    stagedVersion: "1.0.1",
+    status: "complete",
+    createdAt: now,
+    updatedAt: now,
+  });
+  await db.insert(schema.scanFiles).values({
+    id: crypto.randomUUID(),
+    scanId,
+    path: "index.js",
+    status: "modified",
+    sha256: "abc123",
+    flagsJson: [],
+  });
+  await db.insert(schema.scanFindings).values({
+    id: `finding_${scanId}`,
+    scanId,
+    severity: "high",
+    file: "index.js",
+    evidence: "eval(input)",
+    reason: "dynamic eval",
+    line: 3,
+  });
+  return scanId;
+}
+
+function buildTestApp(session: { userId: string }) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.use("*", async (c, next) => {
+    c.set("authSession", { userId: session.userId });
+    await next();
+  });
+  app.route("/api/v1/organizations", organizationsRoutes);
+  app.route("/api/v1/scans", scanCommentsRoutes);
+  app.route("/api/v1/account", accountRoutes);
+  return app;
+}
+
+async function call(
+  app: Hono<{ Bindings: Bindings; Variables: Variables }>,
+  method: string,
+  path: string,
+  options: { body?: unknown; activeOrganizationId?: string } = {},
+) {
+  const ctx = createExecutionContext();
+  const headers: Record<string, string> = {};
+  const init: RequestInit = { method };
+  if (options.body !== undefined) {
+    init.body = JSON.stringify(options.body);
+    headers["content-type"] = "application/json";
+  }
+  if (options.activeOrganizationId) {
+    headers[ACTIVE_ORG_HEADER] = options.activeOrganizationId;
+  }
+  init.headers = headers;
+  const res = await app.fetch(new Request(`http://test.local${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+interface CommentPayload {
+  comment: {
+    id: string;
+    body: string;
+    anchorType: string;
+    filePath: string | null;
+    line: number | null;
+    findingId: string | null;
+    mentionedUserIds: string[];
+    deleted: boolean;
+  };
+}
+
+describe("scan comment routes", () => {
+  test("general comment round-trips through create and list", async () => {
+    const owner = await seedUser();
+    const scanId = await seedScan(owner.personalOrganizationId, owner.userId);
+    const app = buildTestApp(owner);
+
+    const created = await call(app, "POST", `/api/v1/scans/${scanId}/comments`, {
+      body: { body: "looks good to me" },
+      activeOrganizationId: owner.personalOrganizationId,
+    });
+    expect(created.status).toBe(201);
+    const payload = (await created.json()) as CommentPayload;
+    expect(payload.comment.body).toBe("looks good to me");
+    expect(payload.comment.anchorType).toBe("general");
+
+    const list = await call(app, "GET", `/api/v1/scans/${scanId}/comments`, {
+      activeOrganizationId: owner.personalOrganizationId,
+    });
+    expect(list.status).toBe(200);
+    const listed = (await list.json()) as { comments: CommentPayload["comment"][] };
+    expect(listed.comments).toHaveLength(1);
+    expect(listed.comments[0].body).toBe("looks good to me");
+
+    const db = createDb(env.DB);
+    const events = await db
+      .select()
+      .from(schema.scanEvents)
+      .where(eq(schema.scanEvents.type, "scan.comment_created"));
+    expect(events.some((event) => event.scanId === scanId)).toBe(true);
+  });
+
+  test("line anchors validate against scan files and capture the file sha", async () => {
+    const owner = await seedUser();
+    const scanId = await seedScan(owner.personalOrganizationId, owner.userId);
+    const app = buildTestApp(owner);
+
+    const bad = await call(app, "POST", `/api/v1/scans/${scanId}/comments`, {
+      body: { body: "where is this?", anchorType: "line", filePath: "missing.js", line: 1 },
+      activeOrganizationId: owner.personalOrganizationId,
+    });
+    expect(bad.status).toBe(400);
+
+    const good = await call(app, "POST", `/api/v1/scans/${scanId}/comments`, {
+      body: { body: "suspicious", anchorType: "line", filePath: "index.js", line: 3 },
+      activeOrganizationId: owner.personalOrganizationId,
+    });
+    expect(good.status).toBe(201);
+    const payload = (await good.json()) as CommentPayload;
+    expect(payload.comment.filePath).toBe("index.js");
+    expect(payload.comment.line).toBe(3);
+
+    const db = createDb(env.DB);
+    const [row] = await db
+      .select()
+      .from(schema.scanComments)
+      .where(eq(schema.scanComments.id, payload.comment.id));
+    expect(row.fileSha256).toBe("abc123");
+  });
+
+  test("finding anchors validate and inherit the finding location", async () => {
+    const owner = await seedUser();
+    const scanId = await seedScan(owner.personalOrganizationId, owner.userId);
+    const app = buildTestApp(owner);
+
+    const bad = await call(app, "POST", `/api/v1/scans/${scanId}/comments`, {
+      body: { body: "hm", anchorType: "finding", findingId: "nope" },
+      activeOrganizationId: owner.personalOrganizationId,
+    });
+    expect(bad.status).toBe(400);
+
+    const good = await call(app, "POST", `/api/v1/scans/${scanId}/comments`, {
+      body: { body: "real issue", anchorType: "finding", findingId: `finding_${scanId}` },
+      activeOrganizationId: owner.personalOrganizationId,
+    });
+    expect(good.status).toBe(201);
+    const payload = (await good.json()) as CommentPayload;
+    expect(payload.comment.findingId).toBe(`finding_${scanId}`);
+    expect(payload.comment.filePath).toBe("index.js");
+    expect(payload.comment.line).toBe(3);
+  });
+
+  test("comments are scoped to the scan's organization", async () => {
+    const owner = await seedUser();
+    const outsider = await seedUser();
+    const scanId = await seedScan(owner.personalOrganizationId, owner.userId);
+
+    const res = await call(buildTestApp(outsider), "GET", `/api/v1/scans/${scanId}/comments`, {
+      activeOrganizationId: outsider.personalOrganizationId,
+    });
+    expect(res.status).toBe(404);
+
+    const post = await call(buildTestApp(outsider), "POST", `/api/v1/scans/${scanId}/comments`, {
+      body: { body: "should not land" },
+      activeOrganizationId: outsider.personalOrganizationId,
+    });
+    expect(post.status).toBe(404);
+  });
+
+  test("member mentions persist; non-member mentions are dropped silently", async () => {
+    const db = createDb(env.DB);
+    const owner = await seedUser();
+    const teammate = await seedUser();
+    const outsider = await seedUser();
+    await addOrganizationMember(db, {
+      organizationId: owner.personalOrganizationId,
+      userId: teammate.userId,
+      role: "member",
+    });
+    const scanId = await seedScan(owner.personalOrganizationId, owner.userId);
+
+    const res = await call(buildTestApp(owner), "POST", `/api/v1/scans/${scanId}/comments`, {
+      body: { body: `ping @[${teammate.userId}] and @[${outsider.userId}]` },
+      activeOrganizationId: owner.personalOrganizationId,
+    });
+    expect(res.status).toBe(201);
+    const payload = (await res.json()) as CommentPayload;
+    expect(payload.comment.mentionedUserIds).toEqual([teammate.userId]);
+
+    const mentions = await db
+      .select()
+      .from(schema.scanCommentMentions)
+      .where(eq(schema.scanCommentMentions.commentId, payload.comment.id));
+    expect(mentions).toHaveLength(1);
+    expect(mentions[0].mentionedUserId).toBe(teammate.userId);
+  });
+
+  test("mention emails are skipped when the user turned them off", async () => {
+    const db = createDb(env.DB);
+    const owner = await seedUser();
+    const teammate = await seedUser();
+    await addOrganizationMember(db, {
+      organizationId: owner.personalOrganizationId,
+      userId: teammate.userId,
+      role: "member",
+    });
+    await setUserNotificationSettings(db, teammate.userId, { mentionEmails: false });
+    const scanId = await seedScan(owner.personalOrganizationId, owner.userId);
+
+    const res = await call(buildTestApp(owner), "POST", `/api/v1/scans/${scanId}/comments`, {
+      body: { body: `fyi @[${teammate.userId}]` },
+      activeOrganizationId: owner.personalOrganizationId,
+    });
+    expect(res.status).toBe(201);
+
+    const events = await db
+      .select()
+      .from(schema.scanEvents)
+      .where(eq(schema.scanEvents.scanId, scanId));
+    expect(events.some((event) => event.type.startsWith("scan.comment_mention"))).toBe(false);
+  });
+
+  test("editing only notifies newly mentioned users", async () => {
+    const db = createDb(env.DB);
+    const owner = await seedUser();
+    const first = await seedUser();
+    const second = await seedUser();
+    for (const member of [first, second]) {
+      await addOrganizationMember(db, {
+        organizationId: owner.personalOrganizationId,
+        userId: member.userId,
+        role: "member",
+      });
+    }
+    const scanId = await seedScan(owner.personalOrganizationId, owner.userId);
+    const app = buildTestApp(owner);
+
+    const created = await call(app, "POST", `/api/v1/scans/${scanId}/comments`, {
+      body: { body: `hello @[${first.userId}]` },
+      activeOrganizationId: owner.personalOrganizationId,
+    });
+    const payload = (await created.json()) as CommentPayload;
+
+    const edited = await call(
+      app,
+      "PATCH",
+      `/api/v1/scans/${scanId}/comments/${payload.comment.id}`,
+      {
+        body: { body: `hello @[${first.userId}] and @[${second.userId}]` },
+        activeOrganizationId: owner.personalOrganizationId,
+      },
+    );
+    expect(edited.status).toBe(200);
+    const editedPayload = (await edited.json()) as CommentPayload;
+    // PATCH reports the full mention set, but only `second` was newly stored.
+    expect(editedPayload.comment.mentionedUserIds.sort()).toEqual(
+      [first.userId, second.userId].sort(),
+    );
+
+    const mentions = await db
+      .select()
+      .from(schema.scanCommentMentions)
+      .where(eq(schema.scanCommentMentions.commentId, payload.comment.id));
+    expect(mentions).toHaveLength(2);
+  });
+
+  test("only the author edits; admins can delete; deletes are soft", async () => {
+    const db = createDb(env.DB);
+    const owner = await seedUser();
+    const member = await seedUser();
+    await addOrganizationMember(db, {
+      organizationId: owner.personalOrganizationId,
+      userId: member.userId,
+      role: "member",
+    });
+    const scanId = await seedScan(owner.personalOrganizationId, owner.userId);
+
+    const created = await call(buildTestApp(member), "POST", `/api/v1/scans/${scanId}/comments`, {
+      body: { body: "my note" },
+      activeOrganizationId: owner.personalOrganizationId,
+    });
+    const payload = (await created.json()) as CommentPayload;
+
+    const editByOther = await call(
+      buildTestApp(owner),
+      "PATCH",
+      `/api/v1/scans/${scanId}/comments/${payload.comment.id}`,
+      { body: { body: "rewritten" }, activeOrganizationId: owner.personalOrganizationId },
+    );
+    expect(editByOther.status).toBe(403);
+
+    // Owner (admin role) may delete another member's comment.
+    const deleted = await call(
+      buildTestApp(owner),
+      "DELETE",
+      `/api/v1/scans/${scanId}/comments/${payload.comment.id}`,
+      { activeOrganizationId: owner.personalOrganizationId },
+    );
+    expect(deleted.status).toBe(200);
+
+    const [row] = await db
+      .select()
+      .from(schema.scanComments)
+      .where(eq(schema.scanComments.id, payload.comment.id));
+    expect(row.deletedAt).not.toBeNull();
+
+    const list = await call(buildTestApp(owner), "GET", `/api/v1/scans/${scanId}/comments`, {
+      activeOrganizationId: owner.personalOrganizationId,
+    });
+    const listed = (await list.json()) as { comments: CommentPayload["comment"][] };
+    const tombstone = listed.comments.find((comment) => comment.id === payload.comment.id);
+    expect(tombstone?.deleted).toBe(true);
+    expect(tombstone?.body).toBe("");
+  });
+
+  test("members cannot delete someone else's comment", async () => {
+    const db = createDb(env.DB);
+    const owner = await seedUser();
+    const member = await seedUser();
+    await addOrganizationMember(db, {
+      organizationId: owner.personalOrganizationId,
+      userId: member.userId,
+      role: "member",
+    });
+    const scanId = await seedScan(owner.personalOrganizationId, owner.userId);
+
+    const created = await call(buildTestApp(owner), "POST", `/api/v1/scans/${scanId}/comments`, {
+      body: { body: "owner note" },
+      activeOrganizationId: owner.personalOrganizationId,
+    });
+    const payload = (await created.json()) as CommentPayload;
+
+    const deleted = await call(
+      buildTestApp(member),
+      "DELETE",
+      `/api/v1/scans/${scanId}/comments/${payload.comment.id}`,
+      { activeOrganizationId: owner.personalOrganizationId },
+    );
+    expect(deleted.status).toBe(403);
+  });
+
+  test("replies must reference a comment on the same scan", async () => {
+    const owner = await seedUser();
+    const scanId = await seedScan(owner.personalOrganizationId, owner.userId);
+    const otherScanId = await seedScan(owner.personalOrganizationId, owner.userId);
+    const app = buildTestApp(owner);
+
+    const created = await call(app, "POST", `/api/v1/scans/${scanId}/comments`, {
+      body: { body: "root" },
+      activeOrganizationId: owner.personalOrganizationId,
+    });
+    const payload = (await created.json()) as CommentPayload;
+
+    const crossScan = await call(app, "POST", `/api/v1/scans/${otherScanId}/comments`, {
+      body: { body: "reply", parentId: payload.comment.id },
+      activeOrganizationId: owner.personalOrganizationId,
+    });
+    expect(crossScan.status).toBe(400);
+
+    const reply = await call(app, "POST", `/api/v1/scans/${scanId}/comments`, {
+      body: { body: "reply", parentId: payload.comment.id },
+      activeOrganizationId: owner.personalOrganizationId,
+    });
+    expect(reply.status).toBe(201);
+  });
+
+  test("comment bodies are length-capped", async () => {
+    const owner = await seedUser();
+    const scanId = await seedScan(owner.personalOrganizationId, owner.userId);
+
+    const res = await call(buildTestApp(owner), "POST", `/api/v1/scans/${scanId}/comments`, {
+      body: { body: "x".repeat(4001) },
+      activeOrganizationId: owner.personalOrganizationId,
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("account notification settings routes", () => {
+  test("defaults to mention emails on and persists the toggle", async () => {
+    const user = await seedUser();
+    const app = buildTestApp(user);
+
+    const initial = await call(app, "GET", "/api/v1/account/notification-settings");
+    expect(initial.status).toBe(200);
+    expect(await initial.json()).toEqual({ settings: { mentionEmails: true } });
+
+    const updated = await call(app, "PATCH", "/api/v1/account/notification-settings", {
+      body: { mentionEmails: false },
+    });
+    expect(updated.status).toBe(200);
+    expect(await updated.json()).toEqual({ settings: { mentionEmails: false } });
+
+    const db = createDb(env.DB);
+    expect(await getUserNotificationSettings(db, user.userId)).toEqual({ mentionEmails: false });
+
+    const invalid = await call(app, "PATCH", "/api/v1/account/notification-settings", {
+      body: { mentionEmails: "yes" },
+    });
+    expect(invalid.status).toBe(400);
+  });
+});
+
+describe("deletion hygiene", () => {
+  test("comment rows do not leak across scans", async () => {
+    const db = createDb(env.DB);
+    const owner = await seedUser();
+    const scanId = await seedScan(owner.personalOrganizationId, owner.userId);
+    const created = await call(buildTestApp(owner), "POST", `/api/v1/scans/${scanId}/comments`, {
+      body: { body: "scoped" },
+      activeOrganizationId: owner.personalOrganizationId,
+    });
+    expect(created.status).toBe(201);
+
+    const rows = await db
+      .select()
+      .from(schema.scanComments)
+      .where(
+        and(
+          eq(schema.scanComments.scanId, scanId),
+          eq(schema.scanComments.organizationId, owner.personalOrganizationId),
+        ),
+      );
+    expect(rows).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
Adds team discussion on completed scans: general comments, comments anchored to a staged diff line or a finding, @-mentions that email the mentioned teammate (opt-out per user), and the full UI.

**Data model** (migration `0020`, generated via `pnpm db:generate`):
- `scan_comments` — org+scan scoped, `anchor_type` `general|line|finding` (`file_path`/`line` + staged `file_sha256` captured at write time; scans are immutable so anchors never go stale), `parent_id` replies, soft delete via `deleted_at` (API serializes tombstones with body/author redacted)
- `scan_comment_mentions` — unique (comment, user), `notified_at` makes delivery idempotent: `addCommentMentions` returns only *newly added* ids, so editing a comment never re-notifies prior mentions
- `user_notification_settings` — `mention_emails` defaults true; no row ⇒ defaults
- `deleteOrganization` / `deleteUserAccount` batches clean these up explicitly (D1 doesn't enforce FKs); deleted accounts leave comments behind with `author_user_id = null`, rendered as "former member"

**API**:
- `GET/POST /api/v1/scans/:scanId/comments`, `PATCH/DELETE .../:commentId` — org-scoped via the active-org header (cross-org ⇒ 404), anchors validated against the scan's files/findings, 4000-char body cap, 30/h per-user rate limit, `scan.comment_created`/`_deleted` audit events. Author-only edit; delete by author or owner/admin (`roleCanManageMembers`).
- `GET/PATCH /api/v1/account/notification-settings` — per-user mention-email toggle (new Account page section).

**Mentions**: stored as structured `@[userId]` tokens (never display names). Server resolves tokens via `filterOrganizationMemberIds` and silently drops non-members (prevents user-id enumeration). `notifyCommentMention` runs on `waitUntil` (never blocks the response), skips users who opted out, includes only the comment text + `path:line` label — never scan evidence — and records `scan.comment_mention_sent`/`_failed` events.

**UI**:
- Discussion card on the scan detail page (complete scans): chronological list + composer with `@` autocomplete fed by the org member list; tokens render as highlighted `@Name` resolved at render time
- Inline diff comments: line-anchored comments render beneath their staged line in `DiffView` (reuses `partitionFindingsByLine`); hovering a staged line number shows a `+` that sets the composer's anchor chip
- Account page: "Email me when I'm mentioned" toggle

Tests: `test/workers/scan-comments-routes.test.ts` (CRUD, org scoping, anchor validation, non-member mention dropped, pref-off ⇒ no send, edit notifies only new mentions, soft delete/permissions) and `test/comment-mentions.test.ts` (token parsing, composer query/insert helpers). Docs in `docs/scan-comments.md`.

Link to Devin session: https://app.devin.ai/sessions/1626a353de954b9bbda4c6888f305cb1
Requested by: @JoviDeCroock