### PR TITLE
Remove redundant dashboard listing copy

### DIFF
--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -161,9 +161,6 @@ function DashboardHeader() {
       <h1 class="text-3xl font-semibold tracking-[-0.02em] m-0">
         New version docked and ready for inspection
       </h1>
-      <Muted class="text-[14px] leading-[1.55] m-0">
-        Dock held npm and PyPI candidates for inspection before maintainers let them go live.
-      </Muted>
     </header>
   );
 }


### PR DESCRIPTION
## Summary
Remove the extra dashboard listing blurb beneath the "New version docked and ready for inspection" heading. The header now keeps the page focused on the actionable inspection state instead of repeating explanatory copy.

Link to Devin session: https://app.devin.ai/sessions/9a1710c014e746a3943225adead3d781
Requested by: @JoviDeCroock
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jovidecroock/drydock/pull/420" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->