### PR TITLE
Rename npm discovery copy to Drydock wording

### DIFF
--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -229,16 +229,16 @@ function RecentReviewsSection({
             disabled={discoveryRefreshing || !ready}
             title="Find staged npm publishes and dock them for inspection"
           >
-            {discoveryRefreshing ? "Checking npm…" : "Check npm"}
+            {discoveryRefreshing ? "Docking npm…" : "Dock npm"}
           </Button>
           <Button
             variant="ghost"
             size="sm"
             onClick={() => void scans.refresh()}
             disabled={scans.refreshing.value}
-            title="Reload the inspections list"
+            title="Re-dock the inspections list"
           >
-            {scans.refreshing.value ? "Refreshing…" : "Refresh"}
+            {scans.refreshing.value ? "Re-docking…" : "Re-dock"}
           </Button>
         </div>
       </div>
@@ -366,7 +366,7 @@ function emptyStateMessage(filter: ScanDecisionFilter): string {
     case "no_publish":
       return "No held inspections yet.";
     default:
-      return "No versions docked yet. Check npm or wait for auto-discovery to find a staged release.";
+      return "No versions docked yet. Dock npm or wait for auto-discovery to find a staged release.";
   }
 }
 

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -71,7 +71,7 @@ export default function DocsPage() {
                 </>,
                 <>
                   That's it. Drydock picks up new staged publishes automatically, and{" "}
-                  <Code>Check npm</Code> on the dashboard runs an on-demand check.
+                  <Code>Dock npm</Code> on the dashboard runs an on-demand check.
                 </>,
               ]}
             />
@@ -87,7 +87,7 @@ export default function DocsPage() {
               items={[
                 <>
                   Drydock finds a new staged publish, either automatically or when you hit{" "}
-                  <Code>Check npm</Code>, and queues a scan.
+                  <Code>Dock npm</Code>, and queues a scan for it.
                 </>,
                 <>
                   Your npm token is stored encrypted and only decrypted at the moment Drydock needs

--- a/test/agent-tour/drydock-agent-tour.spec.ts
+++ b/test/agent-tour/drydock-agent-tour.spec.ts
@@ -123,10 +123,10 @@ test("agent tour: local Drydock release review walkthrough", async ({
     await tour.capture(page, "failed-review", "Fail-closed review state for unavailable evidence.");
 
     await page.goto("/dashboard?filter=all");
-    await expect(page.getByRole("button", { name: "Check npm" })).toBeEnabled({
+    await expect(page.getByRole("button", { name: "Dock npm" })).toBeEnabled({
       timeout: 30_000,
     });
-    await page.getByRole("button", { name: "Check npm" }).click();
+    await page.getByRole("button", { name: "Dock npm" }).click();
     await expect(
       page.getByText(
         /(?:New version docked|\d+ new versions docked) and ready for inspection from npm|No open staged publishes found/,

--- a/test/e2e/local-registry.spec.ts
+++ b/test/e2e/local-registry.spec.ts
@@ -69,7 +69,7 @@ test("UI smoke: reviews the implicit node-gyp fixture", async ({ browser, baseUR
       timeout: 30_000,
     });
 
-    // Run the report assertions first via the async scan API. Check npm fans
+    // Run the report assertions first via the async scan API. Dock npm fans out
     // out nine concurrent background scans on the dev Worker, and CI's workerd
     // serializes them so badly that one scan can take minutes to surface a
     // report — waiting for this scan to finish before that contention starts
@@ -102,13 +102,13 @@ test("UI smoke: reviews the implicit node-gyp fixture", async ({ browser, baseUR
       fullPage: true,
     });
 
-    // Now exercise Check npm as the live entry point. The button kicks off
+    // Now exercise Dock npm as the live entry point. The button kicks off
     // discovery and we wait only for the "new versions docked" message —
     // the resulting background scans are exercised by the scenarios below.
     await page.goto("/dashboard");
-    const checkNpm = page.getByRole("button", { name: "Check npm" });
-    await expect(checkNpm).toBeEnabled({ timeout: 30_000 });
-    await checkNpm.click();
+    const dockNpm = page.getByRole("button", { name: "Dock npm" });
+    await expect(dockNpm).toBeEnabled({ timeout: 30_000 });
+    await dockNpm.click();
     await expect(
       page.getByText(
         /(?:New version docked|\d+ new versions docked) and ready for inspection from npm/,


### PR DESCRIPTION
## Summary
- Rename the dashboard npm discovery actions from `Check npm` / `Refresh` to `Dock npm` / `Re-dock`, including the loading states and empty-state wording that point at the same flow.
- Update the docs and browser tests so the user-facing copy and assertions stay in sync with the new labels.


Link to Devin session: https://app.devin.ai/sessions/c130f5f471e24236846bd37897efc5fc
Requested by: @JoviDeCroock
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jovidecroock/drydock/pull/418" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->