### PR TITLE
Refactor views to signal rendering utilities

### DIFF
--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -29,7 +29,7 @@ export function Field({
   children,
   class: className,
 }: {
-  label: string;
+  label: ComponentChildren;
   for?: string;
   children: ComponentChildren;
   class?: string;

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,4 +1,5 @@
 import { signal } from "@preact/signals";
+import { For } from "@preact/signals/utils";
 import { cn } from "./cn";
 
 export type ToastTone = "ok" | "critical" | "info";
@@ -43,27 +44,29 @@ export function Toaster() {
       class="fixed bottom-4 right-4 z-50 flex flex-col gap-2 w-[min(92vw,360px)] pointer-events-none"
       aria-live="polite"
     >
-      {items.value.map((item) => (
-        <div
-          key={item.id}
-          class="pointer-events-auto flex items-start gap-2.5 bg-surface border border-border rounded-lg shadow-md px-3.5 py-3"
-          role="status"
-        >
-          <span
-            class={cn("w-4 h-4 rounded-full shrink-0 mt-0.5 opacity-90", toneDisc[item.tone])}
-            aria-hidden
-          />
-          <span class="text-[13px] leading-[1.5] text-ink flex-1">{item.message}</span>
-          <button
-            type="button"
-            onClick={() => dismissToast(item.id)}
-            aria-label="Dismiss"
-            class="shrink-0 -mr-1 -mt-0.5 leading-none text-[13px] text-ink-subtle hover:text-ink"
+      <For each={items}>
+        {(item) => (
+          <div
+            key={item.id}
+            class="pointer-events-auto flex items-start gap-2.5 bg-surface border border-border rounded-lg shadow-md px-3.5 py-3"
+            role="status"
           >
-            ✕
-          </button>
-        </div>
-      ))}
+            <span
+              class={cn("w-4 h-4 rounded-full shrink-0 mt-0.5 opacity-90", toneDisc[item.tone])}
+              aria-hidden
+            />
+            <span class="text-[13px] leading-[1.5] text-ink flex-1">{item.message}</span>
+            <button
+              type="button"
+              onClick={() => dismissToast(item.id)}
+              aria-label="Dismiss"
+              class="shrink-0 -mr-1 -mt-0.5 leading-none text-[13px] text-ink-subtle hover:text-ink"
+            >
+              ✕
+            </button>
+          </div>
+        )}
+      </For>
     </div>
   );
 }

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "preact/hooks";
-import { useSignal } from "@preact/signals";
+import { useComputed, useSignal } from "@preact/signals";
+import { Show } from "@preact/signals/utils";
 import { useLocation } from "preact-iso";
 import { normalizeAuthReturnTo } from "../../lib/auth-return";
 import { AuthError, sessionModel } from "../../models/auth";
@@ -21,6 +22,19 @@ export default function LoginPage() {
   const returnTo = normalizeAuthReturnTo(location.query.returnTo);
   const registerHref =
     returnTo === "/dashboard" ? "/register" : `/register?returnTo=${encodeURIComponent(returnTo)}`;
+  const twoFactorStep = useComputed(() => step.value === "twoFactor");
+  const twoFactorHelp = useComputed(() =>
+    useBackup.value
+      ? "Enter one of your saved backup recovery codes."
+      : "Enter the 6-digit code from your authenticator app.",
+  );
+  const twoFactorLabel = useComputed(() =>
+    useBackup.value ? "Backup code" : "Authentication code",
+  );
+  const twoFactorInputMode = useComputed(() => (useBackup.value ? "text" : "numeric"));
+  const twoFactorToggleLabel = useComputed(() =>
+    useBackup.value ? "Use an authenticator code instead" : "Use a backup code instead",
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -96,132 +110,132 @@ export default function LoginPage() {
     }
   };
 
-  if (needsVerificationFor.value) {
-    return (
-      <PageShell width="narrow">
-        <Card class="flex flex-col gap-4">
-          <Eyebrow>Verify your email</Eyebrow>
-          <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">One more step</h1>
-          <Alert tone="info">
-            Your email isn't verified yet. We sent a verification link to{" "}
-            {needsVerificationFor.value}.
-          </Alert>
-          <Muted class="text-[13px] m-0">
-            Open the link to finish signing in. It expires in 24 hours.
-          </Muted>
-
-          {error.value ? <Alert tone="critical">{error.value}</Alert> : null}
-          {resent.value ? <Alert tone="ok">We sent another verification link.</Alert> : null}
-
-          <Button variant="secondary" disabled={resending.value} onClick={onResend}>
-            {resending.value ? "Resending…" : "Resend verification email"}
-          </Button>
-
-          <p class="text-[13px] text-ink-muted m-0">
-            <a href="/login" onClick={() => (needsVerificationFor.value = null)}>
-              Back to sign in
-            </a>
-          </p>
-        </Card>
-      </PageShell>
-    );
-  }
-
-  if (step.value === "twoFactor") {
-    return (
-      <PageShell width="narrow">
-        <Card class="flex flex-col gap-4">
-          <Eyebrow>Two-factor authentication</Eyebrow>
-          <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">Verify it's you</h1>
-          <Muted class="text-[13px] m-0">
-            {useBackup.value
-              ? "Enter one of your saved backup recovery codes."
-              : "Enter the 6-digit code from your authenticator app."}
-          </Muted>
-
-          <form class="flex flex-col gap-4 mt-2" onSubmit={onVerify}>
-            <Field
-              label={useBackup.value ? "Backup code" : "Authentication code"}
-              for="twofactor-code"
-            >
-              <Input
-                id="twofactor-code"
-                type="text"
-                value={code}
-                inputmode={useBackup.value ? "text" : "numeric"}
-                autocomplete="one-time-code"
-                autoFocus
-                required
-                onInput={(e) => (code.value = (e.target as HTMLInputElement).value)}
-              />
-            </Field>
-
-            {error.value ? <Alert tone="critical">{error.value}</Alert> : null}
-
-            <Button type="submit" disabled={loading.value}>
-              {loading.value ? "Verifying…" : "Verify"}
-            </Button>
-          </form>
-
-          <Button
-            variant="ghost"
-            size="sm"
-            class="self-start"
-            onClick={() => {
-              useBackup.value = !useBackup.value;
-              code.value = "";
-              error.value = null;
-            }}
-          >
-            {useBackup.value ? "Use an authenticator code instead" : "Use a backup code instead"}
-          </Button>
-        </Card>
-      </PageShell>
-    );
-  }
-
   return (
     <PageShell width="narrow">
-      <Card class="flex flex-col gap-4">
-        <Eyebrow>Welcome back</Eyebrow>
-        <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">Sign in</h1>
-        <Muted class="text-[13px] m-0">
-          Sign in to review held releases and revisit saved reports.
-        </Muted>
+      <Show
+        when={needsVerificationFor}
+        fallback={
+          <Show
+            when={twoFactorStep}
+            fallback={
+              <Card class="flex flex-col gap-4">
+                <Eyebrow>Welcome back</Eyebrow>
+                <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">Sign in</h1>
+                <Muted class="text-[13px] m-0">
+                  Sign in to review held releases and revisit saved reports.
+                </Muted>
 
-        <form class="flex flex-col gap-4 mt-2" onSubmit={onSubmit}>
-          <Field label="Email" for="login-email">
-            <Input
-              id="login-email"
-              type="email"
-              value={email}
-              autocomplete="email"
-              required
-              onInput={(e) => (email.value = (e.target as HTMLInputElement).value)}
-            />
-          </Field>
-          <Field label="Password" for="login-password">
-            <Input
-              id="login-password"
-              type="password"
-              value={password}
-              autocomplete="current-password"
-              required
-              onInput={(e) => (password.value = (e.target as HTMLInputElement).value)}
-            />
-          </Field>
+                <form class="flex flex-col gap-4 mt-2" onSubmit={onSubmit}>
+                  <Field label="Email" for="login-email">
+                    <Input
+                      id="login-email"
+                      type="email"
+                      value={email}
+                      autocomplete="email"
+                      required
+                      onInput={(e) => (email.value = (e.target as HTMLInputElement).value)}
+                    />
+                  </Field>
+                  <Field label="Password" for="login-password">
+                    <Input
+                      id="login-password"
+                      type="password"
+                      value={password}
+                      autocomplete="current-password"
+                      required
+                      onInput={(e) => (password.value = (e.target as HTMLInputElement).value)}
+                    />
+                  </Field>
 
-          {error.value ? <Alert tone="critical">{error.value}</Alert> : null}
+                  <Show when={error}>{(message) => <Alert tone="critical">{message}</Alert>}</Show>
 
-          <Button type="submit" disabled={loading.value}>
-            {loading.value ? "Signing in…" : "Sign in"}
-          </Button>
-        </form>
+                  <Button type="submit" disabled={loading}>
+                    <Show when={loading} fallback="Sign in">
+                      Signing in…
+                    </Show>
+                  </Button>
+                </form>
 
-        <p class="text-[13px] text-ink-muted m-0">
-          New here? <a href={registerHref}>Create an account</a>
-        </p>
-      </Card>
+                <p class="text-[13px] text-ink-muted m-0">
+                  New here? <a href={registerHref}>Create an account</a>
+                </p>
+              </Card>
+            }
+          >
+            <Card class="flex flex-col gap-4">
+              <Eyebrow>Two-factor authentication</Eyebrow>
+              <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">Verify it's you</h1>
+              <Muted class="text-[13px] m-0">{twoFactorHelp}</Muted>
+
+              <form class="flex flex-col gap-4 mt-2" onSubmit={onVerify}>
+                <Field label={twoFactorLabel} for="twofactor-code">
+                  <Input
+                    id="twofactor-code"
+                    type="text"
+                    value={code}
+                    inputmode={twoFactorInputMode}
+                    autocomplete="one-time-code"
+                    autoFocus
+                    required
+                    onInput={(e) => (code.value = (e.target as HTMLInputElement).value)}
+                  />
+                </Field>
+
+                <Show when={error}>{(message) => <Alert tone="critical">{message}</Alert>}</Show>
+
+                <Button type="submit" disabled={loading}>
+                  <Show when={loading} fallback="Verify">
+                    Verifying…
+                  </Show>
+                </Button>
+              </form>
+
+              <Button
+                variant="ghost"
+                size="sm"
+                class="self-start"
+                onClick={() => {
+                  useBackup.value = !useBackup.value;
+                  code.value = "";
+                  error.value = null;
+                }}
+              >
+                {twoFactorToggleLabel}
+              </Button>
+            </Card>
+          </Show>
+        }
+      >
+        {(target) => (
+          <Card class="flex flex-col gap-4">
+            <Eyebrow>Verify your email</Eyebrow>
+            <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">One more step</h1>
+            <Alert tone="info">
+              Your email isn't verified yet. We sent a verification link to {target}.
+            </Alert>
+            <Muted class="text-[13px] m-0">
+              Open the link to finish signing in. It expires in 24 hours.
+            </Muted>
+
+            <Show when={error}>{(message) => <Alert tone="critical">{message}</Alert>}</Show>
+            <Show when={resent}>
+              <Alert tone="ok">We sent another verification link.</Alert>
+            </Show>
+
+            <Button variant="secondary" disabled={resending} onClick={onResend}>
+              <Show when={resending} fallback="Resend verification email">
+                Resending…
+              </Show>
+            </Button>
+
+            <p class="text-[13px] text-ink-muted m-0">
+              <a href="/login" onClick={() => (needsVerificationFor.value = null)}>
+                Back to sign in
+              </a>
+            </p>
+          </Card>
+        )}
+      </Show>
     </PageShell>
   );
 }

--- a/src/pages/Auth/Register.tsx
+++ b/src/pages/Auth/Register.tsx
@@ -72,95 +72,95 @@ export default function RegisterPage() {
     }
   };
 
-  if (verificationSentTo.value) {
-    return (
-      <PageShell width="narrow">
-        <Card class="flex flex-col gap-4">
-          <Eyebrow>Almost there</Eyebrow>
-          <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">Check your email</h1>
-          <Alert tone="info">
-            We sent a verification link to {verificationSentTo.value}. Open it to activate your
-            account.
-          </Alert>
-          <Muted class="text-[13px] m-0">
-            The link expires in 24 hours. Check your spam folder if it doesn't arrive.
-          </Muted>
-
-          <Show when={error}>{(message) => <Alert tone="critical">{message}</Alert>}</Show>
-          <Show when={resent}>
-            <Alert tone="ok">We sent another verification link.</Alert>
-          </Show>
-
-          <Button variant="secondary" disabled={resending} onClick={onResend}>
-            <Show when={resending} fallback="Resend verification email">
-              Resending…
-            </Show>
-          </Button>
-
-          <p class="text-[13px] text-ink-muted m-0">
-            Already verified? <a href={signInHref}>Sign in</a>
-          </p>
-        </Card>
-      </PageShell>
-    );
-  }
-
   return (
     <PageShell width="narrow">
-      <Card class="flex flex-col gap-4">
-        <Eyebrow>Get started</Eyebrow>
-        <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">Create account</h1>
-        <Muted class="text-[13px] m-0">
-          Create a workspace, connect npm or a GitHub gate, and review held releases before they go
-          live.
-        </Muted>
+      <Show
+        when={verificationSentTo}
+        fallback={
+          <Card class="flex flex-col gap-4">
+            <Eyebrow>Get started</Eyebrow>
+            <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">Create account</h1>
+            <Muted class="text-[13px] m-0">
+              Create a workspace, connect npm or a GitHub gate, and review held releases before they
+              go live.
+            </Muted>
 
-        <form class="flex flex-col gap-4 mt-2" onSubmit={onSubmit}>
-          <Field label="Name" for="register-name">
-            <Input
-              id="register-name"
-              type="text"
-              value={name}
-              autocomplete="name"
-              required
-              onInput={(e) => (name.value = (e.target as HTMLInputElement).value)}
-            />
-          </Field>
-          <Field label="Email" for="register-email">
-            <Input
-              id="register-email"
-              type="email"
-              value={email}
-              autocomplete="email"
-              required
-              onInput={(e) => (email.value = (e.target as HTMLInputElement).value)}
-            />
-          </Field>
-          <Field label="Password" for="register-password">
-            <Input
-              id="register-password"
-              type="password"
-              value={password}
-              autocomplete="new-password"
-              minlength={12}
-              required
-              onInput={(e) => (password.value = (e.target as HTMLInputElement).value)}
-            />
-          </Field>
+            <form class="flex flex-col gap-4 mt-2" onSubmit={onSubmit}>
+              <Field label="Name" for="register-name">
+                <Input
+                  id="register-name"
+                  type="text"
+                  value={name}
+                  autocomplete="name"
+                  required
+                  onInput={(e) => (name.value = (e.target as HTMLInputElement).value)}
+                />
+              </Field>
+              <Field label="Email" for="register-email">
+                <Input
+                  id="register-email"
+                  type="email"
+                  value={email}
+                  autocomplete="email"
+                  required
+                  onInput={(e) => (email.value = (e.target as HTMLInputElement).value)}
+                />
+              </Field>
+              <Field label="Password" for="register-password">
+                <Input
+                  id="register-password"
+                  type="password"
+                  value={password}
+                  autocomplete="new-password"
+                  minlength={12}
+                  required
+                  onInput={(e) => (password.value = (e.target as HTMLInputElement).value)}
+                />
+              </Field>
 
-          <Show when={error}>{(message) => <Alert tone="critical">{message}</Alert>}</Show>
+              <Show when={error}>{(message) => <Alert tone="critical">{message}</Alert>}</Show>
 
-          <Button type="submit" disabled={loading}>
-            <Show when={loading} fallback="Create account">
-              Creating…
+              <Button type="submit" disabled={loading}>
+                <Show when={loading} fallback="Create account">
+                  Creating…
+                </Show>
+              </Button>
+            </form>
+
+            <p class="text-[13px] text-ink-muted m-0">
+              Already have an account? <a href={signInHref}>Sign in</a>
+            </p>
+          </Card>
+        }
+      >
+        {(target) => (
+          <Card class="flex flex-col gap-4">
+            <Eyebrow>Almost there</Eyebrow>
+            <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">Check your email</h1>
+            <Alert tone="info">
+              We sent a verification link to {target}. Open it to activate your account.
+            </Alert>
+            <Muted class="text-[13px] m-0">
+              The link expires in 24 hours. Check your spam folder if it doesn't arrive.
+            </Muted>
+
+            <Show when={error}>{(message) => <Alert tone="critical">{message}</Alert>}</Show>
+            <Show when={resent}>
+              <Alert tone="ok">We sent another verification link.</Alert>
             </Show>
-          </Button>
-        </form>
 
-        <p class="text-[13px] text-ink-muted m-0">
-          Already have an account? <a href={signInHref}>Sign in</a>
-        </p>
-      </Card>
+            <Button variant="secondary" disabled={resending} onClick={onResend}>
+              <Show when={resending} fallback="Resend verification email">
+                Resending…
+              </Show>
+            </Button>
+
+            <p class="text-[13px] text-ink-muted m-0">
+              Already verified? <a href={signInHref}>Sign in</a>
+            </p>
+          </Card>
+        )}
+      </Show>
     </PageShell>
   );
 }

--- a/src/pages/Auth/VerifyEmail.tsx
+++ b/src/pages/Auth/VerifyEmail.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "preact/hooks";
-import { useSignal } from "@preact/signals";
+import { useComputed, useSignal } from "@preact/signals";
+import { Show } from "@preact/signals/utils";
 import { useLocation } from "preact-iso";
 import { normalizeAuthReturnTo } from "../../lib/auth-return";
 import { sessionModel } from "../../models/auth";
@@ -33,6 +34,8 @@ export default function VerifyEmailPage() {
   const error = useSignal<string | null>(null);
   const resending = useSignal(false);
   const resent = useSignal(false);
+  const verifying = useComputed(() => state.value === "verifying");
+  const verified = useComputed(() => state.value === "verified");
 
   useEffect(() => {
     if (errorCode) return;
@@ -68,63 +71,67 @@ export default function VerifyEmailPage() {
     }
   };
 
-  if (state.value === "verifying") {
-    return (
-      <PageShell width="narrow">
-        <LoadingState title="Verifying your email" detail="confirming link" />
-      </PageShell>
-    );
-  }
-
-  if (state.value === "verified") {
-    return (
-      <PageShell width="narrow">
-        <Card class="flex flex-col gap-4">
-          <Eyebrow>Email verified</Eyebrow>
-          <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">You're all set</h1>
-          <Alert tone="ok">Your email is verified. You can sign in now.</Alert>
-          <Button onClick={() => location.route("/login", true)}>Go to sign in</Button>
-        </Card>
-      </PageShell>
-    );
-  }
-
   return (
     <PageShell width="narrow">
-      <Card class="flex flex-col gap-4">
-        <Eyebrow>Verify your email</Eyebrow>
-        <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">Link didn't work</h1>
-        <Alert tone="critical">{ERROR_COPY[errorCode] ?? "We couldn't verify your email."}</Alert>
-        <Muted class="text-[13px] m-0">
-          Enter your email and we'll send a fresh verification link.
-        </Muted>
+      <Show
+        when={verifying}
+        fallback={
+          <Show
+            when={verified}
+            fallback={
+              <Card class="flex flex-col gap-4">
+                <Eyebrow>Verify your email</Eyebrow>
+                <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">Link didn't work</h1>
+                <Alert tone="critical">
+                  {ERROR_COPY[errorCode] ?? "We couldn't verify your email."}
+                </Alert>
+                <Muted class="text-[13px] m-0">
+                  Enter your email and we'll send a fresh verification link.
+                </Muted>
 
-        <form class="flex flex-col gap-4 mt-2" onSubmit={onResend}>
-          <Field label="Email" for="verify-email">
-            <Input
-              id="verify-email"
-              type="email"
-              value={email}
-              autocomplete="email"
-              required
-              onInput={(e) => (email.value = (e.target as HTMLInputElement).value)}
-            />
-          </Field>
+                <form class="flex flex-col gap-4 mt-2" onSubmit={onResend}>
+                  <Field label="Email" for="verify-email">
+                    <Input
+                      id="verify-email"
+                      type="email"
+                      value={email}
+                      autocomplete="email"
+                      required
+                      onInput={(e) => (email.value = (e.target as HTMLInputElement).value)}
+                    />
+                  </Field>
 
-          {error.value ? <Alert tone="critical">{error.value}</Alert> : null}
-          {resent.value ? (
-            <Alert tone="ok">If that account needs verifying, a new link is on its way.</Alert>
-          ) : null}
+                  <Show when={error}>{(message) => <Alert tone="critical">{message}</Alert>}</Show>
+                  <Show when={resent}>
+                    <Alert tone="ok">
+                      If that account needs verifying, a new link is on its way.
+                    </Alert>
+                  </Show>
 
-          <Button type="submit" disabled={resending.value}>
-            {resending.value ? "Sending…" : "Send new link"}
-          </Button>
-        </form>
+                  <Button type="submit" disabled={resending}>
+                    <Show when={resending} fallback="Send new link">
+                      Sending…
+                    </Show>
+                  </Button>
+                </form>
 
-        <p class="text-[13px] text-ink-muted m-0">
-          <a href="/login">Back to sign in</a>
-        </p>
-      </Card>
+                <p class="text-[13px] text-ink-muted m-0">
+                  <a href="/login">Back to sign in</a>
+                </p>
+              </Card>
+            }
+          >
+            <Card class="flex flex-col gap-4">
+              <Eyebrow>Email verified</Eyebrow>
+              <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">You're all set</h1>
+              <Alert tone="ok">Your email is verified. You can sign in now.</Alert>
+              <Button onClick={() => location.route("/login", true)}>Go to sign in</Button>
+            </Card>
+          </Show>
+        }
+      >
+        <LoadingState title="Verifying your email" detail="confirming link" />
+      </Show>
     </PageShell>
   );
 }

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -1,7 +1,14 @@
 import type { ComponentChildren } from "preact";
 import { useEffect } from "preact/hooks";
-import { useSignal, useModel, useSignalEffect } from "@preact/signals";
-import { Show } from "@preact/signals/utils";
+import {
+  useComputed,
+  useSignal,
+  useModel,
+  useSignalEffect,
+  type ReadonlySignal,
+  type Signal,
+} from "@preact/signals";
+import { For, Show, useLiveSignal } from "@preact/signals/utils";
 import { useLocation } from "preact-iso";
 import { rememberDashboardReturnUrl, useQuerySignal } from "../../lib/query-state";
 import { npmStagedPackagesUrlFor } from "../../lib/npm-staged-url";
@@ -42,6 +49,17 @@ export default function DashboardPage() {
   const organizations = useModel(OrganizationModel);
   const stagedPublishes = useModel(StagedPublishesModel);
   const sessionChecked = useSignal(false);
+  const workspaceLoaded = useComputed(() => scans.loaded.value && npm.loaded.value);
+  const workspaceLoadingDetail = useComputed(() => {
+    const scansLoaded = scans.loaded.value;
+    const npmLoaded = npm.loaded.value;
+    return npmLoaded
+      ? "fetching recent reviews"
+      : scansLoaded
+        ? "checking npm connection"
+        : "loading reviews · checking npm connection";
+  });
+  const needsNpmSetup = useComputed(() => !npm.connection.value);
 
   // Two-way bind the decision filter to ?filter=. The model re-fetches
   // whenever the filter signal changes, so URL → filter → refresh comes
@@ -108,10 +126,6 @@ export default function DashboardPage() {
   }
 
   const user = sessionModel.user.value;
-  const scansLoaded = scans.loaded.value;
-  const npmLoaded = npm.loaded.value;
-  const workspaceLoaded = scansLoaded && npmLoaded;
-
   return (
     <PageShell
       headerActions={
@@ -133,25 +147,23 @@ export default function DashboardPage() {
     >
       <DashboardHeader />
 
-      {workspaceLoaded ? (
+      <Show
+        when={workspaceLoaded}
+        fallback={<WorkspaceLoadingState detail={workspaceLoadingDetail} />}
+      >
         <>
-          {!npm.connection.value ? <NpmSetupCallout /> : null}
+          <Show when={needsNpmSetup}>
+            <NpmSetupCallout />
+          </Show>
           <RecentReviewsSection scans={scans} stagedPublishes={stagedPublishes} npm={npm} />
         </>
-      ) : (
-        <LoadingState
-          title="Loading workspace"
-          detail={
-            npmLoaded
-              ? "fetching recent reviews"
-              : scansLoaded
-                ? "checking npm connection"
-                : "loading reviews · checking npm connection"
-          }
-        />
-      )}
+      </Show>
     </PageShell>
   );
+}
+
+function WorkspaceLoadingState({ detail }: { detail: ReadonlySignal<string> }) {
+  return <LoadingState title="Loading workspace" detail={detail.value} />;
 }
 
 function DashboardHeader() {
@@ -183,12 +195,41 @@ function RecentReviewsSection({
   stagedPublishes: ReturnType<typeof useModel<typeof StagedPublishesModel.prototype>>;
   npm: ReturnType<typeof useModel<typeof NpmConnectionModel.prototype>>;
 }) {
-  const ready = npm.validated.value;
-  const discovery = stagedPublishes.lastResult.value;
-  const discoveryError = stagedPublishes.error.value;
-  const discoveryRefreshing = stagedPublishes.refreshing.value;
   const quickDecisionScan = useSignal<ScanListItem | null>(null);
-  const startedLabels = discovery?.scans.map(formatStartedScanLabel).filter(Boolean) ?? [];
+  const discoverDisabled = useComputed(
+    () => stagedPublishes.refreshing.value || !npm.validated.value,
+  );
+  const freshnessAt = useComputed(() => {
+    const discoveredAt = stagedPublishes.lastDiscoveryAt.value;
+    const discoveryError = stagedPublishes.error.value;
+    const discoveryRefreshing = stagedPublishes.refreshing.value;
+    return discoveredAt !== null && !discoveryError && !discoveryRefreshing ? discoveredAt : null;
+  });
+  const discoveryStartedMessage = useComputed(() => {
+    const discovery = stagedPublishes.lastResult.value;
+    const discoveryError = stagedPublishes.error.value;
+    if (!discovery || discoveryError || !discovery.created) return null;
+    const startedLabels = discovery.scans.map(formatStartedScanLabel).filter(Boolean);
+    return `Started ${discovery.created} new review${discovery.created === 1 ? "" : "s"} from npm${
+      startedLabels.length ? `: ${startedLabels.slice(0, 3).join(", ")}` : ""
+    }${startedLabels.length > 3 ? `, +${startedLabels.length - 3} more` : ""}.`;
+  });
+  const noOpenPublishes = useComputed(() => {
+    const discovery = stagedPublishes.lastResult.value;
+    const discoveryError = stagedPublishes.error.value;
+    return Boolean(discovery && !discoveryError && !discovery.created && !discovery.found);
+  });
+  const showDiscoveryFeedback = useComputed(
+    () =>
+      Boolean(stagedPublishes.error.value) ||
+      freshnessAt.value !== null ||
+      Boolean(discoveryStartedMessage.value) ||
+      noOpenPublishes.value,
+  );
+  const hasScans = useComputed(() => scans.scans.value.length > 0);
+  const emptyMessage = useComputed(() => emptyStateMessage(scans.filter.value));
+  const quickDecisionScanId = useComputed(() => quickDecisionScan.value?.id ?? null);
+  const decisionSaving = useComputed(() => scans.decisionStatus.value === "saving");
   const onDiscover = async () => {
     await discoverStagedPublishes(stagedPublishes, scans);
   };
@@ -203,107 +244,125 @@ function RecentReviewsSection({
     return saved;
   };
 
-  const discoveredAt = stagedPublishes.lastDiscoveryAt.value;
-  const showFreshness = discoveredAt !== null && !discoveryError && !discoveryRefreshing;
-  const showStartedMessage = Boolean(discovery && !discoveryError && discovery.created);
-  const showNoOpenMessage = Boolean(
-    discovery && !discoveryError && !discovery.created && !discovery.found,
-  );
-  const showDiscoveryFeedback = Boolean(
-    discoveryError || showFreshness || showStartedMessage || showNoOpenMessage,
-  );
-
   return (
     <Card as="section" padding="none" class="overflow-hidden">
       <div class="px-5 py-4 flex flex-col gap-3 md:flex-row md:items-center">
         <SectionLabel class="flex-1 min-w-0 after:hidden">Recent reviews</SectionLabel>
         <div class="flex flex-wrap items-center gap-2 shrink-0">
           <ScanStateSelect
-            value={scans.filter.value}
-            disabled={scans.refreshing.value}
+            value={scans.filter}
+            disabled={scans.refreshing}
             onChange={(filter) => (scans.filter.value = filter)}
           />
           <Button
             variant="secondary"
             size="sm"
             onClick={() => void onDiscover()}
-            disabled={discoveryRefreshing || !ready}
+            disabled={discoverDisabled}
             title="Find staged npm publishes and start reviews"
           >
-            {discoveryRefreshing ? "Checking npm…" : "Check npm"}
+            <Show when={stagedPublishes.refreshing} fallback="Check npm">
+              Checking npm…
+            </Show>
           </Button>
           <Button
             variant="ghost"
             size="sm"
             onClick={() => void scans.refresh()}
-            disabled={scans.refreshing.value}
+            disabled={scans.refreshing}
             title="Reload the reviews list"
           >
-            {scans.refreshing.value ? "Refreshing…" : "Refresh"}
+            <Show when={scans.refreshing} fallback="Refresh">
+              Refreshing…
+            </Show>
           </Button>
         </div>
       </div>
-      {showDiscoveryFeedback ? (
+      <Show when={showDiscoveryFeedback}>
         <div class="px-5 pb-4 flex flex-col gap-2">
-          {discoveryError ? <Alert tone="critical">{discoveryError}</Alert> : null}
-          {showFreshness ? <ScanFreshnessIndicator at={discoveredAt} /> : null}
-          {showStartedMessage && discovery ? (
-            <Muted class="text-[13px] m-0">
-              {`Started ${discovery.created} new review${discovery.created === 1 ? "" : "s"} from npm${
-                startedLabels.length ? `: ${startedLabels.slice(0, 3).join(", ")}` : ""
-              }${startedLabels.length > 3 ? `, +${startedLabels.length - 3} more` : ""}.`}
-            </Muted>
-          ) : null}
-          {showNoOpenMessage ? (
+          <Show<string | null> when={stagedPublishes.error}>
+            {(message) => <Alert tone="critical">{message}</Alert>}
+          </Show>
+          <Show when={freshnessAt}>{(at) => <ScanFreshnessIndicator at={at} />}</Show>
+          <Show<string | null> when={discoveryStartedMessage}>
+            {(message) => <Muted class="text-[13px] m-0">{message}</Muted>}
+          </Show>
+          <Show when={noOpenPublishes}>
             <Muted class="text-[13px] m-0">No open staged publishes found.</Muted>
-          ) : null}
+          </Show>
         </div>
-      ) : null}
+      </Show>
       <div class="border-t border-border">
-        {scans.scans.value.length ? (
+        <Show
+          when={hasScans}
+          fallback={
+            <div class="p-5">
+              <EmptyLine>{emptyMessage}</EmptyLine>
+            </div>
+          }
+        >
           <ScanTable
-            scans={scans.scans.value}
-            quickDecisionScanId={quickDecisionScan.value?.id ?? null}
-            decisionSaving={scans.decisionStatus.value === "saving"}
+            scans={scans.scans}
+            quickDecisionScanId={quickDecisionScanId}
+            decisionSaving={decisionSaving}
             onQuickDecide={(scan) => {
               scans.decisionError.value = null;
               quickDecisionScan.value = scan;
             }}
           />
-        ) : (
-          <div class="p-5">
-            <EmptyLine>{emptyStateMessage(scans.filter.value)}</EmptyLine>
-          </div>
-        )}
+        </Show>
       </div>
-      {scans.nextCursor.value ? (
+      <Show when={scans.nextCursor}>
         <div class="border-t border-border px-5 py-4 flex justify-center">
           <Button
             variant="secondary"
             size="sm"
             onClick={() => void scans.loadMore()}
-            disabled={scans.loadingMore.value}
+            disabled={scans.loadingMore}
           >
-            {scans.loadingMore.value ? "Loading…" : "Load more"}
+            <Show when={scans.loadingMore} fallback="Load more">
+              Loading…
+            </Show>
           </Button>
         </div>
-      ) : null}
+      </Show>
       <Show<ScanListItem | null> when={quickDecisionScan}>
         {(scan) => (
-          <DecisionDialog
-            open={true}
-            onClose={() => (quickDecisionScan.value = null)}
-            decision={scan.decision}
-            decisionReason={scan.decisionReason}
-            decidedAt={scan.decidedAt}
-            status={scans.decisionStatus.value}
-            error={scans.decisionError.value}
-            npmStagedPackagesUrl={npmStagedPackagesUrlFor(scan)}
+          <QuickDecisionDialog
+            scan={scan}
+            scans={scans}
+            quickDecisionScan={quickDecisionScan}
             onSubmit={onQuickDecisionSubmit}
           />
         )}
       </Show>
     </Card>
+  );
+}
+
+function QuickDecisionDialog({
+  scan,
+  scans,
+  quickDecisionScan,
+  onSubmit,
+}: {
+  scan: ScanListItem;
+  scans: ReturnType<typeof useModel<typeof ScanListModel.prototype>>;
+  quickDecisionScan: Signal<ScanListItem | null>;
+  onSubmit: (decision: ScanDecision, reason: string | null) => boolean | Promise<boolean>;
+}) {
+  return (
+    <DecisionDialog
+      open={true}
+      onClose={() => (quickDecisionScan.value = null)}
+      decision={scan.decision}
+      decisionReason={scan.decisionReason}
+      decidedAt={scan.decidedAt}
+      status={scans.decisionStatus.value}
+      error={scans.decisionError.value}
+      npmStagedPackagesUrl={npmStagedPackagesUrlFor(scan)}
+      onSubmit={onSubmit}
+    />
   );
 }
 
@@ -329,8 +388,8 @@ function ScanStateSelect({
   disabled,
   onChange,
 }: {
-  value: ScanDecisionFilter;
-  disabled: boolean;
+  value: Signal<ScanDecisionFilter>;
+  disabled: ReadonlySignal<boolean>;
   onChange: (filter: ScanDecisionFilter) => void;
 }) {
   return (
@@ -397,9 +456,9 @@ function ScanTable({
   decisionSaving,
   onQuickDecide,
 }: {
-  scans: ScanListItem[];
-  quickDecisionScanId: string | null;
-  decisionSaving: boolean;
+  scans: ReadonlySignal<ScanListItem[]>;
+  quickDecisionScanId: ReadonlySignal<string | null>;
+  decisionSaving: ReadonlySignal<boolean>;
   onQuickDecide: (scan: ScanListItem) => void;
 }) {
   return (
@@ -416,53 +475,77 @@ function ScanTable({
           </tr>
         </thead>
         <tbody>
-          {scans.map((scan) => (
-            <tr key={scan.id} class="border-b border-border last:border-b-0 hover:bg-surface-2">
-              <Td>
-                <span class="flex items-center gap-2 min-w-[180px]">
-                  <a href={`/dashboard/scans/${encodeURIComponent(scan.id)}`}>
-                    {scan.packageName || scan.stageId}
-                  </a>
-                  {scan.source === "workflow_gate" ? <Badge tone="neutral">gate</Badge> : null}
-                </span>
-              </Td>
-              <Td class="font-mono text-xs text-ink-muted whitespace-nowrap">
-                {scan.previousVersion || "—"} → {scan.stagedVersion || "—"}
-              </Td>
-              <Td>
-                <ScanRiskCell scan={scan} />
-              </Td>
-              <Td>
-                <ScanChangedCell scan={scan} />
-              </Td>
-              <Td>
-                <ScanStatusBadge status={scan.status} />
-              </Td>
-              <Td>
-                <div class="flex flex-wrap items-center gap-2">
-                  <DecisionBadge decision={scan.decision} />
-                  {canQuickDecide(scan) ? (
-                    <Button
-                      variant={scan.decision ? "secondary" : "primary"}
-                      size="sm"
-                      onClick={() => onQuickDecide(scan)}
-                      disabled={decisionSaving}
-                      title="Record a decision without leaving the dashboard"
-                    >
-                      {decisionSaving && quickDecisionScanId === scan.id
-                        ? "Saving…"
-                        : scan.decision
-                          ? "Update"
-                          : "Decide"}
-                    </Button>
-                  ) : null}
-                </div>
-              </Td>
-            </tr>
-          ))}
+          <For each={scans}>
+            {(scan) => (
+              <tr key={scan.id} class="border-b border-border last:border-b-0 hover:bg-surface-2">
+                <Td>
+                  <span class="flex items-center gap-2 min-w-[180px]">
+                    <a href={`/dashboard/scans/${encodeURIComponent(scan.id)}`}>
+                      {scan.packageName || scan.stageId}
+                    </a>
+                    {scan.source === "workflow_gate" ? <Badge tone="neutral">gate</Badge> : null}
+                  </span>
+                </Td>
+                <Td class="font-mono text-xs text-ink-muted whitespace-nowrap">
+                  {scan.previousVersion || "—"} → {scan.stagedVersion || "—"}
+                </Td>
+                <Td>
+                  <ScanRiskCell scan={scan} />
+                </Td>
+                <Td>
+                  <ScanChangedCell scan={scan} />
+                </Td>
+                <Td>
+                  <ScanStatusBadge status={scan.status} />
+                </Td>
+                <Td>
+                  <div class="flex flex-wrap items-center gap-2">
+                    <DecisionBadge decision={scan.decision} />
+                    <Show when={() => canQuickDecide(scan)}>
+                      <QuickDecisionButton
+                        scan={scan}
+                        quickDecisionScanId={quickDecisionScanId}
+                        decisionSaving={decisionSaving}
+                        onQuickDecide={onQuickDecide}
+                      />
+                    </Show>
+                  </div>
+                </Td>
+              </tr>
+            )}
+          </For>
         </tbody>
       </table>
     </div>
+  );
+}
+
+function QuickDecisionButton({
+  scan,
+  quickDecisionScanId,
+  decisionSaving,
+  onQuickDecide,
+}: {
+  scan: ScanListItem;
+  quickDecisionScanId: ReadonlySignal<string | null>;
+  decisionSaving: ReadonlySignal<boolean>;
+  onQuickDecide: (scan: ScanListItem) => void;
+}) {
+  const variant = scan.decision ? "secondary" : "primary";
+  const label = useComputed(() => {
+    if (decisionSaving.value && quickDecisionScanId.value === scan.id) return "Saving…";
+    return scan.decision ? "Update" : "Decide";
+  });
+  return (
+    <Button
+      variant={variant}
+      size="sm"
+      onClick={() => onQuickDecide(scan)}
+      disabled={decisionSaving}
+      title="Record a decision without leaving the dashboard"
+    >
+      {label}
+    </Button>
   );
 }
 
@@ -520,7 +603,9 @@ function Td({ children, class: className }: { children: ComponentChildren; class
 // than a bare ✓ — the check read as a pass/fail state it doesn't represent, and
 // its meaning was hidden in a tooltip.
 function ScanFreshnessIndicator({ at }: { at: number }) {
+  const liveAt = useLiveSignal(at);
   const now = useSignal(Date.now());
+  const label = useComputed(() => `checked ${formatRelativeTime(liveAt.value, now.value)}`);
   useEffect(() => {
     const id = window.setInterval(() => {
       now.value = Date.now();
@@ -528,9 +613,7 @@ function ScanFreshnessIndicator({ at }: { at: number }) {
     return () => window.clearInterval(id);
   }, []);
   return (
-    <span class="font-mono text-[11px] text-ink-subtle whitespace-nowrap select-none">
-      checked {formatRelativeTime(at, now.value)}
-    </span>
+    <span class="font-mono text-[11px] text-ink-subtle whitespace-nowrap select-none">{label}</span>
   );
 }
 


### PR DESCRIPTION
## Summary
- Refactors auth and dashboard view branches from eager `signal.value` render decisions into `Show`/`useComputed` boundaries, keeping signal boxes live through `Button`, `Input`, and derived copy props.
- Switches toast rendering and dashboard scan rows to `For` over signal arrays, and widens `Field.label` to `ComponentChildren` so computed labels can render without unboxing.
- Docs checked, no update needed; validation: `pnpm run verify`.

Link to Devin session: https://app.devin.ai/sessions/212aca376c9348ad9f65970763c1c7f2
Requested by: @JoviDeCroock