### PR TITLE
Add PostHog product analytics

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,22 @@
+# Product analytics
+
+Drydock records product analytics through PostHog Cloud's EU ingestion endpoint:
+
+```text
+https://eu.i.posthog.com
+```
+
+Enable tracking by setting `VITE_POSTHOG_KEY` in the build environment. The key is a public PostHog project key that is bundled into the client; do not use a personal or secret API key.
+
+The client disables autocapture and session recording. Only explicit, product-level events are sent:
+
+- SPA page views.
+- Authentication milestones.
+- Dashboard and settings workspace load events.
+- Organization switching and creation.
+- npm connection save, validation, and removal.
+- Staged publish discovery start, completion, and failure.
+- Scan comparison selection and publish/block decisions.
+- Workflow gate decisions.
+
+Event properties intentionally avoid package contents, tokens, email addresses, names, and raw errors.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.25",
     "hoofd": "^1.7.3",
+    "posthog-js": "^1.386.6",
     "preact": "^10.29.2",
     "preact-iso": "^2.12.0",
     "qrcode": "^1.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       hoofd:
         specifier: ^1.7.3
         version: 1.7.3(react@19.2.7)
+      posthog-js:
+        specifier: ^1.386.6
+        version: 1.386.6
       preact:
         specifier: ^10.29.2
         version: 10.29.2
@@ -1432,6 +1435,12 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
+  '@posthog/core@1.32.3':
+    resolution: {integrity: sha512-vwOEMfZvGv5XxNWV7p9I52NSmvFNMhyW2IHpIoUHW5jLkgUrknzJW1H/qxVGSIrNNVQkfsoaDFzDhJdg10pgrA==}
+
+  '@posthog/types@1.386.3':
+    resolution: {integrity: sha512-LqJoiQi2eyWn7rCUgnn+D+F3Efp6+04o72bjSX6kWHx0nFaYNC/nJuAIRliDTY/X7GPIUAaHAcSjbMI/9wfX1Q==}
+
   '@preact/eslint-plugin-signals@0.2.0':
     resolution: {integrity: sha512-xJz0HogEZ4GbrHkyuWnCnjHlEzmzRHJmMIExLrGh7yfWrSQ+Df7SbK2LYL+v2bFjK4R2PkUMuUSaYlDb/WAd/Q==}
 
@@ -1736,6 +1745,9 @@ packages:
   '@types/qrcode@1.5.6':
     resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -1930,6 +1942,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
@@ -1980,6 +1995,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.10:
+    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -2146,6 +2164,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -2454,6 +2475,9 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.386.6:
+    resolution: {integrity: sha512-xRcbToRtU07Ojk+VaCCos6I/zD60sNKfWxdeZih0xbncgegIqLZJmBzi4HdkSkXrf14b6HhwMI/s2GxWha5ADQ==}
+
   preact-iso@2.12.0:
     resolution: {integrity: sha512-k0Y44UONBJ1zBXXCBhJRAa5O4ww8a5FHdLD6l21IxcnsTmDBto4n7KPQAH6xqegsKDMX4SuJ02qItiUlciIlZQ==}
     peerDependencies:
@@ -2475,6 +2499,9 @@ packages:
     resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
@@ -2746,6 +2773,9 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
@@ -3681,6 +3711,12 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
+  '@posthog/core@1.32.3':
+    dependencies:
+      '@posthog/types': 1.386.3
+
+  '@posthog/types@1.386.3': {}
+
   '@preact/eslint-plugin-signals@0.2.0': {}
 
   '@preact/preset-vite@2.10.5(@babel/core@7.29.7)(preact@10.29.2)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4))':
@@ -3935,6 +3971,9 @@ snapshots:
     dependencies:
       '@types/node': 25.9.2
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.1': {}
@@ -4087,6 +4126,8 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  core-js@3.49.0: {}
+
   css-select@5.2.2:
     dependencies:
       boolbase: 1.0.0
@@ -4128,6 +4169,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.10:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
@@ -4290,6 +4335,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.4.8: {}
 
   find-up@4.1.0:
     dependencies:
@@ -4577,6 +4624,17 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.386.6:
+    dependencies:
+      '@posthog/core': 1.32.3
+      '@posthog/types': 1.386.3
+      core-js: 3.49.0
+      dompurify: 3.4.10
+      fflate: 0.4.8
+      preact: 10.29.2
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+
   preact-iso@2.12.0(preact-render-to-string@6.7.0(preact@10.29.2))(preact@10.29.2):
     dependencies:
       preact: 10.29.2
@@ -4595,6 +4653,8 @@ snapshots:
       dijkstrajs: 1.0.3
       pngjs: 5.0.0
       yargs: 15.4.1
+
+  query-selector-shadow-dom@1.0.1: {}
 
   react@19.2.7: {}
 
@@ -4857,6 +4917,8 @@ snapshots:
       '@types/node': 25.9.2
     transitivePeerDependencies:
       - msw
+
+  web-vitals@5.3.0: {}
 
   which-module@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ allowBuilds:
   "0": esbuild
   "1": sharp
   "2": workerd
+  core-js: false
   esbuild: true
   sharp: true
   workerd: true

--- a/public/_headers
+++ b/public/_headers
@@ -17,4 +17,4 @@
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://eu.i.posthog.com

--- a/server/lib/security-headers.ts
+++ b/server/lib/security-headers.ts
@@ -34,12 +34,14 @@ export const API_CSP = ["default-src 'none'", "frame-ancestors 'none'", "base-ur
   "; ",
 );
 
+const POSTHOG_EU_HOST = "https://eu.i.posthog.com";
+
 // The HTML UI loads same-origin scripts/styles/images plus the Geist webfont
 // from Google Fonts: the stylesheet from fonts.googleapis.com (style-src) pulls
 // font files from fonts.gstatic.com (font-src). 'unsafe-inline' on style-src
 // covers Tailwind's injected styles and the prerendered critical CSS; img-src
-// data: covers inline data-URI images. connect-src stays 'self' — the UI only
-// calls the same-origin /api surface.
+// data: covers inline data-URI images. connect-src allows same-origin /api calls
+// and the EU PostHog ingestion host for product analytics.
 export const DOCUMENT_CSP = [
   "default-src 'self'",
   "base-uri 'self'",
@@ -50,5 +52,5 @@ export const DOCUMENT_CSP = [
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "font-src 'self' https://fonts.gstatic.com",
   "img-src 'self' data:",
-  "connect-src 'self'",
+  `connect-src 'self' ${POSTHOG_EU_HOST}`,
 ].join("; ");

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,16 @@
 import { hydrate, render } from "preact";
-import { ErrorBoundary, LocationProvider, Route, Router, lazy, prerender as ssr } from "preact-iso";
+import {
+  ErrorBoundary,
+  LocationProvider,
+  Route,
+  Router,
+  lazy,
+  prerender as ssr,
+  useLocation,
+} from "preact-iso";
+import { useEffect } from "preact/hooks";
 import { Toaster } from "./components";
+import { trackPageView } from "./lib/analytics";
 import { extractPrerenderHead, getPageSeoMetadata } from "./lib/seo";
 import "./style.css";
 
@@ -20,6 +30,7 @@ const NotFoundPage = lazy(() => import("./pages/NotFound"));
 export function App() {
   return (
     <LocationProvider>
+      <AnalyticsRouteTracker />
       <ErrorBoundary onError={(error) => console.error(error)}>
         <Router>
           <Route path="/" component={LandingPage} />
@@ -39,6 +50,14 @@ export function App() {
       <Toaster />
     </LocationProvider>
   );
+}
+
+function AnalyticsRouteTracker() {
+  const location = useLocation();
+  useEffect(() => {
+    trackPageView(window.location.href);
+  }, [location.url]);
+  return null;
 }
 
 export function isPrerenderedRoute(pathname: string) {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,101 @@
+export const POSTHOG_EU_HOST = "https://eu.i.posthog.com";
+
+type AnalyticsProperty = string | number | boolean | null;
+type AnalyticsProperties = Record<string, AnalyticsProperty | undefined>;
+type PostHogClient = typeof import("posthog-js").default;
+
+const POSTHOG_PROJECT_KEY = import.meta.env.VITE_POSTHOG_KEY;
+
+let clientPromise: Promise<PostHogClient | null> | null = null;
+let client: PostHogClient | null = null;
+
+export function isAnalyticsConfigured(): boolean {
+  return analyticsProjectKey() !== null;
+}
+
+export function currentAnalyticsHost(): string {
+  return POSTHOG_EU_HOST;
+}
+
+export function normalizeAnalyticsPath(url: string): string {
+  try {
+    const parsed = new URL(url, "http://localhost");
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return url;
+  }
+}
+
+export function trackPageView(url: string): void {
+  trackProductEvent("$pageview", {
+    $current_url: url,
+    path: normalizeAnalyticsPath(url),
+  });
+}
+
+export function trackProductEvent(event: string, properties: AnalyticsProperties = {}): void {
+  withPostHog((posthog) => {
+    posthog.capture(event, cleanProperties(properties));
+  });
+}
+
+export function identifyAnalyticsUser(userId: string): void {
+  withPostHog((posthog) => {
+    posthog.identify(userId);
+  });
+}
+
+export function resetAnalytics(): void {
+  withPostHog((posthog) => {
+    posthog.reset();
+  });
+}
+
+function withPostHog(callback: (posthog: PostHogClient) => void): void {
+  void (async () => {
+    try {
+      const posthog = await getPostHogClient();
+      if (!posthog) return;
+      callback(posthog);
+    } catch {
+      // Analytics must never break the product flow.
+    }
+  })();
+}
+
+function cleanProperties(properties: AnalyticsProperties): Record<string, AnalyticsProperty> {
+  const cleaned: Record<string, AnalyticsProperty> = {};
+  for (const [key, value] of Object.entries(properties)) {
+    if (value !== undefined) cleaned[key] = value;
+  }
+  return cleaned;
+}
+
+function getPostHogClient(): Promise<PostHogClient | null> {
+  if (client) return Promise.resolve(client);
+  const projectKey = analyticsProjectKey();
+  if (!projectKey) return Promise.resolve(null);
+  if (typeof window === "undefined") return Promise.resolve(null);
+  clientPromise ??= import("posthog-js")
+    .then((module) => {
+      const posthog = module.default;
+      posthog.init(projectKey, {
+        api_host: POSTHOG_EU_HOST,
+        autocapture: false,
+        capture_pageview: false,
+        disable_session_recording: true,
+        loaded: (loadedClient) => {
+          loadedClient.register({ app: "drydock" });
+        },
+      });
+      client = posthog;
+      return posthog;
+    })
+    .catch(() => null);
+  return clientPromise;
+}
+
+function analyticsProjectKey(): string | null {
+  if (typeof POSTHOG_PROJECT_KEY !== "string" || POSTHOG_PROJECT_KEY.length === 0) return null;
+  return POSTHOG_PROJECT_KEY;
+}

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -1,4 +1,5 @@
 import { computed, createModel, signal } from "@preact/signals";
+import { identifyAnalyticsUser, resetAnalytics, trackProductEvent } from "../lib/analytics";
 import { errorMessage } from "./api";
 
 export interface SessionUser {
@@ -52,6 +53,7 @@ export const SessionModel = createModel(() => {
       try {
         const data = await fetchSession();
         this.session.value = data;
+        if (data?.user.id) identifyAnalyticsUser(data.user.id);
         this.error.value = null;
         return data;
       } catch (err) {
@@ -79,9 +81,11 @@ export const SessionModel = createModel(() => {
         typeof data === "object" &&
         (data as { twoFactorRedirect?: unknown }).twoFactorRedirect
       ) {
+        trackProductEvent("auth_two_factor_requested", { method: "email_password" });
         return { twoFactorRequired: true };
       }
       await this.load();
+      trackProductEvent("auth_sign_in_completed", { method: "email_password" });
       return { twoFactorRequired: false };
     },
 
@@ -91,6 +95,9 @@ export const SessionModel = createModel(() => {
         : "/api/auth/two-factor/verify-totp";
       await authPost(path, { code });
       await this.load();
+      trackProductEvent("auth_two_factor_completed", {
+        method: options.backup ? "backup" : "totp",
+      });
     },
 
     async signUp(name: string, email: string, password: string, returnTo?: string): Promise<void> {
@@ -100,6 +107,7 @@ export const SessionModel = createModel(() => {
         password,
         callbackURL: verificationCallbackPath(returnTo),
       });
+      trackProductEvent("auth_sign_up_submitted", { method: "email_password" });
     },
 
     async resendVerification(email: string, returnTo?: string): Promise<void> {
@@ -112,6 +120,7 @@ export const SessionModel = createModel(() => {
     async signOut(): Promise<void> {
       await authPost("/api/auth/sign-out", {});
       this.session.value = null;
+      resetAnalytics();
     },
 
     // Permanently delete the signed-in account. The password is re-verified

--- a/src/models/npm-connection.ts
+++ b/src/models/npm-connection.ts
@@ -1,4 +1,5 @@
 import { computed, createModel, signal } from "@preact/signals";
+import { trackProductEvent } from "../lib/analytics";
 import { apiFetch, apiJson, errorMessage } from "./api";
 
 export interface PublicNpmConnection {
@@ -108,6 +109,10 @@ export const NpmConnectionModel = createModel(() => {
           this.status.value = "validating";
           const validation = await validateNpmConnection();
           this.applyConnection(validation.connection);
+          trackProductEvent("npm_connection_saved", {
+            validation_ok: validation.validation.ok,
+            registry: validation.validation.capabilities.registryUrl,
+          });
           if (!validation.validation.ok) {
             this.error.value = "Saved token, but npm validation reported invalid access.";
           }
@@ -127,6 +132,10 @@ export const NpmConnectionModel = createModel(() => {
         const stageId = this.validationStageId.value.trim() || undefined;
         const data = await validateNpmConnection(stageId);
         this.applyConnection(data.connection);
+        trackProductEvent("npm_connection_validated", {
+          validation_ok: data.validation.ok,
+          with_stage_id: Boolean(stageId),
+        });
         if (!data.validation.ok) {
           this.error.value = "Npm validation reported invalid access.";
         }
@@ -145,6 +154,7 @@ export const NpmConnectionModel = createModel(() => {
         await apiFetch<{ ok: boolean }>("/api/v1/npm-connection", { method: "DELETE" });
         this.connection.value = null;
         this.token.value = "";
+        trackProductEvent("npm_connection_removed");
       } catch (err) {
         this.error.value = errorMessage(err);
       } finally {

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -5,6 +5,7 @@ import type {
   FindingDiffStatus,
   PackageJsonSummary,
 } from "../../server/lib/review";
+import { trackProductEvent } from "../lib/analytics";
 import { apiFetch, apiJson, errorMessage } from "./api";
 import {
   decideWorkflowGate,
@@ -432,6 +433,7 @@ export const ScanDetailModel = createModel((id: string) => {
 
     selectVersion(version: string | null) {
       this.selectedVersion.value = version;
+      trackProductEvent("scan_comparison_version_selected", { default_version: version === null });
     },
 
     async setDecision(decision: ScanDecision, reason: string | null): Promise<void> {
@@ -442,6 +444,11 @@ export const ScanDetailModel = createModel((id: string) => {
         const updated = await setScanDecision(id, decision, reason);
         this.detail.value = updated;
         this.decisionStatus.value = "idle";
+        trackProductEvent("scan_decision_saved", {
+          decision,
+          source: updated.scan.source ?? "manual",
+          risk: updated.scan.risk,
+        });
       } catch (err) {
         this.decisionError.value = errorMessage(err);
         this.decisionStatus.value = "error";
@@ -489,6 +496,11 @@ export const ScanDetailModel = createModel((id: string) => {
         );
         this.gate.value = updated;
         this.gateDecisionStatus.value = "idle";
+        trackProductEvent("workflow_gate_decision_saved", {
+          decision,
+          package_count: updated.packages.length,
+          status: updated.status,
+        });
         // The decision also writes the scan's publish/no_publish decision and an
         // audit event server-side; refresh so the workbench reflects both.
         await this.load();

--- a/src/models/staged-publishes.ts
+++ b/src/models/staged-publishes.ts
@@ -1,5 +1,6 @@
 import { createModel, signal } from "@preact/signals";
 import type { StagedPublishesScanResponse } from "../../server/lib/staged-publishes";
+import { trackProductEvent } from "../lib/analytics";
 import { apiFetch, errorMessage } from "./api";
 
 export type { StagedPublishesScanResponse };
@@ -33,14 +34,22 @@ export const StagedPublishesModel = createModel(() => {
 
     async discover(): Promise<StagedPublishesScanResponse | null> {
       this.refreshing.value = true;
+      trackProductEvent("staged_publish_discovery_started");
       try {
         const result = await startStagedPublishScans();
         this.lastResult.value = result;
         this.lastDiscoveryAt.value = Date.now();
         this.error.value = null;
+        trackProductEvent("staged_publish_discovery_completed", {
+          found: result.found,
+          created: result.created,
+          skipped: result.skipped,
+          queued: result.queued,
+        });
         return result;
       } catch (err) {
         this.error.value = errorMessage(err);
+        trackProductEvent("staged_publish_discovery_failed");
         return null;
       } finally {
         this.loaded.value = true;

--- a/src/pages/Dashboard/Settings/index.tsx
+++ b/src/pages/Dashboard/Settings/index.tsx
@@ -6,6 +6,7 @@ import {
   rememberDashboardReturnUrl,
   useQuerySignal,
 } from "../../../lib/query-state";
+import { trackProductEvent } from "../../../lib/analytics";
 import { sessionModel } from "../../../models/auth";
 import { NpmConnectionModel } from "../../../models/npm-connection";
 import { NotificationRecipientsModel } from "../../../models/notification-recipients";
@@ -45,6 +46,7 @@ export default function SettingsPage() {
   const slack = useModel(SlackConnectionModel);
   const sessionChecked = useSignal(false);
   const activeTab = useSignal<SettingsTab>("general");
+  const trackedSettingsLoad = useSignal(false);
 
   useQuerySignal(activeTab, {
     name: "tab",
@@ -104,6 +106,7 @@ export default function SettingsPage() {
   const onSwitchOrganization = async (organizationId: string) => {
     if (organizations.activate(organizationId)) {
       await reloadActiveOrgScopedData();
+      trackProductEvent("organization_switched", { surface: "settings" });
     }
   };
 
@@ -111,6 +114,7 @@ export default function SettingsPage() {
     const created = await organizations.create(name);
     if (created) {
       await reloadActiveOrgScopedData();
+      trackProductEvent("organization_created", { surface: "settings" });
     }
   };
 
@@ -118,6 +122,21 @@ export default function SettingsPage() {
     await sessionModel.signOut();
     location.route("/", true);
   };
+
+  const user = sessionModel.user.value;
+  const githubAppLoaded = githubApp.loaded.value;
+  const npmLoaded = npm.loaded.value;
+  const workspaceLoaded = githubAppLoaded && npmLoaded;
+  const tab = activeTab.value;
+
+  useEffect(() => {
+    if (!workspaceLoaded || trackedSettingsLoad.value) return;
+    trackedSettingsLoad.value = true;
+    trackProductEvent("settings_loaded", {
+      has_npm_connection: Boolean(npm.connection.value),
+      tab,
+    });
+  }, [workspaceLoaded, tab]);
 
   if (!sessionChecked.value) {
     return (
@@ -127,12 +146,6 @@ export default function SettingsPage() {
       </PageShell>
     );
   }
-
-  const user = sessionModel.user.value;
-  const githubAppLoaded = githubApp.loaded.value;
-  const npmLoaded = npm.loaded.value;
-  const workspaceLoaded = githubAppLoaded && npmLoaded;
-  const tab = activeTab.value;
 
   return (
     <PageShell

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -2,6 +2,7 @@ import type { ComponentChildren } from "preact";
 import { useEffect } from "preact/hooks";
 import { useSignal, useModel, useSignalEffect } from "@preact/signals";
 import { useLocation } from "preact-iso";
+import { trackProductEvent } from "../../lib/analytics";
 import { rememberDashboardReturnUrl, useQuerySignal } from "../../lib/query-state";
 import { pluralize } from "../../lib/format";
 import { sessionModel } from "../../models/auth";
@@ -33,6 +34,7 @@ export default function DashboardPage() {
   const organizations = useModel(OrganizationModel);
   const stagedPublishes = useModel(StagedPublishesModel);
   const sessionChecked = useSignal(false);
+  const trackedDashboardLoad = useSignal(false);
 
   // Two-way bind the decision filter to ?filter=. The model re-fetches
   // whenever the filter signal changes, so URL → filter → refresh comes
@@ -67,6 +69,7 @@ export default function DashboardPage() {
   const onSwitchOrganization = async (organizationId: string) => {
     if (organizations.activate(organizationId)) {
       await Promise.all([scans.refresh(), npm.load()]);
+      trackProductEvent("organization_switched", { surface: "dashboard" });
     }
   };
 
@@ -74,6 +77,7 @@ export default function DashboardPage() {
     const created = await organizations.create(name);
     if (created) {
       await Promise.all([scans.refresh(), npm.load()]);
+      trackProductEvent("organization_created", { surface: "dashboard" });
     }
   };
 
@@ -89,6 +93,21 @@ export default function DashboardPage() {
     location.route("/", true);
   };
 
+  const user = sessionModel.user.value;
+  const scansLoaded = scans.loaded.value;
+  const npmLoaded = npm.loaded.value;
+  const workspaceLoaded = scansLoaded && npmLoaded;
+
+  useEffect(() => {
+    if (!workspaceLoaded || trackedDashboardLoad.value) return;
+    trackedDashboardLoad.value = true;
+    trackProductEvent("dashboard_loaded", {
+      scan_count: scans.scans.value.length,
+      has_npm_connection: Boolean(npm.connection.value),
+      filter: scans.filter.value,
+    });
+  }, [workspaceLoaded]);
+
   if (!sessionChecked.value) {
     return (
       <PageShell>
@@ -100,11 +119,6 @@ export default function DashboardPage() {
       </PageShell>
     );
   }
-
-  const user = sessionModel.user.value;
-  const scansLoaded = scans.loaded.value;
-  const npmLoaded = npm.loaded.value;
-  const workspaceLoaded = scansLoaded && npmLoaded;
 
   return (
     <PageShell

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "vitest";
+import {
+  currentAnalyticsHost,
+  normalizeAnalyticsPath,
+  POSTHOG_EU_HOST,
+} from "../src/lib/analytics";
+
+describe("product analytics", () => {
+  test("uses the PostHog EU ingestion host", () => {
+    expect(currentAnalyticsHost()).toBe(POSTHOG_EU_HOST);
+    expect(POSTHOG_EU_HOST).toBe("https://eu.i.posthog.com");
+  });
+
+  test("normalizes pageview paths without leaking origins", () => {
+    expect(normalizeAnalyticsPath("https://drydock.org/dashboard?filter=all")).toBe(
+      "/dashboard?filter=all",
+    );
+  });
+});

--- a/test/security-headers.test.ts
+++ b/test/security-headers.test.ts
@@ -45,6 +45,10 @@ describe("public/_headers static-asset security headers", () => {
     expect(catchAll?.["Content-Security-Policy"]).toBe(DOCUMENT_CSP);
   });
 
+  test("allows PostHog EU product analytics ingestion", () => {
+    expect(DOCUMENT_CSP).toContain("connect-src 'self' https://eu.i.posthog.com");
+  });
+
   test("carries the same non-CSP security headers as the Worker", () => {
     for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
       expect(catchAll?.[name]).toBe(value);


### PR DESCRIPTION
## Summary
Adds PostHog product analytics with the EU ingestion endpoint (`https://eu.i.posthog.com`) and a `VITE_POSTHOG_KEY` build-time gate so tracking stays disabled until configured. The client intentionally disables autocapture/session recording and only sends explicit product events for page views, auth milestones, workspace loads, org changes, npm connection actions, staged-publish discovery, scan comparisons, and decisions.

Also updates the document CSP/static `_headers` allowlist for PostHog EU ingestion and documents the analytics setup/events in `docs/analytics.md`.

Link to Devin session: https://app.devin.ai/sessions/7dc3ba15421f4891a1e34b0c41ab0c5d
Requested by: @JoviDeCroock