### PR TITLE
perf(ai-review): bound the agentic loop (step cap, wall-time budget, single retry authority)

### DIFF
--- a/server/env.d.ts
+++ b/server/env.d.ts
@@ -4,6 +4,7 @@ declare global {
       AI: Ai;
       ASSETS?: Fetcher;
       AI_CACHE_AFFINITY?: string;
+      AI_REVIEW_BUDGET_MS?: string;
       LOADER: WorkerLoader;
       DB: D1Database;
       ARTIFACTS?: R2Bucket;

--- a/server/lib/ai-review-contract.ts
+++ b/server/lib/ai-review-contract.ts
@@ -97,12 +97,15 @@ export function buildReviewerSystemPrompt(ecosystem: string | undefined): string
   return `${BASE_REVIEWER_SYSTEM_PROMPT}\n\n${ecosystemPrompt}\n\n${SEVERITY_GUIDANCE}`;
 }
 
-export const MAX_AGENT_STEPS = 20;
+export const MAX_AGENT_STEPS = 16;
 // Per-step output-token cap, sized comfortably above a worst-case submission so
 // findings plus summary serialize without truncation. A slight overshoot is
 // clamped by clampAiReviewSubmission; only a submission truncated mid-JSON by
 // this cap is unrecoverable, and that degrades to `invalid` which the risk layer
 // escalates to manual review.
+// Overall wall-time budget for the whole AI review run. The env override keeps
+// operators able to tune it without changing code.
+export const AI_REVIEW_TOTAL_BUDGET_MS = 75_000;
 export const MAX_REVIEW_OUTPUT_TOKENS = 8_000;
 export const MAX_CHANGED_FILE_MANIFEST = 300;
 export const MAX_TOOL_RESPONSE_CHARS = 16_000;

--- a/server/lib/ai-review.ts
+++ b/server/lib/ai-review.ts
@@ -186,7 +186,10 @@ export async function analyzeWithAi(
           usage,
         };
       } catch (err) {
-        if (isAiReviewBudgetTimeoutError(err)) {
+        // Fail closed on the budget once the deadline has passed, regardless of
+        // whether the abort surfaced as a recognizable TimeoutError or was
+        // wrapped by the SDK/provider into another error shape.
+        if (isAiReviewBudgetTimeoutError(err) || remainingAiReviewBudgetMs(deadline) <= 0) {
           return {
             review: budgetExceededReview(candidateModel, budgetMs),
             usage: null,

--- a/server/lib/ai-review.ts
+++ b/server/lib/ai-review.ts
@@ -298,7 +298,9 @@ function toUsage(usage: LanguageModelUsage, steps: number): AiReviewUsage {
 
 function resolveAiReviewBudgetMs(env: Cloudflare.Env): number {
   const parsed = Number(env.AI_REVIEW_BUDGET_MS);
-  return Number.isFinite(parsed) ? parsed : AI_REVIEW_TOTAL_BUDGET_MS;
+  // Guard against empty/zero/negative overrides (Number("") === 0) that would
+  // otherwise zero the budget and fail every review straight to `unavailable`.
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : AI_REVIEW_TOTAL_BUDGET_MS;
 }
 
 function remainingAiReviewBudgetMs(deadline: number): number {

--- a/server/lib/ai-review.ts
+++ b/server/lib/ai-review.ts
@@ -5,6 +5,7 @@ import {
   buildReviewerSystemPrompt,
   clampAiReviewSubmission,
   MAX_AGENT_STEPS,
+  AI_REVIEW_TOTAL_BUDGET_MS,
   MAX_REVIEW_OUTPUT_TOKENS,
   selectReportedFindings,
   type AiReviewSubmission,
@@ -74,10 +75,28 @@ export async function analyzeWithAi(
   const index = buildEvidenceIndex(options);
   const payload = buildAiReviewPayload(options, index);
   const transientFailures: string[] = [];
+  const budgetMs = resolveAiReviewBudgetMs(env);
+  const deadline = Date.now() + budgetMs;
 
   for (const candidateModel of models) {
+    const remainingBeforeCandidate = remainingAiReviewBudgetMs(deadline);
+    if (remainingBeforeCandidate <= 0) {
+      return {
+        review: budgetExceededReview(null, budgetMs),
+        usage: null,
+      };
+    }
+
     let lastError: unknown;
     for (let attempt = 1; attempt <= AI_REVIEW_MAX_ATTEMPTS; attempt += 1) {
+      const remaining = remainingAiReviewBudgetMs(deadline);
+      if (remaining <= 0) {
+        return {
+          review: budgetExceededReview(candidateModel, budgetMs),
+          usage: null,
+        };
+      }
+
       // Declared per attempt: a retried run starts the agentic loop from scratch,
       // so a submission recorded by a prior (failed) attempt must not leak across.
       let submittedReview: AiReviewSubmission | null = null;
@@ -139,6 +158,10 @@ export async function analyzeWithAi(
           },
           temperature: 0,
           maxOutputTokens: MAX_REVIEW_OUTPUT_TOKENS,
+          // Own the retry loop here so the module's transient-error policy is the
+          // single retry authority instead of stacking on the SDK's defaults.
+          maxRetries: 0,
+          abortSignal: AbortSignal.timeout(remaining),
         });
 
         const usage = toUsage(result.totalUsage, result.steps.length);
@@ -163,6 +186,12 @@ export async function analyzeWithAi(
           usage,
         };
       } catch (err) {
+        if (isAiReviewBudgetTimeoutError(err)) {
+          return {
+            review: budgetExceededReview(candidateModel, budgetMs),
+            usage: null,
+          };
+        }
         lastError = err;
         // Only retry transient capacity/overload failures; a malformed request or a
         // code bug fails identically every time, so retrying just wastes budget.
@@ -179,18 +208,20 @@ export async function analyzeWithAi(
       continue;
     }
 
-    return {
-      review: fallbackReview(
-        candidateModel,
-        "unavailable",
-        `Assistant review didn't run: ${modelFailureSummary(
-          transientFailures,
+    if (lastError) {
+      return {
+        review: fallbackReview(
           candidateModel,
-          lastError,
-        )}`,
-      ),
-      usage: null,
-    };
+          "unavailable",
+          `Assistant review didn't run: ${modelFailureSummary(
+            transientFailures,
+            candidateModel,
+            lastError,
+          )}`,
+        ),
+        usage: null,
+      };
+    }
   }
 
   return {
@@ -263,6 +294,35 @@ function toUsage(usage: LanguageModelUsage, steps: number): AiReviewUsage {
     totalTokens: usage.totalTokens ?? null,
     steps,
   };
+}
+
+function resolveAiReviewBudgetMs(env: Cloudflare.Env): number {
+  const parsed = Number(env.AI_REVIEW_BUDGET_MS);
+  return Number.isFinite(parsed) ? parsed : AI_REVIEW_TOTAL_BUDGET_MS;
+}
+
+function remainingAiReviewBudgetMs(deadline: number): number {
+  return Math.max(0, deadline - Date.now());
+}
+
+function budgetExceededReview(model: string | null, budgetMs: number): AiReview {
+  return fallbackReview(
+    model,
+    "unavailable",
+    `AI review exceeded the ${Math.max(1, Math.ceil(budgetMs / 1000))}s time budget`,
+  );
+}
+
+function isAiReviewBudgetTimeoutError(err: unknown): boolean {
+  return (
+    (typeof DOMException !== "undefined" &&
+      err instanceof DOMException &&
+      err.name === "TimeoutError") ||
+    (typeof err === "object" &&
+      err !== null &&
+      "name" in err &&
+      (err as { name?: unknown }).name === "TimeoutError")
+  );
 }
 
 function scanScopedCacheAffinity(env: Cloudflare.Env, scanId: string | undefined): string {

--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -383,6 +383,38 @@ describe("ai review orchestration", () => {
     expect(ai.summary).toBe("No unusual changes.");
   });
 
+  test("an AI budget timeout fails safe to unavailable and does not thrash models", async () => {
+    const modelCalls = [];
+    const budgetModel = (model) => {
+      modelCalls.push(model);
+      return mockModel(async ({ abortSignal }) => {
+        await new Promise((_, reject) => {
+          if (!abortSignal) {
+            reject(new Error("missing abort signal"));
+            return;
+          }
+          if (abortSignal.aborted) {
+            reject(abortSignal.reason);
+            return;
+          }
+          abortSignal.addEventListener("abort", () => reject(abortSignal.reason), { once: true });
+        });
+      });
+    };
+
+    const { review: ai, usage } = await analyzeWithAi(
+      { AI_REVIEW_BUDGET_MS: "250" },
+      ["primary-reviewer", "fallback-reviewer"],
+      BASE_OPTIONS,
+      budgetModel,
+    );
+
+    expect(modelCalls).toEqual(["primary-reviewer"]);
+    expect(ai.status).toBe("unavailable");
+    expect(ai.summary).toContain("time budget");
+    expect(usage).toBeNull();
+  });
+
   test("a persistent capacity error exhausts retries and fails safe to unavailable", async () => {
     skipRetryDelay();
     let calls = 0;

--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -415,6 +415,39 @@ describe("ai review orchestration", () => {
     expect(usage).toBeNull();
   });
 
+  test("a budget timeout wrapped into another error shape still fails safe to the budget message", async () => {
+    const modelCalls = [];
+    const wrappingModel = (model) => {
+      modelCalls.push(model);
+      return mockModel(async ({ abortSignal }) => {
+        await new Promise((_, reject) => {
+          const fail = () =>
+            // Simulate the SDK/provider re-wrapping the abort: a plain Error
+            // whose name is not "TimeoutError", so detection must fall back to
+            // the deadline check.
+            reject(new Error("APICallError: request aborted by client"));
+          if (abortSignal?.aborted) {
+            fail();
+            return;
+          }
+          abortSignal?.addEventListener("abort", fail, { once: true });
+        });
+      });
+    };
+
+    const { review: ai, usage } = await analyzeWithAi(
+      { AI_REVIEW_BUDGET_MS: "100" },
+      ["primary-reviewer", "fallback-reviewer"],
+      BASE_OPTIONS,
+      wrappingModel,
+    );
+
+    expect(modelCalls).toEqual(["primary-reviewer"]);
+    expect(ai.status).toBe("unavailable");
+    expect(ai.summary).toContain("time budget");
+    expect(usage).toBeNull();
+  });
+
   test("a persistent capacity error exhausts retries and fails safe to unavailable", async () => {
     skipRetryDelay();
     let calls = 0;


### PR DESCRIPTION
## Summary
A scan's wall time stacks 6–14 sequential model calls plus two retry layers, pushing the queue consumer's p99 toward its ~96s ceiling. Nothing caps the *total* time of an AI review. This PR adds three guardrails so a slow/runaway review fails closed to manual review instead of dragging the whole scan. PR 3 of 4 from the perf analysis.

### Changes (all in `server/lib/ai-review.ts` + contract/env)
1. **Step cap:** `MAX_AGENT_STEPS` 20 → 16 (observed real-world max was 14; keeps headroom, trims runaway loops).
2. **Overall wall-time budget:** one deadline for the whole `analyzeWithAi` run.
   ```
   deadline = now + AI_REVIEW_TOTAL_BUDGET_MS   // 75_000ms default, < ~96s queue p99
                                                // overridable via AI_REVIEW_BUDGET_MS env
   generateText({ ..., abortSignal: AbortSignal.timeout(remaining) })
   ```
   When the deadline is hit (before a candidate/attempt, or via a `TimeoutError` `DOMException` from the abort), it returns the `unavailable` fallback with summary `"AI review exceeded the {N}s time budget"` — **no** retry, **no** fallback-model thrash. Exceeding budget escalates to manual review (deterministic findings remain authoritative).
3. **Single retry authority:** set `maxRetries: 0` on `generateText` so this module's `AI_REVIEW_MAX_ATTEMPTS` loop is the only retry layer, instead of stacking on the SDK's default `maxRetries: 2` (which multiplied tail latency).

`AI_REVIEW_BUDGET_MS` is parsed defensively — empty/zero/negative (`Number("") === 0`) falls back to the 75s default rather than zeroing the budget.

### Fail-safe invariant preserved
Every abort/budget path yields `unavailable` (→ manual review), never a falsely-clean review. The forced-final-step `submit_review` logic is unchanged and still verified under `MAX_AGENT_STEPS = 16`.

## Testing
- Added tests in `test/ai-review.test.mjs`: a tiny `AI_REVIEW_BUDGET_MS` with a mock that awaits the abort signal → `status: "unavailable"`, summary mentions the time budget, no fallback-model thrash. Existing transient-retry (`AI_REVIEW_MAX_ATTEMPTS`) and forced-final-step tests still pass.
- `pnpm run verify` passes; re-ran `typecheck` + `test/ai-review.test.mjs` (28 passing) + lint/format after the budget-guard tweak.
- Docs checked, no update needed (`docs/self-hosting.md` documents env knobs generically; the new `AI_REVIEW_BUDGET_MS` is optional with a safe default).

Link to Devin session: https://app.devin.ai/sessions/5c32ebd36f27441fb5181b875968987f
Requested by: @JoviDeCroock
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jovidecroock/drydock/pull/428" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->