### PR TITLE
Add dashboard prerender shells

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,11 @@ import { hydrate, render } from "preact";
 import { ErrorBoundary, LocationProvider, Route, Router, lazy, prerender as ssr } from "preact-iso";
 import { Toaster } from "./components";
 import { extractPrerenderHead, getPageSeoMetadata } from "./lib/seo";
+import {
+  isDashboardShellRoute,
+  isGeneratedIndexRoute,
+  isHydratedPrerenderRoute,
+} from "./lib/prerender-routes";
 import "./style.css";
 
 const LandingPage = lazy(() => import("./pages/Landing"));
@@ -42,15 +47,13 @@ export function App() {
 }
 
 export function isPrerenderedRoute(pathname: string) {
-  const canonicalPathname =
-    pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+  return isHydratedPrerenderRoute(pathname);
+}
 
-  return (
-    canonicalPathname === "/" ||
-    canonicalPathname === "/login" ||
-    canonicalPathname === "/register" ||
-    canonicalPathname === "/docs"
-  );
+export { isGeneratedIndexRoute };
+
+function emptyAppShell() {
+  return { html: "", links: new Set<string>() };
 }
 
 if (typeof window !== "undefined") {
@@ -65,10 +68,13 @@ if (typeof window !== "undefined") {
 }
 
 export async function prerender(data: Record<string, unknown>) {
+  const prerenderUrl = typeof data.url === "string" ? data.url : location.pathname;
+  const pathname = new URL(prerenderUrl, "http://localhost").pathname;
+  if (isDashboardShellRoute(pathname)) return emptyAppShell();
+
   const result = await ssr(<App {...data} />);
   const extractedHead = extractPrerenderHead();
-  const prerenderUrl = typeof data.url === "string" ? data.url : location.pathname;
-  const shouldEmitHead = getPageSeoMetadata(new URL(prerenderUrl, "http://localhost").pathname);
+  const shouldEmitHead = getPageSeoMetadata(pathname);
   const head = shouldEmitHead ? extractedHead : undefined;
 
   // The prerender crawler follows every rendered <a href> as a route to prerender.
@@ -76,7 +82,7 @@ export async function prerender(data: Record<string, unknown>) {
   // page's authenticated "Open settings" link) don't generate stray HTML.
   const links = new Set<string>();
   for (const href of result.links ?? []) {
-    if (isPrerenderedRoute(new URL(href, "http://localhost").pathname)) {
+    if (isGeneratedIndexRoute(new URL(href, "http://localhost").pathname)) {
       links.add(href);
     }
   }

--- a/src/lib/prerender-routes.ts
+++ b/src/lib/prerender-routes.ts
@@ -1,0 +1,36 @@
+export const HYDRATED_PRERENDER_ROUTES = ["/", "/login", "/register", "/docs"] as const;
+
+export const DASHBOARD_SHELL_ROUTES = [
+  "/dashboard",
+  "/dashboard/account",
+  "/dashboard/invite",
+  "/dashboard/settings",
+  "/dashboard/settings/github-app/callback",
+] as const;
+
+export const ADDITIONAL_PRERENDER_ROUTES = [
+  "/login",
+  "/register",
+  "/docs",
+  ...DASHBOARD_SHELL_ROUTES,
+] as const;
+
+export function isHydratedPrerenderRoute(pathname: string) {
+  return routeIncludes(HYDRATED_PRERENDER_ROUTES, pathname);
+}
+
+export function isDashboardShellRoute(pathname: string) {
+  return routeIncludes(DASHBOARD_SHELL_ROUTES, pathname);
+}
+
+export function isGeneratedIndexRoute(pathname: string) {
+  return isHydratedPrerenderRoute(pathname) || isDashboardShellRoute(pathname);
+}
+
+function routeIncludes(routes: readonly string[], pathname: string) {
+  return routes.includes(canonicalizeRoutePath(pathname));
+}
+
+function canonicalizeRoutePath(pathname: string) {
+  return pathname.length > 1 && pathname.endsWith("/") ? pathname.slice(0, -1) : pathname;
+}

--- a/test/prerender-routes.test.ts
+++ b/test/prerender-routes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isPrerenderedRoute } from "../src";
+import { isGeneratedIndexRoute, isPrerenderedRoute, prerender } from "../src";
 import { docsPageSeo, getPageSeoMetadata, homePageSeo } from "../src/lib/seo";
 
 describe("isPrerenderedRoute", () => {
@@ -13,9 +13,25 @@ describe("isPrerenderedRoute", () => {
     expect(isPrerenderedRoute("/docs/")).toBe(true);
   });
 
-  it("does not hydrate pages that are not prerendered by the build", () => {
+  it("matches generated dashboard shell pages with or without canonical trailing slashes", () => {
+    expect(isGeneratedIndexRoute("/dashboard")).toBe(true);
+    expect(isGeneratedIndexRoute("/dashboard/")).toBe(true);
+    expect(isGeneratedIndexRoute("/dashboard/account")).toBe(true);
+    expect(isGeneratedIndexRoute("/dashboard/invite")).toBe(true);
+    expect(isGeneratedIndexRoute("/dashboard/settings")).toBe(true);
+    expect(isGeneratedIndexRoute("/dashboard/settings/github-app/callback")).toBe(true);
+  });
+
+  it("hydrates only pages with prerendered app markup", () => {
     expect(isPrerenderedRoute("/dashboard")).toBe(false);
+    expect(isPrerenderedRoute("/dashboard/settings")).toBe(false);
     expect(isPrerenderedRoute("/docs/intro")).toBe(false);
+  });
+
+  it("emits an empty app shell for dashboard route indexes", async () => {
+    const result = await prerender({ url: "/dashboard/settings" });
+
+    expect(result).toEqual({ html: "", links: new Set() });
   });
 });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import { cloudflare } from "@cloudflare/vite-plugin";
 import preact from "@preact/preset-vite";
 import tailwindcss from "@tailwindcss/vite";
+import { ADDITIONAL_PRERENDER_ROUTES } from "./src/lib/prerender-routes";
 
 declare const process: {
   env: {
@@ -25,7 +26,7 @@ export default defineConfig(({ mode }) => {
         prerender: {
           enabled: true,
           renderTarget: "#app",
-          additionalPrerenderRoutes: ["/login", "/register", "/docs"],
+          additionalPrerenderRoutes: Array.from(ADDITIONAL_PRERENDER_ROUTES),
           previewMiddlewareEnabled: true,
           previewMiddlewareFallback: "/404",
         },


### PR DESCRIPTION
## Summary
Dashboard route entrypoints now get generated `index.html` files with an empty `#app` shell, so direct dashboard loads no longer receive the public landing/docs HTML before client render clears it.

The prerender route table is shared between Vite and the client: public routes still hydrate SSR markup, while dashboard shell routes are generated but intentionally client-rendered.

Link to Devin session: https://app.devin.ai/sessions/6a3a0704882940bbaadc6e51d7c9f3ae
Requested by: @JoviDeCroock