### PR TITLE
Rename clearance buttons to ship

### DIFF
--- a/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
@@ -398,11 +398,11 @@ export function GateDecisionDialog({
                 ? "Submitting…"
                 : reviewFailed
                   ? multi
-                    ? "Clear package anyway"
-                    : "Clear anyway & release"
+                    ? "Ship package anyway"
+                    : "Ship anyway & release"
                   : multi
-                    ? "Clear package"
-                    : "Clear & release"}
+                    ? "Ship package"
+                    : "Ship & release"}
             </Button>
           ) : null}
           <Button

--- a/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
+++ b/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
@@ -77,7 +77,7 @@ export function ScanDetailHeader({
           ) : null}
           {onDecideClick ? (
             <Button variant={decision ? "secondary" : "primary"} onClick={onDecideClick}>
-              {decision ? "Update clearance" : "Clear"}
+              {decision ? "Update clearance" : "Ship"}
             </Button>
           ) : null}
         </div>

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -455,7 +455,7 @@ function ScanTable({
                         ? "Saving…"
                         : scan.decision
                           ? "Update"
-                          : "Clear"}
+                          : "Ship"}
                     </Button>
                   ) : null}
                 </div>

--- a/test/agent-tour/drydock-agent-tour.spec.ts
+++ b/test/agent-tour/drydock-agent-tour.spec.ts
@@ -105,7 +105,7 @@ test("agent tour: local Drydock release review walkthrough", async ({
     await download.saveAs(exportedReportPath);
     tour.note(`Exported canonical report JSON to ${relative(exportedReportPath)}.`);
 
-    await page.getByRole("button", { name: "Clear" }).click();
+    await page.getByRole("button", { name: "Ship" }).click();
     await expect(page.getByRole("heading", { name: "Release clearance" })).toBeVisible();
     await page.getByLabel("Reason (optional)").fill("Agent tour: high-risk implicit node-gyp.");
     await tour.capture(page, "decision-dialog", "Maintainer decision dialog before blocking.");

--- a/test/e2e/smoke.spec.ts
+++ b/test/e2e/smoke.spec.ts
@@ -22,9 +22,9 @@ test("renders and decides a workflow-gate review", async ({ page }) => {
   await expect(page.getByText("Docked packages")).toBeVisible();
   await expect(page.getByText("@drydock/sidecar@0.4.0")).toBeVisible();
 
-  await page.getByRole("button", { name: "Clear", exact: true }).click();
+  await page.getByRole("button", { name: "Ship", exact: true }).click();
   await expect(page.getByRole("dialog", { name: "Package clearance" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Clear package" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Ship package" })).toBeVisible();
   await page.getByRole("button", { name: "Hold release" }).click();
 
   await expect(page.getByText("held · job anchored").first()).toBeVisible();


### PR DESCRIPTION
## Summary
Rename the primary release-decision affordances from `Clear` to `Ship` across the dashboard and scan detail view.

- `ScanDetailHeader` primary action: `Clear` → `Ship`
- Dashboard quick decision action: `Clear` → `Ship`
- Workflow-gate approval dialog: `Clear package` / `Clear & release` → `Ship package` / `Ship & release`
- Updated the affected Playwright expectations to match the new labels

Docs checked, no update needed.

Link to Devin session: https://app.devin.ai/sessions/1c90264f90a843f9b91db4970cdb5544
Requested by: @JoviDeCroock
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jovidecroock/drydock/pull/414" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->