### PR TITLE
Remove scan id from scan details screen

### DIFF
--- a/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
+++ b/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
@@ -44,7 +44,6 @@ export function ScanDetailHeader({
                   release {releaseRisk}
                 </Badge>
               ) : null,
-              <span key="scan-id">scan {detail.scan.id.slice(0, 12)}</span>,
             ]}
           />
         ) : (


### PR DESCRIPTION
## Summary
Remove the mono detail chip that showed `scan <id>` in the scan details header.

The header still shows the version comparison and release risk; it no longer exposes the internal scan identifier on the page.

## Testing
- `pnpm run lint`
- `pnpm run typecheck`

## Docs
- docs checked, no update needed

Link to Devin session: https://app.devin.ai/sessions/67b4a475f746451a808d1a8b0d1a95d5
Requested by: @JoviDeCroock
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jovidecroock/drydock/pull/421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->