### PR TITLE
Add report provenance UI

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,7 +79,7 @@ Organizations store their own encrypted npm connection. The UI validates baselin
 
 ## Report model
 
-Reports should remain canonical and future-signable: stable ordering, explicit release/artifact/context risk sections, redacted evidence, and enough metadata to reproduce the reviewed artifact identity. Public signed reports are future work; do not expose signing semantics until the report contract is finalized.
+Reports should remain canonical and future-signable: stable ordering, explicit release/artifact/context risk sections, redacted evidence, and enough metadata to reproduce the reviewed artifact identity. Persisted scan detail APIs return normalized report provenance: report schema/version/digest, rules version, generated timestamp, package/baseline identity, stage ID or workflow gate ID, reviewed artifact digests, review limitations, and AI availability/model metadata. Public signed reports are future work; do not expose signing semantics until the report contract is finalized.
 
 ## API direction
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -24,6 +24,7 @@ Prefer existing primitives in `src/components/` before adding one-off classes:
 
 - Lead with maintainer action and release risk, not internal pipeline detail.
 - Keep dense review surfaces scannable: short headings, compact metadata, and findings pinned to evidence.
+- On scan detail, persisted report sections show report provenance, manifest changes, and reviewer notes as section-label blocks, not cards.
 - Use severity stacked bars for risk distribution; avoid decorative charts.
 - Icons are text glyphs only; no SVG icon libraries.
 

--- a/docs/workflow-gates.md
+++ b/docs/workflow-gates.md
@@ -112,6 +112,8 @@ The gate review workbench shows the release target, package identity/version, ar
 
 ## Remaining work
 
-- Continue surfacing artifact digests and callback metadata in completed reports.
+- Publish the recommended GitHub Actions digest-verification snippet that checks the reviewed wheel/sdist SHA-256 values immediately before upload.
 - Expand gate-specific e2e coverage as more ecosystems are added.
 - Keep GitHub/PyPI/npm validation failures user-actionable without leaking credentials or private package bytes.
+
+Drydock records reviewed artifact digests in report provenance; the remaining digest item is the publish-side verification contract.

--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -13,6 +13,7 @@ import {
   type PackageJsonSummary,
 } from "../lib/review";
 import { normalizeScanRiskBreakdown, type ScanRiskBreakdown } from "../lib/risk";
+import { buildReportProvenance } from "../lib/report-provenance";
 import {
   deleteScanArtifacts,
   loadScanArtifactFile,
@@ -823,7 +824,7 @@ export async function getScan(
       ? artifactDetail.findingAnnotations
       : readFindingAnnotations(scan.summaryJson),
   });
-  return {
+  const detail = {
     scan,
     files: responseFiles,
     findings: annotatedFindings,
@@ -837,6 +838,7 @@ export async function getScan(
         : null,
     events: events.map(redactScanEventForClient),
   };
+  return { ...detail, provenance: buildReportProvenance(detail) };
 }
 
 export async function getScanFile(

--- a/server/lib/adapters/pypi/index.ts
+++ b/server/lib/adapters/pypi/index.ts
@@ -67,6 +67,7 @@ export const pypiAdapter: PackageAdapter<PyPiAdapterInput, PyPiBroker> = {
   summarizeDetails(details) {
     const d = details as PyPiAdapterDetails;
     return {
+      mode: "workflow_gate",
       manifest: d.manifest,
       artifacts: d.artifacts,
     };

--- a/server/lib/report-export.ts
+++ b/server/lib/report-export.ts
@@ -1,4 +1,5 @@
 import type { getScan } from "../db/scans";
+import { buildReportProvenance, REPORT_EXPORT_SCHEMA } from "./report-provenance";
 
 // A persisted scan detail, as returned by getScan (never null at the call site).
 type ScanDetail = NonNullable<Awaited<ReturnType<typeof getScan>>>;
@@ -9,9 +10,7 @@ interface ReportExportFilenameInput {
   stagedVersion: string | null;
 }
 
-// Schema tag for the exported report document. Bump the suffix when the export
-// shape changes in a way consumers must branch on.
-export const REPORT_EXPORT_SCHEMA = "drydock.report.v1";
+export { REPORT_EXPORT_SCHEMA };
 
 // Build a self-contained, archivable view of a completed review from the data
 // already persisted for it: provenance metadata, package/baseline identity, the
@@ -41,6 +40,7 @@ export function buildReportExport(detail: ScanDetail) {
       stagedVersion: scan.stagedVersion ?? null,
       previousVersion: scan.previousVersion ?? null,
     },
+    provenance: buildReportProvenance(detail),
     baseline: summary.baseline ?? null,
     safety: summary.safety ?? null,
     riskSummary: detail.riskSummary ?? null,

--- a/server/lib/report-provenance.ts
+++ b/server/lib/report-provenance.ts
@@ -107,9 +107,15 @@ export function buildReportProvenance(detail: { scan: ProvenanceScanLike }): Rep
       model: stringOrNull(ai?.model),
     },
     review: {
-      limitations: REPORT_PROVENANCE_LIMITATIONS,
+      limitations: coerceReviewLimitations(summaryProvenance?.reviewLimitations),
     },
   };
+}
+
+function coerceReviewLimitations(value: unknown): readonly string[] {
+  if (!Array.isArray(value)) return REPORT_PROVENANCE_LIMITATIONS;
+  const limitations = value.filter((item): item is string => typeof item === "string" && !!item);
+  return limitations.length ? limitations : REPORT_PROVENANCE_LIMITATIONS;
 }
 
 function coerceArtifactDigests(value: unknown): ReportArtifactDigest[] | null {

--- a/server/lib/report-provenance.ts
+++ b/server/lib/report-provenance.ts
@@ -70,6 +70,7 @@ export function buildReportProvenance(detail: { scan: ProvenanceScanLike }): Rep
   const report = asRecord(summary?.report);
   const summaryProvenance = asRecord(summary?.provenance);
   const stagedPublish = summary?.stagedPublish;
+  const stagedPublishSummary = asRecord(stagedPublish);
   const packageSummary = asRecord(summary?.package);
   const ai = asRecord(scan.aiJson);
 
@@ -94,7 +95,7 @@ export function buildReportProvenance(detail: { scan: ProvenanceScanLike }): Rep
       name: scan.packageName ?? null,
       stagedVersion: scan.stagedVersion ?? null,
       previousVersion: scan.previousVersion ?? null,
-      stagedTag: stringOrNull(packageSummary?.stagedTag),
+      stagedTag: stringOrNull(packageSummary?.stagedTag) ?? stringOrNull(stagedPublishSummary?.tag),
     },
     baseline: summary?.baseline ?? null,
     artifacts: normalizeArtifactSources(
@@ -154,6 +155,7 @@ export function extractArtifactDigests(stagedPublish: unknown): ReportArtifactDi
   const source = details.mode === "workflow_gate" ? "workflow_gate" : "staged_publish";
   const out: ReportArtifactDigest[] = [];
   const manifest = asRecord(details.manifest);
+  const ecosystem = stringOrNull(manifest?.ecosystem);
   const artifacts = Array.isArray(manifest?.artifacts) ? manifest.artifacts : [];
 
   for (const raw of artifacts) {
@@ -163,7 +165,7 @@ export function extractArtifactDigests(stagedPublish: unknown): ReportArtifactDi
     const path = stringOrNull(artifact?.path) ?? "release artifact";
     out.push({
       path,
-      kind: stringOrNull(artifact?.kind) ?? inferArtifactKind(path),
+      kind: stringOrNull(artifact?.kind) ?? inferArtifactKind(path, ecosystem),
       digestAlgorithm: "sha256",
       digest: digest.toLowerCase(),
       source,
@@ -175,7 +177,7 @@ export function extractArtifactDigests(stagedPublish: unknown): ReportArtifactDi
     const path = firstArtifactPath(artifacts) ?? "release artifact";
     out.push({
       path,
-      kind: inferArtifactKind(path),
+      kind: inferArtifactKind(path, ecosystem),
       digestAlgorithm: "sha256",
       digest: reviewedDigest.toLowerCase(),
       source,
@@ -224,10 +226,10 @@ function firstArtifactPath(artifacts: unknown[]): string | null {
   return null;
 }
 
-function inferArtifactKind(path: string): string | null {
+function inferArtifactKind(path: string, ecosystem?: string | null): string | null {
   const lower = path.toLowerCase();
   if (lower.endsWith(".whl")) return "wheel";
-  if (lower.endsWith(".tar.gz")) return "sdist";
+  if (lower.endsWith(".tar.gz")) return ecosystem === "npm" ? "tarball" : "sdist";
   if (lower.endsWith(".tgz")) return "tarball";
   return null;
 }

--- a/server/lib/report-provenance.ts
+++ b/server/lib/report-provenance.ts
@@ -97,9 +97,11 @@ export function buildReportProvenance(detail: { scan: ProvenanceScanLike }): Rep
       stagedTag: stringOrNull(packageSummary?.stagedTag),
     },
     baseline: summary?.baseline ?? null,
-    artifacts:
+    artifacts: normalizeArtifactSources(
       coerceArtifactDigests(summaryProvenance?.artifactDigests) ??
-      extractArtifactDigests(stagedPublish),
+        extractArtifactDigests(stagedPublish),
+      scan.source,
+    ),
     ai: {
       status: stringOrNull(ai?.status),
       model: stringOrNull(ai?.model),
@@ -196,6 +198,16 @@ function dedupeDigests(items: ReportArtifactDigest[]): ReportArtifactDigest[] {
     seen.add(key);
     return true;
   });
+}
+
+function normalizeArtifactSources(
+  items: ReportArtifactDigest[],
+  scanSource: string | null | undefined,
+): ReportArtifactDigest[] {
+  if (scanSource !== "workflow_gate") return items;
+  return items.map((item) =>
+    item.source === "workflow_gate" ? item : { ...item, source: "workflow_gate" },
+  );
 }
 
 function firstArtifactPath(artifacts: unknown[]): string | null {

--- a/server/lib/report-provenance.ts
+++ b/server/lib/report-provenance.ts
@@ -1,0 +1,241 @@
+export const REPORT_EXPORT_SCHEMA = "drydock.report.v1";
+
+export const REPORT_PROVENANCE_LIMITATIONS = [
+  "Drydock reviews staged or release-candidate bytes and persisted redacted evidence; it does not execute package code, install dependencies, or run builds.",
+  "Deterministic findings are authoritative. AI commentary, when enabled, cannot downgrade deterministic findings.",
+  "Raw tarballs and workflow artifacts are not retained by default.",
+] as const;
+
+export interface ReportArtifactDigest {
+  path: string;
+  kind: string | null;
+  digestAlgorithm: "sha256" | "sha1";
+  digest: string;
+  source: "staged_publish" | "workflow_gate";
+}
+
+export interface ReportProvenance {
+  report: {
+    schema: typeof REPORT_EXPORT_SCHEMA;
+    version: number | null;
+    digestAlgorithm: string | null;
+    digest: string | null;
+    generatedAt: string | null;
+    rulesVersion: string | null;
+  };
+  scan: {
+    id: string;
+    source: string | null;
+    stageId: string | null;
+    workflowGateId: string | null;
+    createdAt: string | null;
+    completedAt: string | null;
+  };
+  package: {
+    name: string | null;
+    stagedVersion: string | null;
+    previousVersion: string | null;
+    stagedTag: string | null;
+  };
+  baseline: unknown;
+  artifacts: ReportArtifactDigest[];
+  ai: {
+    status: string | null;
+    model: string | null;
+  };
+  review: {
+    limitations: readonly string[];
+  };
+}
+
+interface ProvenanceScanLike {
+  id: string;
+  stageId?: string | null;
+  source?: string | null;
+  gateId?: string | null;
+  packageName?: string | null;
+  stagedVersion?: string | null;
+  previousVersion?: string | null;
+  reportVersion?: number | null;
+  reportDigest?: string | null;
+  summaryJson?: unknown;
+  aiJson?: unknown;
+  createdAt?: unknown;
+  completedAt?: unknown;
+}
+
+export function buildReportProvenance(detail: { scan: ProvenanceScanLike }): ReportProvenance {
+  const { scan } = detail;
+  const summary = asRecord(scan.summaryJson);
+  const report = asRecord(summary?.report);
+  const summaryProvenance = asRecord(summary?.provenance);
+  const stagedPublish = summary?.stagedPublish;
+  const packageSummary = asRecord(summary?.package);
+  const ai = asRecord(scan.aiJson);
+
+  return {
+    report: {
+      schema: REPORT_EXPORT_SCHEMA,
+      version: numberOrNull(report?.version) ?? scan.reportVersion ?? null,
+      digestAlgorithm: stringOrNull(report?.digestAlgorithm),
+      digest: stringOrNull(report?.digest) ?? scan.reportDigest ?? null,
+      generatedAt: stringOrNull(report?.generatedAt),
+      rulesVersion: stringOrNull(report?.rulesVersion),
+    },
+    scan: {
+      id: scan.id,
+      source: scan.source ?? null,
+      stageId: scan.stageId ?? null,
+      workflowGateId: scan.gateId ?? null,
+      createdAt: toIso(scan.createdAt),
+      completedAt: toIso(scan.completedAt),
+    },
+    package: {
+      name: scan.packageName ?? null,
+      stagedVersion: scan.stagedVersion ?? null,
+      previousVersion: scan.previousVersion ?? null,
+      stagedTag: stringOrNull(packageSummary?.stagedTag),
+    },
+    baseline: summary?.baseline ?? null,
+    artifacts:
+      coerceArtifactDigests(summaryProvenance?.artifactDigests) ??
+      extractArtifactDigests(stagedPublish),
+    ai: {
+      status: stringOrNull(ai?.status),
+      model: stringOrNull(ai?.model),
+    },
+    review: {
+      limitations: REPORT_PROVENANCE_LIMITATIONS,
+    },
+  };
+}
+
+function coerceArtifactDigests(value: unknown): ReportArtifactDigest[] | null {
+  if (!Array.isArray(value)) return null;
+  const items = value.flatMap((raw): ReportArtifactDigest[] => {
+    const item = asRecord(raw);
+    const path = stringOrNull(item?.path);
+    const digest = stringOrNull(item?.digest);
+    const algorithm = item?.digestAlgorithm;
+    const source = item?.source;
+    if (
+      !path ||
+      !digest ||
+      (algorithm !== "sha256" && algorithm !== "sha1") ||
+      (source !== "staged_publish" && source !== "workflow_gate")
+    ) {
+      return [];
+    }
+    return [
+      {
+        path,
+        kind: stringOrNull(item?.kind),
+        digestAlgorithm: algorithm,
+        digest,
+        source,
+      },
+    ];
+  });
+  return items;
+}
+
+export function extractArtifactDigests(stagedPublish: unknown): ReportArtifactDigest[] {
+  const details = asRecord(stagedPublish);
+  if (!details) return [];
+
+  const source = details.mode === "workflow_gate" ? "workflow_gate" : "staged_publish";
+  const out: ReportArtifactDigest[] = [];
+  const manifest = asRecord(details.manifest);
+  const artifacts = Array.isArray(manifest?.artifacts) ? manifest.artifacts : [];
+
+  for (const raw of artifacts) {
+    const artifact = asRecord(raw);
+    const digest = stringOrNull(artifact?.sha256);
+    if (!digest || !isHexDigest(digest, 64)) continue;
+    const path = stringOrNull(artifact?.path) ?? "release artifact";
+    out.push({
+      path,
+      kind: stringOrNull(artifact?.kind) ?? inferArtifactKind(path),
+      digestAlgorithm: "sha256",
+      digest: digest.toLowerCase(),
+      source,
+    });
+  }
+
+  const reviewedDigest = stringOrNull(details.digest);
+  if (reviewedDigest && isHexDigest(reviewedDigest, 64)) {
+    const path = firstArtifactPath(artifacts) ?? "release artifact";
+    out.push({
+      path,
+      kind: inferArtifactKind(path),
+      digestAlgorithm: "sha256",
+      digest: reviewedDigest.toLowerCase(),
+      source,
+    });
+  }
+
+  const npmShasum = stringOrNull(details.shasum);
+  if (npmShasum && isHexDigest(npmShasum, 40)) {
+    out.push({
+      path: "npm staged tarball",
+      kind: "tarball",
+      digestAlgorithm: "sha1",
+      digest: npmShasum.toLowerCase(),
+      source,
+    });
+  }
+
+  return dedupeDigests(out);
+}
+
+function dedupeDigests(items: ReportArtifactDigest[]): ReportArtifactDigest[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    const key = `${item.path}\0${item.digestAlgorithm}\0${item.digest}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function firstArtifactPath(artifacts: unknown[]): string | null {
+  for (const raw of artifacts) {
+    const path = stringOrNull(asRecord(raw)?.path);
+    if (path) return path;
+  }
+  return null;
+}
+
+function inferArtifactKind(path: string): string | null {
+  const lower = path.toLowerCase();
+  if (lower.endsWith(".whl")) return "wheel";
+  if (lower.endsWith(".tar.gz")) return "sdist";
+  if (lower.endsWith(".tgz")) return "tarball";
+  return null;
+}
+
+function isHexDigest(value: string, length: number): boolean {
+  return value.length === length && /^[a-f0-9]+$/i.test(value);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value ? value : null;
+}
+
+function numberOrNull(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function toIso(value: unknown): string | null {
+  if (value == null) return null;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "number") return new Date(value).toISOString();
+  if (typeof value === "string") return value;
+  return null;
+}

--- a/server/lib/scan-pipeline-phases.ts
+++ b/server/lib/scan-pipeline-phases.ts
@@ -25,6 +25,7 @@ import {
   type PackageJsonSummary,
 } from "./review";
 import { computeScanRiskBreakdown, type ScanRiskBreakdown } from "./risk";
+import { extractArtifactDigests, REPORT_PROVENANCE_LIMITATIONS } from "./report-provenance";
 import { maybeWriteScanArtifacts } from "./scan-artifacts";
 import { sha256Hex, stableJson } from "./stable-json";
 import type { ScanResult } from "../types";
@@ -59,6 +60,7 @@ export interface DeterministicFindings {
   redactedStagedManifest: PackageJsonSummary | null;
   redactedPreviousManifest: PackageJsonSummary | null;
   redactedDetails: Record<string, unknown> | null;
+  artifactDigests: ReturnType<typeof extractArtifactDigests>;
   annotatedFindings: Array<Finding & FindingDiffAnnotation>;
   releaseRuleFindings: Finding[];
   findingAnnotations: FindingAnnotationRecord[];
@@ -114,7 +116,9 @@ export function runDeterministicFindings<TInput, TBroker extends AdapterBroker>(
   const redactedPreviousFiles = baseline.artifact ? redactFileRecords(baseline.artifact.files) : [];
   const redactedStagedManifest = redactJson(staged.artifact.manifest ?? null);
   const redactedPreviousManifest = redactJson(baseline.artifact?.manifest ?? null);
-  const redactedDetails = redactJson(adapter.summarizeDetails(staged.details));
+  const rawDetails = adapter.summarizeDetails(staged.details);
+  const redactedDetails = redactJson(rawDetails);
+  const artifactDigests = extractArtifactDigests(rawDetails);
 
   const annotatedFindings = annotateFindingsWithDiffStatus(ruleFindings, diff.fileDiff, {
     previousFiles: redactedPreviousFiles,
@@ -137,6 +141,7 @@ export function runDeterministicFindings<TInput, TBroker extends AdapterBroker>(
     redactedStagedManifest,
     redactedPreviousManifest,
     redactedDetails,
+    artifactDigests,
     annotatedFindings,
     releaseRuleFindings,
     findingAnnotations,
@@ -206,11 +211,17 @@ export async function persistResults<TInput, TBroker extends AdapterBroker>(
     safety,
   };
 
+  const provenanceSummary = {
+    artifactDigests: findings.artifactDigests,
+    reviewLimitations: REPORT_PROVENANCE_LIMITATIONS,
+  };
+
   const reportPayload = {
     version: 1,
     rulesVersion: DETERMINISTIC_RULES_VERSION,
     stageId: identity.stageId,
     stagedPublish: findings.redactedDetails,
+    provenance: provenanceSummary,
     package: result.package,
     baseline: baseline.baseline,
     fileCount: result.fileCount,
@@ -258,6 +269,7 @@ export async function persistResults<TInput, TBroker extends AdapterBroker>(
       diff: diff.fileDiff,
       risk: args.riskSummary,
       stagedPublish: findings.redactedDetails,
+      provenance: provenanceSummary,
       baseline: baseline.baseline,
       safety: result.safety,
     },

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -5,6 +5,7 @@ import type {
   FindingDiffStatus,
   PackageJsonSummary,
 } from "../../server/lib/review";
+import type { ReportProvenance } from "../../server/lib/report-provenance";
 import { apiFetch, apiJson, errorMessage } from "./api";
 import {
   decideWorkflowGate,
@@ -60,6 +61,7 @@ export interface ScanListItem {
   source?: string | null;
   organizationId?: string | null;
   ownerUserId?: string | null;
+  gateId?: string | null;
   packageName: string | null;
   stagedVersion: string | null;
   previousVersion: string | null;
@@ -124,6 +126,7 @@ export interface PersistedScanDetail {
     metadataJson: unknown;
     createdAt: string | number | Date;
   }>;
+  provenance?: ReportProvenance;
 }
 
 export interface ListScansResponse {

--- a/src/pages/Dashboard/ScanDetail/ReportSections.tsx
+++ b/src/pages/Dashboard/ScanDetail/ReportSections.tsx
@@ -1,6 +1,11 @@
 import type { ComponentChildren } from "preact";
 import { sortFindingsBySeverity } from "../../../lib/findings";
+import { formatDateTime } from "../../../lib/format";
 import type { AiFinding, DisplayedAiResult } from "../../../../server/lib/ai-review-types";
+import type {
+  ReportArtifactDigest,
+  ReportProvenance,
+} from "../../../../server/lib/report-provenance";
 import type { PackageJsonDiff } from "../../../../server/types";
 import {
   Badge,
@@ -16,12 +21,16 @@ import type { PersistedSummary } from "./types";
 export function PersistedReportSections({
   summary,
   ai,
+  provenance,
 }: {
   summary: PersistedSummary;
   ai: DisplayedAiResult | null;
+  provenance?: ReportProvenance;
 }) {
   return (
     <section class="flex flex-col gap-6">
+      {provenance ? <ProvenanceSection provenance={provenance} /> : null}
+
       <ReportSection title="Manifest changes">
         {summary.packageJsonDiff ? (
           <PackageJsonDiffView diff={summary.packageJsonDiff} />
@@ -83,6 +92,81 @@ function ReportSection({
   );
 }
 
+function ProvenanceSection({ provenance }: { provenance: ReportProvenance }) {
+  const report = provenance.report;
+  const scan = provenance.scan;
+  const pkg = provenance.package;
+  const baselineVersion = baselineLabel(provenance.baseline) ?? pkg.previousVersion ?? "none";
+  return (
+    <ReportSection title="Report provenance">
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-x-6 gap-y-2 text-[13px]">
+        <InlineMeta label="report digest" value={report.digest ?? "unavailable"} />
+        <InlineMeta
+          label="report schema"
+          value={`${report.schema}${report.version ? ` / v${report.version}` : ""}`}
+        />
+        <InlineMeta label="rules version" value={report.rulesVersion ?? "unavailable"} />
+        <InlineMeta
+          label="generated"
+          value={report.generatedAt ? formatDateTime(report.generatedAt) : "unavailable"}
+        />
+        <InlineMeta label="package" value={pkg.name ?? "unknown"} />
+        <InlineMeta
+          label="version"
+          value={`${pkg.previousVersion ?? baselineVersion} → ${pkg.stagedVersion ?? "unknown"}`}
+        />
+        <InlineMeta label="source" value={scan.source ?? "unknown"} />
+        <InlineMeta
+          label={scan.workflowGateId ? "workflow gate" : "stage id"}
+          value={scan.workflowGateId ?? scan.stageId ?? "unknown"}
+        />
+        <InlineMeta label="baseline" value={baselineVersion} />
+        <InlineMeta label="assistant" value={aiLabel(provenance.ai.status, provenance.ai.model)} />
+      </div>
+
+      {provenance.artifacts.length ? (
+        <div class="flex flex-col gap-2">
+          <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
+            Reviewed artifact digests
+          </span>
+          <ul class="list-none p-0 m-0 flex flex-col border-t border-border">
+            {provenance.artifacts.map((artifact) => (
+              <ArtifactDigestRow
+                key={`${artifact.path}-${artifact.digestAlgorithm}-${artifact.digest}`}
+                artifact={artifact}
+              />
+            ))}
+          </ul>
+        </div>
+      ) : (
+        <EmptyLine>No artifact digest metadata was saved for this review.</EmptyLine>
+      )}
+
+      <ul class="m-0 pl-4 text-[13px] leading-[1.6] text-ink-muted">
+        {provenance.review.limitations.map((limitation) => (
+          <li key={limitation}>{limitation}</li>
+        ))}
+      </ul>
+    </ReportSection>
+  );
+}
+
+function ArtifactDigestRow({ artifact }: { artifact: ReportArtifactDigest }) {
+  return (
+    <li class="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)] gap-x-4 gap-y-1 py-2 border-b border-border text-[13px]">
+      <div class="min-w-0">
+        <span class="font-mono text-[13px] text-ink break-all">{artifact.path}</span>
+        <span class="ml-2 font-mono text-[11px] text-ink-subtle">
+          {artifact.kind ?? "artifact"} · {artifact.source.replace("_", " ")}
+        </span>
+      </div>
+      <span class="font-mono text-[13px] text-ink-muted break-all">
+        {artifact.digestAlgorithm}:{artifact.digest}
+      </span>
+    </li>
+  );
+}
+
 function AiFindingList({ findings }: { findings: AiFinding[] }) {
   return (
     <ul class="list-none p-0 m-0 grid grid-cols-1 md:grid-cols-2 gap-2">
@@ -133,6 +217,21 @@ function InlineMeta({ label, value }: { label: string; value: string }) {
       <code class="text-xs text-ink-muted break-words min-w-0">{value}</code>
     </div>
   );
+}
+
+function baselineLabel(value: unknown): string | null {
+  if (!value || typeof value !== "object") return null;
+  const item = value as { version?: unknown; source?: unknown };
+  const version = typeof item.version === "string" && item.version ? item.version : null;
+  const source = typeof item.source === "string" && item.source ? item.source : null;
+  if (version && source) return `${version} (${source})`;
+  return version ?? source;
+}
+
+function aiLabel(status: string | null, model: string | null): string {
+  if (!status && !model) return "not recorded";
+  if (!model) return status ?? "unavailable";
+  return `${status ?? "available"} / ${model}`;
 }
 
 function ChangeList({

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -374,7 +374,11 @@ export default function ScanDetailPage() {
               />
             ) : null}
 
-            <PersistedReportSections summary={summary.value} ai={ai.value} />
+            <PersistedReportSections
+              summary={summary.value}
+              ai={ai.value}
+              provenance={detail.provenance}
+            />
           </>
         ) : detail.scan.status === "pending" || detail.scan.status === "running" ? (
           // While stalled the pulsing line would falsely promise an

--- a/src/pages/Dashboard/ScanDetail/types.ts
+++ b/src/pages/Dashboard/ScanDetail/types.ts
@@ -1,4 +1,5 @@
 import type { DiffEntry, FindingDiffStatus } from "../../../../server/lib/review";
+import type { ReportArtifactDigest } from "../../../../server/lib/report-provenance";
 import type { PackageJsonDiff } from "../../../../server/types";
 import type { PersistedScanDetail } from "../../../models/scan";
 
@@ -9,6 +10,10 @@ export interface PersistedSummary {
     digestAlgorithm?: string;
     generatedAt?: string;
     rulesVersion?: string;
+  };
+  provenance?: {
+    artifactDigests?: ReportArtifactDigest[];
+    reviewLimitations?: readonly string[];
   };
   packageJsonDiff?: PackageJsonDiff;
   diff?: DiffEntry[];

--- a/test/scan-pipeline-phases.test.mjs
+++ b/test/scan-pipeline-phases.test.mjs
@@ -366,6 +366,21 @@ describe("buildReportProvenance", () => {
       }),
     ]);
   });
+
+  test("uses review limitations saved with the report", () => {
+    const provenance = buildReportProvenance({
+      scan: {
+        id: "scan-1",
+        summaryJson: {
+          provenance: {
+            reviewLimitations: ["saved limitation text"],
+          },
+        },
+      },
+    });
+
+    expect(provenance.review.limitations).toEqual(["saved limitation text"]);
+  });
 });
 
 describe("recordCompletion", () => {

--- a/test/scan-pipeline-phases.test.mjs
+++ b/test/scan-pipeline-phases.test.mjs
@@ -15,6 +15,7 @@ const {
   persistResults,
   recordCompletion,
 } = await import("../server/lib/scan-pipeline-phases.ts");
+const { buildReportProvenance } = await import("../server/lib/report-provenance.ts");
 
 const NPM_TOKEN = "npm_abcdefghijklmnopqrstuvwxyz0123";
 
@@ -331,6 +332,39 @@ describe("persistResults", () => {
     });
 
     expect(persisted).toBe(false);
+  });
+});
+
+describe("buildReportProvenance", () => {
+  test("labels saved PyPI workflow-gate artifact digests as workflow gate sources", () => {
+    const provenance = buildReportProvenance({
+      scan: {
+        id: "scan-1",
+        source: "workflow_gate",
+        summaryJson: {
+          stagedPublish: {
+            manifest: {
+              ecosystem: "pypi",
+              artifacts: [
+                {
+                  path: "dist/demo-1.0.1-py3-none-any.whl",
+                  kind: "wheel",
+                  sha256: "b".repeat(64),
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    expect(provenance.artifacts).toEqual([
+      expect.objectContaining({
+        path: "dist/demo-1.0.1-py3-none-any.whl",
+        digest: "b".repeat(64),
+        source: "workflow_gate",
+      }),
+    ]);
   });
 });
 

--- a/test/scan-pipeline-phases.test.mjs
+++ b/test/scan-pipeline-phases.test.mjs
@@ -361,7 +361,55 @@ describe("buildReportProvenance", () => {
     expect(provenance.artifacts).toEqual([
       expect.objectContaining({
         path: "dist/demo-1.0.1-py3-none-any.whl",
+        kind: "wheel",
         digest: "b".repeat(64),
+        source: "workflow_gate",
+      }),
+    ]);
+  });
+
+  test("preserves npm staged-publish tag from staged metadata", () => {
+    const provenance = buildReportProvenance({
+      scan: {
+        id: "scan-1",
+        summaryJson: {
+          stagedPublish: {
+            tag: "beta",
+          },
+        },
+      },
+    });
+
+    expect(provenance.package.stagedTag).toBe("beta");
+  });
+
+  test("labels npm workflow-gate tar.gz artifacts as tarballs", () => {
+    const provenance = buildReportProvenance({
+      scan: {
+        id: "scan-1",
+        source: "workflow_gate",
+        summaryJson: {
+          stagedPublish: {
+            mode: "workflow_gate",
+            manifest: {
+              ecosystem: "npm",
+              artifacts: [
+                {
+                  path: "dist/demo-1.0.1.tar.gz",
+                  sha256: "c".repeat(64),
+                },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    expect(provenance.artifacts).toEqual([
+      expect.objectContaining({
+        path: "dist/demo-1.0.1.tar.gz",
+        kind: "tarball",
+        digest: "c".repeat(64),
         source: "workflow_gate",
       }),
     ]);

--- a/test/scan-pipeline-phases.test.mjs
+++ b/test/scan-pipeline-phases.test.mjs
@@ -241,7 +241,20 @@ describe("scoreRisk", () => {
 
 describe("persistResults", () => {
   test("assembles the scan result and persists a completed scan", async () => {
-    const adapter = makeAdapter();
+    const adapter = makeAdapter({
+      summarizeDetails: vi.fn(() => ({
+        mode: "workflow_gate",
+        manifest: {
+          artifacts: [
+            {
+              path: "dist/demo-1.0.1-py3-none-any.whl",
+              kind: "wheel",
+              sha256: "a".repeat(64),
+            },
+          ],
+        },
+      })),
+    });
     const diff = computeDiff(resolved);
     const findings = runDeterministicFindings(adapter, resolved, diff);
     const riskSummary = scoreRisk(findings.annotatedFindings, disabledAi);
@@ -285,6 +298,16 @@ describe("persistResults", () => {
     });
     expect(persistArg.summary.report.digest).toMatch(/^[0-9a-f]{64}$/);
     expect(persistArg.summary.report.rulesVersion).toBeDefined();
+    expect(persistArg.summary.provenance.artifactDigests).toEqual([
+      {
+        path: "dist/demo-1.0.1-py3-none-any.whl",
+        kind: "wheel",
+        digestAlgorithm: "sha256",
+        digest: "a".repeat(64),
+        source: "workflow_gate",
+      },
+    ]);
+    expect(persistArg.summary.provenance.reviewLimitations.length).toBeGreaterThan(0);
   });
 
   test("propagates a non-persisted outcome from persistScan", async () => {

--- a/test/workers/scan-report-export.test.ts
+++ b/test/workers/scan-report-export.test.ts
@@ -61,6 +61,20 @@ async function getReport(
   return res;
 }
 
+async function getScanDetail(
+  app: Hono<{ Bindings: Bindings; Variables: Variables }>,
+  scanId: string,
+) {
+  const ctx = createExecutionContext();
+  const res = await app.fetch(
+    new Request(`http://test.local/api/v1/scans/${scanId}`, { method: "GET" }),
+    env,
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
 async function seedCompletedScan(owner: SeededUser): Promise<string> {
   const db = createDb(env.DB);
   const scanId = `scan_${crypto.randomUUID()}`;
@@ -89,6 +103,22 @@ async function seedCompletedScan(owner: SeededUser): Promise<string> {
       },
       baseline: { kind: "registry", version: "1.0.0" },
       safety: { outboundPolicy: "gateway-only" },
+      stagedPublish: {
+        manifest: {
+          artifacts: [
+            {
+              path: "dist/demo-1.1.0-py3-none-any.whl",
+              kind: "wheel",
+              sha256: "a".repeat(64),
+            },
+            {
+              path: "dist/demo-1.1.0.tar.gz",
+              kind: "sdist",
+              sha256: "b".repeat(64),
+            },
+          ],
+        },
+      },
       packageJsonDiff: {
         name: "@org/pkg",
         previousVersion: "1.0.0",
@@ -135,6 +165,12 @@ describe("scan report JSON export", () => {
       report: { digest: string; rulesVersion: string } | null;
       scan: { id: string; status: string };
       package: { name: string | null; stagedVersion: string | null };
+      provenance: {
+        report: { digest: string | null; rulesVersion: string | null };
+        package: { name: string | null; stagedVersion: string | null };
+        artifacts: Array<{ path: string; kind: string | null; digest: string; source: string }>;
+        review: { limitations: string[] };
+      };
       packageJsonDiff: unknown;
       findings: Array<{ ruleId: string | null; severity: string }>;
     };
@@ -144,6 +180,25 @@ describe("scan report JSON export", () => {
     expect(body.scan.id).toBe(scanId);
     expect(body.package.name).toBe("@org/pkg");
     expect(body.package.stagedVersion).toBe("1.1.0");
+    expect(body.provenance.report.digest).toBe("abc123");
+    expect(body.provenance.report.rulesVersion).toBe("1.8.0");
+    expect(body.provenance.package.name).toBe("@org/pkg");
+    expect(body.provenance.package.stagedVersion).toBe("1.1.0");
+    expect(body.provenance.artifacts).toEqual([
+      expect.objectContaining({
+        path: "dist/demo-1.1.0-py3-none-any.whl",
+        kind: "wheel",
+        digest: "a".repeat(64),
+        source: "staged_publish",
+      }),
+      expect.objectContaining({
+        path: "dist/demo-1.1.0.tar.gz",
+        kind: "sdist",
+        digest: "b".repeat(64),
+        source: "staged_publish",
+      }),
+    ]);
+    expect(body.provenance.review.limitations.length).toBeGreaterThan(0);
     expect(body.packageJsonDiff).toBeTruthy();
     expect(body.findings).toEqual([
       expect.objectContaining({ ruleId: "install-script.lifecycle", severity: "high" }),
@@ -170,6 +225,31 @@ describe("scan report JSON export", () => {
     expect(await res.json()).toMatchObject({
       package: { name: "@org/pkg", stagedVersion: "1.1.0" },
     });
+  });
+
+  test("returns normalized provenance on scan detail", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+
+    const res = await getScanDetail(buildTestApp(owner), scanId);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      provenance: {
+        report: { digest: string | null; rulesVersion: string | null };
+        scan: { id: string; stageId: string | null };
+        artifacts: Array<{ digestAlgorithm: string; digest: string }>;
+      };
+    };
+    expect(body.provenance.report.digest).toBe("abc123");
+    expect(body.provenance.report.rulesVersion).toBe("1.8.0");
+    expect(body.provenance.scan.id).toBe(scanId);
+    expect(body.provenance.artifacts.map((artifact) => artifact.digest)).toEqual([
+      "a".repeat(64),
+      "b".repeat(64),
+    ]);
+    expect(
+      body.provenance.artifacts.every((artifact) => artifact.digestAlgorithm === "sha256"),
+    ).toBe(true);
   });
 
   test("does not leak another organization's report", async () => {


### PR DESCRIPTION
Resolves #306 by adding normalized report provenance to scan detail and canonical JSON export, including report fingerprints, package/baseline identity, review limitations, AI status, and reviewed artifact digests.

Also partially addresses #308 by persisting and rendering reviewed artifact digest provenance for new scans before redaction.

HTML export, publish-side digest verification, hosted validation, and operator alerts remain follow-up work.

Validation: pnpm run verify.