### PR TITLE
perf(ai-review): anchor prompt-cache affinity per-ecosystem for cross-scan reuse

### DIFF
--- a/server/lib/ai-review.ts
+++ b/server/lib/ai-review.ts
@@ -6,6 +6,7 @@ import {
   clampAiReviewSubmission,
   MAX_AGENT_STEPS,
   MAX_REVIEW_OUTPUT_TOKENS,
+  normalizeAiReviewEcosystem,
   selectReportedFindings,
   type AiReviewSubmission,
 } from "./ai-review-contract";
@@ -89,7 +90,7 @@ export async function analyzeWithAi(
             gateway: { id: "drydock-gateway" },
           })(candidateModel, {
             extraHeaders: {
-              "x-session-affinity": scanScopedCacheAffinity(env, options.scanId),
+              "x-session-affinity": reviewerCacheAffinity(env, options.ecosystem),
               "cf-aig-metadata": aiGatewayMetadataHeader(options, candidateModel, attempt),
             },
           });
@@ -265,10 +266,14 @@ function toUsage(usage: LanguageModelUsage, steps: number): AiReviewUsage {
   };
 }
 
-function scanScopedCacheAffinity(env: Cloudflare.Env, scanId: string | undefined): string {
+export function reviewerCacheAffinity(env: Cloudflare.Env, ecosystem: string | undefined): string {
   const base = env.AI_CACHE_AFFINITY || DEFAULT_CACHE_AFFINITY;
-  const suffix = scanId || crypto.randomUUID();
-  return `${base}:${suffix}`;
+  // Use a stable per-ecosystem routing key so every scan reuses the same cache
+  // affinity for the static reviewer prefix. This improves cross-scan prompt
+  // reuse while preserving within-scan reuse; concurrent same-ecosystem scans
+  // may share routing and contend slightly, but current volume keeps that risk
+  // negligible. Operators can override the base via AI_CACHE_AFFINITY.
+  return `${base}:${normalizeAiReviewEcosystem(ecosystem)}`;
 }
 
 function normalizeAiResponse(model: string, text: string): AiReview {

--- a/server/lib/ai-review.ts
+++ b/server/lib/ai-review.ts
@@ -90,7 +90,11 @@ export async function analyzeWithAi(
             gateway: { id: "drydock-gateway" },
           })(candidateModel, {
             extraHeaders: {
-              "x-session-affinity": reviewerCacheAffinity(env, options.ecosystem),
+              "x-session-affinity": reviewerCacheAffinity(
+                env,
+                options.ecosystem,
+                options.packageJsonDiff.name,
+              ),
               "cf-aig-metadata": aiGatewayMetadataHeader(options, candidateModel, attempt),
             },
           });
@@ -266,14 +270,33 @@ function toUsage(usage: LanguageModelUsage, steps: number): AiReviewUsage {
   };
 }
 
-export function reviewerCacheAffinity(env: Cloudflare.Env, ecosystem: string | undefined): string {
+export function reviewerCacheAffinity(
+  env: Cloudflare.Env,
+  ecosystem: string | undefined,
+  packageName: string | null | undefined,
+): string {
   const base = env.AI_CACHE_AFFINITY || DEFAULT_CACHE_AFFINITY;
-  // Use a stable per-ecosystem routing key so every scan reuses the same cache
-  // affinity for the static reviewer prefix. This improves cross-scan prompt
-  // reuse while preserving within-scan reuse; concurrent same-ecosystem scans
-  // may share routing and contend slightly, but current volume keeps that risk
-  // negligible. Operators can override the base via AI_CACHE_AFFINITY.
-  return `${base}:${normalizeAiReviewEcosystem(ecosystem)}`;
+  // Use a stable per-ecosystem + per-package routing key so every scan of a
+  // package reuses the same cache affinity for the static reviewer prefix. This
+  // improves cross-scan prompt reuse while preserving within-scan reuse, and
+  // scoping to the package keeps successive versions of the same release routing
+  // together (their evidence overlaps most) rather than contending with
+  // unrelated packages. Operators can override the base via AI_CACHE_AFFINITY.
+  const key = `${base}:${normalizeAiReviewEcosystem(ecosystem)}`;
+  const slug = slugifyPackageName(packageName);
+  return slug ? `${key}:${slug}` : key;
+}
+
+// Package names can be scoped (`@scope/pkg`) and are attacker-controlled, so
+// reduce them to a stable, header-safe slug and never let the `:` separator or
+// unbounded length leak into the routing key.
+function slugifyPackageName(packageName: string | null | undefined): string {
+  if (!packageName) return "";
+  return packageName
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 128);
 }
 
 function normalizeAiResponse(model: string, text: string): AiReview {

--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -132,26 +132,53 @@ describe("AI review prompt selection", () => {
 });
 
 describe("reviewer cache affinity", () => {
-  test("anchors cache affinity on ecosystem instead of scan id", () => {
+  test("anchors cache affinity on ecosystem and package name instead of scan id", () => {
     const base = { AI_CACHE_AFFINITY: "cache-base" };
 
-    expect(reviewerCacheAffinity(base, "npm")).toBe("cache-base:npm");
-    expect(reviewerCacheAffinity(base, "npm")).toBe(reviewerCacheAffinity(base, "npm"));
-    expect(reviewerCacheAffinity(base, "pypi")).toBe("cache-base:pypi");
-    expect(reviewerCacheAffinity(base, "rubygems")).toBe("cache-base:generic");
-    expect(reviewerCacheAffinity({}, "npm")).toBe(
-      "staged-publish-review-agentic-release-reviewer-v1:npm",
+    expect(reviewerCacheAffinity(base, "npm", "left-pad")).toBe("cache-base:npm:left-pad");
+    expect(reviewerCacheAffinity(base, "npm", "left-pad")).toBe(
+      reviewerCacheAffinity(base, "npm", "left-pad"),
+    );
+    expect(reviewerCacheAffinity(base, "pypi", "requests")).toBe("cache-base:pypi:requests");
+    expect(reviewerCacheAffinity(base, "rubygems", "rails")).toBe("cache-base:generic:rails");
+    expect(reviewerCacheAffinity({}, "npm", "left-pad")).toBe(
+      "staged-publish-review-agentic-release-reviewer-v1:npm:left-pad",
+    );
+  });
+
+  test("scopes distinct packages to distinct keys and falls back when the name is missing", () => {
+    const base = { AI_CACHE_AFFINITY: "cache-base" };
+
+    expect(reviewerCacheAffinity(base, "npm", "a")).not.toBe(
+      reviewerCacheAffinity(base, "npm", "b"),
+    );
+    // A missing/empty package name falls back to the ecosystem-only key.
+    expect(reviewerCacheAffinity(base, "npm", null)).toBe("cache-base:npm");
+    expect(reviewerCacheAffinity(base, "npm", "")).toBe("cache-base:npm");
+  });
+
+  test("slugifies scoped and attacker-controlled package names into a header-safe key", () => {
+    const base = { AI_CACHE_AFFINITY: "cache-base" };
+
+    expect(reviewerCacheAffinity(base, "npm", "@scope/Pkg")).toBe("cache-base:npm:scope-pkg");
+    expect(reviewerCacheAffinity(base, "npm", "  weird::name!! ")).toBe(
+      "cache-base:npm:weird-name",
+    );
+    expect(reviewerCacheAffinity(base, "npm", "a".repeat(300))).toBe(
+      `cache-base:npm:${"a".repeat(128)}`,
     );
   });
 
   test("respects the override and ignores scan id", () => {
     const env = { AI_CACHE_AFFINITY: "override-base" };
 
-    expect(reviewerCacheAffinity(env, "npm")).toBe("override-base:npm");
-    expect(reviewerCacheAffinity(env, "npm")).toBe(
-      reviewerCacheAffinity({ ...env, scanId: "scan-a" }, "npm"),
+    expect(reviewerCacheAffinity(env, "npm", "left-pad")).toBe("override-base:npm:left-pad");
+    expect(reviewerCacheAffinity(env, "npm", "left-pad")).toBe(
+      reviewerCacheAffinity({ ...env, scanId: "scan-a" }, "npm", "left-pad"),
     );
-    expect(reviewerCacheAffinity({ ...env, scanId: "scan-b" }, "npm")).toBe("override-base:npm");
+    expect(reviewerCacheAffinity({ ...env, scanId: "scan-b" }, "npm", "left-pad")).toBe(
+      "override-base:npm:left-pad",
+    );
   });
 });
 

--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -7,6 +7,7 @@ import {
   analyzeWithAi,
   aiGatewayMetadataHeader,
   displayedAiResult,
+  reviewerCacheAffinity,
 } from "../server/lib/ai-review.ts";
 import {
   buildReviewerSystemPrompt,
@@ -127,6 +128,30 @@ describe("AI review prompt selection", () => {
     expect(normalizeAiReviewEcosystem("rubygems")).toBe("generic");
     expect(normalizeAiReviewEcosystem(undefined)).toBe("generic");
     expect(buildReviewerSystemPrompt("rubygems")).toContain("Ecosystem: generic package release.");
+  });
+});
+
+describe("reviewer cache affinity", () => {
+  test("anchors cache affinity on ecosystem instead of scan id", () => {
+    const base = { AI_CACHE_AFFINITY: "cache-base" };
+
+    expect(reviewerCacheAffinity(base, "npm")).toBe("cache-base:npm");
+    expect(reviewerCacheAffinity(base, "npm")).toBe(reviewerCacheAffinity(base, "npm"));
+    expect(reviewerCacheAffinity(base, "pypi")).toBe("cache-base:pypi");
+    expect(reviewerCacheAffinity(base, "rubygems")).toBe("cache-base:generic");
+    expect(reviewerCacheAffinity({}, "npm")).toBe(
+      "staged-publish-review-agentic-release-reviewer-v1:npm",
+    );
+  });
+
+  test("respects the override and ignores scan id", () => {
+    const env = { AI_CACHE_AFFINITY: "override-base" };
+
+    expect(reviewerCacheAffinity(env, "npm")).toBe("override-base:npm");
+    expect(reviewerCacheAffinity(env, "npm")).toBe(
+      reviewerCacheAffinity({ ...env, scanId: "scan-a" }, "npm"),
+    );
+    expect(reviewerCacheAffinity({ ...env, scanId: "scan-b" }, "npm")).toBe("override-base:npm");
   });
 });
 


### PR DESCRIPTION
## Summary
In the Cloudflare AI Gateway data, **70/123** model calls had zero cached input tokens, and every scan's *first* call cached nothing. Root cause: the Workers AI `x-session-affinity` key was unique per scan (`${base}:${scanId}`), so the large, static reviewer **system prompt** — identical across scans of a package — was never reused across scans; each scan re-paid for it cold.

This PR anchors the affinity on a **stable per-ecosystem + per-package** key, so the static prefix is reused across scans of the same package. This is PR 2 of 4 from the perf analysis.

```diff
-function scanScopedCacheAffinity(env, scanId) {
-  const suffix = scanId || crypto.randomUUID();   // unique per scan → 0 cross-scan reuse
-  return `${base}:${suffix}`;
-}
+export function reviewerCacheAffinity(env, ecosystem, packageName) {
+  const key = `${base}:${normalizeAiReviewEcosystem(ecosystem)}`;  // npm | pypi | generic
+  const slug = slugifyPackageName(packageName);                    // header-safe, ≤128 chars
+  return slug ? `${key}:${slug}` : key;                            // fall back to eco-only if no name
+}
```

### Why this is safe / strictly additive
Affinity only controls cache-node *routing*; what actually gets reused is still determined by prefix matching, so scans only share the identical system-prompt/evidence-format prefix — never each other's evidence. Within-scan reuse is preserved (all of a scan's sequential calls still share one stable key); this just *adds* cross-scan reuse of the static prefix. Scoping to the package name keeps successive versions of the same release routing together (their evidence overlaps most) rather than contending with unrelated packages.

The package name is slugified (lowercased, non-`[a-z0-9._-]` → `-`, trimmed, capped at 128 chars) since names are scoped (`@scope/pkg`) and attacker-controlled — this keeps the `:` separator and unbounded length out of the routing key. A missing name falls back to the ecosystem-only key.

### Trade-off
Concurrent scans of the *same* package share routing and could evict each other's within-scan evidence cache. At current volume (~12 scans/day) contention is negligible. The base remains overridable via the `AI_CACHE_AFFINITY` env var, and reverting is a one-liner.

Compounds with PR 1 (front-loaded evidence): the larger, stable leading prefix is now also reusable across scans of a package.

## Testing
- Added tests in `test/ai-review.test.mjs`: affinity is deterministic per (ecosystem, package), independent of `scanId`, routes npm/pypi/unknown→generic and distinct packages to distinct keys, slugifies scoped/attacker-controlled names, caps length, and falls back to the ecosystem-only key when the name is missing, plus the `AI_CACHE_AFFINITY` override.
- `pnpm run verify` (lint + format check + typecheck + full test suite) passes.
- Docs checked: `docs/self-hosting.md` already describes `AI_CACHE_AFFINITY` as a "stable prefix-cache affinity string" — the per-ecosystem/per-package key matches that description, no update needed.

Link to Devin session: https://app.devin.ai/sessions/5c32ebd36f27441fb5181b875968987f
Requested by: @JoviDeCroock
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jovidecroock/drydock/pull/427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->