### PR TITLE
Add first-party PostHog product analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Build-time Vite client environment. Copy to `.env` (or `.env.local`) for local
+# builds, or set these in the deploy build environment. These values are inlined
+# into the browser bundle by `vite build`, so only public, non-secret values
+# belong here.
+
+# PostHog project API key for product analytics. This is the write-only public
+# key (not a personal API key) and is safe to ship in the client bundle.
+# Leave unset to disable analytics entirely (local dev, forks, self-hosting).
+# Events reach PostHog EU through the same-origin `/b/*` Worker proxy.
+VITE_PUBLIC_POSTHOG_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ packages/experiments/binding.gyp
 packages/experiments/build/
 .DS_Store
 .dev.vars
+.env
+.env.*
+!.env.example
 .gstack/
 .context/
 agent-tour-output/

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ Start here instead of reading every Markdown file. Pick the smallest set that ma
 - [`two-factor-auth.md`](./two-factor-auth.md) — step-up auth and sensitive actions.
 - [`slack-notifications.md`](./slack-notifications.md) — Slack install and notification flow.
 - [`account-deletion.md`](./account-deletion.md) — account deletion lifecycle.
+- [`product-analytics.md`](./product-analytics.md) — first-party PostHog product analytics, privacy posture, and captured events.
 
 ## Retired or compatibility pointers
 

--- a/docs/product-analytics.md
+++ b/docs/product-analytics.md
@@ -1,0 +1,78 @@
+# Product analytics
+
+Drydock captures a small, deliberate set of product-usage events with
+[PostHog](https://posthog.com) (EU cloud) so we can see how reviewers move
+through the core funnel — discovering staged publishes, opening a scan, and
+recording a Ship/Hold decision. This is distinct from the operational telemetry
+in `server/lib/observability.ts`, which exists for reliability and debugging.
+
+Analytics is **opt-in by configuration**: nothing is sent unless a public
+PostHog key is set at build time, so local dev, forks, and self-hosted
+deployments are analytics-free by default.
+
+## Privacy posture
+
+Drydock is a security product, so analytics is held to the same redaction
+discipline as the rest of the platform:
+
+- **First-party only.** The browser never talks to PostHog directly. All traffic
+  goes through a same-origin reverse proxy on the Worker (`/b/*`), so it is not
+  blocked by content blockers and needs no third-party CSP entry.
+- **No PII, no package data.** Events carry only opaque identifiers and coarse,
+  non-sensitive properties (decision outcome, risk level, status). Never send a
+  name, email, package name, version, finding text, decision reason, or token.
+- **No reviewer IPs.** The proxy strips `cf-connecting-ip`, `x-forwarded-for`,
+  `x-real-ip`, `true-client-ip`, `forwarded`, and cookies before forwarding, so
+  PostHog never sees an end-user IP (GeoIP is traded away for privacy).
+- **Identified-only profiles**, autocapture/session-recording/surveys disabled,
+  and `Do Not Track` respected.
+
+## Architecture
+
+| Piece                                  | File                                                           |
+| -------------------------------------- | -------------------------------------------------------------- |
+| Shared proxy path prefix (`/b`)        | `server/lib/analytics-proxy-path.ts`                           |
+| Worker reverse proxy to PostHog EU     | `server/lib/analytics-proxy.ts` (mounted in `server/index.ts`) |
+| Browser SDK init + typed event helpers | `src/lib/analytics.ts`                                         |
+| Identity/org/pageview wiring           | `src/components/AnalyticsTracker.tsx`                          |
+
+The proxy fans `${prefix}/static/*` to `eu-assets.i.posthog.com` (SDK asset
+bundles) and everything else to `eu.i.posthog.com` (ingestion, flags, decide).
+The `/b/*` route is public and auth-free by design — the browser SDK has no
+session — and is also pre-declared for the legacy zone in `wrangler.jsonc`.
+
+## Events
+
+Event names are centralised in the `AnalyticsEvent` map in `src/lib/analytics.ts`
+— they are stable wire identifiers, so do not rename them casually. Captured
+properties are restricted to non-PII primitives.
+
+| Event                             | Fires when                           | Properties                                             |
+| --------------------------------- | ------------------------------------ | ------------------------------------------------------ |
+| `$pageview`                       | Each SPA route change                | (PostHog defaults)                                     |
+| `scan_discovery_run`              | Staged-publish discovery completes   | `found`, `created`, `skipped`                          |
+| `scan_detail_viewed`              | A scan detail is opened (first load) | `status`, `risk`, `source`                             |
+| `scan_decision_recorded`          | A Ship/Hold decision is saved        | `surface`, `decision`, `outcome`, `risk`, `had_reason` |
+| `workflow_gate_decision_recorded` | A workflow-gate decision is saved    | `decision`, `had_comment`                              |
+
+Identity is set with `posthog.identify(userId)` (no traits) and events are
+grouped by `organization` via `posthog.group(...)` for per-customer funnels.
+
+## Configuration
+
+Set the public PostHog project key (write-only, safe to ship in the client
+bundle) at **build time** — it is inlined by `vite build`:
+
+```sh
+VITE_PUBLIC_POSTHOG_KEY=phc_xxx pnpm run build
+```
+
+See `.env.example`. Leave it unset to disable analytics. No server-side secret is
+required; the proxy targets a fixed PostHog EU upstream.
+
+## Tests
+
+- `test/analytics-proxy.test.ts` — proxy path mapping, asset-host split, header
+  stripping, and `set-cookie` removal.
+- `test/workers/analytics-proxy.test.ts` — the `/b/*` route is public and does
+  not fall through to the asset binding.

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.25",
     "hoofd": "^1.7.3",
+    "posthog-js": "1.393.0",
     "preact": "^10.29.2",
     "preact-iso": "^2.12.0",
     "qrcode": "^1.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       hoofd:
         specifier: ^1.7.3
         version: 1.7.3(react@19.2.7)
+      posthog-js:
+        specifier: 1.393.0
+        version: 1.393.0
       preact:
         specifier: ^10.29.2
         version: 10.29.2
@@ -1167,6 +1170,12 @@ packages:
   '@poppinss/exception@1.2.3':
     resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
+  '@posthog/core@1.38.1':
+    resolution: {integrity: sha512-tsJTugsKzx47eRMjNfG272/GFf0FF0LeI+gyJ/anibpbYAzdNuX5kr6enpmJrhdgLESqzJGH8QF0+I9075Xr1Q==}
+
+  '@posthog/types@1.392.0':
+    resolution: {integrity: sha512-nctNujXL3FC1v99FktaTMSugSD9ZOZekEpahUSafkU2TSvW+XGKNkQZbokuJtiWvPBK208dwMJva8UfBkChqpw==}
+
   '@preact/eslint-plugin-signals@0.3.0':
     resolution: {integrity: sha512-T7FkPg2WmgkNcKYiML/HMuiujMOZh1QDU3OY7wZvs0zuWm4kxwizh8LW6gzUYZSkwetvnvjRzJAMWc9Y/1DgNw==}
 
@@ -1471,6 +1480,9 @@ packages:
   '@types/qrcode@1.5.6':
     resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -1665,6 +1677,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
@@ -1715,6 +1730,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -1875,6 +1893,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -2183,6 +2204,9 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.393.0:
+    resolution: {integrity: sha512-BNu62XUNkFEIq7ZQJwvgtZIgWUfn0HozVcYHO8P1WMq2Crx+d+/l7TJsO6YHf3aUUiJn+L8L8NX7XgFZxW3/tw==}
+
   preact-iso@2.12.0:
     resolution: {integrity: sha512-k0Y44UONBJ1zBXXCBhJRAa5O4ww8a5FHdLD6l21IxcnsTmDBto4n7KPQAH6xqegsKDMX4SuJ02qItiUlciIlZQ==}
     peerDependencies:
@@ -2207,6 +2231,9 @@ packages:
     resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
     engines: {node: '>=10.13.0'}
     hasBin: true
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
@@ -2478,6 +2505,9 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
@@ -3288,6 +3318,12 @@ snapshots:
 
   '@poppinss/exception@1.2.3': {}
 
+  '@posthog/core@1.38.1':
+    dependencies:
+      '@posthog/types': 1.392.0
+
+  '@posthog/types@1.392.0': {}
+
   '@preact/eslint-plugin-signals@0.3.0': {}
 
   '@preact/preset-vite@2.10.5(@babel/core@7.29.7)(preact@10.29.2)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))':
@@ -3542,6 +3578,9 @@ snapshots:
     dependencies:
       '@types/node': 25.9.3
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.1': {}
@@ -3694,6 +3733,8 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  core-js@3.49.0: {}
+
   css-select@5.2.2:
     dependencies:
       boolbase: 1.0.0
@@ -3735,6 +3776,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.11:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
@@ -3847,6 +3892,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fflate@0.4.8: {}
 
   find-up@4.1.0:
     dependencies:
@@ -4134,6 +4181,17 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.393.0:
+    dependencies:
+      '@posthog/core': 1.38.1
+      '@posthog/types': 1.392.0
+      core-js: 3.49.0
+      dompurify: 3.4.11
+      fflate: 0.4.8
+      preact: 10.29.2
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+
   preact-iso@2.12.0(preact-render-to-string@6.7.0(preact@10.29.2))(preact@10.29.2):
     dependencies:
       preact: 10.29.2
@@ -4154,6 +4212,8 @@ snapshots:
       dijkstrajs: 1.0.3
       pngjs: 5.0.0
       yargs: 15.4.1
+
+  query-selector-shadow-dom@1.0.1: {}
 
   react@19.2.7: {}
 
@@ -4416,6 +4476,8 @@ snapshots:
       '@types/node': 25.9.3
     transitivePeerDependencies:
       - msw
+
+  web-vitals@5.3.0: {}
 
   which-module@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ allowBuilds:
   "0": esbuild
   "1": sharp
   "2": workerd
+  core-js: false
   esbuild: true
   sharp: true
   workerd: true

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,6 @@
 import { Hono } from "hono";
+import { ANALYTICS_PROXY_PREFIX } from "./lib/analytics-proxy-path";
+import { proxyAnalyticsRequest } from "./lib/analytics-proxy";
 import {
   createDb,
   enforceRateLimit,
@@ -123,6 +125,12 @@ app.use("*", async (c, next) => canonicalDomainRedirect(c.req.raw) ?? next());
 // CSRF middleware below — the signature verification inside the handler is the
 // trust boundary.
 app.route("/webhooks", githubWebhookRoutes);
+
+// First-party reverse proxy to PostHog EU for product analytics. Public and
+// auth-free by design (the browser SDK has no session), it forwards to PostHog
+// while stripping client IP headers so analytics traffic stays same-origin and
+// no reviewer IP leaves Drydock. See docs/product-analytics.md.
+app.all(`${ANALYTICS_PROXY_PREFIX}/*`, (c) => proxyAnalyticsRequest(c.req.raw));
 
 app.use("/api/*", async (c, next) => {
   try {

--- a/server/lib/analytics-proxy-path.ts
+++ b/server/lib/analytics-proxy-path.ts
@@ -1,0 +1,9 @@
+// First-party path prefix under which the browser talks to PostHog. Requests
+// to `${ANALYTICS_PROXY_PREFIX}/*` are reverse-proxied by the Worker to PostHog
+// EU (see analytics-proxy.ts), so the analytics traffic stays same-origin: it
+// survives content blockers and never needs a third-party entry in the CSP.
+//
+// The short, opaque prefix is shared by the Worker proxy and the browser SDK
+// (src/lib/analytics.ts) and is also pre-declared as a route in wrangler.jsonc
+// for the legacy zone. Keep all three in sync.
+export const ANALYTICS_PROXY_PREFIX = "/b";

--- a/server/lib/analytics-proxy.ts
+++ b/server/lib/analytics-proxy.ts
@@ -1,0 +1,62 @@
+import { ANALYTICS_PROXY_PREFIX } from "./analytics-proxy-path";
+
+// PostHog EU region. Ingestion (event capture, flags, decide) and static SDK
+// assets (recorder/surveys bundles) are served from different hosts, so the
+// proxy fans `${PREFIX}/static/*` out to the assets host and everything else to
+// the ingestion host.
+const POSTHOG_INGESTION_ORIGIN = "https://eu.i.posthog.com";
+const POSTHOG_ASSETS_ORIGIN = "https://eu-assets.i.posthog.com";
+
+// Request headers that would leak the end user's network identity to PostHog.
+// We deliberately strip them: Drydock is the only hop PostHog sees, so no
+// reviewer IP ever leaves the platform (GeoIP is traded away for privacy).
+const CLIENT_IDENTITY_HEADERS = [
+  "cookie",
+  "x-forwarded-for",
+  "x-forwarded-host",
+  "x-real-ip",
+  "forwarded",
+  "cf-connecting-ip",
+  "cf-ipcountry",
+  "true-client-ip",
+];
+
+export function isAnalyticsProxyPath(path: string): boolean {
+  return path === ANALYTICS_PROXY_PREFIX || path.startsWith(`${ANALYTICS_PROXY_PREFIX}/`);
+}
+
+export async function proxyAnalyticsRequest(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  // Drop the proxy prefix; the remainder is PostHog's own path verbatim.
+  const forwardedPath = url.pathname.slice(ANALYTICS_PROXY_PREFIX.length) || "/";
+  const useAssets = forwardedPath === "/static" || forwardedPath.startsWith("/static/");
+  const upstream = new URL(useAssets ? POSTHOG_ASSETS_ORIGIN : POSTHOG_INGESTION_ORIGIN);
+  upstream.pathname = forwardedPath;
+  upstream.search = url.search;
+
+  const headers = new Headers(request.headers);
+  headers.set("host", upstream.host);
+  for (const name of CLIENT_IDENTITY_HEADERS) headers.delete(name);
+
+  // PostHog ingestion payloads are small JSON bodies; buffering avoids the
+  // half-duplex streaming dance and keeps the forwarded request self-contained.
+  const hasBody = request.method !== "GET" && request.method !== "HEAD";
+  const body = hasBody ? await request.arrayBuffer() : undefined;
+
+  const upstreamResponse = await fetch(upstream.toString(), {
+    method: request.method,
+    headers,
+    body,
+    redirect: "manual",
+  });
+
+  const responseHeaders = new Headers(upstreamResponse.headers);
+  // The proxy never sets first-party cookies on PostHog's behalf.
+  responseHeaders.delete("set-cookie");
+
+  return new Response(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    statusText: upstreamResponse.statusText,
+    headers: responseHeaders,
+  });
+}

--- a/src/components/AnalyticsTracker.tsx
+++ b/src/components/AnalyticsTracker.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from "preact/hooks";
+import { useSignalEffect } from "@preact/signals";
+import { useLocation } from "preact-iso";
+import {
+  capturePageview,
+  identifyUser,
+  initAnalytics,
+  resetAnalytics,
+  setOrganizationGroup,
+} from "../lib/analytics";
+import { sessionModel } from "../models/auth";
+import { activeOrganizationId } from "../models/active-organization";
+
+// Headless: boots the analytics SDK once, then keeps PostHog's identity and the
+// SPA pageview stream in sync with the router and auth/org signals. Every call
+// no-ops until the SDK is initialised, so SSR/prerender and unconfigured builds
+// are unaffected.
+export function AnalyticsTracker() {
+  const location = useLocation();
+
+  useEffect(() => {
+    initAnalytics();
+  }, []);
+
+  useEffect(() => {
+    capturePageview();
+  }, [location.url]);
+
+  useSignalEffect(() => {
+    const user = sessionModel.user.value;
+    if (user) identifyUser(user.id);
+    else resetAnalytics();
+  });
+
+  useSignalEffect(() => {
+    const organizationId = activeOrganizationId.value;
+    if (organizationId) setOrganizationGroup(organizationId);
+  });
+
+  return null;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,6 +9,7 @@ export type { Severity, Status, BadgeTone } from "./Badge";
 export { Alert } from "./Alert";
 export type { AlertTone } from "./Alert";
 export { Toaster, pushToast, dismissToast } from "./Toast";
+export { AnalyticsTracker } from "./AnalyticsTracker";
 export type { ToastTone } from "./Toast";
 export { Dialog } from "./Dialog";
 export {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import { hydrate, render } from "preact";
 import { ErrorBoundary, LocationProvider, Route, Router, lazy, prerender as ssr } from "preact-iso";
-import { Toaster } from "./components";
+import { AnalyticsTracker, Toaster } from "./components";
 import { extractPrerenderHead, getPageSeoMetadata } from "./lib/seo";
 import {
   isDashboardShellRoute,
@@ -43,6 +43,7 @@ export function App() {
           <Route default component={NotFoundPage} />
         </Router>
       </ErrorBoundary>
+      <AnalyticsTracker />
       <Toaster />
     </LocationProvider>
   );

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,88 @@
+import posthog from "posthog-js";
+import { ANALYTICS_PROXY_PREFIX } from "../../server/lib/analytics-proxy-path";
+
+// PostHog is reached through the same-origin Worker proxy (see
+// server/lib/analytics-proxy.ts), so `api_host` is the first-party prefix. The
+// UI host only powers "view in PostHog" deep links from the toolbar.
+const POSTHOG_UI_HOST = "https://eu.posthog.com";
+
+const PUBLIC_KEY = import.meta.env.VITE_PUBLIC_POSTHOG_KEY;
+
+// Product funnel event names. Centralised so capture sites and analysis stay in
+// lock-step; values are stable wire identifiers — never rename casually.
+export const AnalyticsEvent = {
+  Pageview: "$pageview",
+  ScanDiscoveryRun: "scan_discovery_run",
+  ScanDetailViewed: "scan_detail_viewed",
+  ScanDecisionRecorded: "scan_decision_recorded",
+  WorkflowGateDecisionRecorded: "workflow_gate_decision_recorded",
+} as const;
+
+export type AnalyticsEventName = (typeof AnalyticsEvent)[keyof typeof AnalyticsEvent];
+
+// Only primitive, non-PII properties may ride along on an event. Package names,
+// reasons, emails, and tokens must never be captured.
+export type AnalyticsProperties = Record<string, string | number | boolean | null | undefined>;
+
+const ORGANIZATION_GROUP_TYPE = "organization";
+
+let started = false;
+
+function enabled(): boolean {
+  return started && typeof window !== "undefined";
+}
+
+// Initialise the browser SDK. No-ops when no key is configured (local dev,
+// self-hosting, forks) or off the browser (SSR/prerender). Safe to call repeatedly.
+export function initAnalytics(): void {
+  if (started) return;
+  if (typeof window === "undefined") return;
+  if (!PUBLIC_KEY) return;
+
+  posthog.init(PUBLIC_KEY, {
+    api_host: ANALYTICS_PROXY_PREFIX,
+    ui_host: POSTHOG_UI_HOST,
+    // Anonymous visitors don't get a stored person profile; we only persist one
+    // once a signed-in reviewer is identified.
+    person_profiles: "identified_only",
+    // SPA navigations are captured manually in AnalyticsTracker.
+    capture_pageview: false,
+    capture_pageleave: true,
+    // A security workbench should never silently hoover up DOM interactions,
+    // session video, or surveys — every signal we send is deliberate.
+    autocapture: false,
+    disable_session_recording: true,
+    disable_surveys: true,
+    respect_dnt: true,
+  });
+  started = true;
+}
+
+export function capturePageview(): void {
+  if (!enabled()) return;
+  posthog.capture(AnalyticsEvent.Pageview);
+}
+
+export function trackEvent(event: AnalyticsEventName, properties?: AnalyticsProperties): void {
+  if (!enabled()) return;
+  posthog.capture(event, properties);
+}
+
+// Associate subsequent events with a stable, opaque user id. We pass no email
+// or name so PostHog never stores reviewer PII.
+export function identifyUser(userId: string): void {
+  if (!enabled()) return;
+  posthog.identify(userId);
+}
+
+// Roll events up by organization for per-customer funnels and retention.
+export function setOrganizationGroup(organizationId: string): void {
+  if (!enabled()) return;
+  posthog.group(ORGANIZATION_GROUP_TYPE, organizationId);
+}
+
+// Clear identity on sign-out so the next account on a shared device starts fresh.
+export function resetAnalytics(): void {
+  if (!enabled()) return;
+  posthog.reset();
+}

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -6,6 +6,7 @@ import type {
   PackageJsonSummary,
 } from "../../server/lib/review";
 import { apiFetch, apiJson, errorMessage } from "./api";
+import { AnalyticsEvent, trackEvent } from "../lib/analytics";
 import {
   decideWorkflowGate,
   getWorkflowGateByScan,
@@ -284,6 +285,13 @@ export const ScanListModel = createModel(() => {
               : scan,
           )
           .filter((scan) => scanMatchesDecisionFilter(scan, activeFilter));
+        trackEvent(AnalyticsEvent.ScanDecisionRecorded, {
+          surface: "list",
+          decision,
+          outcome: decision === "publish" ? "ship" : "hold",
+          risk: updated.scan.risk ?? null,
+          had_reason: Boolean(reason),
+        });
         this.decisionStatus.value = "idle";
       } catch (err) {
         this.decisionError.value = errorMessage(err);
@@ -463,10 +471,18 @@ export const ScanDetailModel = createModel((id: string) => {
     async load(): Promise<void> {
       const id = this.scanId.peek();
       try {
+        const firstView = this.detail.peek() === null;
         const data = await getScan(id);
         this.detail.value = data;
         if (this.selectedPath.peek() === null) {
           this.selectedPath.value = pickInitialPath(data);
+        }
+        if (firstView) {
+          trackEvent(AnalyticsEvent.ScanDetailViewed, {
+            status: data.scan.status ?? null,
+            risk: data.scan.risk ?? null,
+            source: data.scan.source ?? null,
+          });
         }
       } catch (err) {
         this.error.value = errorMessage(err);
@@ -513,6 +529,13 @@ export const ScanDetailModel = createModel((id: string) => {
       try {
         const updated = await setScanDecision(id, decision, reason);
         this.detail.value = updated;
+        trackEvent(AnalyticsEvent.ScanDecisionRecorded, {
+          surface: "detail",
+          decision,
+          outcome: decision === "publish" ? "ship" : "hold",
+          risk: updated.scan.risk ?? null,
+          had_reason: Boolean(reason),
+        });
         this.decisionStatus.value = "idle";
       } catch (err) {
         this.decisionError.value = errorMessage(err);
@@ -560,6 +583,10 @@ export const ScanDetailModel = createModel((id: string) => {
           totpCode,
         );
         this.gate.value = updated;
+        trackEvent(AnalyticsEvent.WorkflowGateDecisionRecorded, {
+          decision,
+          had_comment: Boolean(comment),
+        });
         this.gateDecisionStatus.value = "idle";
         // The decision also writes the scan's publish/no_publish decision and an
         // audit event server-side; refresh so the workbench reflects both.

--- a/src/models/staged-publishes.ts
+++ b/src/models/staged-publishes.ts
@@ -1,6 +1,7 @@
 import { createModel, signal } from "@preact/signals";
 import type { StagedPublishesScanResponse } from "../../server/lib/staged-publishes";
 import { apiFetch, errorMessage } from "./api";
+import { AnalyticsEvent, trackEvent } from "../lib/analytics";
 
 export type { StagedPublishesScanResponse };
 
@@ -38,6 +39,11 @@ export const StagedPublishesModel = createModel(() => {
         this.lastResult.value = result;
         this.lastDiscoveryAt.value = Date.now();
         this.error.value = null;
+        trackEvent(AnalyticsEvent.ScanDiscoveryRun, {
+          found: result.found,
+          created: result.created,
+          skipped: result.skipped,
+        });
         return result;
       } catch (err) {
         this.error.value = errorMessage(err);

--- a/src/pages/Privacy/index.tsx
+++ b/src/pages/Privacy/index.tsx
@@ -118,6 +118,18 @@ export default function PrivacyPage() {
           </Prose>
         </Section>
 
+        <Section id="product-analytics" label="Product analytics">
+          <Prose>
+            We use a privacy-conscious product analytics tool (PostHog, hosted in the EU) to
+            understand how the product is used — for example which steps of an inspection people
+            reach — so we can improve it. Analytics events are sent first-party through Drydock and
+            are keyed only to your opaque account and organization identifiers; we do not send your
+            name, email, package names, release contents, findings, or credentials, and we drop your
+            IP address before the data leaves Drydock. If your browser sends a “Do Not Track” signal
+            we honor it and skip analytics.
+          </Prose>
+        </Section>
+
         <Section id="cookies" label="Cookies">
           <Prose>
             We use first-party cookies that are strictly necessary to sign you in and keep your

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  // PostHog project API key (write-only, safe to ship in the client bundle).
+  // When unset, product analytics is disabled entirely — forks and self-hosted
+  // deployments stay analytics-free unless they opt in at build time.
+  readonly VITE_PUBLIC_POSTHOG_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/test/analytics-proxy.test.ts
+++ b/test/analytics-proxy.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { isAnalyticsProxyPath, proxyAnalyticsRequest } from "../server/lib/analytics-proxy";
+import { ANALYTICS_PROXY_PREFIX } from "../server/lib/analytics-proxy-path";
+
+interface CapturedUpstream {
+  url: string;
+  method: string;
+  headers: Headers;
+  body: string;
+}
+
+function stubUpstream(response = new Response("ok", { status: 200 })): {
+  captured: CapturedUpstream[];
+} {
+  const captured: CapturedUpstream[] = [];
+  vi.stubGlobal("fetch", async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const headers = new Headers(init?.headers);
+    const body = init?.body ? new TextDecoder().decode(init.body as ArrayBuffer) : "";
+    captured.push({ url, method: init?.method ?? "GET", headers, body });
+    return response;
+  });
+  return { captured };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("isAnalyticsProxyPath", () => {
+  test("matches the prefix and its descendants only", () => {
+    expect(isAnalyticsProxyPath(ANALYTICS_PROXY_PREFIX)).toBe(true);
+    expect(isAnalyticsProxyPath(`${ANALYTICS_PROXY_PREFIX}/i/v0/e/`)).toBe(true);
+    expect(isAnalyticsProxyPath("/bored")).toBe(false);
+    expect(isAnalyticsProxyPath("/api/v1/scans")).toBe(false);
+  });
+});
+
+describe("proxyAnalyticsRequest", () => {
+  test("forwards ingestion traffic to PostHog EU with the prefix stripped", async () => {
+    const { captured } = stubUpstream();
+
+    await proxyAnalyticsRequest(
+      new Request("https://drydock.org/b/i/v0/e/?ip=1&ver=1", {
+        method: "POST",
+        headers: { "content-type": "application/json", "cf-connecting-ip": "203.0.113.7" },
+        body: JSON.stringify({ event: "$pageview" }),
+      }),
+    );
+
+    expect(captured).toHaveLength(1);
+    const upstream = captured[0]!;
+    expect(upstream.url).toBe("https://eu.i.posthog.com/i/v0/e/?ip=1&ver=1");
+    expect(upstream.method).toBe("POST");
+    expect(upstream.headers.get("host")).toBe("eu.i.posthog.com");
+    expect(upstream.body).toContain("$pageview");
+  });
+
+  test("routes static asset requests to the PostHog assets host", async () => {
+    const { captured } = stubUpstream();
+
+    await proxyAnalyticsRequest(new Request("https://drydock.org/b/static/recorder.js"));
+
+    expect(captured[0]!.url).toBe("https://eu-assets.i.posthog.com/static/recorder.js");
+  });
+
+  test("strips client identity headers so no reviewer IP reaches PostHog", async () => {
+    const { captured } = stubUpstream();
+
+    await proxyAnalyticsRequest(
+      new Request("https://drydock.org/b/i/v0/e/", {
+        method: "POST",
+        headers: {
+          "cf-connecting-ip": "203.0.113.7",
+          "x-forwarded-for": "203.0.113.7",
+          "x-real-ip": "203.0.113.7",
+          cookie: "drydock_session=secret",
+          "true-client-ip": "203.0.113.7",
+        },
+        body: "{}",
+      }),
+    );
+
+    const headers = captured[0]!.headers;
+    for (const name of [
+      "cf-connecting-ip",
+      "x-forwarded-for",
+      "x-real-ip",
+      "cookie",
+      "true-client-ip",
+    ]) {
+      expect(headers.get(name)).toBeNull();
+    }
+  });
+
+  test("drops upstream set-cookie from the proxied response", async () => {
+    stubUpstream(
+      new Response("ok", { status: 200, headers: { "set-cookie": "ph_session=1; Path=/" } }),
+    );
+
+    const res = await proxyAnalyticsRequest(new Request("https://drydock.org/b/flags/?v=2"));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+});

--- a/test/workers/analytics-proxy.test.ts
+++ b/test/workers/analytics-proxy.test.ts
@@ -1,0 +1,42 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import worker from "../../server/index";
+
+const assetEnv = {
+  ...env,
+  ASSETS: {
+    fetch: async (request: Request) => {
+      const url = new URL(request.url);
+      return new Response(`asset:${url.pathname}${url.search}`);
+    },
+  },
+} satisfies Cloudflare.Env;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+async function fetchWorker(request: Request): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await worker.fetch(request, assetEnv, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+describe("analytics proxy route", () => {
+  test("proxies /b/* to PostHog without auth and without hitting the asset binding", async () => {
+    const seen: string[] = [];
+    vi.stubGlobal("fetch", async (input: string | URL | Request) => {
+      seen.push(typeof input === "string" ? input : input.toString());
+      return new Response("captured", { status: 200 });
+    });
+
+    const res = await fetchWorker(
+      new Request("https://drydock.org/b/i/v0/e/", { method: "POST", body: "{}" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("captured");
+    expect(seen).toEqual(["https://eu.i.posthog.com/i/v0/e/"]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a product-analytics layer (PostHog, EU cloud) so we can see how reviewers move through the core funnel — discover staged publishes → open a scan → record a Ship/Hold decision — separate from the existing ops telemetry in `server/lib/observability.ts`.

It's **first-party and privacy-conscious**, which matters for a security tool:

- The browser never talks to PostHog directly. All traffic goes through a same-origin reverse proxy on the Worker at `/b/*`, so it survives content blockers and needs no third-party CSP entry (existing `connect-src 'self'` already covers it).
- The proxy strips client-IP/forwarding headers and cookies before forwarding, so **no reviewer IP reaches PostHog**. `${prefix}/static/*` fans out to `eu-assets.i.posthog.com`, everything else to `eu.i.posthog.com`.
- Events carry only opaque IDs + coarse non-PII props (decision outcome, risk, status). No names, emails, package names, reasons, or tokens. `identified_only` profiles; autocapture / session recording / surveys disabled; DNT respected.
- **Opt-in by config**: nothing is sent unless `VITE_PUBLIC_POSTHOG_KEY` is set at build time, so local dev / forks / self-hosts stay analytics-free.

## What changed

Server proxy (public, auth-free by design — the SDK has no session):
```
// server/index.ts
app.all(`${ANALYTICS_PROXY_PREFIX}/*`, (c) => proxyAnalyticsRequest(c.req.raw));
```
- `server/lib/analytics-proxy-path.ts` — shared `/b` prefix (also pre-declared for the legacy zone in `wrangler.jsonc`).
- `server/lib/analytics-proxy.ts` — `proxyAnalyticsRequest` rewrites Host, drops `cf-connecting-ip`/`x-forwarded-for`/`x-real-ip`/`true-client-ip`/`forwarded`/`cookie`, buffers the small JSON body, and strips upstream `set-cookie`.

Frontend:
- `src/lib/analytics.ts` — gated `initAnalytics` + typed helpers (`trackEvent`, `identifyUser`, `setOrganizationGroup`, `resetAnalytics`, `capturePageview`). `api_host` points at the `/b` proxy. All helpers no-op when no key / off-browser, so SSR/prerender is unaffected.
- `src/components/AnalyticsTracker.tsx` — headless; boots the SDK, captures `$pageview` on route change, and keeps identity/org group in sync with `sessionModel.user` / `activeOrganizationId` signals. Mounted in `src/index.tsx`.

Funnel events captured at the model layer (`src/models/scan.ts`, `staged-publishes.ts`):

| Event | Fires when | Properties |
| --- | --- | --- |
| `scan_discovery_run` | discovery completes | `found`, `created`, `skipped` |
| `scan_detail_viewed` | scan detail first load | `status`, `risk`, `source` |
| `scan_decision_recorded` | Ship/Hold saved (list + detail) | `surface`, `decision`, `outcome`, `risk`, `had_reason` |
| `workflow_gate_decision_recorded` | gate decision saved | `decision`, `had_comment` |

Config / deps:
- `posthog-js` pinned to `1.393.0`; `pnpm-workspace.yaml` marks the transitive `core-js` build script as not-run (`core-js: false`).
- `.env.example` documents `VITE_PUBLIC_POSTHOG_KEY` (public write-only key, inlined by `vite build`); `.gitignore` ignores local `.env*`.

Docs: new `docs/product-analytics.md` (+ `docs/README.md` link) and a "Product analytics" section in the privacy policy page.

## Testing

- `pnpm run verify` (lint, format:check, typecheck, full node + workers test suites) — green.
- `pnpm run build` — succeeds; all 10 pages prerender (privacy page included).
- New tests: `test/analytics-proxy.test.ts` (path mapping, asset-host split, header/cookie stripping) and `test/workers/analytics-proxy.test.ts` (`/b/*` is public and doesn't fall through to the asset binding).

Note: requires a PostHog EU project + `VITE_PUBLIC_POSTHOG_KEY` set in the deploy build environment to actually emit events.


Link to Devin session: https://app.devin.ai/sessions/6bd05e479c604be092deda34aab0e640
Requested by: @JoviDeCroock
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jovidecroock/drydock/pull/423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->