### PR TITLE
Serve dashboard shell for deep links

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -48,6 +48,18 @@ const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 const CANONICAL_HOSTNAME = "drydock.org";
 const LEGACY_HOSTNAME = "drydock.resynapse.dev";
 const SERVER_OWNED_PATH_PREFIXES = ["/api", "/webhooks"];
+const DASHBOARD_STATIC_ASSET_PATHS = new Set([
+  "/dashboard",
+  "/dashboard/",
+  "/dashboard/account",
+  "/dashboard/account/",
+  "/dashboard/invite",
+  "/dashboard/invite/",
+  "/dashboard/settings",
+  "/dashboard/settings/",
+  "/dashboard/settings/github-app/callback",
+  "/dashboard/settings/github-app/callback/",
+]);
 
 function canonicalDomainRedirect(request: Request): Response | null {
   const url = new URL(request.url);
@@ -60,6 +72,19 @@ function isServerOwnedPath(path: string): boolean {
   return SERVER_OWNED_PATH_PREFIXES.some(
     (prefix) => path === prefix || path.startsWith(`${prefix}/`),
   );
+}
+
+function assetFallbackRequest(request: Request): Request {
+  const url = new URL(request.url);
+  if (
+    (url.pathname === "/dashboard" || url.pathname.startsWith("/dashboard/")) &&
+    !DASHBOARD_STATIC_ASSET_PATHS.has(url.pathname)
+  ) {
+    url.pathname = "/dashboard/index.html";
+    url.search = "";
+    return new Request(url, request);
+  }
+  return request;
 }
 
 function applySecurityHeaders(c: { res: Response; req: { path: string } }) {
@@ -236,7 +261,7 @@ app.route("/api/v1/staged-publishes", stagedPublishesRoutes);
 
 app.notFound((c) => {
   if (!isServerOwnedPath(c.req.path) && c.env.ASSETS) {
-    return c.env.ASSETS.fetch(c.req.raw);
+    return c.env.ASSETS.fetch(assetFallbackRequest(c.req.raw));
   }
   return c.json({ error: "not found" }, 404);
 });

--- a/test/workers/canonical-domain.test.ts
+++ b/test/workers/canonical-domain.test.ts
@@ -5,7 +5,10 @@ import worker from "../../server/index";
 const assetEnv = {
   ...env,
   ASSETS: {
-    fetch: async (request: Request) => new Response(`asset:${new URL(request.url).pathname}`),
+    fetch: async (request: Request) => {
+      const url = new URL(request.url);
+      return new Response(`asset:${url.pathname}${url.search}`);
+    },
   },
 } satisfies Cloudflare.Env;
 
@@ -27,11 +30,19 @@ describe("canonical domain routing", () => {
     );
   });
 
-  test("serves app assets through the Worker-first fallback", async () => {
-    const res = await fetchWorker("https://drydock.org/dashboard/scans/123", assetEnv);
+  test("serves generated app assets through the Worker-first fallback", async () => {
+    const res = await fetchWorker("https://drydock.org/dashboard/settings?tab=general", assetEnv);
 
     expect(res.status).toBe(200);
-    expect(await res.text()).toBe("asset:/dashboard/scans/123");
+    expect(await res.text()).toBe("asset:/dashboard/settings?tab=general");
+    expect(res.headers.get("Content-Security-Policy")).toContain("script-src 'self'");
+  });
+
+  test("serves dashboard deep links from the generated dashboard shell", async () => {
+    const res = await fetchWorker("https://drydock.org/dashboard/scans/123?tab=report", assetEnv);
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("asset:/dashboard/index.html");
     expect(res.headers.get("Content-Security-Policy")).toContain("script-src 'self'");
   });
 


### PR DESCRIPTION
## Summary
Dashboard deep links that are not concrete generated asset paths now fetch `/dashboard/index.html` instead of falling through Cloudflare's SPA asset fallback to the root landing `index.html`.

```ts
/dashboard/settings                -> original asset request
/dashboard/scans/:id?path=...      -> /dashboard/index.html
```

This keeps user-data routes client-rendered while avoiding the landing-page HTML flash on scan detail loads.

Link to Devin session: https://app.devin.ai/sessions/6a3a0704882940bbaadc6e51d7c9f3ae
Requested by: @JoviDeCroock