### PR TITLE
Parallelize staged publish scan enqueueing

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,6 +62,8 @@ Workflow gates reuse the scan pipeline when the registry cannot stage a release 
 
 Cron-triggered npm discovery finds staged publishes for organizations with validated npm connections and creates scans using the same pipeline. Token-expiry and validation issues should surface through settings/UI status and redacted observability events.
 
+Within a single org sweep, new staged publishes are started through a bounded-concurrency pool capped at `STAGED_PUBLISH_SCAN_START_CONCURRENCY` (`mapWithConcurrency` in `server/lib/staged-publishes-discovery.ts`) rather than sequentially. Because the same staged publish can be visible to more than one organization, a cron invocation shares a `StageStartCoordinator` across its concurrent org sweeps: matching stage IDs are started one at a time, while each org still gets its own scan row and queue message. Raise the concurrency constant only after measuring CPU time per tick.
+
 ## Data stores
 
 - **D1** — Better Auth tables, organizations, npm connections, scans, scan files/findings, workflow gates, release targets, summaries, and audit/event metadata. D1 remains the operational source of truth.

--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -157,20 +157,15 @@ export async function listExistingScanStageIds(
 ) {
   if (!stageIds.length) return new Set<string>();
   // Discovery passes every staged publish it saw, which is unbounded; each id
-  // is one bound parameter, so chunk below D1's cap (reserving slots for the
-  // organizationId and status parameters) or the sweep throws
-  // "too many SQL variables" once an org stages ~100 items.
+  // is one bound parameter, so chunk below D1's cap (reserving a slot for the
+  // organizationId parameter) or the sweep throws "too many SQL variables"
+  // once an org stages ~100 items.
   const known = new Set<string>();
-  for (const chunk of chunkForD1([...new Set(stageIds)], 1, 2)) {
+  for (const chunk of chunkForD1([...new Set(stageIds)], 1, 1)) {
     const rows = await db
       .select({ stageId: scans.stageId })
       .from(scans)
-      .where(
-        and(
-          inArray(scans.stageId, chunk),
-          or(eq(scans.organizationId, organizationId), eq(scans.status, "complete")),
-        ),
-      );
+      .where(and(inArray(scans.stageId, chunk), eq(scans.organizationId, organizationId)));
     for (const row of rows) known.add(row.stageId);
   }
   return known;

--- a/server/index.ts
+++ b/server/index.ts
@@ -29,6 +29,7 @@ import {
 } from "./lib/scan-job";
 import { executeWorkflowGateJob } from "./lib/workflow-gate-job";
 import {
+  createStageStartCoordinator,
   discoverAndQueueStagedPublishes,
   ensureUsableNpmConnection,
   isNpmConnectionAuthFailure,
@@ -328,6 +329,7 @@ async function runStagedPublishesDiscoveryCron(env: Cloudflare.Env, ctx: Executi
   const startedAtMs = Date.now();
   const db = createDb(env.DB);
   const connections = await listAutoDiscoveryNpmConnections(db);
+  const stageStartCoordinator = createStageStartCoordinator();
   emitOperationalEvent("info", "staged_publishes.cron.started", {
     organizations: connections.length,
   });
@@ -366,6 +368,7 @@ async function runStagedPublishesDiscoveryCron(env: Cloudflare.Env, ctx: Executi
             source: "auto_discovery",
             eventSource: "staged_publishes.cron",
             allowInsecureLocalhost,
+            stageStartCoordinator,
           },
           usable,
         );

--- a/server/lib/staged-publishes-discovery.ts
+++ b/server/lib/staged-publishes-discovery.ts
@@ -41,6 +41,15 @@ export interface DiscoverStagedPublishesResult {
   scans: StartedStagedPublishScan[];
 }
 
+const STAGED_PUBLISH_SCAN_START_CONCURRENCY = 5;
+
+export class MissingNpmConnectionError extends Error {
+  constructor(public organizationId: string) {
+    super(`npm connection missing for org ${organizationId}`);
+    this.name = "MissingNpmConnectionError";
+  }
+}
+
 export class InvalidNpmConnectionError extends Error {
   constructor(
     public organizationId: string,
@@ -201,63 +210,65 @@ export async function discoverAndQueueStagedPublishes(
   await markNpmConnectionUsed(db, organizationId);
   const stageIds = stagedItems.map((item) => item.id);
   const existingStageIds = await listExistingScanStageIds(db, organizationId, stageIds);
-  const startedScans: StartedStagedPublishScan[] = [];
-
-  for (const item of stagedItems) {
-    const stageId = item.id;
-    if (existingStageIds.has(stageId)) continue;
-    const access = await checkStagedPublishAccess(
-      connection.registryUrl,
-      connection.token,
-      stageId,
-      {
-        allowInsecureLocalhost,
-      },
-    );
-    if (!access.allowed) continue;
-    const scanId = crypto.randomUUID();
-    const detail = await createScanJob(db, {
-      id: scanId,
-      stageId,
-      organizationId,
-      ownerUserId: actorUserId,
-      source,
-      packageName: item.packageName,
-      stagedVersion: item.version,
-    });
-    if (!detail) continue;
-    existingStageIds.add(stageId);
-    startedScans.push({
-      id: scanId,
-      stageId,
-      packageName: item.packageName,
-      version: item.version,
-      tag: item.tag,
-      access: item.access,
-      actor: item.actor,
-      createdAt: item.createdAt,
-    });
-
-    const message: ScanQueueMessage = {
-      stageId,
-      scanId,
-      organizationId,
-      actorUserId,
-      source,
-    };
-    if (env.SCAN_QUEUE) {
-      try {
-        await env.SCAN_QUEUE.send(message);
-      } catch (err) {
-        await deletePendingScanJob(db, scanId, organizationId);
-        throw err;
-      }
-    } else {
-      executionCtx.waitUntil(
-        executeScanJob(env, executionCtx, message, db, { finalAttempt: true }),
+  const scanStarts = await mapWithConcurrency(
+    stagedItems.filter((item) => !existingStageIds.has(item.id)),
+    STAGED_PUBLISH_SCAN_START_CONCURRENCY,
+    async (item) => {
+      const stageId = item.id;
+      const access = await checkStagedPublishAccess(
+        connection.registryUrl,
+        connection.token,
+        stageId,
+        {
+          allowInsecureLocalhost,
+        },
       );
-    }
-  }
+      if (!access.allowed) return null;
+      const scanId = crypto.randomUUID();
+      const detail = await createScanJob(db, {
+        id: scanId,
+        stageId,
+        organizationId,
+        ownerUserId: actorUserId,
+        source,
+        packageName: item.packageName,
+        stagedVersion: item.version,
+      });
+      if (!detail) return null;
+      const startedScan: StartedStagedPublishScan = {
+        id: scanId,
+        stageId,
+        packageName: item.packageName,
+        version: item.version,
+        tag: item.tag,
+        access: item.access,
+        actor: item.actor,
+        createdAt: item.createdAt,
+      };
+
+      const message: ScanQueueMessage = {
+        stageId,
+        scanId,
+        organizationId,
+        actorUserId,
+        source,
+      };
+      if (env.SCAN_QUEUE) {
+        try {
+          await env.SCAN_QUEUE.send(message);
+        } catch (err) {
+          await deletePendingScanJob(db, scanId, organizationId);
+          throw err;
+        }
+      } else {
+        executionCtx.waitUntil(
+          executeScanJob(env, executionCtx, message, db, { finalAttempt: true }),
+        );
+      }
+      return startedScan;
+    },
+  );
+  const startedScans = scanStarts.filter(isStartedStagedPublishScan);
 
   return {
     found: stageIds.length,
@@ -295,3 +306,38 @@ async function listAllStagedPublishes(
 }
 
 export { StagedPublishesFetchError };
+
+function isStartedStagedPublishScan(
+  scan: StartedStagedPublishScan | null,
+): scan is StartedStagedPublishScan {
+  return scan !== null;
+}
+
+async function mapWithConcurrency<T, U>(
+  items: readonly T[],
+  concurrency: number,
+  worker: (item: T) => Promise<U>,
+): Promise<U[]> {
+  if (!items.length) return [];
+  const results = new Map<number, U>();
+  let next = 0;
+  let firstError: unknown = null;
+  const workerCount = Math.min(Math.max(1, concurrency), items.length);
+  const runners = Array.from({ length: workerCount }, async () => {
+    for (;;) {
+      if (firstError) return;
+      const index = next;
+      next += 1;
+      if (index >= items.length) return;
+      try {
+        results.set(index, await worker(items[index]));
+      } catch (err) {
+        firstError ??= err;
+        return;
+      }
+    }
+  });
+  await Promise.all(runners);
+  if (firstError) throw firstError;
+  return items.map((_, index) => results.get(index)!);
+}

--- a/server/lib/staged-publishes-discovery.ts
+++ b/server/lib/staged-publishes-discovery.ts
@@ -44,13 +44,6 @@ export interface DiscoverStagedPublishesResult {
 
 const STAGED_PUBLISH_SCAN_START_CONCURRENCY = 5;
 
-export class MissingNpmConnectionError extends Error {
-  constructor(public organizationId: string) {
-    super(`npm connection missing for org ${organizationId}`);
-    this.name = "MissingNpmConnectionError";
-  }
-}
-
 export class InvalidNpmConnectionError extends Error {
   constructor(
     public organizationId: string,

--- a/server/lib/staged-publishes-discovery.ts
+++ b/server/lib/staged-publishes-discovery.ts
@@ -31,6 +31,7 @@ export interface DiscoverStagedPublishesInput {
   source: ScanSource;
   eventSource: string;
   allowInsecureLocalhost?: boolean;
+  stageStartCoordinator?: StageStartCoordinator;
 }
 
 export interface DiscoverStagedPublishesResult {
@@ -63,6 +64,10 @@ export class InvalidNpmConnectionError extends Error {
 export interface TokenForDiscovery {
   token: string;
   registryUrl: string;
+}
+
+export interface StageStartCoordinator {
+  run<T>(stageId: string, worker: () => Promise<T>): Promise<T>;
 }
 
 /**
@@ -200,8 +205,16 @@ export async function discoverAndQueueStagedPublishes(
   input: DiscoverStagedPublishesInput,
   connection: TokenForDiscovery,
 ): Promise<DiscoverStagedPublishesResult> {
-  const { db, env, executionCtx, organizationId, actorUserId, source, allowInsecureLocalhost } =
-    input;
+  const {
+    db,
+    env,
+    executionCtx,
+    organizationId,
+    actorUserId,
+    source,
+    allowInsecureLocalhost,
+    stageStartCoordinator = createStageStartCoordinator(),
+  } = input;
 
   const stagedItems = await listAllStagedPublishes(connection, {
     perPage: 50,
@@ -214,60 +227,61 @@ export async function discoverAndQueueStagedPublishes(
   const scanStarts = await mapWithConcurrency(
     scanCandidates,
     STAGED_PUBLISH_SCAN_START_CONCURRENCY,
-    async (item) => {
-      const stageId = item.id;
-      const access = await checkStagedPublishAccess(
-        connection.registryUrl,
-        connection.token,
-        stageId,
-        {
-          allowInsecureLocalhost,
-        },
-      );
-      if (!access.allowed) return null;
-      const scanId = crypto.randomUUID();
-      const detail = await createScanJob(db, {
-        id: scanId,
-        stageId,
-        organizationId,
-        ownerUserId: actorUserId,
-        source,
-        packageName: item.packageName,
-        stagedVersion: item.version,
-      });
-      if (!detail) return null;
-      const startedScan: StartedStagedPublishScan = {
-        id: scanId,
-        stageId,
-        packageName: item.packageName,
-        version: item.version,
-        tag: item.tag,
-        access: item.access,
-        actor: item.actor,
-        createdAt: item.createdAt,
-      };
-
-      const message: ScanQueueMessage = {
-        stageId,
-        scanId,
-        organizationId,
-        actorUserId,
-        source,
-      };
-      if (env.SCAN_QUEUE) {
-        try {
-          await env.SCAN_QUEUE.send(message);
-        } catch (err) {
-          await deletePendingScanJob(db, scanId, organizationId);
-          throw err;
-        }
-      } else {
-        executionCtx.waitUntil(
-          executeScanJob(env, executionCtx, message, db, { finalAttempt: true }),
+    (item) =>
+      stageStartCoordinator.run(item.id, async () => {
+        const stageId = item.id;
+        const access = await checkStagedPublishAccess(
+          connection.registryUrl,
+          connection.token,
+          stageId,
+          {
+            allowInsecureLocalhost,
+          },
         );
-      }
-      return startedScan;
-    },
+        if (!access.allowed) return null;
+        const scanId = crypto.randomUUID();
+        const detail = await createScanJob(db, {
+          id: scanId,
+          stageId,
+          organizationId,
+          ownerUserId: actorUserId,
+          source,
+          packageName: item.packageName,
+          stagedVersion: item.version,
+        });
+        if (!detail) return null;
+        const startedScan: StartedStagedPublishScan = {
+          id: scanId,
+          stageId,
+          packageName: item.packageName,
+          version: item.version,
+          tag: item.tag,
+          access: item.access,
+          actor: item.actor,
+          createdAt: item.createdAt,
+        };
+
+        const message: ScanQueueMessage = {
+          stageId,
+          scanId,
+          organizationId,
+          actorUserId,
+          source,
+        };
+        if (env.SCAN_QUEUE) {
+          try {
+            await env.SCAN_QUEUE.send(message);
+          } catch (err) {
+            await deletePendingScanJob(db, scanId, organizationId);
+            throw err;
+          }
+        } else {
+          executionCtx.waitUntil(
+            executeScanJob(env, executionCtx, message, db, { finalAttempt: true }),
+          );
+        }
+        return startedScan;
+      }),
   );
   const startedScans = scanStarts.filter(isStartedStagedPublishScan);
 
@@ -307,6 +321,28 @@ async function listAllStagedPublishes(
 }
 
 export { StagedPublishesFetchError };
+
+export function createStageStartCoordinator(): StageStartCoordinator {
+  const tails = new Map<string, Promise<void>>();
+  return {
+    async run(stageId, worker) {
+      const previous = tails.get(stageId) ?? Promise.resolve();
+      let release: () => void;
+      const current = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const tail = previous.catch(() => undefined).then(() => current);
+      tails.set(stageId, tail);
+      await previous.catch(() => undefined);
+      try {
+        return await worker();
+      } finally {
+        release!();
+        if (tails.get(stageId) === tail) tails.delete(stageId);
+      }
+    },
+  };
+}
 
 function filterNewStagedPublishesByStageId(
   stagedItems: readonly StagedPublishItem[],

--- a/server/lib/staged-publishes-discovery.ts
+++ b/server/lib/staged-publishes-discovery.ts
@@ -210,8 +210,9 @@ export async function discoverAndQueueStagedPublishes(
   await markNpmConnectionUsed(db, organizationId);
   const stageIds = stagedItems.map((item) => item.id);
   const existingStageIds = await listExistingScanStageIds(db, organizationId, stageIds);
+  const scanCandidates = filterNewStagedPublishesByStageId(stagedItems, existingStageIds);
   const scanStarts = await mapWithConcurrency(
-    stagedItems.filter((item) => !existingStageIds.has(item.id)),
+    scanCandidates,
     STAGED_PUBLISH_SCAN_START_CONCURRENCY,
     async (item) => {
       const stageId = item.id;
@@ -306,6 +307,18 @@ async function listAllStagedPublishes(
 }
 
 export { StagedPublishesFetchError };
+
+function filterNewStagedPublishesByStageId(
+  stagedItems: readonly StagedPublishItem[],
+  existingStageIds: ReadonlySet<string>,
+) {
+  const seenStageIds = new Set(existingStageIds);
+  return stagedItems.filter((item) => {
+    if (seenStageIds.has(item.id)) return false;
+    seenStageIds.add(item.id);
+    return true;
+  });
+}
 
 function isStartedStagedPublishScan(
   scan: StartedStagedPublishScan | null,

--- a/test/staged-publishes-discovery.test.mjs
+++ b/test/staged-publishes-discovery.test.mjs
@@ -388,6 +388,12 @@ describe("discoverAndQueueStagedPublishes", () => {
     expect(result).toEqual(
       expect.objectContaining({ found: 3, created: 3, skipped: 0, queued: true }),
     );
+    expect(stagedPublishesMock.checkStagedPublishAccess).toHaveBeenCalledTimes(3);
+    expect(
+      stagedPublishesMock.checkStagedPublishAccess.mock.calls.filter(
+        (call) => call[2] === "stage-page-2",
+      ),
+    ).toHaveLength(1);
   });
 
   test("starts queued scans with bounded concurrency", async () => {

--- a/test/staged-publishes-discovery.test.mjs
+++ b/test/staged-publishes-discovery.test.mjs
@@ -31,6 +31,7 @@ vi.mock("../server/lib/staged-publishes.ts", () => stagedPublishesMock);
 vi.mock("../server/lib/scan-job.ts", () => scanJobMock);
 
 const {
+  createStageStartCoordinator,
   ensureUsableNpmConnection,
   discoverAndQueueStagedPublishes,
   InvalidNpmConnectionError,
@@ -447,6 +448,79 @@ describe("discoverAndQueueStagedPublishes", () => {
       expect.objectContaining({ found: 6, created: 6, skipped: 0, queued: true }),
     );
     expect(env.SCAN_QUEUE.send).toHaveBeenCalledTimes(6);
+  });
+
+  test("serializes duplicate stage starts across organizations", async () => {
+    stagedPublishesMock.listStagedPublishes.mockResolvedValue({
+      items: [{ id: "stage-shared", packageName: "pkg-a", version: "1.0.0" }],
+    });
+    dbMock.listExistingScanStageIds.mockResolvedValue(new Set());
+    dbMock.createScanJob.mockResolvedValue({ id: "scan-new" });
+
+    let activeAccessChecks = 0;
+    let maxActiveAccessChecks = 0;
+    const releases = [];
+    stagedPublishesMock.checkStagedPublishAccess.mockImplementation(async () => {
+      activeAccessChecks++;
+      maxActiveAccessChecks = Math.max(maxActiveAccessChecks, activeAccessChecks);
+      await new Promise((resolve) => releases.push(resolve));
+      activeAccessChecks--;
+      return { allowed: true, status: 206, detail: null };
+    });
+
+    const stageStartCoordinator = createStageStartCoordinator();
+    const first = discoverAndQueueStagedPublishes(
+      {
+        db,
+        env,
+        executionCtx: ctx,
+        organizationId: "org_a",
+        actorUserId: "user_a",
+        source: "auto_discovery",
+        eventSource: "staged_publishes.cron",
+        stageStartCoordinator,
+      },
+      { token: "npm_secret_token_a", registryUrl: "https://registry.npmjs.org" },
+    );
+    const second = discoverAndQueueStagedPublishes(
+      {
+        db,
+        env,
+        executionCtx: ctx,
+        organizationId: "org_b",
+        actorUserId: "user_b",
+        source: "auto_discovery",
+        eventSource: "staged_publishes.cron",
+        stageStartCoordinator,
+      },
+      { token: "npm_secret_token_b", registryUrl: "https://registry.npmjs.org" },
+    );
+    await flushPromises();
+
+    expect(stagedPublishesMock.checkStagedPublishAccess).toHaveBeenCalledTimes(1);
+    expect(maxActiveAccessChecks).toBe(1);
+
+    releases.shift()?.();
+    await flushPromises();
+    expect(stagedPublishesMock.checkStagedPublishAccess).toHaveBeenCalledTimes(2);
+    expect(maxActiveAccessChecks).toBe(1);
+
+    for (const release of releases) release();
+    const results = await Promise.all([first, second]);
+
+    expect(results).toEqual([
+      expect.objectContaining({ created: 1, skipped: 0 }),
+      expect.objectContaining({ created: 1, skipped: 0 }),
+    ]);
+    expect(dbMock.createScanJob).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ organizationId: "org_a", stageId: "stage-shared" }),
+    );
+    expect(dbMock.createScanJob).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ organizationId: "org_b", stageId: "stage-shared" }),
+    );
+    expect(env.SCAN_QUEUE.send).toHaveBeenCalledTimes(2);
   });
 
   test("removes the pending scan when queue dispatch fails", async () => {

--- a/test/staged-publishes-discovery.test.mjs
+++ b/test/staged-publishes-discovery.test.mjs
@@ -390,6 +390,59 @@ describe("discoverAndQueueStagedPublishes", () => {
     );
   });
 
+  test("starts queued scans with bounded concurrency", async () => {
+    stagedPublishesMock.listStagedPublishes.mockResolvedValue({
+      items: Array.from({ length: 6 }, (_, index) => ({
+        id: `stage-${index}`,
+        packageName: `pkg-${index}`,
+        version: "1.0.0",
+      })),
+    });
+    dbMock.listExistingScanStageIds.mockResolvedValue(new Set());
+    dbMock.createScanJob.mockResolvedValue({ id: "scan-new" });
+
+    let activeAccessChecks = 0;
+    let maxActiveAccessChecks = 0;
+    const releases = [];
+    stagedPublishesMock.checkStagedPublishAccess.mockImplementation(async () => {
+      activeAccessChecks++;
+      maxActiveAccessChecks = Math.max(maxActiveAccessChecks, activeAccessChecks);
+      await new Promise((resolve) => releases.push(resolve));
+      activeAccessChecks--;
+      return { allowed: true, status: 206, detail: null };
+    });
+
+    const pending = discoverAndQueueStagedPublishes(
+      {
+        db,
+        env,
+        executionCtx: ctx,
+        organizationId: "org_a",
+        actorUserId: "user_a",
+        source: "auto_discovery",
+        eventSource: "staged_publishes.cron",
+      },
+      { token: "npm_secret_token", registryUrl: "https://registry.npmjs.org" },
+    );
+    await flushPromises();
+
+    expect(stagedPublishesMock.checkStagedPublishAccess).toHaveBeenCalledTimes(5);
+    expect(maxActiveAccessChecks).toBe(5);
+
+    releases.shift()?.();
+    await flushPromises();
+    expect(stagedPublishesMock.checkStagedPublishAccess).toHaveBeenCalledTimes(6);
+    expect(maxActiveAccessChecks).toBe(5);
+
+    for (const release of releases) release();
+    const result = await pending;
+
+    expect(result).toEqual(
+      expect.objectContaining({ found: 6, created: 6, skipped: 0, queued: true }),
+    );
+    expect(env.SCAN_QUEUE.send).toHaveBeenCalledTimes(6);
+  });
+
   test("removes the pending scan when queue dispatch fails", async () => {
     const queueError = new Error("queue unavailable");
     stagedPublishesMock.listStagedPublishes.mockResolvedValue({
@@ -477,3 +530,7 @@ describe("discoverAndQueueStagedPublishes", () => {
     );
   });
 });
+
+async function flushPromises() {
+  for (let i = 0; i < 10; i++) await Promise.resolve();
+}

--- a/test/workers/scan-idempotency.test.ts
+++ b/test/workers/scan-idempotency.test.ts
@@ -213,7 +213,7 @@ describe("scan persistence idempotency", () => {
     });
   });
 
-  test("listExistingScanStageIds dedupes against another org's completed scan", async () => {
+  test("listExistingScanStageIds only dedupes within the active organization", async () => {
     const ownerA = await seedUserAndOrg();
     const ownerB = await seedUserAndOrg();
     const sharedStageId = `stage-${crypto.randomUUID()}`;
@@ -262,7 +262,7 @@ describe("scan persistence idempotency", () => {
       untouchedStageId,
     ]);
 
-    expect(known.has(sharedStageId)).toBe(true);
+    expect(known.has(sharedStageId)).toBe(false);
     expect(known.has(orgBOnlyStageId)).toBe(true);
     expect(known.has(inProgressStageId)).toBe(false);
     expect(known.has(untouchedStageId)).toBe(false);


### PR DESCRIPTION
## Summary
- Fan out per-org staged-publish scan startup through bounded `mapWithConcurrency(..., 5, ...)`, so auto-discovery no longer waits for each `checkStagedPublishAccess` + scan job + queue send to finish before starting the next candidate.
- Build `scanCandidates = filterNewStagedPublishesByStageId(stagedItems, existingStageIds)` before fan-out, so duplicate stage IDs in a single org sweep collapse to one candidate.
- Share `createStageStartCoordinator()` across the cron’s concurrent org sweeps, so duplicate stage IDs across organizations are started one-at-a-time instead of being fanned out together. Each org still gets its own scan row and queue message, allowing the release to surface in each org while preserving AI Gateway cache reuse opportunities.
- Make `listExistingScanStageIds` skip only scans already known to the active org; completed scans in other orgs no longer hide the same staged publish from the current org.
- Add regression coverage for pagination dedupe, cross-org duplicate stage coordination, and org-scoped existing-stage checks.
- Update `docs/architecture.md` so scheduled auto-discovery docs match the new per-org concurrency and org-scoped dedupe behavior.

## Testing
- `pnpm run test -- staged-publishes-discovery scan-idempotency`
- `pnpm run verify`
- `pnpm run test:e2e`
- `pnpm run format:check`

Link to Devin session: https://app.devin.ai/sessions/4308cc10876341c5b88709e7b104b35d