### PR TITLE
Add AI reviewer model-comparison eval (pnpm run eval:ai)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,8 @@ New functionality needs tests at the narrowest useful layer; add broader coverag
 - `pnpm run typecheck` — TypeScript typecheck.
 - `pnpm run test` — Vitest logic + Worker-runtime suites.
 - `pnpm run test:e2e` — Playwright fake-registry e2e.
-- `pnpm run eval` — detection eval harness.
+- `pnpm run eval` — deterministic detection eval harness.
+- `pnpm run eval:ai` — AI-reviewer model comparison (live Workers AI; not in `pnpm test`/CI). See `docs/ai-review-eval.md`.
 - `pnpm db:generate` — generate Drizzle migrations; never hand-write SQL migrations.
 
 ## Documentation expectations

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,7 +27,8 @@ Start here instead of reading every Markdown file. Pick the smallest set that ma
 ## Domain docs
 
 - [`security-detection-corpus.md`](./security-detection-corpus.md) — rule/eval fixture layout and expected findings.
-- [`detection-eval.md`](./detection-eval.md) — eval harness, metrics, and gates.
+- [`detection-eval.md`](./detection-eval.md) — deterministic-rule eval harness, metrics, and gates.
+- [`ai-review-eval.md`](./ai-review-eval.md) — AI-reviewer model comparison eval (`pnpm run eval:ai`).
 - [`organization-members.md`](./organization-members.md) — organization invitation/membership behavior.
 - [`two-factor-auth.md`](./two-factor-auth.md) — step-up auth and sensitive actions.
 - [`slack-notifications.md`](./slack-notifications.md) — Slack install and notification flow.

--- a/docs/ai-review-eval.md
+++ b/docs/ai-review-eval.md
@@ -60,14 +60,14 @@ up in gateway logs/cost analytics). Set `AI_EVAL_NO_GATEWAY=1` to bypass it or
 
 All via environment variables:
 
-| var | default | meaning |
-| --- | --- | --- |
-| `AI_EVAL_MODELS` | shipped candidates + a couple cheaper models | comma-separated model ids to compare |
-| `AI_EVAL_GATEWAY_ID` | `drydock-gateway` | AI Gateway id to route through |
-| `AI_EVAL_NO_GATEWAY` | unset | set to bypass the gateway |
-| `AI_EVAL_PRICES` | `{}` | JSON `{ "<model>": { "input": usdPer1MInput, "output": usdPer1MOutput } }` for cost estimates |
-| `AI_EVAL_CONCURRENCY` | `4` | per-model case concurrency |
-| `AI_EVAL_LIMIT` | all | cap the number of cases (smoke runs) |
+| var                   | default                                      | meaning                                                                                       |
+| --------------------- | -------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `AI_EVAL_MODELS`      | shipped candidates + a couple cheaper models | comma-separated model ids to compare                                                          |
+| `AI_EVAL_GATEWAY_ID`  | `drydock-gateway`                            | AI Gateway id to route through                                                                |
+| `AI_EVAL_NO_GATEWAY`  | unset                                        | set to bypass the gateway                                                                     |
+| `AI_EVAL_PRICES`      | `{}`                                         | JSON `{ "<model>": { "input": usdPer1MInput, "output": usdPer1MOutput } }` for cost estimates |
+| `AI_EVAL_CONCURRENCY` | `4`                                          | per-model case concurrency                                                                    |
+| `AI_EVAL_LIMIT`       | all                                          | cap the number of cases (smoke runs)                                                          |
 
 Example — compare the current primary against a cheaper model, with prices:
 

--- a/docs/ai-review-eval.md
+++ b/docs/ai-review-eval.md
@@ -1,0 +1,117 @@
+# AI reviewer eval harness
+
+Drydock's AI reviewer (`server/lib/ai-review.ts`) is an advisory, agentic
+Workers AI loop. It is default-off behind the `ai-review` flag and pinned to a
+model order (`AI_MODEL` primary, `AI_FALLBACK_MODEL` secondary). When we want to
+switch to a cheaper model — or add a new fallback — we need to _measure_ whether
+it still catches what the current one does, rather than eyeballing a few scans.
+
+This harness scores the AI reviewer on the labeled security corpus and compares
+several models side by side (recall, benign false positives, error rate, agent
+steps, tokens, latency, and optional $ cost). It is the AI-reviewer analogue of
+the deterministic [detection eval](./detection-eval.md).
+
+## What it measures — and what it doesn't
+
+- It exercises the **real** reviewer code path. Each corpus case is turned into
+  the exact `SelectiveAiReviewOptions` the scan pipeline builds
+  (`deterministicFindings` + file/manifest diff over the fixture's staged and
+  previous files), then run through `analyzeWithAi` with the model under test.
+  Nothing mocks the reviewer contract, tools, or retry/fallback logic.
+- It scores the **model's own verdict** — the `risk`/`releaseAssessment` the
+  model reports — not the production risk roll-up (`computeScanRisk`). That is
+  deliberate: the roll-up folds in the deterministic findings, which on this
+  corpus are strong, and would mask the model's contribution. The eval isolates
+  "would this model, on its own, flag the release?"
+- Only **npm** cases are scored. The npm fixture payload maps 1:1 to the npm
+  reviewer options; PyPI cases use a different artifact shape and are skipped.
+
+It reuses the same corpus and labels as the detection eval (`cases/`,
+`cases-frontier/`, `cases-benign/`; see
+[security-detection-corpus.md](./security-detection-corpus.md)), so the two
+evals never drift on what "malicious"/"benign" means.
+
+## Running it
+
+```sh
+pnpm run eval:ai
+```
+
+Unlike `pnpm run eval`, this is **not** part of `pnpm test` or CI: it makes
+live, paid, non-deterministic Workers AI calls. It lives in its own Vitest
+config (`vitest.ai-eval.config.ts`) and is excluded from the default node
+project. Without credentials the run skips cleanly, so an accidental invocation
+never fails.
+
+### Credentials
+
+`createWorkersAI` runs in credentials mode, so the eval works from Node without
+a Worker binding:
+
+- `CLOUDFLARE_ACCOUNT_ID` — Cloudflare account id.
+- `CLOUDFLARE_API_TOKEN` — an API token with Workers AI run permission
+  (`WORKERS_AI_API_TOKEN` is also accepted).
+
+By default requests route through the `drydock-gateway` AI Gateway (so runs show
+up in gateway logs/cost analytics). Set `AI_EVAL_NO_GATEWAY=1` to bypass it or
+`AI_EVAL_GATEWAY_ID=<id>` to use a different gateway.
+
+### Configuration
+
+All via environment variables:
+
+| var | default | meaning |
+| --- | --- | --- |
+| `AI_EVAL_MODELS` | shipped candidates + a couple cheaper models | comma-separated model ids to compare |
+| `AI_EVAL_GATEWAY_ID` | `drydock-gateway` | AI Gateway id to route through |
+| `AI_EVAL_NO_GATEWAY` | unset | set to bypass the gateway |
+| `AI_EVAL_PRICES` | `{}` | JSON `{ "<model>": { "input": usdPer1MInput, "output": usdPer1MOutput } }` for cost estimates |
+| `AI_EVAL_CONCURRENCY` | `4` | per-model case concurrency |
+| `AI_EVAL_LIMIT` | all | cap the number of cases (smoke runs) |
+
+Example — compare the current primary against a cheaper model, with prices:
+
+```sh
+CLOUDFLARE_ACCOUNT_ID=… CLOUDFLARE_API_TOKEN=… \
+AI_EVAL_MODELS='@cf/moonshotai/kimi-k2.7-code,@cf/meta/llama-3.3-70b-instruct-fp8-fast' \
+AI_EVAL_PRICES='{"@cf/meta/llama-3.3-70b-instruct-fp8-fast":{"input":0.29,"output":2.25}}' \
+pnpm run eval:ai
+```
+
+Cost is only shown for models with a price entry; everything else prints `n/a`
+rather than guessing. Token counts and latency are always reported and are the
+model-agnostic proxy for "cheaper".
+
+## Output
+
+The report is written to `.context/eval/ai-review-eval.{md,json,tsv}`
+(gitignored). The `.md` is the human summary, `.json` includes every per-case
+result for debugging, and `.tsv` renders as a table in Slack.
+
+## Metrics
+
+Per model, over the npm corpus:
+
+- **recall** — malicious cases the model's risk reaches the case's labeled
+  `expectMinRisk`. The headline "does the cheaper model still catch the bad
+  ones" number.
+- **risky-recall** — malicious cases the model rolls up to `>= medium`. A
+  looser, model-agnostic bar (useful when a model is consistently one notch
+  less severe).
+- **benign FP rate** — benign hard-negatives the model rolls up to `>= medium`.
+  Precision cost of the model.
+- **error rate** — cases that did not complete (`invalid`/`unavailable`,
+  including model failures, which fail safe to `unavailable`).
+- **avg steps / input tokens / output tokens / latency** — cost and speed.
+- **est. cost** — from `AI_EVAL_PRICES`, or `n/a`.
+
+Misses (uncaught malicious) and benign false positives are listed per model so a
+regression is diagnosable, not just a number.
+
+## Extending
+
+- Add cases the same way as the detection eval — new corpus fixtures under
+  `test/fixtures/security-corpus/` are picked up automatically.
+- The harness (`test/eval/ai-review-harness.mjs`) is pure except for
+  `evaluateModel`; `summarize`/rendering/`estimateCost` are unit-tested with
+  mock reviewer output in `test/eval/ai-review-harness.test.mjs`.

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:node": "vitest run --project node",
     "test:workers": "vitest run --project workers",
     "eval": "vitest run --project node test/eval/detection-eval.test.mjs",
+    "eval:ai": "vitest run --config vitest.ai-eval.config.ts",
     "fuzz": "FUZZ_RUNS=20000 vitest run --project node --testTimeout=600000 test/archive-parser.fuzz.test.mjs",
     "e2e:fixtures": "node test/e2e/build-fixtures.mjs",
     "e2e:registry": "node test/e2e/fake-registry.mjs",

--- a/test/eval/ai-review-eval.test.mjs
+++ b/test/eval/ai-review-eval.test.mjs
@@ -1,0 +1,127 @@
+// AI reviewer model comparison. This is NOT part of `pnpm test`/CI: it makes
+// live, paid Workers AI calls and is non-deterministic. Run it on demand with
+//
+//   pnpm run eval:ai
+//
+// It is deliberately excluded from the default node project (vitest.node.config.ts)
+// and only picked up by vitest.ai-eval.config.ts. Without Workers AI credentials
+// it skips cleanly so an accidental invocation never fails.
+//
+// Configuration (all via env):
+//   CLOUDFLARE_ACCOUNT_ID   Cloudflare account id (required)
+//   CLOUDFLARE_API_TOKEN    Workers AI API token   (required; WORKERS_AI_API_TOKEN also accepted)
+//   AI_EVAL_MODELS          comma-separated model ids to compare (default: the shipped candidates + cheaper ones)
+//   AI_EVAL_GATEWAY_ID      AI Gateway id to route through (default: drydock-gateway; set AI_EVAL_NO_GATEWAY=1 to bypass)
+//   AI_EVAL_PRICES          JSON map { "<model>": { "input": usdPer1MInput, "output": usdPer1MOutput } } for cost estimates
+//   AI_EVAL_CONCURRENCY     per-model case concurrency (default: 4)
+//   AI_EVAL_LIMIT           cap the number of cases (smoke runs)
+//
+// See docs/ai-review-eval.md.
+
+import { describe, expect, test } from "vitest";
+import { createWorkersAI } from "workers-ai-provider";
+import { evaluateModel, estimateCost, loadNpmCorpus, writeReport } from "./ai-review-harness.mjs";
+
+// The shipped reviewer order (see server/lib/ai-review.ts) plus a few cheaper /
+// alternative Workers AI models to compare against. Override with AI_EVAL_MODELS.
+const DEFAULT_MODELS = [
+  "@cf/moonshotai/kimi-k2.7-code",
+  "@cf/qwen/qwen3-30b-a3b-fp8",
+  "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+  "@cf/openai/gpt-oss-120b",
+];
+
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+const apiKey = process.env.CLOUDFLARE_API_TOKEN ?? process.env.WORKERS_AI_API_TOKEN;
+const hasCredentials = Boolean(accountId && apiKey);
+
+const models = (process.env.AI_EVAL_MODELS ?? DEFAULT_MODELS.join(","))
+  .split(",")
+  .map((model) => model.trim())
+  .filter(Boolean);
+
+const gatewayId = process.env.AI_EVAL_NO_GATEWAY
+  ? undefined
+  : (process.env.AI_EVAL_GATEWAY_ID ?? "drydock-gateway");
+
+const concurrency = Number(process.env.AI_EVAL_CONCURRENCY ?? 4);
+
+function parsePrices() {
+  if (!process.env.AI_EVAL_PRICES) return {};
+  try {
+    return JSON.parse(process.env.AI_EVAL_PRICES);
+  } catch (err) {
+    throw new Error(
+      `AI_EVAL_PRICES is not valid JSON: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+}
+
+describe("AI reviewer model comparison", () => {
+  test.skipIf(!hasCredentials || models.length === 0)(
+    "scores every configured model on the npm corpus",
+    async () => {
+      const prices = parsePrices();
+      const provider = createWorkersAI({ accountId, apiKey });
+      const createLanguageModel = (model) =>
+        provider(model, gatewayId ? { gateway: { id: gatewayId } } : {});
+
+      const allCases = loadNpmCorpus();
+      const limit = process.env.AI_EVAL_LIMIT ? Number(process.env.AI_EVAL_LIMIT) : allCases.length;
+      const cases = allCases.slice(0, limit);
+      expect(cases.length).toBeGreaterThan(0);
+
+      const malicious = cases.filter((record) => record.verdict === "malicious").length;
+      const evaluated = [];
+      for (const model of models) {
+        process.stdout.write(`\neval:ai — ${model} (${cases.length} cases)…\n`);
+        let done = 0;
+        const outcome = await evaluateModel({
+          model,
+          createLanguageModel,
+          cases,
+          concurrency,
+          onResult: () => {
+            done += 1;
+            process.stdout.write(`  ${done}/${cases.length}\r`);
+          },
+        });
+        evaluated.push({
+          model,
+          metrics: outcome.metrics,
+          cost: estimateCost(outcome.metrics, prices[model]),
+          cases: outcome.cases,
+        });
+      }
+
+      const report = {
+        generatedAt: new Date().toISOString(),
+        corpusSize: cases.length,
+        malicious,
+        benign: cases.length - malicious,
+        gatewayId: gatewayId ?? null,
+        models: evaluated,
+      };
+
+      const outDir = writeReport(report);
+      process.stdout.write("\n\nmodel comparison:\n");
+      for (const entry of report.models) {
+        const m = entry.metrics;
+        const fmt = (value) => (value == null ? "n/a" : `${(value * 100).toFixed(0)}%`);
+        process.stdout.write(
+          `  ${entry.model}: recall ${fmt(m.recall)}, benign FP ${fmt(m.benignFpRate)}, errors ${fmt(m.errorRate)}, avg ${m.avgTotalTokens == null ? "n/a" : m.avgTotalTokens.toFixed(0)} tok\n`,
+        );
+      }
+      if (outDir)
+        process.stdout.write(`\nreport written to ${outDir}/ai-review-eval.{md,json,tsv}\n`);
+
+      // The eval reports quality; it does not gate. Assert only that every model
+      // produced a scored result so a broken harness/credentials fails loudly.
+      for (const entry of report.models) {
+        expect(entry.metrics.total).toBe(cases.length);
+      }
+    },
+    // Live agentic runs across the corpus for several models are slow.
+    30 * 60 * 1000,
+  );
+});

--- a/test/eval/ai-review-harness.mjs
+++ b/test/eval/ai-review-harness.mjs
@@ -1,0 +1,333 @@
+// AI-reviewer eval harness.
+//
+// The detection harness (test/eval/harness.mjs) scores the *deterministic*
+// rules. This one scores the *AI reviewer* — the agentic Workers AI loop in
+// server/lib/ai-review.ts — so we can compare models (e.g. a cheaper fallback)
+// on the same labeled corpus before switching what production runs.
+//
+// It reuses the real production code path: every case is turned into the exact
+// SelectiveAiReviewOptions the scan pipeline builds (deterministic findings +
+// diff + manifest diff over the fixture's staged/previous files), then fed
+// through analyzeWithAi with a per-model language model. Nothing here mocks the
+// reviewer contract, so a passing eval reflects what a real scan would produce.
+//
+// Only npm cases are scored: the fixture payload maps 1:1 to the npm reviewer
+// options (files/diff/packageJsonDiff). PyPI cases use a different artifact
+// shape and are skipped. See docs/ai-review-eval.md.
+
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  createPackageDiff,
+  deterministicFindings,
+  packageJsonDiffFindings,
+  summarizePackageJsonDiff,
+} from "../../server/lib/review.ts";
+import { analyzeWithAi } from "../../server/lib/ai-review.ts";
+import { loadCorpus } from "./harness.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const RISK_RANK = { low: 0, medium: 1, high: 2, critical: 3 };
+const riskRank = (level) => RISK_RANK[level] ?? 0;
+
+// A review "flags" a release the way production surfaces it: a completed review
+// whose own risk roll-up is medium or higher. invalid/unavailable are not a
+// flag — they fail *open* here (counted as errors), because in production they
+// escalate to manual review rather than asserting risk.
+const FLAG_RISK = RISK_RANK.medium;
+
+// Load the npm slice of the labeled corpus. Each record already carries the
+// eval labels (verdict / expectMinRisk / threatClass) the detection harness
+// derives; we just narrow to npm and tag the group.
+export function loadNpmCorpus() {
+  const { regression, frontier, benign } = loadCorpus();
+  return [...regression, ...frontier, ...benign]
+    .filter((record) => record.ecosystem === "npm")
+    .map((record) => ({ ...record, group: record.kind }));
+}
+
+// Rebuild the exact reviewer input the scan pipeline feeds the model
+// (server/lib/scan-pipeline.ts -> runSelectiveAiReview): deterministic findings
+// plus the file/manifest diff over the fixture's staged and previous files.
+export function buildReviewOptions(record) {
+  const fx = record.fx;
+  const previousFiles = fx.previousFiles ?? [];
+  const stagedFiles = fx.stagedFiles ?? [];
+  const diff = createPackageDiff(previousFiles, stagedFiles);
+  const packageJsonDiff = summarizePackageJsonDiff(fx.previousPackageJson, fx.stagedPackageJson);
+  const ruleFindings = [
+    ...deterministicFindings(stagedFiles, diff, fx.stagedPackageJson),
+    ...packageJsonDiffFindings(packageJsonDiff),
+  ];
+  return {
+    scanId: `eval-${record.id}`,
+    ecosystem: "npm",
+    files: stagedFiles,
+    previousFiles,
+    diff,
+    packageJsonDiff,
+    ruleFindings,
+    previousVersionAvailable: previousFiles.length > 0,
+  };
+}
+
+function scoreCase(record, review, usage, latencyMs, error) {
+  const status = error ? "error" : (review?.status ?? "error");
+  const complete = status === "complete";
+  const risk = complete ? review.risk : "low";
+  // Model-agnostic flag: does the model's own roll-up land >= medium?
+  const flaggedRisky = complete && riskRank(risk) >= FLAG_RISK;
+  // Stricter: does it reach the label's expected minimum risk?
+  const caughtAtExpected = complete && riskRank(risk) >= riskRank(record.expectMinRisk);
+  return {
+    id: record.id,
+    group: record.group,
+    threatClass: record.threatClass,
+    verdict: record.verdict,
+    expectMinRisk: record.expectMinRisk,
+    status,
+    error: error ?? null,
+    risk: complete ? risk : null,
+    releaseAssessment: complete ? review.releaseAssessment : (review?.releaseAssessment ?? null),
+    summary: review?.summary ?? null,
+    findingCount: review?.findings?.length ?? 0,
+    flaggedRisky,
+    caughtAtExpected,
+    steps: usage?.steps ?? null,
+    inputTokens: usage?.inputTokens ?? null,
+    outputTokens: usage?.outputTokens ?? null,
+    totalTokens: usage?.totalTokens ?? null,
+    latencyMs,
+  };
+}
+
+function mean(values) {
+  const nums = values.filter((value) => typeof value === "number");
+  if (nums.length === 0) return null;
+  return nums.reduce((sum, value) => sum + value, 0) / nums.length;
+}
+
+function sum(values) {
+  return values.reduce((total, value) => total + (typeof value === "number" ? value : 0), 0);
+}
+
+// Aggregate one model's per-case results into the comparison metrics. Kept pure
+// (no model calls) so it can be unit-tested against mock reviewer output.
+export function summarize(caseResults) {
+  const malicious = caseResults.filter((result) => result.verdict === "malicious");
+  const benign = caseResults.filter((result) => result.verdict === "benign");
+  const completed = caseResults.filter((result) => result.status === "complete");
+  const errored = caseResults.filter((result) => result.status !== "complete");
+
+  const maliciousCaught = malicious.filter((result) => result.caughtAtExpected);
+  const maliciousFlagged = malicious.filter((result) => result.flaggedRisky);
+  const benignFalsePositives = benign.filter((result) => result.flaggedRisky);
+
+  const rate = (part, whole) => (whole.length ? part.length / whole.length : null);
+
+  const perThreatClass = {};
+  for (const result of malicious) {
+    const bucket = (perThreatClass[result.threatClass] ??= { total: 0, caught: 0 });
+    bucket.total += 1;
+    if (result.caughtAtExpected) bucket.caught += 1;
+  }
+
+  return {
+    total: caseResults.length,
+    malicious: malicious.length,
+    benign: benign.length,
+    completed: completed.length,
+    errored: errored.length,
+    errorRate: rate(errored, caseResults),
+    // Recall at the labeled expected minimum risk.
+    recall: rate(maliciousCaught, malicious),
+    // Recall at any risky roll-up (>= medium) — a looser, model-agnostic bar.
+    riskyRecall: rate(maliciousFlagged, malicious),
+    benignFalsePositives: benignFalsePositives.length,
+    benignFpRate: rate(benignFalsePositives, benign),
+    misses:
+      maliciousCaught.length < malicious.length
+        ? malicious
+            .filter((result) => !result.caughtAtExpected)
+            .map((result) => ({
+              id: result.id,
+              threatClass: result.threatClass,
+              status: result.status,
+            }))
+        : [],
+    falsePositives: benignFalsePositives.map((result) => ({ id: result.id, risk: result.risk })),
+    perThreatClass,
+    avgSteps: mean(completed.map((result) => result.steps)),
+    avgInputTokens: mean(completed.map((result) => result.inputTokens)),
+    avgOutputTokens: mean(completed.map((result) => result.outputTokens)),
+    avgTotalTokens: mean(completed.map((result) => result.totalTokens)),
+    avgLatencyMs: mean(completed.map((result) => result.latencyMs)),
+    totalInputTokens: sum(caseResults.map((result) => result.inputTokens)),
+    totalOutputTokens: sum(caseResults.map((result) => result.outputTokens)),
+    totalTokens: sum(caseResults.map((result) => result.totalTokens)),
+  };
+}
+
+// Run every case through analyzeWithAi for a single model. `createLanguageModel`
+// returns the AI SDK LanguageModel for a given model id — a live Workers AI
+// model in the runner, or a mock in tests. Bounded concurrency keeps a slow
+// model from serializing the whole run without hammering the gateway.
+export async function evaluateModel({
+  model,
+  createLanguageModel,
+  cases,
+  concurrency = 4,
+  onResult,
+}) {
+  const results = Array.from({ length: cases.length });
+  let next = 0;
+
+  async function worker() {
+    while (true) {
+      const index = next++;
+      if (index >= cases.length) return;
+      const record = cases[index];
+      const options = buildReviewOptions(record);
+      const startedAt = Date.now();
+      let review = null;
+      let usage = null;
+      let error = null;
+      try {
+        const outcome = await analyzeWithAi({}, model, options, (modelId) =>
+          createLanguageModel(modelId),
+        );
+        review = outcome.review;
+        usage = outcome.usage;
+      } catch (err) {
+        error = err instanceof Error ? err.message : String(err);
+      }
+      const scored = scoreCase(record, review, usage, Date.now() - startedAt, error);
+      results[index] = scored;
+      onResult?.(scored);
+    }
+  }
+
+  const workers = Array.from({ length: Math.max(1, Math.min(concurrency, cases.length)) }, worker);
+  await Promise.all(workers);
+  return { model, metrics: summarize(results), cases: results };
+}
+
+// price: optional { input, output } USD per 1M tokens. Returns null when no
+// price is known so the report can honestly print "n/a" instead of guessing.
+export function estimateCost(metrics, price) {
+  if (!price || (price.input == null && price.output == null)) return null;
+  const input = (metrics.totalInputTokens / 1_000_000) * (price.input ?? 0);
+  const output = (metrics.totalOutputTokens / 1_000_000) * (price.output ?? 0);
+  return input + output;
+}
+
+function pct(value) {
+  return value == null ? "n/a" : `${(value * 100).toFixed(0)}%`;
+}
+
+function num(value, digits = 0) {
+  return value == null ? "n/a" : value.toFixed(digits);
+}
+
+function usd(value) {
+  return value == null ? "n/a" : `$${value.toFixed(4)}`;
+}
+
+export function renderMarkdown(report) {
+  const lines = [];
+  lines.push("# AI reviewer eval report");
+  lines.push("");
+  lines.push(`- generated: ${report.generatedAt}`);
+  lines.push(
+    `- corpus: ${report.corpusSize} npm cases (${report.malicious} malicious, ${report.benign} benign)`,
+  );
+  lines.push("");
+  lines.push("Recall is measured at each case's labeled expected minimum risk;");
+  lines.push("benign FP rate is the share of benign controls the model rolls up to >= medium.");
+  lines.push("");
+  lines.push(
+    "| model | recall | risky-recall | benign FP | errors | avg steps | avg in tok | avg out tok | avg latency | est. cost |",
+  );
+  lines.push("| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |");
+  for (const entry of report.models) {
+    const m = entry.metrics;
+    lines.push(
+      `| \`${entry.model}\` | ${pct(m.recall)} | ${pct(m.riskyRecall)} | ${pct(m.benignFpRate)} (${m.benignFalsePositives}/${m.benign}) | ${pct(m.errorRate)} | ${num(m.avgSteps, 1)} | ${num(m.avgInputTokens)} | ${num(m.avgOutputTokens)} | ${num(m.avgLatencyMs)}ms | ${usd(entry.cost)} |`,
+    );
+  }
+  lines.push("");
+  for (const entry of report.models) {
+    lines.push(`## \`${entry.model}\``);
+    lines.push("");
+    const m = entry.metrics;
+    if (m.misses.length) {
+      lines.push("Missed malicious cases:");
+      for (const miss of m.misses) {
+        lines.push(`- \`${miss.id}\` (${miss.threatClass}) — status ${miss.status}`);
+      }
+      lines.push("");
+    }
+    if (m.falsePositives.length) {
+      lines.push("Benign false positives:");
+      for (const fp of m.falsePositives) {
+        lines.push(`- \`${fp.id}\` — risk ${fp.risk}`);
+      }
+      lines.push("");
+    }
+    if (!m.misses.length && !m.falsePositives.length) {
+      lines.push("No missed malicious cases or benign false positives.");
+      lines.push("");
+    }
+  }
+  return lines.join("\n");
+}
+
+export function renderTsv(report) {
+  const rows = [
+    [
+      "model",
+      "recall",
+      "riskyRecall",
+      "benignFpRate",
+      "errorRate",
+      "avgSteps",
+      "avgInputTokens",
+      "avgOutputTokens",
+      "avgLatencyMs",
+      "estCostUsd",
+    ].join("\t"),
+  ];
+  for (const entry of report.models) {
+    const m = entry.metrics;
+    rows.push(
+      [
+        entry.model,
+        pct(m.recall),
+        pct(m.riskyRecall),
+        pct(m.benignFpRate),
+        pct(m.errorRate),
+        num(m.avgSteps, 1),
+        num(m.avgInputTokens),
+        num(m.avgOutputTokens),
+        num(m.avgLatencyMs),
+        entry.cost == null ? "n/a" : entry.cost.toFixed(4),
+      ].join("\t"),
+    );
+  }
+  return rows.join("\n");
+}
+
+export function writeReport(report, outDir = join(__dirname, "..", "..", ".context", "eval")) {
+  try {
+    if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+    writeFileSync(join(outDir, "ai-review-eval.json"), JSON.stringify(report, null, 2));
+    writeFileSync(join(outDir, "ai-review-eval.md"), renderMarkdown(report));
+    writeFileSync(join(outDir, "ai-review-eval.tsv"), renderTsv(report));
+    return outDir;
+  } catch {
+    // Report writing is best-effort; never fail the eval over a filesystem issue.
+    return null;
+  }
+}

--- a/test/eval/ai-review-harness.test.mjs
+++ b/test/eval/ai-review-harness.test.mjs
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "vitest";
+import { MockLanguageModelV3 } from "ai/test";
+import {
+  estimateCost,
+  evaluateModel,
+  renderMarkdown,
+  renderTsv,
+  summarize,
+} from "./ai-review-harness.mjs";
+
+// Drives the harness with mock reviewer output so the metric math is covered
+// without any live model call. Each synthetic case carries a unique staged-file
+// path used as a marker; the mock reads the serialized prompt to decide which
+// review (or error) to return for that case.
+function record({ id, verdict, expectMinRisk, threatClass = "test" }) {
+  return {
+    id,
+    group: "regression",
+    threatClass,
+    verdict,
+    expectMinRisk,
+    fx: {
+      previousPackageJson: { name: id, version: "1.0.0" },
+      stagedPackageJson: { name: id, version: "1.0.1" },
+      previousFiles: [
+        {
+          path: "package.json",
+          size: 40,
+          sha256: `prev-${id}`,
+          flags: [],
+          textSample: `{"name":"${id}","version":"1.0.0"}`,
+        },
+      ],
+      stagedFiles: [
+        {
+          path: "package.json",
+          size: 40,
+          sha256: `staged-${id}`,
+          flags: [],
+          textSample: `{"name":"${id}","version":"1.0.1"}`,
+        },
+        {
+          path: `marker-${id}.js`,
+          size: 20,
+          sha256: `code-${id}`,
+          flags: [],
+          textSample: `// marker-${id}\n`,
+        },
+      ],
+    },
+  };
+}
+
+function submission(risk) {
+  return {
+    risk,
+    releaseAssessment:
+      risk === "low" ? "nothing_unusual" : risk === "medium" ? "review_recommended" : "suspicious",
+    summary: `verdict ${risk}`,
+    findings: [],
+    requiresManualReview: risk !== "low",
+  };
+}
+
+function usage() {
+  return {
+    inputTokens: { total: 100, noCache: 100, cacheRead: 0, cacheWrite: 0 },
+    outputTokens: { total: 20, text: 20, reasoning: 0 },
+  };
+}
+
+// review is a risk level to submit, or "error" to throw.
+function scriptedModel(byMarker) {
+  return new MockLanguageModelV3({
+    modelId: "mock",
+    doGenerate: async (options) => {
+      const serialized = JSON.stringify(options.prompt);
+      const match = Object.keys(byMarker).find((marker) =>
+        serialized.includes(`marker-${marker}.js`),
+      );
+      const outcome = match ? byMarker[match] : "low";
+      if (outcome === "error") throw new Error("model exploded");
+      return {
+        content: [
+          {
+            type: "tool-call",
+            toolCallId: "submit-1",
+            toolName: "submit_review",
+            input: JSON.stringify(submission(outcome)),
+          },
+        ],
+        finishReason: "tool-calls",
+        usage: usage(),
+        warnings: [],
+      };
+    },
+  });
+}
+
+describe("ai review eval harness", () => {
+  const cases = [
+    record({ id: "mal-caught", verdict: "malicious", expectMinRisk: "high" }),
+    record({ id: "mal-missed", verdict: "malicious", expectMinRisk: "high" }),
+    record({ id: "mal-error", verdict: "malicious", expectMinRisk: "critical" }),
+    record({ id: "ben-clean", verdict: "benign", expectMinRisk: "low" }),
+    record({ id: "ben-fp", verdict: "benign", expectMinRisk: "low" }),
+  ];
+
+  const byMarker = {
+    "mal-caught": "critical",
+    "mal-missed": "low",
+    "mal-error": "error",
+    "ben-clean": "low",
+    "ben-fp": "high",
+  };
+
+  test("computes recall, benign FP, error rate, and aggregates from mock reviews", async () => {
+    const model = scriptedModel(byMarker);
+    const { metrics } = await evaluateModel({
+      model: "mock",
+      createLanguageModel: () => model,
+      cases,
+      concurrency: 2,
+    });
+
+    expect(metrics.total).toBe(5);
+    expect(metrics.malicious).toBe(3);
+    expect(metrics.benign).toBe(2);
+
+    // Only mal-caught (critical >= high) is caught; mal-missed (low) and
+    // mal-error (threw) are misses.
+    expect(metrics.recall).toBeCloseTo(1 / 3);
+    expect(metrics.misses.map((miss) => miss.id).sort()).toEqual(["mal-error", "mal-missed"]);
+    // A thrown model failure is caught by analyzeWithAi and fails safe to an
+    // `unavailable` review, so the harness sees a non-complete status, not a raw error.
+    expect(metrics.misses.find((miss) => miss.id === "mal-error").status).toBe("unavailable");
+
+    // ben-fp rolls up to high -> false positive; ben-clean stays low.
+    expect(metrics.benignFalsePositives).toBe(1);
+    expect(metrics.benignFpRate).toBeCloseTo(1 / 2);
+    expect(metrics.falsePositives.map((fp) => fp.id)).toEqual(["ben-fp"]);
+
+    // One of five cases errored.
+    expect(metrics.errored).toBe(1);
+    expect(metrics.errorRate).toBeCloseTo(1 / 5);
+
+    // Averages are over the four completed cases (mock usage: 100 in / 20 out).
+    expect(metrics.completed).toBe(4);
+    expect(metrics.avgInputTokens).toBe(100);
+    expect(metrics.avgOutputTokens).toBe(20);
+    expect(metrics.avgSteps).toBe(1);
+    expect(metrics.totalInputTokens).toBe(400);
+  });
+
+  test("risky-recall uses the looser >= medium bar", async () => {
+    // A malicious case the model rolls up to exactly medium: below its `high`
+    // expected minimum (recall miss) but still flagged risky.
+    const single = [record({ id: "mal-medium", verdict: "malicious", expectMinRisk: "high" })];
+    const { metrics } = await evaluateModel({
+      model: "mock",
+      createLanguageModel: () => scriptedModel({ "mal-medium": "medium" }),
+      cases: single,
+    });
+    expect(metrics.recall).toBe(0);
+    expect(metrics.riskyRecall).toBe(1);
+  });
+});
+
+describe("cost + rendering", () => {
+  const metrics = summarize([
+    {
+      id: "a",
+      group: "regression",
+      threatClass: "test",
+      verdict: "malicious",
+      expectMinRisk: "high",
+      status: "complete",
+      risk: "high",
+      flaggedRisky: true,
+      caughtAtExpected: true,
+      inputTokens: 1_000_000,
+      outputTokens: 500_000,
+      totalTokens: 1_500_000,
+      steps: 3,
+      latencyMs: 1000,
+    },
+  ]);
+
+  test("estimateCost multiplies token totals by the per-million price", () => {
+    expect(estimateCost(metrics, { input: 2, output: 4 })).toBeCloseTo(2 * 1 + 4 * 0.5);
+    expect(estimateCost(metrics, null)).toBeNull();
+    expect(estimateCost(metrics, {})).toBeNull();
+  });
+
+  test("renderMarkdown and renderTsv include the model row", () => {
+    const report = {
+      generatedAt: "2026-01-01T00:00:00.000Z",
+      corpusSize: 1,
+      malicious: 1,
+      benign: 0,
+      models: [{ model: "@cf/test/model", metrics, cost: 4 }],
+    };
+    const md = renderMarkdown(report);
+    expect(md).toContain("@cf/test/model");
+    expect(md).toContain("$4.0000");
+    const tsv = renderTsv(report);
+    expect(tsv.split("\n")[0]).toContain("recall");
+    expect(tsv).toContain("@cf/test/model");
+  });
+});

--- a/vitest.ai-eval.config.ts
+++ b/vitest.ai-eval.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "vitest/config";
+
+// Dedicated config for the on-demand AI reviewer model comparison
+// (`pnpm run eval:ai`). It is intentionally NOT part of `pnpm test`/CI — the
+// eval makes live, paid, non-deterministic Workers AI calls — so it lives in
+// its own config and the default node project excludes the file.
+export default defineConfig({
+  test: {
+    name: "ai-eval",
+    include: ["test/eval/ai-review-eval.test.mjs"],
+    environment: "node",
+    globals: false,
+    // A full agentic run per case across several models is slow; give the whole
+    // file room and never bail early on the first slow model.
+    testTimeout: 30 * 60 * 1000,
+    hookTimeout: 60 * 1000,
+  },
+});

--- a/vitest.node.config.ts
+++ b/vitest.node.config.ts
@@ -4,7 +4,13 @@ export default defineConfig({
   test: {
     name: "node",
     include: ["test/**/*.test.{ts,mjs}"],
-    exclude: ["test/workers/**/*.test.{ts,mjs}", "node_modules/**"],
+    exclude: [
+      "test/workers/**/*.test.{ts,mjs}",
+      // On-demand, live-model eval only — never part of `pnpm test`/CI.
+      // Run it with `pnpm run eval:ai` (vitest.ai-eval.config.ts).
+      "test/eval/ai-review-eval.test.mjs",
+      "node_modules/**",
+    ],
     environment: "node",
     globals: false,
   },


### PR DESCRIPTION
## Summary

Adds an eval that scores the AI reviewer (`server/lib/ai-review.ts`) on the labeled security corpus and compares multiple Workers AI models side by side, so we can decide whether a cheaper model is good enough before switching what production runs. It's the AI-reviewer analogue of the existing deterministic `pnpm run eval`.

The core design point: it runs the **real** reviewer path — each npm corpus case is turned into the exact `SelectiveAiReviewOptions` the scan pipeline builds, then fed through `analyzeWithAi` with the model under test (via the existing `languageModelOverride` seam). It scores the **model's own** `risk`/`releaseAssessment`, not the production `computeScanRisk` roll-up, because the roll-up folds in the (strong) deterministic findings and would mask the model's contribution. Only npm cases are scored (their fixture payload maps 1:1 to the npm reviewer options; PyPI uses a different artifact shape).

Live models are reached without a Worker binding by using `createWorkersAI` in credentials mode, routed through `drydock-gateway`:

```js
const provider = createWorkersAI({ accountId, apiKey });          // CLOUDFLARE_ACCOUNT_ID / CLOUDFLARE_API_TOKEN
const createLanguageModel = (m) => provider(m, { gateway: { id: "drydock-gateway" } });
await analyzeWithAi({}, model, buildReviewOptions(record), createLanguageModel);
```

Per model it reports recall (at each case's labeled `expectMinRisk`), a looser risky-recall (`>= medium`), benign false-positive rate, error rate, avg agent steps / input+output tokens / latency, and optional `$` cost from an `AI_EVAL_PRICES` map (prints `n/a` rather than guessing). Output goes to `.context/eval/ai-review-eval.{md,json,tsv}` (gitignored; `.tsv` renders in Slack). Models, gateway, prices, concurrency and a case limit are all env-configurable.

### Not in CI
`pnpm run eval:ai` makes live, paid, non-deterministic calls, so it is **not** part of `pnpm test`/CI. It has its own `vitest.ai-eval.config.ts`; the default node project excludes `test/eval/ai-review-eval.test.mjs`; and the run `test.skipIf`s cleanly when credentials are absent. The harness math (`summarize`/`estimateCost`/rendering) is unit-tested with mock reviewer output in `test/eval/ai-review-harness.test.mjs`, which *does* run in CI.

### Files
- `test/eval/ai-review-harness.mjs` — corpus loading (reuses the detection harness labels), option building, per-model `evaluateModel`, metric aggregation, markdown/tsv/json rendering, cost estimate.
- `test/eval/ai-review-eval.test.mjs` — the on-demand runner (env config, live provider, report writing).
- `test/eval/ai-review-harness.test.mjs` — mock-model unit test for the metric math.
- `vitest.ai-eval.config.ts` + `vitest.node.config.ts` exclude + `package.json` `eval:ai` script.
- `docs/ai-review-eval.md` (+ `docs/README.md`, `AGENTS.md` command list).

## Testing
- `vitest run --project node test/eval/` — detection eval + new harness unit tests pass (8 tests).
- Smoke-ran the full npm corpus (30 cases) through `evaluateModel` with a mock model end-to-end.
- `oxlint`, `oxfmt --check`, `tsc --noEmit` clean.
- Live run not exercised here (needs Workers AI credentials); the runner skips without them.
- docs checked: added `docs/ai-review-eval.md` and cross-linked.


Link to Devin session: https://app.devin.ai/sessions/954b519e884047cd92ede9265bab8108
Requested by: @JoviDeCroock
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jovidecroock/drydock/pull/436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->