### PR TITLE
Align marketing page headers

### DIFF
--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -42,8 +42,8 @@ export default function DocsPage() {
         </nav>
       </header>
 
-      <div class="flex max-w-[880px] flex-col gap-14">
-        <section id="staged-publishing" class="flex flex-col gap-8 scroll-mt-6">
+      <div class="flex flex-col gap-14">
+        <section id="staged-publishing" class="flex max-w-[880px] flex-col gap-8 scroll-mt-6">
           <div class="flex flex-col gap-3">
             <SectionLabel>Staged publishing: npm</SectionLabel>
             <h2 class="text-2xl font-semibold tracking-[-0.015em] m-0 max-w-[680px]">
@@ -112,7 +112,7 @@ export default function DocsPage() {
           </Subsection>
         </section>
 
-        <section id="workflow-gating" class="flex flex-col gap-8 scroll-mt-6">
+        <section id="workflow-gating" class="flex max-w-[880px] flex-col gap-8 scroll-mt-6">
           <div class="flex flex-col gap-3">
             <SectionLabel>
               Workflow gating: PyPI &amp; npm on GitHub Actions <Badge tone="info">Preview</Badge>
@@ -314,7 +314,7 @@ export default function DocsPage() {
           </Subsection>
         </section>
 
-        <section class="flex flex-col gap-4 border-t border-border pt-10">
+        <section class="flex max-w-[880px] flex-col gap-4 border-t border-border pt-10">
           <SectionLabel>Start reviewing releases</SectionLabel>
           <div class="flex flex-wrap gap-3">
             <LinkButton href="/register">Create account</LinkButton>

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -8,38 +8,41 @@ export default function DocsPage() {
   const authed = useAuthedSession();
 
   return (
-    <PageShell headerActions={<MarketingHeaderActions authed={authed} />}>
+    <PageShell class="gap-12" headerActions={<MarketingHeaderActions authed={authed} />}>
       <PageSeo metadata={docsPageSeo} />
-      <div class="flex max-w-[880px] flex-col gap-14">
-        <header class="border-t border-border pt-8 flex flex-col gap-5">
-          <Eyebrow tone="accent">Documentation</Eyebrow>
-          <h1 class="text-4xl md:text-5xl font-semibold tracking-[-0.03em] leading-[1.05] max-w-[760px] m-0">
-            Pick where Drydock pauses your release.
-          </h1>
-          <p class="text-[17px] text-ink-muted max-w-[620px] leading-[1.6] m-0">
-            The package that reaches a registry is not the pull request a maintainer reviewed. It is
-            the built output from scripts, bundlers, and CI. Drydock pauses npm staged publishes or
-            GitHub-gated PyPI and npm jobs, compares the candidate with the last published version,
-            and pins findings to changed lines. Maintainers decide; Drydock never publishes, never
-            stores publish credentials, and never executes package contents.
-          </p>
-          <p class="m-0 max-w-[680px] text-[14px] text-ink-muted leading-[1.65]">
-            Use registry staging when npm can hold the candidate. Use workflow gating when GitHub
-            Actions builds the release and a GitHub Environment can pause the publish job. Both
-            paths produce the same review report:
-          </p>
-          <nav class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-1" aria-label="Integration modes">
-            <ModeCard href="#staged-publishing" title="Staged publishing: npm">
-              Run <Code>npm publish --stage</Code>. npm holds a private candidate, Drydock reviews
-              it, and you complete the publish in npm with your own 2FA.
-            </ModeCard>
-            <ModeCard href="#workflow-gating" title="Workflow gating: PyPI & npm" badge="Preview">
-              GitHub Actions builds and uploads the release artifact. A GitHub Environment pauses
-              publishing until a maintainer approves or rejects the Drydock review.
-            </ModeCard>
-          </nav>
-        </header>
+      <header class="py-8 md:py-12 border-t border-border flex flex-col gap-5">
+        <Eyebrow tone="accent">Documentation</Eyebrow>
+        <h1 class="text-4xl md:text-5xl font-semibold tracking-[-0.03em] leading-[1.05] max-w-[760px] m-0">
+          Pick where Drydock pauses your release.
+        </h1>
+        <p class="text-[17px] text-ink-muted max-w-[620px] leading-[1.6] m-0">
+          The package that reaches a registry is not the pull request a maintainer reviewed. It is
+          the built output from scripts, bundlers, and CI. Drydock pauses npm staged publishes or
+          GitHub-gated PyPI and npm jobs, compares the candidate with the last published version,
+          and pins findings to changed lines. Maintainers decide; Drydock never publishes, never
+          stores publish credentials, and never executes package contents.
+        </p>
+        <p class="m-0 max-w-[680px] text-[14px] text-ink-muted leading-[1.65]">
+          Use registry staging when npm can hold the candidate. Use workflow gating when GitHub
+          Actions builds the release and a GitHub Environment can pause the publish job. Both paths
+          produce the same review report:
+        </p>
+        <nav
+          class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-1 max-w-[880px]"
+          aria-label="Integration modes"
+        >
+          <ModeCard href="#staged-publishing" title="Staged publishing: npm">
+            Run <Code>npm publish --stage</Code>. npm holds a private candidate, Drydock reviews it,
+            and you complete the publish in npm with your own 2FA.
+          </ModeCard>
+          <ModeCard href="#workflow-gating" title="Workflow gating: PyPI & npm" badge="Preview">
+            GitHub Actions builds and uploads the release artifact. A GitHub Environment pauses
+            publishing until a maintainer approves or rejects the Drydock review.
+          </ModeCard>
+        </nav>
+      </header>
 
+      <div class="flex max-w-[880px] flex-col gap-14">
         <section id="staged-publishing" class="flex flex-col gap-8 scroll-mt-6">
           <div class="flex flex-col gap-3">
             <SectionLabel>Staged publishing: npm</SectionLabel>

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -27,10 +27,7 @@ export default function DocsPage() {
           Actions builds the release and a GitHub Environment can pause the publish job. Both paths
           produce the same review report:
         </p>
-        <nav
-          class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-1 max-w-[880px]"
-          aria-label="Integration modes"
-        >
+        <nav class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-1" aria-label="Integration modes">
           <ModeCard href="#staged-publishing" title="Staged publishing: npm">
             Run <Code>npm publish --stage</Code>. npm holds a private candidate, Drydock reviews it,
             and you complete the publish in npm with your own 2FA.
@@ -43,7 +40,7 @@ export default function DocsPage() {
       </header>
 
       <div class="flex flex-col gap-14">
-        <section id="staged-publishing" class="flex max-w-[880px] flex-col gap-8 scroll-mt-6">
+        <section id="staged-publishing" class="flex flex-col gap-8 scroll-mt-6">
           <div class="flex flex-col gap-3">
             <SectionLabel>Staged publishing: npm</SectionLabel>
             <h2 class="text-2xl font-semibold tracking-[-0.015em] m-0 max-w-[680px]">
@@ -112,7 +109,7 @@ export default function DocsPage() {
           </Subsection>
         </section>
 
-        <section id="workflow-gating" class="flex max-w-[880px] flex-col gap-8 scroll-mt-6">
+        <section id="workflow-gating" class="flex flex-col gap-8 scroll-mt-6">
           <div class="flex flex-col gap-3">
             <SectionLabel>
               Workflow gating: PyPI &amp; npm on GitHub Actions <Badge tone="info">Preview</Badge>
@@ -314,7 +311,7 @@ export default function DocsPage() {
           </Subsection>
         </section>
 
-        <section class="flex max-w-[880px] flex-col gap-4 border-t border-border pt-10">
+        <section class="flex flex-col gap-4 border-t border-border pt-10">
           <SectionLabel>Start reviewing releases</SectionLabel>
           <div class="flex flex-wrap gap-3">
             <LinkButton href="/register">Create account</LinkButton>

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -1,16 +1,14 @@
 import type { ComponentChildren } from "preact";
 import { Badge, Card, Eyebrow, LinkButton, PageShell, SectionLabel } from "../../components";
 import { docsPageSeo, PageSeo } from "../../lib/seo";
+import { MarketingHeaderActions } from "../MarketingHeaderActions";
+import { useAuthedSession } from "../useAuthedSession";
 
 export default function DocsPage() {
+  const authed = useAuthedSession();
+
   return (
-    <PageShell
-      headerActions={
-        <LinkButton href="/" variant="ghost" size="sm">
-          Home
-        </LinkButton>
-      }
-    >
+    <PageShell headerActions={<MarketingHeaderActions authed={authed} />}>
       <PageSeo metadata={docsPageSeo} />
       <div class="flex max-w-[880px] flex-col gap-14">
         <header class="border-t border-border pt-8 flex flex-col gap-5">

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -1,9 +1,6 @@
 import type { ComponentChildren } from "preact";
-import { useEffect } from "preact/hooks";
-import { useSignal } from "@preact/signals";
 import { Show } from "@preact/signals/utils";
 import { homePageSeo, PageSeo } from "../../lib/seo";
-import { sessionModel } from "../../models/auth";
 import {
   AikidoPartnerStrip,
   Badge,
@@ -17,37 +14,14 @@ import {
   StatusStrip,
   StatusStripItem,
 } from "../../components";
+import { MarketingHeaderActions } from "../MarketingHeaderActions";
+import { useAuthedSession } from "../useAuthedSession";
 
 export default function LandingPage() {
-  const authed = useSignal(false);
-
-  useEffect(() => {
-    let cancelled = false;
-    void sessionModel.load().then((session) => {
-      if (cancelled) return;
-      authed.value = Boolean(session?.user);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  const authed = useAuthedSession();
 
   return (
-    <PageShell
-      class="gap-12"
-      headerActions={
-        <>
-          <Show when={authed}>
-            <LinkButton href="/dashboard" variant="ghost" size="sm">
-              Dashboard
-            </LinkButton>
-          </Show>
-          <LinkButton href="/docs" variant="ghost" size="sm">
-            Docs
-          </LinkButton>
-        </>
-      }
-    >
+    <PageShell class="gap-12" headerActions={<MarketingHeaderActions authed={authed} />}>
       <PageSeo metadata={homePageSeo} />
       <section class="py-8 md:py-12 border-t border-border flex flex-col gap-5">
         <Eyebrow tone="accent">Package review before npm or PyPI publish</Eyebrow>

--- a/src/pages/MarketingHeaderActions.tsx
+++ b/src/pages/MarketingHeaderActions.tsx
@@ -1,0 +1,21 @@
+import type { Signal } from "@preact/signals";
+import { Show } from "@preact/signals/utils";
+import { LinkButton } from "../components";
+
+export function MarketingHeaderActions({ authed }: { authed: Signal<boolean> }) {
+  return (
+    <>
+      <LinkButton href="/" variant="ghost" size="sm">
+        Home
+      </LinkButton>
+      <LinkButton href="/docs" variant="ghost" size="sm">
+        Docs
+      </LinkButton>
+      <Show when={authed}>
+        <LinkButton href="/dashboard" variant="ghost" size="sm">
+          Dashboard
+        </LinkButton>
+      </Show>
+    </>
+  );
+}

--- a/src/pages/useAuthedSession.ts
+++ b/src/pages/useAuthedSession.ts
@@ -1,0 +1,20 @@
+import { useSignal } from "@preact/signals";
+import { useEffect } from "preact/hooks";
+import { sessionModel } from "../models/auth";
+
+export function useAuthedSession() {
+  const authed = useSignal(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void sessionModel.load().then((session) => {
+      if (cancelled) return;
+      authed.value = Boolean(session?.user);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return authed;
+}


### PR DESCRIPTION
## Summary
- Introduces a shared `MarketingHeaderActions` component so `/` and `/docs` render the same top-level navigation: Home, Docs, and authenticated Dashboard.
- Moves the shared public-page session check into `useAuthedSession`, keeping the landing CTA and header on one signal per page.
- Removes the docs-page `max-w-[880px]` layout constraint so `/docs` uses the same wide `PageShell` treatment as `/`; text readability stays constrained by the existing heading/prose max widths.
- Docs checked, no update needed for this navigation/visual consistency fix.
- Verified with `pnpm run verify`.

Link to Devin session: https://app.devin.ai/sessions/3ed096161e454d36a1faef1fd7df53d8
Requested by: @JoviDeCroock