### PR TITLE
Make package context section always-open and non-collapsible

### DIFF
--- a/src/pages/Dashboard/ScanDetail/FindingsSection.tsx
+++ b/src/pages/Dashboard/ScanDetail/FindingsSection.tsx
@@ -55,19 +55,18 @@ export function RiskSignalsSection({
       )}
 
       {contextualFindings.length ? (
-        <details class="group border-y border-border py-3">
-          <summary class="cursor-pointer list-none flex flex-wrap items-center justify-between gap-3">
-            <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
-              Package context
-            </span>
-            <span class="font-mono text-[11px] text-ink-subtle">
+        <div>
+          <p class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle m-0 flex items-center gap-3">
+            <span>Package context</span>
+            <span aria-hidden class="flex-1 h-px bg-border" />
+            <span class="text-ink-subtle">
               {contextualFindings.length} {pluralize("signal", contextualFindings.length)}
             </span>
-          </summary>
+          </p>
           <div class="pt-3">
             <FindingGrid findings={contextualFindings} onSelect={onSelect} />
           </div>
-        </details>
+        </div>
       ) : null}
     </section>
   );


### PR DESCRIPTION
## Summary
In the scan detail Risk signals view, the "Package context" group was a collapsible `<details>` wrapped in a top/bottom border (`border-y border-border`). This makes it always-visible (no longer collapsible) and replaces the surrounding borders with the same trailing rule used by other section headings (`SectionLabel`'s `flex-1 h-px bg-border` line) sitting next to the title.

```diff
- <details class="group border-y border-border py-3">
-   <summary ...>Package context  <count></summary>
-   <div class="pt-3"><FindingGrid .../></div>
- </details>
+ <div>
+   <p class="font-mono text-[11px] uppercase ... flex items-center gap-3">
+     <span>Package context</span>
+     <span aria-hidden class="flex-1 h-px bg-border" />
+     <span>{count} signals</span>
+   </p>
+   <div class="pt-3"><FindingGrid .../></div>
+ </div>
```


Link to Devin session: https://app.devin.ai/sessions/7433000018f747e8b93869745f088fc6
Requested by: @JoviDeCroock
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jovidecroock/drydock/pull/416" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->