### PR TITLE
Fix atomic scan completion persistence

### DIFF
--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -1,4 +1,5 @@
 import { and, asc, desc, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
+import type { BatchItem } from "drizzle-orm/batch";
 import {
   annotateFindingsWithDiffStatus,
   type CodePatternSet,
@@ -252,57 +253,68 @@ export async function persistScan(db: AppDb, input: PersistedScanInput) {
     updatedAt: now,
   };
 
-  const updated = await db
-    .update(scans)
-    .set({
-      packageName: scanValues.packageName,
-      stagedVersion: scanValues.stagedVersion,
-      previousVersion: scanValues.previousVersion,
-      risk: scanValues.risk,
-      status: scanValues.status,
-      summaryJson: scanValues.summaryJson,
-      aiJson: scanValues.aiJson,
-      errorJson: scanValues.errorJson,
-      changedFileCount: scanValues.changedFileCount,
-      findingCount: scanValues.findingCount,
-      riskSummaryJson: scanValues.riskSummaryJson,
-      reportVersion: scanValues.reportVersion,
-      reportDigest: scanValues.reportDigest,
-      artifactStorageVersion: scanValues.artifactStorageVersion,
-      artifactManifestKey: scanValues.artifactManifestKey,
-      artifactManifestDigest: scanValues.artifactManifestDigest,
-      artifactManifestSize: scanValues.artifactManifestSize,
-      reportArtifactKey: scanValues.reportArtifactKey,
-      fileSamplesArtifactKey: scanValues.fileSamplesArtifactKey,
-      diffArtifactKey: scanValues.diffArtifactKey,
-      completedAt: scanValues.completedAt,
-      updatedAt: now,
-    })
-    .where(
-      and(
-        eq(scans.id, input.id),
-        eq(scans.organizationId, input.organizationId),
-        inArray(scans.status, [...NON_TERMINAL_STATUSES]),
-      ),
-    )
-    .returning({ id: scans.id });
-
-  if (updated.length === 0) {
-    const [existing] = await db
-      .select({ id: scans.id, status: scans.status, reportDigest: scans.reportDigest })
-      .from(scans)
-      .where(and(eq(scans.id, input.id), eq(scans.organizationId, input.organizationId)))
-      .limit(1);
-    if (existing) return { persisted: false, reason: "already_terminal" as const };
-    await db.insert(scans).values(scanValues).onConflictDoNothing({ target: scans.id });
+  const claimToken = `persist:${crypto.randomUUID()}`;
+  const existing = await db
+    .select({ id: scans.id, status: scans.status, reportDigest: scans.reportDigest })
+    .from(scans)
+    .where(and(eq(scans.id, input.id), eq(scans.organizationId, input.organizationId)))
+    .limit(1);
+  if (existing[0] && !NON_TERMINAL_STATUSES.some((status) => status === existing[0]?.status)) {
+    return { persisted: false, reason: "already_terminal" as const };
   }
 
-  // Always clear prior detail rows first so a retry — including one that flips a
-  // scan from D1-backed to R2-backed — never leaves stale rows behind.
-  await Promise.all([
-    db.delete(scanFiles).where(eq(scanFiles.scanId, input.id)),
-    db.delete(scanFindings).where(eq(scanFindings.scanId, input.id)),
-  ]);
+  // D1 rejects SQL BEGIN/SAVEPOINT in Workers, so use a batch: D1 applies the
+  // statements atomically. The temporary reportDigest token gates every child
+  // mutation and is cleared by the final statement before the batch commits.
+  const claimScan = existing[0]
+    ? db
+        .update(scans)
+        .set({
+          packageName: scanValues.packageName,
+          stagedVersion: scanValues.stagedVersion,
+          previousVersion: scanValues.previousVersion,
+          risk: scanValues.risk,
+          status: scanValues.status,
+          summaryJson: scanValues.summaryJson,
+          aiJson: scanValues.aiJson,
+          errorJson: scanValues.errorJson,
+          changedFileCount: scanValues.changedFileCount,
+          findingCount: scanValues.findingCount,
+          riskSummaryJson: scanValues.riskSummaryJson,
+          reportVersion: scanValues.reportVersion,
+          artifactStorageVersion: scanValues.artifactStorageVersion,
+          artifactManifestKey: scanValues.artifactManifestKey,
+          artifactManifestDigest: scanValues.artifactManifestDigest,
+          artifactManifestSize: scanValues.artifactManifestSize,
+          reportArtifactKey: scanValues.reportArtifactKey,
+          fileSamplesArtifactKey: scanValues.fileSamplesArtifactKey,
+          diffArtifactKey: scanValues.diffArtifactKey,
+          completedAt: scanValues.completedAt,
+          reportDigest: claimToken,
+          updatedAt: now,
+        })
+        .where(
+          and(
+            eq(scans.id, input.id),
+            eq(scans.organizationId, input.organizationId),
+            inArray(scans.status, [...NON_TERMINAL_STATUSES]),
+          ),
+        )
+        .returning({ id: scans.id })
+    : db
+        .insert(scans)
+        .values({ ...scanValues, reportDigest: claimToken })
+        .onConflictDoNothing({ target: scans.id })
+        .returning({ id: scans.id });
+
+  const claimExists = scanPersistClaimExists(input.id, input.organizationId, claimToken);
+  const batch: [BatchItem<"sqlite">, ...BatchItem<"sqlite">[]] = [
+    claimScan,
+    // Always clear prior detail rows first so a retry — including one that flips a
+    // scan from D1-backed to R2-backed — never leaves stale rows behind.
+    db.delete(scanFiles).where(and(eq(scanFiles.scanId, input.id), claimExists)),
+    db.delete(scanFindings).where(and(eq(scanFindings.scanId, input.id), claimExists)),
+  ];
 
   // When the scan is R2-artifact-backed, its redacted file samples, file
   // metadata, diff, and findings already live in R2 (files.json / diff.json /
@@ -312,16 +324,104 @@ export async function persistScan(db: AppDb, input: PersistedScanInput) {
   // detail in D1 so the scan stays readable.
   if (!input.artifacts) {
     // D1 caps bound parameters at 100 per query, so insert in chunks sized to
-    // each row's column count. Without this, packages with more than ~12 files
-    // silently drop their scan_files rows and the scan-detail view renders as
-    // "No file content available." for every entry.
-    await Promise.all([
-      ...chunkForD1(fileRows, 8).map((chunk) => db.insert(scanFiles).values(chunk)),
-      ...chunkForD1(findingRows, 10).map((chunk) => db.insert(scanFindings).values(chunk)),
-    ]);
+    // each row's columns plus the claim guard. Without this, packages with more
+    // than ~12 files silently drop their scan_files rows and the scan-detail view
+    // renders as "No file content available." for every entry.
+    for (const chunk of chunkForD1(fileRows, 11)) {
+      batch.push(insertScanFilesWhenClaimed(db, chunk, input.organizationId, claimToken));
+    }
+    for (const chunk of chunkForD1(findingRows, 13)) {
+      batch.push(insertScanFindingsWhenClaimed(db, chunk, input.organizationId, claimToken));
+    }
   }
 
+  batch.push(
+    db
+      .update(scans)
+      .set({ reportDigest: scanValues.reportDigest, updatedAt: now })
+      .where(
+        and(
+          eq(scans.id, input.id),
+          eq(scans.organizationId, input.organizationId),
+          eq(scans.reportDigest, claimToken),
+        ),
+      ),
+  );
+
+  const [claimed] = await db.batch(batch);
+  if (Array.isArray(claimed) && claimed.length === 0) {
+    return { persisted: false, reason: "already_terminal" as const };
+  }
   return { persisted: true as const };
+}
+
+type ScanFileInsertRow = typeof scanFiles.$inferInsert;
+type ScanFindingInsertRow = typeof scanFindings.$inferInsert;
+
+function scanPersistClaimExists(scanId: string, organizationId: string, claimToken: string) {
+  return sql`exists (
+    select 1
+    from ${scans}
+    where ${scans.id} = ${scanId}
+      and ${scans.organizationId} = ${organizationId}
+      and ${scans.reportDigest} = ${claimToken}
+  )`;
+}
+
+function insertScanFilesWhenClaimed(
+  db: AppDb,
+  rows: ScanFileInsertRow[],
+  organizationId: string,
+  claimToken: string,
+) {
+  return db.insert(scanFiles).select(
+    sql.join(
+      rows.map(
+        (row) => sql`
+          select
+            ${row.id},
+            ${row.scanId},
+            ${row.path},
+            ${row.status},
+            ${row.size},
+            ${row.sha256},
+            ${JSON.stringify(row.flagsJson)},
+            ${row.textSample}
+          where ${scanPersistClaimExists(row.scanId, organizationId, claimToken)}
+        `,
+      ),
+      sql.raw(" union all "),
+    ),
+  );
+}
+
+function insertScanFindingsWhenClaimed(
+  db: AppDb,
+  rows: ScanFindingInsertRow[],
+  organizationId: string,
+  claimToken: string,
+) {
+  return db.insert(scanFindings).select(
+    sql.join(
+      rows.map(
+        (row) => sql`
+          select
+            ${row.id},
+            ${row.scanId},
+            ${row.severity},
+            ${row.file},
+            ${row.evidence},
+            ${row.reason},
+            ${row.line},
+            ${row.source},
+            ${row.ruleId},
+            ${row.ruleVersion}
+          where ${scanPersistClaimExists(row.scanId, organizationId, claimToken)}
+        `,
+      ),
+      sql.raw(" union all "),
+    ),
+  );
 }
 
 function withFindingAnnotations(

--- a/test/workers/scan-completion-atomicity.test.ts
+++ b/test/workers/scan-completion-atomicity.test.ts
@@ -1,0 +1,153 @@
+import { env } from "cloudflare:test";
+import { describe, expect, test } from "vitest";
+import {
+  claimScanForRun,
+  createDb,
+  createScanJob,
+  ensurePersonalOrganization,
+  getScan,
+  persistScan,
+} from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { createPackageDiff } from "../../server/lib/review";
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+// Wrap a D1Database so the first atomic D1 batch blocks before it executes.
+// This lets a duplicate completion finish first; when the parked batch resumes,
+// it must not delete or replace the completed scan's findings.
+function gateFirstBatch(d1: D1Database, reached: () => void, gate: Promise<void>): D1Database {
+  let parked = false;
+  return new Proxy(d1, {
+    get(target, prop, receiver) {
+      if (prop === "batch") {
+        return async (statements: D1PreparedStatement[]) => {
+          if (!parked) {
+            parked = true;
+            reached();
+            await gate;
+          }
+          return target.batch(statements);
+        };
+      }
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+async function seedUserAndOrg() {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+describe("scan completion atomicity", () => {
+  // A duplicate Queue delivery may finish while an earlier completion attempt
+  // is still parked before its D1 batch. The stale batch must not clear or
+  // replace the detail rows written by the successful completion.
+  test("stale completion batch cannot clobber findings from a duplicate completion", async () => {
+    const { userId, organizationId } = await seedUserAndOrg();
+    const scanId = `scan_${crypto.randomUUID()}`;
+    const stageId = "stage-atomicity-000001";
+
+    const readerDb = createDb(env.DB);
+    await createScanJob(readerDb, { id: scanId, stageId, organizationId, ownerUserId: userId });
+    await claimScanForRun(readerDb, scanId, organizationId);
+
+    const files = [
+      {
+        path: "binding.gyp",
+        size: 64,
+        sha256: "abc",
+        flags: [],
+        textSample: '{ "targets": [] }\n',
+      },
+    ];
+    const diff = createPackageDiff([], files);
+
+    const reachedSignal = deferred();
+    const gate = deferred();
+    const parkedWriterDb = createDb(gateFirstBatch(env.DB, reachedSignal.resolve, gate.promise));
+
+    const stalePersistPromise = persistScan(parkedWriterDb, {
+      id: scanId,
+      stageId,
+      organizationId,
+      ownerUserId: userId,
+      packageJson: { name: "demo", version: "1.0.0" },
+      previousPackageJson: null,
+      risk: "high",
+      status: "complete",
+      summary: { ok: true },
+      ai: null,
+      files,
+      diff,
+      findings: [
+        {
+          severity: "high",
+          file: "binding.gyp",
+          evidence: "implicit install: node-gyp rebuild",
+          reason: "stale completion should not survive",
+          ruleId: "stale.finding",
+        },
+      ],
+      report: { version: 1, digest: "digest-stale" },
+    });
+
+    // The first completion has prepared its atomic batch but has not committed
+    // anything yet. A duplicate delivery can still complete the scan.
+    await reachedSignal.promise;
+    const duplicate = await persistScan(readerDb, {
+      id: scanId,
+      stageId,
+      organizationId,
+      ownerUserId: userId,
+      packageJson: { name: "demo", version: "1.0.0" },
+      previousPackageJson: null,
+      risk: "high",
+      status: "complete",
+      summary: { ok: true },
+      ai: null,
+      files,
+      diff,
+      findings: [
+        {
+          severity: "high",
+          file: "binding.gyp",
+          evidence: "implicit install: node-gyp rebuild",
+          reason: "package builds a native addon on install",
+          ruleId: "install-script.implicit-node-gyp",
+        },
+      ],
+      report: { version: 1, digest: "digest-atomicity" },
+    });
+    expect(duplicate.persisted).toBe(true);
+
+    gate.resolve();
+    const staleResult = await stalePersistPromise;
+    expect(staleResult.persisted).toBe(false);
+
+    const finalDetail = await getScan(readerDb, scanId, organizationId);
+    expect(finalDetail?.scan.status).toBe("complete");
+    expect(finalDetail?.findings.map((finding) => finding.ruleId)).toEqual([
+      "install-script.implicit-node-gyp",
+    ]);
+  });
+});


### PR DESCRIPTION
Makes scan completion persistence atomic in D1 by claiming a scan with a temporary report digest and gating child row deletes/inserts on that claim. This prevents stale duplicate queue completions from clearing or replacing findings after another completion has already won. Adds a worker regression test that parks one completion batch while a duplicate completion finishes first. Validation: `pnpm run typecheck`, focused worker scan persistence tests, scan list summaries, and scan artifact route tests.