### PR TITLE
Filter staged publishes by organization token access

### DIFF
--- a/docs/diff-baseline.md
+++ b/docs/diff-baseline.md
@@ -30,6 +30,8 @@ The CLI docs also state that the staged tag follows normal publish tag behavior,
 
 The API gives us the staged tag. It does not document an explicit "previous version", nor a snapshot of the tag target at stage creation time. Because npm allows normal publishes while staged packages are pending, the tag target can theoretically move between stage creation and our scan. Therefore, tag-following baseline selection should be treated as an inference from current registry metadata, not as a registry-provided historical fact.
 
+Discovery treats `GET /-/stage` as an account-wide candidate list, not as proof that the organization token is authorized for each publish. Before creating a review, Drydock probes the staged tarball endpoint with that organization token and only persists/queues scans for stage IDs that the token can actually access. Per-stage 401/403/404 responses are filtered out instead of becoming failed reviews.
+
 ## Baseline data stored on reports
 
 Completed scans persist:

--- a/server/lib/staged-publishes-discovery.ts
+++ b/server/lib/staged-publishes-discovery.ts
@@ -16,6 +16,7 @@ import {
 import { notifyNpmConnectionExpired } from "./notify";
 import { executeScanJob, type ScanQueueMessage } from "./scan-job";
 import {
+  checkStagedPublishAccess,
   listStagedPublishes,
   StagedPublishesFetchError,
   type StagedPublishItem,
@@ -221,6 +222,15 @@ export async function discoverAndQueueStagedPublishes(
   for (const item of stagedItems) {
     const stageId = item.id;
     if (existingStageIds.has(stageId)) continue;
+    const access = await checkStagedPublishAccess(
+      connection.registryUrl,
+      connection.token,
+      stageId,
+      {
+        allowInsecureLocalhost,
+      },
+    );
+    if (!access.allowed) continue;
     const scanId = crypto.randomUUID();
     const detail = await createScanJob(db, {
       id: scanId,

--- a/server/lib/staged-publishes.ts
+++ b/server/lib/staged-publishes.ts
@@ -26,6 +26,12 @@ export interface StagedPublishesPage {
   page: number | null;
 }
 
+export interface StagedPublishAccessResult {
+  allowed: boolean;
+  status: number | null;
+  detail: string | null;
+}
+
 export interface StartedStagedPublishScan {
   id: string;
   stageId: string;
@@ -95,6 +101,33 @@ export async function fetchStagedPublishDetails(
   const parsed = parseStagedPublishDetails(data, stageId);
   if (!parsed) throw new StagedPublishesFetchError(response.status, "invalid staged details");
   return parsed;
+}
+
+export async function checkStagedPublishAccess(
+  registryUrl: string,
+  token: string,
+  stageId: string,
+  options: NormalizeRegistryUrlOptions = {},
+): Promise<StagedPublishAccessResult> {
+  if (!isValidStageId(stageId)) throw new Error("invalid stageId");
+  const registry = normalizeRegistryUrl(registryUrl, options);
+  const response = await fetch(`${registry}/-/stage/${encodeURIComponent(stageId)}/tarball`, {
+    headers: npmStageTarballHeaders(token),
+  });
+  if (response.ok || response.status === 206) {
+    await response.body?.cancel();
+    return { allowed: true, status: response.status, detail: null };
+  }
+  if (response.status === 401 || response.status === 403 || response.status === 404) {
+    await response.body?.cancel();
+    return {
+      allowed: false,
+      status: response.status,
+      detail: response.statusText || null,
+    };
+  }
+  const detail = await response.text().catch(() => "");
+  throw new StagedPublishesFetchError(response.status, detail.slice(0, 200));
 }
 
 export class StagedPublishesFetchError extends Error {
@@ -170,6 +203,15 @@ function npmStageHeaders(token: string, userAgentSuffix: string) {
     accept: "application/json",
     authorization: `Bearer ${token}`,
     "user-agent": `staged-publish-review/${userAgentSuffix}`,
+  };
+}
+
+function npmStageTarballHeaders(token: string) {
+  return {
+    accept: "application/octet-stream",
+    authorization: `Bearer ${token}`,
+    range: "bytes=0-0",
+    "user-agent": "staged-publish-review/staged-tarball-access",
   };
 }
 

--- a/server/lib/staged-publishes.ts
+++ b/server/lib/staged-publishes.ts
@@ -113,7 +113,8 @@ export async function checkStagedPublishAccess(
   const registry = normalizeRegistryUrl(registryUrl, options);
   const response = await fetch(`${registry}/-/stage/${encodeURIComponent(stageId)}/tarball`, {
     headers: npmStageTarballHeaders(token),
-  });
+  }).catch(() => null);
+  if (!response) return { allowed: true, status: null, detail: null };
   if (response.ok || response.status === 206) {
     await response.body?.cancel();
     return { allowed: true, status: response.status, detail: null };
@@ -126,8 +127,8 @@ export async function checkStagedPublishAccess(
       detail: response.statusText || null,
     };
   }
-  const detail = await response.text().catch(() => "");
-  throw new StagedPublishesFetchError(response.status, detail.slice(0, 200));
+  await response.body?.cancel();
+  return { allowed: true, status: response.status, detail: null };
 }
 
 export class StagedPublishesFetchError extends Error {

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -25,7 +25,11 @@ import { backfillScanArtifactsBatch } from "../lib/scan-artifact-backfill";
 import { scanArtifactReadBucket } from "../lib/scan-artifacts";
 import { loadCompare, stripTextSamples } from "../lib/compare-cache";
 import { rateLimitResponse } from "../lib/http";
-import { allowInsecureLocalRegistry, getOrganizationNpmToken } from "../lib/npm-connection";
+import {
+  allowInsecureLocalRegistry,
+  decryptNpmToken,
+  getOrganizationNpmToken,
+} from "../lib/npm-connection";
 import { isPublishedTarballUrlAllowed } from "../lib/published-tarball";
 import { compareSemver, fetchPackageMetadata, pickPreviousVersion } from "../lib/registry";
 import { annotateFindingsWithDiffStatus, createPackageDiff, type FileRecord } from "../lib/review";
@@ -34,6 +38,7 @@ import { parseScanInput } from "../lib/scan-input";
 import { reportExportFilename, serializeReportExport } from "../lib/report-export";
 import { executeScanJob, type ScanQueueMessage } from "../lib/scan-job";
 import { roleCanManageIntegrations } from "../lib/roles";
+import { checkStagedPublishAccess, StagedPublishesFetchError } from "../lib/staged-publishes";
 import type { Bindings, ScanInput, Variables } from "../types";
 
 export const scansRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
@@ -65,6 +70,19 @@ scansRoutes.post("/", async (c) => {
       return c.json(
         { error: "Validate the organization npm token before scanning staged publishes." },
         400,
+      );
+    }
+    const token = await decryptNpmToken(c.env, npmConnection);
+    const access = await checkStagedPublishAccess(npmConnection.registryUrl, token, input.stageId, {
+      allowInsecureLocalhost: allowInsecureLocalRegistry(c.env),
+    });
+    if (!access.allowed) {
+      return c.json(
+        {
+          error: "This organization's npm token cannot access that staged publish.",
+          status: access.status,
+        },
+        403,
       );
     }
 
@@ -103,6 +121,16 @@ scansRoutes.post("/", async (c) => {
   } catch (err) {
     if (err instanceof RateLimitError) {
       return rateLimitResponse(c, "scan rate limit exceeded", err);
+    }
+    if (err instanceof StagedPublishesFetchError) {
+      return c.json(
+        {
+          error: "npm registry rejected the staged publish access check",
+          status: err.status,
+          detail: err.detail,
+        },
+        502,
+      );
     }
     throw err;
   }

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -38,7 +38,7 @@ import { parseScanInput } from "../lib/scan-input";
 import { reportExportFilename, serializeReportExport } from "../lib/report-export";
 import { executeScanJob, type ScanQueueMessage } from "../lib/scan-job";
 import { roleCanManageIntegrations } from "../lib/roles";
-import { checkStagedPublishAccess, StagedPublishesFetchError } from "../lib/staged-publishes";
+import { checkStagedPublishAccess } from "../lib/staged-publishes";
 import type { Bindings, ScanInput, Variables } from "../types";
 
 export const scansRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
@@ -121,16 +121,6 @@ scansRoutes.post("/", async (c) => {
   } catch (err) {
     if (err instanceof RateLimitError) {
       return rateLimitResponse(c, "scan rate limit exceeded", err);
-    }
-    if (err instanceof StagedPublishesFetchError) {
-      return c.json(
-        {
-          error: "npm registry rejected the staged publish access check",
-          status: err.status,
-          detail: err.detail,
-        },
-        502,
-      );
     }
     throw err;
   }

--- a/test/scans-route-background.test.mjs
+++ b/test/scans-route-background.test.mjs
@@ -14,6 +14,13 @@ const activeOrgMock = vi.hoisted(() => ({
 const scanJobMock = vi.hoisted(() => ({
   executeScanJob: vi.fn(),
 }));
+const npmConnectionMock = vi.hoisted(() => ({
+  decryptNpmToken: vi.fn(),
+}));
+const stagedPublishesMock = vi.hoisted(() => ({
+  checkStagedPublishAccess: vi.fn(),
+  StagedPublishesFetchError: class StagedPublishesFetchError extends Error {},
+}));
 
 vi.mock("cloudflare:workers", () => ({
   WorkerEntrypoint: class {},
@@ -24,6 +31,14 @@ vi.mock("../server/db/index.ts", async (importOriginal) => {
 });
 vi.mock("../server/lib/active-organization.ts", () => activeOrgMock);
 vi.mock("../server/lib/scan-job.ts", () => scanJobMock);
+vi.mock("../server/lib/npm-connection.ts", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, ...npmConnectionMock };
+});
+vi.mock("../server/lib/staged-publishes.ts", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, ...stagedPublishesMock };
+});
 
 const { scansRoutes } = await import("../server/routes/scans.ts");
 
@@ -42,6 +57,8 @@ afterEach(() => {
     ...Object.values(dbMock),
     activeOrgMock.requireActiveOrganization,
     scanJobMock.executeScanJob,
+    npmConnectionMock.decryptNpmToken,
+    stagedPublishesMock.checkStagedPublishAccess,
   ]) {
     fn.mockReset();
   }
@@ -50,9 +67,18 @@ afterEach(() => {
 describe("scans route background fallback", () => {
   test("runs the waitUntil fallback as a final attempt because no queue retry will occur", async () => {
     activeOrgMock.requireActiveOrganization.mockResolvedValue("org_route");
-    dbMock.getNpmConnection.mockResolvedValue({ validationStatus: "valid" });
+    dbMock.getNpmConnection.mockResolvedValue({
+      validationStatus: "valid",
+      registryUrl: "https://registry.npmjs.org",
+    });
     dbMock.createScanJob.mockResolvedValue({
       scan: { id: "scan_route", stageId: "stage-route-bg-000001" },
+    });
+    npmConnectionMock.decryptNpmToken.mockResolvedValue("npm_secret_token");
+    stagedPublishesMock.checkStagedPublishAccess.mockResolvedValue({
+      allowed: true,
+      status: 206,
+      detail: null,
     });
     scanJobMock.executeScanJob.mockResolvedValue({ id: "scan_route" });
     const backgrounded = [];

--- a/test/staged-publishes-discovery.test.mjs
+++ b/test/staged-publishes-discovery.test.mjs
@@ -17,6 +17,7 @@ const npmConnectionMock = vi.hoisted(() => ({
   validateNpmCredential: vi.fn(),
 }));
 const stagedPublishesMock = vi.hoisted(() => ({
+  checkStagedPublishAccess: vi.fn(),
   listStagedPublishes: vi.fn(),
   StagedPublishesFetchError: class StagedPublishesFetchError extends Error {},
 }));
@@ -39,6 +40,11 @@ const ctx = { waitUntil: vi.fn() };
 const db = {};
 
 beforeEach(() => {
+  stagedPublishesMock.checkStagedPublishAccess.mockResolvedValue({
+    allowed: true,
+    status: 206,
+    detail: null,
+  });
   npmConnectionMock.decryptNpmToken.mockResolvedValue("npm_secret_token");
   npmConnectionMock.validateNpmCredential.mockResolvedValue({
     ok: true,
@@ -286,6 +292,47 @@ describe("discoverAndQueueStagedPublishes", () => {
       expect.objectContaining({ source: "auto_discovery", stageId: "stage-new-1" }),
     );
     expect(dbMock.markNpmConnectionUsed).toHaveBeenCalledWith(db, "org_a");
+  });
+
+  test("filters stage ids the organization token cannot access before creating scans", async () => {
+    stagedPublishesMock.listStagedPublishes.mockResolvedValue({
+      items: [
+        { id: "stage-allowed", packageName: "@org/allowed", version: "1.0.0" },
+        { id: "stage-denied", packageName: "@other/denied", version: "1.0.0" },
+      ],
+    });
+    stagedPublishesMock.checkStagedPublishAccess
+      .mockResolvedValueOnce({ allowed: true, status: 206, detail: null })
+      .mockResolvedValueOnce({ allowed: false, status: 403, detail: "Forbidden" });
+    dbMock.listExistingScanStageIds.mockResolvedValue(new Set());
+    dbMock.createScanJob.mockResolvedValue({ id: "scan-allowed" });
+
+    const result = await discoverAndQueueStagedPublishes(
+      {
+        db,
+        env,
+        executionCtx: ctx,
+        organizationId: "org_a",
+        actorUserId: "user_a",
+        source: "auto_discovery",
+        eventSource: "staged_publishes.cron",
+      },
+      { token: "npm_secret_token", registryUrl: "https://registry.npmjs.org" },
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({ found: 2, created: 1, skipped: 1, queued: true }),
+    );
+    expect(stagedPublishesMock.checkStagedPublishAccess).toHaveBeenCalledTimes(2);
+    expect(dbMock.createScanJob).toHaveBeenCalledTimes(1);
+    expect(dbMock.createScanJob).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ stageId: "stage-allowed" }),
+    );
+    expect(env.SCAN_QUEUE.send).toHaveBeenCalledTimes(1);
+    expect(env.SCAN_QUEUE.send).toHaveBeenCalledWith(
+      expect.objectContaining({ stageId: "stage-allowed" }),
+    );
   });
 
   test("fetches additional staged publish pages before deduping", async () => {

--- a/test/staged-publishes.test.mjs
+++ b/test/staged-publishes.test.mjs
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
+  checkStagedPublishAccess,
   fetchStagedPublishDetails,
   listStagedPublishes,
   parseStagedPublishDetails,
@@ -165,5 +166,38 @@ describe("staged publish metadata", () => {
         page: 2,
       }),
     ).resolves.toMatchObject({ items: [], total: 0, perPage: 50, page: 2 });
+  });
+
+  test("probes staged tarball access with a ranged credentialed request", async () => {
+    const fetchMock = vi.fn(async (url, init) => {
+      expect(String(url)).toBe("https://registry.npmjs.org/-/stage/stage-access-123/tarball");
+      expect(init.headers.authorization).toBe("Bearer npm_secret_token");
+      expect(init.headers.range).toBe("bytes=0-0");
+      expect(init.headers["user-agent"]).toBe("staged-publish-review/staged-tarball-access");
+      return new Response("", { status: 206 });
+    });
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      checkStagedPublishAccess(
+        "https://registry.npmjs.org",
+        "npm_secret_token",
+        "stage-access-123",
+      ),
+    ).resolves.toEqual({ allowed: true, status: 206, detail: null });
+  });
+
+  test("treats per-stage auth failures as unauthorized candidates", async () => {
+    globalThis.fetch = vi.fn(
+      async () => new Response("forbidden", { status: 403, statusText: "Forbidden" }),
+    );
+
+    await expect(
+      checkStagedPublishAccess(
+        "https://registry.npmjs.org",
+        "npm_secret_token",
+        "stage-denied-123",
+      ),
+    ).resolves.toEqual({ allowed: false, status: 403, detail: "Forbidden" });
   });
 });

--- a/test/staged-publishes.test.mjs
+++ b/test/staged-publishes.test.mjs
@@ -200,4 +200,12 @@ describe("staged publish metadata", () => {
       ),
     ).resolves.toEqual({ allowed: false, status: 403, detail: "Forbidden" });
   });
+
+  test("allows non-auth tarball failures to be handled by scan execution", async () => {
+    globalThis.fetch = vi.fn(async () => new Response("registry failure", { status: 503 }));
+
+    await expect(
+      checkStagedPublishAccess("https://registry.npmjs.org", "npm_secret_token", "stage-retry-123"),
+    ).resolves.toEqual({ allowed: true, status: 503, detail: null });
+  });
 });

--- a/test/workers/discovery-cron.test.ts
+++ b/test/workers/discovery-cron.test.ts
@@ -156,6 +156,9 @@ describe("staged publishes discovery cron", () => {
       expect(url).toContain("/-/stage");
       const auth = authHeader(input, init);
       if (auth === `Bearer ${orgA.token}`) {
+        if (url.endsWith(`/-/stage/${STAGE_ID}/tarball`)) {
+          return new Response("", { status: 206 });
+        }
         return Response.json({
           items: [{ id: STAGE_ID, name: "demo-package", version: "1.0.0" }],
           total: 1,
@@ -183,8 +186,9 @@ describe("staged publishes discovery cron", () => {
     );
     await waitOnExecutionContext(ctx);
 
-    // (c) excluded entirely: only (a) and (b) are swept, so only two fetches.
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // (c) excluded entirely: only (a) and (b) are swept. Org A lists and probes
+    // the staged tarball; org B fails on the staged-list auth check.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
 
     // (a) only: exactly one scan enqueued, scoped to org A.
     expect(queue.send).toHaveBeenCalledTimes(1);

--- a/test/workers/scans-route-queue.test.ts
+++ b/test/workers/scans-route-queue.test.ts
@@ -1,7 +1,7 @@
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   createDb,
   ensurePersonalOrganization,
@@ -62,6 +62,10 @@ async function connectValidNpmToken(owner: SeededUser, token: string) {
 }
 
 describe("scans route queue behavior", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   test("POST /scans enqueues a token-free scan message and records the queue event", async () => {
     const owner = await seedUser();
     const token = "npm_route_queue_secret_0123456789";
@@ -69,6 +73,17 @@ describe("scans route queue behavior", () => {
     const queue = { send: vi.fn(async () => undefined) };
     const app = buildTestApp(owner);
     const ctx = createExecutionContext();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+        expect(String(url)).toBe(
+          "https://registry.npmjs.org/-/stage/stage-route-queue-000001/tarball",
+        );
+        expect((init?.headers as Record<string, string>)?.authorization).toBe(`Bearer ${token}`);
+        expect((init?.headers as Record<string, string>)?.range).toBe("bytes=0-0");
+        return new Response("", { status: 206 });
+      }),
+    );
 
     const res = await app.fetch(
       new Request("http://test.local/api/v1/scans", {
@@ -104,6 +119,38 @@ describe("scans route queue behavior", () => {
       .from(schema.scanEvents)
       .where(eq(schema.scanEvents.scanId, body.scan.id));
     expect(events.map((event) => event.type)).toContain("scan.queued");
+  });
+
+  test("POST /scans rejects stage ids the organization token cannot access before persisting", async () => {
+    const owner = await seedUser();
+    await connectValidNpmToken(owner, "npm_route_denied_secret_0123456789");
+    const queue = { send: vi.fn(async () => undefined) };
+    const app = buildTestApp(owner);
+    const ctx = createExecutionContext();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("forbidden", { status: 403 })),
+    );
+
+    const res = await app.fetch(
+      new Request("http://test.local/api/v1/scans", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ stageId: "stage-route-denied-000001" }),
+      }),
+      { ...env, SCAN_QUEUE: queue } as unknown as Bindings,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(403);
+    expect(queue.send).not.toHaveBeenCalled();
+    const db = createDb(env.DB);
+    const scans = await db
+      .select()
+      .from(schema.scans)
+      .where(eq(schema.scans.organizationId, owner.organizationId));
+    expect(scans).toHaveLength(0);
   });
 
   test("POST /scans rejects client-controlled scan limits before queueing", async () => {

--- a/test/workers/staged-publishes-routes.test.ts
+++ b/test/workers/staged-publishes-routes.test.ts
@@ -76,6 +76,9 @@ describe("staged publishes route", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async (url: string | URL | Request) => {
+        if (String(url) === "https://registry.npmjs.org/-/stage/stage-new-123/tarball") {
+          return new Response("", { status: 206 });
+        }
         expect(String(url)).toBe("https://registry.npmjs.org/-/stage?perPage=50");
         return Response.json({
           items: [


### PR DESCRIPTION
## Summary
- Treat `GET /-/stage` as a candidate feed rather than authorization proof: `discoverAndQueueStagedPublishes` now probes `/-/stage/{stageId}/tarball` with the organization token before creating scan jobs, and filters per-stage 401/403/404 candidates without persisting failed reviews.
- Keep non-auth probe failures (for example transient 5xx registry/tarball errors) in the existing scan pipeline so they are reported by scan execution instead of aborting discovery.
- Apply the same access check to manual `POST /api/v1/scans` before scan persistence/queueing so inaccessible stage IDs return 403 instead of producing failed scans.
- Document the candidate-list behavior and add unit/worker/e2e coverage around tarball probes, discovery filtering, manual scan rejection, cron sweeps, and no-queue background fallback.

Validation: `pnpm run verify`; `pnpm run test:e2e`; targeted Vitest coverage for staged publishes, discovery cron, scan route queue/background behavior, and staged-publishes routes.

Link to Devin session: https://app.devin.ai/sessions/207cb6dbc38c42899d54ede5635c58e9
Requested by: @JoviDeCroock