### PR TITLE
Skip security headers in local dev via DISABLE_SECURITY_HEADERS

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -18,6 +18,11 @@ NPM_CONNECTIONS_ENCRYPTION_KEY=replace-with-a-random-32-byte-secret
 # NPM_REGISTRY=https://registry.npmjs.org
 # AI_CACHE_AFFINITY=staged-publish-review-release-reviewer-v1
 
+# Optional. Skip the production security headers (CSP/HSTS/etc.) for local dev.
+# The strict CSP blocks Vite's HMR client and HSTS pins http://localhost to HTTPS.
+# Local dev only — this var is intentionally absent from every deployed config.
+# DISABLE_SECURITY_HEADERS=true
+
 # The AI reviewer is gated by the Cloudflare Flagship flag `ai-review` in the
 # `drydock` app (see the `flagship` binding in wrangler.jsonc). Toggle it from
 # the Cloudflare dashboard; there is no .dev.vars override.

--- a/server/env.d.ts
+++ b/server/env.d.ts
@@ -12,6 +12,9 @@ declare global {
       SCAN_QUEUE?: Queue<import("./lib/scan-job").QueueMessage>;
       NPM_REGISTRY: string;
       ALLOW_INSECURE_LOCAL_REGISTRY?: string;
+      // `.dev.vars`-only escape hatch (see securityHeadersDisabled). Never set in
+      // any deployed config — production must keep the full header policy.
+      DISABLE_SECURITY_HEADERS?: string;
       NPM_CONNECTIONS_ENCRYPTION_KEY?: string;
       BETTER_AUTH_SECRET: string;
       BETTER_AUTH_URL?: string;

--- a/server/index.ts
+++ b/server/index.ts
@@ -9,7 +9,12 @@ import {
 import { createAuth, getAuthSession } from "./lib/auth";
 import { rateLimitResponse } from "./lib/http";
 import { allowInsecureLocalRegistry } from "./lib/npm-connection";
-import { API_CSP, DOCUMENT_CSP, SECURITY_HEADERS } from "./lib/security-headers";
+import {
+  API_CSP,
+  DOCUMENT_CSP,
+  SECURITY_HEADERS,
+  securityHeadersDisabled,
+} from "./lib/security-headers";
 import {
   describeOperationalError,
   durationMsSince,
@@ -104,6 +109,10 @@ function applySecurityHeaders(c: { res: Response; req: { path: string } }) {
 app.use("*", async (c, next) => {
   await next();
   if (c.res.status < 200 || c.res.status > 599) return;
+  // Local-dev escape hatch: the strict CSP breaks Vite's HMR client and HSTS
+  // would pin the loopback origin to HTTPS. Gated behind a `.dev.vars`-only flag
+  // that is absent from every deployed config, so production fails closed.
+  if (securityHeadersDisabled(c.env)) return;
   applySecurityHeaders(c);
 });
 

--- a/server/lib/security-headers.ts
+++ b/server/lib/security-headers.ts
@@ -13,6 +13,22 @@
 // module, so the values are duplicated there by hand. The drift guard in
 // test/security-headers.test.ts fails if the two ever diverge — update both.
 
+// Local-development escape hatch. The production policy actively breaks
+// `pnpm run dev`: CSP `script-src 'self'` (no 'unsafe-inline') blocks Vite's
+// injected HMR client, and HSTS would pin the http://localhost origin to HTTPS.
+//
+// This is a string env var so it follows the same provisioning as
+// ALLOW_INSECURE_LOCAL_REGISTRY: set it in `.dev.vars` (gitignored) for local
+// dev only. It is deliberately absent from wrangler.jsonc and wrangler.test.jsonc
+// — NEVER add it there. Production fails closed: when the var is unset the full
+// header policy applies, so a deployment can't accidentally ship with headers
+// stripped.
+export function securityHeadersDisabled(
+  env: Pick<Cloudflare.Env, "DISABLE_SECURITY_HEADERS">,
+): boolean {
+  return env.DISABLE_SECURITY_HEADERS === "true";
+}
+
 // Non-CSP headers; identical for every response regardless of content type.
 export const SECURITY_HEADERS: Readonly<Record<string, string>> = {
   // Pin clients to HTTPS for a year so a stripped/downgraded request can't reach

--- a/test/workers/security-headers.test.ts
+++ b/test/workers/security-headers.test.ts
@@ -26,4 +26,21 @@ describe("worker security headers", () => {
     const headers = await fetchHeaders("/does-not-exist");
     expect(headers.get("Strict-Transport-Security")).toBe(HSTS_VALUE);
   });
+
+  // Local-dev escape hatch: DISABLE_SECURITY_HEADERS skips the whole policy so
+  // the strict CSP doesn't break Vite HMR and HSTS doesn't pin localhost to
+  // HTTPS. The flag is absent from every deployed config (wrangler.jsonc /
+  // wrangler.test.jsonc), so the tests above prove production fails closed.
+  test("omits all security headers when DISABLE_SECURITY_HEADERS is set", async () => {
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request("http://example.com/api/health"),
+      { ...env, DISABLE_SECURITY_HEADERS: "true" },
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+    expect(res.headers.get("Strict-Transport-Security")).toBeNull();
+    expect(res.headers.get("Content-Security-Policy")).toBeNull();
+    expect(res.headers.get("X-Frame-Options")).toBeNull();
+  });
 });


### PR DESCRIPTION
## What

The production security-header policy actively breaks `pnpm run dev`:

- The document CSP (`script-src 'self'`, no `'unsafe-inline'`, `connect-src 'self'`) blocks Vite's injected HMR client and dev websocket.
- HSTS would pin the `http://localhost` origin to HTTPS.

This adds a **local-dev-only escape hatch**: when `DISABLE_SECURITY_HEADERS=true`, the Worker skips the entire header policy (CSP + HSTS + the rest).

## Why an env var (and why it can't leak to prod)

It mirrors the existing `ALLOW_INSECURE_LOCAL_REGISTRY` precedent — a string flag provisioned only in `.dev.vars` (gitignored). It is **deliberately absent from `wrangler.jsonc` and `wrangler.test.jsonc`**, so:

- **Production fails closed:** when the var is unset (every deployed config) the full header policy applies. A deploy cannot accidentally ship with headers stripped.
- The secure default is *headers ON* by absence, not by runtime inference.

A comment on the helper and in `env.d.ts` explicitly warns never to add the var to any deployed config.

## Changes

- `server/lib/security-headers.ts` — `securityHeadersDisabled(env)` helper (single source of truth for the policy gate), with rationale.
- `server/index.ts` — middleware early-returns before stamping headers when the flag is set.
- `server/env.d.ts` — hand-declared `DISABLE_SECURITY_HEADERS?` binding (not a `wrangler.jsonc` var, so not generated by `cf-typegen`).
- `.dev.vars.example` — documents the opt-in for local dev.
- `test/workers/security-headers.test.ts` — new case asserts all headers are omitted when the flag is set; the two existing cases (flag unset) prove the production path stays covered.

## Testing

- `pnpm run verify` — lint + format + typecheck + tests all pass.
- Worker security-headers suite: 3 passed.

Docs checked, no update needed — this only adds a local-dev toggle and doesn't change the production header policy or any documented behavior.