### PR TITLE
Prepare drydock.org canonical domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,14 +100,14 @@ Current implementation secrets:
 
 Worker non-secret vars and bindings:
 
-| Name                 | Where                                           | Purpose                                                                                                                      |
-| -------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `BETTER_AUTH_URL`    | `.dev.vars` locally; Wrangler var in production | Canonical app origin for Better Auth, for example `http://localhost:5173` locally or your deployed Worker URL. Not a secret. |
-| `NPM_REGISTRY`       | `wrangler.jsonc` `vars`                         | npm registry base URL. Defaults to `https://registry.npmjs.org`.                                                             |
-| `AI_CACHE_AFFINITY`  | `wrangler.jsonc` `vars`                         | Stable `x-session-affinity` value for Cloudflare Workers AI prefix caching.                                                  |
-| `AI`, `LOADER`, `DB` | `wrangler.jsonc` bindings                       | Cloudflare Workers AI, Dynamic Worker loader, and required D1 database binding.                                              |
-| `SCAN_QUEUE`         | `wrangler.jsonc` Queue binding                  | Optional in local dev; production async scan queue. Configure retry/DLQ policy before private beta.                          |
-| `COMPARE_CACHE`      | `wrangler.jsonc` KV binding                     | Cache for parsed published package versions used by alternate-version compare views.                                         |
+| Name                 | Where                                           | Purpose                                                                                                                                 |
+| -------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `BETTER_AUTH_URL`    | `.dev.vars` locally; Wrangler var in production | Canonical app origin for Better Auth, for example `http://localhost:5173` locally or `https://drydock.org` in production. Not a secret. |
+| `NPM_REGISTRY`       | `wrangler.jsonc` `vars`                         | npm registry base URL. Defaults to `https://registry.npmjs.org`.                                                                        |
+| `AI_CACHE_AFFINITY`  | `wrangler.jsonc` `vars`                         | Stable `x-session-affinity` value for Cloudflare Workers AI prefix caching.                                                             |
+| `AI`, `LOADER`, `DB` | `wrangler.jsonc` bindings                       | Cloudflare Workers AI, Dynamic Worker loader, and required D1 database binding.                                                         |
+| `SCAN_QUEUE`         | `wrangler.jsonc` Queue binding                  | Optional in local dev; production async scan queue. Configure retry/DLQ policy before private beta.                                     |
+| `COMPARE_CACHE`      | `wrangler.jsonc` KV binding                     | Cache for parsed published package versions used by alternate-version compare views.                                                    |
 
 Generate the Better Auth secret with either command:
 

--- a/server/env.d.ts
+++ b/server/env.d.ts
@@ -2,6 +2,7 @@ declare global {
   namespace Cloudflare {
     interface Env {
       AI: Ai;
+      ASSETS?: Fetcher;
       AI_CACHE_AFFINITY?: string;
       LOADER: WorkerLoader;
       DB: D1Database;

--- a/server/index.ts
+++ b/server/index.ts
@@ -45,14 +45,28 @@ export { NpmStageGateway } from "./lib/sandbox";
 export { NpmAdapterBroker } from "./lib/adapters/npm";
 
 const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+const CANONICAL_HOSTNAME = "drydock.org";
+const LEGACY_HOSTNAME = "drydock.resynapse.dev";
+const SERVER_OWNED_PATH_PREFIXES = ["/api", "/webhooks"];
+
+function canonicalDomainRedirect(request: Request): Response | null {
+  const url = new URL(request.url);
+  if (url.hostname !== LEGACY_HOSTNAME) return null;
+  url.hostname = CANONICAL_HOSTNAME;
+  return Response.redirect(url.toString(), 308);
+}
+
+function isServerOwnedPath(path: string): boolean {
+  return SERVER_OWNED_PATH_PREFIXES.some(
+    (prefix) => path === prefix || path.startsWith(`${prefix}/`),
+  );
+}
 
 function applySecurityHeaders(c: { res: Response; req: { path: string } }) {
   const headers = new Headers(c.res.headers);
   for (const [name, value] of Object.entries(SECURITY_HEADERS)) headers.set(name, value);
-  // Static assets (the HTML document, JS, CSS) are served by Cloudflare's edge
-  // before the Worker runs, so only run_worker_first paths reach here; those are
-  // all JSON API/webhook responses and take the locked-down policy. The static
-  // document CSP lives in public/_headers — see server/lib/security-headers.ts.
+  // Worker-owned routes carry the locked-down API policy; static asset responses
+  // fetched through the ASSETS binding keep the document policy.
   headers.set("Content-Security-Policy", c.req.path.startsWith("/api/") ? API_CSP : DOCUMENT_CSP);
 
   c.res = new Response(c.res.body, {
@@ -67,6 +81,8 @@ app.use("*", async (c, next) => {
   if (c.res.status < 200 || c.res.status > 599) return;
   applySecurityHeaders(c);
 });
+
+app.use("*", async (c, next) => canonicalDomainRedirect(c.req.raw) ?? next());
 
 // GitHub App webhooks are signed by GitHub itself, not Better Auth, and arrive
 // without an Origin/Referer header. They must be mounted before the auth and
@@ -218,7 +234,12 @@ app.route("/api/v1/scans", scansRoutes);
 app.route("/api/v1/slack", slackRoutes);
 app.route("/api/v1/staged-publishes", stagedPublishesRoutes);
 
-app.notFound((c) => c.json({ error: "not found" }, 404));
+app.notFound((c) => {
+  if (!isServerOwnedPath(c.req.path) && c.env.ASSETS) {
+    return c.env.ASSETS.fetch(c.req.raw);
+  }
+  return c.json({ error: "not found" }, 404);
+});
 
 app.onError((err, c) => {
   emitOperationalEvent("error", "request.unhandled_error", {

--- a/test/workers/canonical-domain.test.ts
+++ b/test/workers/canonical-domain.test.ts
@@ -1,0 +1,44 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { describe, expect, test } from "vitest";
+import worker from "../../server/index";
+
+const assetEnv = {
+  ...env,
+  ASSETS: {
+    fetch: async (request: Request) => new Response(`asset:${new URL(request.url).pathname}`),
+  },
+} satisfies Cloudflare.Env;
+
+async function fetchWorker(url: string, requestEnv: Cloudflare.Env = env): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(new Request(url), requestEnv, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+describe("canonical domain routing", () => {
+  test("redirects legacy host requests to drydock.org", async () => {
+    const res = await fetchWorker("https://drydock.resynapse.dev/dashboard/scans/123?tab=report");
+
+    expect(res.status).toBe(308);
+    expect(res.headers.get("Location")).toBe("https://drydock.org/dashboard/scans/123?tab=report");
+    expect(res.headers.get("Strict-Transport-Security")).toBe(
+      "max-age=31536000; includeSubDomains; preload",
+    );
+  });
+
+  test("serves app assets through the Worker-first fallback", async () => {
+    const res = await fetchWorker("https://drydock.org/dashboard/scans/123", assetEnv);
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("asset:/dashboard/scans/123");
+    expect(res.headers.get("Content-Security-Policy")).toContain("script-src 'self'");
+  });
+
+  test("keeps server-owned misses as JSON 404s", async () => {
+    const res = await fetchWorker("https://drydock.org/webhooks/not-found", assetEnv);
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "not found" });
+  });
+});

--- a/test/wrangler-config.test.mjs
+++ b/test/wrangler-config.test.mjs
@@ -2,14 +2,20 @@ import { readFileSync } from "node:fs";
 import { describe, expect, test } from "vitest";
 
 describe("Wrangler static asset routing", () => {
-  test("runs the Worker before the SPA fallback for server-owned paths", () => {
+  test("runs the Worker before assets so legacy-domain redirects cover every path", () => {
     const config = readFileSync(new URL("../wrangler.jsonc", import.meta.url), "utf8");
     const assetsBlock = config.match(/"assets"\s*:\s*\{(?<body>[\s\S]*?)\n\t\}/)?.groups?.body;
 
     expect(assetsBlock).toContain('"not_found_handling": "single-page-application"');
-    expect(assetsBlock).toContain('"run_worker_first"');
-    for (const route of ["/api", "/api/*", "/webhooks/*"]) {
-      expect(assetsBlock).toContain(`"${route}"`);
-    }
+    expect(assetsBlock).toContain('"binding": "ASSETS"');
+    expect(assetsBlock).toContain('"run_worker_first": true');
+  });
+
+  test("serves the canonical domain while keeping the legacy domain routed", () => {
+    const config = readFileSync(new URL("../wrangler.jsonc", import.meta.url), "utf8");
+
+    expect(config).toContain('"pattern": "drydock.org"');
+    expect(config).toContain('"pattern": "drydock.resynapse.dev"');
+    expect(config).toContain('"BETTER_AUTH_URL": "https://drydock.org"');
   });
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,14 +15,8 @@
 	},
 	"assets": {
 		"not_found_handling": "single-page-application",
-		// Keep server-owned paths out of the SPA fallback. Without this, OAuth
-		// callbacks such as /api/v1/slack/callback can render the client 404
-		// before the Hono route sees the request.
-		"run_worker_first": [
-			"/api",
-			"/api/*",
-			"/webhooks/*"
-		]
+		"binding": "ASSETS",
+		"run_worker_first": true
 	},
 	"ai": {
 		"binding": "AI"
@@ -86,18 +80,22 @@
 			"*/15 * * * *"
 		]
 	},
-	  "routes": [
-    {
-      "pattern": "drydock.resynapse.dev",
-      "custom_domain": true,
-    },
-    {
-      "pattern": "drydock.resynapse.dev/b/*",
-      "zone_name": "resynapse.dev",
-    },
-  ],
+	"routes": [
+		{
+			"pattern": "drydock.org",
+			"custom_domain": true
+		},
+		{
+			"pattern": "drydock.resynapse.dev",
+			"custom_domain": true
+		},
+		{
+			"pattern": "drydock.resynapse.dev/b/*",
+			"zone_name": "resynapse.dev"
+		}
+	],
 	"vars": {
-		"BETTER_AUTH_URL": "https://drydock.resynapse.dev",
+		"BETTER_AUTH_URL": "https://drydock.org",
 		"AI_CACHE_AFFINITY": "staged-publish-review-release-reviewer-v1",
 		"NPM_REGISTRY": "https://registry.npmjs.org",
 		"PNPM_VERSION": "11.1.1",


### PR DESCRIPTION
## Summary
Move production’s canonical origin from `https://drydock.resynapse.dev` to `https://drydock.org` and keep the legacy host routed only to issue a permanent redirect.

Key deployment shape:
```ts
if (new URL(request.url).hostname === "drydock.resynapse.dev") {
  return Response.redirect("https://drydock.org" + pathAndQuery, 308)
}
```

Wrangler now binds the Worker to `drydock.org`, updates `BETTER_AUTH_URL` for Better Auth/OAuth/report links, and enables `run_worker_first` with an `ASSETS` binding so host redirects apply to SPA/static paths as well as Worker-owned API/webhook paths. Non-server app paths fall back to `env.ASSETS.fetch()`, while `/api` and `/webhooks` misses stay Worker JSON responses.

Tests: `pnpm run verify`

Link to Devin session: https://app.devin.ai/sessions/aadab073bfff4b448124f9fa34230b3c
Requested by: @JoviDeCroock