### PR TITLE
Persist package identity at scan creation so failed scans keep their label

### DIFF
--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -63,6 +63,14 @@ export interface CreateScanJobInput {
   source?: ScanSource;
   /** Links a workflow-gate review scan back to its gate. */
   gateId?: string | null;
+  /**
+   * Package identity known before the tarball is inspected (from the staged
+   * publishes listing or the gate bundle). Lets failed scans — including ones
+   * whose tarball never parsed — still carry a display label; the pipeline
+   * overwrites both with tarball-derived values when it completes.
+   */
+  packageName?: string | null;
+  stagedVersion?: string | null;
 }
 
 export const SCAN_SOURCES = ["manual", "auto_discovery", "workflow_gate"] as const;
@@ -76,6 +84,8 @@ export async function createScanJob(db: AppDb, input: CreateScanJobInput) {
     organizationId: input.organizationId,
     ownerUserId: input.ownerUserId,
     gateId: input.gateId ?? null,
+    packageName: input.packageName ?? null,
+    stagedVersion: input.stagedVersion ?? null,
     risk: "unknown",
     status: "pending",
     source: input.source ?? "manual",

--- a/server/lib/staged-publishes-discovery.ts
+++ b/server/lib/staged-publishes-discovery.ts
@@ -238,6 +238,8 @@ export async function discoverAndQueueStagedPublishes(
       organizationId,
       ownerUserId: actorUserId,
       source,
+      packageName: item.packageName,
+      stagedVersion: item.version,
     });
     if (!detail) continue;
     existingStageIds.add(stageId);

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -433,6 +433,8 @@ async function reviewGatePackages(
       ownerUserId,
       source: "workflow_gate",
       gateId: gate.id,
+      packageName: candidate.package.name,
+      stagedVersion: candidate.package.version,
     });
 
     try {

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -52,7 +52,7 @@ import { parseScanInput } from "../lib/scan-input";
 import { reportExportFilename, serializeReportExport } from "../lib/report-export";
 import { executeScanJob, type ScanQueueMessage } from "../lib/scan-job";
 import { roleCanManageIntegrations } from "../lib/roles";
-import { checkStagedPublishAccess } from "../lib/staged-publishes";
+import { checkStagedPublishAccess, fetchStagedPublishDetails } from "../lib/staged-publishes";
 import type { Bindings, ScanInput, Variables } from "../types";
 
 export const scansRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
@@ -100,12 +100,23 @@ scansRoutes.post("/", async (c) => {
       );
     }
 
+    // Best-effort: staged metadata gives the scan a package label up front, so
+    // a scan whose tarball never parses still shows which package it was for.
+    const staged = await fetchStagedPublishDetails(
+      npmConnection.registryUrl,
+      token,
+      input.stageId,
+      { allowInsecureLocalhost: allowInsecureLocalRegistry(c.env) },
+    ).catch(() => null);
+
     const scanId = crypto.randomUUID();
     const detail = await createScanJob(db, {
       id: scanId,
       stageId: input.stageId,
       organizationId,
       ownerUserId: session.userId,
+      packageName: staged?.packageName ?? null,
+      stagedVersion: staged?.version ?? null,
     });
     if (!detail) return c.json({ error: "failed to create scan" }, 500);
     const message: ScanQueueMessage = {

--- a/test/workers/scans-route-queue.test.ts
+++ b/test/workers/scans-route-queue.test.ts
@@ -76,12 +76,18 @@ describe("scans route queue behavior", () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
-        expect(String(url)).toBe(
-          "https://registry.npmjs.org/-/stage/stage-route-queue-000001/tarball",
-        );
+        if (String(url) === "https://registry.npmjs.org/-/stage/stage-route-queue-000001/tarball") {
+          expect((init?.headers as Record<string, string>)?.authorization).toBe(`Bearer ${token}`);
+          expect((init?.headers as Record<string, string>)?.range).toBe("bytes=0-0");
+          return new Response("", { status: 206 });
+        }
+        expect(String(url)).toBe("https://registry.npmjs.org/-/stage/stage-route-queue-000001");
         expect((init?.headers as Record<string, string>)?.authorization).toBe(`Bearer ${token}`);
-        expect((init?.headers as Record<string, string>)?.range).toBe("bytes=0-0");
-        return new Response("", { status: 206 });
+        return Response.json({
+          id: "stage-route-queue-000001",
+          packageName: "@org/queued",
+          version: "2.0.0",
+        });
       }),
     );
 
@@ -97,9 +103,18 @@ describe("scans route queue behavior", () => {
     await waitOnExecutionContext(ctx);
 
     expect(res.status).toBe(202);
-    const body = (await res.json()) as { scan: { id: string; stageId: string }; queued: boolean };
+    const body = (await res.json()) as {
+      scan: {
+        id: string;
+        stageId: string;
+        packageName: string | null;
+        stagedVersion: string | null;
+      };
+      queued: boolean;
+    };
     expect(body.queued).toBe(true);
     expect(body.scan.stageId).toBe("stage-route-queue-000001");
+    expect(body.scan).toMatchObject({ packageName: "@org/queued", stagedVersion: "2.0.0" });
 
     expect(queue.send).toHaveBeenCalledTimes(1);
     const message = queue.send.mock.calls[0]?.[0];

--- a/test/workers/staged-publishes-routes.test.ts
+++ b/test/workers/staged-publishes-routes.test.ts
@@ -130,5 +130,9 @@ describe("staged publishes route", () => {
     expect(queue.send.mock.calls[0]?.[0]).toMatchObject({ stageId: "stage-new-123" });
     const { scans } = await listScans(db, owner.organizationId);
     expect(scans.map((scan) => scan.stageId)).toContain("stage-new-123");
+    expect(scans.find((scan) => scan.stageId === "stage-new-123")).toMatchObject({
+      packageName: "@org/new",
+      stagedVersion: "1.1.0",
+    });
   });
 });


### PR DESCRIPTION
## Summary
A scan whose tarball never parses (e.g. an esbuild-style platform binary package tripping `archive_too_large`) previously had `packageName`/`stagedVersion` set only when the pipeline completed, so the "Version could not dock for inspection" notification and the failed-scan row showed no package name at all.

Now the package identity known *before* the tarball is touched is persisted at scan creation, and the pipeline still overwrites it with tarball-derived truth on completion:

- `CreateScanJobInput` gains optional `packageName`/`stagedVersion`, inserted by `createScanJob`.
- Auto-discovery passes `item.packageName`/`item.version` from the staged-publishes listing.
- Workflow-gate scans pass `candidate.package.name`/`.version` from the prepared bundle.
- Manual `POST /api/v1/scans` does a best-effort `fetchStagedPublishDetails` (staged metadata endpoint, no tarball bytes) and passes the result; failures fall back to `null` and don't block scan creation.

`formatPackageLabel` in `notify.ts` already reads `scan.packageName`/`stagedVersion`, so failed-scan emails/Slack messages now render `pkg@version` with no notification changes needed.

docs checked, no update needed.

Link to Devin session: https://app.devin.ai/sessions/d54f6486efc64c608697350770a4b367
Requested by: @JoviDeCroock