### PR TITLE
Unify settings card spacing

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -2,17 +2,121 @@ import type { ComponentChildren } from "preact";
 import { cn } from "./cn";
 import { SectionLabel } from "./Typography";
 
+export type CardPadding = "default" | "compact" | "none";
+
+const cardPaddingClass: Record<CardPadding, string> = {
+  default: "p-6",
+  compact: "p-5",
+  none: "",
+};
+
 export function Card({
   class: className,
   children,
   as: As = "section",
+  padding = "default",
+}: {
+  class?: string;
+  children: ComponentChildren;
+  as?: "section" | "article" | "div" | "aside";
+  padding?: CardPadding;
+}) {
+  return (
+    <As
+      class={cn("bg-surface border border-border rounded-lg", cardPaddingClass[padding], className)}
+    >
+      {children}
+    </As>
+  );
+}
+
+export function SettingsCard({
+  class: className,
+  children,
+  as,
 }: {
   class?: string;
   children: ComponentChildren;
   as?: "section" | "article" | "div" | "aside";
 }) {
   return (
-    <As class={cn("bg-surface border border-border rounded-lg p-6", className)}>{children}</As>
+    <Card as={as} padding="compact" class={className}>
+      {children}
+    </Card>
+  );
+}
+
+export function SettingsCardBody({
+  class: className,
+  children,
+  inset = "all",
+  gap = "default",
+}: {
+  class?: string;
+  children: ComponentChildren;
+  inset?: "all" | "belowHeader";
+  gap?: "default" | "compact" | "none";
+}) {
+  const insetClass = inset === "belowHeader" ? "px-5 pb-5" : "p-5";
+  const gapClass = gap === "none" ? "" : gap === "compact" ? "gap-4" : "gap-5";
+  return <div class={cn(insetClass, "flex flex-col", gapClass, className)}>{children}</div>;
+}
+
+export function SettingsCardForm({
+  class: className,
+  children,
+  onSubmit,
+  inset = "belowHeader",
+  gap = "compact",
+}: {
+  class?: string;
+  children: ComponentChildren;
+  onSubmit?: (event: Event) => void;
+  inset?: "all" | "belowHeader";
+  gap?: "default" | "compact" | "none";
+}) {
+  const insetClass = inset === "belowHeader" ? "px-5 pb-5" : "p-5";
+  const gapClass = gap === "none" ? "" : gap === "compact" ? "gap-4" : "gap-5";
+  return (
+    <form class={cn(insetClass, "flex flex-col", gapClass, className)} onSubmit={onSubmit}>
+      {children}
+    </form>
+  );
+}
+
+export function SettingsCardHeader({
+  title,
+  aside,
+  class: className,
+}: {
+  title: ComponentChildren;
+  aside?: ComponentChildren;
+  class?: string;
+}) {
+  return (
+    <div class={cn("px-5 py-4 flex items-center justify-between gap-3", className)}>
+      <SectionLabel class="flex-1">{title}</SectionLabel>
+      {aside ? <div class="shrink-0 flex items-center gap-2">{aside}</div> : null}
+    </div>
+  );
+}
+
+export function SettingsCardListItem({
+  class: className,
+  children,
+}: {
+  class?: string;
+  children: ComponentChildren;
+}) {
+  return (
+    <li
+      class={cn(
+        "border-b border-border last:border-b-0 px-5 py-4 flex flex-wrap items-center justify-between gap-3",
+        className,
+      )}
+    >
+      {children}
+    </li>
   );
 }
 
@@ -30,7 +134,7 @@ export function CollapsibleCard({
   children: ComponentChildren;
 }) {
   return (
-    <Card as="section" class={cn("p-0 overflow-hidden", className)}>
+    <Card as="section" padding="none" class={cn("overflow-hidden", className)}>
       <details open={defaultOpen} class="group">
         <summary class="list-none cursor-pointer flex items-center gap-2.5 px-5 py-4 transition-colors hover:bg-surface-2">
           <span

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -11,8 +11,17 @@ export type { AlertTone } from "./Alert";
 export { Toaster, pushToast, dismissToast } from "./Toast";
 export type { ToastTone } from "./Toast";
 export { Dialog } from "./Dialog";
-export { Card, CollapsibleCard, SummaryCard } from "./Card";
-export type { SummaryCardTone, SummaryCardValue } from "./Card";
+export {
+  Card,
+  CollapsibleCard,
+  SettingsCard,
+  SettingsCardBody,
+  SettingsCardForm,
+  SettingsCardHeader,
+  SettingsCardListItem,
+  SummaryCard,
+} from "./Card";
+export type { CardPadding, SummaryCardTone, SummaryCardValue } from "./Card";
 export { PageShell } from "./PageShell";
 export { BrandMark } from "./BrandMark";
 export { AikidoMark, AikidoFootnote, AikidoPartnerStrip } from "./AikidoPartner";

--- a/src/pages/Dashboard/Account/DeleteAccountSection.tsx
+++ b/src/pages/Dashboard/Account/DeleteAccountSection.tsx
@@ -4,12 +4,12 @@ import { errorMessage } from "../../../models/api";
 import {
   Alert,
   Button,
-  Card,
   Dialog,
   Field,
   Input,
   Muted,
   SectionLabel,
+  SettingsCard,
 } from "../../../components";
 
 export function DeleteAccountSection({ onDeleted }: { onDeleted: () => void }) {
@@ -53,7 +53,7 @@ export function DeleteAccountSection({ onDeleted }: { onDeleted: () => void }) {
   };
 
   return (
-    <Card class="flex flex-col gap-3">
+    <SettingsCard class="flex flex-col gap-3">
       <SectionLabel>Danger zone</SectionLabel>
       <Muted class="text-[13px] m-0 max-w-[760px]">
         Deleting your account permanently removes your personal workspace, every organization you
@@ -114,6 +114,6 @@ export function DeleteAccountSection({ onDeleted }: { onDeleted: () => void }) {
           {error.value ? <Alert tone="critical">{error.value}</Alert> : null}
         </form>
       </Dialog>
-    </Card>
+    </SettingsCard>
   );
 }

--- a/src/pages/Dashboard/Account/TwoFactorSection.tsx
+++ b/src/pages/Dashboard/Account/TwoFactorSection.tsx
@@ -5,7 +5,6 @@ import {
   Alert,
   Badge,
   Button,
-  Card,
   Dialog,
   Field,
   Input,
@@ -13,6 +12,7 @@ import {
   MonoDetail,
   Muted,
   SectionLabel,
+  SettingsCard,
 } from "../../../components";
 
 type DialogMode = "none" | "enroll" | "regenerate" | "disable";
@@ -236,7 +236,7 @@ export function TwoFactorSection() {
   }
 
   return (
-    <Card as="section" class="flex flex-col gap-5">
+    <SettingsCard as="section" class="flex flex-col gap-5">
       <div class="flex flex-col gap-1.5">
         <div class="flex items-center gap-3">
           <SectionLabel class="flex-1">Two-factor authentication</SectionLabel>
@@ -279,6 +279,6 @@ export function TwoFactorSection() {
       >
         {dialogBody}
       </Dialog>
-    </Card>
+    </SettingsCard>
   );
 }

--- a/src/pages/Dashboard/Account/index.tsx
+++ b/src/pages/Dashboard/Account/index.tsx
@@ -11,8 +11,8 @@ import {
   Muted,
   PageShell,
   SectionLabel,
+  SettingsCard,
   UserMenu,
-  Card,
 } from "../../../components";
 import { TwoFactorSection } from "./TwoFactorSection";
 import { DeleteAccountSection } from "./DeleteAccountSection";
@@ -72,11 +72,11 @@ export default function AccountPage() {
       <AccountHeader />
 
       <div class="flex flex-col gap-6">
-        <Card class="flex flex-col gap-1.5">
+        <SettingsCard class="flex flex-col gap-1.5">
           <SectionLabel>Profile</SectionLabel>
           {user?.name ? <span class="text-[14px] font-medium text-ink">{user.name}</span> : null}
           <MonoDetail parts={[user?.email ? <span key="email">{user.email}</span> : null]} />
-        </Card>
+        </SettingsCard>
 
         <TwoFactorSection />
 

--- a/src/pages/Dashboard/Settings/GeneralSection.tsx
+++ b/src/pages/Dashboard/Settings/GeneralSection.tsx
@@ -5,13 +5,13 @@ import {
   Alert,
   Badge,
   Button,
-  Card,
   Dialog,
   Field,
   Input,
   MonoDetail,
   Muted,
   SectionLabel,
+  SettingsCard,
 } from "../../../components";
 
 export function GeneralSection({
@@ -56,7 +56,7 @@ export function GeneralSection({
   };
 
   return (
-    <Card class="flex flex-col gap-5">
+    <SettingsCard class="flex flex-col gap-5">
       <SectionLabel>General</SectionLabel>
 
       {active ? (
@@ -138,6 +138,6 @@ export function GeneralSection({
           </form>
         </Dialog>
       ) : null}
-    </Card>
+    </SettingsCard>
   );
 }

--- a/src/pages/Dashboard/Settings/GithubAppSection.tsx
+++ b/src/pages/Dashboard/Settings/GithubAppSection.tsx
@@ -13,7 +13,9 @@ import {
   CollapsibleCard,
   MonoDetail,
   Muted,
-  SectionLabel,
+  SettingsCardBody,
+  SettingsCardHeader,
+  SettingsCardListItem,
   type BadgeTone,
 } from "../../../components";
 import { ReleaseTargetForm } from "./ReleaseTargetForm";
@@ -49,7 +51,7 @@ export function GithubAppSection({
         configured ? <Badge tone="ok">configured</Badge> : <Badge tone="info">not configured</Badge>
       }
     >
-      <div class="p-5 flex flex-col gap-5">
+      <SettingsCardBody>
         {/* Pair the install action with the intro copy and anchor it to the card's
             right edge — same axis as the header badge and section counts — so it
             reads as this section's primary action instead of a stranded button. */}
@@ -96,45 +98,49 @@ export function GithubAppSection({
             <code class="font-mono text-[12px]">{lastLinked.installationId}</code>.
           </Alert>
         ) : null}
-      </div>
+      </SettingsCardBody>
 
       <div>
-        <div class="px-5 py-4 flex items-center justify-between gap-3">
-          <SectionLabel class="flex-1">Linked installations</SectionLabel>
-          <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle shrink-0">
-            {installations.length} linked
-          </span>
-        </div>
+        <SettingsCardHeader
+          title="Linked installations"
+          aside={
+            <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
+              {installations.length} linked
+            </span>
+          }
+        />
         {installations.length ? (
           <InstallationList installations={installations} />
         ) : (
-          <div class="px-5 pb-5">
+          <SettingsCardBody inset="belowHeader" gap="none">
             <Muted class="text-[13px] m-0">No installations linked to this organization yet.</Muted>
-          </div>
+          </SettingsCardBody>
         )}
       </div>
 
       <div>
-        <div class="px-5 py-4 flex items-center justify-between gap-3">
-          <SectionLabel class="flex-1">Release targets</SectionLabel>
-          <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle shrink-0">
-            {releaseTargets.length} mapped
-          </span>
-        </div>
+        <SettingsCardHeader
+          title="Release targets"
+          aside={
+            <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
+              {releaseTargets.length} mapped
+            </span>
+          }
+        />
         {activeInstallations.length ? (
           <ReleaseTargetForm githubApp={githubApp} activeInstallations={activeInstallations} />
         ) : (
-          <div class="px-5 pb-5">
+          <SettingsCardBody inset="belowHeader" gap="none">
             <Muted class="text-[13px] m-0">
               Install the GitHub App on an organization with the repo you want to gate before
               mapping a release target.
             </Muted>
-          </div>
+          </SettingsCardBody>
         )}
         {releaseTargetsError ? (
-          <div class="px-5 pb-5">
+          <SettingsCardBody inset="belowHeader" gap="none">
             <Alert tone="critical">{releaseTargetsError}</Alert>
-          </div>
+          </SettingsCardBody>
         ) : null}
         {releaseTargets.length ? (
           <ReleaseTargetList
@@ -162,10 +168,7 @@ function ReleaseTargetList({
       {releaseTargets.map((target) => {
         const installation = installations.find((row) => row.id === target.installationRowId);
         return (
-          <li
-            key={target.id}
-            class="border-b border-border last:border-b-0 px-5 py-4 flex flex-wrap items-center justify-between gap-3"
-          >
+          <SettingsCardListItem key={target.id}>
             <div class="flex flex-col gap-1.5 min-w-0">
               <div class="flex items-center gap-2 flex-wrap">
                 <span class="font-mono text-[14px] font-medium">{target.repositoryFullName}</span>
@@ -187,7 +190,7 @@ function ReleaseTargetList({
             <Button variant="danger" size="sm" onClick={() => onDelete(target.id)} class="shrink-0">
               Remove
             </Button>
-          </li>
+          </SettingsCardListItem>
         );
       })}
     </ul>
@@ -198,10 +201,7 @@ function InstallationList({ installations }: { installations: PublicGithubAppIns
   return (
     <ul class="m-0 p-0 list-none">
       {installations.map((installation) => (
-        <li
-          key={installation.id}
-          class="border-b border-border last:border-b-0 px-5 py-4 flex flex-wrap items-center justify-between gap-3"
-        >
+        <SettingsCardListItem key={installation.id}>
           <div class="flex flex-col gap-1.5 min-w-0">
             <div class="flex items-center gap-2 flex-wrap">
               <span class="font-mono text-[14px] font-medium">{installation.accountLogin}</span>
@@ -225,7 +225,7 @@ function InstallationList({ installations }: { installations: PublicGithubAppIns
                 : "removed on github · re-install to reconnect"}
             </span>
           ) : null}
-        </li>
+        </SettingsCardListItem>
       ))}
     </ul>
   );

--- a/src/pages/Dashboard/Settings/NotificationRecipientsSection.tsx
+++ b/src/pages/Dashboard/Settings/NotificationRecipientsSection.tsx
@@ -12,6 +12,7 @@ import {
   Input,
   LoadingLine,
   Muted,
+  SettingsCardBody,
 } from "../../../components";
 
 export function NotificationRecipientsSection({
@@ -45,7 +46,7 @@ export function NotificationRecipientsSection({
       defaultOpen={defaultOpen}
       aside={<Badge tone="info">{list.length} configured</Badge>}
     >
-      <div class="p-5 flex flex-col gap-5">
+      <SettingsCardBody>
         <Muted class="text-[13px] m-0 max-w-[760px]">
           Choose who gets emailed when an auto-discovered scan finishes or a release gate needs a
           review decision. Add a shared inbox or teammates. When this list is empty, Drydock emails
@@ -112,7 +113,7 @@ export function NotificationRecipientsSection({
         ) : null}
 
         {error ? <Alert tone="critical">{error}</Alert> : null}
-      </div>
+      </SettingsCardBody>
     </CollapsibleCard>
   );
 }

--- a/src/pages/Dashboard/Settings/NpmConnectionSection.tsx
+++ b/src/pages/Dashboard/Settings/NpmConnectionSection.tsx
@@ -1,7 +1,16 @@
 import { useModel } from "@preact/signals";
 import { formatTimestamp } from "../../../lib/format";
 import { NpmConnectionModel } from "../../../models/npm-connection";
-import { Alert, Badge, Button, CollapsibleCard, Field, Input, Muted } from "../../../components";
+import {
+  Alert,
+  Badge,
+  Button,
+  CollapsibleCard,
+  Field,
+  Input,
+  Muted,
+  SettingsCardBody,
+} from "../../../components";
 
 export function NpmConnectionSection({
   npm,
@@ -42,7 +51,7 @@ export function NpmConnectionSection({
         )
       }
     >
-      <div class="p-5 flex flex-col gap-5">
+      <SettingsCardBody>
         <Muted class="text-[13px] m-0 max-w-[760px]">
           Add a read-only organization npm token so reviews can fetch staged packages securely. We
           encrypt it, hide it after save, and use it only to retrieve release evidence.
@@ -132,7 +141,7 @@ export function NpmConnectionSection({
             </Button>
           </div>
         ) : null}
-      </div>
+      </SettingsCardBody>
     </CollapsibleCard>
   );
 }

--- a/src/pages/Dashboard/Settings/OrganizationMembersSection.tsx
+++ b/src/pages/Dashboard/Settings/OrganizationMembersSection.tsx
@@ -15,8 +15,10 @@ import {
   Input,
   MonoDetail,
   Muted,
-  SectionLabel,
   Select,
+  SettingsCardBody,
+  SettingsCardHeader,
+  SettingsCardListItem,
   type BadgeTone,
 } from "../../../components";
 
@@ -59,7 +61,7 @@ export function OrganizationMembersSection({
         </span>
       }
     >
-      <div class="p-5 flex flex-col gap-5">
+      <SettingsCardBody>
         <Muted class="text-[13px] m-0 max-w-[760px]">
           Invite teammates to collaborate on this organization's release targets, integrations, and
           gate reviews. Owners and admins manage membership; members get read access to org-scoped
@@ -105,7 +107,7 @@ export function OrganizationMembersSection({
             </Button>
           </form>
         ) : null}
-      </div>
+      </SettingsCardBody>
 
       <div>
         <MemberList
@@ -119,12 +121,14 @@ export function OrganizationMembersSection({
 
       {canManage ? (
         <div>
-          <div class="px-5 py-4 flex items-center justify-between gap-3">
-            <SectionLabel class="flex-1">Pending invites</SectionLabel>
-            <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle shrink-0">
-              {invitations.length} pending
-            </span>
-          </div>
+          <SettingsCardHeader
+            title="Pending invites"
+            aside={
+              <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
+                {invitations.length} pending
+              </span>
+            }
+          />
           {invitations.length ? (
             <InvitationList
               invitations={invitations}
@@ -132,9 +136,9 @@ export function OrganizationMembersSection({
               onRevoke={(id) => void members.revokeInvitation(id)}
             />
           ) : (
-            <div class="px-5 pb-5">
+            <SettingsCardBody inset="belowHeader" gap="none">
               <Muted class="text-[13px] m-0">No pending invitations.</Muted>
-            </div>
+            </SettingsCardBody>
           )}
         </div>
       ) : null}
@@ -160,10 +164,7 @@ function MemberList({
       {members.map((member) => {
         const removable = canManage && !member.isOwner && member.userId !== currentUserId;
         return (
-          <li
-            key={member.userId}
-            class="border-b border-border last:border-b-0 px-5 py-4 flex flex-wrap items-center justify-between gap-3"
-          >
+          <SettingsCardListItem key={member.userId}>
             <div class="flex flex-col gap-1.5 min-w-0">
               <div class="flex items-center gap-2 flex-wrap">
                 <span class="text-[14px] font-medium text-ink truncate">
@@ -189,7 +190,7 @@ function MemberList({
                 Remove
               </Button>
             ) : null}
-          </li>
+          </SettingsCardListItem>
         );
       })}
     </ul>
@@ -208,10 +209,7 @@ function InvitationList({
   return (
     <ul class="m-0 p-0 list-none">
       {invitations.map((invitation) => (
-        <li
-          key={invitation.id}
-          class="border-b border-border last:border-b-0 px-5 py-4 flex flex-wrap items-center justify-between gap-3"
-        >
+        <SettingsCardListItem key={invitation.id}>
           <div class="flex flex-col gap-1.5 min-w-0">
             <div class="flex items-center gap-2 flex-wrap">
               <span class="text-[14px] font-medium text-ink truncate">{invitation.email}</span>
@@ -237,7 +235,7 @@ function InvitationList({
           >
             Revoke
           </Button>
-        </li>
+        </SettingsCardListItem>
       ))}
     </ul>
   );

--- a/src/pages/Dashboard/Settings/ReleaseTargetForm.tsx
+++ b/src/pages/Dashboard/Settings/ReleaseTargetForm.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "preact/hooks";
 import { useModel } from "@preact/signals";
 import { GithubAppModel, type PublicGithubAppInstallation } from "../../../models/github-app";
-import { Alert, Button, Field, Muted, Select } from "../../../components";
+import { Alert, Button, Field, Muted, Select, SettingsCardForm } from "../../../components";
 
 type GithubApp = ReturnType<typeof useModel<typeof GithubAppModel.prototype>>;
 
@@ -33,7 +33,7 @@ export function ReleaseTargetForm({
   };
 
   return (
-    <form class="px-5 pb-5 flex flex-col gap-4" onSubmit={onSubmit}>
+    <SettingsCardForm onSubmit={onSubmit}>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
         <RepositorySelector githubApp={githubApp} />
         <EnvironmentSelector githubApp={githubApp} />
@@ -46,7 +46,7 @@ export function ReleaseTargetForm({
           {submitting ? "Mapping…" : "Map release target"}
         </Button>
       </div>
-    </form>
+    </SettingsCardForm>
   );
 }
 

--- a/src/pages/Dashboard/Settings/SlackConnectionSection.tsx
+++ b/src/pages/Dashboard/Settings/SlackConnectionSection.tsx
@@ -16,6 +16,7 @@ import {
   Muted,
   pushToast,
   Select,
+  SettingsCardBody,
 } from "../../../components";
 
 export function SlackConnectionSection({
@@ -69,7 +70,7 @@ export function SlackConnectionSection({
 
   return (
     <CollapsibleCard title="slack" defaultOpen={defaultOpen} aside={aside}>
-      <div class="p-5 flex flex-col gap-5">
+      <SettingsCardBody>
         <Muted class="text-[13px] m-0 max-w-[760px]">
           Connect a Slack workspace and choose one public channel for Drydock to post scan
           completions and release-gate reviews. The bot token is encrypted at rest and only ever
@@ -115,7 +116,7 @@ export function SlackConnectionSection({
         <Show<string | null> when={slack.error}>
           {(message) => <Alert tone="critical">{message}</Alert>}
         </Show>
-      </div>
+      </SettingsCardBody>
     </CollapsibleCard>
   );
 }


### PR DESCRIPTION
## Summary
Standardizes settings-style boxes on the compact 20px inset used by the preferred General/Account settings layout. Adds shared `SettingsCard*` primitives for settings cards, card bodies, section headers, forms, and list rows, then migrates General, Account, Members, GitHub App, npm, Slack, notification recipients, and release-target settings to those primitives.

Testing: `pnpm run verify`

Docs checked, no update needed.

Link to Devin session: https://app.devin.ai/sessions/10b9171053c74f17a98856804d8603cb
Requested by: @JoviDeCroock