### PR TITLE
perf(ai-review): tier model selection — cheaper model first for low-signal releases

### DIFF
--- a/server/lib/ai-review-contract.ts
+++ b/server/lib/ai-review-contract.ts
@@ -125,6 +125,9 @@ export const MAX_REVIEW_OUTPUT_TOKENS = 8_000;
 export const MAX_CHANGED_FILE_MANIFEST = 300;
 export const MAX_TOOL_RESPONSE_CHARS = 16_000;
 export const MAX_TOTAL_TOOL_RESPONSE_CHARS = 48_000;
+// Low-signal releases can lead with the faster fallback model; beyond this many
+// changed files, keep the strong model first.
+export const MAX_LOW_SIGNAL_CHANGED_FILES = 5;
 export const DEFAULT_TOOL_CHARS = 8_000;
 export const MAX_READ_BATCH_PATHS = 10;
 export const MAX_SEARCH_QUERIES = 5;

--- a/server/lib/ai-review.ts
+++ b/server/lib/ai-review.ts
@@ -53,6 +53,9 @@ function isLowSignalReview(options: SelectiveAiReviewOptions): boolean {
     options.ruleFindings.length === 0 &&
     options.packageJsonDiff.entrypointsChanged === false &&
     options.packageJsonDiff.scripts.length === 0 &&
+    // A dependency add/change is a supply-chain vector even with no lifecycle
+    // script, so any manifest dependency delta keeps the strong model first.
+    options.packageJsonDiff.dependencies.length === 0 &&
     options.previousVersionAvailable === true &&
     options.diff.filter((entry) => entry.status !== "unchanged").length <=
       MAX_LOW_SIGNAL_CHANGED_FILES

--- a/server/lib/ai-review.ts
+++ b/server/lib/ai-review.ts
@@ -5,6 +5,7 @@ import {
   buildReviewerSystemPrompt,
   clampAiReviewSubmission,
   MAX_AGENT_STEPS,
+  MAX_LOW_SIGNAL_CHANGED_FILES,
   MAX_REVIEW_OUTPUT_TOKENS,
   selectReportedFindings,
   type AiReviewSubmission,
@@ -43,6 +44,21 @@ const DEFAULT_CACHE_AFFINITY = "staged-publish-review-agentic-release-reviewer-v
 const AI_REVIEW_MAX_ATTEMPTS = 3;
 const AI_REVIEW_RETRY_DELAY_MS = 500;
 
+export function selectModelCandidates(options: SelectiveAiReviewOptions): readonly string[] {
+  return isLowSignalReview(options) ? [AI_FALLBACK_MODEL, AI_MODEL] : AI_MODEL_CANDIDATES;
+}
+
+function isLowSignalReview(options: SelectiveAiReviewOptions): boolean {
+  return (
+    options.ruleFindings.length === 0 &&
+    options.packageJsonDiff.entrypointsChanged === false &&
+    options.packageJsonDiff.scripts.length === 0 &&
+    options.previousVersionAvailable === true &&
+    options.diff.filter((entry) => entry.status !== "unchanged").length <=
+      MAX_LOW_SIGNAL_CHANGED_FILES
+  );
+}
+
 type LanguageModelFactory = (model: string) => LanguageModel;
 type LanguageModelOverride = LanguageModel | LanguageModelFactory;
 
@@ -50,7 +66,7 @@ export async function runSelectiveAiReview(
   env: Cloudflare.Env,
   options: SelectiveAiReviewOptions,
 ): Promise<AiReviewResult> {
-  return analyzeWithAi(env, AI_MODEL_CANDIDATES, options);
+  return analyzeWithAi(env, selectModelCandidates(options), options);
 }
 
 export async function analyzeWithAi(

--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -7,6 +7,7 @@ import {
   analyzeWithAi,
   aiGatewayMetadataHeader,
   displayedAiResult,
+  selectModelCandidates,
 } from "../server/lib/ai-review.ts";
 import {
   buildReviewerSystemPrompt,
@@ -146,6 +147,102 @@ describe("ai review orchestration", () => {
     expect(AI_MODEL).toBe("@cf/moonshotai/kimi-k2.7-code");
     expect(AI_FALLBACK_MODEL).toBe("@cf/qwen/qwen3-30b-a3b-fp8");
     expect(AI_MODEL_CANDIDATES).toEqual([AI_MODEL, AI_FALLBACK_MODEL]);
+  });
+  test("selects the cheaper model first for a clean low-signal release", () => {
+    expect(selectModelCandidates(BASE_OPTIONS)).toEqual([AI_FALLBACK_MODEL, AI_MODEL]);
+  });
+
+  test("keeps the strong model first when deterministic findings are present", () => {
+    const options = {
+      ...BASE_OPTIONS,
+      ruleFindings: [aiFinding("high", "package.json")],
+      diff: [
+        {
+          path: "src/index.js",
+          status: "added",
+          stagedSize: 10,
+          stagedSha256: "sha-1",
+          flags: [],
+        },
+      ],
+    };
+
+    expect(selectModelCandidates(options)).toEqual([AI_MODEL, AI_FALLBACK_MODEL]);
+  });
+
+  test("keeps the strong model first when lifecycle scripts change", () => {
+    const options = {
+      ...BASE_OPTIONS,
+      packageJsonDiff: {
+        ...EMPTY_PACKAGE_JSON_DIFF,
+        scripts: [{ key: "postinstall", status: "added", staged: "node install.js" }],
+      },
+      diff: [
+        {
+          path: "src/index.js",
+          status: "added",
+          stagedSize: 10,
+          stagedSha256: "sha-1",
+          flags: [],
+        },
+      ],
+    };
+
+    expect(selectModelCandidates(options)).toEqual([AI_MODEL, AI_FALLBACK_MODEL]);
+  });
+
+  test("keeps the strong model first when entrypoints change", () => {
+    const options = {
+      ...BASE_OPTIONS,
+      packageJsonDiff: {
+        ...EMPTY_PACKAGE_JSON_DIFF,
+        entrypointsChanged: true,
+      },
+      diff: [
+        {
+          path: "src/index.js",
+          status: "added",
+          stagedSize: 10,
+          stagedSha256: "sha-1",
+          flags: [],
+        },
+      ],
+    };
+
+    expect(selectModelCandidates(options)).toEqual([AI_MODEL, AI_FALLBACK_MODEL]);
+  });
+
+  test("keeps the strong model first when no previous version is available", () => {
+    const options = {
+      ...BASE_OPTIONS,
+      previousVersionAvailable: false,
+      diff: [
+        {
+          path: "src/index.js",
+          status: "added",
+          stagedSize: 10,
+          stagedSha256: "sha-1",
+          flags: [],
+        },
+      ],
+    };
+
+    expect(selectModelCandidates(options)).toEqual([AI_MODEL, AI_FALLBACK_MODEL]);
+  });
+
+  test("keeps the strong model first when the changed-file count exceeds the threshold", () => {
+    const options = {
+      ...BASE_OPTIONS,
+      diff: Array.from({ length: 6 }, (_, index) => ({
+        path: `src/file-${index}.js`,
+        status: "added",
+        stagedSize: 10,
+        stagedSha256: `sha-${index}`,
+        flags: [],
+      })),
+    };
+
+    expect(selectModelCandidates(options)).toEqual([AI_MODEL, AI_FALLBACK_MODEL]);
   });
 
   test("keeps AI Gateway metadata within the five-field log limit", () => {

--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -191,6 +191,27 @@ describe("ai review orchestration", () => {
     expect(selectModelCandidates(options)).toEqual([AI_MODEL, AI_FALLBACK_MODEL]);
   });
 
+  test("keeps the strong model first when dependencies change", () => {
+    const options = {
+      ...BASE_OPTIONS,
+      packageJsonDiff: {
+        ...EMPTY_PACKAGE_JSON_DIFF,
+        dependencies: [{ key: "left-pad", status: "added", staged: "^1.0.0" }],
+      },
+      diff: [
+        {
+          path: "src/index.js",
+          status: "added",
+          stagedSize: 10,
+          stagedSha256: "sha-1",
+          flags: [],
+        },
+      ],
+    };
+
+    expect(selectModelCandidates(options)).toEqual([AI_MODEL, AI_FALLBACK_MODEL]);
+  });
+
   test("keeps the strong model first when entrypoints change", () => {
     const options = {
       ...BASE_OPTIONS,


### PR DESCRIPTION
## Summary
`runSelectiveAiReview` always leads with the strong/expensive model (`AI_MODEL` = kimi-k2.7-code) and falls back to `AI_FALLBACK_MODEL` (qwen3-30b). For clearly low-signal releases this PR leads with the cheaper/faster model to cut per-call latency/cost, while keeping the strong model in the chain so quality is preserved on escalation. PR 4 of 4 from the perf analysis. **Ordering only** — no retry/timeout changes.

```
selectModelCandidates(options) =
  isLowSignal(options) ? [AI_FALLBACK_MODEL, AI_MODEL]   // cheap/fast first, kimi still available
                       : [AI_MODEL, AI_FALLBACK_MODEL]    // unchanged
```

`isLowSignal` is conservative — **all** must hold:
- no deterministic findings (`ruleFindings.length === 0`),
- no entrypoint change (`packageJsonDiff.entrypointsChanged === false`),
- no lifecycle-script changes (`packageJsonDiff.scripts.length === 0`),
- no manifest dependency add/change (`packageJsonDiff.dependencies.length === 0` — a supply-chain vector even without a lifecycle script),
- a baseline exists (`previousVersionAvailable === true` — brand-new packages are higher-signal),
- changed-file count ≤ `MAX_LOW_SIGNAL_CHANGED_FILES` (5).

## Security note (worth a reviewer's attention)
This reorders *advisory* model candidates only — deterministic findings remain authoritative and are never downgraded by model choice, and kimi is never dropped from the chain (only reordered). The residual trade-off: for a low-signal release, the strong model is reached only if the cheaper one *errors* (transient/fallback), not if it returns a clean review — so a subtle, quiet malicious release (no findings, no script/entrypoint/dependency changes, tiny diff) would be reviewed by the weaker model. The low-signal gate is deliberately strict to shrink that surface, but it's a posture decision — easy to disable by reverting `selectModelCandidates` to `AI_MODEL_CANDIDATES`. Happy to gate it behind the `ai-review` flag or a separate flag if you'd prefer.

## Testing
- Added tests in `test/ai-review.test.mjs`: low-signal → fallback-first; each high-signal condition (a finding, a changed script, a changed dependency, `entrypointsChanged`, no baseline, >5 changed files) → kimi-first. Existing `AI_MODEL_CANDIDATES` ordering test unchanged.
- `pnpm run verify` (lint + format check + typecheck + full test suite) passes.
- Docs checked, no update needed.

## On "faster per-call fail-over" (item 4)
I intentionally did **not** add a per-model failover timeout here. PR #428 adds an overall AI wall-time budget (`AbortSignal.timeout`); stacking a second per-call timer would risk doubling tail latency (abort model A after N s, then run model B for another N s). The tiering above already shortens the common-case path by leading with the faster model. If you want a dedicated stalled-call failover on top of the #428 budget, I'll add it as a follow-up — let me know.

Link to Devin session: https://app.devin.ai/sessions/5c32ebd36f27441fb5181b875968987f
Requested by: @JoviDeCroock
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jovidecroock/drydock/pull/431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->