### PR TITLE
Ops-loop findings: kill no-op sweep audit noise, make token failures actionable

### DIFF
--- a/server/lib/staged-publishes-discovery.ts
+++ b/server/lib/staged-publishes-discovery.ts
@@ -277,17 +277,22 @@ export async function discoverAndQueueStagedPublishes(
     }
   }
 
-  await recordScanEvent(db, {
-    organizationId,
-    actorUserId,
-    type: "staged_publishes.scans_started",
-    metadata: {
-      found: stageIds.length,
-      created: startedScans.length,
-      skipped: stageIds.length - startedScans.length,
-      source: eventSource,
-    },
-  });
+  // Only audit sweeps that start scans: the */15min cron emits one event per
+  // connected org per run, and no-op sweeps were ~97% of all scan_events rows.
+  // Sweep observability itself lives in Workers Logs (staged_publishes.cron.*).
+  if (startedScans.length > 0) {
+    await recordScanEvent(db, {
+      organizationId,
+      actorUserId,
+      type: "staged_publishes.scans_started",
+      metadata: {
+        found: stageIds.length,
+        created: startedScans.length,
+        skipped: stageIds.length - startedScans.length,
+        source: eventSource,
+      },
+    });
+  }
 
   return {
     found: stageIds.length,

--- a/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
+++ b/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
@@ -100,15 +100,31 @@ export function VersionPickerSkeleton({ stagedVersion }: { stagedVersion: string
   );
 }
 
+// Token-scope failures are an onboarding dead end without a pointer to the fix:
+// connect-time validation only checks whoami + stage listing, so a granular token
+// can validate fine and still 403 on a specific package's tarball.
+const FAILURE_GUIDANCE: Record<string, { hint: string; action: string }> = {
+  staged_tarball_unavailable: {
+    hint: "This usually means the npm token has expired or its granular scope does not cover this package.",
+    action: "Validate or rotate the token under Settings → npm access.",
+  },
+};
+
 export function ScanFailureAlert({ errorJson }: { errorJson: unknown }) {
   const error =
     errorJson && typeof errorJson === "object"
       ? (errorJson as { message?: unknown; code?: unknown })
       : null;
+  const guidance = typeof error?.code === "string" ? FAILURE_GUIDANCE[error.code] : undefined;
   return (
     <Alert tone="critical">
       <div class="flex flex-col gap-1">
         <strong>{typeof error?.message === "string" ? error.message : "Review failed."}</strong>
+        {guidance ? (
+          <span>
+            {guidance.hint} <a href="/dashboard/settings">{guidance.action}</a>
+          </span>
+        ) : null}
         {typeof error?.code === "string" ? (
           <span class="font-mono text-xs">code: {error.code}</span>
         ) : null}

--- a/test/staged-publishes-discovery.test.mjs
+++ b/test/staged-publishes-discovery.test.mjs
@@ -371,4 +371,60 @@ describe("discoverAndQueueStagedPublishes", () => {
       dbMock.recordScanEvent.mock.calls.some(([, payload]) => payload?.type === "scan.queued"),
     ).toBe(false);
   });
+
+  test("does not record scans_started when the sweep starts nothing", async () => {
+    stagedPublishesMock.listStagedPublishes.mockResolvedValue({
+      items: [{ id: "stage-known", packageName: "pkg-a", version: "1.0.0" }],
+    });
+    dbMock.listExistingScanStageIds.mockResolvedValue(new Set(["stage-known"]));
+
+    const result = await discoverAndQueueStagedPublishes(
+      {
+        db,
+        env,
+        executionCtx: ctx,
+        organizationId: "org_a",
+        actorUserId: "user_a",
+        source: "auto_discovery",
+        eventSource: "staged_publishes.cron",
+      },
+      { token: "npm_secret_token", registryUrl: "https://registry.npmjs.org" },
+    );
+
+    expect(result).toEqual(expect.objectContaining({ found: 1, created: 0, skipped: 1 }));
+    expect(
+      dbMock.recordScanEvent.mock.calls.some(
+        ([, payload]) => payload?.type === "staged_publishes.scans_started",
+      ),
+    ).toBe(false);
+  });
+
+  test("records scans_started when the sweep starts scans", async () => {
+    stagedPublishesMock.listStagedPublishes.mockResolvedValue({
+      items: [{ id: "stage-new", packageName: "pkg-a", version: "1.0.0" }],
+    });
+    dbMock.listExistingScanStageIds.mockResolvedValue(new Set());
+    dbMock.createScanJob.mockResolvedValue({ id: "scan-new" });
+
+    await discoverAndQueueStagedPublishes(
+      {
+        db,
+        env,
+        executionCtx: ctx,
+        organizationId: "org_a",
+        actorUserId: "user_a",
+        source: "auto_discovery",
+        eventSource: "staged_publishes.cron",
+      },
+      { token: "npm_secret_token", registryUrl: "https://registry.npmjs.org" },
+    );
+
+    const startedEvents = dbMock.recordScanEvent.mock.calls.filter(
+      ([, payload]) => payload?.type === "staged_publishes.scans_started",
+    );
+    expect(startedEvents).toHaveLength(1);
+    expect(startedEvents[0]?.[1]?.metadata).toEqual(
+      expect.objectContaining({ found: 1, created: 1, skipped: 0 }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Two fixes that fell out of the first prod-data ops review (2026-06-12):

1. **Stop recording `staged_publishes.scans_started` on no-op sweeps.** The */15min cron emitted one event per connected org per run even when nothing started — ~670 rows/day, **97% of all `scan_events` rows**. The audit event is now only recorded when a sweep actually starts scans; sweep observability itself already lives in Workers Logs (`staged_publishes.cron.org_completed`).

2. **Make `staged_tarball_unavailable` failures actionable.** A real user's only scan failed with this code and the UI showed just the raw message — a dead end (connect-time validation only checks `whoami` + stage listing, so a granular token can validate fine and still 403 on a specific package's tarball). The failure alert now explains the likely cause and links to Settings → npm access.

## Testing

- New unit tests: sweep with nothing started records no event; sweep that starts scans records exactly one with correct metadata.
- `pnpm run verify` green (lint, format, typecheck, tests).

Note for reviewers: #328 also touches `staged-publishes-discovery.ts` and `ScanDetailChrome.tsx`; both changes here are small and should rebase trivially in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)