### PR TITLE
Weight code.process-execution by install-context and diff-novelty

### DIFF
--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -99,7 +99,7 @@ A PyPI review runs two rule families over the staged artifacts:
 
 - `pypi.*` findings come from `pyPiReleaseFindings` and carry `PYPI_RULES_VERSION` (currently `0.2.0`).
 - shared `file.*` / `code.*` / `diff.*` findings come from `deterministicFindings` and carry
-  `DETERMINISTIC_RULES_VERSION` (currently `1.11.0`).
+  `DETERMINISTIC_RULES_VERSION` (currently `1.12.0`).
 
 The harness asserts this per family: every `pypi.*` finding must equal `PYPI_RULES_VERSION` and every
 other finding must equal `DETERMINISTIC_RULES_VERSION`. Bump the relevant constant **and** update the
@@ -128,7 +128,18 @@ dynamic-evaluation family from `WebAssembly.compile` to the whole
 `compile`/`compileStreaming`/`instantiate`/`instantiateStreaming` set, since
 `instantiateStreaming(fetch(...))` is the loader idiom packed wasm payloads actually use;
 `require.resolve` was evaluated for the same family and rejected — it resolves paths without
-executing code and flagged the `legit-require-resolve` benign hard-negative.
+executing code and flagged the `legit-require-resolve` benign hard-negative. `1.12.0` weights the
+JavaScript `code.process-execution` capability by install-context and diff-novelty
+(`processExecutionSeverity` in `server/lib/review-rules/scripts.ts`): a bare child_process/shell
+capability is high only when the file runs on install or is wired up as an entrypoint (a declared
+lifecycle hook or a `bin` target), when it is co-located with a network/credential/dynamic-eval
+capability (the dropper/exfil shape), or when it surfaced only after constant-folding (a runtime-
+assembled identifier — obfuscation that ordinary build tooling does not do). Otherwise it is `low`
+when newly added or changed in this release and `info` when it already shipped in the previous
+version, so a maintainer's local build script (`legit-build-childprocess`) no longer reads as
+install-time command execution. Python keeps the prior high weighting because its install model is
+not described by package.json reachability and the PyPI adapter owns `pypi.setup-install-command`;
+the `build-script-childprocess` and `bin-childprocess` fixtures lock both directions.
 
 ### Fixture format
 

--- a/server/lib/review-rules/index.ts
+++ b/server/lib/review-rules/index.ts
@@ -16,7 +16,7 @@ import { entrypointDiffFindings } from "./entrypoints";
 // way that should invalidate cached scan reports. Stored alongside each finding
 // so historical reports can be traced back to the ruleset that produced them.
 // Lives here (not in a family module) because versioning spans every family.
-export const DETERMINISTIC_RULES_VERSION = "1.11.0";
+export const DETERMINISTIC_RULES_VERSION = "1.12.0";
 
 export { DETERMINISTIC_RULE_IDS } from "./rule-ids";
 export {

--- a/server/lib/review-rules/scripts.ts
+++ b/server/lib/review-rules/scripts.ts
@@ -87,13 +87,25 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
       processExecution.matched || dynamicEvaluation.matched || credentialAccess.matched;
 
     if (processExecution.matched) {
+      const pairedCapability =
+        networkAccess.matched || credentialAccess.matched || dynamicEvaluation.matched;
+      const severity = processExecutionSeverity(
+        ctx,
+        file.path,
+        changed,
+        pairedCapability,
+        processExecution.viaNormalization,
+      );
       findings.push(
         tag("codeProcessExecution", {
-          severity: "high",
+          severity,
           file: file.path,
           line: processExecution.line,
           evidence: `${prefix}process or shell execution`,
-          reason: "package may execute arbitrary commands",
+          reason:
+            severity === "high"
+              ? "package may execute arbitrary commands"
+              : "process or shell execution in ordinary source/build code: not reachable from an install hook or bin entry and not paired with network or credential access, so it reads as build tooling rather than an install-time capability",
         }),
       );
     }
@@ -157,14 +169,18 @@ function matchCategory(
   patterns: RegExp[],
   sample: string,
   normalized: string,
-): { matched: boolean; line: number | undefined } {
+): { matched: boolean; line: number | undefined; viaNormalization: boolean } {
   const line = firstMatchingLine(sample, patterns);
-  if (line !== undefined) return { matched: true, line };
+  if (line !== undefined) return { matched: true, line, viaNormalization: false };
   if (normalized !== sample) {
     const normalizedLine = firstMatchingLine(normalized, patterns);
-    if (normalizedLine !== undefined) return { matched: true, line: normalizedLine };
+    // The literal text missed and only the constant-folded text matched: the
+    // capability was assembled at runtime (`['chi','ld_pro','cess'].join('')`),
+    // which is itself an obfuscation signal callers can weight on.
+    if (normalizedLine !== undefined)
+      return { matched: true, line: normalizedLine, viaNormalization: true };
   }
-  return { matched: false, line: undefined };
+  return { matched: false, line: undefined, viaNormalization: false };
 }
 
 function networkAccessSeverity(
@@ -173,6 +189,61 @@ function networkAccessSeverity(
   adjacentExecutionRisk: boolean,
 ): Finding["severity"] {
   return changed === "added" && (lifecycleScriptFile || adjacentExecutionRisk) ? "high" : "medium";
+}
+
+// Install-context + diff-novelty weighting for process execution (issue #194).
+// A bare child_process/shell capability is weighted by where it sits and whether
+// this release introduced it, so a maintainer's local build script no longer
+// reads the same as an install-time command execution:
+//   - high when the file runs on install or is wired up as an entrypoint (a
+//     declared lifecycle hook or a linked `bin` command), when it is co-located
+//     with a network/credential/dynamic-eval capability (the collect-and-
+//     exfiltrate / dropper shape), or when the capability only surfaced after
+//     constant-folding (the identifier was assembled at runtime — obfuscation
+//     benign build tooling does not do) — all dangerous regardless of novelty;
+//   - low when it is ordinary source/build code newly added or changed in this
+//     release (a release delta worth recording, not a blocker);
+//   - info when that same ordinary capability already shipped in the previous
+//     version (pure pre-existing context).
+// Python keeps the prior high weighting: its install model (setup.py,
+// sitecustomize, .pth) is not described by package.json reachability and the
+// PyPI adapter owns its own install-hook rule (pypi.setup-install-command).
+function processExecutionSeverity(
+  ctx: RuleContext,
+  path: string,
+  changed: RuleContext["diff"][number]["status"] | undefined,
+  pairedCapability: boolean,
+  obfuscated: boolean,
+): Finding["severity"] {
+  if (ctx.codePatternSet === "python") return "high";
+  if (isInstallReachable(ctx, path) || pairedCapability || obfuscated) return "high";
+  return changed === "unchanged" ? "info" : "low";
+}
+
+// Whether `path` runs automatically on install or is an entrypoint npm wires up
+// for consumers: a declared (non-implicit) install lifecycle hook, or a `bin`
+// command linked into the consumer's node_modules/.bin.
+function isInstallReachable(ctx: RuleContext, path: string): boolean {
+  return isLifecycleScriptFile(ctx, path) || isBinTargetFile(ctx, path);
+}
+
+function isBinTargetFile(ctx: RuleContext, path: string): boolean {
+  const bin = ctx.packageJson?.bin;
+  if (!bin) return false;
+  const targets = typeof bin === "string" ? [bin] : Object.values(bin);
+  const filePath = normalizeManifestPath(path);
+  return targets.some(
+    (target) => typeof target === "string" && normalizeManifestPath(target) === filePath,
+  );
+}
+
+// Canonicalize a manifest-relative path for equality against a packed file path:
+// strip a leading `./` and the npm `package/` tarball prefix and unify
+// separators. Exact-path match (no basename fallback) so a bin target never
+// over-claims an unrelated same-named file as install-reachable.
+function normalizeManifestPath(path: string): string {
+  const normalized = path.replaceAll("\\", "/").replace(/^\.\//, "");
+  return normalized.startsWith("package/") ? normalized.slice("package/".length) : normalized;
 }
 
 function isLifecycleScriptFile(ctx: RuleContext, path: string): boolean {

--- a/test/fixtures/security-corpus/cases/bin-childprocess.json
+++ b/test/fixtures/security-corpus/cases/bin-childprocess.json
@@ -1,0 +1,50 @@
+{
+  "id": "bin-childprocess",
+  "title": "Process execution in a newly linked bin command stays high (install-reachable)",
+  "category": "install-context-weighting",
+  "intent": "A release adds a bin command whose target shells out via child_process. npm symlinks bin entries into the consumer's node_modules/.bin, so the file is install-reachable and the process-execution capability stays high even though it is not paired with network/credential access (issue #194). The added bin entry also surfaces diff.bin-added.",
+  "previousPackageJson": { "name": "cli-childprocess", "version": "1.0.0" },
+  "stagedPackageJson": {
+    "name": "cli-childprocess",
+    "version": "1.0.1",
+    "bin": { "cli-childprocess": "cli.js" }
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 50,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"cli-childprocess\",\"version\":\"1.0.0\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 96,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"cli-childprocess\",\"version\":\"1.0.1\",\"bin\":{\"cli-childprocess\":\"cli.js\"}}"
+    },
+    {
+      "path": "cli.js",
+      "size": 96,
+      "sha256": "cli-js",
+      "flags": [],
+      "textSample": "#!/usr/bin/env node\nrequire('child_process').execSync(process.argv[2]);\n"
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "code.process-execution",
+      "severity": "high",
+      "file": "cli.js"
+    },
+    {
+      "ruleId": "diff.bin-added",
+      "severity": "medium",
+      "file": "package.json"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases/build-script-childprocess.json
+++ b/test/fixtures/security-corpus/cases/build-script-childprocess.json
@@ -1,0 +1,60 @@
+{
+  "id": "build-script-childprocess",
+  "title": "Ordinary build scripts that shell out are weighted by install-reachability and novelty",
+  "category": "install-context-weighting",
+  "intent": "Two build helpers run child_process but neither is reachable from an install hook or bin entry and neither is paired with network/credential access. Per issue #194 the process-execution capability is no longer high on its own: the newly added helper is low (a release delta worth recording) and the pre-existing, unchanged helper is info (context). Risk stays low so a maintainer's local build tooling does not read as install-time command execution.",
+  "previousPackageJson": { "name": "build-script-childprocess", "version": "1.0.0" },
+  "stagedPackageJson": { "name": "build-script-childprocess", "version": "1.0.1" },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 56,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"build-script-childprocess\",\"version\":\"1.0.0\"}"
+    },
+    {
+      "path": "scripts/build.js",
+      "size": 96,
+      "sha256": "build-js-stable",
+      "flags": [],
+      "textSample": "const { execSync } = require('child_process');\nexecSync('make', { stdio: 'inherit' });\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 56,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"build-script-childprocess\",\"version\":\"1.0.1\"}"
+    },
+    {
+      "path": "scripts/build.js",
+      "size": 96,
+      "sha256": "build-js-stable",
+      "flags": [],
+      "textSample": "const { execSync } = require('child_process');\nexecSync('make', { stdio: 'inherit' });\n"
+    },
+    {
+      "path": "scripts/postbuild.js",
+      "size": 92,
+      "sha256": "postbuild-js",
+      "flags": [],
+      "textSample": "const { execSync } = require('child_process');\nexecSync('cp -r build dist');\n"
+    }
+  ],
+  "expectedRisk": "low",
+  "expectedFindings": [
+    {
+      "ruleId": "code.process-execution",
+      "severity": "info",
+      "file": "scripts/build.js"
+    },
+    {
+      "ruleId": "code.process-execution",
+      "severity": "low",
+      "file": "scripts/postbuild.js"
+    }
+  ]
+}

--- a/test/scan-pipeline.test.mjs
+++ b/test/scan-pipeline.test.mjs
@@ -625,7 +625,13 @@ describe("scan pipeline baseline selection", () => {
           size: 80,
           sha256: "same-risk",
           flags: [],
-          textSample: "require('child_process').execSync('true');\n",
+          // Pre-existing dropper shape (process execution paired with network
+          // egress in one file). Identical across versions, so it is not a
+          // release delta — it stays high severity (artifact + context risk) but
+          // contributes nothing to release risk. A bare, unpaired execSync in
+          // ordinary code is no longer high on its own (issue #194).
+          textSample:
+            "require('child_process').execSync('true');\nfetch('https://example.invalid/ping');\n",
         },
       ],
       packageJson: { name: "pkg", version: "1.0.1" },
@@ -644,7 +650,13 @@ describe("scan pipeline baseline selection", () => {
           size: 80,
           sha256: "same-risk",
           flags: [],
-          textSample: "require('child_process').execSync('true');\n",
+          // Pre-existing dropper shape (process execution paired with network
+          // egress in one file). Identical across versions, so it is not a
+          // release delta — it stays high severity (artifact + context risk) but
+          // contributes nothing to release risk. A bare, unpaired execSync in
+          // ordinary code is no longer high on its own (issue #194).
+          textSample:
+            "require('child_process').execSync('true');\nfetch('https://example.invalid/ping');\n",
         },
       ],
       packageJson: { name: "pkg", version: "1.0.0" },
@@ -664,7 +676,7 @@ describe("scan pipeline baseline selection", () => {
       releaseRisk: "low",
       contextRisk: "high",
       releaseFindingCount: 0,
-      contextFindingCount: 1,
+      contextFindingCount: 2,
     });
     expect(result.ruleFindings).toContainEqual(
       expect.objectContaining({


### PR DESCRIPTION
Closes #194. `code.process-execution` always fired at `high`, so a maintainer's local build script read the same as install-time RCE; it is now weighted by install-reachability and diff-novelty — `high` only when the file runs on install or is an entrypoint (lifecycle hook or `bin` target), is paired with network/credential/dynamic-eval (the dropper/exfil shape), or surfaced only after constant-folding (a runtime-assembled identifier), otherwise `low` when newly added/changed and `info` when pre-existing. Python keeps the prior `high` weighting because its install model is not described by `package.json` reachability and the PyPI adapter owns `pypi.setup-install-command`. This resolves the `legit-build-childprocess` false positive with no malicious-recall regression (gated recall stays 1.0). Adds `build-script-childprocess` and `bin-childprocess` golden fixtures locking both directions, bumps `DETERMINISTIC_RULES_VERSION` to `1.12.0`, and updates the scan-pipeline context/release-split test plus the detection-corpus doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)