### PR TITLE
Self-host Geist font instead of Google Fonts CDN

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -18,9 +18,9 @@ Source of truth for visual decisions in this repo. Read this before changing fon
 
 ## Typography
 
-- **Display & Body:** Geist (weights 400, 500, 600). Loaded from Google Fonts. Modern, neutral, developer-readable, no licensing concerns.
+- **Display & Body:** Geist (weights 400, 500, 600). Self-hosted, served same-origin. Modern, neutral, developer-readable, no licensing concerns.
 - **Mono:** Geist Mono (weights 400, 500, 600). Used for file paths, severity labels, scan IDs, timestamps, code, and section labels — mono is a first-class typeface here, not just a code fallback.
-- **Loading:** `https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap`. Self-host if the marketing site needs it.
+- **Loading:** Self-hosted via the `@fontsource-variable/geist` and `@fontsource-variable/geist-mono` packages, imported in `src/style.css` (CSS families `"Geist Variable"` / `"Geist Mono Variable"`). Bundled into our own assets — no request to a third-party font CDN, so no visitor IP is sent to Google at page load (a GDPR consideration for EU visitors). Do **not** reintroduce the Google Fonts CDN `@import`.
 - **Feature settings:** `font-feature-settings: "ss01", "cv11"` for Geist (humanist alts), `"ss01", "tnum"` for Geist Mono (tabular numbers — essential for data rows).
 
 ### Scale

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "verify": "node scripts/verify.mjs"
   },
   "dependencies": {
+    "@fontsource-variable/geist": "^5.2.9",
+    "@fontsource-variable/geist-mono": "^5.2.8",
     "@preact/signals": "^2.9.2",
     "ai": "^6.0.207",
     "better-auth": "^1.6.19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
 
   .:
     dependencies:
+      '@fontsource-variable/geist':
+        specifier: ^5.2.9
+        version: 5.2.9
+      '@fontsource-variable/geist-mono':
+        specifier: ^5.2.8
+        version: 5.2.8
       '@preact/signals':
         specifier: ^2.9.2
         version: 2.9.2(preact@10.29.2)
@@ -982,6 +988,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fontsource-variable/geist-mono@5.2.8':
+    resolution: {integrity: sha512-KI5bj+hkkRiHttYHmccotUZ80ZuZyai+RwI1d7UId0clkx/jXxlo8qYK8j54WzmpBjtMoEMPyllV7faDcj+6RA==}
+
+  '@fontsource-variable/geist@5.2.9':
+    resolution: {integrity: sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ==}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -3441,6 +3453,10 @@ snapshots:
 
   '@esbuild/win32-x64@0.28.1':
     optional: true
+
+  '@fontsource-variable/geist-mono@5.2.8': {}
+
+  '@fontsource-variable/geist@5.2.9': {}
 
   '@img/colour@1.1.0': {}
 

--- a/public/_headers
+++ b/public/_headers
@@ -17,4 +17,4 @@
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; style-src-attr 'none'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; style-src 'self'; style-src-attr 'none'; font-src 'self'; img-src 'self' data:; connect-src 'self'

--- a/server/lib/security-headers.ts
+++ b/server/lib/security-headers.ts
@@ -34,12 +34,13 @@ export const API_CSP = ["default-src 'none'", "frame-ancestors 'none'", "base-ur
   "; ",
 );
 
-// The HTML UI loads same-origin scripts/styles/images plus the Geist webfont
-// from Google Fonts: the stylesheet from fonts.googleapis.com (style-src) pulls
-// font files from fonts.gstatic.com (font-src). Inline style attributes are
-// blocked; dynamic visuals use classes or SVG geometry attributes instead.
-// img-src data: covers inline data-URI images. connect-src stays 'self' — the
-// UI only calls the same-origin /api surface.
+// The HTML UI loads only same-origin subresources. The Geist webfont is
+// self-hosted (Fontsource, bundled into our assets), so style-src and font-src
+// stay 'self' with no third-party origins — no visitor IP leaks to a font CDN.
+// No 'unsafe-inline' on style-src, and style-src-attr 'none' blocks inline
+// style attributes outright; dynamic visuals use classes or SVG geometry
+// attributes instead. img-src data: covers inline data-URI images. connect-src
+// stays 'self' — the UI only calls the same-origin /api surface.
 export const DOCUMENT_CSP = [
   "default-src 'self'",
   "base-uri 'self'",
@@ -47,9 +48,9 @@ export const DOCUMENT_CSP = [
   "frame-ancestors 'none'",
   "form-action 'self'",
   "script-src 'self'",
-  "style-src 'self' https://fonts.googleapis.com",
+  "style-src 'self'",
   "style-src-attr 'none'",
-  "font-src 'self' https://fonts.gstatic.com",
+  "font-src 'self'",
   "img-src 'self' data:",
   "connect-src 'self'",
 ].join("; ");

--- a/src/style.css
+++ b/src/style.css
@@ -1,10 +1,16 @@
-@import url("https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap");
+/* Self-hosted Geist (Fontsource variable fonts) — served same-origin so no
+   visitor IP is sent to Google's CDN at page load. The variable axis covers
+   every weight we use (400–700) in one subsetted file per script. */
+@import "@fontsource-variable/geist";
+@import "@fontsource-variable/geist-mono";
 @import "tailwindcss";
 
 @theme {
   --font-sans:
-    "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif;
-  --font-mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, "Courier New", monospace;
+    "Geist Variable", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+    sans-serif;
+  --font-mono:
+    "Geist Mono Variable", ui-monospace, SFMono-Regular, Menlo, Monaco, "Courier New", monospace;
 
   --color-bg: #fafaf9;
   --color-surface: #ffffff;

--- a/test/security-headers.test.ts
+++ b/test/security-headers.test.ts
@@ -46,9 +46,17 @@ describe("public/_headers static-asset security headers", () => {
   });
 
   test("document CSP rejects inline CSS", () => {
-    expect(DOCUMENT_CSP).toContain("style-src 'self' https://fonts.googleapis.com");
+    expect(DOCUMENT_CSP).toContain("style-src 'self'");
     expect(DOCUMENT_CSP).toContain("style-src-attr 'none'");
     expect(DOCUMENT_CSP).not.toContain("'unsafe-inline'");
+  });
+
+  // Geist is self-hosted; the policy must never reach back out to a font CDN
+  // (no third-party origin in style-src/font-src means no visitor-IP leak).
+  test("document CSP loads fonts only from same origin", () => {
+    expect(DOCUMENT_CSP).toContain("font-src 'self'");
+    expect(DOCUMENT_CSP).not.toContain("fonts.googleapis.com");
+    expect(DOCUMENT_CSP).not.toContain("fonts.gstatic.com");
   });
 
   test("carries the same non-CSP security headers as the Worker", () => {


### PR DESCRIPTION
Loads Geist and Geist Mono from the bundled `@fontsource-variable` packages served same-origin, replacing the runtime `@import` from the Google Fonts CDN. This stops every visitor's IP from being sent to Google at page load (a GDPR concern for EU visitors) and removes two third-party connection setups from the render path; the variable axis covers all weights (400–700) in one subsetted file per script. `DOCUMENT_CSP` is tightened to match — `style-src`/`font-src` drop the Google origins back to `'self'` — kept in sync with `public/_headers` (drift-guard test passes), and `DESIGN.md` is updated to document the self-hosted loading. Verified with `pnpm run verify` (lint, format, typecheck, tests) and a production build confirming all woff2 emit same-origin with no `fonts.googleapis.com`/`fonts.gstatic.com` references remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)