### PR TITLE
Align docs with current workflow gate behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,10 @@
 - `useState`/`useReducer` are banned (oxlint `no-restricted-imports`). Component-local state goes through `useSignal`/`useComputed` or `createModel`/`useModel`. See `docs/tooling.md` and the `.claude/skills/preact-signals-*` skills.
 - Comments explain _why_ — rationale, trust boundaries, concurrency/fail-closed behavior, edge cases, units, magic numbers. Don't restate what the code already says, narrate obvious control flow, or label a self-evident symbol; never leave commented-out code or stale TODOs. The codebase keeps a deliberately high signal-to-noise ratio.
 - Never hand-write SQL migrations — run `pnpm db:generate` against `server/db/schema.ts`.
-- Read `docs/` before starting work; update `docs/` when you finish.
+- Read `docs/` before starting work. Before finishing any behavior, API, UI,
+  security, or workflow change, explicitly check whether `docs/` or the public
+  `/docs` page need updates. If no docs change is needed, note "docs checked, no
+  update needed" in the PR summary or testing notes.
 
 ## Testing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -28,7 +28,7 @@ Dynamic Worker sandbox
 
 Scan orchestration lives in `server/lib/scan-pipeline.ts` and is shared by the HTTP and Queue entrypoints. Scans run only through the queued/background lifecycle: `POST /api/v1/scans` creates a scan, a Queue consumer or local `waitUntil()` job runs the pipeline, and the UI reads status/report data from `GET /api/v1/scans/:id`.
 
-The pipeline is **ecosystem-agnostic**: it accepts a `PackageAdapter` (`server/lib/adapters/types.ts`) and delegates ecosystem-specific behavior — input parsing, artifact acquisition, baseline selection, deterministic findings, package projection, staged-details summarization — to it. The npm adapter (`server/lib/adapters/npm/`) backs staged publishes today, and the backend PyPI adapter (`server/lib/adapters/pypi/`) backs workflow-gate release-candidate reviews.
+The pipeline is **ecosystem-agnostic**: it accepts a `PackageAdapter` (`server/lib/adapters/types.ts`) and delegates ecosystem-specific behavior — input parsing, artifact acquisition, baseline selection, deterministic findings, package projection, staged-details summarization — to it. The npm adapter (`server/lib/adapters/npm/`) backs staged publishes and npm workflow gates, and the PyPI adapter (`server/lib/adapters/pypi/`) backs PyPI workflow-gate release-candidate reviews.
 
 Baseline selection should be tag-aware rather than simply highest-semver. See [`diff-baseline.md`](./diff-baseline.md) for the staged metadata constraints and the recommended default comparison strategy.
 
@@ -311,11 +311,11 @@ Implemented pieces:
 - GitHub App install/callback, installation listing, repository/environment proxy reads, and ecosystem-neutral release-target CRUD in `server/routes/github-app.ts`;
 - `deployment_protection_rule` webhook handling in `server/routes/github-webhooks.ts`, backed by `github_workflow_gates`;
 - queue-driven gate review in `server/lib/workflow-gate-job.ts`, including fail-closed rejection for unverifiable artifact bundles and human approve/reject delivery back to GitHub;
-- release-candidate derivation from the held workflow run's uploaded GitHub Actions artifacts: every wheel/sdist SHA-256 is recomputed from upload bytes, package identity is derived from wheel `METADATA` / sdist `PKG-INFO`, and no maintainer-declared manifest is required;
-- PyPI wheel/sdist artifact normalization and metadata extraction;
+- release-candidate derivation from the held workflow run's uploaded GitHub Actions artifacts: every reviewable artifact SHA-256 is recomputed from upload bytes, package identity is derived from artifact metadata (`package.json`, wheel `METADATA`, or sdist `PKG-INFO`), and no maintainer-declared manifest is required;
+- npm tarball and PyPI wheel/sdist artifact normalization and metadata extraction;
 - safe ZIP parsing for `.whl` archives in the sandbox parser;
 - PyPI-specific deterministic findings for manifest/metadata mismatches, missing wheel `RECORD`, `.pth` startup hooks, custom `setup.py` install commands, unusual dependencies, and `.pyd` native extensions;
 - PyPI project JSON metadata helpers for baseline release selection and wheel/sdist download metadata;
 - settings UI for GitHub App installation/release-target mapping and workbench controls for pending gate decisions.
 
-The target gate is a GitHub custom deployment protection rule on the same GitHub Environment configured in PyPI Trusted Publishers. CI must build artifacts before the gate and the publish job must download the reviewed artifact bundle rather than rebuilding. There is no publish-side digest manifest check in the current contract, so byte continuity rests on GitHub artifact immutability plus workflow discipline. Remaining work is to persist the reviewed artifact digests in the report payload for audit/provenance. See [`workflow-gates.md`](./workflow-gates.md).
+The target gate is a GitHub custom deployment protection rule on the same GitHub Environment the publish job uses (for PyPI, usually the Trusted Publisher environment). CI must build artifacts before the gate and the publish job must download the reviewed artifact bundle rather than rebuilding. There is no publish-side digest manifest check in the current contract, so byte continuity rests on GitHub artifact immutability plus workflow discipline. Remaining provenance work is to surface reviewed artifact digests in the dashboard/export views. See [`workflow-gates.md`](./workflow-gates.md).

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -126,15 +126,15 @@ The gateway compares URL origins against the configured npm registry and attache
 
 ## PyPI workflow-gate posture
 
-PyPI support is a workflow-gate mode, not an approval bot and not a registry credential path. PyPI Trusted Publishers use OIDC from GitHub Actions, and PyPI strongly encourages binding the publisher to a GitHub Environment. Drydock's GitHub App reviews the built wheel/sdist artifacts while that environment is pending, records an advisory recommendation, and leaves the gate waiting for a human approve/reject decision. Artifact-resolution failures reject the gate fail-closed.
+Workflow-gate support is not an approval bot and not a registry credential path. PyPI Trusted Publishers use OIDC from GitHub Actions, and PyPI strongly encourages binding the publisher to a GitHub Environment; npm workflow gates likewise publish from the workflow after the gate releases. Drydock's GitHub App reviews the built release artifacts while that environment is pending, records an advisory recommendation, and leaves the gate waiting for a human approve/reject decision. Artifact-resolution failures reject the gate fail-closed.
 
-Additional boundaries for PyPI:
+Additional boundaries for workflow gates:
 
-- Do not mint PyPI OIDC tokens or upload to PyPI.
+- Do not mint PyPI OIDC tokens, hold npm publish tokens, or upload to registries.
 - Do not rebuild artifacts after review; the publish job must download the reviewed GitHub Actions artifact bundle and publish those bytes.
-- Treat the held workflow run's uploaded GitHub Actions artifacts as the release set, optionally narrowed by a configured artifact name. Recompute each wheel/sdist SHA-256 from upload bytes, derive package name/version from wheel `METADATA` and sdist `PKG-INFO`, and reject missing identity, cross-artifact identity/version mismatch, or release-target mismatch.
+- Treat the held workflow run's uploaded GitHub Actions artifacts as the release set, optionally narrowed by a configured artifact name. Recompute each artifact's SHA-256 from upload bytes, derive package name/version from artifact metadata (`package.json`, wheel `METADATA`, or sdist `PKG-INFO`), and reject missing identity, cross-artifact identity/version mismatch, or release-target mismatch.
 - There is no maintainer-declared manifest or publish-side digest-match contract today. Byte continuity rests on GitHub artifact immutability plus workflow discipline that forbids rebuilding after the gate.
-- Treat wheel ZIP and sdist tar contents as hostile evidence, with the same no-execution and bounded-sample rules as npm tarballs.
+- Treat wheel ZIP, sdist tar, and npm tarball contents as hostile evidence, with the same no-execution and bounded-sample rules.
 - Keep GitHub Actions artifact credentials in the trusted parent/GitHub integration path; do not pass them into the sandbox.
 
 ## AI prompt-injection posture

--- a/docs/workflow-gates.md
+++ b/docs/workflow-gates.md
@@ -18,7 +18,9 @@ Official references:
 
 ## Implemented foundation
 
-The repo now has a backend-only PyPI foundation in `server/lib/adapters/pypi/index.ts`:
+The repo now has a shared workflow-gate foundation in `server/lib/workflow-gates/`
+with PyPI and npm adapters behind it. The PyPI adapter
+(`server/lib/adapters/pypi/index.ts`):
 
 - derives a `drydock.release-artifacts.v1` release set from the uploaded artifacts (identity from wheel `METADATA` / sdist `PKG-INFO`, digests recomputed from the bytes) — there is no maintainer-declared manifest;
 - exposes a `PackageAdapter` implementation compatible with the pluggable scan pipeline introduced for npm;
@@ -104,8 +106,8 @@ jobs:
 
 No manifest-writing or checksum step is required — CI just builds and uploads
 `dist/*`. PyPI strongly encourages configuring a GitHub Environment for Trusted
-Publishers. Drydock attaches to that same environment as a GitHub custom
-deployment protection rule.
+Publishers; enable Drydock as a GitHub custom deployment protection rule on that
+same environment.
 
 ## GitHub App mapping
 
@@ -397,14 +399,16 @@ the install:
    linked for the org; repository and environment are dropdowns populated from
    the proxy endpoints. A target left unpinned (no ecosystem) auto-detects each
    package's ecosystem from the uploaded artifacts, so a single target gates every
-   package a monorepo publishes from that environment. The server still
-   revalidates installation ownership, repo access, and environment names on
-   `POST /release-targets`, so the UI cannot bypass the rules. Empty states link
-   to GitHub App settings (no repos) and GitHub Actions environments docs (no
-   environments).
-6. Above the release-targets form, a "gate setup" guide walks through installing
-   the App, adding a GitHub Environment custom deployment protection rule, and
-   matching the PyPI Trusted Publisher environment. It states plainly that
+   package a monorepo publishes from that environment. The API still accepts
+   `ecosystem` / `artifactName` for operator-created targets, but the current
+   product UI intentionally uses the monorepo-friendly auto-detect/all-artifacts
+   path. The server still revalidates installation ownership, repo access, and
+   environment names on `POST /release-targets`, so the UI cannot bypass the
+   rules. Empty states link to GitHub App settings (no repos) and GitHub Actions
+   environments docs (no environments).
+6. The public `/docs` page and the Settings card copy walk through installing the
+   App, adding a GitHub Environment custom deployment protection rule, and
+   matching the PyPI Trusted Publisher environment. They state plainly that
    approval releases or blocks the held GitHub job and that publishing happens
    through the workflow's Trusted Publishing OIDC exchange — Drydock never holds
    or sees PyPI credentials.
@@ -435,10 +439,10 @@ diff-first workbench scoped to that package's baseline.
 ### Resolving artifacts for a pending gate
 
 `server/lib/github-app/artifacts.ts` turns a pending gate into a release bundle
-of recomputed-SHA-256 wheel/sdist bytes on the trusted control-plane side, then
-the PyPI `WorkflowGateAdapter` (`server/lib/workflow-gates/pypi.ts`) hands each
-wheel/sdist to the credentials-free `downloadInSandboxInline` sandbox path so the
-same untrusted-archive parser the npm pipeline uses produces bounded
+of recomputed-SHA-256 artifact bytes on the trusted control-plane side, then the
+selected `WorkflowGateAdapter` (`server/lib/workflow-gates/{pypi,npm}.ts`) hands
+each artifact to the credentials-free `downloadInSandboxInline` sandbox path so
+the same untrusted-archive parser the npm pipeline uses produces bounded
 `FileRecord[]` evidence, and derives the release identity from that parsed
 metadata. The ecosystem-neutral plumbing around it (gate/installation/release-
 target loading, adapter selection, bundle fetch) lives in
@@ -819,10 +823,12 @@ distinguish it.
 
 ## Remaining work
 
-- Record the reviewed artifact SHA-256 digests in the persisted report
-  payload (the resolver returns them; the persister doesn't store them yet).
+- Surface reviewed artifact SHA-256 digests in the dashboard/export views. The
+  gate adapters already recompute digests from the bytes and carry them in the
+  persisted scan details; the workbench does not yet render them as first-class
+  provenance fields.
 
 The end-to-end path now works: a maintainer can configure a gate from settings,
 the webhook holds the publish job, the review surfaces in the workbench, and the
-approve/reject decision releases or blocks the job. The digest-persistence item
+approve/reject decision releases or blocks the job. The digest-surfacing item
 above is an audit-trail enrichment, not a gap in the gate.

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -154,13 +154,14 @@ export default function DocsPage() {
                   to GitHub to pick the account and grant access to the repo, then back to Drydock.
                 </>,
                 <>
-                  In the repository, create a GitHub Environment (for example <Code>pypi</Code>) and
-                  configure it as a PyPI Trusted Publisher. Drydock attaches its protection rule to
-                  that same environment.
+                  In the repository, create a GitHub Environment (for example <Code>pypi</Code>),
+                  configure it as a PyPI Trusted Publisher, and enable Drydock as a custom
+                  deployment protection rule on that same environment.
                 </>,
                 <>
-                  On the same settings page, map the repository, environment, and package so Drydock
-                  knows which organization a held publish belongs to.
+                  On the same settings page, map the repository and environment so Drydock knows
+                  which organization a held publish belongs to. Packages and ecosystems are derived
+                  from the uploaded artifacts.
                 </>,
                 <>
                   Add the build and publish workflow below. The build job uploads the wheels and
@@ -181,18 +182,19 @@ export default function DocsPage() {
             <Prose>
               There is no manifest to write. CI builds and uploads <Code>dist/*</Code>, and Drydock
               treats every <Code>.whl</Code>, <Code>.tar.gz</Code>, and <Code>.tgz</Code> it finds
-              in the upload as part of the release. The settings form can narrow this down to one
-              artifact name, but left blank Drydock inspects every upload from the held run.
+              in the upload as part of the release. Drydock inspects every non-expired artifact from
+              the held run and fails closed if an archive is ambiguous.
             </Prose>
             <Prose>
-              Drydock reads each package's name and version out of the files themselves and verifies
-              every checksum on its own servers. The publish job only downloads the reviewed bundle
-              and never rebuilds, so the bytes that were reviewed are the bytes that get published.
+              Drydock reads each package's name and version out of the files themselves and
+              recomputes SHA-256 digests from the bytes it fetched. The publish job only downloads
+              the reviewed bundle and never rebuilds, so the bytes that were reviewed are the bytes
+              that get published.
             </Prose>
             <Prose>
-              You never declare which ecosystem you're publishing. Drydock tells an npm tarball from
-              a PyPI sdist by looking inside it, so the same gate reviews either, or both at once
-              for a mixed monorepo.
+              You normally never declare which ecosystem you're publishing. Drydock tells an npm
+              tarball from a PyPI sdist by looking inside it, so the same gate reviews either, or
+              both at once for a mixed monorepo.
             </Prose>
           </Subsection>
 
@@ -238,7 +240,7 @@ export default function DocsPage() {
             <Prose>
               No manifest or checksum step is required. CI just builds and uploads{" "}
               <Code>dist/*</Code>. The <Code>environment: pypi</Code> line is the gate: configure
-              that same environment as a PyPI Trusted Publisher and attach Drydock as a deployment
+              that same environment as a PyPI Trusted Publisher and enable Drydock as a deployment
               protection rule on it. The publish job stays blocked until the review is approved in
               Drydock, then publishes the downloaded bundle with whatever tool you prefer.
             </Prose>
@@ -292,13 +294,14 @@ export default function DocsPage() {
                   deliveries that don't match anything you configured are ignored.
                 </>,
                 <>
-                  Drydock fetches the uploaded bundle, verifies the checksums, and reviews each
+                  Drydock fetches the uploaded bundle, recomputes artifact digests, and reviews each
                   package against its own earlier version. The review records a recommendation and
                   leaves the decision to a human.
                 </>,
                 <>
                   A maintainer opens the review on the dashboard and approves or rejects each
-                  package. The held job is released once every package is approved and blocked the
+                  package. If their Drydock account has 2FA enabled, this asks for a fresh TOTP
+                  code. The held job is released once every package is approved and blocked the
                   moment any one is rejected. A bundle Drydock can't verify is rejected
                   automatically.
                 </>,


### PR DESCRIPTION
## Summary
- Updates `/docs` copy and internal docs to match the current workflow-gate implementation: release targets map repo/environment only in the UI, packages/ecosystems are derived from uploaded artifacts, and Drydock is enabled as a GitHub deployment protection rule rather than attaching itself automatically.
- Generalizes architecture/security docs from PyPI-only gate language to the current PyPI + npm gate support, including artifact metadata identity (`package.json`, wheel `METADATA`, sdist `PKG-INFO`) and recomputed SHA-256 provenance.
- Adds an `AGENTS.md` instruction requiring future agents to explicitly check whether `docs/` or public `/docs` need updates before finishing behavior/API/UI/security/workflow changes.
- Replaces stale checksum/digest wording with the actual contract: Drydock recomputes artifact digests, fails closed on ambiguous/unverifiable bundles, and remaining provenance work is surfacing digests in dashboard/export views.

Link to Devin session: https://app.devin.ai/sessions/dd33e4c44a224718b7cc313a1303c874
Requested by: @JoviDeCroock