### PR TITLE
Seed a sample scan into a user's first personal organization

### DIFF
--- a/docs/organization-members.md
+++ b/docs/organization-members.md
@@ -10,7 +10,9 @@ model, the role-based access guards, and the email-token invitation flow.
 - `owner` — the `organizations.ownerUserId`. Exactly one per org. Cannot be
   removed or demoted through the API. Created implicitly when an org is created
   (`createOrganization` / `ensurePersonalOrganization` insert the owner's
-  `organization_members` row with role `owner`).
+  `organization_members` row with role `owner`). The first personal-org
+  creation now also seeds one normal sample scan so a brand-new workbench opens
+  with real findings instead of an empty dashboard.
 - `admin` — full management of members, invitations, npm connections, and GitHub
   release targets.
 - `member` — read access to org-scoped resources; can act on releases (record

--- a/server/db/organizations.ts
+++ b/server/db/organizations.ts
@@ -20,7 +20,10 @@ import {
   user,
 } from "./schema";
 
-export async function ensurePersonalOrganization(db: AppDb, session: WorkspaceSession) {
+export async function ensurePersonalOrganizationWithCreation(
+  db: AppDb,
+  session: WorkspaceSession,
+): Promise<{ organizationId: string; created: boolean }> {
   const organizationId = personalOrganizationId(session.userId);
   const [existing] = await db
     .select({ organizationId: organizationMembers.organizationId })
@@ -32,12 +35,12 @@ export async function ensurePersonalOrganization(db: AppDb, session: WorkspaceSe
       ),
     )
     .limit(1);
-  if (existing) return organizationId;
+  if (existing) return { organizationId, created: false };
 
   const now = new Date();
   const name = session.name || session.email || "Personal workspace";
 
-  await db
+  const inserted = await db
     .insert(organizations)
     .values({
       id: organizationId,
@@ -46,7 +49,8 @@ export async function ensurePersonalOrganization(db: AppDb, session: WorkspaceSe
       createdAt: now,
       updatedAt: now,
     })
-    .onConflictDoNothing();
+    .onConflictDoNothing()
+    .returning({ id: organizations.id });
 
   await db
     .insert(organizationMembers)
@@ -60,6 +64,11 @@ export async function ensurePersonalOrganization(db: AppDb, session: WorkspaceSe
     })
     .onConflictDoNothing();
 
+  return { organizationId, created: inserted.length > 0 };
+}
+
+export async function ensurePersonalOrganization(db: AppDb, session: WorkspaceSession) {
+  const { organizationId } = await ensurePersonalOrganizationWithCreation(db, session);
   return organizationId;
 }
 

--- a/server/lib/active-organization.ts
+++ b/server/lib/active-organization.ts
@@ -1,8 +1,8 @@
 import type { Context } from "hono";
 import { and, eq } from "drizzle-orm";
 import type { AppDb } from "../db";
-import { ensurePersonalOrganization } from "../db";
 import { organizationMembers } from "../db/schema";
+import { resolvePersonalOrganization } from "./personal-organization";
 import { personalOrganizationId } from "./ownership";
 import type { OrganizationRole } from "./roles";
 import type { Bindings, Variables } from "../types";
@@ -28,7 +28,7 @@ export async function requireActiveOrganization(
       .limit(1);
     if (membership) return requested;
   }
-  await ensurePersonalOrganization(db, session);
+  await resolvePersonalOrganization(db, session, c.env);
   return personalOrganizationId(session.userId);
 }
 
@@ -66,6 +66,6 @@ export async function requireActiveOrganizationContext(
       };
     }
   }
-  const organizationId = await ensurePersonalOrganization(db, session);
+  const organizationId = await resolvePersonalOrganization(db, session, c.env);
   return { organizationId, role: "owner" };
 }

--- a/server/lib/personal-organization.ts
+++ b/server/lib/personal-organization.ts
@@ -1,0 +1,28 @@
+import type { AppDb, WorkspaceSession } from "../db";
+import { ensurePersonalOrganizationWithCreation } from "../db";
+import { describeOperationalError, emitOperationalEvent } from "./observability";
+import { seedSampleScan } from "./sample-scan";
+
+export async function resolvePersonalOrganization(
+  db: AppDb,
+  session: WorkspaceSession,
+  env?: Cloudflare.Env,
+): Promise<string> {
+  const { organizationId, created } = await ensurePersonalOrganizationWithCreation(db, session);
+  if (!created) return organizationId;
+
+  try {
+    await seedSampleScan(db, {
+      organizationId,
+      ownerUserId: session.userId,
+      env,
+    });
+  } catch (err) {
+    emitOperationalEvent("error", "sample_scan.seed_failed", {
+      organizationId,
+      error: describeOperationalError(err),
+    });
+  }
+
+  return organizationId;
+}

--- a/server/lib/sample-scan.ts
+++ b/server/lib/sample-scan.ts
@@ -1,0 +1,188 @@
+import { recordScanEvent, type AppDb } from "../db";
+import type { AiReview } from "./ai-review-types";
+import { npmAdapter, type NpmAdapterInput } from "./adapters/npm";
+import type { AcquiredArtifact, StagedDetails } from "./adapters/types";
+import {
+  computeDiff,
+  persistResults,
+  runDeterministicFindings,
+  scoreRisk,
+} from "./scan-pipeline-phases";
+import { sha256Hex } from "./stable-json";
+import type { PackageJsonSummary } from "./review";
+import type { ResolvedArtifacts } from "./scan-pipeline-phases";
+
+export const SAMPLE_SCAN_STAGE_ID = "drydock-sample-release";
+
+export function sampleScanId(organizationId: string): string {
+  return `sample-scan:${organizationId}`;
+}
+
+const disabledAi: AiReview = {
+  status: "unavailable",
+  risk: "low",
+  releaseAssessment: "not_assessed",
+  summary: "AI review is disabled.",
+  findings: [],
+  requiresManualReview: false,
+  model: null,
+};
+
+const SAMPLE_PACKAGE_NAME = "@drydock/sample-utils";
+const SAMPLE_BASELINE_VERSION = "1.4.0";
+const SAMPLE_STAGED_VERSION = "1.5.0";
+const SAMPLE_STAGE_TAG = "latest";
+
+export async function seedSampleScan(
+  db: AppDb,
+  params: { organizationId: string; ownerUserId: string; env?: Cloudflare.Env },
+): Promise<void> {
+  const resolved = await buildSampleResolvedArtifacts();
+  const diff = computeDiff(resolved);
+  const findings = runDeterministicFindings(npmAdapter, resolved, diff);
+  const riskSummary = scoreRisk(findings.annotatedFindings, disabledAi);
+
+  const result = await persistResults({
+    env: params.env,
+    db,
+    session: { userId: params.ownerUserId },
+    adapter: npmAdapter,
+    adapterInput: { stageId: SAMPLE_SCAN_STAGE_ID } satisfies NpmAdapterInput,
+    identity: {
+      scanId: sampleScanId(params.organizationId),
+      stageId: SAMPLE_SCAN_STAGE_ID,
+      organizationId: params.organizationId,
+    },
+    resolved,
+    diff,
+    findings,
+    aiFindings: disabledAi,
+    riskSummary,
+  });
+
+  if (result.persisted) {
+    await recordScanEvent(db, {
+      organizationId: params.organizationId,
+      actorUserId: params.ownerUserId,
+      scanId: sampleScanId(params.organizationId),
+      type: "scan.completed",
+      metadata: {
+        stageId: SAMPLE_SCAN_STAGE_ID,
+        packageName: result.result.package.name,
+        stagedVersion: result.result.package.stagedVersion,
+        stagedTag: result.result.package.stagedTag,
+        baseline: result.result.baseline,
+        risk: result.result.risk,
+        releaseRisk: result.result.riskSummary.releaseRisk,
+        artifactRisk: result.result.risk,
+        contextRisk: result.result.riskSummary.contextRisk,
+      },
+    });
+  }
+}
+
+async function buildSampleResolvedArtifacts(): Promise<ResolvedArtifacts> {
+  const baselineManifest = sampleManifest(SAMPLE_BASELINE_VERSION, false);
+  const stagedManifest = sampleManifest(SAMPLE_STAGED_VERSION, true);
+  const baselinePackageJson = toPackageJsonText(baselineManifest);
+  const stagedPackageJson = toPackageJsonText(stagedManifest);
+
+  const baselineFiles = await buildSampleFiles({
+    packageJsonText: baselinePackageJson,
+    includeCollectFile: false,
+  });
+  const stagedFiles = await buildSampleFiles({
+    packageJsonText: stagedPackageJson,
+    includeCollectFile: true,
+  });
+
+  const stagedDetails: StagedDetails = {
+    id: "sample-stage:drydock-sample-release",
+    packageName: SAMPLE_PACKAGE_NAME,
+    version: SAMPLE_STAGED_VERSION,
+    tag: SAMPLE_STAGE_TAG,
+    access: "public",
+    actor: "drydock-bot",
+    actorType: "bot",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    shasum: stagedFiles.find((file) => file.path === "package.json")?.sha256 ?? null,
+    packageJson: stagedManifest,
+  };
+
+  return {
+    staged: {
+      artifact: {
+        files: stagedFiles,
+        manifest: stagedManifest,
+      },
+      details: stagedDetails,
+    },
+    baseline: {
+      artifact: {
+        files: baselineFiles,
+        manifest: baselineManifest,
+      },
+      baseline: {
+        version: SAMPLE_BASELINE_VERSION,
+        tag: SAMPLE_STAGE_TAG,
+        source: "latest-published",
+        distTagVersion: SAMPLE_BASELINE_VERSION,
+        reason: "sample fixture resolved from the latest published version",
+      },
+    },
+  };
+}
+
+async function buildSampleFiles(args: {
+  packageJsonText: string;
+  includeCollectFile: boolean;
+}): Promise<AcquiredArtifact["files"]> {
+  const files: AcquiredArtifact["files"] = [
+    await fileRecord("package.json", args.packageJsonText),
+    await fileRecord(
+      "lib/index.js",
+      "module.exports = function index() {\n  return 'sample-utils';\n};\n",
+    ),
+  ];
+
+  if (args.includeCollectFile) {
+    files.push(
+      await fileRecord(
+        "lib/collect.js",
+        [
+          'const { exec } = require("child_process");',
+          "",
+          "module.exports = async function collect() {",
+          '  await exec("npm view @drydock/sample-utils version");',
+          '  return fetch("https://example.com/telemetry");',
+          "};",
+          "",
+        ].join("\n"),
+      ),
+    );
+  }
+
+  return files;
+}
+
+function sampleManifest(version: string, includePostinstall: boolean): PackageJsonSummary {
+  return {
+    name: SAMPLE_PACKAGE_NAME,
+    version,
+    ...(includePostinstall ? { scripts: { postinstall: "node lib/collect.js" } } : {}),
+  };
+}
+
+function toPackageJsonText(manifest: PackageJsonSummary): string {
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+}
+
+async function fileRecord(path: string, textSample: string) {
+  return {
+    path,
+    size: new TextEncoder().encode(textSample).length,
+    sha256: await sha256Hex(textSample),
+    textSample,
+    flags: [],
+  };
+}

--- a/server/routes/organizations.ts
+++ b/server/routes/organizations.ts
@@ -7,7 +7,6 @@ import {
   deleteNotificationRecipient,
   deleteOrganization,
   enforceRateLimit,
-  ensurePersonalOrganization,
   getOrganizationRole,
   isOrganizationOwner,
   listNotificationRecipients,
@@ -22,6 +21,7 @@ import { sanitizeAddress } from "../lib/email";
 import { rateLimitResponse } from "../lib/http";
 import { describeOperationalError, emitOperationalEvent } from "../lib/observability";
 import { personalOrganizationId } from "../lib/ownership";
+import { resolvePersonalOrganization } from "../lib/personal-organization";
 import { roleCanManageIntegrations, type OrganizationRole } from "../lib/roles";
 import type { Bindings, Variables } from "../types";
 
@@ -35,7 +35,7 @@ export const organizationsRoutes = new Hono<{ Bindings: Bindings; Variables: Var
 organizationsRoutes.get("/", async (c) => {
   const db = createDb(c.env.DB);
   const session = c.get("authSession");
-  await ensurePersonalOrganization(db, session);
+  await resolvePersonalOrganization(db, session, c.env);
   const organizations = await listUserOrganizations(db, session.userId);
   return c.json({ organizations });
 });

--- a/test/workers/sample-scan-seed.test.ts
+++ b/test/workers/sample-scan-seed.test.ts
@@ -1,0 +1,103 @@
+import { env } from "cloudflare:test";
+import { describe, expect, test } from "vitest";
+import {
+  createDb,
+  ensurePersonalOrganization,
+  getScan,
+  listScans,
+  recordScanDecision,
+} from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { personalOrganizationId } from "../../server/lib/ownership";
+import { resolvePersonalOrganization } from "../../server/lib/personal-organization";
+import { sampleScanId } from "../../server/lib/sample-scan";
+
+async function seedUser(userId: string) {
+  const db = createDb(env.DB);
+  const now = new Date();
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  return db;
+}
+
+describe("sample scan seeding", () => {
+  test("seeds one realistic scan when the personal org is first resolved", async () => {
+    const userId = `user_${crypto.randomUUID()}`;
+    const db = await seedUser(userId);
+
+    const organizationId = await resolvePersonalOrganization(db, { userId }, env);
+    expect(organizationId).toBe(personalOrganizationId(userId));
+
+    const scans = await listScans(db, organizationId, { decisionFilter: "all" });
+    expect(scans.scans).toHaveLength(1);
+
+    const scanId = sampleScanId(organizationId);
+    const scanDetail = await getScan(db, scanId, organizationId, env.ARTIFACTS);
+    expect(scanDetail).not.toBeNull();
+    expect(scanDetail?.scan.status).toBe("complete");
+    expect(scanDetail?.scan.source).toBe("manual");
+    expect(scanDetail?.scan.decision).toBeNull();
+    expect(scanDetail?.scan.findingCount).toBeGreaterThan(0);
+    expect(scanDetail?.scan.risk).not.toBe("unknown");
+    expect(scanDetail?.files.map((file) => file.path)).toEqual(
+      expect.arrayContaining(["package.json", "lib/collect.js"]),
+    );
+    expect(scanDetail?.findings.length).toBeGreaterThan(0);
+  });
+
+  test("records and preserves a normal publish decision", async () => {
+    const userId = `user_${crypto.randomUUID()}`;
+    const db = await seedUser(userId);
+
+    const organizationId = await resolvePersonalOrganization(db, { userId }, env);
+    const scanId = sampleScanId(organizationId);
+
+    const result = await recordScanDecision(
+      db,
+      {
+        scanId,
+        organizationId,
+        actorUserId: userId,
+        decision: "publish",
+        reason: "looks good",
+      },
+      env.ARTIFACTS,
+    );
+
+    expect(result?.scan.decision).toBe("publish");
+    expect(result?.scan.decisionReason).toBe("looks good");
+
+    const scanDetail = await getScan(db, scanId, organizationId, env.ARTIFACTS);
+    expect(scanDetail?.scan.decision).toBe("publish");
+    expect(scanDetail?.scan.decisionReason).toBe("looks good");
+  });
+
+  test("is idempotent across repeated personal-org resolution", async () => {
+    const userId = `user_${crypto.randomUUID()}`;
+    const db = await seedUser(userId);
+
+    const firstOrganizationId = await resolvePersonalOrganization(db, { userId }, env);
+    const secondOrganizationId = await resolvePersonalOrganization(db, { userId }, env);
+
+    expect(secondOrganizationId).toBe(firstOrganizationId);
+    const scans = await listScans(db, firstOrganizationId, { decisionFilter: "all" });
+    expect(scans.scans).toHaveLength(1);
+  });
+
+  test("plain personal-org creation still stays unseeded", async () => {
+    const userId = `user_${crypto.randomUUID()}`;
+    const db = await seedUser(userId);
+
+    const organizationId = await ensurePersonalOrganization(db, { userId });
+    expect(organizationId).toBe(personalOrganizationId(userId));
+
+    const scans = await listScans(db, organizationId, { decisionFilter: "all" });
+    expect(scans.scans).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Onboarding analysis showed the biggest funnel drop-off is *before the first scan*: new users land on an empty dashboard and must connect+validate an npm token before they see any value (heavy `GET /npm-connection` polling, almost no token writes). This seeds one realistic, completed scan into a user's **personal/first** org the moment it's created, so the workbench opens populated with findings/diff/risk and the user can immediately ship/reject — no setup required. It's a normal `source: "manual"` scan, not a special read-only fixture.

### How it works

A new `seedSampleScan` reuses the **real** pipeline phases against an in-memory npm fixture (no sandbox, no network, no npm token), so the sample is genuine and tracks type/rule changes:

```
resolved = { staged, baseline }  // in-memory AcquiredArtifacts for @drydock/sample-utils 1.4.0 -> 1.5.0
diff      = computeDiff(resolved)
findings  = runDeterministicFindings(npmAdapter, resolved, diff)
risk      = scoreRisk(findings.annotatedFindings, disabledAi)
persistResults({ env, db, adapter: npmAdapter, identity: { scanId: sampleScanId(org), ... }, ... })
```

The staged version introduces a `postinstall` script and a new `lib/collect.js` that uses `child_process.exec` + an outbound `fetch`, so deterministic rules fire and the report has real release-delta findings. `env` is optional: with `ARTIFACTS` bound it's R2-backed like a normal scan, otherwise it falls back to the D1 degraded path.

### Wiring (first-creation only, fail-safe)

`ensurePersonalOrganization` is split so the creation path is observable without changing its ~30 existing callers:

```
ensurePersonalOrganizationWithCreation(db, session) -> { organizationId, created }
ensurePersonalOrganization(db, session) -> organizationId   // thin wrapper, unchanged signature
```

A new `resolvePersonalOrganization(db, session, env?)` seeds **only when `created` is true**, inside a try/catch that logs `sample_scan.seed_failed` and never blocks org resolution. The two `active-organization.ts` resolvers and the `GET /api/v1/organizations` lazy-create path call it; every other direct `ensurePersonalOrganization` caller (tests, cron) stays unseeded. Idempotency is doubly guaranteed — the `created` flag gates seeding, and `sampleScanId(org)` is deterministic so `persistScan` no-ops on a re-run.

## Testing

- `pnpm run verify` — lint, format:check, typecheck, full test suite all pass.
- New `test/workers/sample-scan-seed.test.ts`: first resolution seeds exactly one complete/populated/undecided scan; the decision endpoint persists a normal publish decision; repeated resolution is idempotent (still one scan); plain `ensurePersonalOrganization` stays unseeded (guards existing tests).
- Docs: updated `docs/organization-members.md` to note the seeded sample scan on first personal-org creation.
</body>
</invoke>


Link to Devin session: https://app.devin.ai/sessions/32deb056cb844f99b860045a8d790cf3
Requested by: @JoviDeCroock
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jovidecroock/drydock/pull/419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->