### PR TITLE
Fix loading bar sweep animation

### DIFF
--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -11,7 +11,7 @@ export function IndeterminateBar({ class: className }: { class?: string }) {
       aria-label="Loading"
     >
       <span
-        class="absolute inset-y-0 left-0 w-1/3 rounded-sm bg-accent motion-safe:animate-progress-sweep"
+        class="absolute inset-y-0 left-0 w-1/3 rounded-sm bg-accent animate-progress-sweep"
         aria-hidden
       />
     </div>

--- a/test/style-theme.test.mjs
+++ b/test/style-theme.test.mjs
@@ -6,6 +6,10 @@ import { describe, expect, test } from "vitest";
 // light-mode bug these protect against was invisible in normal development
 // (the site renders fine in dark mode), so it needs a source-level guard.
 const css = readFileSync(fileURLToPath(new URL("../src/style.css", import.meta.url)), "utf8");
+const loading = readFileSync(
+  fileURLToPath(new URL("../src/components/Loading.tsx", import.meta.url)),
+  "utf8",
+);
 
 /** Return the body of the first `@media (prefers-color-scheme: dark)` block. */
 function darkMediaBlock(source) {
@@ -77,5 +81,14 @@ describe("theme tokens", () => {
       // 4.5:1 is the AA floor for the 11px mono labels / detail line.
       expect(contrast(subtle, surface)).toBeGreaterThanOrEqual(4.5);
     }
+  });
+});
+
+describe("loading progress animation", () => {
+  test("the indeterminate bar always uses the left-to-right sweep", () => {
+    expect(loading).toContain("animate-progress-sweep");
+    expect(loading).not.toContain("motion-safe:animate-progress-sweep");
+    expect(css).toContain("--animate-progress-sweep");
+    expect(css).toMatch(/@keyframes\s+progress-sweep/);
   });
 });


### PR DESCRIPTION
## Summary
- Keep `IndeterminateBar` on the left-to-right `progress-sweep` animation directly instead of gating it behind Tailwind's `motion-safe:` variant; that variant makes the bar static whenever the browser reports `prefers-reduced-motion: reduce`.
- Add a source-level regression guard so the loading bar continues to use the sweep animation and the theme still defines the supporting keyframes/token.

Link to Devin session: https://app.devin.ai/sessions/8c37a076b15c4781bde00998d6eb394c
Requested by: @JoviDeCroock