### PR TITLE
Add FSL license and wrangler template for self-hosting

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,105 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2026 Resynapse
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publicly perform, publicly display
+and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use
+means making the Software available to others in a commercial product or
+service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of
+the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR
+PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE
+SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES,
+EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under
+the Apache License, Version 2.0 that is effective on the second anniversary of
+the date we make the Software available. On or after that date, you may use the
+Software under the Apache License, Version 2.0, in which case the following
+will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -85,3 +85,11 @@ Consult route definitions under `server/routes/` for exact request/response shap
 - Raw tarballs are not retained by default; persisted reports use redacted summaries and canonical report JSON.
 
 See [`docs/security-model.md`](docs/security-model.md) for the full contract.
+
+## License
+
+Drydock is released under the [Functional Source License, Version 1.1, Apache 2.0
+Future License](LICENSE.md) (`FSL-1.1-Apache-2.0`). You may read, self-host,
+modify, and contribute to Drydock for free; the license only bars using it to
+offer a competing commercial product or service. Each release converts to the
+Apache License 2.0 two years after it is made available.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -56,14 +56,20 @@ pnpm exec wrangler r2 bucket create staged-publish-review-artifacts
 ```
 
 The checked-in `wrangler.jsonc` targets the maintainers' production deployment.
-Do not deploy from it. Instead, copy the template and fill in your own values:
+Do not deploy from it. In your own fork, replace the contents of `wrangler.jsonc`
+with `wrangler.template.jsonc` and fill in your account values:
 
 ```sh
 cp wrangler.template.jsonc wrangler.jsonc
 ```
 
-`wrangler.template.jsonc` marks every account-owned value with a `REPLACE_*`
-placeholder. Replace at least:
+`wrangler.jsonc` is tracked in git, so this leaves your fork with account-specific
+edits in a tracked file. That is expected for a fork; just do not include those
+edits in pull requests you send back upstream.
+
+`wrangler.template.jsonc` keeps the production resource names (so the
+`db:migrate:*` scripts work unchanged) and marks every account-owned value with a
+`REPLACE_*` placeholder. Replace at least:
 
 - `d1_databases[].database_id` and `kv_namespaces[].id`;
 - custom `routes` with your own custom domain, or remove `routes` and use the

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -55,12 +55,19 @@ pnpm exec wrangler kv namespace create COMPARE_CACHE
 pnpm exec wrangler r2 bucket create staged-publish-review-artifacts
 ```
 
-The checked-in `wrangler.jsonc` is the Drydock deployment config. Before
-deploying from another Cloudflare account, replace account-owned values:
+The checked-in `wrangler.jsonc` targets the maintainers' production deployment.
+Do not deploy from it. Instead, copy the template and fill in your own values:
+
+```sh
+cp wrangler.template.jsonc wrangler.jsonc
+```
+
+`wrangler.template.jsonc` marks every account-owned value with a `REPLACE_*`
+placeholder. Replace at least:
 
 - `d1_databases[].database_id` and `kv_namespaces[].id`;
-- custom `routes` for `drydock.org` / `drydock.resynapse.dev`, or remove
-  `routes` and use `workers_dev` / your own routes instead;
+- custom `routes` with your own custom domain, or remove `routes` and use the
+  generated `workers_dev` subdomain instead;
 - the `flagship` app id if you use Cloudflare Flagship for AI review, or remove
   the `flagship` block to keep AI review disabled;
 - public integration vars such as `BETTER_AUTH_URL`, `EMAIL_FROM_ADDRESS`,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "staged-publish-review",
   "private": true,
+  "license": "SEE LICENSE IN LICENSE.md",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/wrangler.template.jsonc
+++ b/wrangler.template.jsonc
@@ -1,0 +1,118 @@
+// Wrangler configuration template for self-hosting Drydock on your own
+// Cloudflare account. Copy this to `wrangler.jsonc` and replace every
+// REPLACE_* placeholder with values from your account. See
+// `docs/self-hosting.md` for the full walkthrough.
+//
+// The canonical `wrangler.jsonc` in this repo targets the maintainers'
+// production deployment; do not deploy with it. Fork from this template.
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "drydock",
+	"main": "./server/index.ts",
+	"compatibility_date": "2026-05-20",
+	"compatibility_flags": [
+		"nodejs_compat"
+	],
+	"workers_dev": true,
+	"observability": {
+		"logs": {
+			"enabled": true,
+			"invocation_logs": true
+		}
+	},
+	"assets": {
+		"not_found_handling": "single-page-application",
+		"binding": "ASSETS",
+		"run_worker_first": true
+	},
+	"ai": {
+		"binding": "AI"
+	},
+	// Optional: only needed if you use Cloudflare Flagship to gate the AI
+	// reviewer. Remove this block to keep AI review disabled, or set your own
+	// Flagship app id.
+	"flagship": [
+		{
+			"binding": "FLAGS",
+			"app_id": "REPLACE_WITH_YOUR_FLAGSHIP_APP_ID"
+		}
+	],
+	"worker_loaders": [
+		{
+			"binding": "LOADER"
+		}
+	],
+	"d1_databases": [
+		{
+			"binding": "DB",
+			"database_name": "drydock",
+			// From: pnpm exec wrangler d1 create drydock
+			"database_id": "REPLACE_WITH_YOUR_D1_DATABASE_ID",
+			"migrations_dir": "drizzle"
+		}
+	],
+	"kv_namespaces": [
+		{
+			"binding": "COMPARE_CACHE",
+			// From: pnpm exec wrangler kv namespace create COMPARE_CACHE
+			"id": "REPLACE_WITH_YOUR_KV_NAMESPACE_ID"
+		}
+	],
+	"r2_buckets": [
+		{
+			"binding": "ARTIFACTS",
+			"bucket_name": "drydock-artifacts"
+		}
+	],
+	"queues": {
+		"producers": [
+			{
+				"binding": "SCAN_QUEUE",
+				"queue": "drydock-scans"
+			}
+		],
+		"consumers": [
+			{
+				"queue": "drydock-scans",
+				"max_batch_size": 1,
+				"max_batch_timeout": 5,
+				"max_concurrency": 10,
+				"max_retries": 3,
+				"dead_letter_queue": "drydock-scans-dlq"
+			}
+		]
+	},
+	"send_email": [
+		{
+			"name": "SEND_EMAIL"
+		}
+	],
+	"triggers": {
+		"crons": [
+			"*/15 * * * *"
+		]
+	},
+	// Remove `routes` to serve on your generated *.workers.dev subdomain, or
+	// replace these with your own custom domain(s).
+	"routes": [
+		{
+			"pattern": "REPLACE_WITH_YOUR_DOMAIN",
+			"custom_domain": true
+		}
+	],
+	"vars": {
+		// Must match your deployed origin (custom domain or *.workers.dev URL).
+		"BETTER_AUTH_URL": "https://REPLACE_WITH_YOUR_ORIGIN",
+		"AI_CACHE_AFFINITY": "drydock-release-reviewer-v1",
+		"NPM_REGISTRY": "https://registry.npmjs.org",
+		"PNPM_VERSION": "11.1.1",
+		"EMAIL_FROM_ADDRESS": "drydock@REPLACE_WITH_YOUR_DOMAIN",
+		"EMAIL_FROM_NAME": "Drydock",
+		// Optional GitHub App (workflow gates). Remove if unused.
+		"GITHUB_APP_ID": "REPLACE_WITH_YOUR_GITHUB_APP_ID",
+		"GITHUB_APP_SLUG": "REPLACE_WITH_YOUR_GITHUB_APP_SLUG",
+		"GITHUB_APP_CLIENT_ID": "REPLACE_WITH_YOUR_GITHUB_APP_CLIENT_ID",
+		// Optional Slack app (notifications). Remove if unused.
+		"SLACK_CLIENT_ID": "REPLACE_WITH_YOUR_SLACK_CLIENT_ID"
+	}
+}

--- a/wrangler.template.jsonc
+++ b/wrangler.template.jsonc
@@ -7,7 +7,10 @@
 // production deployment; do not deploy with it. Fork from this template.
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
-	"name": "drydock",
+	// Worker service name. Kept as `staged-publish-review` so the `db:migrate:*`
+	// scripts in package.json (which target the D1 database `staged-publish-review`)
+	// work unchanged. Rename both together if you prefer a different name.
+	"name": "staged-publish-review",
 	"main": "./server/index.ts",
 	"compatibility_date": "2026-05-20",
 	"compatibility_flags": [
@@ -45,8 +48,8 @@
 	"d1_databases": [
 		{
 			"binding": "DB",
-			"database_name": "drydock",
-			// From: pnpm exec wrangler d1 create drydock
+			"database_name": "staged-publish-review",
+			// From: pnpm exec wrangler d1 create staged-publish-review
 			"database_id": "REPLACE_WITH_YOUR_D1_DATABASE_ID",
 			"migrations_dir": "drizzle"
 		}
@@ -61,24 +64,24 @@
 	"r2_buckets": [
 		{
 			"binding": "ARTIFACTS",
-			"bucket_name": "drydock-artifacts"
+			"bucket_name": "staged-publish-review-artifacts"
 		}
 	],
 	"queues": {
 		"producers": [
 			{
 				"binding": "SCAN_QUEUE",
-				"queue": "drydock-scans"
+				"queue": "staged-publish-review-scans"
 			}
 		],
 		"consumers": [
 			{
-				"queue": "drydock-scans",
+				"queue": "staged-publish-review-scans",
 				"max_batch_size": 1,
 				"max_batch_timeout": 5,
 				"max_concurrency": 10,
 				"max_retries": 3,
-				"dead_letter_queue": "drydock-scans-dlq"
+				"dead_letter_queue": "staged-publish-review-scans-dlq"
 			}
 		]
 	},


### PR DESCRIPTION
## Summary

Prep for making the repo public: pick a license and stop a fresh clone from deploying against the maintainers' production Cloudflare account.

- **`LICENSE.md`** — Functional Source License `FSL-1.1-Apache-2.0` (Sentry's Fair Source license). Free to read/self-host/modify/contribute; the only bar is a *competing commercial offering* (a paid hosted Drydock). Each release auto-converts to Apache-2.0 after 2 years. Copyright notice reads `Copyright 2026 Resynapse` — flag if the licensor entity should be different (e.g. your name or another legal entity).
- **`package.json`** — `"license": "SEE LICENSE IN LICENSE.md"` (npm-recommended form for a non-SPDX license; kept `"private": true`).
- **`wrangler.template.jsonc`** — new; mirrors `wrangler.jsonc` structure with every account-owned value replaced by a `REPLACE_*` placeholder (D1/KV IDs, Flagship app id, routes/domain, origin, email, GitHub App + Slack IDs). The real `wrangler.jsonc` (production config) is left untouched.
- **`docs/self-hosting.md`** — now instructs `cp wrangler.template.jsonc wrangler.jsonc` and fill placeholders, instead of editing the checked-in production config.
- **`README.md`** — adds a License section.

Docs checked; self-hosting doc updated.

### Not included (open questions from the thread)
- Branded legal/marketing surfaces (e.g. `privacy@drydock.org` in `src/pages/Privacy`) are left as-is — decide separately whether to template them for self-hosters.
- Repo-settings hygiene (private vulnerability reporting, secret scanning/push protection, branch protection, issue/PR templates) is out of scope for this PR.

Link to Devin session: https://app.devin.ai/sessions/ae503695de54462382d796edd9a9bde9
Requested by: @JoviDeCroock
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jovidecroock/drydock/pull/435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->