### PR TITLE
Add public read-only report share links and risk badges

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Start here instead of reading every Markdown file. Pick the smallest set that ma
 - [`workflow-gates.md`](./workflow-gates.md) — GitHub Environment gate flow for PyPI and npm workflow-gated releases.
 - [`diff-baseline.md`](./diff-baseline.md) — default previous-version comparison strategy.
 - [`artifact-storage.md`](./artifact-storage.md) — D1/R2 report and artifact persistence.
+- [`report-sharing.md`](./report-sharing.md) — public read-only report share links and badges.
 
 ## Operations and setup
 

--- a/docs/report-sharing.md
+++ b/docs/report-sharing.md
@@ -1,0 +1,36 @@
+# Public report sharing
+
+Completed inspections can be shared outside the organization through a read-only link, so maintainers can show a release review to consumers, stakeholders, or a README audience without a Drydock account.
+
+## How it works
+
+- An org owner or admin creates a share from the inspection detail page (`Share report`). The server generates a 32-byte base64url bearer token and stores only its SHA-256 hash in `scan_report_shares` (one row per scan). The raw token exists only in the returned link, mirroring the invitation-token pattern.
+- The shared page lives at `/reports/{token}` and renders the same redacted canonical export served by the authenticated `report.json` download — package identity, versions, release risk, decision, and deterministic findings. Organization identity, audit events, and staged file bodies are not part of the export.
+- Creating a share again rotates the token in place: every previously issued link stops resolving. `Revoke link` disables the share without deleting the audit trail. Share creation and revocation are recorded as scan events.
+
+## API surface
+
+| Route                                  | Auth                     | Behavior                                                                                            |
+| -------------------------------------- | ------------------------ | --------------------------------------------------------------------------------------------------- |
+| `GET /api/v1/scans/:id/share`          | session, org member      | Share status (`active`, `createdAt`); the token is never recoverable.                               |
+| `POST /api/v1/scans/:id/share`         | session, org owner/admin | Create or rotate the share; returns the raw token once. Completed scans only (409 otherwise).       |
+| `DELETE /api/v1/scans/:id/share`       | session, org owner/admin | Revoke the share.                                                                                   |
+| `GET /api/public/reports/:token`       | bearer token only        | Redacted canonical report export JSON (`cache-control: no-store`).                                  |
+| `GET /api/public/reports/:token/badge` | bearer token only        | [Shields endpoint-badge](https://shields.io/badges/endpoint-badge) JSON reporting the release risk. |
+
+The public routes are mounted before the auth/CSRF middleware; the unguessable token (format-checked, then hash-matched against unrevoked rows) is the trust boundary. Requests are IP rate limited and always answer `404` for malformed, unknown, or revoked tokens.
+
+## README badge
+
+Embed a live risk badge with Shields:
+
+```markdown
+![drydock](https://img.shields.io/endpoint?url=https%3A%2F%2Fdrydock.org%2Fapi%2Fpublic%2Freports%2F{token}%2Fbadge)
+```
+
+Rotating or revoking the share breaks the badge (it renders Shields' error state), which is the intended failure mode.
+
+## Boundaries
+
+- Reports are shared unsigned; see the known gaps in [`security-model.md`](./security-model.md). Keep the export canonical and future-signable.
+- A share must never widen beyond the report export: no staged file bodies, no organization or member identity, no npm connection state.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -80,13 +80,15 @@ For npm registry tarballs, consumer install lifecycle hooks are `preinstall`, `i
 
 Every non-auth `/api/*` endpoint requires a Better Auth session and organization resolution. Reads and writes for scans, reports, npm connections, Slack installs, release targets, workflow gates, and settings must check organization ownership. UI state is not an authority; server routes make all access-control decisions.
 
+The one deliberate exception is `/api/public/reports/*`: read-only access to the redacted canonical report export, gated by a high-entropy bearer token whose hash is stored in `scan_report_shares`. Only org owners/admins can create, rotate, or revoke a share; a share never exposes anything beyond the report export and never writes scan state. See [`report-sharing.md`](./report-sharing.md).
+
 ## Browser response headers
 
 Production responses should keep conservative security headers: no package-provided active content, no cross-origin credential leakage, and no relaxed CSP/CORS decisions for convenience.
 
 ## Known gaps / future work
 
-- Public signed reports are not exposed yet; report data should remain canonical and future-signable.
+- Shared report links expose the unsigned canonical export; report signing is not implemented yet, so report data should remain canonical and future-signable.
 - Raw-artifact retention, if ever added, must be explicit, short-TTL, organization-scoped, and documented.
 - Additional ecosystems need adapter-specific credential, baseline, artifact, and failure-mode review before enablement.
 - Keep dependency and parser updates covered by regression/fuzz tests because archive handling is a trust boundary.

--- a/drizzle/0022_overjoyed_rocket_racer.sql
+++ b/drizzle/0022_overjoyed_rocket_racer.sql
@@ -1,0 +1,17 @@
+CREATE TABLE `scan_report_shares` (
+	`id` text PRIMARY KEY NOT NULL,
+	`scan_id` text NOT NULL,
+	`organization_id` text NOT NULL,
+	`token_hash` text NOT NULL,
+	`created_by_user_id` text,
+	`revoked_at` integer,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	FOREIGN KEY (`scan_id`) REFERENCES `scans`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`created_by_user_id`) REFERENCES `user`(`id`) ON UPDATE no action ON DELETE set null
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `scan_report_shares_scan_unique_idx` ON `scan_report_shares` (`scan_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `scan_report_shares_token_hash_unique_idx` ON `scan_report_shares` (`token_hash`);--> statement-breakpoint
+CREATE INDEX `scan_report_shares_org_idx` ON `scan_report_shares` (`organization_id`);

--- a/drizzle/meta/0022_snapshot.json
+++ b/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,2517 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "cdf2ea09-36fd-4654-850e-e96eebd3ad28",
+  "prevId": "d381d227-a90a-4475-8065-4d87f9902fea",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_app_installations": {
+      "name": "github_app_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Organization'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uninstalled_at": {
+          "name": "uninstalled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_app_installations_installation_unique_idx": {
+          "name": "github_app_installations_installation_unique_idx",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        },
+        "github_app_installations_org_idx": {
+          "name": "github_app_installations_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installations_created_by_user_id_user_id_fk": {
+          "name": "github_app_installations_created_by_user_id_user_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_release_targets": {
+      "name": "github_release_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ecosystem": {
+          "name": "ecosystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_release_targets_org_repo_env_unique_idx": {
+          "name": "github_release_targets_org_repo_env_unique_idx",
+          "columns": [
+            "organization_id",
+            "repository_id",
+            "environment"
+          ],
+          "isUnique": true
+        },
+        "github_release_targets_installation_idx": {
+          "name": "github_release_targets_installation_idx",
+          "columns": [
+            "installation_row_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_release_targets_organization_id_organizations_id_fk": {
+          "name": "github_release_targets_organization_id_organizations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_release_targets_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_created_by_user_id_user_id_fk": {
+          "name": "github_release_targets_created_by_user_id_user_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_workflow_gates": {
+      "name": "github_workflow_gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_target_id": {
+          "name": "release_target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deployment_callback_url": {
+          "name": "deployment_callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_comment": {
+          "name": "decision_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_url": {
+          "name": "report_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_started_at": {
+          "name": "review_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_workflow_gates_delivery_unique_idx": {
+          "name": "github_workflow_gates_delivery_unique_idx",
+          "columns": [
+            "delivery_id"
+          ],
+          "isUnique": true
+        },
+        "github_workflow_gates_org_status_idx": {
+          "name": "github_workflow_gates_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_release_target_idx": {
+          "name": "github_workflow_gates_release_target_idx",
+          "columns": [
+            "release_target_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_workflow_gates_organization_id_organizations_id_fk": {
+          "name": "github_workflow_gates_organization_id_organizations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_workflow_gates_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_release_target_id_github_release_targets_id_fk": {
+          "name": "github_workflow_gates_release_target_id_github_release_targets_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_release_targets",
+          "columnsFrom": [
+            "release_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_scan_id_scans_id_fk": {
+          "name": "github_workflow_gates_scan_id_scans_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_unique_idx": {
+          "name": "npm_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_invitations": {
+      "name": "organization_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_invitations_token_hash_unique_idx": {
+          "name": "organization_invitations_token_hash_unique_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "organization_invitations_org_status_idx": {
+          "name": "organization_invitations_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "organization_invitations_org_email_idx": {
+          "name": "organization_invitations_org_email_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_invitations_organization_id_organizations_id_fk": {
+          "name": "organization_invitations_organization_id_organizations_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_invited_by_user_id_user_id_fk": {
+          "name": "organization_invitations_invited_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_accepted_by_user_id_user_id_fk": {
+          "name": "organization_invitations_accepted_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_notification_recipients": {
+      "name": "organization_notification_recipients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_notification_recipients_org_email_unique_idx": {
+          "name": "organization_notification_recipients_org_email_unique_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_notification_recipients_organization_id_organizations_id_fk": {
+          "name": "organization_notification_recipients_organization_id_organizations_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_notification_recipients_created_by_user_id_user_id_fk": {
+          "name": "organization_notification_recipients_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_slack_connections": {
+      "name": "organization_slack_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_token_ciphertext": {
+          "name": "bot_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bot_token_nonce": {
+          "name": "bot_token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slack_connections_org_unique_idx": {
+          "name": "organization_slack_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_slack_connections_organization_id_organizations_id_fk": {
+          "name": "organization_slack_connections_organization_id_organizations_id_fk",
+          "tableFrom": "organization_slack_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_slack_connections_created_by_user_id_user_id_fk": {
+          "name": "organization_slack_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_slack_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "require_two_factor_for_release_decisions": {
+          "name": "require_two_factor_for_release_decisions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_findings_scan_severity_idx": {
+          "name": "scan_findings_scan_severity_idx",
+          "columns": [
+            "scan_id",
+            "severity"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_report_shares": {
+      "name": "scan_report_shares",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_report_shares_scan_unique_idx": {
+          "name": "scan_report_shares_scan_unique_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": true
+        },
+        "scan_report_shares_token_hash_unique_idx": {
+          "name": "scan_report_shares_token_hash_unique_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "scan_report_shares_org_idx": {
+          "name": "scan_report_shares_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_report_shares_scan_id_scans_id_fk": {
+          "name": "scan_report_shares_scan_id_scans_id_fk",
+          "tableFrom": "scan_report_shares",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_report_shares_organization_id_organizations_id_fk": {
+          "name": "scan_report_shares_organization_id_organizations_id_fk",
+          "tableFrom": "scan_report_shares",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_report_shares_created_by_user_id_user_id_fk": {
+          "name": "scan_report_shares_created_by_user_id_user_id_fk",
+          "tableFrom": "scan_report_shares",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changed_file_count": {
+          "name": "changed_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_summary_json": {
+          "name": "risk_summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_storage_version": {
+          "name": "artifact_storage_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_key": {
+          "name": "artifact_manifest_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_digest": {
+          "name": "artifact_manifest_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_size": {
+          "name": "artifact_manifest_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_artifact_key": {
+          "name": "report_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_samples_artifact_key": {
+          "name": "file_samples_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "diff_artifact_key": {
+          "name": "diff_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        },
+        "scans_gate_org_idx": {
+          "name": "scans_gate_org_idx",
+          "columns": [
+            "gate_id",
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_artifact_backfill_idx": {
+          "name": "scans_artifact_backfill_idx",
+          "columns": [
+            "organization_id",
+            "status",
+            "artifact_storage_version",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "scans_org_decision_created_idx": {
+          "name": "scans_org_decision_created_idx",
+          "columns": [
+            "organization_id",
+            "decision",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scans_org_created_idx": {
+          "name": "scans_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_gate_id_github_workflow_gates_id_fk": {
+          "name": "scans_gate_id_github_workflow_gates_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "github_workflow_gates",
+          "columnsFrom": [
+            "gate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_decided_by_user_id_user_id_fk": {
+          "name": "scans_decided_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "two_factor": {
+      "name": "two_factor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1781546985955,
       "tag": "0021_magical_exiles",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "6",
+      "when": 1782974035239,
+      "tag": "0022_overjoyed_rocket_racer",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/index.ts
+++ b/server/db/index.ts
@@ -5,4 +5,5 @@ export * from "./organizations";
 export * from "./slack-connection";
 export * from "./invitations";
 export * from "./npm-connections";
+export * from "./report-shares";
 export * from "./scans";

--- a/server/db/report-shares.ts
+++ b/server/db/report-shares.ts
@@ -1,0 +1,101 @@
+import { and, eq, isNull } from "drizzle-orm";
+import type { AppDb } from "./client";
+import { scanReportShares } from "./schema";
+
+export interface ScanReportShareStatus {
+  active: boolean;
+  createdAt: Date | null;
+}
+
+// Read-only status for the settings/detail UI: whether an unrevoked share link
+// exists for the scan. The token itself is never recoverable from the database.
+export async function getScanReportShareStatus(
+  db: AppDb,
+  scanId: string,
+  organizationId: string,
+): Promise<ScanReportShareStatus> {
+  const rows = await db
+    .select({ createdAt: scanReportShares.createdAt, revokedAt: scanReportShares.revokedAt })
+    .from(scanReportShares)
+    .where(
+      and(eq(scanReportShares.scanId, scanId), eq(scanReportShares.organizationId, organizationId)),
+    )
+    .limit(1);
+  const row = rows[0];
+  if (!row || row.revokedAt) return { active: false, createdAt: null };
+  return { active: true, createdAt: row.createdAt };
+}
+
+// Create the share row for a scan, or rotate it in place: the previous token
+// hash is replaced, which invalidates every previously issued link.
+export async function upsertScanReportShare(
+  db: AppDb,
+  input: {
+    scanId: string;
+    organizationId: string;
+    createdByUserId: string;
+    tokenHash: string;
+  },
+): Promise<void> {
+  const now = new Date();
+  await db
+    .insert(scanReportShares)
+    .values({
+      id: crypto.randomUUID(),
+      scanId: input.scanId,
+      organizationId: input.organizationId,
+      tokenHash: input.tokenHash,
+      createdByUserId: input.createdByUserId,
+      revokedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: scanReportShares.scanId,
+      set: {
+        tokenHash: input.tokenHash,
+        createdByUserId: input.createdByUserId,
+        revokedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+    });
+}
+
+export async function revokeScanReportShare(
+  db: AppDb,
+  scanId: string,
+  organizationId: string,
+): Promise<boolean> {
+  const now = new Date();
+  const result = await db
+    .update(scanReportShares)
+    .set({ revokedAt: now, updatedAt: now })
+    .where(
+      and(
+        eq(scanReportShares.scanId, scanId),
+        eq(scanReportShares.organizationId, organizationId),
+        isNull(scanReportShares.revokedAt),
+      ),
+    )
+    .returning({ id: scanReportShares.id });
+  return result.length > 0;
+}
+
+// Resolve an unrevoked share token hash to the scan it exposes. This is the
+// only authorization step on the public report path, so it must never match a
+// revoked row.
+export async function getScanReportShareByTokenHash(
+  db: AppDb,
+  tokenHash: string,
+): Promise<{ scanId: string; organizationId: string } | null> {
+  const rows = await db
+    .select({
+      scanId: scanReportShares.scanId,
+      organizationId: scanReportShares.organizationId,
+    })
+    .from(scanReportShares)
+    .where(and(eq(scanReportShares.tokenHash, tokenHash), isNull(scanReportShares.revokedAt)))
+    .limit(1);
+  return rows[0] ?? null;
+}

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -436,6 +436,32 @@ export const githubWorkflowGates = sqliteTable(
   }),
 );
 
+// One share link per scan. Only the SHA-256 hash of the bearer token is stored,
+// so a database read never yields a usable link; rotation replaces the hash and
+// revocation clears the row's active state without deleting the audit trail.
+export const scanReportShares = sqliteTable(
+  "scan_report_shares",
+  {
+    id: text("id").primaryKey(),
+    scanId: text("scan_id")
+      .notNull()
+      .references(() => scans.id, { onDelete: "cascade" }),
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    tokenHash: text("token_hash").notNull(),
+    createdByUserId: text("created_by_user_id").references(() => user.id, { onDelete: "set null" }),
+    revokedAt: integer("revoked_at", { mode: "timestamp_ms" }),
+    createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
+  },
+  (table) => ({
+    scanUniqueIdx: uniqueIndex("scan_report_shares_scan_unique_idx").on(table.scanId),
+    tokenHashUniqueIdx: uniqueIndex("scan_report_shares_token_hash_unique_idx").on(table.tokenHash),
+    orgIdx: index("scan_report_shares_org_idx").on(table.organizationId),
+  }),
+);
+
 export const session = sqliteTable("session", {
   id: text("id").primaryKey(),
   expiresAt: integer("expires_at", { mode: "timestamp_ms" }).notNull(),

--- a/server/index.ts
+++ b/server/index.ts
@@ -41,6 +41,7 @@ import { githubWebhookRoutes } from "./routes/github-webhooks";
 import { npmConnectionRoutes } from "./routes/npm-connection";
 import { organizationMembersRoutes } from "./routes/organization-members";
 import { organizationsRoutes } from "./routes/organizations";
+import { publicReportsRoutes } from "./routes/public-reports";
 import { slackRoutes } from "./routes/slack";
 import { scansRoutes } from "./routes/scans";
 import { stagedPublishesRoutes } from "./routes/staged-publishes";
@@ -123,6 +124,11 @@ app.use("*", async (c, next) => canonicalDomainRedirect(c.req.raw) ?? next());
 // CSRF middleware below — the signature verification inside the handler is the
 // trust boundary.
 app.route("/webhooks", githubWebhookRoutes);
+
+// Public report shares are bearer-token gated, not session gated, so they are
+// mounted before the auth/CSRF middleware below. The unguessable share token
+// (hash-checked in the handler) is the trust boundary.
+app.route("/api/public/reports", publicReportsRoutes);
 
 app.use("/api/*", async (c, next) => {
   try {

--- a/server/lib/report-share-token.ts
+++ b/server/lib/report-share-token.ts
@@ -1,0 +1,32 @@
+// Public report links carry a high-entropy bearer token. Only its SHA-256 hash
+// is persisted (scan_report_shares.token_hash), so a database read never yields
+// a usable link and rotation/revocation is a single row update. This mirrors
+// the invitation-token pattern: the raw token exists only in the shared URL.
+
+const TOKEN_BYTES = 32;
+
+// base64url of 32 bytes is 43 characters; the format check lets the public
+// route reject junk before touching the database.
+export const REPORT_SHARE_TOKEN_RE = /^[A-Za-z0-9_-]{40,48}$/;
+
+export interface ReportShareToken {
+  token: string;
+  tokenHash: string;
+}
+
+function toBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+export async function hashReportShareToken(token: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token));
+  return toBase64Url(new Uint8Array(digest));
+}
+
+export async function generateReportShareToken(): Promise<ReportShareToken> {
+  const token = toBase64Url(crypto.getRandomValues(new Uint8Array(TOKEN_BYTES)));
+  const tokenHash = await hashReportShareToken(token);
+  return { token, tokenHash };
+}

--- a/server/routes/public-reports.ts
+++ b/server/routes/public-reports.ts
@@ -1,0 +1,96 @@
+import { Hono, type Context } from "hono";
+import {
+  RateLimitError,
+  createDb,
+  enforceRateLimit,
+  getScan,
+  getScanReportShareByTokenHash,
+} from "../db";
+import { rateLimitResponse } from "../lib/http";
+import { buildReportExport } from "../lib/report-export";
+import { REPORT_SHARE_TOKEN_RE, hashReportShareToken } from "../lib/report-share-token";
+import { scanArtifactReadBucket } from "../lib/scan-artifacts";
+import type { Bindings, Variables } from "../types";
+
+// Unauthenticated report access, gated only by an unguessable bearer token in
+// the URL. These routes are mounted before the Better Auth session middleware;
+// they must never expose anything beyond the redacted canonical report export
+// and must never write scan state.
+export const publicReportsRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+async function resolveSharedScan(
+  c: Context<{ Bindings: Bindings; Variables: Variables }>,
+): Promise<{ detail: NonNullable<Awaited<ReturnType<typeof getScan>>> } | { error: Response }> {
+  const token = c.req.param("token") ?? "";
+  if (!REPORT_SHARE_TOKEN_RE.test(token)) {
+    return { error: c.json({ error: "not found" }, 404) };
+  }
+
+  const db = createDb(c.env.DB);
+  const ip =
+    c.req.header("cf-connecting-ip") || c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
+  if (ip) {
+    try {
+      await enforceRateLimit(db, {
+        key: `public-report:${ip}`,
+        limit: 60,
+        windowMs: 60 * 1000,
+      });
+    } catch (err) {
+      if (err instanceof RateLimitError) {
+        return { error: rateLimitResponse(c, "rate limit exceeded", err) };
+      }
+      throw err;
+    }
+  }
+
+  const share = await getScanReportShareByTokenHash(db, await hashReportShareToken(token));
+  if (!share) return { error: c.json({ error: "not found" }, 404) };
+
+  const detail = await getScan(
+    db,
+    share.scanId,
+    share.organizationId,
+    scanArtifactReadBucket(c.env),
+  );
+  if (!detail || detail.scan.status !== "complete") {
+    return { error: c.json({ error: "not found" }, 404) };
+  }
+  return { detail };
+}
+
+publicReportsRoutes.get("/:token", async (c) => {
+  const resolved = await resolveSharedScan(c);
+  if ("error" in resolved) return resolved.error;
+  // Same redacted canonical shape as the authenticated report.json export;
+  // organization identity and audit events are not part of the export.
+  return c.json(buildReportExport(resolved.detail), 200, { "cache-control": "no-store" });
+});
+
+const BADGE_COLORS: Record<string, string> = {
+  none: "brightgreen",
+  low: "green",
+  medium: "yellow",
+  high: "orange",
+  critical: "red",
+};
+
+// Shields endpoint-badge JSON. Consumers embed it with
+// https://img.shields.io/endpoint?url=<this route>, which keeps badge
+// rendering out of the Worker entirely.
+publicReportsRoutes.get("/:token/badge", async (c) => {
+  const resolved = await resolveSharedScan(c);
+  if ("error" in resolved) return resolved.error;
+  const { scan } = resolved.detail;
+  const risk = resolved.detail.riskSummary?.releaseRisk ?? scan.risk;
+  return c.json(
+    {
+      schemaVersion: 1,
+      label: "drydock",
+      message: `${risk} risk`,
+      color: BADGE_COLORS[risk] ?? "lightgrey",
+    },
+    200,
+    { "cache-control": "public, max-age=300" },
+  );
+});

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -15,10 +15,13 @@ import {
   getScan,
   getScanCompareData,
   getScanFile,
+  getScanReportShareStatus,
   getScanStatus,
   listScans,
   recordScanDecision,
   recordScanEvent,
+  revokeScanReportShare,
+  upsertScanReportShare,
 } from "../db";
 import {
   requireActiveOrganization,
@@ -50,6 +53,7 @@ import { annotateFindingsWithDiffStatus, createPackageDiff, type FileRecord } fr
 import { describeOperationalError, emitOperationalEvent } from "../lib/observability";
 import { parseScanInput } from "../lib/scan-input";
 import { reportExportFilename, serializeReportExport } from "../lib/report-export";
+import { generateReportShareToken } from "../lib/report-share-token";
 import { executeScanJob, type ScanQueueMessage } from "../lib/scan-job";
 import { roleCanManageIntegrations } from "../lib/roles";
 import { checkStagedPublishAccess } from "../lib/staged-publishes";
@@ -262,6 +266,68 @@ scansRoutes.post("/:id/decision", async (c) => {
   }
 
   return c.json(updated);
+});
+
+scansRoutes.get("/:id/share", async (c) => {
+  const db = createDb(c.env.DB);
+  const organizationId = await requireActiveOrganization(c, db);
+  const scan = await getScanStatus(db, c.req.param("id"), organizationId);
+  if (!scan) return c.json({ error: "not found" }, 404);
+  const share = await getScanReportShareStatus(db, scan.id, organizationId);
+  return c.json({ share });
+});
+
+scansRoutes.post("/:id/share", async (c) => {
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const { organizationId, role } = await requireActiveOrganizationContext(c, db);
+  if (!roleCanManageIntegrations(role)) return c.json({ error: "forbidden" }, 403);
+
+  const scan = await getScanStatus(db, c.req.param("id"), organizationId);
+  if (!scan) return c.json({ error: "not found" }, 404);
+  if (scan.status !== "complete") {
+    return c.json({ error: "share links are only available for completed scans" }, 409);
+  }
+
+  // The raw token exists only in this response; rotating replaces the stored
+  // hash, so every previously issued link stops resolving.
+  const { token, tokenHash } = await generateReportShareToken();
+  await upsertScanReportShare(db, {
+    scanId: scan.id,
+    organizationId,
+    createdByUserId: session.userId,
+    tokenHash,
+  });
+  await recordScanEvent(db, {
+    organizationId,
+    actorUserId: session.userId,
+    scanId: scan.id,
+    type: "scan.report_share.created",
+    metadata: { stageId: scan.stageId },
+  });
+  const share = await getScanReportShareStatus(db, scan.id, organizationId);
+  return c.json({ share, token, path: `/reports/${token}` }, 201);
+});
+
+scansRoutes.delete("/:id/share", async (c) => {
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const { organizationId, role } = await requireActiveOrganizationContext(c, db);
+  if (!roleCanManageIntegrations(role)) return c.json({ error: "forbidden" }, 403);
+
+  const scan = await getScanStatus(db, c.req.param("id"), organizationId);
+  if (!scan) return c.json({ error: "not found" }, 404);
+  const revoked = await revokeScanReportShare(db, scan.id, organizationId);
+  if (revoked) {
+    await recordScanEvent(db, {
+      organizationId,
+      actorUserId: session.userId,
+      scanId: scan.id,
+      type: "scan.report_share.revoked",
+      metadata: { stageId: scan.stageId },
+    });
+  }
+  return c.json({ share: { active: false, createdAt: null } });
 });
 
 scansRoutes.get("/:id", async (c) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -21,6 +21,7 @@ const SettingsPage = lazy(() => import("./pages/Dashboard/Settings"));
 const AccountPage = lazy(() => import("./pages/Dashboard/Account"));
 const InvitePage = lazy(() => import("./pages/Dashboard/Invite"));
 const GithubAppCallbackPage = lazy(() => import("./pages/Dashboard/GithubAppCallback"));
+const ReportPage = lazy(() => import("./pages/Report"));
 const NotFoundPage = lazy(() => import("./pages/NotFound"));
 
 export function App() {
@@ -34,6 +35,7 @@ export function App() {
           <Route path="/login" component={LoginPage} />
           <Route path="/register" component={RegisterPage} />
           <Route path="/verify-email" component={VerifyEmailPage} />
+          <Route path="/reports/:token" component={ReportPage} />
           <Route path="/dashboard" component={DashboardPage} />
           <Route path="/dashboard/scans/:id" component={ScanDetailPage} />
           <Route path="/dashboard/settings" component={SettingsPage} />

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -192,6 +192,30 @@ export function getScanCompareFile(
   );
 }
 
+export interface ReportShareStatus {
+  active: boolean;
+  createdAt: string | number | Date | null;
+}
+
+export function getReportShare(id: string): Promise<{ share: ReportShareStatus }> {
+  return apiFetch<{ share: ReportShareStatus }>(`/api/v1/scans/${encodeURIComponent(id)}/share`);
+}
+
+export function createReportShare(
+  id: string,
+): Promise<{ share: ReportShareStatus; token: string; path: string }> {
+  return apiJson<{ share: ReportShareStatus; token: string; path: string }>(
+    `/api/v1/scans/${encodeURIComponent(id)}/share`,
+    {},
+  );
+}
+
+export function revokeReportShare(id: string): Promise<{ share: ReportShareStatus }> {
+  return apiFetch<{ share: ReportShareStatus }>(`/api/v1/scans/${encodeURIComponent(id)}/share`, {
+    method: "DELETE",
+  });
+}
+
 export type DecisionStatus = "idle" | "saving" | "error";
 
 export function scanMatchesDecisionFilter(

--- a/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
+++ b/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
@@ -2,6 +2,7 @@ import { getDashboardReturnUrl } from "../../../lib/query-state";
 import { formatDateTime } from "../../../lib/format";
 import { reportExportFilename } from "../../../../server/lib/report-export";
 import type { PersistedScanDetail } from "../../../models/scan";
+import { ShareReportControl } from "./ShareReportControl";
 import {
   Alert,
   Badge,
@@ -64,6 +65,7 @@ export function ScanDetailHeader({
               ) : null}
             </div>
           ) : null}
+          {detail && isComplete ? <ShareReportControl scanId={detail.scan.id} /> : null}
           {detail && isComplete ? (
             <LinkButton
               variant="ghost"

--- a/src/pages/Dashboard/ScanDetail/ShareReportControl.tsx
+++ b/src/pages/Dashboard/ScanDetail/ShareReportControl.tsx
@@ -1,0 +1,84 @@
+import { useEffect } from "preact/hooks";
+import { useComputed, useSignal } from "@preact/signals";
+import { Show } from "@preact/signals/utils";
+import {
+  createReportShare,
+  getReportShare,
+  revokeReportShare,
+  type ReportShareStatus,
+} from "../../../models/scan";
+import { errorMessage } from "../../../models/api";
+import { Button, pushToast } from "../../../components";
+
+// Creates, rotates, and revokes the public read-only share link for a completed
+// inspection. The raw link is only available at creation time (the server keeps
+// a hash), so creating or rotating immediately copies it to the clipboard.
+export function ShareReportControl({ scanId }: { scanId: string }) {
+  const share = useSignal<ReportShareStatus | null>(null);
+  const busy = useSignal(false);
+  const active = useComputed(() => share.value?.active === true);
+
+  useEffect(() => {
+    let cancelled = false;
+    getReportShare(scanId)
+      .then((data) => {
+        if (!cancelled) share.value = data.share;
+      })
+      .catch(() => {
+        // Members without share visibility just don't see the state; the
+        // buttons still work or fail with a toast on click.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [scanId]);
+
+  const createLink = async () => {
+    if (busy.peek()) return;
+    busy.value = true;
+    try {
+      const data = await createReportShare(scanId);
+      share.value = data.share;
+      const url = `${location.origin}${data.path}`;
+      try {
+        await navigator.clipboard.writeText(url);
+        pushToast("Share link copied to clipboard", "ok");
+      } catch {
+        pushToast(`Share link: ${url}`, "ok");
+      }
+    } catch (err) {
+      pushToast(errorMessage(err), "critical");
+    } finally {
+      busy.value = false;
+    }
+  };
+
+  const revokeLink = async () => {
+    if (busy.peek()) return;
+    busy.value = true;
+    try {
+      const data = await revokeReportShare(scanId);
+      share.value = data.share;
+      pushToast("Share link revoked", "ok");
+    } catch (err) {
+      pushToast(errorMessage(err), "critical");
+    } finally {
+      busy.value = false;
+    }
+  };
+
+  return (
+    <div class="flex items-center gap-2">
+      <Button variant="ghost" size="sm" onClick={createLink}>
+        <Show when={active} fallback="Share report">
+          Rotate share link
+        </Show>
+      </Button>
+      <Show when={active}>
+        <Button variant="ghost" size="sm" onClick={revokeLink}>
+          Revoke link
+        </Button>
+      </Show>
+    </div>
+  );
+}

--- a/src/pages/Report/index.tsx
+++ b/src/pages/Report/index.tsx
@@ -1,0 +1,190 @@
+import { useEffect } from "preact/hooks";
+import { useSignal } from "@preact/signals";
+import { useRoute } from "preact-iso";
+import { formatDateTime } from "../../lib/format";
+import {
+  Badge,
+  Card,
+  FindingCard,
+  LinkButton,
+  LoadingState,
+  MonoDetail,
+  Muted,
+  PageShell,
+  SectionLabel,
+  severityTone,
+} from "../../components";
+
+interface PublicReportExport {
+  schema: string;
+  scan: {
+    id: string;
+    status: string;
+    source: string;
+    risk: string;
+    decision: string | null;
+    createdAt: string | null;
+    completedAt: string | null;
+  };
+  package: {
+    name: string | null;
+    stagedVersion: string | null;
+    previousVersion: string | null;
+  };
+  riskSummary: {
+    releaseRisk: string;
+    artifactRisk: string;
+    contextRisk: string;
+  } | null;
+  diff: Array<{ path: string; status: string }> | null;
+  findings: Array<{
+    severity: string;
+    file: string;
+    line: number | null;
+    ruleId: string | null;
+    evidence: string;
+    reason: string;
+  }>;
+}
+
+// Read-only shared report view. Loaded through the unauthenticated
+// token-gated endpoint; anything rendered here is public to whoever holds
+// the link, so it only shows the redacted canonical export.
+export default function ReportPage() {
+  const route = useRoute();
+  const token = route.params.token ?? "";
+  const report = useSignal<PublicReportExport | null>(null);
+  const failed = useSignal(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/public/reports/${encodeURIComponent(token)}`, {
+      headers: { accept: "application/json" },
+    })
+      .then(async (res) => {
+        if (!res.ok) throw new Error("not found");
+        const data = (await res.json()) as PublicReportExport;
+        if (!cancelled) report.value = data;
+      })
+      .catch(() => {
+        if (!cancelled) failed.value = true;
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  if (failed.value) {
+    return (
+      <PageShell width="narrow">
+        <Card class="flex flex-col gap-3">
+          <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">Report unavailable</h1>
+          <Muted class="text-[13px] m-0">
+            This share link is invalid or has been revoked by the organization that owns the
+            inspection.
+          </Muted>
+          <div class="mt-2">
+            <LinkButton href="/" variant="secondary">
+              About Drydock
+            </LinkButton>
+          </div>
+        </Card>
+      </PageShell>
+    );
+  }
+
+  const data = report.value;
+  if (!data) {
+    return (
+      <PageShell width="doc">
+        <LoadingState title="Loading shared report" />
+      </PageShell>
+    );
+  }
+
+  const releaseRisk = data.riskSummary?.releaseRisk ?? data.scan.risk;
+  const changedFiles = data.diff?.length ?? 0;
+
+  return (
+    <PageShell width="doc">
+      <div class="flex flex-col gap-6">
+        <header class="flex flex-wrap items-start justify-between gap-4">
+          <div class="flex flex-col gap-2 min-w-0">
+            <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
+              Shared inspection report
+            </span>
+            <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">
+              {data.package.name || "Release inspection"}
+            </h1>
+            <MonoDetail
+              parts={[
+                <span key="version">
+                  {data.package.previousVersion || "—"} → {data.package.stagedVersion || "—"}
+                </span>,
+                <Badge key="risk" tone={severityTone(releaseRisk)}>
+                  release {releaseRisk}
+                </Badge>,
+                data.scan.decision ? (
+                  <Badge key="decision" tone={data.scan.decision === "publish" ? "ok" : "critical"}>
+                    {data.scan.decision === "publish" ? "cleared" : "held"}
+                  </Badge>
+                ) : null,
+              ]}
+            />
+          </div>
+          <div class="flex flex-col items-end gap-1">
+            {data.scan.completedAt ? (
+              <span class="font-mono text-[11px] text-ink-subtle">
+                inspected {formatDateTime(data.scan.completedAt)}
+              </span>
+            ) : null}
+            <span class="font-mono text-[11px] text-ink-subtle">
+              {changedFiles} changed file{changedFiles === 1 ? "" : "s"} · {data.findings.length}{" "}
+              finding{data.findings.length === 1 ? "" : "s"}
+            </span>
+          </div>
+        </header>
+
+        <section class="flex flex-col gap-3">
+          <SectionLabel>Findings</SectionLabel>
+          {data.findings.length === 0 ? (
+            <Card>
+              <Muted class="text-[13px] m-0">
+                No deterministic findings were raised for this release.
+              </Muted>
+            </Card>
+          ) : (
+            data.findings.map((finding, index) => (
+              <FindingCard
+                key={`${finding.file}-${finding.ruleId ?? index}-${finding.line ?? 0}`}
+                severity={finding.severity}
+                file={finding.file}
+                line={finding.line}
+                ruleId={finding.ruleId}
+              >
+                <p class="m-0 text-[13px] leading-[1.6]">{finding.reason}</p>
+                <pre class="m-0 mt-2 font-mono text-[12px] leading-[1.5] text-ink-muted whitespace-pre-wrap break-all">
+                  {finding.evidence}
+                </pre>
+              </FindingCard>
+            ))
+          )}
+        </section>
+
+        <footer class="flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4">
+          <Muted class="text-[13px] m-0">
+            Generated by Drydock — deterministic supply-chain checks on the staged release. This is
+            a read-only, redacted report; the owning organization can revoke this link at any time.
+          </Muted>
+          <LinkButton
+            variant="ghost"
+            size="sm"
+            href={`/api/public/reports/${encodeURIComponent(token)}`}
+          >
+            View JSON
+          </LinkButton>
+        </footer>
+      </div>
+    </PageShell>
+  );
+}

--- a/test/workers/report-share-routes.test.ts
+++ b/test/workers/report-share-routes.test.ts
@@ -1,0 +1,232 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { describe, expect, test } from "vitest";
+import {
+  addOrganizationMember,
+  createDb,
+  createScanJob,
+  ensurePersonalOrganization,
+  persistScan,
+} from "../../server/db";
+import * as schema from "../../server/db/schema";
+import { publicReportsRoutes } from "../../server/routes/public-reports";
+import { scansRoutes } from "../../server/routes/scans";
+import type { Bindings, Variables } from "../../server/types";
+
+interface SeededUser {
+  userId: string;
+  organizationId: string;
+}
+
+async function seedUser(): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+function buildApp(session?: { userId: string }) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.route("/api/public/reports", publicReportsRoutes);
+  if (session) {
+    app.use("/api/v1/*", async (c, next) => {
+      c.set("authSession", { userId: session.userId });
+      await next();
+    });
+    app.route("/api/v1/scans", scansRoutes);
+  }
+  return app;
+}
+
+async function request(
+  app: Hono<{ Bindings: Bindings; Variables: Variables }>,
+  path: string,
+  init: RequestInit = {},
+) {
+  const ctx = createExecutionContext();
+  const res = await app.fetch(new Request(`http://test.local${path}`, init), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+async function seedCompletedScan(owner: SeededUser): Promise<string> {
+  const db = createDb(env.DB);
+  const scanId = `scan_${crypto.randomUUID()}`;
+  const stageId = `stage-${scanId.slice(-12)}`;
+  await createScanJob(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+  });
+  await persistScan(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+    packageJson: { name: "@org/pkg", version: "1.1.0" },
+    risk: "high",
+    status: "complete",
+    summary: {
+      baseline: { kind: "registry", version: "1.0.0" },
+      diff: [{ path: "package.json", status: "modified" }],
+    },
+    ai: null,
+    files: [{ path: "package.json", size: 10, sha256: "a", flags: [], textSample: "{}" }],
+    diff: [{ path: "package.json", status: "modified", flags: [] }],
+    findings: [
+      {
+        severity: "high",
+        file: "package.json",
+        evidence: "postinstall: node install.js",
+        reason: "install lifecycle hooks execute on consumer machines",
+        ruleId: "install-script.lifecycle",
+        ruleVersion: "1.8.0",
+      },
+    ],
+    report: { version: 1, digest: "abc123" },
+  });
+  return scanId;
+}
+
+async function createShare(
+  app: Hono<{ Bindings: Bindings; Variables: Variables }>,
+  scanId: string,
+): Promise<{ token: string; path: string }> {
+  const res = await request(app, `/api/v1/scans/${scanId}/share`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: "{}",
+  });
+  expect(res.status).toBe(201);
+  return (await res.json()) as { token: string; path: string };
+}
+
+describe("scan report share links", () => {
+  test("creating a share exposes the report through the public token route", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const app = buildApp(owner);
+
+    const { token, path } = await createShare(app, scanId);
+    expect(path).toBe(`/reports/${token}`);
+
+    const res = await request(app, `/api/public/reports/${token}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    const body = (await res.json()) as {
+      schema: string;
+      package: { name: string | null };
+      findings: Array<{ ruleId: string | null }>;
+    };
+    expect(body.schema).toBe("drydock.report.v1");
+    expect(body.package.name).toBe("@org/pkg");
+    expect(body.findings).toEqual([
+      expect.objectContaining({ ruleId: "install-script.lifecycle" }),
+    ]);
+  });
+
+  test("serves a shields endpoint badge for a shared report", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const app = buildApp(owner);
+
+    const { token } = await createShare(app, scanId);
+    const res = await request(app, `/api/public/reports/${token}/badge`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      schemaVersion: 1,
+      label: "drydock",
+      message: "high risk",
+      color: "orange",
+    });
+  });
+
+  test("revoking a share makes the token stop resolving", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const app = buildApp(owner);
+
+    const { token } = await createShare(app, scanId);
+    const revoke = await request(app, `/api/v1/scans/${scanId}/share`, { method: "DELETE" });
+    expect(revoke.status).toBe(200);
+    expect(await revoke.json()).toMatchObject({ share: { active: false } });
+
+    expect((await request(app, `/api/public/reports/${token}`)).status).toBe(404);
+    expect((await request(app, `/api/public/reports/${token}/badge`)).status).toBe(404);
+  });
+
+  test("rotating a share invalidates previously issued links", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const app = buildApp(owner);
+
+    const first = await createShare(app, scanId);
+    const second = await createShare(app, scanId);
+    expect(second.token).not.toBe(first.token);
+
+    expect((await request(app, `/api/public/reports/${first.token}`)).status).toBe(404);
+    expect((await request(app, `/api/public/reports/${second.token}`)).status).toBe(200);
+  });
+
+  test("share status is readable by members but creation requires admin", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const member = await seedUser();
+    const db = createDb(env.DB);
+    await addOrganizationMember(db, {
+      organizationId: owner.organizationId,
+      userId: member.userId,
+      role: "member",
+    });
+
+    const memberApp = buildApp(member);
+    const headers = { "x-organization-id": owner.organizationId };
+    const status = await request(memberApp, `/api/v1/scans/${scanId}/share`, { headers });
+    expect(status.status).toBe(200);
+    expect(await status.json()).toMatchObject({ share: { active: false } });
+
+    const create = await request(memberApp, `/api/v1/scans/${scanId}/share`, {
+      method: "POST",
+      headers: { ...headers, "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(create.status).toBe(403);
+  });
+
+  test("refuses to share an incomplete scan", async () => {
+    const owner = await seedUser();
+    const db = createDb(env.DB);
+    const scanId = `scan_${crypto.randomUUID()}`;
+    await createScanJob(db, {
+      id: scanId,
+      stageId: `stage-${scanId.slice(-12)}`,
+      organizationId: owner.organizationId,
+      ownerUserId: owner.userId,
+    });
+
+    const res = await request(buildApp(owner), `/api/v1/scans/${scanId}/share`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    expect(res.status).toBe(409);
+  });
+
+  test("rejects malformed and unknown tokens", async () => {
+    const app = buildApp();
+    expect((await request(app, "/api/public/reports/short")).status).toBe(404);
+    expect((await request(app, "/api/public/reports/..%2F..%2Fetc")).status).toBe(404);
+    const unknown = "A".repeat(43);
+    expect((await request(app, `/api/public/reports/${unknown}`)).status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

Lets an org owner/admin share a completed inspection outside Drydock: a read-only report page at `/reports/{token}` and a Shields README badge, both gated only by a high-entropy bearer token.

- New `scan_report_shares` table (one row per scan). Only the SHA-256 hash of the token is stored (mirrors the invitation-token pattern in `server/lib/report-share-token.ts`); creating again rotates the hash in place so old links die, `DELETE` revokes.
- Authed management routes on `scansRoutes`:
  - `GET /api/v1/scans/:id/share` → status (any member)
  - `POST /api/v1/scans/:id/share` → create/rotate, returns the raw token once; owners/admins only, completed scans only (409); records `scan.report_share.created`/`.revoked` events
- Public routes (`server/routes/public-reports.ts`), mounted **before** the auth/CSRF middleware like the GitHub webhooks — the token is the trust boundary:
  - `GET /api/public/reports/:token` → the same redacted canonical export as the authed `report.json` (via `buildReportExport`), `no-store`
  - `GET /api/public/reports/:token/badge` → [Shields endpoint-badge](https://shields.io/badges/endpoint-badge) JSON with the release risk, so `img.shields.io/endpoint?url=…` renders a live README badge
  - Format-checked tokens, IP rate limiting, and a uniform 404 for malformed/unknown/revoked tokens
- UI: `ShareReportControl` (Share/Rotate + Revoke, copies link to clipboard) in the scan detail header, plus a public `/reports/:token` page rendering package, versions, release risk, decision, and findings.

Docs: new `docs/report-sharing.md`; `security-model.md` updated to document the public-route exception (reports remain unsigned — signing is still future work).

## Testing

`pnpm run verify` green. New `test/workers/report-share-routes.test.ts` covers create→public fetch, badge, revoke, rotation invalidating old tokens, member/admin role split, incomplete-scan 409, and malformed/unknown tokens.

Link to Devin session: https://app.devin.ai/sessions/6716e1475b684504b1999441447b687b
Requested by: @JoviDeCroock
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/jovidecroock/drydock/pull/443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->