### PR TITLE
Improve PR and release test reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -59,12 +58,6 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
-      - name: Comment detection eval report
-        if: ${{ always() && github.event_name == 'pull_request' }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: node scripts/comment-detection-eval.mjs
-
   e2e:
     name: e2e
     runs-on: ubuntu-latest
@@ -115,3 +108,27 @@ jobs:
             .context/e2e-registry/requests.jsonl
           if-no-files-found: ignore
           retention-days: 7
+
+  detection-eval-comment:
+    name: detection eval PR comment
+    runs-on: ubuntu-latest
+    needs: check
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Download detection eval report
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        continue-on-error: true
+        with:
+          name: detection-eval-report
+          path: .context/eval
+
+      - name: Comment detection eval report
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/comment-detection-eval.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -45,6 +49,21 @@ jobs:
       - name: Test
         if: ${{ !cancelled() }}
         run: pnpm run test
+
+      - name: Upload detection eval report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: detection-eval-report
+          path: .context/eval/detection-eval.*
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Comment detection eval report
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/comment-detection-eval.mjs
 
   e2e:
     name: e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           name: detection-eval-report
           path: .context/eval/detection-eval.*
+          include-hidden-files: true
           if-no-files-found: ignore
           retention-days: 14
 

--- a/docs/detection-eval.md
+++ b/docs/detection-eval.md
@@ -29,6 +29,14 @@ The report is written to `.context/eval/detection-eval.md` (and `.json`), which
 is gitignored. `pnpm test` also runs the gated thresholds, since the harness is
 a normal Vitest file (`test/eval/detection-eval.test.mjs`).
 
+## CI visibility
+
+GitHub Actions uploads `.context/eval/detection-eval.*` as the
+`detection-eval-report` artifact from the main check job. Pull requests also get
+a sticky detection-eval comment that is updated on every run, so reviewers see
+the gated regression numbers, reported frontier misses, benign hard-negative
+false positives, and evasion robustness without digging through logs.
+
 ## Corpus layout
 
 ```

--- a/docs/e2e-test-environment.md
+++ b/docs/e2e-test-environment.md
@@ -9,6 +9,7 @@ The normal end-to-end loop is local and deterministic. It uses fixture packages 
 - `test/e2e/fake-registry.mjs` serves only the staged-publish, packument, and tarball endpoints the app uses.
 - `test/e2e/dev-server.mjs` starts the fake registry and the Vite/Cloudflare Worker dev server together, after applying D1 migrations to an isolated `.context/e2e/state` persistence path that is reset on each run.
 - `test/e2e/local-registry.spec.ts` creates one authenticated browser state, runs the implicit node-gyp fixture through the UI, then runs each remaining fixture as its own Playwright test through the local Worker API. Each scenario asserts its `scenario.json` expected outcome independently, so CI points at the exact fixture that regressed.
+- `test/e2e/smoke.spec.ts` is a cheap browser smoke suite with mocked API responses. It covers the workflow-gate scan-detail surface and decision dialog without touching the fake-registry journal, so Playwright can run it across desktop, mobile, and dark-mode projects without multiplying the full scan matrix.
 
 The fake registry writes `.context/e2e-registry/requests.jsonl`. The browser test checks this journal so we can verify authorization headers only appear on expected npm-like endpoints.
 
@@ -49,6 +50,11 @@ pnpm exec playwright install --with-deps chromium
 ```
 
 The workflow uploads `.context/e2e-artifacts/` and `.context/e2e-registry/requests.jsonl` as `e2e-artifacts` for every run, so failed browser tests keep traces, screenshots, videos, and the fake-registry request journal.
+
+`playwright.config.ts` keeps the expensive scenario coverage in the `chromium`
+project (`local-registry.spec.ts` and `two-factor.spec.ts`). The lightweight
+`smoke.spec.ts` runs in `desktop-smoke`, `mobile-smoke`, and `dark-smoke`, giving
+responsive/theme coverage without rerunning every staged-publish fixture.
 
 ## Conductor
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,23 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
+      testMatch: ["**/local-registry.spec.ts", "**/two-factor.spec.ts"],
       use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "desktop-smoke",
+      testMatch: "**/smoke.spec.ts",
+      use: { ...devices["Desktop Chrome"], colorScheme: "light" },
+    },
+    {
+      name: "mobile-smoke",
+      testMatch: "**/smoke.spec.ts",
+      use: { ...devices["Pixel 7"], colorScheme: "light" },
+    },
+    {
+      name: "dark-smoke",
+      testMatch: "**/smoke.spec.ts",
+      use: { ...devices["Desktop Chrome"], colorScheme: "dark" },
     },
   ],
   webServer: {

--- a/scripts/comment-detection-eval.mjs
+++ b/scripts/comment-detection-eval.mjs
@@ -25,13 +25,7 @@ const report = readFileSync(reportPath, "utf8").trim();
 const body = trimComment(`${marker}\n${report}\n\n_Updated by CI for this PR._`);
 
 try {
-  const comments = await github(
-    "GET",
-    `/repos/${owner}/${repo}/issues/${pullNumber}/comments?per_page=100`,
-  );
-  const existing = comments.find(
-    (comment) => typeof comment.body === "string" && comment.body.includes(marker),
-  );
+  const existing = await findExistingComment();
 
   if (existing) {
     await github("PATCH", `/repos/${owner}/${repo}/issues/comments/${existing.id}`, { body });
@@ -53,6 +47,19 @@ function trimComment(value) {
   const suffix =
     "\n\n_Report truncated for GitHub comment size; download the CI artifact for full JSON._";
   return `${value.slice(0, maxBodyChars - suffix.length)}${suffix}`;
+}
+
+async function findExistingComment() {
+  for (let page = 1; ; page += 1) {
+    const comments = await github(
+      "GET",
+      `/repos/${owner}/${repo}/issues/${pullNumber}/comments?per_page=100&page=${page}`,
+    );
+    const existing = comments.find(
+      (comment) => typeof comment.body === "string" && comment.body.includes(marker),
+    );
+    if (existing || comments.length < 100) return existing;
+  }
 }
 
 async function github(method, path, body) {

--- a/scripts/comment-detection-eval.mjs
+++ b/scripts/comment-detection-eval.mjs
@@ -1,0 +1,78 @@
+import { existsSync, readFileSync } from "node:fs";
+
+const marker = "<!-- drydock:detection-eval-report -->";
+const reportPath = ".context/eval/detection-eval.md";
+const maxBodyChars = 60_000;
+
+const token = process.env.GITHUB_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY;
+const eventPath = process.env.GITHUB_EVENT_PATH;
+
+if (!token || !repository || !eventPath || !existsSync(reportPath)) {
+  console.log("detection eval comment skipped: missing token, event, repository, or report");
+  process.exit(0);
+}
+
+const event = JSON.parse(readFileSync(eventPath, "utf8"));
+const pullNumber = event.pull_request?.number;
+if (!pullNumber) {
+  console.log("detection eval comment skipped: not a pull_request event");
+  process.exit(0);
+}
+
+const [owner, repo] = repository.split("/");
+const report = readFileSync(reportPath, "utf8").trim();
+const body = trimComment(`${marker}\n${report}\n\n_Updated by CI for this PR._`);
+
+try {
+  const comments = await github(
+    "GET",
+    `/repos/${owner}/${repo}/issues/${pullNumber}/comments?per_page=100`,
+  );
+  const existing = comments.find(
+    (comment) => typeof comment.body === "string" && comment.body.includes(marker),
+  );
+
+  if (existing) {
+    await github("PATCH", `/repos/${owner}/${repo}/issues/comments/${existing.id}`, { body });
+    console.log(`updated detection eval report comment #${existing.id}`);
+  } else {
+    const created = await github("POST", `/repos/${owner}/${repo}/issues/${pullNumber}/comments`, {
+      body,
+    });
+    console.log(`created detection eval report comment #${created.id}`);
+  }
+} catch (err) {
+  console.log(
+    `detection eval comment skipped: ${err instanceof Error ? err.message : String(err)}`,
+  );
+}
+
+function trimComment(value) {
+  if (value.length <= maxBodyChars) return value;
+  const suffix =
+    "\n\n_Report truncated for GitHub comment size; download the CI artifact for full JSON._";
+  return `${value.slice(0, maxBodyChars - suffix.length)}${suffix}`;
+}
+
+async function github(method, path, body) {
+  const response = await fetch(`https://api.github.com${path}`, {
+    method,
+    headers: {
+      accept: "application/vnd.github+json",
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+      "x-github-api-version": "2022-11-28",
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  const data = await response.json().catch(() => null);
+  if (!response.ok) {
+    const message =
+      data && typeof data === "object" && "message" in data
+        ? String(data.message)
+        : `${response.status} ${response.statusText}`;
+    throw new Error(message);
+  }
+  return data;
+}

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,5 +1,5 @@
 import type { ComponentChildren } from "preact";
-import { useEffect, useRef } from "preact/hooks";
+import { useEffect, useId, useRef } from "preact/hooks";
 import { cn } from "./cn";
 
 interface DialogProps {
@@ -22,6 +22,8 @@ export function Dialog({
   class: className,
 }: DialogProps) {
   const ref = useRef<HTMLDialogElement | null>(null);
+  const titleId = useId();
+  const descriptionId = useId();
 
   useEffect(() => {
     const node = ref.current;
@@ -45,6 +47,8 @@ export function Dialog({
   return (
     <dialog
       ref={ref}
+      aria-labelledby={titleId}
+      aria-describedby={description ? descriptionId : undefined}
       onClose={onClose}
       onCancel={onCancel}
       onClick={onBackdropClick}
@@ -65,9 +69,13 @@ export function Dialog({
           ✕
         </button>
         <header class="flex flex-col gap-1 pr-7">
-          <h2 class="text-[18px] font-medium tracking-[-0.01em] leading-[1.35] m-0">{title}</h2>
+          <h2 id={titleId} class="text-[18px] font-medium tracking-[-0.01em] leading-[1.35] m-0">
+            {title}
+          </h2>
           {description ? (
-            <p class="text-[13px] leading-[1.55] text-ink-muted m-0">{description}</p>
+            <p id={descriptionId} class="text-[13px] leading-[1.55] text-ink-muted m-0">
+              {description}
+            </p>
           ) : null}
         </header>
         <div class="flex flex-col gap-3">{children}</div>

--- a/test/e2e/smoke.spec.ts
+++ b/test/e2e/smoke.spec.ts
@@ -1,0 +1,237 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+const scanId = "gate-smoke-scan-000001";
+const gateId = "gate-smoke-000001";
+const now = "2026-06-15T12:00:00.000Z";
+
+test("renders and decides a workflow-gate review", async ({ page }) => {
+  await installWorkflowGateMocks(page);
+
+  await page.goto(`/dashboard/scans/${scanId}`);
+
+  await expect(page.getByRole("heading", { name: "@drydock/gate-demo" })).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.getByText("Deployment gate")).toBeVisible();
+  await expect(page.getByText("awaiting decision").first()).toBeVisible();
+  await expect(page.getByText("drydock/example").first()).toBeVisible();
+  await expect(page.getByText("Release packages")).toBeVisible();
+  await expect(page.getByText("@drydock/sidecar@0.4.0")).toBeVisible();
+
+  await page.getByRole("button", { name: "Decide", exact: true }).click();
+  await expect(page.getByRole("dialog", { name: "Package decision" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Approve package" })).toBeVisible();
+  await page.getByRole("button", { name: "Reject & block release" }).click();
+
+  await expect(page.getByText("rejected · job blocked").first()).toBeVisible();
+  await expect(page.getByText("blocked").first()).toBeVisible();
+});
+
+async function installWorkflowGateMocks(page: Page) {
+  let packageDecision: "publish" | "no_publish" | null = null;
+  let gateStatus: "pending" | "rejected" = "pending";
+
+  await page.route("**/api/**", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname;
+
+    if (path === "/api/auth/get-session") {
+      await fulfillJson(route, {
+        user: {
+          id: "user-smoke",
+          name: "Smoke Tester",
+          email: "smoke@example.test",
+          twoFactorEnabled: false,
+        },
+      });
+      return;
+    }
+
+    if (path === `/api/v1/scans/${scanId}`) {
+      await fulfillJson(route, scanDetail(packageDecision));
+      return;
+    }
+
+    if (path === `/api/v1/scans/${scanId}/versions`) {
+      await fulfillJson(route, {
+        packageName: "@drydock/gate-demo",
+        stagedVersion: "1.2.0",
+        defaultPreviousVersion: null,
+        versions: [],
+      });
+      return;
+    }
+
+    if (path === `/api/v1/github-app/workflow-gates/by-scan/${scanId}`) {
+      await fulfillJson(route, { gate: workflowGate(gateStatus, packageDecision) });
+      return;
+    }
+
+    if (path === `/api/v1/github-app/workflow-gates/${gateId}/decision`) {
+      expect(request.method()).toBe("POST");
+      const body = JSON.parse(request.postData() || "{}") as {
+        scanId?: string;
+        decision?: string;
+      };
+      expect(body.scanId).toBe(scanId);
+      expect(body.decision).toBe("rejected");
+      packageDecision = "no_publish";
+      gateStatus = "rejected";
+      await fulfillJson(route, { gate: workflowGate(gateStatus, packageDecision) });
+      return;
+    }
+
+    await fulfillJson(route, { error: `unexpected e2e smoke API request: ${path}` }, 404);
+  });
+}
+
+function scanDetail(packageDecision: "publish" | "no_publish" | null) {
+  return {
+    scan: {
+      id: scanId,
+      stageId: `workflow-gate:${gateId}:pypi:@drydock/gate-demo`,
+      source: "workflow_gate",
+      organizationId: "org-smoke",
+      ownerUserId: "user-smoke",
+      packageName: "@drydock/gate-demo",
+      stagedVersion: "1.2.0",
+      previousVersion: "1.1.0",
+      risk: "high",
+      status: "complete",
+      decision: packageDecision,
+      decisionReason: null,
+      decidedByUserId: packageDecision ? "user-smoke" : null,
+      decidedAt: packageDecision ? now : null,
+      changedFileCount: 1,
+      findingCount: 1,
+      riskSummary: riskSummary(),
+      summaryJson: {
+        report: {
+          version: 1,
+          digest: "a".repeat(64),
+          digestAlgorithm: "sha256",
+          generatedAt: now,
+          rulesVersion: "smoke",
+        },
+        diff: [
+          {
+            path: "src/gate_demo/__init__.py",
+            status: "added",
+            stagedSize: 102,
+            stagedSha256: "b".repeat(64),
+            flags: [],
+          },
+        ],
+      },
+      aiJson: {
+        status: "unavailable",
+        risk: "low",
+        releaseAssessment: "not_assessed",
+        summary: "AI review unavailable for smoke fixture.",
+        findings: [],
+        requiresManualReview: false,
+        model: null,
+      },
+      errorJson: null,
+      reportVersion: 1,
+      reportDigest: "a".repeat(64),
+      startedAt: now,
+      completedAt: now,
+      createdAt: now,
+      updatedAt: now,
+    },
+    riskSummary: riskSummary(),
+    files: [
+      {
+        id: "file-smoke-1",
+        scanId,
+        path: "src/gate_demo/__init__.py",
+        status: "added",
+        size: 102,
+        sha256: "b".repeat(64),
+        flagsJson: [],
+        textSample:
+          "import os\nimport urllib.request\nurllib.request.urlopen(os.environ['TOKEN'])\n",
+      },
+    ],
+    findings: [
+      {
+        id: "finding-smoke-1",
+        scanId,
+        severity: "high",
+        file: "src/gate_demo/__init__.py",
+        evidence: "network call reads an environment secret",
+        reason: "credential access and network egress appear in release-added code",
+        line: 3,
+        source: "deterministic",
+        ruleId: "code.network-credential-exfil",
+        ruleVersion: "smoke",
+        diffStatus: "added",
+        releaseDelta: true,
+      },
+    ],
+    events: [],
+  };
+}
+
+function riskSummary() {
+  return {
+    artifactRisk: "high",
+    releaseRisk: "high",
+    contextRisk: "low",
+    releaseFindingCount: 1,
+    contextFindingCount: 0,
+    unknownFindingCount: 0,
+  };
+}
+
+function workflowGate(
+  status: "pending" | "rejected",
+  packageDecision: "publish" | "no_publish" | null,
+) {
+  return {
+    id: gateId,
+    organizationId: "org-smoke",
+    releaseTargetId: "target-smoke",
+    repositoryFullName: "drydock/example",
+    environment: "pypi",
+    runId: 12345,
+    status,
+    decision: status === "rejected" ? "rejected" : null,
+    decisionComment: null,
+    reportUrl: null,
+    scanId,
+    failureReason: null,
+    packages: [
+      {
+        scanId,
+        packageName: "@drydock/gate-demo",
+        version: "1.2.0",
+        status: "complete",
+        releaseRisk: "high",
+        decision: packageDecision,
+      },
+      {
+        scanId: "gate-smoke-sidecar-000001",
+        packageName: "@drydock/sidecar",
+        version: "0.4.0",
+        status: "complete",
+        releaseRisk: "low",
+        decision: "publish",
+      },
+    ],
+    requestedAt: now,
+    decidedAt: status === "rejected" ? now : null,
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+async function fulfillJson(route: Route, json: unknown, status = 200) {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(json),
+  });
+}


### PR DESCRIPTION
## Summary
- Upload and sticky-comment detection eval reports from PR CI so reviewers see regression, frontier, benign-FP, and evasion metrics.
- Split Playwright into full Chromium coverage plus lightweight desktop, mobile, and dark smoke projects, including a mocked workflow-gate decision smoke.
- Add accessible dialog names so role-based E2E assertions and assistive tech can identify dialogs.

## Validation
- pnpm run typecheck
- pnpm run eval
- pnpm run lint
- pnpm run format:check
- pnpm exec playwright test --project desktop-smoke --project mobile-smoke --project dark-smoke
- pnpm exec playwright test --project chromium --list
