### PR TITLE
Skip email verification for local auth origin

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -224,7 +224,7 @@ Deletion, audit-log UI, billing, and quotas remain deferred as team/commercial-r
 
 ## Account email verification
 
-Email/password signup is gated on email verification, but only when the Worker can actually send mail. `createAuth` flips `emailAndPassword.requireEmailVerification` on `Boolean(env.SEND_EMAIL)`: production has the Email binding bound, so a fresh signup gets no session and must click a verification link first; local dev and the e2e harness have no binding, so signup auto-signs-in and the verification flow is inert. This keeps the gate from locking users out during an email outage and keeps the existing e2e auth flow unchanged.
+Email/password signup is gated on email verification, but only when the Worker can actually send mail and is not running against a local Better Auth origin. `createAuth` flips `emailAndPassword.requireEmailVerification` on `Boolean(env.SEND_EMAIL) && !isLocalAuthUrl(env.BETTER_AUTH_URL)`: production has the Email binding bound and `BETTER_AUTH_URL=https://drydock.org`, so a fresh signup gets no session and must click a verification link first; local dev uses `.dev.vars` with `BETTER_AUTH_URL=http://localhost:5173`, so signup auto-signs-in even though the shared Wrangler config also declares `SEND_EMAIL`. This keeps the gate from locking users out during local development or an email outage while preserving production verification.
 
 Better Auth's `emailVerification` block wires the link delivery and post-verify behavior:
 

--- a/server/lib/auth.ts
+++ b/server/lib/auth.ts
@@ -76,17 +76,23 @@ const nativeScryptAvailable = (() => {
   }
 })();
 
+function isLocalAuthUrl(url: string | undefined): boolean {
+  if (!url) return false;
+  try {
+    const hostname = new URL(url).hostname;
+    return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+  } catch {
+    return false;
+  }
+}
+
 export function createAuth(env: Cloudflare.Env) {
   if (!env.DB) throw new Error("DB binding is required for Better Auth");
   if (!env.BETTER_AUTH_SECRET) throw new Error("BETTER_AUTH_SECRET is required");
 
   const db = createDb(env.DB);
   const trustedOrigins = env.BETTER_AUTH_URL ? [env.BETTER_AUTH_URL] : [];
-  // Only enforce email verification when an email transport is actually wired
-  // up. Without SEND_EMAIL (local dev, e2e harness) we can't deliver the link,
-  // so requiring it would lock every new account out of sign-in. Production
-  // always binds SEND_EMAIL, so verification is always enforced there.
-  const emailVerificationEnabled = Boolean(env.SEND_EMAIL);
+  const emailVerificationEnabled = Boolean(env.SEND_EMAIL) && !isLocalAuthUrl(env.BETTER_AUTH_URL);
   return betterAuth({
     appName: "Drydock",
     secret: env.BETTER_AUTH_SECRET,

--- a/test/workers/email-verification.test.ts
+++ b/test/workers/email-verification.test.ts
@@ -6,6 +6,7 @@ import { createDb } from "../../server/db";
 import * as schema from "../../server/db/schema";
 
 const ORIGIN = "http://example.com";
+const LOCAL_ORIGIN = "http://localhost:5173";
 const PASSWORD = "correct horse battery staple";
 const WORKER_AUTH_TIMEOUT_MS = 15_000;
 
@@ -13,12 +14,12 @@ function uniqueEmail() {
   return `verify-${crypto.randomUUID()}@example.test`;
 }
 
-async function authPost(path: string, body: unknown) {
+async function authPost(path: string, body: unknown, origin = ORIGIN) {
   const ctx = createExecutionContext();
   const res = await worker.fetch(
-    new Request(`${ORIGIN}${path}`, {
+    new Request(`${origin}${path}`, {
       method: "POST",
-      headers: { "content-type": "application/json", origin: ORIGIN },
+      headers: { "content-type": "application/json", origin },
       body: JSON.stringify(body),
     }),
     env,
@@ -38,11 +39,43 @@ function clearEmailBinding() {
   delete (env as { SEND_EMAIL?: unknown }).SEND_EMAIL;
 }
 
+function setAuthUrl(url: string) {
+  (env as { BETTER_AUTH_URL?: string }).BETTER_AUTH_URL = url;
+}
+
 afterEach(() => {
   clearEmailBinding();
+  setAuthUrl(ORIGIN);
 });
 
 describe("email verification gating", () => {
+  test(
+    "with email configured, local sign-up still signs the user in immediately",
+    async () => {
+      const { send } = withEmailBinding();
+      setAuthUrl(LOCAL_ORIGIN);
+      const email = uniqueEmail();
+
+      const res = await authPost(
+        "/api/auth/sign-up/email",
+        {
+          name: "Verify Tester",
+          email,
+          password: PASSWORD,
+          callbackURL: "/verify-email",
+        },
+        LOCAL_ORIGIN,
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { token: string | null };
+      expect(typeof body.token).toBe("string");
+      expect(res.headers.get("set-cookie") ?? "").toContain("session_token");
+      expect(send).not.toHaveBeenCalled();
+    },
+    WORKER_AUTH_TIMEOUT_MS,
+  );
+
   test(
     "with email configured, sign-up sends a verification email and withholds the session",
     async () => {


### PR DESCRIPTION
## Summary
- Skip Better Auth email verification when `BETTER_AUTH_URL` points at `localhost`, `127.0.0.1`, or `::1`, so local dev signups auto-sign-in even though the shared Wrangler config declares `SEND_EMAIL`.
- Keep non-local `SEND_EMAIL` behavior unchanged: production still withholds the session and sends a verification email.
- Add worker auth coverage for the local-with-email-binding case and update the architecture docs.

Link to Devin session: https://app.devin.ai/sessions/91e694649dc841c08af732d21067a1a6
Requested by: @JoviDeCroock