### PR TITLE
Remove release target mapping explanation

### DIFF
--- a/src/pages/Dashboard/Settings/ReleaseTargetForm.tsx
+++ b/src/pages/Dashboard/Settings/ReleaseTargetForm.tsx
@@ -45,11 +45,6 @@ export function ReleaseTargetForm({
         <Button type="submit" disabled={submitting || !formValid}>
           {submitting ? "Mapping…" : "Map release target"}
         </Button>
-        <Muted class="text-[12px] m-0">
-          Drydock revalidates installation, repo access, and environment before saving, then scans
-          every artifact the held run uploads — detecting each package's ecosystem (npm or PyPI)
-          automatically.
-        </Muted>
       </div>
     </form>
   );


### PR DESCRIPTION
## Summary
- Removes the helper text rendered beside the Settings “Map release target” submit button so the CTA stands alone.

## Testing
- `pnpm run lint`
- `pnpm run typecheck`

Link to Devin session: https://app.devin.ai/sessions/f654c13de1b34a9b9c9b081aaa4121a8
Requested by: @JoviDeCroock