### PR TITLE
Remove double border below landing hero

### DIFF
--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -47,7 +47,7 @@ export default function LandingPage() {
         </>
       }
     >
-      <section class="py-8 md:py-12 border-y border-border flex flex-col gap-5">
+      <section class="py-8 md:py-12 border-t border-border flex flex-col gap-5">
         <Eyebrow tone="accent">Pre-publish review for npm and PyPI packages</Eyebrow>
         <h1 class="text-4xl md:text-5xl font-semibold tracking-[-0.03em] leading-[1.05] max-w-[760px] m-0">
           See exactly what your next publish ships.


### PR DESCRIPTION
The landing hero `<section>` used `border-y`, which drew a full-width bottom border that stacked against the "Sponsored by" `SectionLabel`'s trailing rule just below it, reading as a double border. This switches the hero to `border-t` so the `SectionLabel` rule is the single divider between the hero and the Aikido sponsor strip. The shared `SectionLabel` component is left untouched since it's used elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)