### PR TITLE
Allow manual Slack channel ID selection

### DIFF
--- a/server/db/slack-connection.ts
+++ b/server/db/slack-connection.ts
@@ -8,6 +8,7 @@ export interface SlackConnection {
   teamId: string;
   teamName: string | null;
   botUserId: string | null;
+  scope: string | null;
   channelId: string | null;
   channelName: string | null;
   enabled: boolean;
@@ -23,6 +24,7 @@ export interface SlackConnectionSecret {
   channelId: string | null;
   channelName: string | null;
   enabled: boolean;
+  scope: string | null;
   botTokenCiphertext: string;
   botTokenNonce: string;
 }
@@ -33,6 +35,7 @@ const PUBLIC_COLUMNS = {
   teamId: organizationSlackConnections.teamId,
   teamName: organizationSlackConnections.teamName,
   botUserId: organizationSlackConnections.botUserId,
+  scope: organizationSlackConnections.scope,
   channelId: organizationSlackConnections.channelId,
   channelName: organizationSlackConnections.channelName,
   enabled: organizationSlackConnections.enabled,
@@ -70,6 +73,7 @@ export async function getSlackConnectionSecret(
       channelId: organizationSlackConnections.channelId,
       channelName: organizationSlackConnections.channelName,
       enabled: organizationSlackConnections.enabled,
+      scope: organizationSlackConnections.scope,
       botTokenCiphertext: organizationSlackConnections.botTokenCiphertext,
       botTokenNonce: organizationSlackConnections.botTokenNonce,
     })

--- a/server/lib/slack.ts
+++ b/server/lib/slack.ts
@@ -5,14 +5,14 @@ import { errorMessage } from "./errors";
 //
 // Drydock connects a Slack workspace through the "Add to Slack" OAuth v2 flow and
 // posts release alerts with the resulting bot token (`xoxb-…`). We request the
-// minimum scopes for a single public channel:
+// minimum scopes for posting to a manually supplied public channel:
 //   - chat:write          — post messages
 //   - chat:write.public    — post to any *public* channel without an invite
-//   - channels:read        — list public channels for the in-app picker
 // Restricting to public channels is deliberate: chat:write.public means the bot
 // never has to be invited, so delivery to the chosen channel always works.
 
-export const SLACK_OAUTH_SCOPES = "chat:write,chat:write.public,channels:read";
+export const SLACK_CHANNEL_LIST_SCOPE = "channels:read";
+export const SLACK_OAUTH_SCOPES = "chat:write,chat:write.public";
 
 const SLACK_AUTHORIZE_URL = "https://slack.com/oauth/v2/authorize";
 const SLACK_OAUTH_ACCESS_URL = "https://slack.com/api/oauth.v2.access";
@@ -62,6 +62,15 @@ export function buildSlackAuthorizeUrl(input: {
   url.searchParams.set("redirect_uri", input.redirectUri);
   url.searchParams.set("state", input.state);
   return url.toString();
+}
+
+export function canListSlackChannels(scope: string | null): boolean {
+  return (
+    scope
+      ?.split(",")
+      .map((item) => item.trim())
+      .includes(SLACK_CHANNEL_LIST_SCOPE) ?? false
+  );
 }
 
 export interface SlackOAuthResult {

--- a/server/routes/slack.ts
+++ b/server/routes/slack.ts
@@ -22,6 +22,7 @@ import { roleCanManageIntegrations } from "../lib/roles";
 import { decryptSlackBotToken, encryptSlackBotToken } from "../lib/secret-box";
 import {
   buildSlackAuthorizeUrl,
+  canListSlackChannels,
   exchangeSlackOAuthCode,
   listSlackPublicChannels,
   postSlackMessage,
@@ -145,6 +146,9 @@ slackRoutes.get("/channels", async (c) => {
 
   const secret = await getSlackConnectionSecret(db, organizationId);
   if (!secret) return c.json({ error: "Slack is not connected" }, 404);
+  if (!canListSlackChannels(secret.scope)) {
+    return c.json({ error: "Slack channel list permission is unavailable" }, 403);
+  }
 
   try {
     await enforceRateLimit(db, {
@@ -300,6 +304,7 @@ function publicConnection(connection: SlackConnection) {
     teamName: connection.teamName,
     channelId: connection.channelId,
     channelName: connection.channelName,
+    canListChannels: canListSlackChannels(connection.scope),
     enabled: connection.enabled,
     createdAt: connection.createdAt,
   };

--- a/src/models/slack-connection.ts
+++ b/src/models/slack-connection.ts
@@ -6,6 +6,7 @@ export interface SlackConnection {
   teamName: string | null;
   channelId: string | null;
   channelName: string | null;
+  canListChannels: boolean;
   enabled: boolean;
   createdAt: string | number | Date;
 }
@@ -69,6 +70,33 @@ export const SlackConnectionModel = createModel(() => {
   let loadRequestId = 0;
 
   const busy = computed(() => status.value !== "idle");
+
+  async function saveChannel(channelId: string, channelName: string | null): Promise<boolean> {
+    const org = currentOrganizationId;
+    const trimmedChannelId = channelId.trim();
+    if (!trimmedChannelId) return false;
+    status.value = "savingChannel";
+    error.value = null;
+    try {
+      const data = await apiJson<{ connection: SlackConnection }>(
+        `${SLACK_BASE}/channel`,
+        { channelId: trimmedChannelId, channelName },
+        { method: "PUT" },
+      );
+      if (currentOrganizationId !== org) return false;
+      connection.value = data.connection;
+      return true;
+    } catch (err) {
+      if (currentOrganizationId === org) {
+        error.value = errorMessage(err);
+      }
+      return false;
+    } finally {
+      if (currentOrganizationId === org) {
+        status.value = "idle";
+      }
+    }
+  }
 
   function resetChannelPicker() {
     channels.value = [];
@@ -163,28 +191,13 @@ export const SlackConnectionModel = createModel(() => {
     },
 
     async selectChannel(channelId: string): Promise<void> {
-      const org = currentOrganizationId;
       const channel = this.channels.peek().find((option) => option.id === channelId);
       if (!channel) return;
-      this.status.value = "savingChannel";
-      this.error.value = null;
-      try {
-        const data = await apiJson<{ connection: SlackConnection }>(
-          `${SLACK_BASE}/channel`,
-          { channelId: channel.id, channelName: channel.name },
-          { method: "PUT" },
-        );
-        if (currentOrganizationId !== org) return;
-        this.connection.value = data.connection;
-      } catch (err) {
-        if (currentOrganizationId === org) {
-          this.error.value = errorMessage(err);
-        }
-      } finally {
-        if (currentOrganizationId === org) {
-          this.status.value = "idle";
-        }
-      }
+      await saveChannel(channel.id, channel.name);
+    },
+
+    async saveChannelId(channelId: string): Promise<boolean> {
+      return saveChannel(channelId, null);
     },
 
     async disconnect(): Promise<void> {

--- a/src/pages/Dashboard/Settings/SlackConnectionSection.tsx
+++ b/src/pages/Dashboard/Settings/SlackConnectionSection.tsx
@@ -1,4 +1,4 @@
-import { useComputed, useModel, useSignalEffect, type Signal } from "@preact/signals";
+import { useComputed, useModel, useSignal, useSignalEffect, type Signal } from "@preact/signals";
 import { For, Show, useLiveSignal } from "@preact/signals/utils";
 import {
   SlackConnectionModel,
@@ -11,6 +11,7 @@ import {
   Badge,
   Button,
   CollapsibleCard,
+  Input,
   LoadingLine,
   Muted,
   pushToast,
@@ -50,10 +51,18 @@ export function SlackConnectionSection({
   // unconditionally so they are always tracked as dependencies.
   useSignalEffect(() => {
     const hasConnection = slack.connection.value !== null;
+    const canListChannels = slack.connection.value?.canListChannels === true;
     const loadedChannels = slack.channelsLoaded.value;
     const channelsFailed = slack.channelsError.value !== null;
     const idle = slack.status.value === "idle";
-    if (canManage && hasConnection && !loadedChannels && !channelsFailed && idle) {
+    if (
+      canManage &&
+      hasConnection &&
+      canListChannels &&
+      !loadedChannels &&
+      !channelsFailed &&
+      idle
+    ) {
       void slack.loadChannels();
     }
   });
@@ -126,8 +135,10 @@ function ConnectedSlackState({
   onSelectChannel: (channelId: string) => void;
   onTest: () => Promise<void>;
 }) {
+  const manualChannelId = useSignal("");
+  const canListChannels = useComputed(() => slack.connection.value?.canListChannels === true);
   const showChannelPicker = useComputed(
-    () => canManage.value && slack.channelsError.value === null,
+    () => canManage.value && canListChannels.value && slack.channelsError.value === null,
   );
   const channelPickerLoading = useComputed(
     () => showChannelPicker.value && !slack.channelsLoaded.value,
@@ -144,13 +155,26 @@ function ConnectedSlackState({
     if (loading) return "Loading channels…";
     return channels.length === 0 ? "No public channels found" : "Choose a channel…";
   });
-  const selectedChannelName = useComputed(() => slack.connection.value?.channelName ?? null);
+  const selectedChannelLabel = useComputed(() => {
+    const current = slack.connection.value;
+    if (!current?.channelId) return null;
+    return current.channelName ? `#${current.channelName}` : current.channelId;
+  });
   const savingChannel = useComputed(() => slack.status.value === "savingChannel");
   const testDisabled = useComputed(() => slack.busy.value || !slack.connection.value?.channelId);
   const testingLabel = useComputed(() => (slack.status.value === "testing" ? "Testing…" : "Test"));
   const disconnectLabel = useComputed(() =>
     slack.status.value === "disconnecting" ? "Disconnecting…" : "Disconnect",
   );
+  const manualChannelDisabled = useComputed(
+    () => slack.busy.value || manualChannelId.value.trim().length === 0,
+  );
+  const onSaveManualChannel = async (event: Event) => {
+    event.preventDefault();
+    const channelId = manualChannelId.peek();
+    const saved = await slack.saveChannelId(channelId);
+    if (saved) manualChannelId.value = "";
+  };
 
   return (
     <div class="flex flex-col gap-4">
@@ -160,10 +184,10 @@ function ConnectedSlackState({
             {connection.teamName ?? "Slack workspace"}
           </span>
           <Show<string | null>
-            when={selectedChannelName}
+            when={selectedChannelLabel}
             fallback={<Badge tone="medium">no channel</Badge>}
           >
-            {(channelName) => <Badge tone="info">#{channelName}</Badge>}
+            {(channelLabel) => <Badge tone="info">{channelLabel}</Badge>}
           </Show>
         </div>
         <Show when={canManage}>
@@ -185,7 +209,7 @@ function ConnectedSlackState({
 
       <Show
         when={showChannelPicker}
-        fallback={<ReadOnlyChannelSelection channelName={selectedChannelName} />}
+        fallback={<ReadOnlyChannelSelection channelLabel={selectedChannelLabel} />}
       >
         <div class="flex flex-wrap items-center gap-3">
           <label
@@ -219,6 +243,34 @@ function ConnectedSlackState({
         </div>
       </Show>
 
+      <Show when={canManage}>
+        <form class="flex flex-wrap items-center gap-3" onSubmit={onSaveManualChannel}>
+          <label
+            for="slackChannelId"
+            class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle shrink-0"
+          >
+            Channel ID
+          </label>
+          <div class="flex-1 min-w-[200px] max-w-[360px]">
+            <Input
+              id="slackChannelId"
+              type="text"
+              value={manualChannelId}
+              placeholder="C0123ABCDEF"
+              onInput={(e) => (manualChannelId.value = (e.target as HTMLInputElement).value)}
+              disabled={slack.busy}
+              spellcheck={false}
+            />
+          </div>
+          <Button type="submit" variant="secondary" disabled={manualChannelDisabled}>
+            Save
+          </Button>
+          <Muted class="basis-full text-[12px] m-0">
+            Paste a channel ID when the channel is not listed or list permission is unavailable.
+          </Muted>
+        </form>
+      </Show>
+
       <Show<string | null> when={slack.channelsError}>
         {(message) => <Alert tone="critical">{message}</Alert>}
       </Show>
@@ -226,15 +278,15 @@ function ConnectedSlackState({
   );
 }
 
-function ReadOnlyChannelSelection({ channelName }: { channelName: Signal<string | null> }) {
+function ReadOnlyChannelSelection({ channelLabel }: { channelLabel: Signal<string | null> }) {
   return (
     <Show<string | null>
-      when={channelName}
+      when={channelLabel}
       fallback={<Muted class="text-[13px] m-0">No channel selected yet.</Muted>}
     >
-      {(name) => (
+      {(label) => (
         <Muted class="text-[13px] m-0">
-          Posting to <span class="text-ink">#{name}</span>.
+          Posting to <span class="text-ink">{label}</span>.
         </Muted>
       )}
     </Show>

--- a/test/slack.test.mjs
+++ b/test/slack.test.mjs
@@ -62,6 +62,7 @@ describe("buildSlackAuthorizeUrl", () => {
     expect(url.origin + url.pathname).toBe("https://slack.com/oauth/v2/authorize");
     expect(url.searchParams.get("client_id")).toBe("client-id");
     expect(url.searchParams.get("scope")).toBe(SLACK_OAUTH_SCOPES);
+    expect(url.searchParams.get("scope")).not.toContain("channels:read");
     expect(url.searchParams.get("redirect_uri")).toBe("https://drydock.test/api/v1/slack/callback");
     expect(url.searchParams.get("state")).toBe("state-token");
   });

--- a/test/workers/slack-routes.test.ts
+++ b/test/workers/slack-routes.test.ts
@@ -47,6 +47,7 @@ async function seedConnection(
   options: {
     token?: string;
     teamId?: string;
+    scope?: string | null;
     channelId?: string | null;
     channelName?: string | null;
     enabled?: boolean;
@@ -59,7 +60,7 @@ async function seedConnection(
     teamId: options.teamId ?? "T0FAKE0001",
     teamName: "Acme",
     botUserId: "U0BOT0001",
-    scope: "chat:write,chat:write.public,channels:read",
+    scope: options.scope ?? "chat:write,chat:write.public,channels:read",
     botTokenCiphertext: encrypted.ciphertext,
     botTokenNonce: encrypted.nonce,
     createdByUserId: null,
@@ -177,6 +178,7 @@ describe("GET /api/v1/slack", () => {
     await seedConnection(owner.personalOrganizationId, {
       channelId: "C0RELEASE",
       channelName: "releases",
+      canListChannels: true,
     });
 
     const res = await call(buildTestApp(owner), "GET", "/api/v1/slack");
@@ -430,6 +432,18 @@ describe("GET /api/v1/slack/channels", () => {
       activeOrganizationId: owner.personalOrganizationId,
     });
     expect(res.status).toBe(403);
+  });
+
+  test("skips Slack API calls when channel list permission is unavailable", async () => {
+    const owner = await seedUser();
+    await seedConnection(owner.personalOrganizationId, {
+      scope: "chat:write,chat:write.public",
+    });
+    globalThis.fetch = vi.fn(async () => jsonResponse({ ok: true }));
+
+    const res = await call(buildTestApp(owner), "GET", "/api/v1/slack/channels");
+    expect(res.status).toBe(403);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- Removes `channels:read` from new Slack OAuth installs so Drydock no longer requires workspace-wide channel listing permission just to post release notifications.
- Exposes `canListChannels` from the stored Slack OAuth scopes, keeping the channel picker for existing connections that already have `channels:read` while skipping list calls for new minimal-scope installs.
- Adds a Channel ID fallback in Slack settings that saves directly through the existing `/api/v1/slack/channel` path when a public channel is missing from `conversations.list` or list permission is unavailable.
- Validation: `oxlint`, `tsc --noEmit`, `oxfmt --check .`, `vitest run --project node test/slack.test.mjs`, `vitest run --project workers test/workers/slack-routes.test.ts`.

Link to Devin session: https://app.devin.ai/sessions/82d0d0bb1e444a70af39cc125b01aabb
Requested by: @JoviDeCroock