### PR TITLE
Add drydock.org Wrangler domain

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -86,18 +86,22 @@
 			"*/15 * * * *"
 		]
 	},
-	  "routes": [
-    {
-      "pattern": "drydock.resynapse.dev",
-      "custom_domain": true,
-    },
-    {
-      "pattern": "drydock.resynapse.dev/b/*",
-      "zone_name": "resynapse.dev",
-    },
-  ],
+	"routes": [
+		{
+			"pattern": "drydock.org",
+			"custom_domain": true
+		},
+		{
+			"pattern": "drydock.resynapse.dev",
+			"custom_domain": true
+		},
+		{
+			"pattern": "drydock.resynapse.dev/b/*",
+			"zone_name": "resynapse.dev"
+		}
+	],
 	"vars": {
-		"BETTER_AUTH_URL": "https://drydock.resynapse.dev",
+		"BETTER_AUTH_URL": "https://drydock.org",
 		"AI_CACHE_AFFINITY": "staged-publish-review-release-reviewer-v1",
 		"NPM_REGISTRY": "https://registry.npmjs.org",
 		"PNPM_VERSION": "11.1.1",


### PR DESCRIPTION
## Summary
Add `drydock.org` to the Worker’s Wrangler route configuration and make it the production `BETTER_AUTH_URL` used by Better Auth, OAuth callbacks, and generated app URLs.

This PR is intentionally limited to deployment configuration:
```jsonc
"routes": [
  { "pattern": "drydock.org", "custom_domain": true },
  { "pattern": "drydock.resynapse.dev", "custom_domain": true },
  { "pattern": "drydock.resynapse.dev/b/*", "zone_name": "resynapse.dev" }
],
"vars": { "BETTER_AUTH_URL": "https://drydock.org" }
```

The legacy-host redirect/API fallback code is split into a follow-up PR.

Tests: `pnpm run format:check`

Link to Devin session: https://app.devin.ai/sessions/aadab073bfff4b448124f9fa34230b3c
Requested by: @JoviDeCroock