### PR TITLE
Remove redundant tests

### DIFF
--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -394,40 +394,6 @@ describe("ai review orchestration", () => {
     expect(ai.model).toBe("fallback-reviewer");
   });
 
-  test("a persistent request timeout falls back to the secondary reviewer", async () => {
-    const calls = new Map();
-    const modelFactory = (model) =>
-      mockModel(async () => {
-        calls.set(model, (calls.get(model) ?? 0) + 1);
-        if (model === "primary-reviewer") {
-          throw new Error("3046: Request timeout");
-        }
-        return generateResult(
-          [
-            {
-              type: "tool-call",
-              toolCallId: "submit-1",
-              toolName: "submit_review",
-              input: JSON.stringify(VALID_REVIEW),
-            },
-          ],
-          "tool-calls",
-        );
-      });
-
-    const { review: ai } = await analyzeWithAi(
-      {},
-      ["primary-reviewer", "fallback-reviewer"],
-      BASE_OPTIONS,
-      modelFactory,
-    );
-
-    expect(calls.get("primary-reviewer")).toBe(3);
-    expect(calls.get("fallback-reviewer")).toBe(1);
-    expect(ai.status).toBe("complete");
-    expect(ai.model).toBe("fallback-reviewer");
-  });
-
   test("a complete submission slightly over the summary bound is clamped, not discarded", async () => {
     // Reproduces the reported failure: validation used to reject the whole call
     // over a few-char overage, dropping a critical finding and collapsing to low.

--- a/test/style-theme.test.mjs
+++ b/test/style-theme.test.mjs
@@ -51,10 +51,6 @@ function tokenInBlock(block, name) {
 describe("theme tokens", () => {
   const dark = darkMediaBlock(css);
 
-  test("a prefers-color-scheme: dark media block exists", () => {
-    expect(dark).not.toBeNull();
-  });
-
   test("dark tokens are NOT inside a nested @theme", () => {
     // Tailwind v4 hoists every `@theme` to one unconditional top-level `:root`
     // and drops the surrounding @media. A dark `@theme` therefore overrides the


### PR DESCRIPTION
## Summary
- Remove two low-value Vitest cases found during the suite review:
  - `test/ai-review.test.mjs`: drops the persistent request-timeout fallback matrix case; timeout retry behavior remains covered by the transient timeout test, and fallback behavior remains covered by the capacity fallback test.
  - `test/style-theme.test.mjs`: drops the standalone dark-media-block existence precondition; the remaining theme-token assertions still fail if the block is missing.
- Testing: `pnpm run verify`.
- Docs checked, no update needed (test-only cleanup).

Link to Devin session: https://app.devin.ai/sessions/28fe4aefc89c4e3c928b0da1f27236cd
Requested by: @JoviDeCroock