### PR TITLE
Make discovery cron due-time based

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,7 +60,11 @@ Workflow gates reuse the scan pipeline when the registry cannot stage a release 
 
 ## Scheduled discovery
 
-Cron-triggered npm discovery finds staged publishes for organizations with validated npm connections and creates scans using the same pipeline. Token-expiry and validation issues should surface through settings/UI status and redacted observability events.
+Cron-triggered npm discovery finds staged publishes for organizations with validated or revalidatable npm connections and creates scans using the same pipeline. The `*/15 * * * *` handler selects at most `DISCOVERY_CRON_BATCH_SIZE` due connections, validates `unvalidated` tokens before use, skips known-invalid tokens, paginates staged-list results, deduplicates stage IDs, and removes a just-created pending scan if Queue dispatch fails.
+
+Discovery is due-time based rather than a full-table poll. Organizations that create scans stay on the base 15-minute cadence; quiet organizations back off to 1 hour, then 6 hours, then 24 hours with jitter; transient failures retry on the base cadence without resetting quiet backoff. Sweeps run with `DISCOVERY_CRON_CONCURRENCY = 5` and emit redacted `staged_publishes.cron.swept` metrics including selected/processed org counts, quiet/failed/expired counts, created scans, fetched pages, and access probes.
+
+Token-expiry and validation issues surface through settings/UI status, audit events, maintainer notification, and redacted observability events. Auth failures mark the connection `invalid`, which removes it from future discovery until the token is rotated.
 
 ## Data stores
 

--- a/drizzle/0022_awesome_guardsmen.sql
+++ b/drizzle/0022_awesome_guardsmen.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `npm_connections` ADD `next_discovery_at` integer;--> statement-breakpoint
+ALTER TABLE `npm_connections` ADD `discovery_backoff_level` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+CREATE INDEX `npm_connections_discovery_due_idx` ON `npm_connections` (`validation_status`,`next_discovery_at`);

--- a/drizzle/meta/0022_snapshot.json
+++ b/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,2412 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "dc88c2d0-6df1-4332-8bd6-438077a34139",
+  "prevId": "d381d227-a90a-4475-8065-4d87f9902fea",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_app_installations": {
+      "name": "github_app_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Organization'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uninstalled_at": {
+          "name": "uninstalled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_app_installations_installation_unique_idx": {
+          "name": "github_app_installations_installation_unique_idx",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        },
+        "github_app_installations_org_idx": {
+          "name": "github_app_installations_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installations_created_by_user_id_user_id_fk": {
+          "name": "github_app_installations_created_by_user_id_user_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_release_targets": {
+      "name": "github_release_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ecosystem": {
+          "name": "ecosystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_release_targets_org_repo_env_unique_idx": {
+          "name": "github_release_targets_org_repo_env_unique_idx",
+          "columns": [
+            "organization_id",
+            "repository_id",
+            "environment"
+          ],
+          "isUnique": true
+        },
+        "github_release_targets_installation_idx": {
+          "name": "github_release_targets_installation_idx",
+          "columns": [
+            "installation_row_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_release_targets_organization_id_organizations_id_fk": {
+          "name": "github_release_targets_organization_id_organizations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_release_targets_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_created_by_user_id_user_id_fk": {
+          "name": "github_release_targets_created_by_user_id_user_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_workflow_gates": {
+      "name": "github_workflow_gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_target_id": {
+          "name": "release_target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deployment_callback_url": {
+          "name": "deployment_callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_comment": {
+          "name": "decision_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_url": {
+          "name": "report_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_started_at": {
+          "name": "review_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_workflow_gates_delivery_unique_idx": {
+          "name": "github_workflow_gates_delivery_unique_idx",
+          "columns": [
+            "delivery_id"
+          ],
+          "isUnique": true
+        },
+        "github_workflow_gates_org_status_idx": {
+          "name": "github_workflow_gates_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_release_target_idx": {
+          "name": "github_workflow_gates_release_target_idx",
+          "columns": [
+            "release_target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_workflow_gates_organization_id_organizations_id_fk": {
+          "name": "github_workflow_gates_organization_id_organizations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_workflow_gates_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_release_target_id_github_release_targets_id_fk": {
+          "name": "github_workflow_gates_release_target_id_github_release_targets_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_release_targets",
+          "columnsFrom": [
+            "release_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_scan_id_scans_id_fk": {
+          "name": "github_workflow_gates_scan_id_scans_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_discovery_at": {
+          "name": "next_discovery_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "discovery_backoff_level": {
+          "name": "discovery_backoff_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_unique_idx": {
+          "name": "npm_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        },
+        "npm_connections_discovery_due_idx": {
+          "name": "npm_connections_discovery_due_idx",
+          "columns": [
+            "validation_status",
+            "next_discovery_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_invitations": {
+      "name": "organization_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_invitations_token_hash_unique_idx": {
+          "name": "organization_invitations_token_hash_unique_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "organization_invitations_org_status_idx": {
+          "name": "organization_invitations_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "organization_invitations_org_email_idx": {
+          "name": "organization_invitations_org_email_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_invitations_organization_id_organizations_id_fk": {
+          "name": "organization_invitations_organization_id_organizations_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_invited_by_user_id_user_id_fk": {
+          "name": "organization_invitations_invited_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_accepted_by_user_id_user_id_fk": {
+          "name": "organization_invitations_accepted_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_notification_recipients": {
+      "name": "organization_notification_recipients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_notification_recipients_org_email_unique_idx": {
+          "name": "organization_notification_recipients_org_email_unique_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_notification_recipients_organization_id_organizations_id_fk": {
+          "name": "organization_notification_recipients_organization_id_organizations_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_notification_recipients_created_by_user_id_user_id_fk": {
+          "name": "organization_notification_recipients_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_slack_connections": {
+      "name": "organization_slack_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_token_ciphertext": {
+          "name": "bot_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bot_token_nonce": {
+          "name": "bot_token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slack_connections_org_unique_idx": {
+          "name": "organization_slack_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_slack_connections_organization_id_organizations_id_fk": {
+          "name": "organization_slack_connections_organization_id_organizations_id_fk",
+          "tableFrom": "organization_slack_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_slack_connections_created_by_user_id_user_id_fk": {
+          "name": "organization_slack_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_slack_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "require_two_factor_for_release_decisions": {
+          "name": "require_two_factor_for_release_decisions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_findings_scan_severity_idx": {
+          "name": "scan_findings_scan_severity_idx",
+          "columns": [
+            "scan_id",
+            "severity"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changed_file_count": {
+          "name": "changed_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_summary_json": {
+          "name": "risk_summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_storage_version": {
+          "name": "artifact_storage_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_key": {
+          "name": "artifact_manifest_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_digest": {
+          "name": "artifact_manifest_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_size": {
+          "name": "artifact_manifest_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_artifact_key": {
+          "name": "report_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_samples_artifact_key": {
+          "name": "file_samples_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "diff_artifact_key": {
+          "name": "diff_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        },
+        "scans_gate_org_idx": {
+          "name": "scans_gate_org_idx",
+          "columns": [
+            "gate_id",
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_artifact_backfill_idx": {
+          "name": "scans_artifact_backfill_idx",
+          "columns": [
+            "organization_id",
+            "status",
+            "artifact_storage_version",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "scans_org_decision_created_idx": {
+          "name": "scans_org_decision_created_idx",
+          "columns": [
+            "organization_id",
+            "decision",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scans_org_created_idx": {
+          "name": "scans_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_gate_id_github_workflow_gates_id_fk": {
+          "name": "scans_gate_id_github_workflow_gates_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "github_workflow_gates",
+          "columnsFrom": [
+            "gate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_decided_by_user_id_user_id_fk": {
+          "name": "scans_decided_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "two_factor": {
+      "name": "two_factor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1781546985955,
       "tag": "0021_magical_exiles",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1782231218811,
+      "tag": "0022_awesome_guardsmen",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/npm-connections.ts
+++ b/server/db/npm-connections.ts
@@ -1,6 +1,16 @@
-import { eq, inArray } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, lte, or } from "drizzle-orm";
 import type { AppDb } from "./client";
 import { npmConnections } from "./schema";
+
+export const DISCOVERY_ACTIVE_INTERVAL_MS = 15 * 60 * 1000;
+export const DISCOVERY_QUIET_INTERVALS_MS = [
+  60 * 60 * 1000,
+  6 * 60 * 60 * 1000,
+  24 * 60 * 60 * 1000,
+] as const;
+export const DISCOVERY_MAX_JITTER_MS = 15 * 60 * 1000;
+
+export type NpmConnectionDiscoveryOutcome = "active" | "quiet" | "retry";
 
 export interface NpmConnectionInput {
   organizationId: string;
@@ -20,6 +30,52 @@ export interface NpmConnectionValidationInput {
   validatedAt?: Date | null;
 }
 
+export interface NpmConnectionDiscoveryScheduleInput {
+  organizationId: string;
+  outcome: NpmConnectionDiscoveryOutcome;
+  currentBackoffLevel?: number | null;
+  now?: Date;
+}
+
+export interface NpmConnectionDiscoverySchedule {
+  nextDiscoveryAt: Date;
+  discoveryBackoffLevel: number;
+  delayMs: number;
+}
+
+export function computeNextNpmConnectionDiscovery(
+  input: Omit<NpmConnectionDiscoveryScheduleInput, "organizationId"> & { jitterMs?: number },
+): NpmConnectionDiscoverySchedule {
+  const now = input.now ?? new Date();
+  const currentBackoffLevel = clampBackoffLevel(input.currentBackoffLevel ?? 0);
+  const discoveryBackoffLevel =
+    input.outcome === "quiet"
+      ? Math.min(currentBackoffLevel + 1, DISCOVERY_QUIET_INTERVALS_MS.length)
+      : input.outcome === "active"
+        ? 0
+        : currentBackoffLevel;
+  const intervalMs =
+    input.outcome === "quiet"
+      ? DISCOVERY_QUIET_INTERVALS_MS[discoveryBackoffLevel - 1]!
+      : DISCOVERY_ACTIVE_INTERVAL_MS;
+  const jitterMs =
+    input.jitterMs ??
+    Math.floor(Math.random() * Math.min(intervalMs * 0.1, DISCOVERY_MAX_JITTER_MS));
+  const safeJitterMs = Math.max(0, Math.min(jitterMs, DISCOVERY_MAX_JITTER_MS));
+  const delayMs = intervalMs + safeJitterMs;
+
+  return {
+    nextDiscoveryAt: new Date(now.getTime() + delayMs),
+    discoveryBackoffLevel,
+    delayMs,
+  };
+}
+
+function clampBackoffLevel(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(Math.max(Math.floor(value), 0), DISCOVERY_QUIET_INTERVALS_MS.length);
+}
+
 export async function upsertNpmConnection(db: AppDb, input: NpmConnectionInput) {
   const now = new Date();
   const values = {
@@ -35,6 +91,8 @@ export async function upsertNpmConnection(db: AppDb, input: NpmConnectionInput) 
     capabilitiesJson: null,
     validatedAt: null,
     lastUsedAt: null,
+    nextDiscoveryAt: null,
+    discoveryBackoffLevel: 0,
     createdByUserId: input.createdByUserId,
     createdAt: now,
     updatedAt: now,
@@ -55,6 +113,8 @@ export async function upsertNpmConnection(db: AppDb, input: NpmConnectionInput) 
         validationStatus: values.validationStatus,
         capabilitiesJson: values.capabilitiesJson,
         validatedAt: values.validatedAt,
+        nextDiscoveryAt: values.nextDiscoveryAt,
+        discoveryBackoffLevel: values.discoveryBackoffLevel,
         updatedAt: now,
       },
     });
@@ -71,11 +131,22 @@ export async function getNpmConnection(db: AppDb, organizationId: string) {
   return connection ?? null;
 }
 
-export async function listAutoDiscoveryNpmConnections(db: AppDb) {
+export async function listAutoDiscoveryNpmConnections(
+  db: AppDb,
+  input: { now?: Date; limit?: number } = {},
+) {
+  const now = input.now ?? new Date();
   return db
     .select()
     .from(npmConnections)
-    .where(inArray(npmConnections.validationStatus, ["valid", "unvalidated"]));
+    .where(
+      and(
+        inArray(npmConnections.validationStatus, ["valid", "unvalidated"]),
+        or(isNull(npmConnections.nextDiscoveryAt), lte(npmConnections.nextDiscoveryAt, now)),
+      ),
+    )
+    .orderBy(asc(npmConnections.nextDiscoveryAt), asc(npmConnections.createdAt))
+    .limit(input.limit ?? 100);
 }
 
 export async function updateNpmConnectionValidation(
@@ -88,6 +159,8 @@ export async function updateNpmConnectionValidation(
       validationStatus: input.validationStatus,
       capabilitiesJson: input.capabilities ?? null,
       validatedAt: input.validatedAt ?? null,
+      nextDiscoveryAt: null,
+      discoveryBackoffLevel: 0,
       updatedAt: new Date(),
     })
     .where(eq(npmConnections.organizationId, input.organizationId));
@@ -99,6 +172,22 @@ export async function markNpmConnectionUsed(db: AppDb, organizationId: string) {
     .update(npmConnections)
     .set({ lastUsedAt: new Date(), updatedAt: new Date() })
     .where(eq(npmConnections.organizationId, organizationId));
+}
+
+export async function scheduleNextNpmConnectionDiscovery(
+  db: AppDb,
+  input: NpmConnectionDiscoveryScheduleInput,
+) {
+  const schedule = computeNextNpmConnectionDiscovery(input);
+  await db
+    .update(npmConnections)
+    .set({
+      nextDiscoveryAt: schedule.nextDiscoveryAt,
+      discoveryBackoffLevel: schedule.discoveryBackoffLevel,
+      updatedAt: new Date(),
+    })
+    .where(eq(npmConnections.organizationId, input.organizationId));
+  return schedule;
 }
 
 export async function deleteNpmConnection(db: AppDb, organizationId: string) {

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -283,6 +283,8 @@ export const npmConnections = sqliteTable(
     capabilitiesJson: text("capabilities_json", { mode: "json" }),
     validatedAt: integer("validated_at", { mode: "timestamp_ms" }),
     lastUsedAt: integer("last_used_at", { mode: "timestamp_ms" }),
+    nextDiscoveryAt: integer("next_discovery_at", { mode: "timestamp_ms" }),
+    discoveryBackoffLevel: integer("discovery_backoff_level").notNull().default(0),
     createdByUserId: text("created_by_user_id").references(() => user.id, { onDelete: "set null" }),
     createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
     updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
@@ -290,6 +292,10 @@ export const npmConnections = sqliteTable(
   (table) => ({
     orgUniqueIdx: uniqueIndex("npm_connections_org_unique_idx").on(table.organizationId),
     fingerprintIdx: index("npm_connections_fingerprint_idx").on(table.tokenFingerprint),
+    discoveryDueIdx: index("npm_connections_discovery_due_idx").on(
+      table.validationStatus,
+      table.nextDiscoveryAt,
+    ),
   }),
 );
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,6 +5,7 @@ import {
   getOrganizationOwnerUserId,
   listAutoDiscoveryNpmConnections,
   RateLimitError,
+  scheduleNextNpmConnectionDiscovery,
 } from "./db";
 import { createAuth, getAuthSession } from "./lib/auth";
 import { rateLimitResponse } from "./lib/http";
@@ -290,6 +291,7 @@ app.onError((err, c) => {
 // flight keeps us comfortably under budget while still draining a large org
 // count within a single 15-minute cycle. Raise only after measuring CPU time.
 const DISCOVERY_CRON_CONCURRENCY = 5;
+const DISCOVERY_CRON_BATCH_SIZE = 100;
 
 async function runWithConcurrency<T>(
   items: readonly T[],
@@ -306,16 +308,32 @@ async function runWithConcurrency<T>(
   await Promise.all(runners);
 }
 
-async function runStagedPublishesDiscoveryCron(env: Cloudflare.Env, ctx: ExecutionContext) {
+async function runStagedPublishesDiscoveryCron(
+  env: Cloudflare.Env,
+  ctx: ExecutionContext,
+  scheduledAt = new Date(),
+) {
   const startedAtMs = Date.now();
   const db = createDb(env.DB);
-  const connections = await listAutoDiscoveryNpmConnections(db);
+  const connections = await listAutoDiscoveryNpmConnections(db, {
+    now: scheduledAt,
+    limit: DISCOVERY_CRON_BATCH_SIZE,
+  });
   emitOperationalEvent("info", "staged_publishes.cron.started", {
-    organizations: connections.length,
+    organizationsSelected: connections.length,
+    batchSize: DISCOVERY_CRON_BATCH_SIZE,
   });
   const allowInsecureLocalhost = allowInsecureLocalRegistry(env);
 
   let orgsProcessed = 0;
+  let orgsWithScans = 0;
+  let orgsQuiet = 0;
+  let orgsFailed = 0;
+  let orgsExpired = 0;
+  let scansCreated = 0;
+  let stagedPublishesFound = 0;
+  let pagesFetched = 0;
+  let accessProbes = 0;
   const sweepConnection = async (connection: (typeof connections)[number]) => {
     try {
       const notificationOwnerUserId = await getOrganizationOwnerUserId(
@@ -327,6 +345,13 @@ async function runStagedPublishesDiscoveryCron(env: Cloudflare.Env, ctx: Executi
         emitOperationalEvent("error", "staged_publishes.cron.skipped", {
           organizationId: connection.organizationId,
           reason: "organization_owner_missing",
+        });
+        orgsFailed++;
+        await scheduleNextNpmConnectionDiscovery(db, {
+          organizationId: connection.organizationId,
+          outcome: "retry",
+          currentBackoffLevel: connection.discoveryBackoffLevel,
+          now: scheduledAt,
         });
         return;
       }
@@ -351,9 +376,23 @@ async function runStagedPublishesDiscoveryCron(env: Cloudflare.Env, ctx: Executi
           },
           usable,
         );
+        stagedPublishesFound += result.found;
+        scansCreated += result.created;
+        pagesFetched += result.pagesFetched;
+        accessProbes += result.accessProbes;
+        if (result.created > 0) orgsWithScans++;
+        else orgsQuiet++;
+        const schedule = await scheduleNextNpmConnectionDiscovery(db, {
+          organizationId: connection.organizationId,
+          outcome: result.created > 0 ? "active" : "quiet",
+          currentBackoffLevel: connection.discoveryBackoffLevel,
+          now: scheduledAt,
+        });
         emitOperationalEvent("info", "staged_publishes.cron.org_completed", {
           organizationId: connection.organizationId,
           ...result,
+          nextDiscoveryAt: schedule.nextDiscoveryAt.toISOString(),
+          discoveryBackoffLevel: schedule.discoveryBackoffLevel,
         });
       } catch (err) {
         if (isNpmConnectionAuthFailure(err)) {
@@ -375,6 +414,7 @@ async function runStagedPublishesDiscoveryCron(env: Cloudflare.Env, ctx: Executi
               error: describeOperationalError(alertErr),
             });
           }
+          orgsExpired++;
           return;
         }
         const detail =
@@ -384,6 +424,13 @@ async function runStagedPublishesDiscoveryCron(env: Cloudflare.Env, ctx: Executi
         emitOperationalEvent("error", "staged_publishes.cron.org_failed", {
           organizationId: connection.organizationId,
           error: detail,
+        });
+        orgsFailed++;
+        await scheduleNextNpmConnectionDiscovery(db, {
+          organizationId: connection.organizationId,
+          outcome: "retry",
+          currentBackoffLevel: connection.discoveryBackoffLevel,
+          now: scheduledAt,
         });
       }
     } finally {
@@ -395,15 +442,25 @@ async function runStagedPublishesDiscoveryCron(env: Cloudflare.Env, ctx: Executi
 
   emitOperationalEvent("info", "staged_publishes.cron.swept", {
     orgsProcessed,
+    orgsSelected: connections.length,
+    orgsWithScans,
+    orgsQuiet,
+    orgsFailed,
+    orgsExpired,
+    scansCreated,
+    stagedPublishesFound,
+    pagesFetched,
+    accessProbes,
     durationMs: durationMsSince(startedAtMs),
     concurrencyLimit: DISCOVERY_CRON_CONCURRENCY,
+    batchSize: DISCOVERY_CRON_BATCH_SIZE,
   });
 }
 
 export default {
   fetch: app.fetch,
-  async scheduled(_event: ScheduledController, env: Cloudflare.Env, ctx: ExecutionContext) {
-    await runStagedPublishesDiscoveryCron(env, ctx);
+  async scheduled(event: ScheduledController, env: Cloudflare.Env, ctx: ExecutionContext) {
+    await runStagedPublishesDiscoveryCron(env, ctx, new Date(event.scheduledTime));
   },
   async queue(batch: MessageBatch<QueueMessage>, env: Cloudflare.Env, ctx: ExecutionContext) {
     for (const message of batch.messages) {

--- a/server/lib/staged-publishes-discovery.ts
+++ b/server/lib/staged-publishes-discovery.ts
@@ -2,7 +2,6 @@ import {
   createScanJob,
   deletePendingScanJob,
   listExistingScanStageIds,
-  markNpmConnectionUsed,
   recordScanEvent,
   updateNpmConnectionValidation,
   type AppDb,
@@ -39,6 +38,8 @@ export interface DiscoverStagedPublishesResult {
   created: number;
   skipped: number;
   queued: boolean;
+  pagesFetched: number;
+  accessProbes: number;
   scans: StartedStagedPublishScan[];
 }
 
@@ -210,18 +211,20 @@ export async function discoverAndQueueStagedPublishes(
     allowInsecureLocalhost,
   } = input;
 
-  const stagedItems = await listAllStagedPublishes(connection, {
+  const listed = await listAllStagedPublishes(connection, {
     perPage: 50,
     allowInsecureLocalhost,
   });
-  await markNpmConnectionUsed(db, organizationId);
+  const stagedItems = listed.items;
   const stageIds = stagedItems.map((item) => item.id);
   const existingStageIds = await listExistingScanStageIds(db, organizationId, stageIds);
   const startedScans: StartedStagedPublishScan[] = [];
+  let accessProbes = 0;
 
   for (const item of stagedItems) {
     const stageId = item.id;
     if (existingStageIds.has(stageId)) continue;
+    accessProbes++;
     const access = await checkStagedPublishAccess(
       connection.registryUrl,
       connection.token,
@@ -299,6 +302,8 @@ export async function discoverAndQueueStagedPublishes(
         found: stageIds.length,
         created: startedScans.length,
         skipped: stageIds.length - startedScans.length,
+        pagesFetched: listed.pagesFetched,
+        accessProbes,
         source: eventSource,
       },
     });
@@ -309,6 +314,8 @@ export async function discoverAndQueueStagedPublishes(
     created: startedScans.length,
     skipped: stageIds.length - startedScans.length,
     queued: Boolean(env.SCAN_QUEUE),
+    pagesFetched: listed.pagesFetched,
+    accessProbes,
     scans: startedScans,
   };
 }
@@ -316,14 +323,15 @@ export async function discoverAndQueueStagedPublishes(
 async function listAllStagedPublishes(
   connection: TokenForDiscovery,
   options: { perPage: number; allowInsecureLocalhost?: boolean },
-): Promise<StagedPublishItem[]> {
+): Promise<{ items: StagedPublishItem[]; pagesFetched: number }> {
   const byId = new Map<string, StagedPublishItem>();
+  let pagesFetched = 1;
   let page = await listStagedPublishes(connection.registryUrl, connection.token, options);
   for (const item of page.items) byId.set(item.id, item);
 
   const perPage = page.perPage ?? options.perPage;
   let nextPage = typeof page.page === "number" ? page.page + 1 : 1;
-  for (let pagesFetched = 1; pagesFetched < 100; pagesFetched++) {
+  for (let pagesChecked = 1; pagesChecked < 100; pagesChecked++) {
     if (page.total !== null && byId.size >= page.total) break;
     if (page.items.length < perPage) break;
 
@@ -331,12 +339,13 @@ async function listAllStagedPublishes(
       ...options,
       page: nextPage,
     });
+    pagesFetched++;
     if (!page.items.length) break;
     for (const item of page.items) byId.set(item.id, item);
     nextPage = typeof page.page === "number" ? page.page + 1 : nextPage + 1;
   }
 
-  return [...byId.values()];
+  return { items: [...byId.values()], pagesFetched };
 }
 
 export { StagedPublishesFetchError };

--- a/server/lib/staged-publishes.ts
+++ b/server/lib/staged-publishes.ts
@@ -50,6 +50,8 @@ export interface StagedPublishesScanResponse {
   created: number;
   skipped: number;
   queued: boolean;
+  pagesFetched: number;
+  accessProbes: number;
   scans: StartedStagedPublishScan[];
 }
 

--- a/server/routes/staged-publishes.ts
+++ b/server/routes/staged-publishes.ts
@@ -1,5 +1,11 @@
 import { Hono } from "hono";
-import { RateLimitError, createDb, enforceRateLimit, getNpmConnection } from "../db";
+import {
+  RateLimitError,
+  createDb,
+  enforceRateLimit,
+  getNpmConnection,
+  scheduleNextNpmConnectionDiscovery,
+} from "../db";
 import { requireActiveOrganization } from "../lib/active-organization";
 import { rateLimitResponse } from "../lib/http";
 import { allowInsecureLocalRegistry } from "../lib/npm-connection";
@@ -67,6 +73,13 @@ stagedPublishesRoutes.post("/scan", async (c) => {
       },
       usable,
     );
+    if (result.created > 0) {
+      await scheduleNextNpmConnectionDiscovery(db, {
+        organizationId,
+        outcome: "active",
+        currentBackoffLevel: savedConnection.discoveryBackoffLevel,
+      });
+    }
     return c.json(result, 202);
   } catch (err) {
     if (err instanceof InvalidNpmConnectionError) {

--- a/test/npm-connection-utils.test.mjs
+++ b/test/npm-connection-utils.test.mjs
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
 import {
+  computeNextNpmConnectionDiscovery,
+  DISCOVERY_ACTIVE_INTERVAL_MS,
+  DISCOVERY_QUIET_INTERVALS_MS,
+} from "../server/db/npm-connections.ts";
+import {
   allowInsecureLocalRegistry,
   isLoopbackHostname,
   publicNpmConnection,
@@ -32,6 +37,57 @@ describe("isLoopbackHostname", () => {
     expect(isLoopbackHostname("192.168.1.1")).toBe(false);
     expect(isLoopbackHostname("0.0.0.0")).toBe(false);
     expect(isLoopbackHostname("example.com")).toBe(false);
+  });
+});
+
+describe("computeNextNpmConnectionDiscovery", () => {
+  const now = new Date("2026-06-23T12:00:00.000Z");
+
+  test("keeps active discoveries on the base cadence and resets quiet backoff", () => {
+    const schedule = computeNextNpmConnectionDiscovery({
+      outcome: "active",
+      currentBackoffLevel: 2,
+      now,
+      jitterMs: 0,
+    });
+
+    expect(schedule.discoveryBackoffLevel).toBe(0);
+    expect(schedule.delayMs).toBe(DISCOVERY_ACTIVE_INTERVAL_MS);
+    expect(schedule.nextDiscoveryAt.getTime()).toBe(now.getTime() + DISCOVERY_ACTIVE_INTERVAL_MS);
+  });
+
+  test("backs quiet connections off through the capped intervals", () => {
+    const firstQuiet = computeNextNpmConnectionDiscovery({
+      outcome: "quiet",
+      currentBackoffLevel: 0,
+      now,
+      jitterMs: 0,
+    });
+    const cappedQuiet = computeNextNpmConnectionDiscovery({
+      outcome: "quiet",
+      currentBackoffLevel: 99,
+      now,
+      jitterMs: 0,
+    });
+
+    expect(firstQuiet.discoveryBackoffLevel).toBe(1);
+    expect(firstQuiet.delayMs).toBe(DISCOVERY_QUIET_INTERVALS_MS[0]);
+    expect(cappedQuiet.discoveryBackoffLevel).toBe(DISCOVERY_QUIET_INTERVALS_MS.length);
+    expect(cappedQuiet.delayMs).toBe(
+      DISCOVERY_QUIET_INTERVALS_MS[DISCOVERY_QUIET_INTERVALS_MS.length - 1],
+    );
+  });
+
+  test("keeps retry discoveries on the base cadence without changing backoff", () => {
+    const schedule = computeNextNpmConnectionDiscovery({
+      outcome: "retry",
+      currentBackoffLevel: 2,
+      now,
+      jitterMs: 0,
+    });
+
+    expect(schedule.discoveryBackoffLevel).toBe(2);
+    expect(schedule.delayMs).toBe(DISCOVERY_ACTIVE_INTERVAL_MS);
   });
 });
 

--- a/test/staged-publishes-discovery.test.mjs
+++ b/test/staged-publishes-discovery.test.mjs
@@ -291,7 +291,7 @@ describe("discoverAndQueueStagedPublishes", () => {
     expect(env.SCAN_QUEUE.send).toHaveBeenCalledWith(
       expect.objectContaining({ source: "auto_discovery", stageId: "stage-new-1" }),
     );
-    expect(dbMock.markNpmConnectionUsed).toHaveBeenCalledWith(db, "org_a");
+    expect(dbMock.markNpmConnectionUsed).not.toHaveBeenCalled();
   });
 
   test("filters stage ids the organization token cannot access before creating scans", async () => {
@@ -321,7 +321,13 @@ describe("discoverAndQueueStagedPublishes", () => {
     );
 
     expect(result).toEqual(
-      expect.objectContaining({ found: 2, created: 1, skipped: 1, queued: true }),
+      expect.objectContaining({
+        found: 2,
+        created: 1,
+        skipped: 1,
+        queued: true,
+        accessProbes: 2,
+      }),
     );
     expect(stagedPublishesMock.checkStagedPublishAccess).toHaveBeenCalledTimes(2);
     expect(dbMock.createScanJob).toHaveBeenCalledTimes(1);
@@ -384,7 +390,14 @@ describe("discoverAndQueueStagedPublishes", () => {
       "stage-page-3",
     ]);
     expect(result).toEqual(
-      expect.objectContaining({ found: 3, created: 3, skipped: 0, queued: true }),
+      expect.objectContaining({
+        found: 3,
+        created: 3,
+        skipped: 0,
+        queued: true,
+        pagesFetched: 2,
+        accessProbes: 3,
+      }),
     );
   });
 
@@ -438,7 +451,9 @@ describe("discoverAndQueueStagedPublishes", () => {
       { token: "npm_secret_token", registryUrl: "https://registry.npmjs.org" },
     );
 
-    expect(result).toEqual(expect.objectContaining({ found: 1, created: 0, skipped: 1 }));
+    expect(result).toEqual(
+      expect.objectContaining({ found: 1, created: 0, skipped: 1, accessProbes: 0 }),
+    );
     expect(
       dbMock.recordScanEvent.mock.calls.some(
         ([, payload]) => payload?.type === "staged_publishes.scans_started",

--- a/test/workers/discovery-cron.test.ts
+++ b/test/workers/discovery-cron.test.ts
@@ -82,9 +82,9 @@ async function seedOrg(input: {
   };
 }
 
-function scheduledController(): ScheduledController {
+function scheduledController(scheduledTime = Date.now()): ScheduledController {
   return {
-    scheduledTime: Date.now(),
+    scheduledTime,
     cron: "*/15 * * * *",
     noRetry() {},
   } as unknown as ScheduledController;
@@ -228,7 +228,78 @@ describe("staged publishes discovery cron", () => {
     // Sweep finished cleanly over the two eligible orgs.
     const sweptCall = logSpy.mock.calls.find((call) => call[0] === "staged_publishes.cron.swept");
     expect(sweptCall).toBeDefined();
-    expect(sweptCall![1]).toMatchObject({ orgsProcessed: 2 });
+    expect(sweptCall![1]).toMatchObject({
+      orgsProcessed: 2,
+      orgsSelected: 2,
+      orgsWithScans: 1,
+      orgsExpired: 1,
+      scansCreated: 1,
+      stagedPublishesFound: 1,
+      pagesFetched: 1,
+      accessProbes: 1,
+    });
+  });
+
+  test("skips valid connections whose next discovery time is still in the future", async () => {
+    const dueOrg = await seedOrg({
+      index: 0,
+      token: "npm_valid_due_aaaaaaaa",
+      validationStatus: "valid",
+    });
+    const futureOrg = await seedOrg({
+      index: 1,
+      token: "npm_valid_future_bbbbb",
+      validationStatus: "valid",
+    });
+    const now = Date.now();
+    await createDb(env.DB)
+      .update(schema.npmConnections)
+      .set({ nextDiscoveryAt: new Date(now + 60 * 60 * 1000), discoveryBackoffLevel: 1 })
+      .where(eq(schema.npmConnections.organizationId, futureOrg.organizationId));
+
+    const fetchMock = vi.fn(async (input: Request | string | URL, init?: RequestInit) => {
+      expect(authHeader(input, init)).toBe(`Bearer ${dueOrg.token}`);
+      return Response.json({ items: [], total: 0, perPage: 50, page: 0 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const ctx = createExecutionContext();
+    await worker.scheduled(scheduledController(now), env, ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const sweptCall = logSpy.mock.calls.find((call) => call[0] === "staged_publishes.cron.swept");
+    expect(sweptCall).toBeDefined();
+    expect(sweptCall![1]).toMatchObject({
+      orgsSelected: 1,
+      orgsProcessed: 1,
+      orgsQuiet: 1,
+      scansCreated: 0,
+    });
+  });
+
+  test("backs off quiet orgs after an empty discovery result", async () => {
+    const org = await seedOrg({
+      index: 0,
+      token: "npm_valid_quiet_aaaaaaaa",
+      validationStatus: "valid",
+    });
+    const now = Date.now();
+    const fetchMock = vi.fn(async () =>
+      Response.json({ items: [], total: 0, perPage: 50, page: 0 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const ctx = createExecutionContext();
+    await worker.scheduled(scheduledController(now), env, ctx);
+    await waitOnExecutionContext(ctx);
+
+    const connection = await getNpmConnection(createDb(env.DB), org.organizationId);
+    expect(connection?.discoveryBackoffLevel).toBe(1);
+    expect(connection?.nextDiscoveryAt?.getTime()).toBeGreaterThanOrEqual(now + 60 * 60 * 1000);
+    expect(connection?.nextDiscoveryAt?.getTime()).toBeLessThanOrEqual(now + 75 * 60 * 1000);
   });
 
   test("logs a generic per-org failure for a non-auth registry error without alerting", async () => {

--- a/test/workers/staged-publishes-routes.test.ts
+++ b/test/workers/staged-publishes-routes.test.ts
@@ -1,10 +1,12 @@
 import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   createDb,
   createScanJob,
   ensurePersonalOrganization,
+  getNpmConnection,
   listScans,
   updateNpmConnectionValidation,
   upsertNpmConnection,
@@ -66,6 +68,14 @@ describe("staged publishes route", () => {
       validationStatus: "valid",
       validatedAt: new Date(),
     });
+    const now = Date.now();
+    await db
+      .update(schema.npmConnections)
+      .set({
+        nextDiscoveryAt: new Date(now + 24 * 60 * 60 * 1000),
+        discoveryBackoffLevel: 3,
+      })
+      .where(eq(schema.npmConnections.organizationId, owner.organizationId));
     await createScanJob(db, {
       id: `scan_${crypto.randomUUID()}`,
       stageId: "stage-existing-123",
@@ -130,5 +140,9 @@ describe("staged publishes route", () => {
     expect(queue.send.mock.calls[0]?.[0]).toMatchObject({ stageId: "stage-new-123" });
     const { scans } = await listScans(db, owner.organizationId);
     expect(scans.map((scan) => scan.stageId)).toContain("stage-new-123");
+    const connection = await getNpmConnection(db, owner.organizationId);
+    expect(connection?.discoveryBackoffLevel).toBe(0);
+    expect(connection?.nextDiscoveryAt?.getTime()).toBeGreaterThanOrEqual(now + 15 * 60 * 1000);
+    expect(connection?.nextDiscoveryAt?.getTime()).toBeLessThanOrEqual(now + 30 * 60 * 1000);
   });
 });


### PR DESCRIPTION
## Summary
Adds due-time scheduling fields for npm discovery, selects a bounded due batch in the cron, and backs quiet orgs off from 15m to 1h/6h/24h with jitter.
Manual and automatic discoveries that create scans reset the org to active cadence, while cron metrics now report selected/quiet orgs, scans, pages, and access probes.
Updates docs and tests for the new scheduling model.

## Validation
`pnpm run verify`