### PR TITLE
Remove status badge from file tree

### DIFF
--- a/src/components/FileTree.tsx
+++ b/src/components/FileTree.tsx
@@ -1,5 +1,5 @@
 import type { DiffEntry } from "../../server/lib/review";
-import { Badge, type BadgeTone, severityTone, statusTone } from "./Badge";
+import { Badge, severityTone } from "./Badge";
 import { cn } from "./cn";
 import {
   buildTree,
@@ -10,16 +10,17 @@ import {
 } from "./file-tree-model";
 import { EmptyLine } from "./Typography";
 
-function statusToTone(status: FolderStatus): BadgeTone {
-  return statusTone(status);
-}
-
 function statusToText(status: FolderStatus): string {
   if (status === "mixed") return "text-accent";
   if (status === "added") return "text-ok-text";
   if (status === "removed") return "text-danger-text";
   if (status === "modified") return "text-warn-text";
   return "text-ink-muted";
+}
+
+function StatusLabel({ status }: { status: FolderStatus }) {
+  if (status === "unchanged") return null;
+  return <span class="sr-only">{` (${status})`}</span>;
 }
 
 function TreeIndent({ depth }: { depth: number }) {
@@ -108,11 +109,9 @@ function TreeNode({
             </span>
             <span class={cn("flex-1 truncate", statusToText(node.status))} title={`${node.name}/`}>
               {node.name}/
+              <StatusLabel status={node.status} />
             </span>
             <FindingCountBadge count={node.findingCount} severity={node.findingSeverity} />
-            {node.status !== "unchanged" ? (
-              <Badge tone={statusToTone(node.status)}>{node.status}</Badge>
-            ) : null}
           </summary>
           <ul class="list-none p-0 m-0">
             {node.children.map((child) => (
@@ -148,11 +147,9 @@ function TreeNode({
           title={node.name}
         >
           {node.name}
+          <StatusLabel status={node.status} />
         </span>
         <FindingCountBadge count={node.findingCount} severity={node.findingSeverity} />
-        {node.status !== "unchanged" ? (
-          <Badge tone={statusToTone(node.status)}>{node.status}</Badge>
-        ) : null}
       </button>
     </li>
   );


### PR DESCRIPTION
## Summary
The file tree showed an `added`/`modified`/`removed` text `Badge` on each changed folder/file, duplicating information already conveyed by the filename color and taking up horizontal space. This removes the visible badge while keeping the status accessible.

- Drop the `<Badge tone={statusToTone(...)}>` for both folder and file nodes (and the now-unused `statusToTone`/`statusTone`/`BadgeTone` import).
- Color still indicates status via `statusToText` on the filename.
- Add a visually-hidden `StatusLabel` so screen readers still hear the status (e.g. `name (added)`), since color alone isn't accessible:

```tsx
function StatusLabel({ status }) {
  if (status === "unchanged") return null;
  return <span class="sr-only">{` (${status})`}</span>;
}
```

Lint + typecheck pass. No tests assert on the file-tree badge text. docs checked, no update needed.

Link to Devin session: https://app.devin.ai/sessions/8b36672d0b7f458bbc743b73e016ede1
Requested by: @JoviDeCroock