### PR TITLE
Clarify maintainer-focused publish copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="dark light" />
-    <title>Drydock — see exactly what your next publish ships</title>
+    <title>Drydock — pre-publish review for package maintainers</title>
   </head>
   <body>
     <div id="app"></div>

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -21,9 +21,9 @@ export interface PrerenderHead {
 }
 
 export const homePageSeo: PageSeoMetadata = {
-  title: "Drydock — pre-publish security review for npm and PyPI",
+  title: "Drydock — pre-publish security review for package maintainers",
   description:
-    "Drydock reviews npm and PyPI release candidates before they go public, diffs the exact package artifact against the last published version, and pins supply-chain risk findings to the lines that introduced them.",
+    "Drydock helps npm and PyPI maintainers review release candidates before they go public, diff the exact package artifact against the last published version, and pin supply-chain risk findings to the lines that introduced them.",
   path: "/",
 };
 

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -20,11 +20,12 @@ export default function DocsPage() {
             How Drydock guards a publish.
           </h1>
           <p class="text-[17px] text-ink-muted max-w-[620px] leading-[1.6] m-0">
-            The package that reaches a registry is built, packed output that code review never sees.
-            Drydock holds a release before it goes public, diffs it against the last published
-            version, and pins risk findings to the lines that introduced them. A maintainer makes
-            the final call. Drydock never publishes, never holds a publish credential, and never
-            executes package contents.
+            The package that reaches a registry is not the pull request a maintainer reviewed. It is
+            built, packed output shaped by scripts, bundlers, and CI. Drydock holds a release before
+            it goes public, diffs it against the last published version, and pins risk findings to
+            the lines that introduced them. A maintainer makes the final call about what goes live.
+            Drydock never publishes, never holds a publish credential, and never executes package
+            contents.
           </p>
           <p class="m-0 max-w-[680px] text-[14px] text-ink-muted leading-[1.65]">
             How the release is held depends on how you publish. npm can stage a publish on the

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -50,7 +50,7 @@ export default function LandingPage() {
     >
       <PageSeo metadata={homePageSeo} />
       <section class="py-8 md:py-12 border-t border-border flex flex-col gap-5">
-        <Eyebrow tone="accent">Pre-publish review for npm and PyPI packages</Eyebrow>
+        <Eyebrow tone="accent">Pre-publish review for npm and PyPI maintainers</Eyebrow>
         <h1 class="text-4xl md:text-5xl font-semibold tracking-[-0.03em] leading-[1.05] max-w-[760px] m-0">
           See exactly what your next publish ships.
         </h1>

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -50,7 +50,7 @@ export default function LandingPage() {
     >
       <PageSeo metadata={homePageSeo} />
       <section class="py-8 md:py-12 border-t border-border flex flex-col gap-5">
-        <Eyebrow tone="accent">Pre-publish review for npm and PyPI maintainers</Eyebrow>
+        <Eyebrow tone="accent">Pre-publish review for maintainers of npm and PyPI packages</Eyebrow>
         <h1 class="text-4xl md:text-5xl font-semibold tracking-[-0.03em] leading-[1.05] max-w-[760px] m-0">
           See exactly what your next publish ships.
         </h1>

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -55,10 +55,10 @@ export default function LandingPage() {
           See exactly what your next publish ships.
         </h1>
         <p class="text-[17px] text-ink-muted max-w-[620px] leading-[1.6] m-0">
-          The package that lands on the registry is built, packed output, not the pull request you
-          reviewed. Drydock holds each release before it goes public, diffs it against the last
-          published version, and pins risk findings to the lines that introduced them. You make the
-          final call.
+          The package that lands on the registry is not the pull request you reviewed. It is built,
+          packed output shaped by scripts, bundlers, and CI. Drydock holds each release before it
+          goes public, diffs it against the last published version, and pins risk findings to the
+          lines that introduced them. You make the final call about what goes live.
         </p>
         <div class="flex gap-3 mt-2">
           <Show


### PR DESCRIPTION
## Summary
Refines the landing/docs hero copy to position Drydock for maintainers of npm and PyPI packages, not package consumers, while making the registry artifact distinction easier to parse.

Key copy shape:
```text
Pre-publish review for maintainers of npm and PyPI packages

The package that lands on the registry is not the pull request you reviewed.
It is built, packed output shaped by scripts, bundlers, and CI.
...
You make the final call about what goes live.
```

Checks run locally:
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run typecheck`

Link to Devin session: https://app.devin.ai/sessions/a840dbe75d9047c89b6cee56d975bf18
Requested by: @JoviDeCroock