### PR TITLE
Route authenticated header brand to dashboard

### DIFF
--- a/src/components/BrandMark.tsx
+++ b/src/components/BrandMark.tsx
@@ -1,3 +1,4 @@
+import type { Signal } from "@preact/signals";
 import { cn } from "./cn";
 
 type Size = "sm" | "md" | "lg";
@@ -12,10 +13,12 @@ export function BrandMark({
   href,
   size = "sm",
   class: className,
+  ariaLabel,
 }: {
-  href?: string;
+  href?: string | Signal<string>;
   size?: Size;
   class?: string;
+  ariaLabel?: string | Signal<string>;
 }) {
   const classes = cn(
     "inline-block font-semibold text-accent select-none",
@@ -25,7 +28,7 @@ export function BrandMark({
   );
   if (href) {
     return (
-      <a href={href} class={classes} aria-label="Drydock home">
+      <a href={href} class={classes} aria-label={ariaLabel ?? "Drydock home"}>
         drydock
       </a>
     );

--- a/src/components/PageShell.tsx
+++ b/src/components/PageShell.tsx
@@ -1,4 +1,6 @@
 import type { ComponentChildren } from "preact";
+import { useComputed } from "@preact/signals";
+import { sessionModel } from "../models/auth";
 import { cn } from "./cn";
 import { BrandMark } from "./BrandMark";
 import { LinkButton } from "./Button";
@@ -43,7 +45,7 @@ export function PageShell({
         {brand ? (
           <div class="flex flex-wrap items-center justify-between gap-3">
             <div class="flex items-center gap-2.5">
-              <BrandMark href="/" size="sm" />
+              <HeaderBrandMark />
               <span aria-hidden class="h-3.5 w-px bg-border-strong" />
               <a
                 href={AIKIDO_URL}
@@ -78,6 +80,14 @@ export function PageShell({
       <SiteFooter maxWidth={maxWidth} />
     </div>
   );
+}
+
+function HeaderBrandMark() {
+  const href = useComputed(() => (sessionModel.authenticated.value ? "/dashboard" : "/"));
+  const ariaLabel = useComputed(() =>
+    sessionModel.authenticated.value ? "Drydock dashboard" : "Drydock home",
+  );
+  return <BrandMark href={href} size="sm" ariaLabel={ariaLabel} />;
 }
 
 function SiteFooter({ maxWidth }: { maxWidth: string }) {

--- a/test/e2e/smoke.spec.ts
+++ b/test/e2e/smoke.spec.ts
@@ -12,6 +12,10 @@ test("renders and decides a workflow-gate review", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "@drydock/gate-demo" })).toBeVisible({
     timeout: 30_000,
   });
+  await expect(page.getByRole("link", { name: "Drydock dashboard" })).toHaveAttribute(
+    "href",
+    "/dashboard",
+  );
   await expect(page.getByText("Deployment gate")).toBeVisible();
   await expect(page.getByText("awaiting decision").first()).toBeVisible();
   await expect(page.getByText("drydock/example").first()).toBeVisible();


### PR DESCRIPTION
## Summary
- Header `BrandMark` now derives its link from `sessionModel.authenticated`: `/dashboard` for signed-in sessions, `/` otherwise.
- `BrandMark` accepts reactive `href` and aria-label values so the header link updates after the existing session load without forcing page-level signal unwraps.
- Added smoke coverage that the authenticated workbench header exposes the brand link as `/dashboard`.
- Docs checked, no update needed.

Tests:
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm run verify`
- `pnpm exec playwright test test/e2e/smoke.spec.ts --grep "renders and decides"

Link to Devin session: https://app.devin.ai/sessions/f4085c97272a4685ad979e3c773e2857
Requested by: @JoviDeCroock