### PR TITLE
Use report artifacts for scan metadata reads

### DIFF
--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -16,6 +16,7 @@ import { normalizeScanRiskBreakdown, type ScanRiskBreakdown } from "../lib/risk"
 import {
   deleteScanArtifacts,
   loadScanArtifactFile,
+  loadScanArtifactMetadata,
   loadScanArtifacts,
   scanFileRowsForArtifacts,
   type ScanArtifactFileRow,
@@ -234,9 +235,6 @@ export async function discardGateScans(
 export async function persistScan(db: AppDb, input: PersistedScanInput) {
   const now = new Date();
   const artifactFileRows = scanFileRowsForArtifacts(input.files, input.diff);
-  // These rows are only persisted on the degraded path (no R2 artifacts), so
-  // they carry the full redacted sample — R2-backed scans skip the insert
-  // entirely below and serve samples from files.json instead.
   const fileRows = artifactFileRows.map((file) => {
     return {
       id: crypto.randomUUID(),
@@ -853,15 +851,16 @@ export async function getScan(
   ]);
   const scan = scanRows[0];
   if (!scan) return null;
-  const artifactDetail = await loadScanArtifacts(artifactBucket, scan);
+  const includeFileSamples = options.includeFileSamples ?? true;
+  const artifactDetail =
+    includeFileSamples
+      ? await loadScanArtifacts(artifactBucket, scan)
+      : needsArtifactMetadataFallback(scan, files, findings)
+        ? await loadScanArtifactMetadata(artifactBucket, scan)
+        : null;
   const detailFiles = artifactDetail ? mergeArtifactFiles(files, artifactDetail.files, id) : files;
-  const responseFiles =
-    (options.includeFileSamples ?? true) ? detailFiles : detailFiles.map(stripFileSampleForList);
+  const responseFiles = includeFileSamples ? detailFiles : detailFiles.map(stripFileSampleForList);
   const diff = artifactDetail?.diff ?? diffForFindingAnnotations(scan.summaryJson, detailFiles);
-  // Artifact-backed scans no longer duplicate their findings into `scan_findings`
-  // (see persistScan); read them, with annotations, from the digest-verified
-  // report.json. The D1 rows + summary-embedded annotations stay the source for
-  // legacy/degraded scans that were never R2-backed.
   const findingRows = artifactDetail ? artifactDetail.findings : findings;
   const annotatedFindings = annotateFindingsWithDiffStatus(findingRows, diff, {
     persistedAnnotations: artifactDetail
@@ -939,13 +938,34 @@ export async function getScanCompareData(
   ]);
   const scan = scanRows[0];
   if (!scan) return null;
-  // Compare annotations need this scan's file metadata + findings. For
-  // artifact-backed scans those no longer live in D1, so source them from R2
-  // (samples are stripped either way — compare diffs at file granularity).
-  const artifactDetail = await loadScanArtifacts(artifactBucket, scan);
+  const artifactDetail = needsArtifactMetadataFallback(scan, files, findings)
+    ? await loadScanArtifactMetadata(artifactBucket, scan)
+    : null;
   const detailFiles = artifactDetail ? mergeArtifactFiles(files, artifactDetail.files, id) : files;
   const findingRows = artifactDetail ? artifactDetail.findings : findings;
   return { scan, files: detailFiles.map(stripFileSampleForList), findings: findingRows };
+}
+
+function needsArtifactMetadataFallback(
+  scan: typeof scans.$inferSelect,
+  files: Array<typeof scanFiles.$inferSelect>,
+  findings: Array<typeof scanFindings.$inferSelect>,
+): boolean {
+  if (!hasArtifactReferences(scan)) return false;
+  if (files.length === 0) return true;
+  return typeof scan.findingCount === "number" && findings.length < scan.findingCount;
+}
+
+function hasArtifactReferences(scan: typeof scans.$inferSelect): boolean {
+  return (
+    scan.artifactStorageVersion !== null &&
+    scan.artifactManifestKey !== null &&
+    scan.artifactManifestDigest !== null &&
+    scan.artifactManifestSize !== null &&
+    scan.reportArtifactKey !== null &&
+    scan.fileSamplesArtifactKey !== null &&
+    scan.diffArtifactKey !== null
+  );
 }
 
 function stripFileSampleForList<T extends { textSample: string | null }>(file: T): T {

--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -852,12 +852,11 @@ export async function getScan(
   const scan = scanRows[0];
   if (!scan) return null;
   const includeFileSamples = options.includeFileSamples ?? true;
-  const artifactDetail =
-    includeFileSamples
-      ? await loadScanArtifacts(artifactBucket, scan)
-      : needsArtifactMetadataFallback(scan, files, findings)
-        ? await loadScanArtifactMetadata(artifactBucket, scan)
-        : null;
+  const artifactDetail = includeFileSamples
+    ? await loadScanArtifacts(artifactBucket, scan)
+    : needsArtifactMetadataFallback(scan, files, findings)
+      ? await loadScanArtifactMetadata(artifactBucket, scan)
+      : null;
   const detailFiles = artifactDetail ? mergeArtifactFiles(files, artifactDetail.files, id) : files;
   const responseFiles = includeFileSamples ? detailFiles : detailFiles.map(stripFileSampleForList);
   const diff = artifactDetail?.diff ?? diffForFindingAnnotations(scan.summaryJson, detailFiles);

--- a/server/lib/scan-artifacts.ts
+++ b/server/lib/scan-artifacts.ts
@@ -318,6 +318,31 @@ export async function loadScanArtifacts(
   }
 }
 
+export async function loadScanArtifactMetadata(
+  bucket: R2Bucket | undefined,
+  scan: ScanArtifactScanRow,
+): Promise<ScanArtifactsDetail | null> {
+  if (!bucket || !hasReportArtifactMetadata(scan)) return null;
+
+  try {
+    const reportText = await readDigestVerifiedJsonText(bucket, {
+      key: scan.reportArtifactKey,
+      digest: scan.reportDigest,
+      scanId: scan.id,
+      kind: "report",
+    });
+    const detail = parseReportArtifactMetadata(reportText, scan.id);
+    if (!detail) {
+      emitArtifactFallback("artifact_payload_invalid", scan);
+      return null;
+    }
+    return detail;
+  } catch (err) {
+    emitArtifactFallback("read_failed", scan, { error: describeOperationalError(err) });
+    return null;
+  }
+}
+
 export async function loadScanArtifactFile(
   bucket: R2Bucket | undefined,
   scan: ScanArtifactScanRow,
@@ -434,6 +459,18 @@ function hasArtifactMetadata(scan: ScanArtifactScanRow): scan is ScanArtifactSca
   );
 }
 
+function hasReportArtifactMetadata(scan: ScanArtifactScanRow): scan is ScanArtifactScanRow & {
+  reportDigest: string;
+  artifactStorageVersion: number;
+  reportArtifactKey: string;
+} {
+  return (
+    scan.reportDigest !== null &&
+    scan.artifactStorageVersion === SCAN_ARTIFACT_STORAGE_VERSION &&
+    typeof scan.reportArtifactKey === "string"
+  );
+}
+
 async function putVerifiedJson(
   bucket: R2Bucket,
   key: string,
@@ -458,6 +495,27 @@ async function putVerifiedJson(
     kind: customMetadata.artifactKind,
   });
   return { key, digest, size, contentType: ARTIFACT_CONTENT_TYPE };
+}
+
+async function readDigestVerifiedJsonText(
+  bucket: R2Bucket,
+  descriptor: {
+    key: string;
+    digest: string;
+    scanId: string;
+    kind: string;
+  },
+): Promise<string> {
+  const object = await bucket.get(descriptor.key);
+  if (!object) {
+    throw new Error(`missing ${descriptor.kind} artifact`);
+  }
+  const bytes = await object.arrayBuffer();
+  const actualDigest = await sha256Hex(bytes);
+  if (actualDigest !== descriptor.digest) {
+    throw new Error(`${descriptor.kind} artifact digest mismatch`);
+  }
+  return new TextDecoder().decode(bytes);
 }
 
 async function readVerifiedJsonText(
@@ -616,12 +674,46 @@ function parseFilesArtifact(text: string, scanId: string): ScanArtifactFileRow[]
   return files;
 }
 
+function parseReportArtifactMetadata(text: string, scanId: string): ScanArtifactsDetail | null {
+  const parsed = parseJsonObject(text);
+  if (!parsed) return null;
+  const reportFindings = parseReportFindingsObject(parsed, scanId);
+  const diff = parseDiffEntries(parsed.diff);
+  if (!diff || !reportFindings) return null;
+  return {
+    files: scanFileRowsForDiffMetadata(diff),
+    diff,
+    findings: reportFindings.findings,
+    findingAnnotations: reportFindings.annotations,
+  };
+}
+
+function scanFileRowsForDiffMetadata(diff: DiffEntry[]): ScanArtifactFileRow[] {
+  return diff.flatMap((entry) => {
+    if (entry.status === "removed") return [];
+    return [
+      {
+        path: entry.path,
+        status: entry.status,
+        size: entry.stagedSize ?? null,
+        sha256: entry.stagedSha256 ?? null,
+        flagsJson: entry.flags,
+        textSample: null,
+      },
+    ];
+  });
+}
+
 function parseDiffArtifact(text: string, scanId: string): DiffEntry[] | null {
   const parsed = parseJsonObject(text);
   if (parsed?.version !== SCAN_ARTIFACT_STORAGE_VERSION || parsed.scanId !== scanId) return null;
-  if (!Array.isArray(parsed.diff)) return null;
+  return parseDiffEntries(parsed.diff);
+}
+
+function parseDiffEntries(value: unknown): DiffEntry[] | null {
+  if (!Array.isArray(value)) return null;
   const diff: DiffEntry[] = [];
-  for (const entry of parsed.diff) {
+  for (const entry of value) {
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) return null;
     const item = entry as Partial<DiffEntry>;
     if (typeof item.path !== "string" || typeof item.status !== "string") return null;
@@ -666,6 +758,14 @@ function parseReportFindings(
   scanId: string,
 ): { findings: ScanArtifactFindingRow[]; annotations: Map<string, FindingDiffAnnotation> } | null {
   const parsed = parseJsonObject(text);
+  if (!parsed) return null;
+  return parseReportFindingsObject(parsed, scanId);
+}
+
+function parseReportFindingsObject(
+  parsed: Record<string, unknown>,
+  scanId: string,
+): { findings: ScanArtifactFindingRow[]; annotations: Map<string, FindingDiffAnnotation> } | null {
   const rawFindings = parsed?.ruleFindings;
   if (!Array.isArray(rawFindings)) return null;
 

--- a/test/workers/scan-artifacts-routes.test.ts
+++ b/test/workers/scan-artifacts-routes.test.ts
@@ -4,7 +4,7 @@ import { Hono } from "hono";
 import { describe, expect, test } from "vitest";
 import { createDb } from "../../server/db/client";
 import { ensurePersonalOrganization } from "../../server/db/organizations";
-import { createScanJob, getScan, persistScan } from "../../server/db/scans";
+import { createScanJob, getScan, getScanCompareData, persistScan } from "../../server/db/scans";
 import * as schema from "../../server/db/schema";
 import {
   DETERMINISTIC_RULES_VERSION,
@@ -115,6 +115,17 @@ function createFlakyArtifactBucket(options: { failFirstPuts?: number; failAllPut
     },
   } as unknown as R2Bucket;
   return { bucket, putCalls: () => putCalls };
+}
+
+function createReadCountingBucket(delegate: R2Bucket) {
+  let getCalls = 0;
+  const bucket = {
+    async get(key: string) {
+      getCalls += 1;
+      return delegate.get(key);
+    },
+  } as unknown as R2Bucket;
+  return { bucket, getCalls: () => getCalls };
 }
 
 async function buildArtifactWriteInput(owner: SeededUser) {
@@ -344,32 +355,45 @@ describe("scan artifact backfill route", () => {
     expect(fake.putCalls()).toBe(SCAN_ARTIFACT_WRITE_ATTEMPTS);
   });
 
-  test("new artifact-backed scans skip D1 detail rows and serve files + findings from R2", async () => {
+  test("new artifact-backed scans serve metadata from report artifacts and file bodies from R2", async () => {
     const owner = await seedUser();
     const app = buildTestApp(owner);
     const { db, scanId } = await seedDigestMatchedLegacyScan(owner, { artifactBacked: true });
 
-    // The duplicate per-row detail is no longer written to D1 once the scan is
-    // R2-backed; files.json / report.json hold it instead.
     const fileRows = await db
-      .select({ path: schema.scanFiles.path })
+      .select({ path: schema.scanFiles.path, textSample: schema.scanFiles.textSample })
       .from(schema.scanFiles)
       .where(eq(schema.scanFiles.scanId, scanId));
     const findingRows = await db
       .select({ id: schema.scanFindings.id })
       .from(schema.scanFindings)
       .where(eq(schema.scanFindings.scanId, scanId));
-    expect(fileRows.length).toBe(0);
-    expect(findingRows.length).toBe(0);
+    expect(fileRows).toHaveLength(0);
+    expect(findingRows).toHaveLength(0);
 
-    // Without the artifact bucket a compacted scan exposes no file/finding detail
-    // (graceful degradation, not a crash).
     const d1Only = await getScan(db, scanId, owner.organizationId);
-    expect(d1Only?.files.length).toBe(0);
-    expect(d1Only?.findings.length).toBe(0);
+    expect(d1Only?.files).toHaveLength(0);
+    expect(d1Only?.findings).toHaveLength(0);
 
-    // The detail route loads the bucket, so file metadata and findings come back
-    // from R2 (staged bodies are stripped here and fetched via /file).
+    const readCounter = createReadCountingBucket(env.ARTIFACTS);
+    const metadataOnly = await getScan(db, scanId, owner.organizationId, readCounter.bucket, {
+      includeFileSamples: false,
+    });
+    expect(metadataOnly?.files.find((file) => file.path === "index.js")?.textSample).toBeNull();
+    expect(metadataOnly?.findings).toHaveLength(1);
+    expect(readCounter.getCalls()).toBe(1);
+
+    const compareCounter = createReadCountingBucket(env.ARTIFACTS);
+    const compareData = await getScanCompareData(
+      db,
+      scanId,
+      owner.organizationId,
+      compareCounter.bucket,
+    );
+    expect(compareData?.files.find((file) => file.path === "index.js")?.textSample).toBeNull();
+    expect(compareData?.findings).toHaveLength(1);
+    expect(compareCounter.getCalls()).toBe(1);
+
     const detailRes = await fetchJsonWithSession(app, `/api/v1/scans/${scanId}`, {
       method: "GET",
     });
@@ -384,8 +408,6 @@ describe("scan artifact backfill route", () => {
         releaseDelta: boolean;
       }>;
     };
-    // The detail route strips staged bodies (fetched separately via /file), but
-    // findings still come from R2, annotated from the report's findingAnnotations.
     expect(detail.files.find((file) => file.path === "index.js")?.textSample).toBeNull();
     expect(detail.findings).toHaveLength(1);
     expect(detail.findings[0]).toMatchObject({
@@ -404,7 +426,7 @@ describe("scan artifact backfill route", () => {
       scan: { id: scanId, status: "complete" },
     });
 
-    // The staged body has no D1 row, so the file-body route serves it from R2.
+    // The staged body is not duplicated in D1, so /file serves it from R2.
     const fileRes = await fetchJsonWithSession(app, `/api/v1/scans/${scanId}/file?path=index.js`, {
       method: "GET",
     });
@@ -412,8 +434,8 @@ describe("scan artifact backfill route", () => {
     const fileDetail = (await fileRes.json()) as { file: { textSample: string | null } };
     expect(fileDetail.file.textSample).toContain("npm_config_user_agent");
 
-    // The report.json export is a full-detail read, so it must also pull findings
-    // from R2 for a compacted scan rather than the (now empty) D1 rows.
+    // Full-detail export should still hydrate artifact samples for report shape
+    // compatibility.
     const exportRes = await fetchJsonWithSession(app, `/api/v1/scans/${scanId}/report.json`, {
       method: "GET",
     });


### PR DESCRIPTION
## Summary
Rebased on `main` and removed the D1 file/finding-row duplication from the previous version. R2-backed scans now keep file samples and metadata out of D1; metadata-only detail/compare reads hydrate only digest-verified `report.json` and derive:

```ts
files = report.diff.filter(status !== "removed").map({ path, status, stagedSize, stagedSha256, flags, textSample: null })
findings = report.ruleFindings
```

Full report export still uses `loadScanArtifacts()` for compatibility, and lazy `/file?path=` remains the only path that reads `files.json` file-body samples. The degraded no-R2 path still persists D1 rows so scans remain readable without artifacts.

Verified with `pnpm run test:workers -- test/workers/scan-artifacts-routes.test.ts` and `pnpm run verify`. Docs checked, no update needed.

Link to Devin session: https://app.devin.ai/sessions/1b57e203bad84769819e99d1b3af2b49