### PR TITLE
Remove existing context from recommendation

### DIFF
--- a/src/pages/Dashboard/ScanDetail/ReleaseRecommendation.tsx
+++ b/src/pages/Dashboard/ScanDetail/ReleaseRecommendation.tsx
@@ -133,18 +133,18 @@ function buildRecommendationEvidence(
 ): Array<{ label: string; value: ComponentChildren }> {
   const evidence: Array<{ label: string; value: ComponentChildren }> = [];
   const releaseFindings: RecommendationFinding[] = [...changedFindings, ...assistantFindings];
-  const topFindings = sortFindingsBySeverity(
-    releaseFindings.length ? releaseFindings : detail.findings,
-  ).slice(0, 3);
-  for (const finding of topFindings) {
-    evidence.push({
-      label: releaseFindings.length ? (finding.severity ?? "signal") : "existing",
-      value: (
-        <>
-          <code>{finding.file}</code>: {finding.reason}
-        </>
-      ),
-    });
+  if (releaseFindings.length) {
+    const topFindings = sortFindingsBySeverity(releaseFindings).slice(0, 3);
+    for (const finding of topFindings) {
+      evidence.push({
+        label: finding.severity ?? "signal",
+        value: (
+          <>
+            <code>{finding.file}</code>: {finding.reason}
+          </>
+        ),
+      });
+    }
   }
 
   const manifest = summary.packageJsonDiff;

--- a/src/pages/Dashboard/recommendation.ts
+++ b/src/pages/Dashboard/recommendation.ts
@@ -42,7 +42,7 @@ export function getReleaseRecommendation(
     return {
       label: "package context only",
       tone: "neutral",
-      copy: "The changed files have no deterministic risk signals. Existing package context is still shown below.",
+      copy: "The changed files have no deterministic risk signals. Package context is summarized below.",
     };
   }
   return {

--- a/test/recommendation.test.ts
+++ b/test/recommendation.test.ts
@@ -13,6 +13,7 @@ describe("scan detail recommendation", () => {
     expect(getReleaseRecommendation("high", "low", 0)).toMatchObject({
       label: "package context only",
       tone: "neutral",
+      copy: "The changed files have no deterministic risk signals. Package context is summarized below.",
     });
   });
 });


### PR DESCRIPTION
## Summary
Keep the neutral "package context only" recommendation from implying that historical findings are still listed below.

- `getReleaseRecommendation()` now describes the neutral state as package context being summarized, not existing context being shown.
- `ReleaseRecommendation` no longer falls back to `detail.findings` when there are no release findings, so the recommendation card only surfaces release-delta evidence.
- Added a unit assertion for the updated neutral copy.

Link to Devin session: https://app.devin.ai/sessions/faa7579a74aa40bcaf948dd631475658
Requested by: @JoviDeCroock
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jovidecroock/drydock/pull/417" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->