### PR TITLE
Retry Workers AI request timeouts

### DIFF
--- a/server/lib/ai-review.ts
+++ b/server/lib/ai-review.ts
@@ -202,12 +202,13 @@ export async function analyzeWithAi(
   };
 }
 
-// Workers AI capacity/overload/rate-limit rejections are transient and worth a
-// retry; anything else (bad request, code bug) is not. Matched on message text
-// because the binding throws plain Errors, not classified APICallErrors — `3040`
-// is Workers AI's "Capacity temporarily exceeded" code.
+// Workers AI capacity/overload/rate-limit/time-out rejections are transient and
+// worth a retry; anything else (bad request, code bug) is not. Matched on
+// message text because the binding throws plain Errors, not classified
+// APICallErrors — `3040` is "Capacity temporarily exceeded" and `3046` is
+// "Request timeout".
 const RETRYABLE_AI_ERROR_PATTERN =
-  /\b(?:3040|429|502|503)\b|capacity .*exceeded|temporarily unavailable|overloaded|rate.?limit|too many requests/i;
+  /\b(?:3040|3046|408|429|502|503)\b|capacity .*exceeded|request timeout|temporarily unavailable|overloaded|rate.?limit|too many requests/i;
 
 function isRetryableAiError(err: unknown): boolean {
   return RETRYABLE_AI_ERROR_PATTERN.test(errorMessage(err));

--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -317,6 +317,33 @@ describe("ai review orchestration", () => {
     expect(ai.summary).toBe("No unusual changes.");
   });
 
+  test("a transient request timeout is retried and the review completes", async () => {
+    let calls = 0;
+    const flakyModel = mockModel(async () => {
+      calls += 1;
+      if (calls === 1) {
+        throw new Error("AiError: AiError: Request timeout (ca4ebee2)");
+      }
+      return generateResult(
+        [
+          {
+            type: "tool-call",
+            toolCallId: "submit-1",
+            toolName: "submit_review",
+            input: JSON.stringify(VALID_REVIEW),
+          },
+        ],
+        "tool-calls",
+      );
+    });
+
+    const { review: ai } = await analyzeWithAi({}, "mock-reviewer", BASE_OPTIONS, flakyModel);
+
+    expect(calls).toBe(2);
+    expect(ai.status).toBe("complete");
+    expect(ai.summary).toBe("No unusual changes.");
+  });
+
   test("a persistent capacity error exhausts retries and fails safe to unavailable", async () => {
     let calls = 0;
     const downModel = mockModel(async () => {
@@ -340,6 +367,40 @@ describe("ai review orchestration", () => {
         calls.set(model, (calls.get(model) ?? 0) + 1);
         if (model === "primary-reviewer") {
           throw new Error("3040: Capacity temporarily exceeded, please try again.");
+        }
+        return generateResult(
+          [
+            {
+              type: "tool-call",
+              toolCallId: "submit-1",
+              toolName: "submit_review",
+              input: JSON.stringify(VALID_REVIEW),
+            },
+          ],
+          "tool-calls",
+        );
+      });
+
+    const { review: ai } = await analyzeWithAi(
+      {},
+      ["primary-reviewer", "fallback-reviewer"],
+      BASE_OPTIONS,
+      modelFactory,
+    );
+
+    expect(calls.get("primary-reviewer")).toBe(3);
+    expect(calls.get("fallback-reviewer")).toBe(1);
+    expect(ai.status).toBe("complete");
+    expect(ai.model).toBe("fallback-reviewer");
+  });
+
+  test("a persistent request timeout falls back to the secondary reviewer", async () => {
+    const calls = new Map();
+    const modelFactory = (model) =>
+      mockModel(async () => {
+        calls.set(model, (calls.get(model) ?? 0) + 1);
+        if (model === "primary-reviewer") {
+          throw new Error("3046: Request timeout");
         }
         return generateResult(
           [


### PR DESCRIPTION
## Summary
- Treat Workers AI `3046` / HTTP `408` request timeouts as retryable alongside capacity and rate-limit errors, so Kimi timeouts get bounded retries and can fall through to the Qwen fallback instead of immediately degrading AI review to unavailable.
- Add AI-review orchestration coverage for transient timeout recovery and persistent timeout fallback:
  ```ts
  /\b(?:3040|3046|408|429|502|503)\b|...|request timeout|.../i
  ```
- Tested with `pnpm exec vitest run test/ai-review.test.mjs`, `pnpm run lint`, `pnpm run typecheck`, and `pnpm run verify`.
- Docs checked, no update needed: this is an internal resilience change to existing AI-review retry behavior.

Link to Devin session: https://app.devin.ai/sessions/6387b57e43154885bc5b83614f4beb78
Requested by: @JoviDeCroock