### PR TITLE
Harden document CSP fallback directives

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -17,4 +17,4 @@
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; style-src 'self'; style-src-attr 'none'; font-src 'self'; img-src 'self' data:; connect-src 'self'
+  Content-Security-Policy: default-src 'none'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self'; script-src-elem 'self'; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'none'; font-src 'self'; img-src 'self' data:; connect-src 'self'; frame-src 'none'; child-src 'none'; worker-src 'none'; manifest-src 'self'; media-src 'self'

--- a/server/lib/security-headers.ts
+++ b/server/lib/security-headers.ts
@@ -30,27 +30,40 @@ export const SECURITY_HEADERS: Readonly<Record<string, string>> = {
 // API/webhook responses are JSON and never load any subresource, so the policy
 // denies everything. frame-ancestors/base-uri are still pinned in case a
 // response is ever rendered directly in a browser tab.
-export const API_CSP = ["default-src 'none'", "frame-ancestors 'none'", "base-uri 'none'"].join(
-  "; ",
-);
+export const API_CSP = [
+  "default-src 'none'",
+  "base-uri 'none'",
+  "object-src 'none'",
+  "frame-ancestors 'none'",
+  "form-action 'none'",
+].join("; ");
 
-// The HTML UI loads only same-origin subresources. The Geist webfont is
-// self-hosted (Fontsource, bundled into our assets), so style-src and font-src
-// stay 'self' with no third-party origins — no visitor IP leaks to a font CDN.
-// No 'unsafe-inline' on style-src, and style-src-attr 'none' blocks inline
-// style attributes outright; dynamic visuals use classes or SVG geometry
-// attributes instead. img-src data: covers inline data-URI images. connect-src
-// stays 'self' — the UI only calls the same-origin /api surface.
+// The HTML UI starts from a deny-all fallback, then opens only the same-origin
+// fetch surfaces the app actually uses. The Geist webfont is self-hosted
+// (Fontsource, bundled into our assets), so style-src and font-src stay 'self'
+// with no third-party origins. No 'unsafe-inline' on style-src, and
+// style-src-attr 'none' blocks inline style attributes outright; dynamic visuals
+// use classes or SVG geometry attributes instead. img-src data: covers inline
+// data-URI images. connect-src stays 'self' — the UI only calls the same-origin
+// /api surface.
 export const DOCUMENT_CSP = [
-  "default-src 'self'",
+  "default-src 'none'",
   "base-uri 'self'",
   "object-src 'none'",
   "frame-ancestors 'none'",
   "form-action 'self'",
   "script-src 'self'",
+  "script-src-elem 'self'",
+  "script-src-attr 'none'",
   "style-src 'self'",
+  "style-src-elem 'self'",
   "style-src-attr 'none'",
   "font-src 'self'",
   "img-src 'self' data:",
   "connect-src 'self'",
+  "frame-src 'none'",
+  "child-src 'none'",
+  "worker-src 'none'",
+  "manifest-src 'self'",
+  "media-src 'self'",
 ].join("; ");

--- a/test/security-headers.test.ts
+++ b/test/security-headers.test.ts
@@ -33,6 +33,15 @@ function parseHeaders(source: string): Map<string, Record<string, string>> {
   return rules;
 }
 
+function parseCsp(policy: string): Map<string, string> {
+  const directives = new Map<string, string>();
+  for (const directive of policy.split(";")) {
+    const [name, ...value] = directive.trim().split(/\s+/);
+    if (name) directives.set(name, value.join(" "));
+  }
+  return directives;
+}
+
 describe("public/_headers static-asset security headers", () => {
   const rules = parseHeaders(headersFile);
   const catchAll = rules.get("/*");
@@ -69,5 +78,24 @@ describe("public/_headers static-asset security headers", () => {
   // block its own scripts, styles and webfont and white-screen the app.
   test("does not ship the locked-down API CSP to the document", () => {
     expect(catchAll?.["Content-Security-Policy"]).not.toBe(API_CSP);
+  });
+
+  test("ships a deny-all CSP fallback with explicit document directives", () => {
+    const directives = parseCsp(DOCUMENT_CSP);
+    expect(directives.get("default-src")).toBe("'none'");
+    expect(directives.get("base-uri")).toBe("'self'");
+    expect(directives.get("object-src")).toBe("'none'");
+    expect(directives.get("frame-ancestors")).toBe("'none'");
+    expect(directives.get("form-action")).toBe("'self'");
+    expect(directives.get("script-src")).toBe("'self'");
+    expect(directives.get("style-src")).toContain("'self'");
+    expect(directives.get("font-src")).toBe("'self'");
+    expect(directives.get("img-src")).toContain("data:");
+    expect(directives.get("connect-src")).toBe("'self'");
+    expect(directives.get("frame-src")).toBe("'none'");
+    expect(directives.get("child-src")).toBe("'none'");
+    expect(directives.get("worker-src")).toBe("'none'");
+    expect(directives.get("manifest-src")).toBe("'self'");
+    expect(directives.get("media-src")).toBe("'self'");
   });
 });


### PR DESCRIPTION
## Summary
- Rebased onto latest `main` and kept the stricter self-hosted-font / no-inline-style CSP from recent `main` while hardening the browser-facing `DOCUMENT_CSP` from `default-src 'self'` to `default-src 'none'`.
- Explicitly allow the app's required same-origin script, style, font, image, connect, manifest, and media surfaces; explicitly deny frame, child, and worker fallbacks.
- Keep Cloudflare static asset headers in sync via `public/_headers` and add a regression assertion that the document policy keeps a deny-all fallback plus explicit directives.
- Docs checked, no update needed. Validated after rebase with `pnpm run verify`.

Link to Devin session: https://app.devin.ai/sessions/9babea0628ad4d3082f0c2802baf5e7a
Requested by: @JoviDeCroock