### PR TITLE
Use package and version in report export filenames

### DIFF
--- a/docs/artifact-storage.md
+++ b/docs/artifact-storage.md
@@ -41,6 +41,8 @@ Path segments are URL-encoded with `%` replaced by `~` so object keys stay path-
 
 The manifest records each object key, SHA-256 digest, byte size, content type, and count where applicable. `report.json` is the canonical report JSON whose digest must equal `scans.report_digest`. `files.json` stores redacted staged file samples plus file metadata. `diff.json` stores the generated file diff.
 
+User-initiated report downloads serve the same canonical `report.json` bytes with a package-scoped filename: `drydock-{package-name}-{version}.json`. Package names are normalized to a path-safe filename segment for the `Content-Disposition` header.
+
 ## Write And Read Flow
 
 New completed scans try to write `report.json`, `files.json`, `diff.json`, and `manifest.json` to R2 before `persistScan` marks the D1 row artifact-backed. Each object is read back and verified against its expected size and SHA-256 digest before D1 metadata is saved. Transient write or verification failures are retried; exhausted failures log `scan.artifacts.write_failed` and fail closed so the scan can retry instead of persisting new file samples into D1. When the R2 write succeeds, D1 stores compact file metadata only and leaves `scan_files.text_sample` null.

--- a/server/lib/report-export.ts
+++ b/server/lib/report-export.ts
@@ -3,6 +3,12 @@ import type { getScan } from "../db/scans";
 // A persisted scan detail, as returned by getScan (never null at the call site).
 type ScanDetail = NonNullable<Awaited<ReturnType<typeof getScan>>>;
 
+interface ReportExportFilenameInput {
+  id: string;
+  packageName: string | null;
+  stagedVersion: string | null;
+}
+
 // Schema tag for the exported report document. Bump the suffix when the export
 // shape changes in a way consumers must branch on.
 export const REPORT_EXPORT_SCHEMA = "drydock.report.v1";
@@ -62,6 +68,13 @@ export function serializeReportExport(detail: ScanDetail): string {
   return stableStringify(buildReportExport(detail));
 }
 
+export function reportExportFilename(scan: ReportExportFilenameInput): string {
+  const packageName = filenameSegment(scan.packageName);
+  const version = filenameSegment(scan.stagedVersion);
+  if (packageName && version) return `drydock-${packageName}-${version}.json`;
+  return `drydock-report-${filenameSegment(scan.id) || "scan"}.json`;
+}
+
 function compareFindings(
   a: ScanDetail["findings"][number],
   b: ScanDetail["findings"][number],
@@ -97,4 +110,13 @@ function toIso(value: unknown): string | null {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function filenameSegment(value: string | null | undefined): string | null {
+  const segment = value
+    ?.trim()
+    .replace(/[/\\]+/g, "-")
+    .replace(/[^A-Za-z0-9@._+-]+/g, "-");
+  const trimmed = segment?.replace(/-+/g, "-").replace(/^-|-$/g, "");
+  return trimmed || null;
 }

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -30,7 +30,7 @@ import { compareSemver, fetchPackageMetadata, pickPreviousVersion } from "../lib
 import { annotateFindingsWithDiffStatus, createPackageDiff, type FileRecord } from "../lib/review";
 import { describeOperationalError, emitOperationalEvent } from "../lib/observability";
 import { parseScanInput } from "../lib/scan-input";
-import { serializeReportExport } from "../lib/report-export";
+import { reportExportFilename, serializeReportExport } from "../lib/report-export";
 import { executeScanJob, type ScanQueueMessage } from "../lib/scan-job";
 import { roleCanManageIntegrations } from "../lib/roles";
 import type { Bindings, ScanInput, Variables } from "../types";
@@ -264,7 +264,7 @@ scansRoutes.get("/:id/report.json", async (c) => {
     status: 200,
     headers: {
       "content-type": "application/json; charset=utf-8",
-      "content-disposition": `attachment; filename="drydock-report-${detail.scan.id}.json"`,
+      "content-disposition": `attachment; filename="${reportExportFilename(detail.scan)}"`,
       "cache-control": "private, no-store",
     },
   });

--- a/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
+++ b/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
@@ -1,5 +1,6 @@
 import { getDashboardReturnUrl } from "../../../lib/query-state";
 import { formatDateTime } from "../../../lib/format";
+import { reportExportFilename } from "../../../../server/lib/report-export";
 import type { PersistedScanDetail } from "../../../models/scan";
 import {
   Alert,
@@ -69,7 +70,7 @@ export function ScanDetailHeader({
               variant="ghost"
               size="sm"
               href={`/api/v1/scans/${detail.scan.id}/report.json`}
-              download={`drydock-report-${detail.scan.id}.json`}
+              download={reportExportFilename(detail.scan)}
             >
               Export JSON
             </LinkButton>

--- a/test/workers/scan-report-export.test.ts
+++ b/test/workers/scan-report-export.test.ts
@@ -113,7 +113,7 @@ describe("scan report JSON export", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("application/json");
     expect(res.headers.get("content-disposition")).toBe(
-      `attachment; filename="drydock-report-${scanId}.json"`,
+      `attachment; filename="drydock-@org-pkg-1.1.0.json"`,
     );
 
     const text = await res.text();


### PR DESCRIPTION
## Summary
- Report JSON downloads now derive their filename from package identity when available:
  ```ts
  packageName && stagedVersion
    ? `drydock-${safePackageName}-${safeVersion}.json`
    : `drydock-report-${scanId}.json`
  ```
- The dashboard `download` attribute and `/api/v1/scans/:id/report.json` `Content-Disposition` header share `reportExportFilename`, so scoped names like `@org/pkg` are normalized consistently.
- Updated the worker-route regression coverage and artifact-storage docs for the new export filename.

Link to Devin session: https://app.devin.ai/sessions/626413fd5897458ea777826ae54cef9f
Requested by: @JoviDeCroock