### PR TITLE
Fix org-scoped report JSON downloads

### DIFF
--- a/docs/artifact-storage.md
+++ b/docs/artifact-storage.md
@@ -41,7 +41,7 @@ Path segments are URL-encoded with `%` replaced by `~` so object keys stay path-
 
 The manifest records each object key, SHA-256 digest, byte size, content type, and count where applicable. `report.json` is the canonical report JSON whose digest must equal `scans.report_digest`. `files.json` stores redacted staged file samples plus file metadata. `diff.json` stores the generated file diff.
 
-User-initiated report downloads serve the same canonical `report.json` bytes with a package-scoped filename: `drydock-{package-name}-{version}.json`. Package names are normalized to a path-safe filename segment for the `Content-Disposition` header.
+User-initiated report downloads serve the same canonical `report.json` bytes with a package-scoped filename: `drydock-{package-name}-{version}.json`. Package names are normalized to a path-safe filename segment for the `Content-Disposition` header. Dashboard download links include the active organization as a validated query parameter because native browser downloads cannot attach the dashboard's `x-organization-id` fetch header.
 
 ## Write And Read Flow
 

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -1,4 +1,4 @@
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import {
   LIST_SCANS_DEFAULT_LIMIT,
   LIST_SCANS_MAX_LIMIT,
@@ -11,6 +11,7 @@ import {
   createScanJob,
   enforceRateLimit,
   getNpmConnection,
+  getOrganizationRole,
   getScan,
   listScans,
   recordScanDecision,
@@ -251,7 +252,8 @@ scansRoutes.get("/:id", async (c) => {
 
 scansRoutes.get("/:id/report.json", async (c) => {
   const db = createDb(c.env.DB);
-  const organizationId = await requireActiveOrganization(c, db);
+  const organizationId = await resolveReportExportOrganization(c, db);
+  if (!organizationId) return c.json({ error: "not found" }, 404);
   const detail = await getScan(db, c.req.param("id"), organizationId);
   if (!detail) return c.json({ error: "not found" }, 404);
   if (detail.scan.status !== "complete") {
@@ -269,6 +271,16 @@ scansRoutes.get("/:id/report.json", async (c) => {
     },
   });
 });
+
+async function resolveReportExportOrganization(
+  c: Context<{ Bindings: Bindings; Variables: Variables }>,
+  db: ReturnType<typeof createDb>,
+): Promise<string | null> {
+  const requested = c.req.query("organizationId")?.trim() || null;
+  if (!requested) return requireActiveOrganization(c, db);
+  const session = c.get("authSession");
+  return (await getOrganizationRole(db, requested, session.userId)) ? requested : null;
+}
 
 scansRoutes.get("/:id/versions", async (c) => {
   const db = createDb(c.env.DB);

--- a/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
+++ b/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
@@ -69,7 +69,7 @@ export function ScanDetailHeader({
             <LinkButton
               variant="ghost"
               size="sm"
-              href={`/api/v1/scans/${detail.scan.id}/report.json`}
+              href={reportExportHref(detail)}
               download={reportExportFilename(detail.scan)}
             >
               Export JSON
@@ -84,6 +84,12 @@ export function ScanDetailHeader({
       ) : null}
     </header>
   );
+}
+
+function reportExportHref(detail: PersistedScanDetail): string {
+  const href = `/api/v1/scans/${encodeURIComponent(detail.scan.id)}/report.json`;
+  const organizationId = detail.scan.organizationId;
+  return organizationId ? `${href}?organizationId=${encodeURIComponent(organizationId)}` : href;
 }
 
 export function VersionPickerSkeleton({ stagedVersion }: { stagedVersion: string | null }) {

--- a/test/workers/scan-report-export.test.ts
+++ b/test/workers/scan-report-export.test.ts
@@ -1,7 +1,13 @@
 import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
 import { Hono } from "hono";
 import { describe, expect, test } from "vitest";
-import { createDb, createScanJob, ensurePersonalOrganization, persistScan } from "../../server/db";
+import {
+  createDb,
+  createOrganization,
+  createScanJob,
+  ensurePersonalOrganization,
+  persistScan,
+} from "../../server/db";
 import * as schema from "../../server/db/schema";
 import { scansRoutes } from "../../server/routes/scans";
 import type { Bindings, Variables } from "../../server/types";
@@ -37,10 +43,17 @@ function buildTestApp(session: { userId: string }) {
   return app;
 }
 
-async function getReport(app: Hono<{ Bindings: Bindings; Variables: Variables }>, scanId: string) {
+async function getReport(
+  app: Hono<{ Bindings: Bindings; Variables: Variables }>,
+  scanId: string,
+  options: { organizationId?: string } = {},
+) {
   const ctx = createExecutionContext();
+  const query = options.organizationId
+    ? `?organizationId=${encodeURIComponent(options.organizationId)}`
+    : "";
   const res = await app.fetch(
-    new Request(`http://test.local/api/v1/scans/${scanId}/report.json`, { method: "GET" }),
+    new Request(`http://test.local/api/v1/scans/${scanId}/report.json${query}`, { method: "GET" }),
     env,
     ctx,
   );
@@ -141,6 +154,24 @@ describe("scan report JSON export", () => {
     expect(await again.text()).toBe(text);
   });
 
+  test("uses an organization query for native browser downloads", async () => {
+    const owner = await seedUser();
+    const db = createDb(env.DB);
+    const organizationId = await createOrganization(db, {
+      ownerUserId: owner.userId,
+      name: "Team workspace",
+    });
+    const scanId = await seedCompletedScan({ ...owner, organizationId });
+
+    expect((await getReport(buildTestApp(owner), scanId)).status).toBe(404);
+
+    const res = await getReport(buildTestApp(owner), scanId, { organizationId });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      package: { name: "@org/pkg", stagedVersion: "1.1.0" },
+    });
+  });
+
   test("does not leak another organization's report", async () => {
     const owner = await seedUser();
     const scanId = await seedCompletedScan(owner);
@@ -148,6 +179,11 @@ describe("scan report JSON export", () => {
 
     const res = await getReport(buildTestApp(outsider), scanId);
     expect(res.status).toBe(404);
+
+    const queried = await getReport(buildTestApp(outsider), scanId, {
+      organizationId: owner.organizationId,
+    });
+    expect(queried.status).toBe(404);
   });
 
   test("refuses export for a scan that has not completed", async () => {


### PR DESCRIPTION
## Summary
Native browser downloads cannot attach the dashboard API client's `x-organization-id` header, so `GET /api/v1/scans/:id/report.json` fell back to the user's personal org and returned 404 for scans in another workspace. This keeps the export as a normal download link, but adds a validated `organizationId` query parameter for dashboard-generated links:

```ts
/api/v1/scans/:id/report.json?organizationId=:activeOrg
```

The export route only honors that org when the signed-in user is a member; otherwise it still returns 404. Added Worker-route coverage for non-personal org downloads and outsider leakage.

Link to Devin session: https://app.devin.ai/sessions/4a7f300626cb4816a6dd064867b996a5
Requested by: @JoviDeCroock