### PR TITLE
Add AI Gateway review metadata

### DIFF
--- a/server/lib/ai-review-types.ts
+++ b/server/lib/ai-review-types.ts
@@ -45,6 +45,8 @@ export interface AiReviewResult {
 
 export interface SelectiveAiReviewOptions {
   scanId?: string;
+  stageId?: string;
+  organizationId?: string;
   ecosystem: AiReviewEcosystem | string;
   files: FileRecord[];
   previousFiles?: FileRecord[];

--- a/server/lib/ai-review.ts
+++ b/server/lib/ai-review.ts
@@ -90,6 +90,7 @@ export async function analyzeWithAi(
           })(candidateModel, {
             extraHeaders: {
               "x-session-affinity": scanScopedCacheAffinity(env, options.scanId),
+              "cf-aig-metadata": aiGatewayMetadataHeader(options, candidateModel, attempt),
             },
           });
         const tools = createAiReviewTools(
@@ -216,6 +217,27 @@ function isRetryableAiError(err: unknown): boolean {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function aiGatewayMetadataHeader(
+  options: SelectiveAiReviewOptions,
+  model: string,
+  attempt: number,
+): string {
+  const metadata: Record<string, string | number> = {
+    scanId: options.scanId || "unknown",
+    organizationId: options.organizationId || "unknown",
+    ecosystem: options.ecosystem || "unknown",
+    model,
+    attempt,
+  };
+
+  if (options.stageId) {
+    metadata.stageId = options.stageId;
+    delete metadata.model;
+  }
+
+  return JSON.stringify(metadata);
 }
 
 function resolveLanguageModelOverride(

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -149,6 +149,8 @@ async function maybeRunAiReview(args: AiReviewArgs): Promise<AiReview> {
   try {
     const { review, usage } = await runSelectiveAiReview(args.env, {
       scanId: args.identity.scanId,
+      stageId: args.identity.stageId,
+      organizationId: args.identity.organizationId,
       ecosystem: args.ecosystem,
       files: args.findings.redactedStagedFiles,
       previousFiles: args.findings.redactedPreviousFiles,

--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -5,6 +5,7 @@ import {
   AI_MODEL,
   AI_MODEL_CANDIDATES,
   analyzeWithAi,
+  aiGatewayMetadataHeader,
   displayedAiResult,
 } from "../server/lib/ai-review.ts";
 import {
@@ -121,6 +122,29 @@ describe("ai review orchestration", () => {
     expect(AI_MODEL).toBe("@cf/moonshotai/kimi-k2.5");
     expect(AI_FALLBACK_MODEL).toBe("@cf/qwen/qwen3-30b-a3b-fp8");
     expect(AI_MODEL_CANDIDATES).toEqual([AI_MODEL, AI_FALLBACK_MODEL]);
+  });
+
+  test("keeps AI Gateway metadata within the five-field log limit", () => {
+    expect(
+      JSON.parse(
+        aiGatewayMetadataHeader(
+          {
+            ...BASE_OPTIONS,
+            scanId: "scan_123",
+            stageId: "stage_123",
+            organizationId: "org_123",
+          },
+          AI_MODEL,
+          2,
+        ),
+      ),
+    ).toEqual({
+      scanId: "scan_123",
+      organizationId: "org_123",
+      ecosystem: "npm",
+      attempt: 2,
+      stageId: "stage_123",
+    });
   });
 
   test("a submit_review tool call produces a complete review and records the model", async () => {

--- a/test/scan-pipeline.test.mjs
+++ b/test/scan-pipeline.test.mjs
@@ -276,6 +276,12 @@ describe("scan pipeline baseline selection", () => {
       findings: [],
       model: "@cf/moonshotai/kimi-k2.5",
     });
+    expect(aiReviewMock.runSelectiveAiReview.mock.calls[0]?.[1]).toMatchObject({
+      scanId: "scan_ai_failure",
+      stageId: "stage-beta-123",
+      organizationId: "org_1",
+      ecosystem: "npm",
+    });
     expect(result.risk).toBe("medium");
     expect(dbMock.persistScan).toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- Adds `cf-aig-metadata` to Workers AI review requests so AI Gateway logs can be filtered by `scanId`, `organizationId`, `stageId`, `ecosystem`, and retry `attempt` without opening request payloads.
- Threads `stageId` and `organizationId` into `SelectiveAiReviewOptions`; keeps metadata within Cloudflare AI Gateway’s five-entry limit, relying on the native log `model` field when `stageId` is present.
- Adds targeted coverage for metadata cardinality and pipeline correlation propagation.
- Docs checked, no update needed: public product behavior is unchanged; this is internal observability metadata.

Link to Devin session: https://app.devin.ai/sessions/755e79fed66247a1aac2030d3bd217c3
Requested by: @JoviDeCroock