### PR TITLE
Align dashboard state select height with toolbar buttons

### DIFF
--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -1,5 +1,18 @@
 import type { ComponentChildren } from "preact";
 import type { Signal } from "@preact/signals";
+import { cn } from "./cn";
+
+export type SelectSize = "sm" | "md";
+
+const sizeStyles: Record<SelectSize, string> = {
+  sm: "text-xs leading-none pl-2.5 pr-8 py-1.5",
+  md: "text-[13px] pl-3 pr-9 py-2",
+};
+
+const arrowStyles: Record<SelectSize, string> = {
+  sm: "right-2.5",
+  md: "right-3",
+};
 
 export function Select({
   id,
@@ -7,12 +20,14 @@ export function Select({
   disabled,
   onChange,
   children,
+  size = "md",
 }: {
   id?: string;
   value: string | Signal<string>;
   disabled?: boolean | Signal<boolean>;
   onChange: (value: string) => void;
   children: ComponentChildren;
+  size?: SelectSize;
 }) {
   return (
     <div class="relative inline-block w-full">
@@ -21,13 +36,19 @@ export function Select({
         value={value}
         disabled={disabled}
         onChange={(event) => onChange((event.currentTarget as HTMLSelectElement).value)}
-        class="appearance-none w-full bg-bg border border-border rounded-md text-[13px] text-ink pl-3 pr-9 py-2 outline-none transition-[border-color,box-shadow] duration-150 ease-out focus:border-accent focus:shadow-[0_0_0_3px_var(--color-accent-soft)] disabled:opacity-60 disabled:cursor-not-allowed"
+        class={cn(
+          "appearance-none w-full bg-bg border border-border rounded-md text-ink outline-none transition-[border-color,box-shadow] duration-150 ease-out focus:border-accent focus:shadow-[0_0_0_3px_var(--color-accent-soft)] disabled:opacity-60 disabled:cursor-not-allowed",
+          sizeStyles[size],
+        )}
       >
         {children}
       </select>
       <span
         aria-hidden="true"
-        class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[10px] text-ink-muted"
+        class={cn(
+          "pointer-events-none absolute top-1/2 -translate-y-1/2 text-[10px] text-ink-muted",
+          arrowStyles[size],
+        )}
       >
         ▾
       </span>

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -344,6 +344,7 @@ function ScanStateSelect({
       <span class="w-[160px]">
         <Select
           id="scan-state-filter"
+          size="sm"
           value={value}
           disabled={disabled}
           onChange={(next) => onChange(parseDecisionFilter(next))}


### PR DESCRIPTION
## Summary

The `STATE` filter `<select>` on the dashboard listing screen rendered noticeably taller/larger than the `Check npm` / `Refresh` buttons beside it, because `Select` was hard-coded to the `md`-equivalent sizing (`text-[13px] py-2`) while the toolbar buttons are `size="sm"` — a clear height mismatch.

Fix: add a `size` prop to the shared `Select` component (mirroring `Button`), defaulting to `md` so existing Settings forms and the canonical control are unchanged, and use `size="sm"` for the dashboard filter so it lines up with the adjacent `sm` buttons.

```
Select({ ..., size = "md" })
  sm -> text-xs leading-none pl-2.5 pr-8 py-1.5   (arrow right-2.5)
  md -> text-[13px] pl-3 pr-9 py-2                 (arrow right-3)  // unchanged default
```

Only the Dashboard toolbar opts into `sm`; `VersionPicker` has its own `<select>` and is untouched.

Verified with `pnpm run lint`, `pnpm run typecheck`, `pnpm run format:check` (all pass). The Cloudflare dev server requires remote auth that isn't available here, so I confirmed the height alignment with a faithful static reproduction of the exact computed classes in dark mode (before vs. after):

![before/after](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctOWJlNTAzZmJmODRhNDVjMTg2NDQyZDhmMWY2NDVkODQiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctOWJlNTAzZmJmODRhNDVjMTg2NDQyZDhmMWY2NDVkODQvY2M5YThhMGQtYjhhYS00NDYwLWJlNTMtYjA5YWM2NWM1OWYxIiwiaWF0IjoxNzgyODQyODc3LCJleHAiOjE3ODM0NDc2NzcsImZpbGVuYW1lIjoic3Nfem9vbV83MDQ4MDlhMC5wbmcifQ.T1ZliuWMisx6nZn49AJ-NWuu0L4mo37hBeBQcOZ3Scs)

docs checked, no update needed (the canonical `md` select sizing in `DESIGN.md` is preserved as the default).

Link to Devin session: https://app.devin.ai/sessions/ede612e4ad3f4671a8a7bd510a566f94
Requested by: @JoviDeCroock
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jovidecroock/drydock/pull/432" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->