### PR TITLE
Add dashboard quick-decide action

### DIFF
--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -192,6 +192,17 @@ export function getScanCompareFile(
   );
 }
 
+export type DecisionStatus = "idle" | "saving" | "error";
+
+export function scanMatchesDecisionFilter(
+  scan: Pick<ScanListItem, "decision">,
+  filter: ScanDecisionFilter,
+): boolean {
+  if (filter === "all") return true;
+  if (filter === "undecided") return !scan.decision;
+  return scan.decision === filter;
+}
+
 export const ScanListModel = createModel(() => {
   const scans = signal<ScanListItem[]>([]);
   const loaded = signal(false);
@@ -200,6 +211,8 @@ export const ScanListModel = createModel(() => {
   const filter = signal<ScanDecisionFilter>("undecided");
   const nextCursor = signal<string | null>(null);
   const error = signal<string | null>(null);
+  const decisionStatus = signal<DecisionStatus>("idle");
+  const decisionError = signal<string | null>(null);
 
   async function refresh(): Promise<void> {
     const currentFilter = filter.peek();
@@ -234,6 +247,8 @@ export const ScanListModel = createModel(() => {
     filter,
     nextCursor,
     error,
+    decisionStatus,
+    decisionError,
     refresh,
 
     async loadMore(): Promise<void> {
@@ -251,10 +266,32 @@ export const ScanListModel = createModel(() => {
         this.loadingMore.value = false;
       }
     },
+
+    async setDecision(id: string, decision: ScanDecision, reason: string | null): Promise<void> {
+      this.decisionStatus.value = "saving";
+      this.decisionError.value = null;
+      try {
+        const updated = await setScanDecision(id, decision, reason);
+        const activeFilter = this.filter.peek();
+        this.scans.value = this.scans.value
+          .map((scan) =>
+            scan.id === id
+              ? {
+                  ...scan,
+                  ...updated.scan,
+                  riskSummary: updated.riskSummary ?? updated.scan.riskSummary ?? scan.riskSummary,
+                }
+              : scan,
+          )
+          .filter((scan) => scanMatchesDecisionFilter(scan, activeFilter));
+        this.decisionStatus.value = "idle";
+      } catch (err) {
+        this.decisionError.value = errorMessage(err);
+        this.decisionStatus.value = "error";
+      }
+    },
   };
 });
-
-export type DecisionStatus = "idle" | "saving" | "error";
 
 // Polling cadence for scans still in pending/running. The base delay doubles
 // per consecutive poll failure (so an unreachable API isn't hammered at a

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -1,13 +1,19 @@
 import type { ComponentChildren } from "preact";
 import { useEffect } from "preact/hooks";
 import { useSignal, useModel, useSignalEffect } from "@preact/signals";
+import { Show } from "@preact/signals/utils";
 import { useLocation } from "preact-iso";
 import { rememberDashboardReturnUrl, useQuerySignal } from "../../lib/query-state";
 import { pluralize } from "../../lib/format";
 import { sessionModel } from "../../models/auth";
 import { NpmConnectionModel } from "../../models/npm-connection";
 import { OrganizationModel } from "../../models/organization";
-import { ScanListModel, type ScanDecisionFilter, type ScanListItem } from "../../models/scan";
+import {
+  ScanListModel,
+  type ScanDecision,
+  type ScanDecisionFilter,
+  type ScanListItem,
+} from "../../models/scan";
 import { StagedPublishesModel } from "../../models/staged-publishes";
 import {
   Alert,
@@ -26,6 +32,7 @@ import {
   UserMenu,
   severityTone,
 } from "../../components";
+import { DecisionDialog } from "./ScanDetail/DecisionDialog";
 
 export default function DashboardPage() {
   const location = useLocation();
@@ -179,9 +186,18 @@ function RecentReviewsSection({
   const discovery = stagedPublishes.lastResult.value;
   const discoveryError = stagedPublishes.error.value;
   const discoveryRefreshing = stagedPublishes.refreshing.value;
+  const quickDecisionScan = useSignal<ScanListItem | null>(null);
   const startedLabels = discovery?.scans.map(formatStartedScanLabel).filter(Boolean) ?? [];
   const onDiscover = async () => {
     await discoverStagedPublishes(stagedPublishes, scans);
+  };
+  const onQuickDecisionSubmit = async (decision: ScanDecision, reason: string | null) => {
+    const scan = quickDecisionScan.peek();
+    if (!scan) return;
+    await scans.setDecision(scan.id, decision, reason);
+    if (scans.decisionStatus.peek() === "idle") {
+      quickDecisionScan.value = null;
+    }
   };
 
   const discoveredAt = stagedPublishes.lastDiscoveryAt.value;
@@ -242,7 +258,15 @@ function RecentReviewsSection({
       ) : null}
       <div class="border-t border-border">
         {scans.scans.value.length ? (
-          <ScanTable scans={scans.scans.value} />
+          <ScanTable
+            scans={scans.scans.value}
+            quickDecisionScanId={quickDecisionScan.value?.id ?? null}
+            decisionSaving={scans.decisionStatus.value === "saving"}
+            onQuickDecide={(scan) => {
+              scans.decisionError.value = null;
+              quickDecisionScan.value = scan;
+            }}
+          />
         ) : (
           <div class="p-5">
             <EmptyLine>{emptyStateMessage(scans.filter.value)}</EmptyLine>
@@ -261,6 +285,20 @@ function RecentReviewsSection({
           </Button>
         </div>
       ) : null}
+      <Show<ScanListItem | null> when={quickDecisionScan}>
+        {(scan) => (
+          <DecisionDialog
+            open={true}
+            onClose={() => (quickDecisionScan.value = null)}
+            decision={scan.decision}
+            decisionReason={scan.decisionReason}
+            decidedAt={scan.decidedAt}
+            status={scans.decisionStatus.value}
+            error={scans.decisionError.value}
+            onSubmit={onQuickDecisionSubmit}
+          />
+        )}
+      </Show>
     </Card>
   );
 }
@@ -349,7 +387,17 @@ function NpmSetupCallout() {
   );
 }
 
-function ScanTable({ scans }: { scans: ScanListItem[] }) {
+function ScanTable({
+  scans,
+  quickDecisionScanId,
+  decisionSaving,
+  onQuickDecide,
+}: {
+  scans: ScanListItem[];
+  quickDecisionScanId: string | null;
+  decisionSaving: boolean;
+  onQuickDecide: (scan: ScanListItem) => void;
+}) {
   return (
     <div class="overflow-x-auto">
       <table class="w-full border-collapse text-[13px]">
@@ -387,7 +435,24 @@ function ScanTable({ scans }: { scans: ScanListItem[] }) {
                 <ScanStatusBadge status={scan.status} />
               </Td>
               <Td>
-                <DecisionBadge decision={scan.decision} />
+                <div class="flex flex-wrap items-center gap-2">
+                  <DecisionBadge decision={scan.decision} />
+                  {canQuickDecide(scan) ? (
+                    <Button
+                      variant={scan.decision ? "secondary" : "primary"}
+                      size="sm"
+                      onClick={() => onQuickDecide(scan)}
+                      disabled={decisionSaving}
+                      title="Record a decision without leaving the dashboard"
+                    >
+                      {decisionSaving && quickDecisionScanId === scan.id
+                        ? "Saving…"
+                        : scan.decision
+                          ? "Update"
+                          : "Decide"}
+                    </Button>
+                  ) : null}
+                </div>
               </Td>
             </tr>
           ))}
@@ -395,6 +460,10 @@ function ScanTable({ scans }: { scans: ScanListItem[] }) {
       </table>
     </div>
   );
+}
+
+function canQuickDecide(scan: ScanListItem): boolean {
+  return scan.status === "complete" && scan.source !== "workflow_gate";
 }
 
 function ScanRiskCell({ scan }: { scan: ScanListItem }) {

--- a/test/scan-list-model.test.ts
+++ b/test/scan-list-model.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  ScanListModel,
+  scanMatchesDecisionFilter,
+  type PersistedScanDetail,
+} from "../src/models/scan";
+
+type ScanListModelInstance = InstanceType<typeof ScanListModel>;
+
+let model: ScanListModelInstance | null = null;
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function scanDetail(decision: "publish" | "no_publish" | null): PersistedScanDetail {
+  return {
+    scan: {
+      id: "scan-1",
+      stageId: "stage-1",
+      packageName: "left-pad",
+      stagedVersion: "1.0.1",
+      previousVersion: "1.0.0",
+      risk: "none",
+      status: "complete",
+      decision,
+      decisionReason: "reviewed",
+      createdAt: "2026-06-21T00:00:00.000Z",
+      updatedAt: "2026-06-21T00:00:00.000Z",
+    },
+    riskSummary: {
+      artifactRisk: "none",
+      releaseRisk: "none",
+      contextRisk: "none",
+      releaseFindingCount: 0,
+      contextFindingCount: 0,
+      unknownFindingCount: 0,
+    },
+    files: [],
+    findings: [],
+    events: [],
+  };
+}
+
+describe("ScanListModel decisions", () => {
+  afterEach(() => {
+    model?.[Symbol.dispose]();
+    model = null;
+    vi.unstubAllGlobals();
+  });
+
+  test("filters a decided scan out of the default undecided list", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse(scanDetail("publish"))));
+    vi.stubGlobal("fetch", fetchMock);
+
+    model = new ScanListModel();
+    model.scans.value = [scanDetail(null).scan];
+    model.filter.value = "undecided";
+
+    await model.setDecision("scan-1", "publish", "reviewed");
+
+    expect(model.decisionStatus.value).toBe("idle");
+    expect(model.scans.value).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/v1/scans/scan-1/decision",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ decision: "publish", reason: "reviewed" }),
+      }),
+    );
+  });
+
+  test("keeps an updated decided scan in the all list", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(jsonResponse(scanDetail("no_publish")))),
+    );
+
+    model = new ScanListModel();
+    model.scans.value = [scanDetail(null).scan];
+    model.filter.value = "all";
+
+    await model.setDecision("scan-1", "no_publish", "reviewed");
+
+    expect(model.scans.value).toHaveLength(1);
+    expect(model.scans.value[0]?.decision).toBe("no_publish");
+    expect(model.scans.value[0]?.riskSummary?.releaseRisk).toBe("none");
+  });
+});
+
+describe("scanMatchesDecisionFilter", () => {
+  test("matches dashboard decision filter semantics", () => {
+    expect(scanMatchesDecisionFilter({ decision: null }, "undecided")).toBe(true);
+    expect(scanMatchesDecisionFilter({ decision: "publish" }, "undecided")).toBe(false);
+    expect(scanMatchesDecisionFilter({ decision: "publish" }, "publish")).toBe(true);
+    expect(scanMatchesDecisionFilter({ decision: "no_publish" }, "publish")).toBe(false);
+    expect(scanMatchesDecisionFilter({ decision: "no_publish" }, "all")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an inline `Decide` / `Update` action to completed non-gate rows in the dashboard review table, reusing the existing publish decision dialog so maintainers can approve/block without opening the scan detail page.
- Extends `ScanListModel` with `setDecision(...)` and local filter reconciliation so the default undecided list drops a row immediately after a decision while `all` / decided filters stay consistent.
- Adds focused model coverage for dashboard decision updates and decision-filter matching.

## Testing
- `pnpm run verify`
- CI passed: `e2e`, `lint · format · typecheck · test`, Workers build, detection eval PR comment
- docs checked, no update needed

Link to Devin session: https://app.devin.ai/sessions/48b909dda5c847b7ae4ef8fb36e8ade9
Requested by: @JoviDeCroock