### PR TITLE
Redirect legacy drydock host in Worker

### DIFF
--- a/server/env.d.ts
+++ b/server/env.d.ts
@@ -2,6 +2,7 @@ declare global {
   namespace Cloudflare {
     interface Env {
       AI: Ai;
+      ASSETS?: Fetcher;
       AI_CACHE_AFFINITY?: string;
       LOADER: WorkerLoader;
       DB: D1Database;

--- a/server/index.ts
+++ b/server/index.ts
@@ -45,14 +45,28 @@ export { NpmStageGateway } from "./lib/sandbox";
 export { NpmAdapterBroker } from "./lib/adapters/npm";
 
 const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+const CANONICAL_HOSTNAME = "drydock.org";
+const LEGACY_HOSTNAME = "drydock.resynapse.dev";
+const SERVER_OWNED_PATH_PREFIXES = ["/api", "/webhooks"];
+
+function canonicalDomainRedirect(request: Request): Response | null {
+  const url = new URL(request.url);
+  if (url.hostname !== LEGACY_HOSTNAME) return null;
+  url.hostname = CANONICAL_HOSTNAME;
+  return Response.redirect(url.toString(), 308);
+}
+
+function isServerOwnedPath(path: string): boolean {
+  return SERVER_OWNED_PATH_PREFIXES.some(
+    (prefix) => path === prefix || path.startsWith(`${prefix}/`),
+  );
+}
 
 function applySecurityHeaders(c: { res: Response; req: { path: string } }) {
   const headers = new Headers(c.res.headers);
   for (const [name, value] of Object.entries(SECURITY_HEADERS)) headers.set(name, value);
-  // Static assets (the HTML document, JS, CSS) are served by Cloudflare's edge
-  // before the Worker runs, so only run_worker_first paths reach here; those are
-  // all JSON API/webhook responses and take the locked-down policy. The static
-  // document CSP lives in public/_headers — see server/lib/security-headers.ts.
+  // Worker-owned routes carry the locked-down API policy; static asset responses
+  // fetched through the ASSETS binding keep the document policy.
   headers.set("Content-Security-Policy", c.req.path.startsWith("/api/") ? API_CSP : DOCUMENT_CSP);
 
   c.res = new Response(c.res.body, {
@@ -67,6 +81,8 @@ app.use("*", async (c, next) => {
   if (c.res.status < 200 || c.res.status > 599) return;
   applySecurityHeaders(c);
 });
+
+app.use("*", async (c, next) => canonicalDomainRedirect(c.req.raw) ?? next());
 
 // GitHub App webhooks are signed by GitHub itself, not Better Auth, and arrive
 // without an Origin/Referer header. They must be mounted before the auth and
@@ -218,7 +234,12 @@ app.route("/api/v1/scans", scansRoutes);
 app.route("/api/v1/slack", slackRoutes);
 app.route("/api/v1/staged-publishes", stagedPublishesRoutes);
 
-app.notFound((c) => c.json({ error: "not found" }, 404));
+app.notFound((c) => {
+  if (!isServerOwnedPath(c.req.path) && c.env.ASSETS) {
+    return c.env.ASSETS.fetch(c.req.raw);
+  }
+  return c.json({ error: "not found" }, 404);
+});
 
 app.onError((err, c) => {
   emitOperationalEvent("error", "request.unhandled_error", {

--- a/test/workers/canonical-domain.test.ts
+++ b/test/workers/canonical-domain.test.ts
@@ -1,0 +1,44 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { describe, expect, test } from "vitest";
+import worker from "../../server/index";
+
+const assetEnv = {
+  ...env,
+  ASSETS: {
+    fetch: async (request: Request) => new Response(`asset:${new URL(request.url).pathname}`),
+  },
+} satisfies Cloudflare.Env;
+
+async function fetchWorker(url: string, requestEnv: Cloudflare.Env = env): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(new Request(url), requestEnv, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+describe("canonical domain routing", () => {
+  test("redirects legacy host requests to drydock.org", async () => {
+    const res = await fetchWorker("https://drydock.resynapse.dev/dashboard/scans/123?tab=report");
+
+    expect(res.status).toBe(308);
+    expect(res.headers.get("Location")).toBe("https://drydock.org/dashboard/scans/123?tab=report");
+    expect(res.headers.get("Strict-Transport-Security")).toBe(
+      "max-age=31536000; includeSubDomains; preload",
+    );
+  });
+
+  test("serves app assets through the Worker-first fallback", async () => {
+    const res = await fetchWorker("https://drydock.org/dashboard/scans/123", assetEnv);
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("asset:/dashboard/scans/123");
+    expect(res.headers.get("Content-Security-Policy")).toContain("script-src 'self'");
+  });
+
+  test("keeps server-owned misses as JSON 404s", async () => {
+    const res = await fetchWorker("https://drydock.org/webhooks/not-found", assetEnv);
+
+    expect(res.status).toBe(404);
+    expect(await res.json()).toEqual({ error: "not found" });
+  });
+});

--- a/test/wrangler-config.test.mjs
+++ b/test/wrangler-config.test.mjs
@@ -2,14 +2,12 @@ import { readFileSync } from "node:fs";
 import { describe, expect, test } from "vitest";
 
 describe("Wrangler static asset routing", () => {
-  test("runs the Worker before the SPA fallback for server-owned paths", () => {
+  test("runs the Worker before assets so legacy-domain redirects cover every path", () => {
     const config = readFileSync(new URL("../wrangler.jsonc", import.meta.url), "utf8");
     const assetsBlock = config.match(/"assets"\s*:\s*\{(?<body>[\s\S]*?)\n\t\}/)?.groups?.body;
 
     expect(assetsBlock).toContain('"not_found_handling": "single-page-application"');
-    expect(assetsBlock).toContain('"run_worker_first"');
-    for (const route of ["/api", "/api/*", "/webhooks/*"]) {
-      expect(assetsBlock).toContain(`"${route}"`);
-    }
+    expect(assetsBlock).toContain('"binding": "ASSETS"');
+    expect(assetsBlock).toContain('"run_worker_first": true');
   });
 });

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -15,14 +15,8 @@
 	},
 	"assets": {
 		"not_found_handling": "single-page-application",
-		// Keep server-owned paths out of the SPA fallback. Without this, OAuth
-		// callbacks such as /api/v1/slack/callback can render the client 404
-		// before the Hono route sees the request.
-		"run_worker_first": [
-			"/api",
-			"/api/*",
-			"/webhooks/*"
-		]
+		"binding": "ASSETS",
+		"run_worker_first": true
 	},
 	"ai": {
 		"binding": "AI"


### PR DESCRIPTION
## Summary
Add the Worker-side behavior that makes `drydock.org` canonical after the Wrangler domain config from #339: requests for `drydock.resynapse.dev` now get a path-preserving `308` redirect to `drydock.org`.

Key request flow:
```ts
if (hostname === "drydock.resynapse.dev") redirect("https://drydock.org" + pathAndQuery, 308)
else if (!serverOwnedPath && env.ASSETS) return env.ASSETS.fetch(request)
else return Hono route / JSON 404
```

Because SPA/static asset requests previously bypassed the Worker, this switches static asset routing to Worker-first with an `ASSETS` binding. `/api` and `/webhooks` remain Worker-owned JSON routes; app paths fall back to Cloudflare static assets.

Tests: `pnpm run verify`

Link to Devin session: https://app.devin.ai/sessions/aadab073bfff4b448124f9fa34230b3c
Requested by: @JoviDeCroock