### PR TITLE
[codex] Add portable Drydock agent tour

### DIFF
--- a/.claude/skills/drydock-agent-tour/SKILL.md
+++ b/.claude/skills/drydock-agent-tour/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: drydock-agent-tour
+description: Run, inspect, and summarize the portable Drydock local product walkthrough. Use when an agent or developer needs to experience the end-to-end Drydock flow outside Conductor, generate screenshots/traces/report artifacts, validate the fake-registry local review path, or report product feel issues from the staged-publish workbench.
+---
+
+# Drydock Agent Tour
+
+## Workflow
+
+1. From the repository root, run `pnpm run agent:tour`.
+2. If a browser needs to stay visible, run `pnpm run agent:tour -- --headed`.
+3. If an existing local server should be reused without deleting prior tour artifacts, run `pnpm run agent:tour -- --no-clean`.
+4. Read `agent-tour-output/report.md`, unless `AGENT_TOUR_DIR` points elsewhere.
+5. Inspect screenshots in `agent-tour-output/screenshots/` and the Playwright trace/video in `agent-tour-output/test-results/`.
+6. Summarize both correctness and product feel: confusing UI states, missing cues, slow waits, awkward copy, layout issues, unexpected console/network errors, and any security-boundary concerns.
+
+## What The Tour Exercises
+
+The script uses the same fake-registry harness as `pnpm run test:e2e`, but writes agent-readable artifacts instead of only pass/fail output. It walks:
+
+- landing page and docs
+- registration
+- dashboard before npm setup
+- organization npm access setup against the fake registry
+- a completed implicit `node-gyp` staged-publish review
+- diff workbench filtering and file selection
+- risk signals
+- JSON report export
+- manual block decision
+- fail-closed staged tarball failure
+- dashboard npm discovery
+
+The tour starts targeted fixture scans through the authenticated scan API so the browser can inspect specific states reliably. UI surfaces that matter for product feel are still driven through Playwright.
+
+## Artifact Contract
+
+Expect these outputs after a run:
+
+- `agent-tour-output/report.md` — primary narrative report
+- `agent-tour-output/screenshots/*.png` — ordered screenshots for every major state
+- `agent-tour-output/exported-report.json` — downloaded canonical report
+- `agent-tour-output/playwright-report/` — HTML report
+- `agent-tour-output/test-results/` — traces, videos, and per-test artifacts
+- `agent-tour-output/registry-state/requests.jsonl` — fake npm registry journal
+
+Do not treat the tour as a replacement for `pnpm run verify` or `pnpm run test:e2e`. Use it when the task asks what the flow feels like, whether the full local product path is understandable, or when screenshots/traces are useful evidence.

--- a/.claude/skills/drydock-agent-tour/agents/openai.yaml
+++ b/.claude/skills/drydock-agent-tour/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Drydock Agent Tour"
+  short_description: "Run and inspect the local Drydock walkthrough."
+  default_prompt: "Run the Drydock agent tour and summarize the generated report, screenshots, and any product issues you observe."

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ packages/experiments/build/
 .dev.vars
 .gstack/
 .context/
+agent-tour-output/
 .claude/scheduled_tasks.lock

--- a/README.md
+++ b/README.md
@@ -81,11 +81,12 @@ cp .dev.vars.example .dev.vars
 pnpm test         # Vitest logic suite
 pnpm dev          # vite + cloudflare plugin, http://localhost:5173
 pnpm test:e2e     # Playwright + local fake npm staging registry
+pnpm run agent:tour # local product walkthrough with screenshots/traces/report
 ```
 
 The Vite dev server runs the Worker locally and serves the UI at the same origin, so authenticated `fetch("/api/v1/scans")` works without CORS.
 
-For deterministic browser testing without real npm staged publishes, use the local E2E harness in [`docs/e2e-test-environment.md`](docs/e2e-test-environment.md). It packs fixture packages, runs a fake npm staging registry, starts the Worker locally, and writes inspectable screenshots/traces/journals under `.context/`.
+For deterministic browser testing without real npm staged publishes, use the local E2E harness in [`docs/e2e-test-environment.md`](docs/e2e-test-environment.md). It packs fixture packages, runs a fake npm staging registry, starts the Worker locally, and writes inspectable screenshots/traces/journals to local artifact directories. For an agent-readable product walkthrough with screenshots, traces, an exported report, and a narrative Markdown summary, use [`docs/agent-tour.md`](docs/agent-tour.md).
 
 ## Configuration and secrets
 

--- a/docs/agent-tour.md
+++ b/docs/agent-tour.md
@@ -1,0 +1,41 @@
+# Agent tour
+
+The agent tour is a portable product walkthrough for Drydock. It is not tied to
+Conductor: any agent or developer with the repo checked out can run it from a
+normal shell.
+
+```sh
+pnpm run agent:tour
+```
+
+Useful variants:
+
+```sh
+pnpm run agent:tour -- --headed
+pnpm run agent:tour -- --no-clean
+AGENT_TOUR_DIR=/tmp/drydock-agent-tour pnpm run agent:tour
+E2E_APP_PORT=5200 E2E_REGISTRY_PORT=5201 pnpm run agent:tour
+```
+
+The tour uses the existing local fake-registry harness, starts the Worker through
+Playwright's web server config, and writes inspectable artifacts under
+`agent-tour-output/` by default:
+
+- `report.md` — the main narrative report
+- `screenshots/` — ordered screenshots for each product state
+- `exported-report.json` — the report downloaded from the app
+- `playwright-report/` and `test-results/` — trace, video, and HTML artifacts
+
+It also writes the fake npm registry journal under `registry-state/`, so agents
+can inspect which registry endpoints were touched and whether authorization
+stayed on expected npm-like paths.
+
+## Scope
+
+`pnpm run test:e2e` remains the regression suite. The agent tour is for product
+inspection: it walks landing/docs, registration, npm connection, a completed
+staged-publish review, diff workbench, risk signals, report export, manual
+decision, a fail-closed error state, and dashboard discovery.
+
+Repository agents can discover the workflow through the
+`drydock-agent-tour` skill in `.claude/skills/` and the `.agents/skills` symlink.

--- a/docs/e2e-test-environment.md
+++ b/docs/e2e-test-environment.md
@@ -23,6 +23,7 @@ fixture scenario and journal assertion in this harness. See
 pnpm run e2e:fixtures
 pnpm run e2e:dev
 pnpm run test:e2e
+pnpm run agent:tour
 ```
 
 `pnpm run e2e:dev` prints the app URL, fake registry URL, request journal, artifact directory, and Worker state directory. By default it uses:
@@ -37,6 +38,11 @@ E2E_APP_PORT=5200 E2E_REGISTRY_PORT=5201 pnpm run test:e2e
 ```
 
 Playwright artifacts are written under `.context/e2e-artifacts/`, including traces on failure and `implicit-node-gyp-report.png` on a successful smoke run.
+
+`pnpm run agent:tour` is the portable product walkthrough for agents and manual
+inspection. It uses the same fake registry and Worker harness, but writes a
+narrative report, screenshots, exported JSON, trace, and video under the tour
+output directory. See [`agent-tour.md`](./agent-tour.md).
 
 Vite ignores `.context/**` in its file watcher. The E2E runner writes registry state, Worker state, traces, screenshots, and reports there while the app is open; watching those files can cause hot-reload loops that interrupt browser interactions in CI.
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -20,6 +20,7 @@
 | `pnpm run e2e:fixtures` | Pack local E2E fixture packages and generate `.context/e2e-registry/registry.json`.                                                                                                                               |
 | `pnpm run e2e:dev`      | Start the fake npm staging registry plus the Vite/Worker dev server for browser testing.                                                                                                                          |
 | `pnpm run test:e2e`     | Run Playwright against the local fake-registry harness.                                                                                                                                                           |
+| `pnpm run agent:tour`   | Run the portable local product walkthrough and write `agent-tour-output/report.md`, screenshots, traces, video, and an exported report JSON.                                                                      |
 | `pnpm run verify`       | Run lint + format check + typecheck + tests **in parallel** (`scripts/verify.mjs`); the cheap checks finish while the worker pool runs. All four always run to completion and every failure is reported together. |
 
 `pnpm lint` (the shorthand without `run`) can collide with workspace forwarding or shell wrappers — always use `pnpm run lint`.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "e2e:fixtures": "node test/e2e/build-fixtures.mjs",
     "e2e:registry": "node test/e2e/fake-registry.mjs",
     "e2e:dev": "node test/e2e/dev-server.mjs",
+    "agent:tour": "node scripts/agent-tour.mjs",
     "test:e2e": "playwright test",
     "verify": "node scripts/verify.mjs"
   },

--- a/playwright.agent-tour.config.ts
+++ b/playwright.agent-tour.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from "@playwright/test";
+import path from "node:path";
+
+const appPort = Number(process.env.E2E_APP_PORT || process.env.CONDUCTOR_PORT || 5173);
+const baseURL = process.env.E2E_APP_URL || `http://127.0.0.1:${appPort}`;
+const tourDir = process.env.AGENT_TOUR_DIR || "agent-tour-output";
+
+export default defineConfig({
+  testDir: "./test/agent-tour",
+  timeout: 240_000,
+  expect: {
+    timeout: 20_000,
+  },
+  outputDir: path.join(tourDir, "test-results"),
+  reporter: [
+    ["list"],
+    ["html", { outputFolder: path.join(tourDir, "playwright-report"), open: "never" }],
+  ],
+  use: {
+    baseURL,
+    trace: "on",
+    screenshot: "on",
+    video: "on",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "pnpm e2e:dev",
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/scripts/agent-tour.mjs
+++ b/scripts/agent-tour.mjs
@@ -1,0 +1,65 @@
+import { spawn } from "node:child_process";
+import { mkdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(scriptDir, "..");
+const tourDir = path.resolve(repoRoot, process.env.AGENT_TOUR_DIR || "agent-tour-output");
+const args = process.argv.slice(2);
+const passThrough = [];
+let clean = true;
+
+for (const arg of args) {
+  if (arg === "--no-clean") {
+    clean = false;
+  } else {
+    passThrough.push(arg);
+  }
+}
+
+if (clean) {
+  await rm(tourDir, { recursive: true, force: true });
+}
+await mkdir(tourDir, { recursive: true });
+
+const command = "pnpm";
+const commandArgs = [
+  "exec",
+  "playwright",
+  "test",
+  "--config",
+  "playwright.agent-tour.config.ts",
+  ...passThrough,
+];
+const childEnv = {
+  ...process.env,
+  AGENT_TOUR_DIR: tourDir,
+  E2E_ARTIFACTS_DIR: process.env.E2E_ARTIFACTS_DIR || path.join(tourDir, "e2e-artifacts"),
+  E2E_CONFIG_DIR: process.env.E2E_CONFIG_DIR || path.join(tourDir, "e2e-config"),
+  E2E_REGISTRY_STATE_DIR:
+    process.env.E2E_REGISTRY_STATE_DIR || path.join(tourDir, "registry-state"),
+};
+const relativeTourDir = path.relative(repoRoot, tourDir) || ".";
+
+console.log(`Running Drydock agent tour: ${command} ${commandArgs.join(" ")}`);
+console.log(`Output directory: ${relativeTourDir}`);
+
+const child = spawn(command, commandArgs, {
+  cwd: repoRoot,
+  env: childEnv,
+  stdio: "inherit",
+});
+
+child.on("exit", (code, signal) => {
+  console.log("");
+  console.log("Agent tour artifacts:");
+  console.log(`  report: ${path.join(relativeTourDir, "report.md")}`);
+  console.log(`  screenshots: ${path.join(relativeTourDir, "screenshots")}/`);
+  console.log(`  Playwright report: ${path.join(relativeTourDir, "playwright-report")}/`);
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});

--- a/test/agent-tour/drydock-agent-tour.spec.ts
+++ b/test/agent-tour/drydock-agent-tour.spec.ts
@@ -1,0 +1,367 @@
+import { expect, test, type Page, type TestInfo } from "@playwright/test";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const appPort = Number(process.env.E2E_APP_PORT || process.env.CONDUCTOR_PORT || 5173);
+const registryUrl = process.env.E2E_NPM_REGISTRY || `http://127.0.0.1:${appPort + 1}`;
+const tourDir = path.resolve(process.env.AGENT_TOUR_DIR || "agent-tour-output");
+const screenshotsDir = path.join(tourDir, "screenshots");
+const reportPath = path.join(tourDir, "report.md");
+const exportedReportPath = path.join(tourDir, "exported-report.json");
+const registryStateDir = path.resolve(
+  process.env.E2E_REGISTRY_STATE_DIR || path.join(tourDir, "registry-state"),
+);
+const journalPath = path.join(registryStateDir, "requests.jsonl");
+const playwrightReportDir = path.join(tourDir, "playwright-report");
+
+interface ScanDetailBody {
+  scan: {
+    id: string;
+    stageId: string;
+    status: string;
+    risk: string;
+    packageName: string | null;
+    stagedVersion: string | null;
+    errorJson?: { code?: string; message?: string } | null;
+  };
+  riskSummary?: { artifactRisk: string; releaseRisk: string } | null;
+  findings: Array<{ ruleId?: string | null; severity?: string | null; file?: string | null }>;
+}
+
+test("agent tour: local Drydock release review walkthrough", async ({
+  page,
+  baseURL,
+}, testInfo) => {
+  const tour = new TourReport(testInfo, baseURL ?? `http://127.0.0.1:${appPort}`);
+  await tour.prepare(page);
+
+  try {
+    await page.goto("/");
+    await expect(
+      page.getByRole("heading", { name: "See exactly what your next publish ships." }),
+    ).toBeVisible();
+    await tour.capture(page, "landing", "Marketing entry point and product promise.");
+
+    await page.goto("/docs");
+    await expect(
+      page.getByRole("heading", { name: "How Drydock guards a publish." }),
+    ).toBeVisible();
+    await tour.capture(page, "docs", "Setup documentation for staged publishing and gates.");
+
+    await register(page);
+    await expect(page.getByRole("heading", { name: "Ready for the next release" })).toBeVisible();
+    await tour.capture(page, "dashboard-no-npm", "Fresh workspace before npm access is connected.");
+
+    await connectNpmThroughSettings(page);
+    await tour.capture(page, "settings-npm-connected", "Organization npm access saved and valid.");
+
+    await page.goto("/dashboard");
+    await expect(page.getByRole("heading", { name: "Ready for the next release" })).toBeVisible();
+    const reviewScan = await createScan(page, "stage-implicit-node-gyp-000001");
+    tour.note(`Started targeted review scan ${reviewScan.scan.id}.`);
+    await tour.capture(
+      page,
+      "dashboard-review-started",
+      "Dashboard after starting a fixture scan.",
+    );
+
+    const completed = await pollScanUntilTerminal(page, reviewScan.scan.id);
+    expect(completed.scan.status).toBe("complete");
+    expect(completed.scan.packageName).toBe("@drydock/e2e-native");
+    tour.note(
+      `Completed ${completed.scan.packageName}@${completed.scan.stagedVersion} with release risk ${completed.riskSummary?.releaseRisk ?? completed.scan.risk}.`,
+    );
+
+    await page.goto(`/dashboard/scans/${reviewScan.scan.id}`);
+    await expect(page.getByRole("heading", { name: "@drydock/e2e-native" })).toBeVisible({
+      timeout: 60_000,
+    });
+    await expect(page.getByText("install-script.implicit-node-gyp").first()).toBeVisible();
+    await tour.capture(page, "scan-report", "Completed report with recommendation and diff tree.");
+
+    await page.getByPlaceholder("Filter files").fill("binding");
+    await page
+      .getByRole("complementary")
+      .getByRole("button", { name: /binding\.gyp/ })
+      .click();
+    await expect(page).toHaveURL(/path=binding\.gyp/);
+    await tour.capture(
+      page,
+      "diff-workbench",
+      "File-level diff with the finding pinned to evidence.",
+    );
+
+    await page.getByText("Risk signals").scrollIntoViewIfNeeded();
+    await tour.capture(page, "risk-signals", "Risk signal index below the diff workbench.");
+
+    const download = await Promise.all([
+      page.waitForEvent("download"),
+      page.getByRole("link", { name: "Export JSON" }).click(),
+    ]).then(([file]) => file);
+    await download.saveAs(exportedReportPath);
+    tour.note(`Exported canonical report JSON to ${relative(exportedReportPath)}.`);
+
+    await page.getByRole("button", { name: "Decide" }).click();
+    await expect(page.getByRole("heading", { name: "Publish decision" })).toBeVisible();
+    await page.getByLabel("Reason (optional)").fill("Agent tour: high-risk implicit node-gyp.");
+    await tour.capture(page, "decision-dialog", "Maintainer decision dialog before blocking.");
+    await page.getByRole("button", { name: "Block publish" }).click();
+    await expect(page.getByText("blocked").first()).toBeVisible({ timeout: 30_000 });
+    await tour.capture(page, "decision-recorded", "Audit decision recorded on the report.");
+
+    const failedScan = await createScan(page, "stage-registry-failure-000001");
+    const failed = await pollScanUntilTerminal(page, failedScan.scan.id);
+    expect(failed.scan.status).toBe("failed");
+    await page.goto(`/dashboard/scans/${failedScan.scan.id}`);
+    await expect(page.getByText("code: sandbox_download_transient")).toBeVisible({
+      timeout: 60_000,
+    });
+    await tour.capture(page, "failed-review", "Fail-closed review state for unavailable evidence.");
+
+    await page.goto("/dashboard?filter=all");
+    await expect(page.getByRole("button", { name: "Check npm" })).toBeEnabled({
+      timeout: 30_000,
+    });
+    await page.getByRole("button", { name: "Check npm" }).click();
+    await expect(
+      page.getByText(/Started \d+ new reviews? from npm|No open staged publishes found/),
+    ).toBeVisible({ timeout: 60_000 });
+    await tour.capture(page, "dashboard-discovery", "Manual npm discovery from the dashboard.");
+
+    tour.pass();
+  } catch (err) {
+    tour.fail(err);
+    await tour.capture(page, "failure", "State at the moment the tour failed.").catch(() => {});
+    throw err;
+  } finally {
+    await tour.write();
+  }
+});
+
+async function register(page: Page) {
+  const unique = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  await page.goto("/register");
+  await page.getByLabel("Name").fill("Agent Tour");
+  await page.getByLabel("Email").fill(`agent-tour-${unique}@example.test`);
+  await page.getByLabel("Password").fill("correct horse battery staple");
+  await page.getByRole("button", { name: "Create account" }).click();
+  await page.waitForURL(/\/dashboard$/, { timeout: 30_000 });
+}
+
+async function connectNpmThroughSettings(page: Page) {
+  await page.goto("/dashboard/settings?tab=integrations");
+  await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible({ timeout: 30_000 });
+  await page.getByLabel("Connection name").fill("Fake npm staging registry");
+  await page.getByLabel("Registry").fill(registryUrl);
+  await page.getByLabel("npm token").fill("npm_agent_tour_token_0123456789");
+  await page.getByRole("button", { name: "Save" }).click();
+  await expect(page.getByText("valid").first()).toBeVisible({ timeout: 30_000 });
+}
+
+async function createScan(page: Page, stageId: string): Promise<{ scan: { id: string } }> {
+  const { status, body } = await evaluateOnStablePage(
+    page,
+    async (inputStageId) => {
+      const response = await fetch("/api/v1/scans", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ stageId: inputStageId }),
+      });
+      return { status: response.status, body: await response.json().catch(() => null) };
+    },
+    stageId,
+  );
+  expect(status, `${stageId} accepted`).toBe(202);
+  expect(body?.scan?.id, `${stageId} scan id`).toBeTruthy();
+  return body;
+}
+
+async function pollScanUntilTerminal(
+  page: Page,
+  scanId: string,
+  timeoutMs = 120_000,
+): Promise<ScanDetailBody> {
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus: string | undefined;
+  for (;;) {
+    const { status, body } = await evaluateOnStablePage(
+      page,
+      async (id) => {
+        const response = await fetch(`/api/v1/scans/${encodeURIComponent(id)}?poll=1`);
+        return { status: response.status, body: await response.json().catch(() => null) };
+      },
+      scanId,
+    );
+    expect(status, `scan ${scanId} detail fetch`).toBe(200);
+    const detail = body as ScanDetailBody;
+    lastStatus = detail?.scan?.status;
+    if (lastStatus === "complete" || lastStatus === "failed") return detail;
+    if (Date.now() > deadline) {
+      throw new Error(
+        `scan ${scanId} did not reach a terminal status within ${timeoutMs}ms (last status: ${lastStatus})`,
+      );
+    }
+    await page.waitForTimeout(1_000);
+  }
+}
+
+async function evaluateOnStablePage<Arg, Result>(
+  page: Page,
+  pageFunction: (arg: Arg) => Promise<Result>,
+  arg: Arg,
+): Promise<Result> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      return await page.evaluate(pageFunction, arg);
+    } catch (err) {
+      if (!isNavigationContextError(err) || attempt === 2) throw err;
+      await page.waitForLoadState("domcontentloaded").catch(() => {});
+      await page.waitForLoadState("networkidle", { timeout: 5_000 }).catch(() => {});
+    }
+  }
+  throw new Error("page evaluation failed");
+}
+
+function isNavigationContextError(err: unknown) {
+  const message = err instanceof Error ? err.message : String(err);
+  return (
+    message.includes("Execution context was destroyed") ||
+    message.includes("Cannot find context with specified id")
+  );
+}
+
+class TourReport {
+  private screenshotIndex = 0;
+  private status: "running" | "passed" | "failed" = "running";
+  private failure: string | null = null;
+  private readonly steps: Array<{ title: string; url: string; image: string; note: string }> = [];
+  private readonly notes: string[] = [];
+  private readonly browserEvents: string[] = [];
+
+  constructor(
+    private readonly testInfo: TestInfo,
+    private readonly baseUrl: string,
+  ) {}
+
+  async prepare(page: Page) {
+    await mkdir(screenshotsDir, { recursive: true });
+    page.on("console", (message) => {
+      if (message.type() === "error" || message.type() === "warning") {
+        this.browserEvents.push(`console.${message.type()}: ${message.text()}`);
+      }
+    });
+    page.on("pageerror", (err) => {
+      this.browserEvents.push(`pageerror: ${err.message}`);
+    });
+    page.on("requestfailed", (request) => {
+      this.browserEvents.push(
+        `requestfailed: ${request.method()} ${request.url()} (${request.failure()?.errorText ?? "unknown"})`,
+      );
+    });
+  }
+
+  async capture(page: Page, title: string, note: string) {
+    const file = path.join(
+      screenshotsDir,
+      `${String(++this.screenshotIndex).padStart(2, "0")}-${slug(title)}.png`,
+    );
+    await page.screenshot({ path: file, fullPage: true });
+    this.steps.push({ title, url: page.url(), image: relative(file), note });
+    await this.testInfo.attach(title, { path: file, contentType: "image/png" });
+  }
+
+  note(message: string) {
+    this.notes.push(message);
+  }
+
+  pass() {
+    this.status = "passed";
+  }
+
+  fail(err: unknown) {
+    this.status = "failed";
+    this.failure = err instanceof Error ? err.stack || err.message : String(err);
+  }
+
+  async write() {
+    const journal = await readJournalSummary();
+    const lines = [
+      "# Drydock Agent Tour",
+      "",
+      `Status: ${this.status}`,
+      `App URL: ${this.baseUrl}`,
+      `Fake registry: ${registryUrl}`,
+      `Generated: ${new Date().toISOString()}`,
+      "",
+      "## Artifacts",
+      "",
+      `- Screenshots: ${relative(screenshotsDir)}`,
+      `- Exported report JSON: ${relative(exportedReportPath)}`,
+      `- Registry journal: ${relative(journalPath)}`,
+      `- Playwright report: ${relative(playwrightReportDir)}/`,
+      "",
+      "## Walkthrough",
+      "",
+      ...this.steps.flatMap((step, index) => [
+        `${index + 1}. ${step.title}`,
+        `   - URL: ${step.url}`,
+        `   - Screenshot: ${step.image}`,
+        `   - Note: ${step.note}`,
+      ]),
+      "",
+      "## Notes",
+      "",
+      ...(this.notes.length ? this.notes.map((note) => `- ${note}`) : ["- No extra notes."]),
+      "",
+      "## Browser Events",
+      "",
+      ...(this.browserEvents.length
+        ? this.browserEvents.map((event) => `- ${event}`)
+        : [
+            "- No console warnings, console errors, page errors, or failed browser requests recorded.",
+          ]),
+      "",
+      "## Registry Journal Summary",
+      "",
+      ...journal,
+    ];
+    if (this.failure) {
+      lines.push("", "## Failure", "", "```text", this.failure, "```");
+    }
+    await writeFile(reportPath, `${lines.join("\n")}\n`);
+  }
+}
+
+async function readJournalSummary() {
+  const text = await readFile(journalPath, "utf8").catch(() => "");
+  const entries = text
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as { path: string; authorization: string; status: number });
+  if (!entries.length) return ["- No registry requests recorded."];
+  const authorized = entries.filter((entry) => entry.authorization === "present").length;
+  const statusCounts = new Map<number, number>();
+  for (const entry of entries) {
+    statusCounts.set(entry.status, (statusCounts.get(entry.status) ?? 0) + 1);
+  }
+  return [
+    `- Requests: ${entries.length}`,
+    `- Requests with Authorization: ${authorized}`,
+    `- Statuses: ${[...statusCounts].map(([status, count]) => `${status}=${count}`).join(", ")}`,
+    `- First paths: ${entries
+      .slice(0, 8)
+      .map((entry) => entry.path)
+      .join(", ")}`,
+  ];
+}
+
+function slug(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function relative(filePath: string) {
+  return path.relative(process.cwd(), filePath);
+}

--- a/test/agent-tour/drydock-agent-tour.spec.ts
+++ b/test/agent-tour/drydock-agent-tour.spec.ts
@@ -38,13 +38,13 @@ test("agent tour: local Drydock release review walkthrough", async ({
   try {
     await page.goto("/");
     await expect(
-      page.getByRole("heading", { name: "See exactly what your next publish ships." }),
+      page.getByRole("heading", { name: "Review the package that will actually ship." }),
     ).toBeVisible();
     await tour.capture(page, "landing", "Marketing entry point and product promise.");
 
     await page.goto("/docs");
     await expect(
-      page.getByRole("heading", { name: "How Drydock guards a publish." }),
+      page.getByRole("heading", { name: "Pick where Drydock pauses your release." }),
     ).toBeVisible();
     await tour.capture(page, "docs", "Setup documentation for staged publishing and gates.");
 

--- a/test/e2e/dev-server.mjs
+++ b/test/e2e/dev-server.mjs
@@ -92,11 +92,15 @@ function resolveOptionalRepoPath(value) {
   return path.resolve(repoRoot, value);
 }
 
+function configRelativePath(...segments) {
+  return path.relative(outputConfigDir, path.join(repoRoot, ...segments));
+}
+
 async function writeWranglerConfig() {
   const config = {
-    $schema: "../../node_modules/wrangler/config-schema.json",
+    $schema: configRelativePath("node_modules/wrangler/config-schema.json"),
     name: "staged-publish-review-e2e",
-    main: "../../server/index.ts",
+    main: configRelativePath("server/index.ts"),
     compatibility_date: "2026-05-20",
     compatibility_flags: ["nodejs_compat"],
     assets: {
@@ -109,7 +113,7 @@ async function writeWranglerConfig() {
         binding: "DB",
         database_name: "staged-publish-review-e2e",
         database_id: "00000000-0000-0000-0000-0000000000e2",
-        migrations_dir: "../../drizzle",
+        migrations_dir: configRelativePath("drizzle"),
       },
     ],
     kv_namespaces: [

--- a/test/e2e/dev-server.mjs
+++ b/test/e2e/dev-server.mjs
@@ -13,12 +13,15 @@ const registryUrl = `http://127.0.0.1:${registryPort}`;
 const stateDir = path.join(repoRoot, ".context/e2e-registry");
 const artifactsDir = path.join(repoRoot, ".context/e2e-artifacts");
 const configDir = path.join(repoRoot, ".context/e2e");
-const persistRoot = path.join(configDir, "state");
-const wranglerConfigPath = path.join(configDir, "wrangler.jsonc");
+const outputStateDir = resolveOptionalRepoPath(process.env.E2E_REGISTRY_STATE_DIR) ?? stateDir;
+const outputArtifactsDir = resolveOptionalRepoPath(process.env.E2E_ARTIFACTS_DIR) ?? artifactsDir;
+const outputConfigDir = resolveOptionalRepoPath(process.env.E2E_CONFIG_DIR) ?? configDir;
+const persistRoot = path.join(outputConfigDir, "state");
+const wranglerConfigPath = path.join(outputConfigDir, "wrangler.jsonc");
 let shuttingDown = false;
 
-await mkdir(configDir, { recursive: true });
-await mkdir(artifactsDir, { recursive: true });
+await mkdir(outputConfigDir, { recursive: true });
+await mkdir(outputArtifactsDir, { recursive: true });
 await rm(persistRoot, { recursive: true, force: true });
 await mkdir(persistRoot, { recursive: true });
 await writeWranglerConfig();
@@ -39,7 +42,7 @@ run("pnpm", [
 
 const children = [];
 const registry = start("node", ["test/e2e/fake-registry.mjs", "--port", String(registryPort)], {
-  E2E_REGISTRY_STATE_DIR: stateDir,
+  E2E_REGISTRY_STATE_DIR: outputStateDir,
 });
 children.push(registry);
 await waitForUrl(`${registryUrl}/__health`);
@@ -59,8 +62,10 @@ await waitForUrl(appUrl);
 
 console.log(`E2E app: ${appUrl}`);
 console.log(`Fake npm registry: ${registryUrl}`);
-console.log(`Registry journal: ${path.relative(repoRoot, path.join(stateDir, "requests.jsonl"))}`);
-console.log(`Artifacts: ${path.relative(repoRoot, artifactsDir)}`);
+console.log(
+  `Registry journal: ${path.relative(repoRoot, path.join(outputStateDir, "requests.jsonl"))}`,
+);
+console.log(`Artifacts: ${path.relative(repoRoot, outputArtifactsDir)}`);
 console.log(`Worker state: ${path.relative(repoRoot, persistRoot)}`);
 
 await new Promise((resolve, reject) => {
@@ -80,6 +85,11 @@ function shutdown(resolve) {
     if (!child.killed) child.kill("SIGTERM");
   }
   setTimeout(resolve, 250);
+}
+
+function resolveOptionalRepoPath(value) {
+  if (!value) return null;
+  return path.resolve(repoRoot, value);
 }
 
 async function writeWranglerConfig() {


### PR DESCRIPTION
Adds `pnpm run agent:tour` with a dedicated Playwright config and walkthrough spec that generates screenshots, traces, video, exported JSON, and `agent-tour-output/report.md` from the local fake-registry harness.

Adds a repo-local `drydock-agent-tour` skill so agents can discover and run the flow outside Conductor. Documents the workflow in `docs/agent-tour.md`, README, E2E docs, and tooling docs, with `AGENT_TOUR_DIR` available for custom output locations. Validation: `pnpm run verify`, `pnpm run agent:tour`, and skill validation.