### PR TITLE
Reorder marketing header to Home/Dashboard, Docs, Feedback

### DIFF
--- a/src/components/PageShell.tsx
+++ b/src/components/PageShell.tsx
@@ -26,12 +26,14 @@ export function PageShell({
   width = "wide",
   brand = true,
   headerActions,
+  feedbackPosition = "start",
 }: {
   class?: string;
   children: ComponentChildren;
   width?: "narrow" | "doc" | "wide";
   brand?: boolean;
   headerActions?: ComponentChildren;
+  feedbackPosition?: "start" | "end";
 }) {
   const maxWidth = WIDTH_CLASS[width];
   // Narrow pages are single short cards (auth, 404, invite). Center them in the
@@ -63,15 +65,9 @@ export function PageShell({
               )}
             </div>
             <div class="flex items-center gap-2">
-              <LinkButton
-                href={FEEDBACK_MAILTO}
-                variant="ghost"
-                size="sm"
-                title="Email drydock@drydock.org with any issues"
-              >
-                Feedback
-              </LinkButton>
+              {feedbackPosition === "start" ? <FeedbackButton /> : null}
               {headerActions}
+              {feedbackPosition === "end" ? <FeedbackButton /> : null}
             </div>
           </div>
         ) : null}
@@ -84,6 +80,19 @@ export function PageShell({
       </main>
       <SiteFooter maxWidth={maxWidth} />
     </div>
+  );
+}
+
+function FeedbackButton() {
+  return (
+    <LinkButton
+      href={FEEDBACK_MAILTO}
+      variant="ghost"
+      size="sm"
+      title="Email drydock@drydock.org with any issues"
+    >
+      Feedback
+    </LinkButton>
   );
 }
 

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -8,7 +8,11 @@ export default function DocsPage() {
   const authed = useAuthedSession();
 
   return (
-    <PageShell class="gap-12" headerActions={<MarketingHeaderActions authed={authed} />}>
+    <PageShell
+      class="gap-12"
+      headerActions={<MarketingHeaderActions authed={authed} />}
+      feedbackPosition="end"
+    >
       <PageSeo metadata={docsPageSeo} />
       <header class="py-8 md:py-12 border-t border-border flex flex-col gap-5">
         <Eyebrow tone="accent">Documentation</Eyebrow>

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -21,7 +21,11 @@ export default function LandingPage() {
   const authed = useAuthedSession();
 
   return (
-    <PageShell class="gap-12" headerActions={<MarketingHeaderActions authed={authed} />}>
+    <PageShell
+      class="gap-12"
+      headerActions={<MarketingHeaderActions authed={authed} />}
+      feedbackPosition="end"
+    >
       <PageSeo metadata={homePageSeo} />
       <section class="py-8 md:py-12 border-t border-border flex flex-col gap-5">
         <Eyebrow tone="accent">Package review before npm or PyPI publish</Eyebrow>

--- a/src/pages/MarketingHeaderActions.tsx
+++ b/src/pages/MarketingHeaderActions.tsx
@@ -5,17 +5,21 @@ import { LinkButton } from "../components";
 export function MarketingHeaderActions({ authed }: { authed: Signal<boolean> }) {
   return (
     <>
-      <LinkButton href="/" variant="ghost" size="sm">
-        Home
-      </LinkButton>
-      <LinkButton href="/docs" variant="ghost" size="sm">
-        Docs
-      </LinkButton>
-      <Show when={authed}>
+      <Show
+        when={authed}
+        fallback={
+          <LinkButton href="/" variant="ghost" size="sm">
+            Home
+          </LinkButton>
+        }
+      >
         <LinkButton href="/dashboard" variant="ghost" size="sm">
           Dashboard
         </LinkButton>
       </Show>
+      <LinkButton href="/docs" variant="ghost" size="sm">
+        Docs
+      </LinkButton>
     </>
   );
 }


### PR DESCRIPTION
## Summary
Reorders the marketing header (Landing + Docs) so the nav reads `Home/Dashboard · Docs · Feedback`, with `Home` shown when unauthenticated and `Dashboard` when authenticated (previously both could appear, with `Feedback` first).

Two changes:
- `MarketingHeaderActions` now renders `Home`/`Dashboard` mutually exclusively via `<Show when={authed} fallback={Home}>Dashboard</Show>`, followed by `Docs`.
- `PageShell` gains a `feedbackPosition?: "start" | "end"` prop (default `"start"`, preserving current behavior on dashboard/account pages where the user menu stays rightmost). Landing and Docs pass `"end"` so `Feedback` renders after `headerActions`.

The `Feedback` button markup was extracted into a small `FeedbackButton` helper to render in either position without duplicating the mailto config.

docs checked, no update needed (DESIGN.md doesn't pin header action ordering).

Link to Devin session: https://app.devin.ai/sessions/b9cbce62a4314e398ddc0aba1c809624
Requested by: @JoviDeCroock
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jovidecroock/drydock/pull/433" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->