### PR TITLE
Reduce pending scan polling cadence

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -120,7 +120,7 @@ Current async-capable flow:
 4. Pipeline stores derived/redacted report data and marks the scan `complete`.
 5. Terminal failures are persisted as `failed` with structured `error_json`; transient npm/sandbox failures are retried before they are marked failed.
 6. Exhausted retryable Queue jobs are sent to the configured dead-letter queue for operator review.
-7. UI polls `GET /api/v1/scans/:id` until terminal state. The scan detail model polls every 2.5s, doubling the delay on consecutive failures (capped at 30s, reset on success), and stops outright after ~10 minutes without a terminal status — the page then surfaces a warn alert whose "Resume refresh" action (`ScanDetailModel.resumePolling`) refetches immediately and restarts a fresh backoff chain.
+7. UI polls `GET /api/v1/scans/:id` until terminal state. The scan detail model polls every 10s, doubling the delay on consecutive failures (capped at 30s, reset on success), and stops outright after ~10 minutes without a terminal status — the page then surfaces a warn alert whose "Resume refresh" action (`ScanDetailModel.resumePolling`) refetches immediately and restarts a fresh backoff chain.
 
 ### One scan-submit surface
 

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -244,7 +244,7 @@ export type DecisionStatus = "idle" | "saving" | "error";
 // fixed rate) up to the max, and resets on success. A scan that never reaches
 // a terminal status stops polling entirely after the stall window; the UI
 // offers a manual resume via `resumePolling()`.
-export const SCAN_POLL_BASE_DELAY_MS = 2_500;
+export const SCAN_POLL_BASE_DELAY_MS = 10_000;
 export const SCAN_POLL_MAX_DELAY_MS = 30_000;
 export const SCAN_POLL_STALL_AFTER_MS = 10 * 60_000;
 

--- a/test/scan-detail-polling-model.test.ts
+++ b/test/scan-detail-polling-model.test.ts
@@ -62,6 +62,10 @@ describe("ScanDetailModel polling", () => {
     vi.useRealTimers();
   });
 
+  test("uses a ten second healthy polling cadence", () => {
+    expect(SCAN_POLL_BASE_DELAY_MS).toBe(10_000);
+  });
+
   test("backs off exponentially on consecutive failures, capped at the max delay", async () => {
     const fetchMock = vi.fn(() => Promise.resolve(failedResponse()));
     vi.stubGlobal("fetch", fetchMock);
@@ -74,27 +78,27 @@ describe("ScanDetailModel polling", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(model.error.value).not.toBeNull();
 
-    // One failure doubles the delay: nothing at 4999ms, the poll at 5000ms.
+    // One failure doubles the delay: nothing until the doubled base delay.
     await vi.advanceTimersByTimeAsync(2 * SCAN_POLL_BASE_DELAY_MS - 1);
     expect(fetchMock).toHaveBeenCalledTimes(1);
     await vi.advanceTimersByTimeAsync(1);
     expect(fetchMock).toHaveBeenCalledTimes(2);
 
-    // Keeps doubling: 10s, 20s, then clamps to the 30s cap.
-    await vi.advanceTimersByTimeAsync(4 * SCAN_POLL_BASE_DELAY_MS);
+    // The next failure clamps the cadence to the max delay.
+    await vi.advanceTimersByTimeAsync(SCAN_POLL_MAX_DELAY_MS - 1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    await vi.advanceTimersByTimeAsync(8 * SCAN_POLL_BASE_DELAY_MS);
+    await vi.advanceTimersByTimeAsync(SCAN_POLL_MAX_DELAY_MS);
     expect(fetchMock).toHaveBeenCalledTimes(4);
     await vi.advanceTimersByTimeAsync(SCAN_POLL_MAX_DELAY_MS);
     expect(fetchMock).toHaveBeenCalledTimes(5);
-    await vi.advanceTimersByTimeAsync(SCAN_POLL_MAX_DELAY_MS);
-    expect(fetchMock).toHaveBeenCalledTimes(6);
 
     // Disposal clears the pending timer; no further polls leak.
     model[Symbol.dispose]();
     model = null;
     await vi.advanceTimersByTimeAsync(10 * SCAN_POLL_MAX_DELAY_MS);
-    expect(fetchMock).toHaveBeenCalledTimes(6);
+    expect(fetchMock).toHaveBeenCalledTimes(5);
   });
 
   test("resets to the base delay after a successful poll", async () => {


### PR DESCRIPTION
## Summary
- Change `ScanDetailModel`’s healthy pending/running scan polling cadence from 2.5s to 10s while preserving failure backoff, 30s cap, stall handling, and manual resume behavior.
- Update polling model coverage to pin the 10s cadence and adjust capped-backoff expectations for the new base delay.
- Keep `docs/architecture.md` aligned with the new polling interval.

Link to Devin session: https://app.devin.ai/sessions/6c47552127cf44838dd907474a9a1414
Requested by: @JoviDeCroock