### PR TITLE
Align docs page width with home

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -132,7 +132,7 @@ Don't naively invert. Surfaces darken (true neutrals, no warm tint), accent + se
 ## Layout
 
 - **Approach:** Grid-disciplined for app surfaces. Marketing pages get more whitespace and a deliberate single-column hero column.
-- **Grid:** 12-column, 24px gutters. App content max-width `1160px`. Report bodies sit comfortably inside `~880px`. Marketing hero copy capped at `760px` so headings remain typographically scaled.
+- **Grid:** 12-column, 24px gutters. App content max-width `1160px`. Public landing/docs pages share that outer shell so header/footer alignment stays stable; docs article bodies sit comfortably inside `~880px`. Marketing hero copy capped at `760px` so headings remain typographically scaled.
 - **Border radius:**
   - `0` — Severity badges and document-style elements (squarish, terminal-adjacent — not pills).
   - `3–4px` — Small chrome (inline mono pills, file-path tags).

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -5,7 +5,6 @@ import { docsPageSeo, PageSeo } from "../../lib/seo";
 export default function DocsPage() {
   return (
     <PageShell
-      width="doc"
       headerActions={
         <LinkButton href="/" variant="ghost" size="sm">
           Home
@@ -13,7 +12,7 @@ export default function DocsPage() {
       }
     >
       <PageSeo metadata={docsPageSeo} />
-      <div class="flex flex-col gap-14">
+      <div class="flex max-w-[880px] flex-col gap-14">
         <header class="border-t border-border pt-8 flex flex-col gap-5">
           <Eyebrow tone="accent">Documentation</Eyebrow>
           <h1 class="text-4xl md:text-5xl font-semibold tracking-[-0.03em] leading-[1.05] max-w-[760px] m-0">


### PR DESCRIPTION
## Summary
- Align `/docs` with the landing page’s outer `PageShell` width so header/footer chrome no longer jumps between the public pages.
- Keep the docs article content capped at `880px` inside the shared `1160px` shell for readable documentation copy.
- Update `DESIGN.md` to document the public landing/docs shell rule.

Validation: `pnpm run verify`

Link to Devin session: https://app.devin.ai/sessions/e0d35316569c487b92f48b74aff6d863
Requested by: @JoviDeCroock