### PR TITLE
Speed up Vitest suite

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -14,7 +14,7 @@
 | `pnpm run lint:fix`     | Apply oxlint autofixes.                                                                                                                                                                                           |
 | `pnpm run format`       | Rewrite files with oxfmt.                                                                                                                                                                                         |
 | `pnpm run format:check` | Report files that would change without writing.                                                                                                                                                                   |
-| `pnpm run test`         | Node logic tests (`test/**`) plus D1-backed worker tests (`test/workers/**`) in one Vitest run via the `node`/`workers` projects (root `vitest.config.ts`), so the fast node suite overlaps the slow worker pool. |
+| `pnpm run test`         | Node logic tests (`test/**`) plus D1-backed worker tests (`test/workers/**`) via `scripts/test.mjs`; the node project and four isolated worker shards run in parallel.                                            |
 | `pnpm run test:node`    | Just the node logic suite (`vitest run --project node`).                                                                                                                                                          |
 | `pnpm run test:workers` | Just the worker suite (`vitest run --project workers`; Miniflare D1 from `wrangler.test.jsonc` + `drizzle/`).                                                                                                     |
 | `pnpm run e2e:fixtures` | Pack local E2E fixture packages and generate `.context/e2e-registry/registry.json`.                                                                                                                               |
@@ -36,6 +36,11 @@ The `workers` Vitest project runs every test file in its own Miniflare isolate,
 so every per-file startup cost is multiplied across the suite. Two deliberate
 choices keep it fast:
 
+- **`pnpm run test` shards worker files across four Vitest processes.** Each
+  shard keeps default per-file isolation, so cross-file mocks and D1 fixtures do
+  not leak, while the expensive Worker import/transform work overlaps across
+  CPU cores. `pnpm run test:workers` remains the unsharded single-project
+  command for focused debugging.
 - **`wrangler.test.jsonc` has no `main`.** The worker tests don't use `SELF` —
   they `import worker from "../../server/index"` and call `worker.fetch(req, env, ctx)`
   directly. Setting `main` makes Miniflare eagerly evaluate the whole app graph
@@ -43,7 +48,7 @@ choices keep it fast:
   it unset drops per-file boot to ~0.3s; the files that need the app still import
   it themselves. **Do not add `main` back** unless a test genuinely needs `SELF`
   or a Durable Object binding — and if one does, scope it to a separate project
-  rather than taxing all 24 files.
+  rather than taxing the whole worker suite.
 - **Native scrypt for password hashing.** `server/lib/auth.ts` overrides Better
   Auth's KDF with `node:crypto`'s native scrypt (same params, byte-identical
   output — see `test/workers/auth-password-hash.test.ts`). On `workerd` the

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "scan-artifacts:backfill": "node scripts/backfill-scan-artifacts.mjs",
     "db:backfill:scan-list-summaries:local": "wrangler d1 execute staged-publish-review --local --file scripts/backfill-scan-list-summaries.sql",
     "db:backfill:scan-list-summaries:remote": "wrangler d1 execute staged-publish-review --remote --file scripts/backfill-scan-list-summaries.sql",
-    "test": "vitest run",
+    "test": "node scripts/test.mjs",
     "test:node": "vitest run --project node",
     "test:workers": "vitest run --project workers",
     "eval": "vitest run --project node test/eval/detection-eval.test.mjs",

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -1,0 +1,75 @@
+import { spawn } from "node:child_process";
+
+const forwardedArgs = process.argv.slice(2);
+const extraArgs = forwardedArgs[0] === "--" ? forwardedArgs.slice(1) : forwardedArgs;
+const workerShards = 4;
+const checks =
+  extraArgs.length > 0
+    ? [{ name: "vitest", args: ["exec", "vitest", "run", ...extraArgs] }]
+    : [
+        { name: "node", args: ["exec", "vitest", "run", "--project", "node"] },
+        ...Array.from({ length: workerShards }, (_, index) => ({
+          name: `workers ${index + 1}/${workerShards}`,
+          args: [
+            "exec",
+            "vitest",
+            "run",
+            "--project",
+            "workers",
+            `--shard=${index + 1}/${workerShards}`,
+          ],
+        })),
+      ];
+
+function runCheck(check) {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const child = spawn("pnpm", check.args, { stdio: ["ignore", "pipe", "pipe"] });
+    let output = "";
+    child.stdout.on("data", (chunk) => (output += chunk));
+    child.stderr.on("data", (chunk) => (output += chunk));
+    child.on("close", (code) => {
+      resolve({ name: check.name, code: code ?? 1, output, seconds: (Date.now() - start) / 1000 });
+    });
+  });
+}
+
+function vitestSummary(output) {
+  return output
+    .split("\n")
+    .filter((line) => /^\s*(Test Files|Tests|Duration)\b/.test(line))
+    .join("\n");
+}
+
+const pending = new Set(checks.map((check) => check.name));
+process.stdout.write(
+  `test: running ${checks.length} Vitest jobs in parallel (${[...pending].join(", ")})\n`,
+);
+
+const results = await Promise.all(
+  checks.map(async (check) => {
+    const result = await runCheck(check);
+    pending.delete(check.name);
+    const status = result.code === 0 ? "PASS" : "FAIL";
+    const waiting = pending.size > 0 ? `  still running: ${[...pending].join(", ")}` : "";
+    process.stdout.write(`  ${status} ${result.name} (${result.seconds.toFixed(1)}s)${waiting}\n`);
+    return result;
+  }),
+);
+
+for (const result of results) {
+  const summary = vitestSummary(result.output);
+  if (summary) {
+    process.stdout.write(`\n──── ${result.name} summary ────\n${summary}\n`);
+  }
+}
+
+const failures = results.filter((result) => result.code !== 0);
+for (const failure of failures) {
+  process.stdout.write(`\n──── ${failure.name} output ────\n${failure.output}\n`);
+}
+
+if (failures.length > 0) {
+  process.stdout.write(`\ntest failed: ${failures.map((failure) => failure.name).join(", ")}\n`);
+  process.exit(1);
+}

--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { MockLanguageModelV3 } from "ai/test";
 import {
   AI_FALLBACK_MODEL,
@@ -55,6 +55,19 @@ function generateResult(content, finishReason) {
 
 function mockModel(doGenerate) {
   return new MockLanguageModelV3({ modelId: "mock-reviewer", doGenerate });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function skipRetryDelay() {
+  vi.spyOn(globalThis, "setTimeout").mockImplementation((handler, _timeout, ...args) => {
+    if (typeof handler === "function") {
+      queueMicrotask(() => handler(...args));
+    }
+    return 0;
+  });
 }
 
 // A model that immediately submits a review through the submit_review tool.
@@ -289,6 +302,7 @@ describe("ai review orchestration", () => {
   });
 
   test("a transient capacity error is retried and the review completes", async () => {
+    skipRetryDelay();
     // Reproduces the reported 3040 failure: the first call hits a capacity
     // rejection that the model itself asks us to retry; the retry succeeds.
     let calls = 0;
@@ -318,6 +332,7 @@ describe("ai review orchestration", () => {
   });
 
   test("a transient request timeout is retried and the review completes", async () => {
+    skipRetryDelay();
     let calls = 0;
     const flakyModel = mockModel(async () => {
       calls += 1;
@@ -345,6 +360,7 @@ describe("ai review orchestration", () => {
   });
 
   test("a persistent capacity error exhausts retries and fails safe to unavailable", async () => {
+    skipRetryDelay();
     let calls = 0;
     const downModel = mockModel(async () => {
       calls += 1;
@@ -361,6 +377,7 @@ describe("ai review orchestration", () => {
   });
 
   test("a persistent capacity error falls back to the secondary reviewer", async () => {
+    skipRetryDelay();
     const calls = new Map();
     const modelFactory = (model) =>
       mockModel(async () => {


### PR DESCRIPTION
## Summary
- Replaces `pnpm run test` with `scripts/test.mjs`, which runs the node Vitest project plus four default-isolated worker shards in parallel. This keeps per-file Worker isolation intact while overlapping the expensive import/transform work across CPU cores.
- Removes real 500ms/1000ms retry sleeps from AI-review retry tests by stubbing `setTimeout` only around those tests.
- Updates `docs/tooling.md` with the new test runner behavior.

Measured locally:
```text
before: pnpm test       37.1s wall, Vitest duration 35.5s
after:  pnpm test       17.9s wall
before: pnpm test:node   7.4s wall, Vitest duration 6.1s
after:  pnpm test:node   3.5s wall, Vitest duration 2.2s
```

docs checked, `docs/tooling.md` updated.

Link to Devin session: https://app.devin.ai/sessions/992d789b72a444eea293f4ef0c8d0bb3
Requested by: @JoviDeCroock