### PR TITLE
Disallow inline CSS in document CSP

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -17,4 +17,4 @@
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; style-src-attr 'none'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'

--- a/server/lib/security-headers.ts
+++ b/server/lib/security-headers.ts
@@ -36,10 +36,10 @@ export const API_CSP = ["default-src 'none'", "frame-ancestors 'none'", "base-ur
 
 // The HTML UI loads same-origin scripts/styles/images plus the Geist webfont
 // from Google Fonts: the stylesheet from fonts.googleapis.com (style-src) pulls
-// font files from fonts.gstatic.com (font-src). 'unsafe-inline' on style-src
-// covers Tailwind's injected styles and the prerendered critical CSS; img-src
-// data: covers inline data-URI images. connect-src stays 'self' — the UI only
-// calls the same-origin /api surface.
+// font files from fonts.gstatic.com (font-src). Inline style attributes are
+// blocked; dynamic visuals use classes or SVG geometry attributes instead.
+// img-src data: covers inline data-URI images. connect-src stays 'self' — the
+// UI only calls the same-origin /api surface.
 export const DOCUMENT_CSP = [
   "default-src 'self'",
   "base-uri 'self'",
@@ -47,7 +47,8 @@ export const DOCUMENT_CSP = [
   "frame-ancestors 'none'",
   "form-action 'self'",
   "script-src 'self'",
-  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "style-src 'self' https://fonts.googleapis.com",
+  "style-src-attr 'none'",
   "font-src 'self' https://fonts.gstatic.com",
   "img-src 'self' data:",
   "connect-src 'self'",

--- a/src/components/AikidoPartner.tsx
+++ b/src/components/AikidoPartner.tsx
@@ -5,21 +5,19 @@ import { SectionLabel } from "./Typography";
 
 const AIKIDO_URL = "https://www.aikido.dev";
 
-const HEIGHTS = {
-  xs: 14,
-  sm: 18,
-  md: 24,
-  lg: 32,
+const markSizeClass = {
+  xs: "h-[14px]",
+  sm: "h-[18px]",
+  md: "h-6",
+  lg: "h-8",
 } as const;
 
-type MarkSize = keyof typeof HEIGHTS;
+type MarkSize = keyof typeof markSizeClass;
 
 export function AikidoMark({ size = "sm", class: className }: { size?: MarkSize; class?: string }) {
-  const height = HEIGHTS[size];
+  const imageClass = cn("w-auto", markSizeClass[size]);
   const imgProps = {
     alt: "Aikido Security",
-    height,
-    style: { height: `${height}px`, width: "auto" },
     loading: "lazy",
     decoding: "async",
   } as const;
@@ -28,8 +26,8 @@ export function AikidoMark({ size = "sm", class: className }: { size?: MarkSize;
     // use (Tailwind `dark:`), so the mark can never disagree with the page
     // theme — <picture> source selection is evaluated separately from CSS.
     <span class={cn("inline-flex items-center leading-none", className)}>
-      <img src={aikidoLight} class="dark:hidden" {...imgProps} />
-      <img src={aikidoDark} class="hidden dark:inline-block" {...imgProps} />
+      <img src={aikidoLight} {...imgProps} class={cn(imageClass, "dark:hidden")} />
+      <img src={aikidoDark} {...imgProps} class={cn(imageClass, "hidden dark:inline-block")} />
     </span>
   );
 }

--- a/src/components/DiffView.tsx
+++ b/src/components/DiffView.tsx
@@ -113,7 +113,7 @@ function LineContent({ text, tokens }: { text: string; tokens: TokenLine | null 
   return (
     <>
       {tokens.map((token, index) => (
-        <span key={index} style={{ color: token.color }}>
+        <span key={index} class={token.className}>
           {token.content}
         </span>
       ))}

--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -22,11 +22,15 @@ function statusToText(status: FolderStatus): string {
   return "text-ink-muted";
 }
 
-const INDENT_BASE = 8;
-const INDENT_PER_DEPTH = 20;
-
-function rowPaddingLeft(depth: number): string {
-  return `${INDENT_BASE + depth * INDENT_PER_DEPTH}px`;
+function TreeIndent({ depth }: { depth: number }) {
+  if (depth <= 0) return null;
+  return (
+    <>
+      {Array.from({ length: depth }, (_, index) => (
+        <span key={index} class="w-5 shrink-0" aria-hidden />
+      ))}
+    </>
+  );
 }
 
 function FindingCountBadge({ count, severity }: { count: number; severity: string | null }) {
@@ -91,11 +95,11 @@ function TreeNode({
         <details open={initiallyOpen} class="group">
           <summary
             class={cn(
-              "list-none cursor-pointer flex items-center gap-2 py-1 pr-2 rounded hover:bg-surface-2",
+              "list-none cursor-pointer flex items-center gap-2 py-1 pr-2 pl-2 rounded hover:bg-surface-2",
               "text-[13px] font-mono",
             )}
-            style={{ paddingLeft: rowPaddingLeft(depth) }}
           >
+            <TreeIndent depth={depth} />
             <span
               aria-hidden
               class="text-ink-subtle text-[10px] inline-block transition-transform duration-150 ease-out group-open:rotate-90"
@@ -131,12 +135,12 @@ function TreeNode({
         type="button"
         onClick={() => onSelect(node.path)}
         class={cn(
-          "w-full flex items-center gap-2 py-1 pr-2 rounded text-left transition-colors",
+          "w-full flex items-center gap-2 py-1 pr-2 pl-2 rounded text-left transition-colors",
           "text-[13px] font-mono",
           isSelected ? "bg-surface-2 text-ink" : "text-ink-muted hover:bg-surface-2 hover:text-ink",
         )}
-        style={{ paddingLeft: rowPaddingLeft(depth) }}
       >
+        <TreeIndent depth={depth} />
         <span class={cn("flex-1 truncate", isSelected ? "text-ink" : statusToText(node.status))}>
           {node.name}
         </span>

--- a/src/components/SeverityBar.tsx
+++ b/src/components/SeverityBar.tsx
@@ -7,7 +7,8 @@ export type SeverityCounts = Partial<Record<SeverityKey, number>>;
 interface Segment {
   key: SeverityKey;
   count: number;
-  width: string;
+  x: number;
+  width: number;
   className: string;
   swatchClass: string;
   label: string;
@@ -16,12 +17,12 @@ interface Segment {
 const ORDER: SeverityKey[] = ["critical", "high", "medium", "low", "info", "ok"];
 
 const segmentClass: Record<SeverityKey, string> = {
-  critical: "bg-danger",
-  high: "bg-danger opacity-[0.78]",
-  medium: "bg-warn",
-  low: "bg-info",
-  info: "bg-info opacity-50",
-  ok: "bg-ok",
+  critical: "text-danger",
+  high: "text-danger opacity-[0.78]",
+  medium: "text-warn",
+  low: "text-info",
+  info: "text-info opacity-50",
+  ok: "text-ok",
 };
 
 const swatchClass: Record<SeverityKey, string> = {
@@ -60,15 +61,24 @@ export function SeverityBar({
     );
   }
 
+  let x = 0;
+  const lastKey = segmentsLastKey(counts);
   const segments: Segment[] = ORDER.filter((key) => (counts[key] ?? 0) > 0).map((key) => {
     const count = counts[key] ?? 0;
-    return {
+    const width = (count / total) * 100;
+    const segment = {
       key,
       count,
-      width: `${(count / total) * 100}%`,
+      x,
+      width,
       className: segmentClass[key],
       swatchClass: swatchClass[key],
       label: key,
+    };
+    x += width;
+    return {
+      ...segment,
+      width: key === lastKey ? 100 - segment.x : segment.width,
     };
   });
 
@@ -80,20 +90,25 @@ export function SeverityBar({
         </span>
         <span class="font-mono text-[11px] text-ink-subtle">{total} total</span>
       </div>
-      <div
-        class="h-2 rounded overflow-hidden bg-surface-2 flex"
+      <svg
+        class="h-2 w-full rounded overflow-hidden bg-surface-2 block"
+        viewBox="0 0 100 4"
+        preserveAspectRatio="none"
         role="img"
         aria-label={`${total} findings: ${segments.map((s) => `${s.count} ${s.label}`).join(", ")}`}
       >
         {segments.map((segment) => (
-          <span
+          <rect
             key={segment.key}
-            class={cn("h-full block", segment.className)}
-            style={{ width: segment.width }}
+            x={segment.x}
+            y="0"
+            width={segment.width}
+            height="4"
+            class={cn("severity-bar-segment", segment.className)}
             aria-hidden
           />
         ))}
-      </div>
+      </svg>
       <ul class="list-none p-0 m-0 flex flex-wrap gap-x-4 gap-y-1.5">
         {segments.map((segment) => (
           <li
@@ -109,4 +124,12 @@ export function SeverityBar({
       </ul>
     </div>
   );
+}
+
+function segmentsLastKey(counts: SeverityCounts): SeverityKey | null {
+  for (let index = ORDER.length - 1; index >= 0; index -= 1) {
+    const key = ORDER[index];
+    if ((counts[key] ?? 0) > 0) return key;
+  }
+  return null;
 }

--- a/src/components/highlight.ts
+++ b/src/components/highlight.ts
@@ -3,7 +3,7 @@ import type { HighlighterCore } from "shiki/core";
 
 export interface Token {
   content: string;
-  color?: string;
+  className?: string;
 }
 
 export type TokenLine = Token[];
@@ -38,6 +38,25 @@ let loading: Promise<void> | null = null;
 // Flips to true once the highlighter finishes loading. Reading it inside a
 // component subscribes that component to re-render and re-tokenize.
 export const highlighterReady = signal(false);
+
+const tokenClassByCssVariable: Record<string, string> = {
+  "--sh-foreground": "sh-token-foreground",
+  "--sh-token-keyword": "sh-token-keyword",
+  "--sh-token-constant": "sh-token-constant",
+  "--sh-token-number": "sh-token-number",
+  "--sh-token-function": "sh-token-function",
+  "--sh-token-parameter": "sh-token-parameter",
+  "--sh-token-punctuation": "sh-token-punctuation",
+  "--sh-token-comment": "sh-token-comment",
+  "--sh-token-string": "sh-token-string",
+  "--sh-token-string-expression": "sh-token-string-expression",
+  "--sh-token-link": "sh-token-link",
+};
+
+function tokenClassName(color: string | undefined): string | undefined {
+  const variableName = color?.match(/^var\((--sh-[a-z-]+)\)$/)?.[1];
+  return variableName ? tokenClassByCssVariable[variableName] : undefined;
+}
 
 export function ensureHighlighter(): void {
   if (highlighter || loading) return;
@@ -76,7 +95,10 @@ export function tokenizeLines(text: string, lang: string): TokenLine[] | null {
   try {
     const { tokens } = highlighter.codeToTokens(text, { lang, theme: "css-variables" });
     return tokens.map((line) =>
-      line.map((token) => ({ content: token.content, color: token.color })),
+      line.map((token) => ({
+        content: token.content,
+        className: tokenClassName(token.color),
+      })),
     );
   } catch {
     return null;

--- a/src/components/highlight.ts
+++ b/src/components/highlight.ts
@@ -3,6 +3,7 @@ import type { HighlighterCore } from "shiki/core";
 
 export interface Token {
   content: string;
+  color?: string;
   className?: string;
 }
 
@@ -97,6 +98,7 @@ export function tokenizeLines(text: string, lang: string): TokenLine[] | null {
     return tokens.map((line) =>
       line.map((token) => ({
         content: token.content,
+        color: token.color,
         className: tokenClassName(token.color),
       })),
     );

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -315,11 +315,13 @@ function TreeRow({
             : "text-ink-muted";
   return (
     <li
-      class={`flex items-center gap-2 py-0.5 pr-1.5 rounded ${
+      class={`flex items-center gap-2 py-0.5 pr-1.5 pl-1 rounded ${
         selected ? "bg-surface-2 text-ink" : toneClass
       }`}
-      style={{ paddingLeft: `${4 + depth * 16}px` }}
     >
+      {Array.from({ length: depth }, (_, index) => (
+        <span key={index} class="w-4 shrink-0" aria-hidden />
+      ))}
       {folder ? (
         <span aria-hidden class="text-[10px] text-ink-subtle">
           {open ? "▾" : "▸"}

--- a/src/style.css
+++ b/src/style.css
@@ -118,6 +118,54 @@
     --sh-token-link: #0f766e;
   }
 
+  .sh-token-foreground {
+    color: var(--sh-foreground);
+  }
+
+  .sh-token-keyword {
+    color: var(--sh-token-keyword);
+  }
+
+  .sh-token-constant {
+    color: var(--sh-token-constant);
+  }
+
+  .sh-token-number {
+    color: var(--sh-token-number);
+  }
+
+  .sh-token-function {
+    color: var(--sh-token-function);
+  }
+
+  .sh-token-parameter {
+    color: var(--sh-token-parameter);
+  }
+
+  .sh-token-punctuation {
+    color: var(--sh-token-punctuation);
+  }
+
+  .sh-token-comment {
+    color: var(--sh-token-comment);
+  }
+
+  .sh-token-string {
+    color: var(--sh-token-string);
+  }
+
+  .sh-token-string-expression {
+    color: var(--sh-token-string-expression);
+  }
+
+  .sh-token-link {
+    color: var(--sh-token-link);
+  }
+
+  .severity-bar-segment {
+    fill: currentColor;
+  }
+
   html,
   body {
     margin: 0;

--- a/test/security-headers.test.ts
+++ b/test/security-headers.test.ts
@@ -45,6 +45,12 @@ describe("public/_headers static-asset security headers", () => {
     expect(catchAll?.["Content-Security-Policy"]).toBe(DOCUMENT_CSP);
   });
 
+  test("document CSP rejects inline CSS", () => {
+    expect(DOCUMENT_CSP).toContain("style-src 'self' https://fonts.googleapis.com");
+    expect(DOCUMENT_CSP).toContain("style-src-attr 'none'");
+    expect(DOCUMENT_CSP).not.toContain("'unsafe-inline'");
+  });
+
   test("carries the same non-CSP security headers as the Worker", () => {
     for (const [name, value] of Object.entries(SECURITY_HEADERS)) {
       expect(catchAll?.[name]).toBe(value);


### PR DESCRIPTION
## Summary
Tightens the document CSP by removing `'unsafe-inline'` from `style-src` and adding `style-src-attr 'none'` in both `DOCUMENT_CSP` and Cloudflare static asset `_headers`.

Reworks the UI paths that previously needed inline style attributes so the stricter policy does not break rendering:
- Shiki token colors map CSS-variable colors to classes.
- File-tree/landing indentation uses classed spacer elements.
- The severity bar uses SVG geometry attributes instead of CSS widths.
- Aikido mark sizing uses Tailwind height classes.

Adds a header guard that rejects `'unsafe-inline'`. Verified locally with `pnpm run verify`, `pnpm run build`, and a built HTML scan for `<style` / `style=`. docs checked, no update needed.

Link to Devin session: https://app.devin.ai/sessions/2dea82d9ac4f496b89b4fd971c6e3daf
Requested by: @JoviDeCroock