### PR TITLE
Show full file name on hover in file tree

### DIFF
--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -106,7 +106,9 @@ function TreeNode({
             >
               ▸
             </span>
-            <span class={cn("flex-1 truncate", statusToText(node.status))}>{node.name}/</span>
+            <span class={cn("flex-1 truncate", statusToText(node.status))} title={`${node.name}/`}>
+              {node.name}/
+            </span>
             <FindingCountBadge count={node.findingCount} severity={node.findingSeverity} />
             {node.status !== "unchanged" ? (
               <Badge tone={statusToTone(node.status)}>{node.status}</Badge>
@@ -141,7 +143,10 @@ function TreeNode({
         )}
       >
         <TreeIndent depth={depth} />
-        <span class={cn("flex-1 truncate", isSelected ? "text-ink" : statusToText(node.status))}>
+        <span
+          class={cn("flex-1 truncate", isSelected ? "text-ink" : statusToText(node.status))}
+          title={node.name}
+        >
           {node.name}
         </span>
         <FindingCountBadge count={node.findingCount} severity={node.findingSeverity} />


### PR DESCRIPTION
## Summary
File and folder labels in the diff `FileTree` use `truncate`, so long names get cut off with no way to see the full name. This adds a native `title` attribute to the truncating label span so hovering reveals the full name.

- File nodes: `title={node.name}`
- Folder nodes: `title={`${node.name}/`}`

Link to Devin session: https://app.devin.ai/sessions/26c252faafdd4dd89b069c1ae68e8d55
Requested by: @JoviDeCroock
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jovidecroock/drydock/pull/415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->