### PR TITLE
Optimize scan detail and compare hot paths

### DIFF
--- a/docs/artifact-storage.md
+++ b/docs/artifact-storage.md
@@ -47,14 +47,19 @@ User-initiated report downloads serve the same canonical `report.json` bytes wit
 
 New completed scans try to write `report.json`, `files.json`, `diff.json`, and `manifest.json` to R2 before `persistScan` marks the D1 row artifact-backed. Each object is read back and verified against its expected size and SHA-256 digest before D1 metadata is saved. Transient write or verification failures are retried; exhausted failures log `scan.artifacts.write_failed` and fail closed so the scan can retry instead of persisting new file samples into D1. When the R2 write succeeds, D1 stores compact file metadata only and leaves `scan_files.text_sample` null.
 
-`GET /api/v1/scans/:id` shadow-reads R2 when all artifact metadata exists. The read path verifies:
+`GET /api/v1/scans/:id` returns D1-backed scan metadata, findings, events, and file metadata without loading staged file bodies. The dashboard fetches a selected staged body through:
+
+```http
+GET /api/v1/scans/:id/file?path=package.json
+```
+
+The file-body route shadow-reads R2 when all artifact metadata exists. The artifact read path verifies:
 
 - manifest key, size, and digest;
 - manifest scan/org identity and object-key references;
-- report object digest against `scans.report_digest`;
 - file/diff payload shape.
 
-Any mismatch, missing object, invalid payload, or R2 read failure logs `scan.artifacts.fallback_read` and returns the existing D1-backed detail instead. For artifact-backed scans created after this rollout, that fallback keeps file metadata and findings readable but does not include redacted file text samples because new samples are not duplicated into D1.
+Any mismatch, missing object, invalid payload, or R2 read failure logs `scan.artifacts.fallback_read` and returns the existing D1-backed metadata instead. For artifact-backed scans created after this rollout, that fallback keeps file metadata and findings readable but does not include redacted file text samples because new samples are not duplicated into D1.
 
 ## Backfill
 

--- a/docs/workflow-gates.md
+++ b/docs/workflow-gates.md
@@ -27,7 +27,7 @@ The repo now has a backend-only PyPI foundation in `server/lib/adapters/pypi/ind
 - parses wheel `METADATA`, `WHEEL`, and `RECORD` evidence from ZIP archives;
 - strips the common root directory from sdists before reading `PKG-INFO`;
 - compares flattened candidate artifact files against the previous PyPI release using stable wheel/sdist namespaces instead of versioned artifact filenames (callers may inject explicit `previousArtifacts`, otherwise the adapter resolves and downloads the baseline itself);
-- groups the bundle's artifacts by normalized (PEP 503) package name into one reviewable release per distinct package (a monorepo publishes several), requiring artifacts that share a name to agree on the version before forming that package's release;
+- parses uploaded artifacts with bounded concurrency, then groups the bundle by normalized (PEP 503) package name into one reviewable release per distinct package (a monorepo publishes several), requiring artifacts that share a name to agree on the version before forming that package's release;
 - adds PyPI-specific deterministic findings for metadata mismatches, missing wheel `RECORD`, `.pth` startup hooks, custom `setup.py` install commands, and `.pyd` native extensions;
 - fetches PyPI project metadata from `GET /pypi/<project>/json`;
 - selects a default PyPI baseline release from `info.version`, falling back to newest non-yanked upload time;

--- a/drizzle/0020_gifted_leo.sql
+++ b/drizzle/0020_gifted_leo.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `scans_org_created_idx` ON `scans` (`organization_id`,`created_at`,`id`);

--- a/drizzle/meta/0020_snapshot.json
+++ b/drizzle/meta/0020_snapshot.json
@@ -1,0 +1,2381 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "344597f7-1ae0-4c54-936d-3494de781fd0",
+  "prevId": "be683958-6507-4fe0-a22f-258e3726906d",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_app_installations": {
+      "name": "github_app_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Organization'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uninstalled_at": {
+          "name": "uninstalled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_app_installations_installation_unique_idx": {
+          "name": "github_app_installations_installation_unique_idx",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        },
+        "github_app_installations_org_idx": {
+          "name": "github_app_installations_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installations_created_by_user_id_user_id_fk": {
+          "name": "github_app_installations_created_by_user_id_user_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_release_targets": {
+      "name": "github_release_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ecosystem": {
+          "name": "ecosystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_release_targets_org_repo_env_unique_idx": {
+          "name": "github_release_targets_org_repo_env_unique_idx",
+          "columns": [
+            "organization_id",
+            "repository_id",
+            "environment"
+          ],
+          "isUnique": true
+        },
+        "github_release_targets_installation_idx": {
+          "name": "github_release_targets_installation_idx",
+          "columns": [
+            "installation_row_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_release_targets_organization_id_organizations_id_fk": {
+          "name": "github_release_targets_organization_id_organizations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_release_targets_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_created_by_user_id_user_id_fk": {
+          "name": "github_release_targets_created_by_user_id_user_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_workflow_gates": {
+      "name": "github_workflow_gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_target_id": {
+          "name": "release_target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deployment_callback_url": {
+          "name": "deployment_callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_comment": {
+          "name": "decision_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_url": {
+          "name": "report_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_started_at": {
+          "name": "review_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_workflow_gates_delivery_unique_idx": {
+          "name": "github_workflow_gates_delivery_unique_idx",
+          "columns": [
+            "delivery_id"
+          ],
+          "isUnique": true
+        },
+        "github_workflow_gates_org_status_idx": {
+          "name": "github_workflow_gates_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_release_target_idx": {
+          "name": "github_workflow_gates_release_target_idx",
+          "columns": [
+            "release_target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_workflow_gates_organization_id_organizations_id_fk": {
+          "name": "github_workflow_gates_organization_id_organizations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_workflow_gates_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_release_target_id_github_release_targets_id_fk": {
+          "name": "github_workflow_gates_release_target_id_github_release_targets_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_release_targets",
+          "columnsFrom": [
+            "release_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_scan_id_scans_id_fk": {
+          "name": "github_workflow_gates_scan_id_scans_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_unique_idx": {
+          "name": "npm_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_invitations": {
+      "name": "organization_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_invitations_token_hash_unique_idx": {
+          "name": "organization_invitations_token_hash_unique_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "organization_invitations_org_status_idx": {
+          "name": "organization_invitations_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "organization_invitations_org_email_idx": {
+          "name": "organization_invitations_org_email_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_invitations_organization_id_organizations_id_fk": {
+          "name": "organization_invitations_organization_id_organizations_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_invited_by_user_id_user_id_fk": {
+          "name": "organization_invitations_invited_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_accepted_by_user_id_user_id_fk": {
+          "name": "organization_invitations_accepted_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_notification_recipients": {
+      "name": "organization_notification_recipients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_notification_recipients_org_email_unique_idx": {
+          "name": "organization_notification_recipients_org_email_unique_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_notification_recipients_organization_id_organizations_id_fk": {
+          "name": "organization_notification_recipients_organization_id_organizations_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_notification_recipients_created_by_user_id_user_id_fk": {
+          "name": "organization_notification_recipients_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_slack_connections": {
+      "name": "organization_slack_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_token_ciphertext": {
+          "name": "bot_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bot_token_nonce": {
+          "name": "bot_token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slack_connections_org_unique_idx": {
+          "name": "organization_slack_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_slack_connections_organization_id_organizations_id_fk": {
+          "name": "organization_slack_connections_organization_id_organizations_id_fk",
+          "tableFrom": "organization_slack_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_slack_connections_created_by_user_id_user_id_fk": {
+          "name": "organization_slack_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_slack_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_findings_scan_severity_idx": {
+          "name": "scan_findings_scan_severity_idx",
+          "columns": [
+            "scan_id",
+            "severity"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changed_file_count": {
+          "name": "changed_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_summary_json": {
+          "name": "risk_summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_storage_version": {
+          "name": "artifact_storage_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_key": {
+          "name": "artifact_manifest_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_digest": {
+          "name": "artifact_manifest_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_size": {
+          "name": "artifact_manifest_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_artifact_key": {
+          "name": "report_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_samples_artifact_key": {
+          "name": "file_samples_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "diff_artifact_key": {
+          "name": "diff_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        },
+        "scans_gate_org_idx": {
+          "name": "scans_gate_org_idx",
+          "columns": [
+            "gate_id",
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_artifact_backfill_idx": {
+          "name": "scans_artifact_backfill_idx",
+          "columns": [
+            "organization_id",
+            "status",
+            "artifact_storage_version",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "scans_org_decision_created_idx": {
+          "name": "scans_org_decision_created_idx",
+          "columns": [
+            "organization_id",
+            "decision",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scans_org_created_idx": {
+          "name": "scans_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_gate_id_github_workflow_gates_id_fk": {
+          "name": "scans_gate_id_github_workflow_gates_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "github_workflow_gates",
+          "columnsFrom": [
+            "gate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_decided_by_user_id_user_id_fk": {
+          "name": "scans_decided_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "two_factor": {
+      "name": "two_factor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1780937563979,
       "tag": "0019_serious_aaron_stack",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "6",
+      "when": 1781543124536,
+      "tag": "0020_gifted_leo",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/organizations.ts
+++ b/server/db/organizations.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray } from "drizzle-orm";
+import { and, asc, eq, inArray, sql } from "drizzle-orm";
 import { personalOrganizationId } from "../lib/ownership";
 import type { AppDb, WorkspaceSession } from "./client";
 import {
@@ -21,6 +21,18 @@ import {
 
 export async function ensurePersonalOrganization(db: AppDb, session: WorkspaceSession) {
   const organizationId = personalOrganizationId(session.userId);
+  const [existing] = await db
+    .select({ organizationId: organizationMembers.organizationId })
+    .from(organizationMembers)
+    .where(
+      and(
+        eq(organizationMembers.organizationId, organizationId),
+        eq(organizationMembers.userId, session.userId),
+      ),
+    )
+    .limit(1);
+  if (existing) return organizationId;
+
   const now = new Date();
   const name = session.name || session.email || "Personal workspace";
 
@@ -101,11 +113,14 @@ export async function listUserOrganizations(
       role: organizationMembers.role,
       createdAt: organizations.createdAt,
       updatedAt: organizations.updatedAt,
-      npmConnectionId: npmConnections.id,
+      npmConnectionConfigured: sql<boolean>`exists (
+        select 1
+        from ${npmConnections}
+        where ${npmConnections.organizationId} = ${organizations.id}
+      )`,
     })
     .from(organizationMembers)
     .innerJoin(organizations, eq(organizations.id, organizationMembers.organizationId))
-    .leftJoin(npmConnections, eq(npmConnections.organizationId, organizations.id))
     .where(eq(organizationMembers.userId, userId));
 
   return rows
@@ -115,7 +130,7 @@ export async function listUserOrganizations(
       ownerUserId: row.ownerUserId,
       role: row.role,
       isPersonal: row.id === personalId,
-      npmConnectionConfigured: Boolean(row.npmConnectionId),
+      npmConnectionConfigured: Boolean(row.npmConnectionConfigured),
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
     }))

--- a/server/db/rate-limit.ts
+++ b/server/db/rate-limit.ts
@@ -2,6 +2,9 @@ import { eq, lt, sql } from "drizzle-orm";
 import type { AppDb } from "./client";
 import { rateLimits } from "./schema";
 
+const RATE_LIMIT_CLEANUP_INTERVAL_MS = 5 * 60_000;
+let nextRateLimitCleanupAtMs = 0;
+
 export interface RateLimitInput {
   key: string;
   limit: number;
@@ -39,7 +42,8 @@ export async function enforceRateLimit(db: AppDb, input: RateLimitInput) {
     });
 
   const [entry] = await db.select().from(rateLimits).where(eq(rateLimits.key, key)).limit(1);
-  if (Math.random() < 0.01) {
+  if (nowMs >= nextRateLimitCleanupAtMs) {
+    nextRateLimitCleanupAtMs = nowMs + RATE_LIMIT_CLEANUP_INTERVAL_MS;
     await db.delete(rateLimits).where(lt(rateLimits.expiresAt, new Date(nowMs - input.windowMs)));
   }
   if ((entry?.count ?? 0) > input.limit) {

--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -13,6 +13,7 @@ import {
 } from "../lib/review";
 import { normalizeScanRiskBreakdown, type ScanRiskBreakdown } from "../lib/risk";
 import {
+  loadScanArtifactFile,
   loadScanArtifacts,
   scanFileRowsForArtifacts,
   type ScanArtifactFileRow,
@@ -663,6 +664,7 @@ export async function getScan(
   id: string,
   organizationId: string,
   artifactBucket?: R2Bucket,
+  options: { includeFileSamples?: boolean } = {},
 ) {
   const [scanRows, files, findings, events] = await Promise.all([
     db
@@ -682,13 +684,15 @@ export async function getScan(
   if (!scan) return null;
   const artifactDetail = await loadScanArtifacts(artifactBucket, scan);
   const detailFiles = artifactDetail ? mergeArtifactFiles(files, artifactDetail.files, id) : files;
+  const responseFiles =
+    (options.includeFileSamples ?? true) ? detailFiles : detailFiles.map(stripFileSampleForList);
   const diff = artifactDetail?.diff ?? diffForFindingAnnotations(scan.summaryJson, detailFiles);
   const annotatedFindings = annotateFindingsWithDiffStatus(findings, diff, {
     persistedAnnotations: readFindingAnnotations(scan.summaryJson),
   });
   return {
     scan,
-    files: detailFiles,
+    files: responseFiles,
     findings: annotatedFindings,
     riskSummary:
       scan.status === "complete"
@@ -700,6 +704,63 @@ export async function getScan(
         : null,
     events: events.map(redactScanEventForClient),
   };
+}
+
+export async function getScanFile(
+  db: AppDb,
+  id: string,
+  organizationId: string,
+  path: string,
+  artifactBucket?: R2Bucket,
+) {
+  const [scanRows, fileRows] = await Promise.all([
+    db
+      .select()
+      .from(scans)
+      .where(and(eq(scans.id, id), eq(scans.organizationId, organizationId)))
+      .limit(1),
+    db
+      .select()
+      .from(scanFiles)
+      .where(and(eq(scanFiles.scanId, id), eq(scanFiles.path, path)))
+      .limit(1),
+  ]);
+  const scan = scanRows[0];
+  if (!scan) return null;
+
+  const file = fileRows[0] ?? null;
+  const artifactFile = await loadScanArtifactFile(artifactBucket, scan, path);
+  if (!file && !artifactFile) return null;
+  if (!artifactFile) return file;
+  return mergeArtifactFiles(file ? [file] : [], [artifactFile], id)[0] ?? null;
+}
+
+export async function getScanStatus(db: AppDb, id: string, organizationId: string) {
+  const [scan] = await db
+    .select()
+    .from(scans)
+    .where(and(eq(scans.id, id), eq(scans.organizationId, organizationId)))
+    .limit(1);
+  return scan ?? null;
+}
+
+export async function getScanCompareData(db: AppDb, id: string, organizationId: string) {
+  const [scanRows, files, findings] = await Promise.all([
+    db
+      .select()
+      .from(scans)
+      .where(and(eq(scans.id, id), eq(scans.organizationId, organizationId)))
+      .limit(1),
+    db.select().from(scanFiles).where(eq(scanFiles.scanId, id)),
+    db.select().from(scanFindings).where(eq(scanFindings.scanId, id)),
+  ]);
+  const scan = scanRows[0];
+  if (!scan) return null;
+  return { scan, files: files.map(stripFileSampleForList), findings };
+}
+
+function stripFileSampleForList<T extends { textSample: string | null }>(file: T): T {
+  return file.textSample === null ? file : { ...file, textSample: null };
 }
 
 function mergeArtifactFiles(

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -177,6 +177,11 @@ export const scans = sqliteTable(
       table.decision,
       table.createdAt,
     ),
+    orgCreatedIdx: index("scans_org_created_idx").on(
+      table.organizationId,
+      table.createdAt,
+      table.id,
+    ),
   }),
 );
 

--- a/server/lib/active-organization.ts
+++ b/server/lib/active-organization.ts
@@ -1,7 +1,7 @@
 import type { Context } from "hono";
 import { and, eq } from "drizzle-orm";
 import type { AppDb } from "../db";
-import { ensurePersonalOrganization, getOrganizationRole } from "../db";
+import { ensurePersonalOrganization } from "../db";
 import { organizationMembers } from "../db/schema";
 import { personalOrganizationId } from "./ownership";
 import type { OrganizationRole } from "./roles";
@@ -37,16 +37,35 @@ export interface ActiveOrganizationContext {
   role: OrganizationRole;
 }
 
-// Resolve the active organization and the caller's role within it. Because
-// requireActiveOrganization only returns an org the caller is a member of (or
-// their own personal org), a membership row always exists, so role defaults to
-// "member" only defensively.
+// Resolve the active organization and role in one membership read; falling back
+// to the caller's personal organization lazily creates its owner membership.
 export async function requireActiveOrganizationContext(
   c: Context<{ Bindings: Bindings; Variables: Variables }>,
   db: AppDb,
 ): Promise<ActiveOrganizationContext> {
-  const organizationId = await requireActiveOrganization(c, db);
   const session = c.get("authSession");
-  const role = (await getOrganizationRole(db, organizationId, session.userId)) ?? "member";
-  return { organizationId, role };
+  const requested = c.req.header(ACTIVE_ORG_HEADER)?.trim() || null;
+  if (requested) {
+    const [membership] = await db
+      .select({
+        organizationId: organizationMembers.organizationId,
+        role: organizationMembers.role,
+      })
+      .from(organizationMembers)
+      .where(
+        and(
+          eq(organizationMembers.organizationId, requested),
+          eq(organizationMembers.userId, session.userId),
+        ),
+      )
+      .limit(1);
+    if (membership) {
+      return {
+        organizationId: membership.organizationId,
+        role: membership.role as OrganizationRole,
+      };
+    }
+  }
+  const organizationId = await ensurePersonalOrganization(db, session);
+  return { organizationId, role: "owner" };
 }

--- a/server/lib/compare-cache.ts
+++ b/server/lib/compare-cache.ts
@@ -1,4 +1,5 @@
 import { downloadPublishedTarball } from "./published-tarball";
+import type { RegistryMetadata } from "./registry";
 import { redactFileRecords, redactJson, type FileRecord, type PackageJsonSummary } from "./review";
 
 export interface CachedCompare {
@@ -10,6 +11,8 @@ export interface CachedCompare {
 
 const CACHE_PREFIX = "compare:v3:";
 const CACHE_TTL_SECONDS = 60 * 60 * 24 * 30;
+const METADATA_CACHE_PREFIX = "compare-metadata:v1:";
+const METADATA_CACHE_TTL_SECONDS = 5 * 60;
 
 export async function computeCompareCacheKey(
   registryUrl: string,
@@ -32,6 +35,44 @@ export async function readCompareCache(
   } catch {
     return null;
   }
+}
+
+export async function computeCompareMetadataCacheKey(input: {
+  registryUrl: string;
+  packageName: string;
+  cacheScope: string;
+}): Promise<string> {
+  const data = new TextEncoder().encode(
+    `${input.cacheScope}|${input.registryUrl}|${input.packageName}`,
+  );
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  const hex = [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+  return `${METADATA_CACHE_PREFIX}${hex}`;
+}
+
+export async function readCompareMetadataCache(
+  env: Cloudflare.Env,
+  key: string,
+): Promise<RegistryMetadata | null> {
+  if (!env.COMPARE_CACHE) return null;
+  try {
+    return await env.COMPARE_CACHE.get<RegistryMetadata>(key, "json");
+  } catch {
+    return null;
+  }
+}
+
+export async function writeCompareMetadataCache(
+  env: Cloudflare.Env,
+  ctx: ExecutionContext,
+  key: string,
+  payload: RegistryMetadata,
+) {
+  if (!env.COMPARE_CACHE) return;
+  const write = env.COMPARE_CACHE.put(key, JSON.stringify(payload), {
+    expirationTtl: METADATA_CACHE_TTL_SECONDS,
+  }).catch(() => undefined);
+  ctx.waitUntil(write);
 }
 
 async function writeCompareCache(

--- a/server/lib/scan-artifacts.ts
+++ b/server/lib/scan-artifacts.ts
@@ -50,6 +50,10 @@ export interface ScanArtifactsDetail {
   diff: DiffEntry[];
 }
 
+export interface ScanArtifactsManifestDetail {
+  manifest: ScanArtifactsManifest;
+}
+
 export function scanArtifactReadBucket(
   env: Pick<Cloudflare.Env, "ARTIFACTS" | "SCAN_ARTIFACT_READS_DISABLED">,
 ): R2Bucket | undefined {
@@ -232,6 +236,66 @@ export async function loadScanArtifacts(
   bucket: R2Bucket | undefined,
   scan: ScanArtifactScanRow,
 ): Promise<ScanArtifactsDetail | null> {
+  const manifestDetail = await loadScanArtifactsManifest(bucket, scan);
+  if (!manifestDetail) return null;
+
+  try {
+    const [filesText, diffText] = await Promise.all([
+      readVerifiedJsonText(bucket as R2Bucket, {
+        ...manifestDetail.manifest.artifacts.files,
+        scanId: scan.id,
+        kind: "files",
+      }),
+      readVerifiedJsonText(bucket as R2Bucket, {
+        ...manifestDetail.manifest.artifacts.diff,
+        scanId: scan.id,
+        kind: "diff",
+      }),
+    ]);
+
+    const files = parseFilesArtifact(filesText, scan.id);
+    const diff = parseDiffArtifact(diffText, scan.id);
+    if (!files || !diff) {
+      emitArtifactFallback("artifact_payload_invalid", scan);
+      return null;
+    }
+    return { files, diff };
+  } catch (err) {
+    emitArtifactFallback("read_failed", scan, { error: describeOperationalError(err) });
+    return null;
+  }
+}
+
+export async function loadScanArtifactFile(
+  bucket: R2Bucket | undefined,
+  scan: ScanArtifactScanRow,
+  path: string,
+): Promise<ScanArtifactFileRow | null> {
+  const manifestDetail = await loadScanArtifactsManifest(bucket, scan);
+  if (!manifestDetail) return null;
+
+  try {
+    const filesText = await readVerifiedJsonText(bucket as R2Bucket, {
+      ...manifestDetail.manifest.artifacts.files,
+      scanId: scan.id,
+      kind: "files",
+    });
+    const files = parseFilesArtifact(filesText, scan.id);
+    if (!files) {
+      emitArtifactFallback("artifact_payload_invalid", scan);
+      return null;
+    }
+    return files.find((file) => file.path === path) ?? null;
+  } catch (err) {
+    emitArtifactFallback("read_failed", scan, { error: describeOperationalError(err) });
+    return null;
+  }
+}
+
+async function loadScanArtifactsManifest(
+  bucket: R2Bucket | undefined,
+  scan: ScanArtifactScanRow,
+): Promise<ScanArtifactsManifestDetail | null> {
   if (!bucket || !hasArtifactMetadata(scan)) return null;
 
   try {
@@ -255,41 +319,7 @@ export async function loadScanArtifacts(
       emitArtifactFallback("manifest_invalid", scan);
       return null;
     }
-
-    const reportText = await readVerifiedJsonText(bucket, {
-      ...manifest.artifacts.report,
-      scanId: scan.id,
-      kind: "report",
-    });
-    const reportDigest = await sha256Hex(reportText);
-    if (reportDigest !== scan.reportDigest) {
-      emitArtifactFallback("report_digest_mismatch", scan, {
-        expectedDigest: scan.reportDigest,
-        actualDigest: reportDigest,
-      });
-      return null;
-    }
-
-    const [filesText, diffText] = await Promise.all([
-      readVerifiedJsonText(bucket, {
-        ...manifest.artifacts.files,
-        scanId: scan.id,
-        kind: "files",
-      }),
-      readVerifiedJsonText(bucket, {
-        ...manifest.artifacts.diff,
-        scanId: scan.id,
-        kind: "diff",
-      }),
-    ]);
-
-    const files = parseFilesArtifact(filesText, scan.id);
-    const diff = parseDiffArtifact(diffText, scan.id);
-    if (!files || !diff) {
-      emitArtifactFallback("artifact_payload_invalid", scan);
-      return null;
-    }
-    return { files, diff };
+    return { manifest };
   } catch (err) {
     emitArtifactFallback("read_failed", scan, { error: describeOperationalError(err) });
     return null;

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -404,6 +404,8 @@ interface ReviewedPackage {
   releaseRisk: RiskLevel;
 }
 
+const GATE_PACKAGE_SCAN_CONCURRENCY = 3;
+
 /**
  * Run one scan per discovered package, each against its own baseline, and link
  * every scan back to the gate via `scans.gate_id`. A monorepo release bundle
@@ -419,9 +421,8 @@ async function reviewGatePackages(
   const { env, executionCtx, db } = ctx;
   const { gate, ownerUserId, packages } = args;
   const organizationId = gate.organizationId;
-  const reviewed: ReviewedPackage[] = [];
 
-  for (const pkg of packages) {
+  return mapWithConcurrency(packages, GATE_PACKAGE_SCAN_CONCURRENCY, async (pkg) => {
     const { candidate, packageAdapter } = pkg;
     const scanId = crypto.randomUUID();
     const stageId = `workflow-gate:${gate.id}:${candidate.ecosystem}:${candidate.package.name}`;
@@ -440,22 +441,39 @@ async function reviewGatePackages(
         packageAdapter,
         { scanId, stageId, organizationId, ...candidate.pipelineInput },
       );
-      reviewed.push({
+      return {
         scanId,
         packageName: result.package.name,
         version: result.package.stagedVersion,
         releaseRisk: result.riskSummary.releaseRisk,
-      });
+      };
     } catch (err) {
       await markScanFailed(db, scanId, organizationId, classifyScanError(err));
       throw err;
     }
-  }
-
-  return reviewed;
+  });
 }
 
 // ── Internals ────────────────────────────────────────────────────────────────
+
+async function mapWithConcurrency<T, U>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<U>,
+): Promise<U[]> {
+  const results = new Map<number, U>();
+  let next = 0;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    for (;;) {
+      const index = next;
+      next += 1;
+      if (index >= items.length) return;
+      results.set(index, await worker(items[index]));
+    }
+  });
+  await Promise.all(workers);
+  return items.map((_, index) => results.get(index)!);
+}
 
 async function rejectGateForArtifactError(
   env: Cloudflare.Env,

--- a/server/lib/workflow-gates/resolve.ts
+++ b/server/lib/workflow-gates/resolve.ts
@@ -3,6 +3,8 @@ import { downloadInSandboxInline } from "../sandbox";
 import { AMBIGUOUS_ARCHIVE_ECOSYSTEM, detectArchiveEcosystems } from "./registry";
 import type { ParsedGateArtifact } from "./types";
 
+const GATE_ARTIFACT_PARSE_CONCURRENCY = 4;
+
 /**
  * Parse every verified bundle artifact once in the credentials-free sandbox and
  * resolve each one's ecosystem.
@@ -24,8 +26,7 @@ export async function resolveBundleArtifacts(
   ctx: ExecutionContext,
   bundle: ResolvedReleaseBundle,
 ): Promise<ParsedGateArtifact[]> {
-  const resolved: ParsedGateArtifact[] = [];
-  for (const file of bundle.artifacts) {
+  return mapWithConcurrency(bundle.artifacts, GATE_ARTIFACT_PARSE_CONCURRENCY, async (file) => {
     const format = file.path.toLowerCase().endsWith(".whl") ? "zip" : "tgz";
     const parsed = await downloadInSandboxInline(env, ctx, { bytes: file.bytes, format });
     const contents = { files: parsed.files, packageJson: parsed.packageJson ?? null };
@@ -55,7 +56,7 @@ export async function resolveBundleArtifacts(
       kind = claims[0].kind;
     }
 
-    resolved.push({
+    return {
       path: file.path,
       sha256: file.sha256,
       ecosystem,
@@ -63,7 +64,25 @@ export async function resolveBundleArtifacts(
       files: parsed.files,
       packageJson: parsed.packageJson ?? null,
       ...(parsed.suspiciousEntries ? { suspiciousEntries: parsed.suspiciousEntries } : {}),
-    });
-  }
-  return resolved;
+    };
+  });
+}
+
+async function mapWithConcurrency<T, U>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<U>,
+): Promise<U[]> {
+  const results = new Map<number, U>();
+  let next = 0;
+  const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+    for (;;) {
+      const index = next;
+      next += 1;
+      if (index >= items.length) return;
+      results.set(index, await worker(items[index]));
+    }
+  });
+  await Promise.all(workers);
+  return items.map((_, index) => results.get(index)!);
 }

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -13,6 +13,9 @@ import {
   getNpmConnection,
   getOrganizationRole,
   getScan,
+  getScanCompareData,
+  getScanFile,
+  getScanStatus,
   listScans,
   recordScanDecision,
   recordScanEvent,
@@ -23,11 +26,22 @@ import {
 } from "../lib/active-organization";
 import { backfillScanArtifactsBatch } from "../lib/scan-artifact-backfill";
 import { scanArtifactReadBucket } from "../lib/scan-artifacts";
-import { loadCompare, stripTextSamples } from "../lib/compare-cache";
+import {
+  computeCompareMetadataCacheKey,
+  loadCompare,
+  readCompareMetadataCache,
+  stripTextSamples,
+  writeCompareMetadataCache,
+} from "../lib/compare-cache";
 import { rateLimitResponse } from "../lib/http";
 import { allowInsecureLocalRegistry, getOrganizationNpmToken } from "../lib/npm-connection";
 import { isPublishedTarballUrlAllowed } from "../lib/published-tarball";
-import { compareSemver, fetchPackageMetadata, pickPreviousVersion } from "../lib/registry";
+import {
+  compareSemver,
+  fetchPackageMetadata,
+  pickPreviousVersion,
+  type RegistryMetadata,
+} from "../lib/registry";
 import { annotateFindingsWithDiffStatus, createPackageDiff, type FileRecord } from "../lib/review";
 import { describeOperationalError, emitOperationalEvent } from "../lib/observability";
 import { parseScanInput } from "../lib/scan-input";
@@ -236,7 +250,9 @@ scansRoutes.get("/:id", async (c) => {
   const db = createDb(c.env.DB);
   const session = c.get("authSession");
   const organizationId = await requireActiveOrganization(c, db);
-  const scan = await getScan(db, c.req.param("id"), organizationId, scanArtifactReadBucket(c.env));
+  const scan = await getScan(db, c.req.param("id"), organizationId, scanArtifactReadBucket(c.env), {
+    includeFileSamples: false,
+  });
   if (!scan) return c.json({ error: "not found" }, 404);
   if (c.req.query("poll") !== "1") {
     await recordScanEvent(db, {
@@ -248,6 +264,30 @@ scansRoutes.get("/:id", async (c) => {
     });
   }
   return c.json(scan);
+});
+
+scansRoutes.get("/:id/status", async (c) => {
+  const db = createDb(c.env.DB);
+  const organizationId = await requireActiveOrganization(c, db);
+  const scan = await getScanStatus(db, c.req.param("id"), organizationId);
+  if (!scan) return c.json({ error: "not found" }, 404);
+  return c.json({ scan });
+});
+
+scansRoutes.get("/:id/file", async (c) => {
+  const path = c.req.query("path") || "";
+  if (!path) return c.json({ error: "path is required" }, 400);
+  const db = createDb(c.env.DB);
+  const organizationId = await requireActiveOrganization(c, db);
+  const file = await getScanFile(
+    db,
+    c.req.param("id"),
+    organizationId,
+    path,
+    scanArtifactReadBucket(c.env),
+  );
+  if (!file) return c.json({ error: "file not found in scan" }, 404);
+  return c.json({ file }, 200, { "cache-control": "private, max-age=300" });
 });
 
 scansRoutes.get("/:id/report.json", async (c) => {
@@ -286,14 +326,13 @@ scansRoutes.get("/:id/versions", async (c) => {
   const db = createDb(c.env.DB);
   const session = c.get("authSession");
   const organizationId = await requireActiveOrganization(c, db);
-  // Metadata-only read (package name/versions) — skip the R2 artifact load.
-  const scan = await getScan(db, c.req.param("id"), organizationId);
+  const scan = await getScanStatus(db, c.req.param("id"), organizationId);
   if (!scan) return c.json({ error: "not found" }, 404);
-  if (!scan.scan.packageName) {
+  if (!scan.packageName) {
     return c.json({
       packageName: null,
-      stagedVersion: scan.scan.stagedVersion ?? null,
-      defaultPreviousVersion: scan.scan.previousVersion ?? null,
+      stagedVersion: scan.stagedVersion ?? null,
+      defaultPreviousVersion: scan.previousVersion ?? null,
       versions: [],
     });
   }
@@ -321,21 +360,24 @@ scansRoutes.get("/:id/versions", async (c) => {
     throw err;
   }
 
-  const metadata = await fetchPackageMetadata(c.env, scan.scan.packageName, {
+  const registryUrl = connection?.registryUrl || c.env.NPM_REGISTRY || "https://registry.npmjs.org";
+  const metadata = await fetchPackageMetadataCached(c, {
+    packageName: scan.packageName,
+    registryUrl,
+    cacheScope: `org:${organizationId}`,
     npmToken: connection?.token,
-    npmRegistry: connection?.registryUrl,
   }).catch((err) => {
     emitOperationalEvent("warn", "registry.metadata_fetch_failed", {
-      packageName: scan.scan.packageName,
+      packageName: scan.packageName,
       error: describeOperationalError(err),
     });
     return null;
   });
   if (!metadata) {
     return c.json({
-      packageName: scan.scan.packageName,
-      stagedVersion: scan.scan.stagedVersion ?? null,
-      defaultPreviousVersion: scan.scan.previousVersion ?? null,
+      packageName: scan.packageName,
+      stagedVersion: scan.stagedVersion ?? null,
+      defaultPreviousVersion: scan.previousVersion ?? null,
       versions: [],
     });
   }
@@ -348,7 +390,7 @@ scansRoutes.get("/:id/versions", async (c) => {
     tagsByVersion.set(version, list);
   }
   const times = metadata.time ?? {};
-  const stagedVersion = scan.scan.stagedVersion ?? null;
+  const stagedVersion = scan.stagedVersion ?? null;
   const versions = Object.keys(metadata.versions ?? {})
     .filter((version) => version !== stagedVersion)
     .sort((a, b) => compareSemver(b, a))
@@ -359,11 +401,10 @@ scansRoutes.get("/:id/versions", async (c) => {
     }));
 
   return c.json({
-    packageName: scan.scan.packageName,
+    packageName: scan.packageName,
     stagedVersion,
     defaultPreviousVersion:
-      scan.scan.previousVersion ??
-      (stagedVersion ? pickPreviousVersion(metadata, stagedVersion) : null),
+      scan.previousVersion ?? (stagedVersion ? pickPreviousVersion(metadata, stagedVersion) : null),
     versions,
   });
 });
@@ -384,7 +425,7 @@ async function resolveCompareContext(
   const db = createDb(c.env.DB);
   const session = c.get("authSession");
   const organizationId = await requireActiveOrganization(c, db);
-  const scan = await getScan(db, scanId, organizationId, scanArtifactReadBucket(c.env));
+  const scan = await getScanCompareData(db, scanId, organizationId);
   if (!scan) return { error: c.json({ error: "not found" }, 404) } as const;
   if (!scan.scan.packageName)
     return { error: c.json({ error: "scan has no package name" }, 400) } as const;
@@ -457,9 +498,12 @@ async function loadCompareArchive(
     throw err;
   }
 
-  const metadata = await fetchPackageMetadata(c.env, ctx.packageName, {
+  const registryUrl = connection?.registryUrl || c.env.NPM_REGISTRY || "https://registry.npmjs.org";
+  const metadata = await fetchPackageMetadataCached(c, {
+    packageName: ctx.packageName,
+    registryUrl,
+    cacheScope: `org:${ctx.organizationId}`,
     npmToken: connection?.token,
-    npmRegistry: connection?.registryUrl,
   }).catch((err) => {
     emitOperationalEvent("warn", "registry.metadata_fetch_failed", {
       packageName: ctx.packageName,
@@ -470,7 +514,6 @@ async function loadCompareArchive(
   const tarballUrl = metadata?.versions?.[ctx.version]?.dist?.tarball;
   if (!tarballUrl) return { error: c.json({ error: "unknown version" }, 404) } as const;
 
-  const registryUrl = connection?.registryUrl || c.env.NPM_REGISTRY || "https://registry.npmjs.org";
   const allowInsecureLocalhost = allowInsecureLocalRegistry(c.env);
   if (!isPublishedTarballUrlAllowed(tarballUrl, registryUrl, allowInsecureLocalhost)) {
     return {
@@ -489,8 +532,29 @@ async function loadCompareArchive(
   return { cached } as const;
 }
 
+async function fetchPackageMetadataCached(
+  c: import("hono").Context<{ Bindings: Bindings; Variables: Variables }>,
+  input: {
+    packageName: string;
+    registryUrl: string;
+    cacheScope: string;
+    npmToken?: string;
+  },
+): Promise<RegistryMetadata> {
+  const key = await computeCompareMetadataCacheKey(input);
+  const cached = await readCompareMetadataCache(c.env, key);
+  if (cached) return cached;
+
+  const metadata = await fetchPackageMetadata(c.env, input.packageName, {
+    npmToken: input.npmToken,
+    npmRegistry: input.registryUrl,
+  });
+  await writeCompareMetadataCache(c.env, c.executionCtx, key, metadata);
+  return metadata;
+}
+
 function buildCompareFindingAnnotations(
-  scan: NonNullable<Awaited<ReturnType<typeof getScan>>>,
+  scan: NonNullable<Awaited<ReturnType<typeof getScanCompareData>>>,
   previousFiles: FileRecord[],
 ) {
   const stagedFiles = scanFilesToFileRecords(scan.files);

--- a/server/routes/slack.ts
+++ b/server/routes/slack.ts
@@ -30,11 +30,15 @@ import {
   renderSlackTestMessage,
   signSlackState,
   slackRedirectUri,
+  type SlackChannel,
   verifySlackState,
 } from "../lib/slack";
 import type { Bindings, Variables } from "../types";
 
 export const slackRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+const SLACK_CHANNEL_CACHE_TTL_MS = 60_000;
+const slackChannelCache = new Map<string, { channels: SlackChannel[]; expiresAt: number }>();
 
 const MAX_CHANNEL_ID_LENGTH = 64;
 const MAX_CHANNEL_NAME_LENGTH = 80;
@@ -167,11 +171,23 @@ slackRoutes.get("/channels", async (c) => {
     ciphertext: secret.botTokenCiphertext,
     nonce: secret.botTokenNonce,
   });
+  const cacheKey = `${organizationId}:${secret.teamId}`;
+  const cached = slackChannelCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) {
+    return c.json({ channels: cached.channels }, 200, {
+      "cache-control": "private, max-age=60",
+    });
+  }
   const result = await listSlackPublicChannels(botToken);
   if (!result.ok) {
     return c.json({ error: "could not list Slack channels", reason: result.error }, 502);
   }
-  return c.json({ channels: result.channels ?? [] });
+  const channels = result.channels ?? [];
+  slackChannelCache.set(cacheKey, {
+    channels,
+    expiresAt: Date.now() + SLACK_CHANNEL_CACHE_TTL_MS,
+  });
+  return c.json({ channels }, 200, { "cache-control": "private, max-age=60" });
 });
 
 slackRoutes.put("/channel", async (c) => {

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -34,6 +34,14 @@ export interface ScanCompareFileResponse {
   file: FileRecord;
 }
 
+export interface ScanStatusResponse {
+  scan: PersistedScanDetail["scan"];
+}
+
+export interface ScanFileResponse {
+  file: PersistedScanDetail["files"][number];
+}
+
 export type ScanDecision = "publish" | "no_publish";
 export type ScanDecisionFilter = "undecided" | "publish" | "no_publish" | "all";
 
@@ -155,6 +163,15 @@ export function getScan(
   return apiFetch<PersistedScanDetail>(`/api/v1/scans/${encodeURIComponent(id)}${suffix}`);
 }
 
+export function getScanStatus(id: string): Promise<ScanStatusResponse> {
+  return apiFetch<ScanStatusResponse>(`/api/v1/scans/${encodeURIComponent(id)}/status`);
+}
+
+export function getScanFile(id: string, path: string): Promise<ScanFileResponse> {
+  const query = `?path=${encodeURIComponent(path)}`;
+  return apiFetch<ScanFileResponse>(`/api/v1/scans/${encodeURIComponent(id)}/file${query}`);
+}
+
 export function getScanVersions(id: string): Promise<ScanVersionsResponse> {
   return apiFetch<ScanVersionsResponse>(`/api/v1/scans/${encodeURIComponent(id)}/versions`);
 }
@@ -257,6 +274,7 @@ export const ScanDetailModel = createModel((id: string) => {
   const versions = signal<ScanVersionsResponse | null>(null);
   const selectedVersion = signal<string | null>(null);
   const compareCache = signal<Record<string, ScanCompareResponse>>({});
+  const stagedFileContentCache = signal<Record<string, PersistedScanDetail["files"][number]>>({});
   const fileContentCache = signal<Record<string, FileRecord>>({});
   const compareLoading = signal(false);
   const fileLoading = signal(false);
@@ -334,11 +352,27 @@ export const ScanDetailModel = createModel((id: string) => {
   async function pollDetail(): Promise<boolean> {
     const id = scanId.peek();
     try {
-      const data = await getScan(id, { poll: true });
-      detail.value = data;
+      const data = await getScanStatus(id);
+      const current = detail.peek();
+      if (data.scan.status === "pending" || data.scan.status === "running") {
+        detail.value = current
+          ? {
+              ...current,
+              scan: data.scan,
+            }
+          : {
+              scan: data.scan,
+              files: [],
+              findings: [],
+              events: [],
+            };
+      } else {
+        detail.value = await getScan(id, { poll: true });
+      }
       error.value = null;
-      if (selectedPath.peek() === null) {
-        selectedPath.value = pickInitialPath(data);
+      const updated = detail.peek();
+      if (updated && selectedPath.peek() === null) {
+        selectedPath.value = pickInitialPath(updated);
       }
       return true;
     } catch (err) {
@@ -371,6 +405,7 @@ export const ScanDetailModel = createModel((id: string) => {
     selectedVersion,
     compareCache,
     fileContentCache,
+    stagedFileContentCache,
     compareLoading,
     fileLoading,
     compareError,
@@ -522,6 +557,23 @@ export const ScanDetailModel = createModel((id: string) => {
       try {
         const data = await getScanCompareFile(id, version, path);
         this.fileContentCache.value = { ...this.fileContentCache.peek(), [key]: data.file };
+      } catch (err) {
+        this.compareError.value = errorMessage(err);
+      } finally {
+        this.fileLoading.value = false;
+      }
+    },
+
+    async loadStagedFile(path: string): Promise<void> {
+      if (this.stagedFileContentCache.peek()[path]) return;
+      const id = this.scanId.peek();
+      this.fileLoading.value = true;
+      try {
+        const data = await getScanFile(id, path);
+        this.stagedFileContentCache.value = {
+          ...this.stagedFileContentCache.peek(),
+          [path]: data.file,
+        };
       } catch (err) {
         this.compareError.value = errorMessage(err);
       } finally {

--- a/src/pages/Dashboard/ScanDetail/DiffWorkbench.tsx
+++ b/src/pages/Dashboard/ScanDetail/DiffWorkbench.tsx
@@ -11,6 +11,7 @@ import { selectDiffWorkbenchState } from "./diff-helpers";
 
 export function DiffWorkbench({
   entry,
+  stagedMeta,
   staged,
   previousMeta,
   previousContent,
@@ -21,6 +22,7 @@ export function DiffWorkbench({
   findings,
 }: {
   entry: DiffEntry | null;
+  stagedMeta: PersistedScanDetail["files"][number] | null;
   staged: PersistedScanDetail["files"][number] | null;
   previousMeta: FileRecord | null;
   previousContent: FileRecord | null;
@@ -37,7 +39,9 @@ export function DiffWorkbench({
   const state = selectDiffWorkbenchState({
     hasEntry: true,
     entryStatus: entry.status,
-    hasStaged: Boolean(staged),
+    hasStagedMeta: Boolean(stagedMeta),
+    hasStagedContent: Boolean(staged),
+    stagedIsBinary: isPersistedBinary(stagedMeta),
     hasPreviousMeta: Boolean(previousMeta),
     hasPreviousContent: Boolean(previousContent),
     previousIsBinary: Boolean(previousMeta?.flags?.includes("binary")),
@@ -70,6 +74,10 @@ export function DiffWorkbench({
       findings={findings}
     />
   );
+}
+
+function isPersistedBinary(file: PersistedScanDetail["files"][number] | null): boolean {
+  return Array.isArray(file?.flagsJson) && (file.flagsJson as unknown[]).includes("binary");
 }
 
 // A centered processing block that fills the diff panel so the "still working"

--- a/src/pages/Dashboard/ScanDetail/diff-helpers.ts
+++ b/src/pages/Dashboard/ScanDetail/diff-helpers.ts
@@ -54,7 +54,9 @@ export type DiffWorkbenchState =
 export function selectDiffWorkbenchState(input: {
   hasEntry: boolean;
   entryStatus: DiffEntry["status"] | null;
-  hasStaged: boolean;
+  hasStagedMeta: boolean;
+  hasStagedContent: boolean;
+  stagedIsBinary: boolean;
   hasPreviousMeta: boolean;
   hasPreviousContent: boolean;
   previousIsBinary: boolean;
@@ -66,6 +68,7 @@ export function selectDiffWorkbenchState(input: {
   }
 
   const needsPrevious = input.entryStatus !== "added";
+  const needsStaged = input.entryStatus !== "removed";
 
   // Previous version still being fetched via the sandbox. Keyed off
   // compareLoading too (not just compareReady) so a stale cache entry from a
@@ -96,7 +99,15 @@ export function selectDiffWorkbenchState(input: {
     };
   }
 
-  if (!input.hasStaged && !input.hasPreviousContent && !input.hasPreviousMeta) {
+  if (needsStaged && input.hasStagedMeta && !input.stagedIsBinary && !input.hasStagedContent) {
+    return {
+      kind: "processing",
+      title: "Loading file diff",
+      detail: "fetching file contents",
+    };
+  }
+
+  if (!input.hasStagedMeta && !input.hasPreviousContent && !input.hasPreviousMeta) {
     return { kind: "empty", message: "No file content available." };
   }
 

--- a/src/pages/Dashboard/ScanDetail/hooks/useScanFileContent.ts
+++ b/src/pages/Dashboard/ScanDetail/hooks/useScanFileContent.ts
@@ -1,24 +1,54 @@
 import { useComputed, useSignalEffect, type ReadonlySignal } from "@preact/signals";
 import type { FileRecord } from "../../../../../server/lib/review";
-import type { ScanDetailModelInstance } from "../../../../models/scan";
+import type { PersistedScanDetail, ScanDetailModelInstance } from "../../../../models/scan";
+
+type PersistedScanFile = PersistedScanDetail["files"][number];
 
 export interface ScanFileContent {
+  stagedFileMeta: ReadonlySignal<PersistedScanFile | null>;
+  stagedFile: ReadonlySignal<PersistedScanFile | null>;
   previousFileMeta: ReadonlySignal<FileRecord | null>;
   previousFile: ReadonlySignal<FileRecord | null>;
 }
 
-// Owns the previous-file metadata/content computeds and lazily fetches the
-// previous file body once the user has picked both a file and a version.
+// Owns file metadata/content computeds and lazily fetches file bodies once the
+// user has selected a path. The detail payload carries metadata only.
 export function useScanFileContent(
   model: ScanDetailModelInstance,
   selectedPath: ReadonlySignal<string | null>,
   selectedVersion: ReadonlySignal<string | null>,
 ): ScanFileContent {
+  const stagedFileMeta = useComputed(() => {
+    const path = selectedPath.value;
+    const detail = model.detail.value;
+    if (!path) return null;
+    return detail?.files.find((file) => file.path === path) ?? null;
+  });
+
+  const stagedFile = useComputed(() => {
+    const path = selectedPath.value;
+    const cache = model.stagedFileContentCache.value;
+    const meta = stagedFileMeta.value;
+    if (!path) return null;
+    return cache[path] ?? (meta?.textSample || isPersistedBinary(meta) ? meta : null);
+  });
+
   const previousFileMeta = useComputed(() => {
     const path = selectedPath.value;
     const compare = model.compare.value;
     if (!path || !compare) return null;
     return compare.files.find((file) => file.path === path) ?? null;
+  });
+
+  useSignalEffect(() => {
+    const path = selectedPath.value;
+    const meta = stagedFileMeta.value;
+    const cache = model.stagedFileContentCache.value;
+    if (!path) return;
+    if (cache[path]) return;
+    if (!meta) return;
+    if (meta.textSample || isPersistedBinary(meta)) return;
+    void model.loadStagedFile(path);
   });
 
   const previousFileKey = useComputed(() => {
@@ -47,5 +77,9 @@ export function useScanFileContent(
     void model.loadPreviousFile(version, path);
   });
 
-  return { previousFileMeta, previousFile };
+  return { stagedFileMeta, stagedFile, previousFileMeta, previousFile };
+}
+
+function isPersistedBinary(file: PersistedScanFile | null): boolean {
+  return Array.isArray(file?.flagsJson) && (file.flagsJson as unknown[]).includes("binary");
 }

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -166,14 +166,7 @@ export default function ScanDetailPage() {
   // that feeds the inline annotations and the risk-signals index.
   const findingCounts = useComputed(() => findingCountsByPath(findingsWithDiffStatus.value));
 
-  const stagedFile = useComputed(() => {
-    const path = model.selectedPath.value;
-    const detail = model.detail.value;
-    if (!path) return null;
-    return detail?.files.find((file) => file.path === path) ?? null;
-  });
-
-  const { previousFileMeta, previousFile } = useScanFileContent(
+  const { stagedFileMeta, stagedFile, previousFileMeta, previousFile } = useScanFileContent(
     model,
     model.selectedPath,
     model.selectedVersion,
@@ -354,6 +347,7 @@ export default function ScanDetailPage() {
                 <SectionLabel>File diff</SectionLabel>
                 <DiffWorkbench
                   entry={selectedEntry.value}
+                  stagedMeta={stagedFileMeta.value}
                   staged={stagedFile.value}
                   previousMeta={previousFileMeta.value}
                   previousContent={previousFile.value}

--- a/test/scan-detail-diff-helpers.test.mjs
+++ b/test/scan-detail-diff-helpers.test.mjs
@@ -96,7 +96,9 @@ describe("selectDiffWorkbenchState", () => {
   const base = {
     hasEntry: true,
     entryStatus: "modified",
-    hasStaged: true,
+    hasStagedMeta: true,
+    hasStagedContent: true,
+    stagedIsBinary: false,
     hasPreviousMeta: true,
     hasPreviousContent: true,
     previousIsBinary: false,
@@ -132,6 +134,12 @@ describe("selectDiffWorkbenchState", () => {
     expect(state.title).toBe("Loading file diff");
   });
 
+  test("shows processing while staged file content is loading", () => {
+    const state = selectDiffWorkbenchState({ ...base, hasStagedContent: false });
+    expect(state.kind).toBe("processing");
+    expect(state.title).toBe("Loading file diff");
+  });
+
   test("renders the diff for an added file without waiting on a previous version", () => {
     const state = selectDiffWorkbenchState({
       ...base,
@@ -139,6 +147,15 @@ describe("selectDiffWorkbenchState", () => {
       compareReady: false,
       hasPreviousMeta: false,
       hasPreviousContent: false,
+    });
+    expect(state).toEqual({ kind: "diff" });
+  });
+
+  test("renders the diff for a binary staged file instead of waiting on its body", () => {
+    const state = selectDiffWorkbenchState({
+      ...base,
+      hasStagedContent: false,
+      stagedIsBinary: true,
     });
     expect(state).toEqual({ kind: "diff" });
   });
@@ -167,7 +184,8 @@ describe("selectDiffWorkbenchState", () => {
     const state = selectDiffWorkbenchState({
       ...base,
       entryStatus: "unchanged",
-      hasStaged: false,
+      hasStagedMeta: false,
+      hasStagedContent: false,
       hasPreviousMeta: false,
       hasPreviousContent: false,
     });

--- a/test/workers/scan-artifacts-routes.test.ts
+++ b/test/workers/scan-artifacts-routes.test.ts
@@ -373,9 +373,22 @@ describe("scan artifact backfill route", () => {
     const detail = (await detailRes.json()) as {
       files: Array<{ path: string; textSample: string | null }>;
     };
-    expect(detail.files.find((file) => file.path === "index.js")?.textSample).toContain(
-      "npm_config_user_agent",
-    );
+    expect(detail.files.find((file) => file.path === "index.js")?.textSample).toBeNull();
+
+    const statusRes = await fetchJsonWithSession(app, `/api/v1/scans/${scanId}/status`, {
+      method: "GET",
+    });
+    expect(statusRes.status).toBe(200);
+    await expect(statusRes.json()).resolves.toMatchObject({
+      scan: { id: scanId, status: "complete" },
+    });
+
+    const fileRes = await fetchJsonWithSession(app, `/api/v1/scans/${scanId}/file?path=index.js`, {
+      method: "GET",
+    });
+    expect(fileRes.status).toBe(200);
+    const fileDetail = (await fileRes.json()) as { file: { textSample: string | null } };
+    expect(fileDetail.file.textSample).toContain("npm_config_user_agent");
   });
 
   test("backfills legacy scan artifacts and detail reads survive D1 sample compaction", async () => {
@@ -422,9 +435,14 @@ describe("scan artifact backfill route", () => {
     const detail = (await detailRes.json()) as {
       files: Array<{ path: string; textSample: string | null }>;
     };
-    expect(detail.files.find((file) => file.path === "index.js")?.textSample).toContain(
-      "npm_config_user_agent",
-    );
+    expect(detail.files.find((file) => file.path === "index.js")?.textSample).toBeNull();
+
+    const fileRes = await fetchJsonWithSession(app, `/api/v1/scans/${scanId}/file?path=index.js`, {
+      method: "GET",
+    });
+    expect(fileRes.status).toBe(200);
+    const fileDetail = (await fileRes.json()) as { file: { textSample: string | null } };
+    expect(fileDetail.file.textSample).toContain("npm_config_user_agent");
 
     const second = await fetchJsonWithSession(app, "/api/v1/scans/artifacts/backfill", {
       method: "POST",


### PR DESCRIPTION
## Summary

- Makes scan detail metadata-first: `GET /api/v1/scans/:id` no longer hydrates staged file samples, polling uses `GET /status`, and the UI lazy-loads the selected staged body through `GET /file?path=...`.
- Narrows compare/versions request work: compare context reads only scan/files/findings, registry metadata is cached briefly in KV, and scan detail R2 reads skip the canonical report payload unless a file body is requested.
- Parallelizes workflow-gate artifact parsing/package scans with bounded concurrency, removes random rate-limit cleanup, adds lightweight org/Slack caching, and adds `scans_org_created_idx` for all-scan ordering.
- Updates artifact/workflow-gate docs plus route/UI tests for metadata-first detail loading.

## Testing

- `pnpm run verify`
- `pnpm run test:e2e`

Link to Devin session: https://app.devin.ai/sessions/1b57e203bad84769819e99d1b3af2b49
Requested by: @JoviDeCroock