### PR TITLE
Delete R2 scan artifacts when their D1 rows are deleted

### DIFF
--- a/docs/artifact-storage.md
+++ b/docs/artifact-storage.md
@@ -94,6 +94,18 @@ pnpm run scan-artifacts:backfill -- \
 
 The script defaults to the production `staged-publish-review` D1 database and `staged-publish-review-artifacts` R2 bucket through remote Wrangler operations. Use `--database`, `--bucket`, `--config`, `--env`, `--local`, or `--persist-to` when targeting a different Wrangler setup. The script prints one progress line per batch and exits nonzero if any row-level `failed` count remains. Use `--cursor <scan_id>` to resume a single-organization run from the last printed `nextCursor`; `--cursor` is intentionally not accepted with `--all-organizations` because cursors are organization-scoped. `digestMismatch` rows are reported but do not fail the script because they remain safely D1-backed.
 
+## Deletion Lifecycle
+
+R2 artifacts are torn down whenever the D1 rows that point at them are deleted, so redacted evidence never outlives its metadata:
+
+- **Organization deletion** (`deleteOrganization`) removes every object under `orgs/{organizationId}/` after the D1 batch completes.
+- **Account deletion** (`deleteUserAccount`, invoked by the Better Auth `beforeDelete` hook) deletes each owned organization through `deleteOrganization`, so the personal-workspace and any sole-owned org artifacts go with it.
+- **Gate re-run discard** (`discardGateScans`) deletes the per-scan prefixes `orgs/{organizationId}/scans/{scanId}/` for the scans it discards, since a prior attempt may have completed some packages and written their artifacts.
+
+Deletion uses the raw `ARTIFACTS` binding, not the read-gated bucket: `SCAN_ARTIFACT_READS_DISABLED` is a read kill-switch and must not strand objects. The delete prefixes intentionally stop before the `v{N}` segment so a cleanup removes every storage version. Cleanup is fail-soft — a delete error is logged (`scan.artifacts.delete_failed`) but never thrown, so it cannot abort the surrounding D1 teardown; a leaked object is recoverable by re-running the prefix sweep. A successful sweep logs `scan.artifacts.deleted` with the object count. Pending/running scans that are discarded before completion (`discardScanAttempt`, `deletePendingScanJob`) carry no artifacts, so they skip R2 cleanup.
+
+Time-based retention (a TTL sweep that deletes old scans on a schedule) is not yet implemented and is tracked separately.
+
 ## Rollback
 
 Set `SCAN_ARTIFACT_READS_DISABLED=true` (or `1`) to force scan-detail reads back to D1 while leaving R2 artifacts untouched. Do not delete R2 objects during rollback. This restores D1-backed detail for legacy/degraded rows that still have `scan_files` / `scan_findings` content. It does **not** recover detail for compacted artifact-backed scans (the rows were never written), so disabling reads for those rows shows metadata only — keep R2 reads enabled for them. The safe operational lever for a suspect R2 read remains the per-object digest/size verification, which already fails closed to the metadata view.

--- a/server/db/organizations.ts
+++ b/server/db/organizations.ts
@@ -1,5 +1,6 @@
 import { and, asc, eq, inArray, sql } from "drizzle-orm";
 import { personalOrganizationId } from "../lib/ownership";
+import { deleteOrganizationArtifacts } from "../lib/scan-artifacts";
 import type { AppDb, WorkspaceSession } from "./client";
 import {
   githubAppInstallations,
@@ -227,9 +228,16 @@ export async function setRequireTwoFactorForReleaseDecisions(
  * `ON DELETE CASCADE`, because D1 does not enforce foreign keys by default and a
  * silent orphan here would leak one org's scans/credentials past its deletion.
  * scan_files / scan_findings hang off scan_id, so they're cleared via a subquery
- * over the org's scans before the scans themselves go.
+ * over the org's scans before the scans themselves go. The org's derived R2
+ * artifacts are removed after the D1 teardown so redacted evidence doesn't
+ * outlive the org; pass the ARTIFACTS bucket (the deletion is a no-op without
+ * it, e.g. in environments with no bucket bound).
  */
-export async function deleteOrganization(db: AppDb, organizationId: string): Promise<void> {
+export async function deleteOrganization(
+  db: AppDb,
+  organizationId: string,
+  artifactBucket?: R2Bucket,
+): Promise<void> {
   const orgScans = db
     .select({ id: scans.id })
     .from(scans)
@@ -258,6 +266,8 @@ export async function deleteOrganization(db: AppDb, organizationId: string): Pro
     db.delete(organizationMembers).where(eq(organizationMembers.organizationId, organizationId)),
     db.delete(organizations).where(eq(organizations.id, organizationId)),
   ]);
+
+  await deleteOrganizationArtifacts(artifactBucket, organizationId);
 }
 
 export interface CoOwnedOrganization {
@@ -313,7 +323,11 @@ export async function findCoOwnedOrganizations(
  * findCoOwnedOrganizations before this runs; if one reaches here it is left
  * intact rather than destroying another member's data.
  */
-export async function deleteUserAccount(db: AppDb, userId: string): Promise<void> {
+export async function deleteUserAccount(
+  db: AppDb,
+  userId: string,
+  artifactBucket?: R2Bucket,
+): Promise<void> {
   const personalId = personalOrganizationId(userId);
   const owned = await db
     .select({ id: organizations.id })
@@ -330,7 +344,7 @@ export async function deleteUserAccount(db: AppDb, userId: string): Promise<void
       ).filter((member) => member.userId !== userId).length;
       if (others > 0) continue; // co-owned: rejected upstream, never wiped here
     }
-    await deleteOrganization(db, org.id);
+    await deleteOrganization(db, org.id, artifactBucket);
   }
 
   await db.batch([

--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -13,6 +13,7 @@ import {
 } from "../lib/review";
 import { normalizeScanRiskBreakdown, type ScanRiskBreakdown } from "../lib/risk";
 import {
+  deleteScanArtifacts,
   loadScanArtifactFile,
   loadScanArtifacts,
   scanFileRowsForArtifacts,
@@ -164,12 +165,24 @@ export async function discardScanAttempt(db: AppDb, scanId: string, organization
  * review batch before it is re-run, so a retry does not leave orphaned
  * per-package scans behind (cascades to scan_files / scan_findings). Safe only
  * once the caller holds the gate's review claim and no representative scan is
- * attached.
+ * attached. A prior attempt may have completed some packages and written their
+ * R2 artifacts, so pass the ARTIFACTS bucket to tear those down too — the scan
+ * ids are read before the D1 delete so the per-scan artifact prefixes are known.
  */
-export async function discardGateScans(db: AppDb, gateId: string, organizationId: string) {
-  await db
-    .delete(scans)
-    .where(and(eq(scans.gateId, gateId), eq(scans.organizationId, organizationId)));
+export async function discardGateScans(
+  db: AppDb,
+  gateId: string,
+  organizationId: string,
+  artifactBucket?: R2Bucket,
+) {
+  const condition = and(eq(scans.gateId, gateId), eq(scans.organizationId, organizationId));
+  const discarded = artifactBucket
+    ? await db.select({ id: scans.id }).from(scans).where(condition)
+    : [];
+  await db.delete(scans).where(condition);
+  for (const { id } of discarded) {
+    await deleteScanArtifacts(artifactBucket, organizationId, id);
+  }
 }
 
 export async function persistScan(db: AppDb, input: PersistedScanInput) {

--- a/server/lib/auth.ts
+++ b/server/lib/auth.ts
@@ -143,7 +143,7 @@ export function createAuth(env: Cloudflare.Env) {
               } before deleting your account: ${names}`,
             });
           }
-          await deleteUserAccount(db, deletedUser.id);
+          await deleteUserAccount(db, deletedUser.id, env.ARTIFACTS);
         },
       },
     },

--- a/server/lib/scan-artifacts.ts
+++ b/server/lib/scan-artifacts.ts
@@ -344,6 +344,38 @@ export async function loadScanArtifactFile(
   }
 }
 
+// R2 lifecycle cleanup: drop derived artifacts when the D1 rows that point at
+// them are deleted, so redacted evidence never outlives its metadata. Both take
+// the raw ARTIFACTS bucket — not scanArtifactReadBucket — because deletion is a
+// teardown concern, and SCAN_ARTIFACT_READS_DISABLED (a read kill-switch) must
+// not strand objects. Both are fail-soft: a delete error is logged, never
+// thrown, so it can't abort the surrounding D1 teardown (account/org deletion
+// must still complete). A leaked object is recoverable by re-running the sweep.
+
+export async function deleteOrganizationArtifacts(
+  bucket: R2Bucket | undefined,
+  organizationId: string,
+): Promise<void> {
+  if (!bucket) return;
+  await deleteArtifactsByPrefix(bucket, organizationArtifactPrefix(organizationId), {
+    organizationId,
+    scope: "organization",
+  });
+}
+
+export async function deleteScanArtifacts(
+  bucket: R2Bucket | undefined,
+  organizationId: string,
+  scanId: string,
+): Promise<void> {
+  if (!bucket) return;
+  await deleteArtifactsByPrefix(bucket, scanArtifactPrefix(organizationId, scanId), {
+    organizationId,
+    scanId,
+    scope: "scan",
+  });
+}
+
 async function loadScanArtifactsManifest(
   bucket: R2Bucket | undefined,
   scan: ScanArtifactScanRow,
@@ -468,6 +500,53 @@ function artifactKeys(organizationId: string, scanId: string) {
 
 function safeSegment(value: string): string {
   return encodeURIComponent(value).replace(/%/g, "~");
+}
+
+// Deletion prefixes intentionally stop *before* the `v{N}` segment so a cleanup
+// removes every storage version of the scan/org, not just the current one. They
+// must match the `artifactKeys` layout exactly or a sweep would miss objects.
+function organizationArtifactPrefix(organizationId: string): string {
+  return `orgs/${safeSegment(organizationId)}/`;
+}
+
+function scanArtifactPrefix(organizationId: string, scanId: string): string {
+  return `orgs/${safeSegment(organizationId)}/scans/${safeSegment(scanId)}/`;
+}
+
+// R2 caps list() and delete() at 1000 keys per call, so we page until the prefix
+// is drained. Caller-supplied logFields identify the scope (org vs scan) for the
+// emitted event.
+const ARTIFACT_LIST_PAGE = 1000;
+
+async function deleteArtifactsByPrefix(
+  bucket: R2Bucket,
+  prefix: string,
+  logFields: Record<string, unknown>,
+): Promise<void> {
+  try {
+    let deleted = 0;
+    let cursor: string | undefined;
+    do {
+      const listed = await bucket.list({ prefix, limit: ARTIFACT_LIST_PAGE, cursor });
+      const keys = listed.objects.map((object) => object.key);
+      if (keys.length > 0) {
+        await bucket.delete(keys);
+        deleted += keys.length;
+      }
+      cursor = listed.truncated ? listed.cursor : undefined;
+    } while (cursor);
+    if (deleted > 0) {
+      emitOperationalEvent("info", "scan.artifacts.deleted", {
+        ...logFields,
+        objectsDeleted: deleted,
+      });
+    }
+  } catch (err) {
+    emitOperationalEvent("error", "scan.artifacts.delete_failed", {
+      ...logFields,
+      error: describeOperationalError(err),
+    });
+  }
 }
 
 function parseManifest(text: string): ScanArtifactsManifest | null {

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -244,7 +244,7 @@ export async function executeWorkflowGateJob(
     // A retried batch (a prior attempt released its claim mid-flight) discards
     // the half-finished scans first so the gate's package set is exactly this
     // batch.
-    await discardGateScans(db, gate.id, organizationId);
+    await discardGateScans(db, gate.id, organizationId, env.ARTIFACTS);
     reviewed = await reviewGatePackages(
       { env, executionCtx, db },
       { gate, ownerUserId, packages: prepared.packages },

--- a/server/routes/organizations.ts
+++ b/server/routes/organizations.ts
@@ -203,8 +203,9 @@ organizationsRoutes.delete("/:id", async (c) => {
   }
 
   // No scan_event is recorded: the org and its scan_events are removed together,
-  // so the audit row would be deleted in the same breath.
-  await deleteOrganization(db, organizationId);
+  // so the audit row would be deleted in the same breath. ARTIFACTS is passed so
+  // the org's R2 artifacts are torn down alongside its D1 rows.
+  await deleteOrganization(db, organizationId, c.env.ARTIFACTS);
   return c.json({ ok: true });
 });
 

--- a/test/workers/scan-artifact-cleanup.test.ts
+++ b/test/workers/scan-artifact-cleanup.test.ts
@@ -1,0 +1,230 @@
+import { env } from "cloudflare:test";
+import { eq } from "drizzle-orm";
+import { describe, expect, test } from "vitest";
+import {
+  createDb,
+  createScanJob,
+  deleteOrganization,
+  deleteUserAccount,
+  discardGateScans,
+  ensurePersonalOrganization,
+} from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { createReleaseTarget, upsertInstallation } from "../../server/lib/github-app";
+import type { DiffEntry, FileRecord } from "../../server/lib/review";
+import {
+  deleteOrganizationArtifacts,
+  deleteScanArtifacts,
+  writeScanArtifacts,
+} from "../../server/lib/scan-artifacts";
+import { sha256Hex, stableJson } from "../../server/lib/stable-json";
+
+// Mirrors the private safeSegment in scan-artifacts.ts: object keys live under
+// `orgs/{seg(orgId)}/scans/{seg(scanId)}/...`, so listing/asserting in the test
+// has to encode the same way the writer does.
+function safeSegment(value: string): string {
+  return encodeURIComponent(value).replace(/%/g, "~");
+}
+
+// writeScanArtifacts emits exactly four objects per scan: report/files/diff +
+// the manifest. The cleanup assertions count against this.
+const OBJECTS_PER_SCAN = 4;
+
+const files: FileRecord[] = [
+  { path: "index.js", size: 14, sha256: "a".repeat(64), textSample: "console.log(1)", flags: [] },
+];
+const diff: DiffEntry[] = [
+  { path: "index.js", status: "added", stagedSize: 14, stagedSha256: "a".repeat(64), flags: [] },
+];
+
+async function seedUser() {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Cleanup Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { db, userId, organizationId };
+}
+
+async function seedScanArtifacts(organizationId: string, scanId: string) {
+  // Contents are irrelevant to deletion; the cleanup tests never read them back.
+  const reportJson = stableJson({ version: 1, ruleFindings: [], findingAnnotations: [] });
+  const reportDigest = await sha256Hex(reportJson);
+  await writeScanArtifacts(env.ARTIFACTS, {
+    organizationId,
+    scanId,
+    reportJson,
+    reportDigest,
+    files,
+    diff,
+    generatedAt: "2026-06-17T00:00:00.000Z",
+  });
+}
+
+async function listOrgKeys(organizationId: string): Promise<string[]> {
+  const listed = await env.ARTIFACTS.list({ prefix: `orgs/${safeSegment(organizationId)}/` });
+  return listed.objects.map((object) => object.key);
+}
+
+// scans.gate_id is an enforced FK in the test D1, so a gate-attached scan needs
+// the full installation → release-target → gate chain to exist first.
+async function seedGate(db: ReturnType<typeof createDb>, organizationId: string): Promise<string> {
+  const now = new Date();
+  const installation = await upsertInstallation(db, {
+    organizationId,
+    installationId: `inst_${crypto.randomUUID()}`,
+    accountLogin: "octo",
+    accountType: "Organization",
+    targetType: "Organization",
+    status: "active",
+    createdByUserId: null,
+  });
+  const releaseTarget = await createReleaseTarget(db, {
+    organizationId,
+    installationRowId: installation.id,
+    ecosystem: "npm",
+    repositoryId: 1234,
+    repositoryFullName: "octo/example",
+    environment: "npm",
+    createdByUserId: null,
+  });
+  const gateId = crypto.randomUUID();
+  await db.insert(schema.githubWorkflowGates).values({
+    id: gateId,
+    organizationId,
+    installationRowId: installation.id,
+    releaseTargetId: releaseTarget.id,
+    deliveryId: crypto.randomUUID(),
+    repositoryId: 1234,
+    repositoryFullName: "octo/example",
+    environment: "npm",
+    runId: 1,
+    deploymentCallbackUrl: "https://api.github.com/example",
+    eventAction: "requested",
+    status: "pending",
+    requestedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  });
+  return gateId;
+}
+
+async function scanExists(db: ReturnType<typeof createDb>, scanId: string): Promise<boolean> {
+  const rows = await db
+    .select({ id: schema.scans.id })
+    .from(schema.scans)
+    .where(eq(schema.scans.id, scanId));
+  return rows.length > 0;
+}
+
+describe("scan artifact deletion helpers", () => {
+  test("deleteOrganizationArtifacts removes only the target org's objects", async () => {
+    const orgA = `org_${crypto.randomUUID()}`;
+    const orgB = `org_${crypto.randomUUID()}`;
+    await seedScanArtifacts(orgA, "scan_1");
+    await seedScanArtifacts(orgA, "scan_2");
+    await seedScanArtifacts(orgB, "scan_1");
+
+    expect((await listOrgKeys(orgA)).length).toBe(OBJECTS_PER_SCAN * 2);
+
+    await deleteOrganizationArtifacts(env.ARTIFACTS, orgA);
+
+    expect(await listOrgKeys(orgA)).toEqual([]);
+    expect((await listOrgKeys(orgB)).length).toBe(OBJECTS_PER_SCAN);
+  });
+
+  test("deleteScanArtifacts removes one scan and leaves siblings in the same org", async () => {
+    const org = `org_${crypto.randomUUID()}`;
+    await seedScanArtifacts(org, "scan_keep");
+    await seedScanArtifacts(org, "scan_drop");
+
+    await deleteScanArtifacts(env.ARTIFACTS, org, "scan_drop");
+
+    const remaining = await listOrgKeys(org);
+    expect(remaining.length).toBe(OBJECTS_PER_SCAN);
+    expect(remaining.every((key) => key.includes("/scans/scan_keep/"))).toBe(true);
+  });
+
+  test("a missing bucket is a no-op rather than a throw", async () => {
+    await expect(deleteOrganizationArtifacts(undefined, "org_x")).resolves.toBeUndefined();
+    await expect(deleteScanArtifacts(undefined, "org_x", "scan_x")).resolves.toBeUndefined();
+  });
+});
+
+describe("R2 cleanup follows D1 deletion", () => {
+  test("deleteOrganization tears down the org's R2 artifacts with its D1 scans", async () => {
+    const { db, userId, organizationId } = await seedUser();
+    const scanId = `scan_${crypto.randomUUID()}`;
+    await seedScanArtifacts(organizationId, scanId);
+    await createScanJob(db, {
+      id: scanId,
+      stageId: "stage-1",
+      organizationId,
+      ownerUserId: userId,
+    });
+
+    expect((await listOrgKeys(organizationId)).length).toBe(OBJECTS_PER_SCAN);
+
+    await deleteOrganization(db, organizationId, env.ARTIFACTS);
+
+    expect(await listOrgKeys(organizationId)).toEqual([]);
+    expect(await scanExists(db, scanId)).toBe(false);
+  });
+
+  test("deleteUserAccount clears the user's personal-org artifacts", async () => {
+    const { db, userId, organizationId } = await seedUser();
+    const scanId = `scan_${crypto.randomUUID()}`;
+    await seedScanArtifacts(organizationId, scanId);
+    await createScanJob(db, {
+      id: scanId,
+      stageId: "stage-1",
+      organizationId,
+      ownerUserId: userId,
+    });
+
+    await deleteUserAccount(db, userId, env.ARTIFACTS);
+
+    expect(await listOrgKeys(organizationId)).toEqual([]);
+  });
+
+  test("discardGateScans clears artifacts for the gate's discarded scans", async () => {
+    const { db, userId, organizationId } = await seedUser();
+    const gateId = await seedGate(db, organizationId);
+    const scanId = `scan_${crypto.randomUUID()}`;
+    await seedScanArtifacts(organizationId, scanId);
+    await createScanJob(db, {
+      id: scanId,
+      stageId: "stage-1",
+      organizationId,
+      ownerUserId: userId,
+      gateId,
+    });
+
+    await discardGateScans(db, gateId, organizationId, env.ARTIFACTS);
+
+    expect(await listOrgKeys(organizationId)).toEqual([]);
+    expect(await scanExists(db, scanId)).toBe(false);
+  });
+
+  test("deleteOrganization without a bucket leaves D1 clean and never throws", async () => {
+    const { db, userId, organizationId } = await seedUser();
+    const scanId = `scan_${crypto.randomUUID()}`;
+    await createScanJob(db, {
+      id: scanId,
+      stageId: "stage-1",
+      organizationId,
+      ownerUserId: userId,
+    });
+
+    await deleteOrganization(db, organizationId);
+
+    expect(await scanExists(db, scanId)).toBe(false);
+  });
+});


### PR DESCRIPTION
Derived scan artifacts in R2 were never deleted on any path, so organization/account deletion and gate re-run discards orphaned the redacted evidence in R2 permanently. This adds prefix-based `deleteOrganizationArtifacts` / `deleteScanArtifacts` helpers — paged, fail-soft, observable, and using the raw `ARTIFACTS` binding so `SCAN_ARTIFACT_READS_DISABLED` (a read kill-switch) can't strand objects — and wires them into `deleteOrganization`, `deleteUserAccount`, and `discardGateScans`. Pending/running discards are deliberately skipped since they never carry artifacts. New worker tests cover the helpers (org-isolated, sibling-preserving, no-binding no-op) plus integration through all three D1 deletion paths, and `docs/artifact-storage.md` documents the deletion lifecycle. Time-based TTL retention, historical D1 compaction, and export/signing remain separate follow-ups (Phase 5 issue #310).

🤖 Generated with [Claude Code](https://claude.com/claude-code)