### PR TITLE
Harden external API fetches

### DIFF
--- a/server/lib/github-app/api.ts
+++ b/server/lib/github-app/api.ts
@@ -2,6 +2,7 @@ import { GithubAppValidationError, type GithubAppConfig } from "./config";
 import { githubAppHeaders, githubInstallationHeaders, nextLink } from "./http";
 import { generateGithubAppJwt } from "./jwt";
 import { parseRepositoryFullName } from "./validation";
+import { reliableFetch } from "../reliable-fetch";
 
 export interface GithubInstallationMetadata {
   installationId: string;
@@ -16,9 +17,12 @@ export async function fetchInstallationMetadata(
   installationId: string,
 ): Promise<GithubInstallationMetadata> {
   const jwt = await generateGithubAppJwt(config);
-  const response = await fetch(`https://api.github.com/app/installations/${installationId}`, {
-    headers: githubAppHeaders(jwt),
-  });
+  const response = await reliableFetch(
+    `https://api.github.com/app/installations/${installationId}`,
+    {
+      headers: githubAppHeaders(jwt),
+    },
+  );
   if (!response.ok) {
     const text = await response.text().catch(() => "");
     throw new GithubAppValidationError(
@@ -55,11 +59,12 @@ export async function getInstallationAccessToken(
   installationId: string,
 ): Promise<string> {
   const jwt = await generateGithubAppJwt(config);
-  const response = await fetch(
+  const response = await reliableFetch(
     `https://api.github.com/app/installations/${installationId}/access_tokens`,
     {
       method: "POST",
       headers: githubAppHeaders(jwt),
+      retryMethods: ["POST"],
     },
   );
   if (!response.ok) {
@@ -99,7 +104,7 @@ export async function fetchRepository(
   }
   const token = await getInstallationAccessToken(config, installationId);
   const repositoryPath = `${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.name)}`;
-  const response = await fetch(`https://api.github.com/repos/${repositoryPath}`, {
+  const response = await reliableFetch(`https://api.github.com/repos/${repositoryPath}`, {
     headers: githubInstallationHeaders(token),
   });
   if (response.status === 404) {
@@ -146,7 +151,7 @@ export async function listInstallationRepositories(
       );
     }
     seenUrls.add(url);
-    const response = await fetch(url, { headers: githubInstallationHeaders(token) });
+    const response = await reliableFetch(url, { headers: githubInstallationHeaders(token) });
     if (!response.ok) {
       const text = await response.text().catch(() => "");
       throw new GithubAppValidationError(
@@ -198,7 +203,7 @@ export async function listRepositoryEnvironments(
   let url = `https://api.github.com/repos/${repositoryPath}/environments?per_page=100`;
 
   for (let page = 0; page < 10 && url; page += 1) {
-    const response = await fetch(url, { headers: githubInstallationHeaders(token) });
+    const response = await reliableFetch(url, { headers: githubInstallationHeaders(token) });
     if (response.status === 404) {
       throw new GithubAppValidationError(
         "repository_not_accessible",

--- a/server/lib/github-app/artifacts.ts
+++ b/server/lib/github-app/artifacts.ts
@@ -1,4 +1,5 @@
 import { readStreamBounded } from "../tar-parser.js";
+import { reliableFetch } from "../reliable-fetch";
 import { getInstallationAccessToken } from "./api";
 import type { GithubAppConfig } from "./config";
 import { githubInstallationHeaders, nextLink } from "./http";
@@ -243,7 +244,7 @@ async function listRunArtifacts(
     `/actions/runs/${runId}/artifacts?per_page=100`;
   const found: RunArtifactRef[] = [];
   for (let page = 0; page < MAX_LIST_PAGES && url; page += 1) {
-    const response = await fetch(url, { headers: githubInstallationHeaders(token) });
+    const response = await reliableFetch(url, { headers: githubInstallationHeaders(token) });
     if (response.status === 404) {
       throw new WorkflowArtifactError(
         "bundle_unavailable",
@@ -329,7 +330,11 @@ async function downloadArtifactZip(
       headers.Accept = "application/vnd.github+json";
       headers["X-GitHub-Api-Version"] = "2022-11-28";
     }
-    const hopResponse = await fetch(target, { headers, redirect: "manual" });
+    const hopResponse = await reliableFetch(target, {
+      headers,
+      redirect: "manual",
+      timeoutMs: 60_000,
+    });
     if (hopResponse.status < 300 || hopResponse.status >= 400) {
       response = hopResponse;
       break;

--- a/server/lib/github-app/oauth.ts
+++ b/server/lib/github-app/oauth.ts
@@ -1,4 +1,5 @@
 import { base64UrlDecode, base64UrlEncode, hmacSha256, timingSafeEqual } from "../crypto-utils";
+import { reliableFetch } from "../reliable-fetch";
 import { GithubAppValidationError, type GithubAppConfig } from "./config";
 import { githubUserHeaders, nextLink } from "./http";
 
@@ -70,7 +71,7 @@ export async function exchangeGithubUserCode(
   config: GithubAppConfig,
   code: string,
 ): Promise<string> {
-  const response = await fetch("https://github.com/login/oauth/access_token", {
+  const response = await reliableFetch("https://github.com/login/oauth/access_token", {
     method: "POST",
     headers: {
       Accept: "application/json",
@@ -118,7 +119,7 @@ export async function listUserAccessibleInstallations(
   let url = "https://api.github.com/user/installations?per_page=100";
 
   for (let page = 0; page < 10 && url; page += 1) {
-    const response = await fetch(url, {
+    const response = await reliableFetch(url, {
       headers: githubUserHeaders(userAccessToken),
     });
     if (!response.ok) {

--- a/server/lib/github-app/webhook.ts
+++ b/server/lib/github-app/webhook.ts
@@ -2,6 +2,7 @@ import { hexDecode, hmacSha256, timingSafeEqual } from "../crypto-utils";
 import type { AppDb } from "../../db";
 import { getInstallationAccessToken } from "./api";
 import type { GithubAppConfig } from "./config";
+import { reliableFetch } from "../reliable-fetch";
 import { markInstallationStatus, resolveDeploymentProtectionTarget } from "./persistence";
 import { recordGateRequest, type WorkflowGateRecord } from "./webhook-gates";
 
@@ -286,7 +287,7 @@ export async function postDeploymentProtectionDecision(
   }
   const token = await getInstallationAccessToken(input.config, input.installationExternalId);
   const comment = input.comment.slice(0, 140);
-  const response = await fetch(input.callbackUrl, {
+  const response = await reliableFetch(input.callbackUrl, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${token}`,
@@ -300,6 +301,7 @@ export async function postDeploymentProtectionDecision(
       environment_name: input.environment,
       comment,
     }),
+    retryMethods: ["POST"],
   });
   if (!response.ok) {
     const text = await response.text().catch(() => "");

--- a/server/lib/npm-connection.ts
+++ b/server/lib/npm-connection.ts
@@ -2,6 +2,7 @@ import type { AppDb } from "../db";
 import { getNpmConnection, markNpmConnectionUsed } from "../db";
 import { base64UrlDecode, base64UrlEncode } from "./crypto-utils";
 import { errorMessage } from "./errors";
+import { reliableFetch } from "./reliable-fetch";
 
 const DEFAULT_REGISTRY = "https://registry.npmjs.org";
 
@@ -208,7 +209,7 @@ export async function validateNpmCredential(
 
 async function validateRegistryAuth(registry: string, token: string) {
   try {
-    const response = await fetch(`${registry}/-/whoami`, {
+    const response = await reliableFetch(`${registry}/-/whoami`, {
       headers: npmAuthHeaders(token, "application/json"),
     });
     const data = (await response.json().catch(() => null)) as {
@@ -237,7 +238,7 @@ async function validateRegistryAuth(registry: string, token: string) {
 
 async function validateStagedListAccess(registry: string, token: string) {
   try {
-    const response = await fetch(`${registry}/-/stage?perPage=1`, {
+    const response = await reliableFetch(`${registry}/-/stage?perPage=1`, {
       headers: npmAuthHeaders(token, "application/json"),
     });
     await response.body?.cancel();
@@ -257,7 +258,7 @@ async function validateStagedListAccess(registry: string, token: string) {
 async function validateStagedViewAccess(registry: string, token: string, stageId: string) {
   const url = `${registry}/-/stage/${encodeURIComponent(stageId)}`;
   try {
-    const response = await fetch(url, {
+    const response = await reliableFetch(url, {
       headers: npmAuthHeaders(token, "application/json"),
     });
     await response.body?.cancel();
@@ -279,7 +280,7 @@ async function validateStagedViewAccess(registry: string, token: string, stageId
 async function validateStagedTarballAccess(registry: string, token: string, stageId: string) {
   const url = `${registry}/-/stage/${encodeURIComponent(stageId)}/tarball`;
   try {
-    const ranged = await fetch(url, {
+    const ranged = await reliableFetch(url, {
       headers: {
         ...npmAuthHeaders(token, "application/octet-stream"),
         range: "bytes=0-0",

--- a/server/lib/published-tarball.ts
+++ b/server/lib/published-tarball.ts
@@ -1,4 +1,5 @@
 import { registryProtocolAllowed } from "./npm-connection";
+import { reliableFetch } from "./reliable-fetch";
 import {
   downloadInSandboxInline,
   SandboxError,
@@ -70,7 +71,7 @@ export async function fetchPublishedTarballBytes(
 
   let response: Response;
   try {
-    response = await fetch(tarballUrl, { headers });
+    response = await reliableFetch(tarballUrl, { headers, timeoutMs: 60_000 });
   } catch {
     throw new SandboxError(JSON.stringify({ error: "download failed", status: 502 }));
   }

--- a/server/lib/registry.ts
+++ b/server/lib/registry.ts
@@ -1,3 +1,5 @@
+import { reliableFetch } from "./reliable-fetch";
+
 export interface RegistryMetadata {
   versions?: Record<string, { dist?: { tarball?: string } }>;
   "dist-tags"?: Record<string, string>;
@@ -41,7 +43,7 @@ export async function fetchPackageMetadata(
   ).replace(/\/$/, "");
   const headers = new Headers({ accept: "application/json" });
   if (options.npmToken) headers.set("authorization", `Bearer ${options.npmToken}`);
-  const res = await fetch(`${registry}/${encodeURIComponent(name).replace(/^%40/, "@")}`, {
+  const res = await reliableFetch(`${registry}/${encodeURIComponent(name).replace(/^%40/, "@")}`, {
     headers,
   });
   if (!res.ok) throw new Error(`metadata fetch failed: ${res.status}`);

--- a/server/lib/reliable-fetch.ts
+++ b/server/lib/reliable-fetch.ts
@@ -1,0 +1,114 @@
+const DEFAULT_ATTEMPTS = 3;
+const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_BASE_DELAY_MS = 250;
+const DEFAULT_MAX_DELAY_MS = 2_000;
+const DEFAULT_RETRY_METHODS = new Set(["GET", "HEAD"]);
+const DEFAULT_RETRY_STATUSES = new Set([408, 429, 500, 502, 503, 504]);
+
+export interface ReliableFetchOptions extends RequestInit {
+  attempts?: number;
+  timeoutMs?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  retryMethods?: readonly string[];
+  retryStatuses?: readonly number[];
+}
+
+export async function reliableFetch(
+  input: RequestInfo | URL,
+  options: ReliableFetchOptions = {},
+): Promise<Response> {
+  const {
+    attempts = DEFAULT_ATTEMPTS,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    baseDelayMs = DEFAULT_BASE_DELAY_MS,
+    maxDelayMs = DEFAULT_MAX_DELAY_MS,
+    retryMethods,
+    retryStatuses,
+    ...init
+  } = options;
+  const method = requestMethod(input, init);
+  const allowedMethods = retryMethods
+    ? new Set(retryMethods.map((entry) => entry.toUpperCase()))
+    : DEFAULT_RETRY_METHODS;
+  const retryableStatuses = retryStatuses ? new Set(retryStatuses) : DEFAULT_RETRY_STATUSES;
+  const maxAttempts = allowedMethods.has(method) ? Math.max(1, Math.floor(attempts)) : 1;
+
+  let lastError: unknown = null;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const timeout = fetchTimeout(init, timeoutMs);
+    try {
+      const response = await fetch(input, timeout.init);
+      timeout.clear();
+      if (!retryableStatuses.has(response.status) || attempt === maxAttempts) {
+        return response;
+      }
+      await response.body?.cancel();
+      await delay(retryDelayMs(response, attempt, baseDelayMs, maxDelayMs));
+    } catch (err) {
+      timeout.clear();
+      lastError = err;
+      if (attempt === maxAttempts) break;
+      await delay(retryDelayMs(null, attempt, baseDelayMs, maxDelayMs));
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error("fetch failed");
+}
+
+function requestMethod(input: RequestInfo | URL, init: RequestInit): string {
+  if (init.method) return init.method.toUpperCase();
+  if (input instanceof Request) return input.method.toUpperCase();
+  return "GET";
+}
+
+function fetchTimeout(
+  init: RequestInit,
+  timeoutMs: number,
+): { init: RequestInit; clear: () => void } {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return { init, clear: () => undefined };
+  }
+
+  const controller = new AbortController();
+  const originalSignal = init.signal;
+  const abortFromCaller = () => controller.abort(originalSignal?.reason);
+  if (originalSignal?.aborted) {
+    abortFromCaller();
+  } else {
+    originalSignal?.addEventListener("abort", abortFromCaller, { once: true });
+  }
+  const timer = setTimeout(() => controller.abort(new Error("fetch timeout")), timeoutMs);
+
+  return {
+    init: { ...init, signal: controller.signal },
+    clear: () => {
+      clearTimeout(timer);
+      originalSignal?.removeEventListener("abort", abortFromCaller);
+    },
+  };
+}
+
+function retryDelayMs(
+  response: Response | null,
+  attempt: number,
+  baseDelayMs: number,
+  maxDelayMs: number,
+): number {
+  const retryAfter = parseRetryAfterMs(response?.headers.get("retry-after") ?? null);
+  if (retryAfter !== null) return Math.min(retryAfter, maxDelayMs);
+  return Math.min(Math.max(0, baseDelayMs) * 2 ** Math.max(0, attempt - 1), maxDelayMs);
+}
+
+function parseRetryAfterMs(value: string | null): number | null {
+  if (!value) return null;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  const dateMs = Date.parse(value);
+  if (!Number.isFinite(dateMs)) return null;
+  return Math.max(0, dateMs - Date.now());
+}
+
+async function delay(ms: number): Promise<void> {
+  if (ms <= 0) return;
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/server/lib/staged-publishes.ts
+++ b/server/lib/staged-publishes.ts
@@ -1,4 +1,6 @@
+import { errorMessage } from "./errors";
 import { normalizeRegistryUrl, type NormalizeRegistryUrlOptions } from "./npm-connection";
+import { reliableFetch } from "./reliable-fetch";
 import { normalizeStringRecord } from "./tar-parser.js";
 import type { PackageJsonSummary } from "./review";
 import { isValidStageId } from "./stage-id";
@@ -71,9 +73,14 @@ export async function listStagedPublishes(
     params.set("page", String(Math.max(0, Math.floor(options.page))));
   }
   if (options.packageName) params.set("package", options.packageName);
-  const response = await fetch(`${registry}/-/stage?${params.toString()}`, {
-    headers: npmStageHeaders(token, "staged-list"),
-  });
+  let response: Response;
+  try {
+    response = await reliableFetch(`${registry}/-/stage?${params.toString()}`, {
+      headers: npmStageHeaders(token, "staged-list"),
+    });
+  } catch (err) {
+    throw new StagedPublishesFetchError(0, errorMessage(err));
+  }
   if (!response.ok) {
     const detail = await response.text().catch(() => "");
     throw new StagedPublishesFetchError(response.status, detail.slice(0, 200));
@@ -90,9 +97,14 @@ export async function fetchStagedPublishDetails(
 ): Promise<StagedPublishDetails> {
   if (!isValidStageId(stageId)) throw new Error("invalid stageId");
   const registry = normalizeRegistryUrl(registryUrl, options);
-  const response = await fetch(`${registry}/-/stage/${encodeURIComponent(stageId)}`, {
-    headers: npmStageHeaders(token, "staged-view"),
-  });
+  let response: Response;
+  try {
+    response = await reliableFetch(`${registry}/-/stage/${encodeURIComponent(stageId)}`, {
+      headers: npmStageHeaders(token, "staged-view"),
+    });
+  } catch (err) {
+    throw new StagedPublishesFetchError(0, errorMessage(err));
+  }
   if (!response.ok) {
     const detail = await response.text().catch(() => "");
     throw new StagedPublishesFetchError(response.status, detail.slice(0, 200));
@@ -111,9 +123,12 @@ export async function checkStagedPublishAccess(
 ): Promise<StagedPublishAccessResult> {
   if (!isValidStageId(stageId)) throw new Error("invalid stageId");
   const registry = normalizeRegistryUrl(registryUrl, options);
-  const response = await fetch(`${registry}/-/stage/${encodeURIComponent(stageId)}/tarball`, {
-    headers: npmStageTarballHeaders(token),
-  }).catch(() => null);
+  const response = await reliableFetch(
+    `${registry}/-/stage/${encodeURIComponent(stageId)}/tarball`,
+    {
+      headers: npmStageTarballHeaders(token),
+    },
+  ).catch(() => null);
   if (!response) return { allowed: true, status: null, detail: null };
   if (response.ok || response.status === 206) {
     await response.body?.cancel();

--- a/test/reliable-fetch.test.mjs
+++ b/test/reliable-fetch.test.mjs
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { reliableFetch } from "../server/lib/reliable-fetch.ts";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("reliableFetch", () => {
+  test("retries transient GET responses", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("busy", { status: 503 }))
+      .mockResolvedValueOnce(Response.json({ ok: true }));
+    globalThis.fetch = fetchMock;
+
+    const response = await reliableFetch("https://registry.npmjs.org/pkg", {
+      baseDelayMs: 0,
+    });
+
+    await expect(response.json()).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not retry POST unless explicitly opted in", async () => {
+    const fetchMock = vi.fn(async () => new Response("busy", { status: 503 }));
+    globalThis.fetch = fetchMock;
+
+    const response = await reliableFetch("https://api.github.com/callback", {
+      method: "POST",
+      baseDelayMs: 0,
+    });
+
+    expect(response.status).toBe(503);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries opted-in POST responses", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("busy", { status: 503 }))
+      .mockResolvedValueOnce(new Response(null, { status: 204 }));
+    globalThis.fetch = fetchMock;
+
+    const response = await reliableFetch("https://api.github.com/callback", {
+      method: "POST",
+      retryMethods: ["POST"],
+      baseDelayMs: 0,
+    });
+
+    expect(response.status).toBe(204);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/workers/workflow-gate-job.test.ts
+++ b/test/workers/workflow-gate-job.test.ts
@@ -827,8 +827,15 @@ describe("executeWorkflowGateJob", () => {
       "GitHub deployment protection decision failed (503)",
     );
 
+    const redeliveryUrls = redeliveryFetch.mock.calls.map(([input, init]) => {
+      const request = input instanceof Request ? input : new Request(input, init);
+      return request.url;
+    });
     expect(loaderMock.calls.length).toBe(loaderCallsAfterFirst);
-    expect(redeliveryFetch).toHaveBeenCalledTimes(2);
+    expect(redeliveryFetch).toHaveBeenCalledTimes(4);
+    expect(
+      redeliveryUrls.filter((url) => url.endsWith("/deployment_protection_rule")),
+    ).toHaveLength(3);
   });
 
   test("throws final workflow-gate queue callback failure so the message can reach the DLQ", async () => {


### PR DESCRIPTION
## Summary
Drydock API paths now use a shared `reliableFetch` wrapper for outbound npm/GitHub calls so transient 408/429/5xx responses and network failures get bounded retries instead of immediately surfacing as scan/discovery/integration failures.

Key behavior:
```ts
reliableFetch(url, {
  attempts: 3,
  timeoutMs: 15_000,
  retryMethods: ["POST"], // opt-in for safe callback/token POSTs only
})
```

Applied to npm staged-publish discovery/credential checks, package metadata/baseline tarball fetches, GitHub App repository/artifact APIs, OAuth installation reads, and deployment-protection callbacks. `StagedPublishesFetchError` now also wraps exhausted staged-list network failures so API/cron callers keep receiving structured failures.

Tests: `pnpm run lint`; `pnpm run typecheck`; `pnpm run format:check`; `pnpm run test`; `pnpm run test:node -- test/reliable-fetch.test.mjs`. Docs checked, no update needed.

Link to Devin session: https://app.devin.ai/sessions/4ea0d86084384864990a487b53e8f59a
Requested by: @JoviDeCroock