### PR TITLE
Stream tar extraction: skip oversized bodies and record them as content-skipped findings

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,7 +38,7 @@ The Worker is the trusted control plane; the sandbox treats package bytes as hos
 
 ## Sandbox parser
 
-Archive parsing is shared by the sandbox and tests rather than copied as strings. Tar parsing lives in `server/lib/tar-parser.js`; ZIP wheel parsing is covered by `test/zip-parser.test.mjs`; shared fixture writers live in `test/helpers/archive-fixtures.mjs`. The parser enforces path safety, file-count and expansion caps, unsupported-entry reporting, duplicate-path handling, and fail-closed behavior. `pnpm run fuzz` scales the archive-parser property suite for deeper exploration.
+Archive parsing is shared by the sandbox and tests rather than copied as strings. Tar parsing lives in `server/lib/tar-parser.js`; ZIP wheel parsing is covered by `test/zip-parser.test.mjs`; shared fixture writers live in `test/helpers/archive-fixtures.mjs`. The parser enforces path safety, file-count and expansion caps, unsupported-entry reporting, duplicate-path handling, and fail-closed behavior. Tarballs are parsed as a stream: entry bodies beyond the retention budget (`SANDBOX_MAX_TAR_BYTES`) — typically prepackaged platform binaries — are skipped rather than buffered, recorded as `content-skipped` files/findings with path and size only, under a total stream cap (`SANDBOX_MAX_STREAM_TAR_BYTES`). `pnpm run fuzz` scales the archive-parser property suite for deeper exploration.
 
 ## Scan pipeline
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -64,7 +64,7 @@ The sandbox parses untrusted bytes under archive/file/expanded-size caps and ret
 - PyPI artifact downloads restricted to `https://files.pythonhosted.org`;
 - GitHub artifact downloads scoped to the workflow-gate installation/run being reviewed.
 
-The sandbox must remain small and boring. Parser bugs should fail scans, not skip evidence.
+The sandbox must remain small and boring. Genuine parser bugs and malformed archives fail closed — the scan errors rather than returning partial evidence. Size is the one deliberate exception: tarballs are parsed as a stream, and a regular-file body larger than the per-file inspection limit, or one that no longer fits the archive's cumulative retention budget, is recorded as a `content-skipped` finding (path and declared size only, no hash or text) so oversized prepackaged binaries can be reviewed without buffering them. Skipped content is surfaced as a medium finding on every ecosystem path and must be verified out of band; manifests are always retained, or the scan fails closed. An oversized baseline (previous-version) archive degrades to a no-baseline scan rather than failing the staged review.
 
 ## Workflow-gate posture
 

--- a/server/lib/adapters/npm/acquire.ts
+++ b/server/lib/adapters/npm/acquire.ts
@@ -1,4 +1,5 @@
 import { pickBaselineVersion } from "../../registry";
+import { SandboxError } from "../../sandbox";
 import type { PackageJsonSummary } from "../../review";
 import type { StagedPublishDetails } from "../../staged-publishes";
 import type { AcquiredArtifact, AdapterContext, BaselineInfo, StagedDetails } from "../types";
@@ -80,9 +81,23 @@ export async function acquireBaselineNpm(
     };
   }
 
-  const previous = await broker.downloadPublished(tarballUrl, {
-    maxFiles: input.maxFiles,
-  });
+  let previous;
+  try {
+    previous = await broker.downloadPublished(tarballUrl, {
+      maxFiles: input.maxFiles,
+    });
+  } catch (err) {
+    // A baseline too large to fetch degrades to a no-baseline scan (the staged
+    // artifact still gets fully reviewed) instead of failing the whole scan —
+    // prepackaged-binary packages routinely publish multi-hundred-MB tarballs.
+    if (isArchiveTooLarge(err)) {
+      return {
+        artifact: null,
+        baseline: { ...baseline, reason: `${baseline.reason}:baseline-too-large` },
+      };
+    }
+    throw err;
+  }
   return {
     artifact: {
       files: previous.files,
@@ -107,6 +122,16 @@ function hasMetadataMismatch(
   if (details.packageName && pkg.name && details.packageName !== pkg.name) return true;
   if (details.version && pkg.version && details.version !== pkg.version) return true;
   return false;
+}
+
+function isArchiveTooLarge(err: unknown): boolean {
+  if (!(err instanceof SandboxError)) return false;
+  try {
+    const detail = JSON.parse(err.message) as { error?: string; status?: number };
+    return detail.status === 413;
+  } catch {
+    return false;
+  }
 }
 
 function emptyBaseline(tag: string | null, reason: string): BaselineInfo {

--- a/server/lib/adapters/npm/acquire.ts
+++ b/server/lib/adapters/npm/acquire.ts
@@ -129,10 +129,11 @@ function hasMetadataMismatch(
 
 /**
  * Classify a sandbox baseline-download failure into the specific safety limit it
- * hit, or null if it is an unrelated error that must still fail the scan. The
- * sandbox maps every safety-limit rejection to status 413, so the status gates
- * the branch and the error string names the cause — matching the classification
- * `classifyScanError` uses for the staged tarball.
+ * hit, or null if it is an unrelated error that must still fail the scan. Only
+ * whole-archive size limits (oversized tarball, decompression-bomb expansion,
+ * too-many-files) degrade the baseline; the sandbox maps those to status 413, so
+ * the status gates the branch and the error string names the cause. A malformed
+ * baseline (truncated/invalid entry, status 400) still fails the scan.
  */
 function baselineSafetyLimit(
   err: unknown,

--- a/server/lib/adapters/npm/acquire.ts
+++ b/server/lib/adapters/npm/acquire.ts
@@ -1,5 +1,5 @@
 import { pickBaselineVersion } from "../../registry";
-import { SandboxError } from "../../sandbox";
+import { sandboxErrorDetail } from "../../sandbox";
 import type { PackageJsonSummary } from "../../review";
 import type { StagedPublishDetails } from "../../staged-publishes";
 import type { AcquiredArtifact, AdapterContext, BaselineInfo, StagedDetails } from "../types";
@@ -125,9 +125,10 @@ function hasMetadataMismatch(
 }
 
 function isArchiveTooLarge(err: unknown): boolean {
-  if (!(err instanceof SandboxError)) return false;
+  const detailText = sandboxErrorDetail(err);
+  if (detailText === null) return false;
   try {
-    const detail = JSON.parse(err.message) as { error?: string; status?: number };
+    const detail = JSON.parse(detailText) as { error?: string; status?: number };
     return detail.status === 413;
   } catch {
     return false;

--- a/server/lib/adapters/npm/acquire.ts
+++ b/server/lib/adapters/npm/acquire.ts
@@ -1,5 +1,5 @@
 import { pickBaselineVersion } from "../../registry";
-import { sandboxErrorDetail } from "../../sandbox";
+import { parseSandboxErrorDetail } from "../../sandbox";
 import type { PackageJsonSummary } from "../../review";
 import type { StagedPublishDetails } from "../../staged-publishes";
 import type { AcquiredArtifact, AdapterContext, BaselineInfo, StagedDetails } from "../types";
@@ -87,13 +87,16 @@ export async function acquireBaselineNpm(
       maxFiles: input.maxFiles,
     });
   } catch (err) {
-    // A baseline too large to fetch degrades to a no-baseline scan (the staged
-    // artifact still gets fully reviewed) instead of failing the whole scan —
-    // prepackaged-binary packages routinely publish multi-hundred-MB tarballs.
-    if (isArchiveTooLarge(err)) {
+    // A baseline the sandbox rejects on a safety limit degrades to a no-baseline
+    // scan (the staged artifact still gets fully reviewed) instead of failing the
+    // whole scan — prepackaged-binary packages routinely publish multi-hundred-MB
+    // tarballs. The reason names the actual limit so operators are not told
+    // "too large" when the baseline instead had too many entries.
+    const limit = baselineSafetyLimit(err);
+    if (limit) {
       return {
         artifact: null,
-        baseline: { ...baseline, reason: `${baseline.reason}:baseline-too-large` },
+        baseline: { ...baseline, reason: `${baseline.reason}:${limit}` },
       };
     }
     throw err;
@@ -124,15 +127,22 @@ function hasMetadataMismatch(
   return false;
 }
 
-function isArchiveTooLarge(err: unknown): boolean {
-  const detailText = sandboxErrorDetail(err);
-  if (detailText === null) return false;
-  try {
-    const detail = JSON.parse(detailText) as { error?: string; status?: number };
-    return detail.status === 413;
-  } catch {
-    return false;
-  }
+/**
+ * Classify a sandbox baseline-download failure into the specific safety limit it
+ * hit, or null if it is an unrelated error that must still fail the scan. The
+ * sandbox maps every safety-limit rejection to status 413, so the status gates
+ * the branch and the error string names the cause — matching the classification
+ * `classifyScanError` uses for the staged tarball.
+ */
+function baselineSafetyLimit(
+  err: unknown,
+): "baseline-too-large" | "baseline-too-many-files" | null {
+  const detail = parseSandboxErrorDetail(err);
+  if (!detail || detail.status !== 413) return null;
+  const error = detail.error ?? "";
+  if (error.includes("too many files")) return "baseline-too-many-files";
+  if (error.includes("too large") || error.includes("safety limit")) return "baseline-too-large";
+  return null;
 }
 
 function emptyBaseline(tag: string | null, reason: string): BaselineInfo {

--- a/server/lib/adapters/pypi/acquire.ts
+++ b/server/lib/adapters/pypi/acquire.ts
@@ -26,6 +26,7 @@ export function preparePyPiArtifact(input: PyPiArtifactInput): PyPiPreparedArtif
     kind,
     files,
     summary: summarizePyPiArtifact(input.path, kind, files),
+    ...(input.suspiciousEntries ? { suspiciousEntries: input.suspiciousEntries } : {}),
   };
 }
 

--- a/server/lib/adapters/pypi/findings.ts
+++ b/server/lib/adapters/pypi/findings.ts
@@ -1,4 +1,9 @@
-import { type FileRecord, type Finding, PYTHON_EXECUTION_CAPABILITY_PATTERNS } from "../../review";
+import {
+  type FileRecord,
+  type Finding,
+  PYTHON_EXECUTION_CAPABILITY_PATTERNS,
+  tarSuspiciousEntryFindings,
+} from "../../review";
 import { firstMatchingLine } from "../../text-utils";
 import { normalizePyPiProjectName } from "./manifest";
 import {
@@ -29,6 +34,13 @@ export function pyPiReleaseFindings(
 
   for (const artifact of artifacts) {
     const { summary } = artifact;
+    // Surface tar-parser evidence (oversized content-skipped bodies, non-regular
+    // entries, duplicates, confusable paths) the sandbox recorded for this
+    // artifact. Without this the gate would drop them and pass an sdist whose
+    // oversized file was never inspected — a fail-open gap the npm path avoids.
+    for (const finding of tarSuspiciousEntryFindings(artifact.suspiciousEntries)) {
+      findings.push({ ...finding, file: namespacedPath(artifact.path, finding.file) });
+    }
     const metadataEvidencePath = namespacedPath(artifact.path, summary.metadataPath ?? "METADATA");
     if (!summary.metadataPath || !summary.name || !summary.version) {
       findings.push(

--- a/server/lib/adapters/pypi/manifest.ts
+++ b/server/lib/adapters/pypi/manifest.ts
@@ -117,13 +117,18 @@ const SUSPICIOUS_ENTRY_KINDS = new Set([
   "content-skipped",
 ]);
 
+// The sandbox parser caps suspicious entries at maxFiles; this bounds the
+// re-validation on the adapter-input boundary so a hand-crafted input (not
+// straight from the sandbox) cannot materialize an unbounded array.
+const SUSPICIOUS_ENTRY_INPUT_LIMIT = 5_000;
+
 // Preserve (and re-validate) the tar-parser's suspicious entries across the
 // adapter-input boundary so oversized content-skipped bodies still reach the
 // gate's findings instead of being silently dropped during input parsing.
 function parseSuspiciousEntries(raw: unknown): TarSuspiciousEntry[] | undefined {
   if (!Array.isArray(raw) || !raw.length) return undefined;
   const entries: TarSuspiciousEntry[] = [];
-  for (const item of raw) {
+  for (const item of raw.slice(0, SUSPICIOUS_ENTRY_INPUT_LIMIT)) {
     if (!isRecord(item)) continue;
     if (typeof item.kind !== "string" || !SUSPICIOUS_ENTRY_KINDS.has(item.kind)) continue;
     entries.push({

--- a/server/lib/adapters/pypi/manifest.ts
+++ b/server/lib/adapters/pypi/manifest.ts
@@ -1,4 +1,5 @@
 import type { FileRecord } from "../../review";
+import type { TarSuspiciousEntry } from "../../tar-parser.js";
 import {
   PYPI_ARTIFACT_LIMIT,
   PYPI_PROJECT_NAME_RE,
@@ -98,13 +99,40 @@ function parsePyPiArtifactInputs(raw: unknown, field: string): PyPiArtifactInput
     if (!isSafeManifestPath(path)) throw new Error(`${field}[${index}] path is not safe`);
     if (!Array.isArray(artifact.files))
       throw new Error(`${field}[${index}] files must be an array`);
+    const suspiciousEntries = parseSuspiciousEntries(artifact.suspiciousEntries);
     return {
       path,
       files: artifact.files.map((file, fileIndex) =>
         parseFileRecord(file, field, index, fileIndex),
       ),
+      ...(suspiciousEntries ? { suspiciousEntries } : {}),
     };
   });
+}
+
+const SUSPICIOUS_ENTRY_KINDS = new Set([
+  "non-regular",
+  "duplicate",
+  "unicode-confusable",
+  "content-skipped",
+]);
+
+// Preserve (and re-validate) the tar-parser's suspicious entries across the
+// adapter-input boundary so oversized content-skipped bodies still reach the
+// gate's findings instead of being silently dropped during input parsing.
+function parseSuspiciousEntries(raw: unknown): TarSuspiciousEntry[] | undefined {
+  if (!Array.isArray(raw) || !raw.length) return undefined;
+  const entries: TarSuspiciousEntry[] = [];
+  for (const item of raw) {
+    if (!isRecord(item)) continue;
+    if (typeof item.kind !== "string" || !SUSPICIOUS_ENTRY_KINDS.has(item.kind)) continue;
+    entries.push({
+      kind: item.kind as TarSuspiciousEntry["kind"],
+      path: typeof item.path === "string" ? item.path : "",
+      detail: typeof item.detail === "string" ? item.detail : "",
+    });
+  }
+  return entries.length ? entries : undefined;
 }
 
 function parseFileRecord(

--- a/server/lib/adapters/pypi/types.ts
+++ b/server/lib/adapters/pypi/types.ts
@@ -1,4 +1,5 @@
 import type { DiffEntry, FileRecord, Finding, RiskLevel } from "../../review";
+import type { TarSuspiciousEntry } from "../../tar-parser.js";
 
 export const PYPI_RELEASE_MANIFEST_SCHEMA = "drydock.release-artifacts.v1";
 export const PYPI_RULES_VERSION = "0.2.0";
@@ -40,6 +41,10 @@ export interface PyPiReleaseManifest {
 export interface PyPiArtifactInput {
   path: string;
   files: FileRecord[];
+  // Tar-parser findings (oversized content-skipped bodies, non-regular entries,
+  // duplicates, confusable paths) for this artifact. Carried through so the gate
+  // surfaces them as findings instead of dropping evidence the sandbox recorded.
+  suspiciousEntries?: TarSuspiciousEntry[];
 }
 
 export interface PyPiArtifactSummary {

--- a/server/lib/review-diff.ts
+++ b/server/lib/review-diff.ts
@@ -37,7 +37,11 @@ export function createPackageDiff(
         previousSha256: before.sha256,
         flags: before.flags,
       };
-    if (before && after && before.sha256 !== after.sha256) {
+    if (
+      before &&
+      after &&
+      (before.sha256 !== after.sha256 || hasUninspectableContent(before, after))
+    ) {
       return {
         path,
         status: "modified",
@@ -58,4 +62,8 @@ export function createPackageDiff(
       flags: [...new Set([...(before?.flags || []), ...(after?.flags || [])])],
     };
   });
+}
+
+function hasUninspectableContent(...files: FileRecord[]): boolean {
+  return files.some((file) => file.flags.includes("content-skipped"));
 }

--- a/server/lib/review-diff.ts
+++ b/server/lib/review-diff.ts
@@ -40,7 +40,9 @@ export function createPackageDiff(
     if (
       before &&
       after &&
-      (before.sha256 !== after.sha256 || hasUninspectableContent(before, after))
+      (before.sha256 !== after.sha256 ||
+        hasUninspectableContent(before) ||
+        hasUninspectableContent(after))
     ) {
       return {
         path,
@@ -64,6 +66,6 @@ export function createPackageDiff(
   });
 }
 
-function hasUninspectableContent(...files: FileRecord[]): boolean {
-  return files.some((file) => file.flags.includes("content-skipped"));
+function hasUninspectableContent(file: FileRecord): boolean {
+  return file.flags.includes("content-skipped");
 }

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -123,6 +123,8 @@ function tarSuspiciousReason(entry: TarSuspiciousEntry): string {
       return "two entries share the same normalized path; last-write-wins extraction means a benign first entry can mask a malicious second";
     case "unicode-confusable":
       return "path contains zero-width or visually-confusable characters; the consumer's tar implementation may canonicalize this differently than the reviewer and let it bypass deterministic file checks";
+    case "content-skipped":
+      return "file body exceeded the scanner's retention limit, so only its path and size were recorded; the content was never inspected and must be verified through provenance or out-of-band review";
   }
 }
 

--- a/server/lib/sandbox.ts
+++ b/server/lib/sandbox.ts
@@ -6,8 +6,14 @@ import type { TarSuspiciousEntry } from "./tar-parser.js";
 
 export const SANDBOX_MAX_FILES = 2_500;
 export const SANDBOX_MAX_TAR_BYTES = 25 * 1024 * 1024;
+// Total decompressed bytes the streaming tar reader may consume. Bodies beyond
+// the retention budget (SANDBOX_MAX_TAR_BYTES) are skipped, not buffered, so
+// this cap bounds CPU/streaming work rather than memory — it is what lets big
+// prepackaged-binary packages dock without buffering their binaries.
+export const SANDBOX_MAX_STREAM_TAR_BYTES = 10 * SANDBOX_MAX_TAR_BYTES;
 const MAX_FILES = SANDBOX_MAX_FILES;
 const MAX_TAR_BYTES = SANDBOX_MAX_TAR_BYTES;
+const MAX_STREAM_TAR_BYTES = SANDBOX_MAX_STREAM_TAR_BYTES;
 
 // Functions whose source text is concatenated into the sandbox worker module.
 // They must remain referenced only by lexical name (no closures) so the order
@@ -30,7 +36,8 @@ const SANDBOX_TAR_PARSER_EXPORTS = [
   tarParser.sha256Hex,
   tarParser.shouldSkipTextSample,
   tarParser.summarizeFile,
-  tarParser.readTar,
+  tarParser.summarizeSkippedFile,
+  tarParser.readTarStream,
   tarParser.readUint16Le,
   tarParser.readUint32Le,
   tarParser.findZipEndOfCentralDirectory,
@@ -38,7 +45,6 @@ const SANDBOX_TAR_PARSER_EXPORTS = [
   tarParser.readZipArchive,
   tarParser.readStreamBounded,
   tarParser.parsePackageJson,
-  tarParser.gunzipBounded,
 ];
 
 function renderTarParserSource() {
@@ -194,6 +200,7 @@ export async function downloadInSandboxInline(
       ARCHIVE_FORMAT: options.format,
       MAX_FILES: Math.min(options.maxFiles ?? MAX_FILES, MAX_FILES),
       MAX_TAR_BYTES,
+      MAX_STREAM_TAR_BYTES,
     },
     globalOutbound: (
       ctx as unknown as {
@@ -256,6 +263,7 @@ export async function downloadInSandbox(
       ARCHIVE_FORMAT: options.archiveFormat || "tgz",
       MAX_FILES: Math.min(options.maxFiles ?? MAX_FILES, MAX_FILES),
       MAX_TAR_BYTES,
+      MAX_STREAM_TAR_BYTES,
     },
     globalOutbound: (
       ctx as unknown as {
@@ -308,8 +316,10 @@ export default {
       res = await fetch(url, { headers: { accept: "application/octet-stream" } });
       if (!res.ok) return json({ error: "download failed", status: res.status }, 502);
 
+      // Only the zip path buffers the whole archive, so only it needs the wire-size
+      // gate. The tgz path streams: oversized bodies are skipped, never buffered.
       const contentLength = Number(res.headers.get("content-length") || "0");
-      if (contentLength > maxTarBytes) return json({ error: "tarball too large", status: 413 }, 413);
+      if (archiveFormat === "zip" && contentLength > maxTarBytes) return json({ error: "tarball too large", status: 413 }, 413);
     }
     if (archiveFormat === "zip") {
       let zip;
@@ -337,30 +347,28 @@ export default {
       return json({ files, packageJson: null });
     }
 
-    let tar;
-    try {
-      tar = await gunzipBounded(res.body, maxTarBytes);
-    } catch (err) {
-      const reason = err && err.message === "archive expands beyond safety limit"
-        ? "archive expands beyond safety limit"
-        : "tarball decompression failed";
-      const status = reason === "archive expands beyond safety limit" ? 413 : 400;
-      return json({ error: reason, status }, status);
-    }
-    if (tar.byteLength > maxTarBytes) return json({ error: "archive expands beyond safety limit", status: 413 }, 413);
+    const maxStreamTarBytes = env.MAX_STREAM_TAR_BYTES || maxTarBytes * 10;
     let files;
     let suspiciousEntries;
     try {
-      const parsed = await readTar(tar, env.MAX_FILES || 2_500, maxTarBytes);
+      if (!res.body) return json({ error: "tarball decompression failed", status: 400 }, 400);
+      const tarStream = res.body.pipeThrough(new DecompressionStream("gzip"));
+      const parsed = await readTarStream(tarStream, env.MAX_FILES || 2_500, maxTarBytes, maxStreamTarBytes);
       files = parsed.files;
       suspiciousEntries = parsed.suspicious;
     } catch (err) {
-      const reason = err && err.message === "archive contains too many files"
-        ? "archive contains too many files"
-        : err && err.message
-          ? err.message
-          : "tarball parse failed";
-      const status = reason === "archive contains too many files" ? 413 : 400;
+      const message = err && err.message ? err.message : "";
+      const parserMessages = [
+        "archive contains too many files",
+        "archive expands beyond safety limit",
+        "truncated tar entry",
+        "invalid tar entry size",
+        "invalid pax path",
+        "invalid long-name path",
+      ];
+      // Anything the parser did not throw itself is a gzip stream failure.
+      const reason = parserMessages.includes(message) ? message : "tarball decompression failed";
+      const status = reason === "archive contains too many files" || reason === "archive expands beyond safety limit" ? 413 : 400;
       return json({ error: reason, status }, status);
     }
     const packageJson = parsePackageJson(files);

--- a/server/lib/sandbox.ts
+++ b/server/lib/sandbox.ts
@@ -38,6 +38,7 @@ const SANDBOX_TAR_PARSER_EXPORTS = [
   tarParser.summarizeFile,
   tarParser.summarizeSkippedFile,
   tarParser.isRetainedManifestPath,
+  tarParser.isRootManifestPath,
   tarParser.tarError,
   tarParser.readTarStream,
   tarParser.readUint16Le,

--- a/server/lib/sandbox.ts
+++ b/server/lib/sandbox.ts
@@ -37,6 +37,8 @@ const SANDBOX_TAR_PARSER_EXPORTS = [
   tarParser.shouldSkipTextSample,
   tarParser.summarizeFile,
   tarParser.summarizeSkippedFile,
+  tarParser.isRetainedManifestPath,
+  tarParser.tarError,
   tarParser.readTarStream,
   tarParser.readUint16Le,
   tarParser.readUint32Le,
@@ -148,6 +150,28 @@ export function sandboxErrorDetail(err: unknown): string | null {
     return value.message;
   }
   return null;
+}
+
+/**
+ * Parse a sandbox error's serialized `{ error, status }` detail. Returns null
+ * when the error is not a sandbox error or its detail is not the expected shape,
+ * so callers can branch on the sandbox's own status/error without each
+ * re-implementing the JSON.parse dance.
+ */
+export function parseSandboxErrorDetail(
+  err: unknown,
+): { error: string | null; status: number | null } | null {
+  const detailText = sandboxErrorDetail(err);
+  if (detailText === null) return null;
+  try {
+    const parsed = JSON.parse(detailText) as { error?: unknown; status?: unknown };
+    return {
+      error: typeof parsed.error === "string" ? parsed.error : null,
+      status: typeof parsed.status === "number" ? parsed.status : null,
+    };
+  } catch {
+    return null;
+  }
 }
 
 function isSerializedSandboxDetail(message: string): boolean {
@@ -357,17 +381,10 @@ export default {
       files = parsed.files;
       suspiciousEntries = parsed.suspicious;
     } catch (err) {
-      const message = err && err.message ? err.message : "";
-      const parserMessages = [
-        "archive contains too many files",
-        "archive expands beyond safety limit",
-        "truncated tar entry",
-        "invalid tar entry size",
-        "invalid pax path",
-        "invalid long-name path",
-      ];
-      // Anything the parser did not throw itself is a gzip stream failure.
-      const reason = parserMessages.includes(message) ? message : "tarball decompression failed";
+      // The parser tags its own safety-limit / malformed-archive errors, so
+      // anything untagged is an upstream gzip/stream failure. This avoids
+      // matching on exact message text, which silently drifts on a reword.
+      const reason = err && err.tarSafety && err.message ? err.message : "tarball decompression failed";
       const status = reason === "archive contains too many files" || reason === "archive expands beyond safety limit" ? 413 : 400;
       return json({ error: reason, status }, status);
     }

--- a/server/lib/tar-parser.d.ts
+++ b/server/lib/tar-parser.d.ts
@@ -24,7 +24,11 @@ export interface ParsedPackageJson {
   exports?: unknown;
 }
 
-export type TarSuspiciousEntryKind = "non-regular" | "duplicate" | "unicode-confusable";
+export type TarSuspiciousEntryKind =
+  | "non-regular"
+  | "duplicate"
+  | "unicode-confusable"
+  | "content-skipped";
 
 export interface TarSuspiciousEntry {
   kind: TarSuspiciousEntryKind;
@@ -57,10 +61,17 @@ export function describeNonRegularType(type: string): string;
 export function sha256Hex(bytes: Uint8Array): Promise<string>;
 export function shouldSkipTextSample(path: string): boolean;
 export function summarizeFile(path: string, body: Uint8Array): Promise<ParsedFile>;
+export function summarizeSkippedFile(path: string, size: number): ParsedFile;
 export function readTar(
   buffer: ArrayBuffer | Uint8Array,
   maxFiles: number,
   maxTarBytes: number,
+): Promise<ReadTarResult>;
+export function readTarStream(
+  body: ReadableStream<Uint8Array> | null,
+  maxFiles: number,
+  maxTarBytes: number,
+  maxStreamBytes: number,
 ): Promise<ReadTarResult>;
 export function readUint16Le(bytes: Uint8Array, offset: number): number;
 export function readUint32Le(bytes: Uint8Array, offset: number): number;

--- a/server/lib/tar-parser.d.ts
+++ b/server/lib/tar-parser.d.ts
@@ -63,6 +63,7 @@ export function shouldSkipTextSample(path: string): boolean;
 export function summarizeFile(path: string, body: Uint8Array): Promise<ParsedFile>;
 export function summarizeSkippedFile(path: string, size: number): ParsedFile;
 export function isRetainedManifestPath(path: string | null | undefined): boolean;
+export function isRootManifestPath(path: string | null | undefined): boolean;
 export function tarError(message: string): Error & { tarSafety: true };
 export function readTar(
   buffer: ArrayBuffer | Uint8Array,

--- a/server/lib/tar-parser.d.ts
+++ b/server/lib/tar-parser.d.ts
@@ -62,6 +62,8 @@ export function sha256Hex(bytes: Uint8Array): Promise<string>;
 export function shouldSkipTextSample(path: string): boolean;
 export function summarizeFile(path: string, body: Uint8Array): Promise<ParsedFile>;
 export function summarizeSkippedFile(path: string, size: number): ParsedFile;
+export function isRetainedManifestPath(path: string | null | undefined): boolean;
+export function tarError(message: string): Error & { tarSafety: true };
 export function readTar(
   buffer: ArrayBuffer | Uint8Array,
   maxFiles: number,
@@ -87,7 +89,3 @@ export function readStreamBounded(
   maxBytes: number,
 ): Promise<Uint8Array>;
 export function parsePackageJson(files: ParsedFile[]): ParsedPackageJson | null;
-export function gunzipBounded(
-  body: ReadableStream<Uint8Array> | null,
-  maxBytes: number,
-): Promise<ArrayBuffer>;

--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -231,6 +231,34 @@ export function summarizeSkippedFile(path, size) {
   return { path, size, sha256: "", flags: ["content-skipped"] };
 }
 
+// Manifests carry the identity/metadata every ecosystem review depends on
+// (name, version, install hooks, dependency and RECORD/METADATA data), so they
+// must always be inspected even when the retention budget has been spent on
+// large prepackaged binaries. Matching by basename covers npm's `package.json`,
+// PyPI sdists' `PKG-INFO`/`pyproject.toml`, and wheel `METADATA` regardless of
+// the version directory the archive nests them under. A manifest too large to
+// inspect fails the parse (see readTarStream) rather than silently nulling the
+// package's identity.
+export function isRetainedManifestPath(path) {
+  const normalized = String(path || "").replaceAll("\\", "/");
+  const basename = normalized.slice(normalized.lastIndexOf("/") + 1);
+  return (
+    basename === "package.json" ||
+    basename === "PKG-INFO" ||
+    basename === "pyproject.toml" ||
+    basename === "METADATA"
+  );
+}
+
+// Tags a parser safety-limit / malformed-archive error so the sandbox worker can
+// distinguish it from an upstream gzip/stream failure without matching on exact
+// message strings (which silently drift when a message is reworded).
+export function tarError(message) {
+  const err = new Error(message);
+  err.tarSafety = true;
+  return err;
+}
+
 export async function readTar(buffer, maxFiles, maxTarBytes) {
   const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
   return readTarStream(new Response(bytes).body, maxFiles, maxTarBytes, Infinity);
@@ -246,9 +274,8 @@ export async function readTar(buffer, maxFiles, maxTarBytes) {
 // platform binaries alongside a small manifest.
 export async function readTarStream(body, maxFiles, maxTarBytes, maxStreamBytes) {
   const nul = String.fromCharCode(0);
-  if (!body) throw new Error("tarball decompression failed");
+  if (!body) throw tarError("tarball decompression failed");
   const reader = body.getReader();
-  const streamLimit = Number.isFinite(maxStreamBytes) ? maxStreamBytes : Infinity;
   const chunks = [];
   let buffered = 0;
   let streamed = 0;
@@ -262,10 +289,7 @@ export async function readTarStream(body, maxFiles, maxTarBytes, maxStreamBytes)
         break;
       }
       streamed += value.byteLength;
-      if (streamed > streamLimit) {
-        reader.cancel().catch(() => undefined);
-        throw new Error("archive expands beyond safety limit");
-      }
+      if (streamed > maxStreamBytes) throw tarError("archive expands beyond safety limit");
       chunks.push(value);
       buffered += value.byteLength;
     }
@@ -316,6 +340,10 @@ export async function readTarStream(body, maxFiles, maxTarBytes, maxStreamBytes)
   const suspiciousLimit = Math.max(1, Number.isFinite(maxFiles) ? maxFiles : 250);
   let suspiciousLimitReached = false;
   const seenPaths = new Map();
+  // Bytes each retained path contributes to `retainedBytes`, so a later
+  // duplicate that replaces an entry releases the earlier body's budget instead
+  // of double-counting it (which would prematurely exhaust the retention limit).
+  const retainedByPath = new Map();
   let nextLongName = null;
   let pax = null;
   let retainedBytes = 0;
@@ -335,122 +363,144 @@ export async function readTarStream(body, maxFiles, maxTarBytes, maxStreamBytes)
     }
   }
 
-  while (await fill(512)) {
-    const header = take(512);
-    if (header.every((b) => b === 0)) break;
+  try {
+    while (await fill(512)) {
+      const header = take(512);
+      if (header.every((b) => b === 0)) break;
 
-    const rawName = readString(header, 0, 100);
-    const prefix = readString(header, 345, 155);
-    const sizeText = readString(header, 124, 12).trim() || "0";
-    if (!/^[0-7]+$/.test(sizeText)) throw new Error("invalid tar entry size");
-    const size = parseInt(sizeText, 8);
-    if (!Number.isFinite(size) || size < 0) throw new Error("invalid tar entry size");
-    const type = String.fromCharCode(header[156] || 48);
-    const padding = Math.ceil(size / 512) * 512 - size;
+      const rawName = readString(header, 0, 100);
+      const prefix = readString(header, 345, 155);
+      const sizeText = readString(header, 124, 12).trim() || "0";
+      if (!/^[0-7]+$/.test(sizeText)) throw tarError("invalid tar entry size");
+      const size = parseInt(sizeText, 8);
+      if (!Number.isFinite(size) || size < 0) throw tarError("invalid tar entry size");
+      const type = String.fromCharCode(header[156] || 48);
+      const isRegular = type === "0" || type === nul;
+      const padding = Math.ceil(size / 512) * 512 - size;
 
-    if (type === "x" || type === "g" || type === "L") {
-      // Metadata entries must be materialized to be interpreted; a metadata
-      // body beyond the retention limit is only ever hand-crafted.
-      if (size > maxTarBytes) throw new Error("invalid tar entry size");
-      if (!(await fill(size))) throw new Error("truncated tar entry");
-      const body = take(size);
-      if (type === "x") {
-        // Local PAX header. Its path attribute applies only to the next entry.
-        pax = parsePax(body);
-        if (pax && typeof pax.path === "string" && !isSafePaxPath(pax.path)) {
-          throw new Error("invalid pax path");
+      // Only regular files stream-skip oversized bodies (the prepackaged-binary
+      // case). Metadata (x/g/L) and non-regular entries must be materialized or
+      // are never legitimately huge, so an oversized body is malformed/hostile —
+      // fail closed rather than burn the sandbox's CPU budget discarding it.
+      if (!isRegular && size > maxTarBytes) throw tarError("invalid tar entry size");
+
+      if (type === "x" || type === "g" || type === "L") {
+        if (!(await fill(size))) throw tarError("truncated tar entry");
+        const body = take(size);
+        if (type === "x") {
+          // Local PAX header. Its path attribute applies only to the next entry.
+          pax = parsePax(body);
+          if (pax && typeof pax.path === "string" && !isSafePaxPath(pax.path)) {
+            throw tarError("invalid pax path");
+          }
+        } else if (type === "g") {
+          // Global PAX metadata does not override the path of following entries.
+          // Ignoring path here keeps scanner paths aligned with tar extraction.
+          parsePax(body);
+          nextLongName = null;
+          pax = null;
+        } else {
+          // readString already stops at the first NUL terminator, so the long-name
+          // payload is implicitly trimmed at the NUL boundary.
+          const candidate = readString(body, 0, body.length);
+          if (!isSafePaxPath(candidate)) throw tarError("invalid long-name path");
+          nextLongName = candidate;
         }
-      } else if (type === "g") {
-        // Global PAX metadata does not override the path of following entries.
-        // Ignoring path here keeps scanner paths aligned with tar extraction.
-        parsePax(body);
+      } else if (isRegular) {
+        const rawCandidate =
+          (pax && pax.path) || nextLongName || (prefix ? prefix + "/" : "") + rawName;
+        const canonicalCandidate = canonicalizePath(rawCandidate);
+        const path = normalizeTarPath(rawCandidate);
+        const canonicalPath = normalizeTarPath(canonicalCandidate);
+        if (rawCandidate !== canonicalCandidate) {
+          addSuspicious({
+            kind: "unicode-confusable",
+            path: canonicalPath || path || "<invalid-path>",
+            detail: canonicalPath
+              ? "path contained zero-width or visually-confusable characters"
+              : "path contained zero-width or visually-confusable characters and normalized to an unsafe path",
+          });
+        }
+        // A manifest too large to inspect must fail the scan, never silently
+        // become a null manifest that disables every manifest-derived detection.
+        if (path && isRetainedManifestPath(path) && size > maxTarBytes) {
+          throw tarError("invalid tar entry size");
+        }
+        const mustRetainBody = path ? isRetainedManifestPath(path) : false;
+        const retainBody =
+          size <= maxTarBytes && (mustRetainBody || retainedBytes + size <= maxTarBytes);
+        let summarized = null;
+        let contributed = 0;
+        if (path && retainBody) {
+          if (!(await fill(size))) throw tarError("truncated tar entry");
+          summarized = await summarizeFile(path, take(size));
+          contributed = size;
+        } else {
+          if (!(await discard(size))) throw tarError("truncated tar entry");
+          if (path) {
+            summarized = summarizeSkippedFile(path, size);
+            // Distinguish a body too large to inspect on its own from a small
+            // body skipped only because earlier files spent the shared budget —
+            // the message is user-facing evidence and must be accurate.
+            const detail =
+              size > maxTarBytes
+                ? `file body (${size} bytes) exceeds the ${maxTarBytes}-byte per-file inspection limit`
+                : `file body (${size} bytes) did not fit the archive's ${maxTarBytes}-byte cumulative retention budget already spent on earlier files`;
+            addSuspicious({
+              kind: "content-skipped",
+              path,
+              detail: `${detail}; metadata recorded but content not inspected`,
+            });
+          }
+        }
+        if (path && summarized) {
+          if (seenPaths.has(path)) {
+            // Match last-write-wins extraction so downstream checks inspect the
+            // bytes consumers are likely to receive, while still surfacing the duplicate.
+            addSuspicious({
+              kind: "duplicate",
+              path,
+              detail: "duplicate path; later entry replaced earlier entry",
+            });
+            retainedBytes -= retainedByPath.get(path) || 0;
+            files[seenPaths.get(path)] = summarized;
+          } else {
+            if (files.length >= maxFiles) throw tarError("archive contains too many files");
+            seenPaths.set(path, files.length);
+            files.push(summarized);
+          }
+          retainedByPath.set(path, contributed);
+          retainedBytes += contributed;
+        }
         nextLongName = null;
         pax = null;
       } else {
-        // readString already stops at the first NUL terminator, so the long-name
-        // payload is implicitly trimmed at the NUL boundary.
-        const candidate = readString(body, 0, body.length);
-        if (!isSafePaxPath(candidate)) throw new Error("invalid long-name path");
-        nextLongName = candidate;
-      }
-    } else if (type === "0" || type === nul) {
-      const rawCandidate =
-        (pax && pax.path) || nextLongName || (prefix ? prefix + "/" : "") + rawName;
-      const canonicalCandidate = canonicalizePath(rawCandidate);
-      const path = normalizeTarPath(rawCandidate);
-      const canonicalPath = normalizeTarPath(canonicalCandidate);
-      if (rawCandidate !== canonicalCandidate) {
+        // Non-regular entry (hardlink, symlink, device, directory, fifo,
+        // reserved). npm publish never emits these; a hand-crafted tar can.
+        const rawCandidate =
+          (pax && pax.path) || nextLongName || (prefix ? prefix + "/" : "") + rawName;
+        const reportedPath = normalizeTarPath(canonicalizePath(rawCandidate)) || rawCandidate || "";
         addSuspicious({
-          kind: "unicode-confusable",
-          path: canonicalPath || path || "<invalid-path>",
-          detail: canonicalPath
-            ? "path contained zero-width or visually-confusable characters"
-            : "path contained zero-width or visually-confusable characters and normalized to an unsafe path",
+          kind: "non-regular",
+          path: reportedPath,
+          detail: `typeflag ${type} (${describeNonRegularType(type)})`,
         });
+        if (!(await discard(size))) throw tarError("truncated tar entry");
+        nextLongName = null;
+        pax = null;
       }
-      const mustRetainBody = path === "package.json";
-      const retainBody =
-        size <= maxTarBytes && (mustRetainBody || retainedBytes + size <= maxTarBytes);
-      let summarized = null;
-      if (path && retainBody) {
-        if (!(await fill(size))) throw new Error("truncated tar entry");
-        summarized = await summarizeFile(path, take(size));
-        retainedBytes += size;
-      } else {
-        if (!(await discard(size))) throw new Error("truncated tar entry");
-        if (path) {
-          summarized = summarizeSkippedFile(path, size);
-          addSuspicious({
-            kind: "content-skipped",
-            path,
-            detail: `file body (${size} bytes) exceeds the ${maxTarBytes}-byte retention limit; metadata recorded but content not inspected`,
-          });
-        }
-      }
-      if (path && summarized) {
-        if (seenPaths.has(path)) {
-          // Match last-write-wins extraction so downstream checks inspect the
-          // bytes consumers are likely to receive, while still surfacing the duplicate.
-          addSuspicious({
-            kind: "duplicate",
-            path,
-            detail: "duplicate path; later entry replaced earlier entry",
-          });
-          files[seenPaths.get(path)] = summarized;
-        } else {
-          if (files.length >= maxFiles) throw new Error("archive contains too many files");
-          seenPaths.set(path, files.length);
-          files.push(summarized);
-        }
-      }
-      nextLongName = null;
-      pax = null;
-    } else {
-      // Non-regular entry (hardlink, symlink, device, directory, fifo,
-      // reserved). npm publish never emits these; a hand-crafted tar can.
-      // Unlike regular files, there is no legitimate reason to stream-discard
-      // a huge body here, so fail fast instead of burning the sandbox's CPU
-      // budget on content that is never retained.
-      if (size > maxTarBytes) throw new Error("invalid tar entry size");
-      const rawCandidate =
-        (pax && pax.path) || nextLongName || (prefix ? prefix + "/" : "") + rawName;
-      const reportedPath = normalizeTarPath(canonicalizePath(rawCandidate)) || rawCandidate || "";
-      addSuspicious({
-        kind: "non-regular",
-        path: reportedPath,
-        detail: `typeflag ${type} (${describeNonRegularType(type)})`,
-      });
-      if (!(await discard(size))) throw new Error("truncated tar entry");
-      nextLongName = null;
-      pax = null;
-    }
 
-    // Inter-entry padding; a missing final pad block is tolerated like the
-    // buffer reader tolerated a trailing partial block.
-    if (padding > 0) await discard(padding);
+      // Inter-entry padding; a missing final pad block is tolerated like the
+      // buffer reader tolerated a trailing partial block.
+      if (padding > 0) await discard(padding);
+    }
+    return { files, suspicious };
+  } finally {
+    // Release the stream on every exit — success, break, or any thrown parser
+    // error — so a malformed archive never leaves the reader lock held and the
+    // upstream fetch/DecompressionStream pipe open against the sandbox budget.
+    reader.cancel().catch(() => undefined);
   }
-  reader.cancel().catch(() => undefined);
-  return { files, suspicious };
 }
 
 export function readUint16Le(bytes, offset) {
@@ -632,29 +682,4 @@ export function parsePackageJson(files) {
   } catch {
     return null;
   }
-}
-
-export async function gunzipBounded(body, maxBytes) {
-  if (!body) throw new Error("tarball decompression failed");
-  const ds = new DecompressionStream("gzip");
-  const reader = body.pipeThrough(ds).getReader();
-  const chunks = [];
-  let total = 0;
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    total += value.byteLength;
-    if (total > maxBytes) {
-      reader.cancel().catch(() => undefined);
-      throw new Error("archive expands beyond safety limit");
-    }
-    chunks.push(value);
-  }
-  const out = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) {
-    out.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return out.buffer;
 }

--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -250,6 +250,24 @@ export function isRetainedManifestPath(path) {
   );
 }
 
+// The *root* manifest an ecosystem derives package identity/dependencies from:
+// npm's `package.json` (the `package/` prefix is already stripped) and a PyPI
+// sdist's `PKG-INFO`/`pyproject.toml`, which live at the archive root or under a
+// single `<name>-<version>/` directory. A body too large to inspect here would
+// null the manifest and leave identity/deps uninspected, so it fails the parse
+// rather than degrading to a finding. Matching is anchored to the root (not the
+// basename anywhere) so a benign deeply-nested/vendored manifest-named file is
+// skipped, not fatal.
+export function isRootManifestPath(path) {
+  const normalized = String(path || "").replaceAll("\\", "/");
+  if (normalized === "package.json") return true;
+  if (normalized === "PKG-INFO" || normalized === "pyproject.toml") return true;
+  const slash = normalized.indexOf("/");
+  if (slash === -1 || normalized.indexOf("/", slash + 1) !== -1) return false;
+  const rest = normalized.slice(slash + 1);
+  return rest === "PKG-INFO" || rest === "pyproject.toml";
+}
+
 // Tags a parser safety-limit / malformed-archive error so the sandbox worker can
 // distinguish it from an upstream gzip/stream failure without matching on exact
 // message strings (which silently drift when a message is reworded).
@@ -421,12 +439,13 @@ export async function readTarStream(body, maxFiles, maxTarBytes, maxStreamBytes)
               : "path contained zero-width or visually-confusable characters and normalized to an unsafe path",
           });
         }
-        // The root npm manifest is the one file parsePackageJson depends on, and
-        // a body too large to inspect there would silently null the manifest and
-        // disable every manifest-derived detection. A >25MB package.json is only
-        // ever hostile, so fail closed. Nested/vendored manifest-named files are
-        // not the package manifest, so they are skipped (below), not fatal.
-        if (path === "package.json" && size > maxTarBytes) {
+        // A root manifest (npm package.json, PyPI PKG-INFO/pyproject.toml) too
+        // large to inspect would null the package's identity/dependency metadata
+        // and disable every manifest-derived detection. A >25MB manifest is only
+        // ever hostile, so fail closed rather than downgrade the trust-boundary
+        // failure to a finding. Nested/vendored manifest-named files are not the
+        // root manifest, so they are skipped (below), not fatal.
+        if (path && isRootManifestPath(path) && size > maxTarBytes) {
           throw tarError("invalid tar entry size");
         }
         // Retention tiers, tightest first:

--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -439,15 +439,12 @@ export async function readTarStream(body, maxFiles, maxTarBytes, maxStreamBytes)
               : "path contained zero-width or visually-confusable characters and normalized to an unsafe path",
           });
         }
-        // A root manifest (npm package.json, PyPI PKG-INFO/pyproject.toml) too
-        // large to inspect would null the package's identity/dependency metadata
-        // and disable every manifest-derived detection. A >25MB manifest is only
-        // ever hostile, so fail closed rather than downgrade the trust-boundary
-        // failure to a finding. Nested/vendored manifest-named files are not the
-        // root manifest, so they are skipped (below), not fatal.
-        if (path && isRootManifestPath(path) && size > maxTarBytes) {
-          throw tarError("invalid tar entry size");
-        }
+        // A duplicate path replaces (does not add to) its earlier entry under
+        // last-write-wins, so exclude that earlier copy's retained bytes from the
+        // budget here — otherwise a duplicate that would fit after the release is
+        // wrongly skipped, leaving the very bytes a consumer receives uninspected.
+        const priorContribution = path && seenPaths.has(path) ? retainedByPath.get(path) || 0 : 0;
+        const budgetBase = retainedBytes - priorContribution;
         // Retention tiers, tightest first:
         //  - the root npm manifest is ALWAYS inspected — parsePackageJson depends
         //    on it, and it is a single deduped path, so this adds at most one
@@ -457,13 +454,23 @@ export async function readTarStream(body, maxFiles, maxTarBytes, maxStreamBytes)
         //    second maxTarBytes of headroom, so a tar stuffed with manifest-named
         //    files still cannot amplify retained memory;
         //  - everything else must fit the shared maxTarBytes budget.
-        const isRootManifest = path === "package.json";
+        const isNpmRootManifest = path === "package.json";
         const mustRetainBody = path ? isRetainedManifestPath(path) : false;
         const retainBody =
           size <= maxTarBytes &&
-          (isRootManifest ||
-            retainedBytes + size <= maxTarBytes ||
-            (mustRetainBody && retainedBytes + size <= 2 * maxTarBytes));
+          (isNpmRootManifest ||
+            budgetBase + size <= maxTarBytes ||
+            (mustRetainBody && budgetBase + size <= 2 * maxTarBytes));
+        // A root manifest we cannot inspect — too large for the per-file limit, or
+        // crowded out of the retention budget by earlier manifest-named entries —
+        // must fail the parse rather than degrade its name/version/dependency
+        // metadata to a content-skipped finding, honoring the fail-closed manifest
+        // guarantee for PyPI (whose attacker-shaped root path cannot get npm's
+        // always-retain guarantee) as well as npm. Nested/vendored manifest-named
+        // files are not root manifests and are skipped below, not fatal.
+        if (path && isRootManifestPath(path) && !retainBody) {
+          throw tarError("invalid tar entry size");
+        }
         let summarized = null;
         let contributed = 0;
         if (path && retainBody) {

--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -429,15 +429,21 @@ export async function readTarStream(body, maxFiles, maxTarBytes, maxStreamBytes)
         if (path === "package.json" && size > maxTarBytes) {
           throw tarError("invalid tar entry size");
         }
-        // Manifests bypass the shared retention budget so a package's identity is
-        // always inspected even behind large binaries, but they draw on a bounded
-        // headroom (a second maxTarBytes) rather than an unlimited bypass — a tar
-        // stuffed with manifest-named files cannot amplify retained memory past
-        // 2×maxTarBytes.
+        // Retention tiers, tightest first:
+        //  - the root npm manifest is ALWAYS inspected — parsePackageJson depends
+        //    on it, and it is a single deduped path, so this adds at most one
+        //    manifest body (≤ maxTarBytes) and cannot be starved by earlier files;
+        //  - other manifests (nested npm, PyPI/wheel metadata, whose root path is
+        //    attacker-shaped and so cannot get the guarantee) draw on a bounded
+        //    second maxTarBytes of headroom, so a tar stuffed with manifest-named
+        //    files still cannot amplify retained memory;
+        //  - everything else must fit the shared maxTarBytes budget.
+        const isRootManifest = path === "package.json";
         const mustRetainBody = path ? isRetainedManifestPath(path) : false;
         const retainBody =
           size <= maxTarBytes &&
-          (retainedBytes + size <= maxTarBytes ||
+          (isRootManifest ||
+            retainedBytes + size <= maxTarBytes ||
             (mustRetainBody && retainedBytes + size <= 2 * maxTarBytes));
         let summarized = null;
         let contributed = 0;

--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -388,7 +388,9 @@ export async function readTarStream(body, maxFiles, maxTarBytes, maxStreamBytes)
             : "path contained zero-width or visually-confusable characters and normalized to an unsafe path",
         });
       }
-      const retainBody = size <= maxTarBytes && retainedBytes + size <= maxTarBytes;
+      const mustRetainBody = path === "package.json";
+      const retainBody =
+        size <= maxTarBytes && (mustRetainBody || retainedBytes + size <= maxTarBytes);
       let summarized = null;
       if (path && retainBody) {
         if (!(await fill(size))) throw new Error("truncated tar entry");

--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -194,8 +194,8 @@ export async function summarizeFile(path, body) {
   // over textSample in the parent worker, so clipping here is exactly the
   // truncation hole that lets an attacker bury a payload past a fixed window
   // (issue #191). The persisted/display sample is bounded separately at the
-  // persistence layer; total work stays bounded by the archive cap
-  // (MAX_TAR_BYTES) and MAX_FILES.
+  // persistence layer; per-body work is bounded by the per-file cap and total
+  // retained bytes by the streaming reader's retention budget and MAX_FILES.
   const text = decodeText(body);
   if (!text) flags.push("binary");
   return {
@@ -421,14 +421,24 @@ export async function readTarStream(body, maxFiles, maxTarBytes, maxStreamBytes)
               : "path contained zero-width or visually-confusable characters and normalized to an unsafe path",
           });
         }
-        // A manifest too large to inspect must fail the scan, never silently
-        // become a null manifest that disables every manifest-derived detection.
-        if (path && isRetainedManifestPath(path) && size > maxTarBytes) {
+        // The root npm manifest is the one file parsePackageJson depends on, and
+        // a body too large to inspect there would silently null the manifest and
+        // disable every manifest-derived detection. A >25MB package.json is only
+        // ever hostile, so fail closed. Nested/vendored manifest-named files are
+        // not the package manifest, so they are skipped (below), not fatal.
+        if (path === "package.json" && size > maxTarBytes) {
           throw tarError("invalid tar entry size");
         }
+        // Manifests bypass the shared retention budget so a package's identity is
+        // always inspected even behind large binaries, but they draw on a bounded
+        // headroom (a second maxTarBytes) rather than an unlimited bypass — a tar
+        // stuffed with manifest-named files cannot amplify retained memory past
+        // 2×maxTarBytes.
         const mustRetainBody = path ? isRetainedManifestPath(path) : false;
         const retainBody =
-          size <= maxTarBytes && (mustRetainBody || retainedBytes + size <= maxTarBytes);
+          size <= maxTarBytes &&
+          (retainedBytes + size <= maxTarBytes ||
+            (mustRetainBody && retainedBytes + size <= 2 * maxTarBytes));
         let summarized = null;
         let contributed = 0;
         if (path && retainBody) {

--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -428,6 +428,10 @@ export async function readTarStream(body, maxFiles, maxTarBytes, maxStreamBytes)
     } else {
       // Non-regular entry (hardlink, symlink, device, directory, fifo,
       // reserved). npm publish never emits these; a hand-crafted tar can.
+      // Unlike regular files, there is no legitimate reason to stream-discard
+      // a huge body here, so fail fast instead of burning the sandbox's CPU
+      // budget on content that is never retained.
+      if (size > maxTarBytes) throw new Error("invalid tar entry size");
       const rawCandidate =
         (pax && pax.path) || nextLongName || (prefix ? prefix + "/" : "") + rawName;
       const reportedPath = normalizeTarPath(canonicalizePath(rawCandidate)) || rawCandidate || "";

--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -14,7 +14,7 @@
 //     cross-function calls resolve by the lexical names below.
 
 /** @typedef {{ path: string, size: number, sha256: string, flags: string[], textSample?: string }} ParsedFile */
-/** @typedef {{ kind: "non-regular"|"duplicate"|"unicode-confusable", path: string, detail: string }} TarSuspiciousEntry */
+/** @typedef {{ kind: "non-regular"|"duplicate"|"unicode-confusable"|"content-skipped", path: string, detail: string }} TarSuspiciousEntry */
 
 export function readString(bytes, start, len) {
   let end = start;
@@ -224,9 +224,93 @@ export function shouldSkipTextSample(path) {
   return false;
 }
 
+export function summarizeSkippedFile(path, size) {
+  // Metadata-only record for an entry whose body exceeded the retention limit:
+  // path and declared size are kept so the release manifest stays complete, but
+  // the content was never buffered, so there is no hash or text sample.
+  return { path, size, sha256: "", flags: ["content-skipped"] };
+}
+
 export async function readTar(buffer, maxFiles, maxTarBytes) {
-  const nul = String.fromCharCode(0);
   const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  return readTarStream(new Response(bytes).body, maxFiles, maxTarBytes, Infinity);
+}
+
+// Streaming tar reader. Walks entries sequentially as decompressed bytes
+// arrive, so the whole archive never has to fit in memory: `maxTarBytes`
+// bounds the bytes *retained* for inspection (per entry and cumulatively),
+// while `maxStreamBytes` bounds the total bytes consumed from the stream.
+// Regular files whose body would blow the retention budget are recorded as
+// content-skipped (path + declared size, no hash/text) instead of failing the
+// parse — the esbuild/rover pattern of multi-hundred-megabyte prepackaged
+// platform binaries alongside a small manifest.
+export async function readTarStream(body, maxFiles, maxTarBytes, maxStreamBytes) {
+  const nul = String.fromCharCode(0);
+  if (!body) throw new Error("tarball decompression failed");
+  const reader = body.getReader();
+  const streamLimit = Number.isFinite(maxStreamBytes) ? maxStreamBytes : Infinity;
+  const chunks = [];
+  let buffered = 0;
+  let streamed = 0;
+  let streamDone = false;
+
+  async function fill(target) {
+    while (buffered < target && !streamDone) {
+      const { value, done } = await reader.read();
+      if (done) {
+        streamDone = true;
+        break;
+      }
+      streamed += value.byteLength;
+      if (streamed > streamLimit) {
+        reader.cancel().catch(() => undefined);
+        throw new Error("archive expands beyond safety limit");
+      }
+      chunks.push(value);
+      buffered += value.byteLength;
+    }
+    return buffered >= target;
+  }
+
+  function take(count) {
+    const out = new Uint8Array(count);
+    let offset = 0;
+    while (offset < count) {
+      const head = chunks[0];
+      const need = count - offset;
+      if (head.byteLength <= need) {
+        out.set(head, offset);
+        offset += head.byteLength;
+        buffered -= head.byteLength;
+        chunks.shift();
+      } else {
+        out.set(head.subarray(0, need), offset);
+        chunks[0] = head.subarray(need);
+        buffered -= need;
+        offset = count;
+      }
+    }
+    return out;
+  }
+
+  async function discard(count) {
+    let remaining = count;
+    while (remaining > 0) {
+      if (!buffered && !(await fill(1))) return false;
+      const head = chunks[0];
+      if (head.byteLength <= remaining) {
+        remaining -= head.byteLength;
+        buffered -= head.byteLength;
+        chunks.shift();
+      } else {
+        chunks[0] = head.subarray(remaining);
+        buffered -= remaining;
+        remaining = 0;
+      }
+    }
+    return true;
+  }
+
   const files = [];
   const suspicious = [];
   const suspiciousLimit = Math.max(1, Number.isFinite(maxFiles) ? maxFiles : 250);
@@ -234,6 +318,7 @@ export async function readTar(buffer, maxFiles, maxTarBytes) {
   const seenPaths = new Map();
   let nextLongName = null;
   let pax = null;
+  let retainedBytes = 0;
 
   function addSuspicious(entry) {
     if (suspicious.length < suspiciousLimit) {
@@ -250,8 +335,8 @@ export async function readTar(buffer, maxFiles, maxTarBytes) {
     }
   }
 
-  for (let offset = 0; offset + 512 <= bytes.length; ) {
-    const header = bytes.subarray(offset, offset + 512);
+  while (await fill(512)) {
+    const header = take(512);
     if (header.every((b) => b === 0)) break;
 
     const rawName = readString(header, 0, 100);
@@ -259,31 +344,35 @@ export async function readTar(buffer, maxFiles, maxTarBytes) {
     const sizeText = readString(header, 124, 12).trim() || "0";
     if (!/^[0-7]+$/.test(sizeText)) throw new Error("invalid tar entry size");
     const size = parseInt(sizeText, 8);
-    if (!Number.isFinite(size) || size < 0 || size > maxTarBytes)
-      throw new Error("invalid tar entry size");
+    if (!Number.isFinite(size) || size < 0) throw new Error("invalid tar entry size");
     const type = String.fromCharCode(header[156] || 48);
-    offset += 512;
-    if (offset + size > bytes.length) throw new Error("truncated tar entry");
-    const body = bytes.subarray(offset, offset + size);
+    const padding = Math.ceil(size / 512) * 512 - size;
 
-    if (type === "x") {
-      // Local PAX header. Its path attribute applies only to the next entry.
-      pax = parsePax(body);
-      if (pax && typeof pax.path === "string" && !isSafePaxPath(pax.path)) {
-        throw new Error("invalid pax path");
+    if (type === "x" || type === "g" || type === "L") {
+      // Metadata entries must be materialized to be interpreted; a metadata
+      // body beyond the retention limit is only ever hand-crafted.
+      if (size > maxTarBytes) throw new Error("invalid tar entry size");
+      if (!(await fill(size))) throw new Error("truncated tar entry");
+      const body = take(size);
+      if (type === "x") {
+        // Local PAX header. Its path attribute applies only to the next entry.
+        pax = parsePax(body);
+        if (pax && typeof pax.path === "string" && !isSafePaxPath(pax.path)) {
+          throw new Error("invalid pax path");
+        }
+      } else if (type === "g") {
+        // Global PAX metadata does not override the path of following entries.
+        // Ignoring path here keeps scanner paths aligned with tar extraction.
+        parsePax(body);
+        nextLongName = null;
+        pax = null;
+      } else {
+        // readString already stops at the first NUL terminator, so the long-name
+        // payload is implicitly trimmed at the NUL boundary.
+        const candidate = readString(body, 0, body.length);
+        if (!isSafePaxPath(candidate)) throw new Error("invalid long-name path");
+        nextLongName = candidate;
       }
-    } else if (type === "g") {
-      // Global PAX metadata does not override the path of following entries.
-      // Ignoring path here keeps scanner paths aligned with tar extraction.
-      parsePax(body);
-      nextLongName = null;
-      pax = null;
-    } else if (type === "L") {
-      // readString already stops at the first NUL terminator, so the long-name
-      // payload is implicitly trimmed at the NUL boundary.
-      const candidate = readString(body, 0, body.length);
-      if (!isSafePaxPath(candidate)) throw new Error("invalid long-name path");
-      nextLongName = candidate;
     } else if (type === "0" || type === nul) {
       const rawCandidate =
         (pax && pax.path) || nextLongName || (prefix ? prefix + "/" : "") + rawName;
@@ -299,7 +388,24 @@ export async function readTar(buffer, maxFiles, maxTarBytes) {
             : "path contained zero-width or visually-confusable characters and normalized to an unsafe path",
         });
       }
-      if (path) {
+      const retainBody = size <= maxTarBytes && retainedBytes + size <= maxTarBytes;
+      let summarized = null;
+      if (path && retainBody) {
+        if (!(await fill(size))) throw new Error("truncated tar entry");
+        summarized = await summarizeFile(path, take(size));
+        retainedBytes += size;
+      } else {
+        if (!(await discard(size))) throw new Error("truncated tar entry");
+        if (path) {
+          summarized = summarizeSkippedFile(path, size);
+          addSuspicious({
+            kind: "content-skipped",
+            path,
+            detail: `file body (${size} bytes) exceeds the ${maxTarBytes}-byte retention limit; metadata recorded but content not inspected`,
+          });
+        }
+      }
+      if (path && summarized) {
         if (seenPaths.has(path)) {
           // Match last-write-wins extraction so downstream checks inspect the
           // bytes consumers are likely to receive, while still surfacing the duplicate.
@@ -308,11 +414,9 @@ export async function readTar(buffer, maxFiles, maxTarBytes) {
             path,
             detail: "duplicate path; later entry replaced earlier entry",
           });
-          const summarized = await summarizeFile(path, body);
           files[seenPaths.get(path)] = summarized;
         } else {
           if (files.length >= maxFiles) throw new Error("archive contains too many files");
-          const summarized = await summarizeFile(path, body);
           seenPaths.set(path, files.length);
           files.push(summarized);
         }
@@ -330,12 +434,16 @@ export async function readTar(buffer, maxFiles, maxTarBytes) {
         path: reportedPath,
         detail: `typeflag ${type} (${describeNonRegularType(type)})`,
       });
+      if (!(await discard(size))) throw new Error("truncated tar entry");
       nextLongName = null;
       pax = null;
     }
 
-    offset += Math.ceil(size / 512) * 512;
+    // Inter-entry padding; a missing final pad block is tolerated like the
+    // buffer reader tolerated a trailing partial block.
+    if (padding > 0) await discard(padding);
   }
+  reader.cancel().catch(() => undefined);
   return { files, suspicious };
 }
 

--- a/server/lib/workflow-gates/pypi.ts
+++ b/server/lib/workflow-gates/pypi.ts
@@ -47,7 +47,11 @@ export const pypiWorkflowGateAdapter: WorkflowGateAdapter = {
 
   prepareReleaseCandidates(artifacts: ParsedGateArtifact[]): PreparedReleaseCandidate[] {
     const entries: PreparedArtifactEntry[] = artifacts.map((artifact) => {
-      const input: PyPiArtifactInput = { path: artifact.path, files: artifact.files };
+      const input: PyPiArtifactInput = {
+        path: artifact.path,
+        files: artifact.files,
+        ...(artifact.suspiciousEntries ? { suspiciousEntries: artifact.suspiciousEntries } : {}),
+      };
       return { artifact, input, prepared: preparePyPiArtifact(input) };
     });
     return deriveReleaseCandidates(entries);

--- a/src/components/DiffView.tsx
+++ b/src/components/DiffView.tsx
@@ -489,8 +489,9 @@ export function DiffView({
   const ignoreWhitespace = useSignal(false);
 
   const binary = hasFlag(before, "binary") || hasFlag(after, "binary");
+  const contentSkipped = hasFlag(before, "content-skipped") || hasFlag(after, "content-skipped");
   const truncated = hasFlag(before, "truncated") || hasFlag(after, "truncated");
-  const showDiffOptions = !binary && Boolean(beforeSample && afterSample);
+  const showDiffOptions = !binary && !contentSkipped && Boolean(beforeSample && afterSample);
 
   return (
     <div class="flex flex-col gap-3 min-h-0">
@@ -500,6 +501,7 @@ export function DiffView({
           <code class="font-mono text-xs text-ink-muted break-all">{path}</code>
           {truncated ? <Badge tone="neutral">truncated</Badge> : null}
           {binary ? <Badge tone="neutral">binary</Badge> : null}
+          {contentSkipped ? <Badge tone="neutral">content skipped</Badge> : null}
         </div>
         {showDiffOptions ? (
           <DiffControls wordDiff={wordDiff} ignoreWhitespace={ignoreWhitespace} />
@@ -519,6 +521,7 @@ export function DiffView({
         beforeSample={beforeSample}
         afterSample={afterSample}
         binary={binary}
+        contentSkipped={contentSkipped}
         beforeLabel={beforeLabel}
         afterLabel={afterLabel}
         findings={findings}
@@ -586,6 +589,7 @@ function DiffBody({
   beforeSample,
   afterSample,
   binary,
+  contentSkipped,
   beforeLabel,
   afterLabel,
   findings,
@@ -597,6 +601,7 @@ function DiffBody({
   beforeSample: string;
   afterSample: string;
   binary: boolean;
+  contentSkipped: boolean;
   beforeLabel: string;
   afterLabel: string;
   findings: DiffFinding[];
@@ -610,6 +615,14 @@ function DiffBody({
 
   if (binary) {
     return <DiffMessage findings={findings}>Binary file. No text diff available.</DiffMessage>;
+  }
+
+  if (contentSkipped) {
+    return (
+      <DiffMessage findings={findings}>
+        File content was not retained. No text diff available.
+      </DiffMessage>
+    );
   }
 
   if (status === "added") {

--- a/src/pages/Dashboard/ScanDetail/DiffWorkbench.tsx
+++ b/src/pages/Dashboard/ScanDetail/DiffWorkbench.tsx
@@ -3,7 +3,7 @@ import type { PersistedScanDetail } from "../../../models/scan";
 import { type DiffFinding, DiffView } from "../../../components/DiffView";
 import { IndeterminateBar } from "../../../components/Loading";
 import { EmptyLine, LoadingLine } from "../../../components/Typography";
-import { selectDiffWorkbenchState } from "./diff-helpers";
+import { hasNoLoadableBodyFlags, selectDiffWorkbenchState } from "./diff-helpers";
 
 export function DiffWorkbench({
   entry,
@@ -37,10 +37,10 @@ export function DiffWorkbench({
     entryStatus: entry.status,
     hasStagedMeta: Boolean(stagedMeta),
     hasStagedContent: Boolean(staged),
-    stagedIsBinary: isPersistedBinary(stagedMeta),
+    stagedHasNoLoadableBody: isPersistedUnpreviewable(stagedMeta),
     hasPreviousMeta: Boolean(previousMeta),
     hasPreviousContent: Boolean(previousContent),
-    previousIsBinary: Boolean(previousMeta?.flags?.includes("binary")),
+    previousHasNoLoadableBody: isUnpreviewable(previousMeta),
     compareReady,
     compareLoading,
   });
@@ -72,8 +72,12 @@ export function DiffWorkbench({
   );
 }
 
-function isPersistedBinary(file: PersistedScanDetail["files"][number] | null): boolean {
-  return Array.isArray(file?.flagsJson) && (file.flagsJson as unknown[]).includes("binary");
+function isPersistedUnpreviewable(file: PersistedScanDetail["files"][number] | null): boolean {
+  return hasNoLoadableBodyFlags(Array.isArray(file?.flagsJson) ? file.flagsJson : []);
+}
+
+function isUnpreviewable(file: FileRecord | null): boolean {
+  return hasNoLoadableBodyFlags(file?.flags ?? []);
 }
 
 // A centered processing block that fills the diff panel so the "still working"

--- a/src/pages/Dashboard/ScanDetail/diff-helpers.ts
+++ b/src/pages/Dashboard/ScanDetail/diff-helpers.ts
@@ -45,6 +45,10 @@ export type DiffWorkbenchState =
   | { kind: "processing"; title: string; detail: string }
   | { kind: "diff" };
 
+export function hasNoLoadableBodyFlags(flags: readonly unknown[]): boolean {
+  return flags.includes("binary") || flags.includes("content-skipped");
+}
+
 // Decides what the diff panel should show for the selected file. Extracted so
 // the loading/empty/diff guards are testable: the previous version is fetched
 // through the sandbox after the file tree already renders, and during that
@@ -56,10 +60,10 @@ export function selectDiffWorkbenchState(input: {
   entryStatus: DiffEntry["status"] | null;
   hasStagedMeta: boolean;
   hasStagedContent: boolean;
-  stagedIsBinary: boolean;
+  stagedHasNoLoadableBody: boolean;
   hasPreviousMeta: boolean;
   hasPreviousContent: boolean;
-  previousIsBinary: boolean;
+  previousHasNoLoadableBody: boolean;
   compareReady: boolean;
   compareLoading: boolean;
 }): DiffWorkbenchState {
@@ -89,7 +93,7 @@ export function selectDiffWorkbenchState(input: {
   if (
     needsPrevious &&
     input.hasPreviousMeta &&
-    !input.previousIsBinary &&
+    !input.previousHasNoLoadableBody &&
     !input.hasPreviousContent
   ) {
     return {
@@ -99,7 +103,12 @@ export function selectDiffWorkbenchState(input: {
     };
   }
 
-  if (needsStaged && input.hasStagedMeta && !input.stagedIsBinary && !input.hasStagedContent) {
+  if (
+    needsStaged &&
+    input.hasStagedMeta &&
+    !input.stagedHasNoLoadableBody &&
+    !input.hasStagedContent
+  ) {
     return {
       kind: "processing",
       title: "Loading file diff",

--- a/src/pages/Dashboard/ScanDetail/hooks/useScanFileContent.ts
+++ b/src/pages/Dashboard/ScanDetail/hooks/useScanFileContent.ts
@@ -30,7 +30,7 @@ export function useScanFileContent(
     const cache = model.stagedFileContentCache.value;
     const meta = stagedFileMeta.value;
     if (!path) return null;
-    return cache[path] ?? (meta?.textSample || isPersistedBinary(meta) ? meta : null);
+    return cache[path] ?? (meta?.textSample || hasNoLoadableBody(meta) ? meta : null);
   });
 
   const previousFileMeta = useComputed(() => {
@@ -47,7 +47,7 @@ export function useScanFileContent(
     if (!path) return;
     if (cache[path]) return;
     if (!meta) return;
-    if (meta.textSample || isPersistedBinary(meta)) return;
+    if (meta.textSample || hasNoLoadableBody(meta)) return;
     void model.loadStagedFile(path);
   });
 
@@ -72,7 +72,7 @@ export function useScanFileContent(
     if (!key) return;
     if (cache[key]) return;
     if (!meta) return;
-    if (meta.flags?.includes("binary")) return;
+    if (meta.flags?.includes("binary") || meta.flags?.includes("content-skipped")) return;
     if (!version || !path) return;
     void model.loadPreviousFile(version, path);
   });
@@ -80,6 +80,12 @@ export function useScanFileContent(
   return { stagedFileMeta, stagedFile, previousFileMeta, previousFile };
 }
 
-function isPersistedBinary(file: PersistedScanFile | null): boolean {
-  return Array.isArray(file?.flagsJson) && (file.flagsJson as unknown[]).includes("binary");
+// A file whose body the scanner never captured as text: binary payloads (bytes
+// but no text sample) and content-skipped entries (oversized bodies recorded as
+// metadata only). Neither can be lazily fetched, so the UI shows the metadata
+// placeholder instead of spinning on a load that would never resolve.
+function hasNoLoadableBody(file: PersistedScanFile | null): boolean {
+  if (!Array.isArray(file?.flagsJson)) return false;
+  const flags = file.flagsJson as unknown[];
+  return flags.includes("binary") || flags.includes("content-skipped");
 }

--- a/test/archive-parser.fuzz.test.mjs
+++ b/test/archive-parser.fuzz.test.mjs
@@ -38,7 +38,6 @@ const {
   shouldSkipTextSample,
   readTar,
   readZipArchive,
-  gunzipBounded,
 } = parser;
 
 const SEED = 0xc0ffee;
@@ -439,38 +438,6 @@ describe("regression invariants", () => {
         expect(files[0].textSample).toContain(marker);
       }),
       { seed: SEED, numRuns: runs(40, 300) },
-    );
-  });
-
-  test("gunzipBounded round-trips within the cap and refuses to overrun it", async () => {
-    const gzip = async (input) => {
-      const cs = new CompressionStream("gzip");
-      const writer = cs.writable.getWriter();
-      writer.write(input);
-      writer.close();
-      return new Uint8Array(await new Response(cs.readable).arrayBuffer());
-    };
-    const streamFrom = (bytes) =>
-      new ReadableStream({
-        start(controller) {
-          controller.enqueue(bytes);
-          controller.close();
-        },
-      });
-
-    await fc.assert(
-      fc.asyncProperty(fc.uint8Array({ maxLength: 8192 }), async (original) => {
-        const compressed = await gzip(original);
-        const out = new Uint8Array(await gunzipBounded(streamFrom(compressed), original.length));
-        expect(out.length).toBe(original.length);
-        expect(out).toEqual(original);
-        if (original.length > 0) {
-          await expect(gunzipBounded(streamFrom(compressed), original.length - 1)).rejects.toThrow(
-            /expands beyond safety limit/,
-          );
-        }
-      }),
-      { seed: SEED, numRuns: runs(60, 400) },
     );
   });
 });

--- a/test/npm-acquire.test.mjs
+++ b/test/npm-acquire.test.mjs
@@ -65,4 +65,47 @@ describe("acquireBaselineNpm", () => {
       { maxFiles: undefined },
     );
   });
+
+  test.each([
+    ["too large", "tarball too large", "dist-tag:latest:baseline-too-large"],
+    ["expansion bomb", "archive expands beyond safety limit", "dist-tag:latest:baseline-too-large"],
+    [
+      "too many files",
+      "archive contains too many files",
+      "dist-tag:latest:baseline-too-many-files",
+    ],
+  ])("labels a 413 %s baseline with its actual cause", async (_name, error, expectedReason) => {
+    const broker = {
+      dispose() {},
+      fetchPackageMetadata: vi.fn(async () => metadata()),
+      fetchStagedDetails: vi.fn(async () => null),
+      downloadStaged: vi.fn(async () => {
+        throw new Error("unused");
+      }),
+      downloadPublished: vi.fn(async () => {
+        throw new SandboxError(JSON.stringify({ error, status: 413 }));
+      }),
+    };
+
+    const result = await acquireBaselineNpm({}, {}, broker, stagedArtifact());
+
+    expect(result.artifact).toBeNull();
+    expect(result.baseline).toMatchObject({ version: "1.0.0", reason: expectedReason });
+  });
+
+  test("rethrows a non-safety-limit sandbox error instead of degrading", async () => {
+    const broker = {
+      dispose() {},
+      fetchPackageMetadata: vi.fn(async () => metadata()),
+      fetchStagedDetails: vi.fn(async () => null),
+      downloadStaged: vi.fn(async () => {
+        throw new Error("unused");
+      }),
+      downloadPublished: vi.fn(async () => {
+        throw new SandboxError(JSON.stringify({ error: "download failed", status: 502 }));
+      }),
+    };
+
+    await expect(acquireBaselineNpm({}, {}, broker, stagedArtifact())).rejects.toThrow();
+  });
 });

--- a/test/npm-acquire.test.mjs
+++ b/test/npm-acquire.test.mjs
@@ -1,0 +1,68 @@
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("cloudflare:workers", () => ({
+  WorkerEntrypoint: class {},
+}));
+
+const { acquireBaselineNpm } = await import("../server/lib/adapters/npm/acquire.ts");
+const { SandboxError } = await import("../server/lib/sandbox.ts");
+
+function stagedArtifact() {
+  return {
+    artifact: {
+      files: [],
+      manifest: { name: "pkg", version: "2.0.0" },
+    },
+    details: { tag: "latest" },
+  };
+}
+
+function metadata() {
+  return {
+    versions: {
+      "1.0.0": { dist: { tarball: "https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz" } },
+    },
+    "dist-tags": { latest: "1.0.0" },
+  };
+}
+
+describe("acquireBaselineNpm", () => {
+  test.each([
+    [
+      "local SandboxError",
+      () => new SandboxError(JSON.stringify({ error: "tarball too large", status: 413 })),
+    ],
+    [
+      "RPC-safe SandboxError",
+      () => {
+        const err = new Error(JSON.stringify({ error: "tarball too large", status: 413 }));
+        err.name = "SandboxError";
+        return err;
+      },
+    ],
+  ])("degrades oversized baseline downloads for %s", async (_name, makeError) => {
+    const broker = {
+      dispose() {},
+      fetchPackageMetadata: vi.fn(async () => metadata()),
+      fetchStagedDetails: vi.fn(async () => null),
+      downloadStaged: vi.fn(async () => {
+        throw new Error("unused");
+      }),
+      downloadPublished: vi.fn(async () => {
+        throw makeError();
+      }),
+    };
+
+    const result = await acquireBaselineNpm({}, {}, broker, stagedArtifact());
+
+    expect(result.artifact).toBeNull();
+    expect(result.baseline).toMatchObject({
+      version: "1.0.0",
+      reason: "dist-tag:latest:baseline-too-large",
+    });
+    expect(broker.downloadPublished).toHaveBeenCalledWith(
+      "https://registry.npmjs.org/pkg/-/pkg-1.0.0.tgz",
+      { maxFiles: undefined },
+    );
+  });
+});

--- a/test/pypi.test.mjs
+++ b/test/pypi.test.mjs
@@ -230,6 +230,55 @@ describe("PyPI artifact summaries and review", () => {
     });
   });
 
+  test("surfaces content-skipped tar entries as findings instead of dropping them", () => {
+    const manifest = parsePyPiReleaseManifest({
+      schema: "drydock.release-artifacts.v1",
+      ecosystem: "pypi",
+      package: "demo-package",
+      version: "1.2.0",
+      artifacts: [{ path: "dist/demo_package-1.2.0.tar.gz", sha256: "b".repeat(64) }],
+    });
+
+    const review = createPyPiReleaseCandidateReview({
+      manifest,
+      artifacts: [
+        {
+          path: "dist/demo_package-1.2.0.tar.gz",
+          files: [
+            file(
+              "demo_package-1.2.0/PKG-INFO",
+              "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n",
+            ),
+            {
+              path: "demo_package-1.2.0/big.so",
+              size: 50_000_000,
+              sha256: "",
+              flags: ["content-skipped"],
+            },
+          ],
+          suspiciousEntries: [
+            {
+              kind: "content-skipped",
+              path: "demo_package-1.2.0/big.so",
+              detail:
+                "file body (50000000 bytes) exceeds the 26214400-byte per-file inspection limit",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(review.ruleFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          ruleId: "tar.suspicious-entry",
+          severity: "medium",
+          file: "dist/demo_package-1.2.0.tar.gz/demo_package-1.2.0/big.so",
+        }),
+      ]),
+    );
+  });
+
   test("marks manifest and artifact metadata mismatches as critical", () => {
     const manifest = parsePyPiReleaseManifest({
       schema: "drydock.release-artifacts.v1",

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -52,6 +52,32 @@ describe("review", () => {
     expect(diff.find((entry) => entry.path === "index.js")?.status).toBe("unchanged");
   });
 
+  test("diff treats skipped file content as modified even when placeholder hashes match", () => {
+    const before = [
+      {
+        path: "bin/native.node",
+        size: 50_000_000,
+        sha256: "",
+        flags: ["content-skipped"],
+      },
+    ];
+    const staged = [
+      {
+        path: "bin/native.node",
+        size: 50_000_000,
+        sha256: "",
+        flags: ["content-skipped"],
+      },
+    ];
+
+    const diff = createPackageDiff(before, staged);
+
+    expect(diff.find((entry) => entry.path === "bin/native.node")).toMatchObject({
+      status: "modified",
+      flags: ["content-skipped"],
+    });
+  });
+
   test("deterministic policy escalates risky new staged changes", () => {
     const staged = [
       {

--- a/test/scan-detail-diff-helpers.test.mjs
+++ b/test/scan-detail-diff-helpers.test.mjs
@@ -3,6 +3,7 @@ import {
   annotatePersistedFindings,
   filterDiffEntries,
   findingCountsByPath,
+  hasNoLoadableBodyFlags,
   scanFilesToFileRecords,
   selectDiffWorkbenchState,
 } from "../src/pages/Dashboard/ScanDetail/diff-helpers.ts";
@@ -92,16 +93,25 @@ describe("scanFilesToFileRecords", () => {
   });
 });
 
+describe("hasNoLoadableBodyFlags", () => {
+  test("treats binary and content-skipped files as unpreviewable", () => {
+    expect(hasNoLoadableBodyFlags(["binary"])).toBe(true);
+    expect(hasNoLoadableBodyFlags(["content-skipped"])).toBe(true);
+    expect(hasNoLoadableBodyFlags(["truncated"])).toBe(false);
+    expect(hasNoLoadableBodyFlags([])).toBe(false);
+  });
+});
+
 describe("selectDiffWorkbenchState", () => {
   const base = {
     hasEntry: true,
     entryStatus: "modified",
     hasStagedMeta: true,
     hasStagedContent: true,
-    stagedIsBinary: false,
+    stagedHasNoLoadableBody: false,
     hasPreviousMeta: true,
     hasPreviousContent: true,
-    previousIsBinary: false,
+    previousHasNoLoadableBody: false,
     compareReady: true,
     compareLoading: false,
   };
@@ -151,19 +161,19 @@ describe("selectDiffWorkbenchState", () => {
     expect(state).toEqual({ kind: "diff" });
   });
 
-  test("renders the diff for a binary staged file instead of waiting on its body", () => {
+  test("renders the diff for an unpreviewable staged file instead of waiting on its body", () => {
     const state = selectDiffWorkbenchState({
       ...base,
       hasStagedContent: false,
-      stagedIsBinary: true,
+      stagedHasNoLoadableBody: true,
     });
     expect(state).toEqual({ kind: "diff" });
   });
 
-  test("renders the diff for a binary previous file instead of waiting on its body", () => {
+  test("renders the diff for an unpreviewable previous file instead of waiting on its body", () => {
     const state = selectDiffWorkbenchState({
       ...base,
-      previousIsBinary: true,
+      previousHasNoLoadableBody: true,
       hasPreviousContent: false,
     });
     expect(state).toEqual({ kind: "diff" });

--- a/test/scan-pipeline.test.mjs
+++ b/test/scan-pipeline.test.mjs
@@ -15,6 +15,12 @@ const registryMock = vi.hoisted(() => ({
 }));
 const sandboxMock = vi.hoisted(() => ({
   downloadInSandbox: vi.fn(),
+  sandboxErrorDetail: vi.fn((err) => {
+    if (err?.name !== "SandboxError") return null;
+    if (typeof err.detail === "string") return err.detail;
+    if (typeof err.message === "string" && err.message.trim().startsWith("{")) return err.message;
+    return null;
+  }),
 }));
 const publishedTarballMock = vi.hoisted(() => ({
   downloadPublishedTarball: vi.fn(),

--- a/test/scan-pipeline.test.mjs
+++ b/test/scan-pipeline.test.mjs
@@ -15,12 +15,6 @@ const registryMock = vi.hoisted(() => ({
 }));
 const sandboxMock = vi.hoisted(() => ({
   downloadInSandbox: vi.fn(),
-  sandboxErrorDetail: vi.fn((err) => {
-    if (err?.name !== "SandboxError") return null;
-    if (typeof err.detail === "string") return err.detail;
-    if (typeof err.message === "string" && err.message.trim().startsWith("{")) return err.message;
-    return null;
-  }),
 }));
 const publishedTarballMock = vi.hoisted(() => ({
   downloadPublishedTarball: vi.fn(),
@@ -43,7 +37,10 @@ vi.mock("../server/lib/registry.ts", async () => ({
   ...(await vi.importActual("../server/lib/registry.ts")),
   fetchPackageMetadata: registryMock.fetchPackageMetadata,
 }));
-vi.mock("../server/lib/sandbox.ts", () => sandboxMock);
+vi.mock("../server/lib/sandbox.ts", async () => ({
+  ...(await vi.importActual("../server/lib/sandbox.ts")),
+  downloadInSandbox: sandboxMock.downloadInSandbox,
+}));
 vi.mock("../server/lib/published-tarball.ts", () => publishedTarballMock);
 vi.mock("../server/lib/staged-publishes.ts", async () => ({
   ...(await vi.importActual("../server/lib/staged-publishes.ts")),

--- a/test/tar-parser.test.mjs
+++ b/test/tar-parser.test.mjs
@@ -6,7 +6,6 @@ import { buildTar, encoder } from "./helpers/archive-fixtures.mjs";
 const {
   canonicalizePath,
   decodeText,
-  gunzipBounded,
   hasUnicodeConfusables,
   isRootGypPath,
   isSafePaxPath,
@@ -651,6 +650,71 @@ describe("readTar limits and malformed archives", () => {
     const files = await parse(extended);
     expect(files.map((f) => f.path)).toEqual(["a.js"]);
   });
+
+  test("fails closed on an oversized manifest instead of nulling the package identity", async () => {
+    // A package.json too large to inspect must fail the scan: skipping it would
+    // return packageJson:null and silently disable every manifest-derived rule.
+    const limits = { maxFiles: 100, maxTarBytes: 1024 };
+    const bigManifest = JSON.stringify({ name: "pkg", version: "1.0.0", _pad: "x".repeat(2000) });
+    const tar = buildTar([{ name: "package/package.json", body: bigManifest }]);
+    await expect(parse(tar, limits)).rejects.toThrow(/invalid tar entry size/);
+  });
+
+  test("retains a PyPI sdist manifest (PKG-INFO) even under budget pressure", async () => {
+    // The tgz path is shared with PyPI sdists, whose manifest is PKG-INFO under a
+    // version directory. It must be force-retained the same way package.json is.
+    const limits = { maxFiles: 100, maxTarBytes: 950 };
+    const filler = new Uint8Array(900).fill(0x61);
+    const tar = buildTar([
+      { name: "foo-1.0.0/big.bin", body: filler },
+      { name: "foo-1.0.0/PKG-INFO", body: "Metadata-Version: 2.1\nName: foo\nVersion: 1.0.0\n" },
+    ]);
+    const { files } = await parseFull(tar, limits);
+    const manifest = files.find((file) => file.path.endsWith("PKG-INFO"));
+    expect(manifest?.textSample).toContain("Name: foo");
+    expect(manifest?.flags ?? []).not.toContain("content-skipped");
+  });
+
+  test("distinguishes per-file-limit skips from cumulative-budget skips in the detail", async () => {
+    const limits = { maxFiles: 100, maxTarBytes: 1024 };
+    const tar = buildTar([
+      { name: "package/huge.node", body: new Uint8Array(2048).fill(0x42) },
+      { name: "package/filler.bin", body: new Uint8Array(1000).fill(0x61) },
+      { name: "package/late.js", body: "x".repeat(100) },
+    ]);
+    const { suspicious } = await parseFull(tar, limits);
+    const huge = suspicious.find((s) => s.path === "huge.node");
+    const late = suspicious.find((s) => s.path === "late.js");
+    expect(huge.detail).toContain("per-file inspection limit");
+    expect(late.detail).toContain("cumulative retention budget");
+  });
+
+  test("releases a replaced duplicate's bytes so later files are not needlessly skipped", async () => {
+    // Both copies of dup.bin fit the budget at their own decision point, so the
+    // old accounting counted 1200 bytes for a 600-byte record and then wrongly
+    // skipped other.bin. The replacement must release the earlier body's budget.
+    const limits = { maxFiles: 100, maxTarBytes: 2000 };
+    const tar = buildTar([
+      { name: "package/dup.bin", body: new Uint8Array(600).fill(0x61) },
+      { name: "package/dup.bin", body: new Uint8Array(600).fill(0x62) },
+      { name: "package/other.bin", body: new Uint8Array(900).fill(0x63) },
+    ]);
+    const { files, suspicious } = await parseFull(tar, limits);
+    const other = files.find((file) => file.path === "other.bin");
+    expect(other?.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(other?.flags ?? []).not.toContain("content-skipped");
+    expect(suspicious.map((s) => s.kind)).toContain("duplicate");
+  });
+
+  test("isRetainedManifestPath matches ecosystem manifests by basename", () => {
+    expect(tarParser.isRetainedManifestPath("package.json")).toBe(true);
+    expect(tarParser.isRetainedManifestPath("foo-1.0.0/PKG-INFO")).toBe(true);
+    expect(tarParser.isRetainedManifestPath("foo-1.0.0/pyproject.toml")).toBe(true);
+    expect(tarParser.isRetainedManifestPath("foo/bar.whl/METADATA")).toBe(true);
+    expect(tarParser.isRetainedManifestPath("lib/index.js")).toBe(false);
+    expect(tarParser.isRetainedManifestPath("")).toBe(false);
+    expect(tarParser.isRetainedManifestPath(null)).toBe(false);
+  });
 });
 
 describe("parsePackageJson", () => {
@@ -768,6 +832,8 @@ describe("rendered sandbox parser source", () => {
     "shouldSkipTextSample",
     "summarizeFile",
     "summarizeSkippedFile",
+    "isRetainedManifestPath",
+    "tarError",
     "readTarStream",
     "parsePackageJson",
   ];
@@ -796,42 +862,5 @@ return {
 };`,
     );
     expect(run()).toEqual({ safe: true, unsafe: false, normalized: "index.js" });
-  });
-});
-
-describe("gunzipBounded", () => {
-  function streamFrom(bytes) {
-    return new ReadableStream({
-      start(controller) {
-        controller.enqueue(bytes);
-        controller.close();
-      },
-    });
-  }
-
-  async function gzip(input) {
-    const cs = new CompressionStream("gzip");
-    const writer = cs.writable.getWriter();
-    writer.write(input);
-    writer.close();
-    return new Uint8Array(await new Response(cs.readable).arrayBuffer());
-  }
-
-  test("decompresses a small gzip stream", async () => {
-    const compressed = await gzip(encoder.encode("hello hello hello"));
-    const buf = await gunzipBounded(streamFrom(compressed), 1024);
-    expect(new TextDecoder().decode(buf)).toBe("hello hello hello");
-  });
-
-  test("throws when decompressed bytes exceed the cap", async () => {
-    // 64 KB of repeated text compresses well — small input expands past the cap.
-    const compressed = await gzip(encoder.encode("a".repeat(64 * 1024)));
-    await expect(gunzipBounded(streamFrom(compressed), 1024)).rejects.toThrow(
-      /archive expands beyond safety limit/,
-    );
-  });
-
-  test("throws on a missing body", async () => {
-    await expect(gunzipBounded(null, 1024)).rejects.toThrow(/tarball decompression failed/);
   });
 });

--- a/test/tar-parser.test.mjs
+++ b/test/tar-parser.test.mjs
@@ -557,6 +557,35 @@ describe("readTar limits and malformed archives", () => {
     expect(suspicious.map((s) => s.kind)).toEqual(["content-skipped"]);
   });
 
+  test("retains package.json even after earlier entries consume the retention budget", async () => {
+    const limits = { maxFiles: 100, maxTarBytes: 950 };
+    const filler = new Uint8Array(900).fill(0x61);
+    const tar = buildTar([
+      { name: "package/filler.bin", body: filler },
+      {
+        name: "package/package.json",
+        body: JSON.stringify({
+          name: "pkg",
+          version: "1.0.0",
+          scripts: { postinstall: "node install.js" },
+        }),
+      },
+      { name: "package/install.js", body: 'require("child_process").exec("x")\n' },
+    ]);
+    const { files, suspicious } = await parseFull(tar, limits);
+    const manifest = files.find((file) => file.path === "package.json");
+
+    expect(manifest?.textSample).toContain('"postinstall"');
+    expect(parsePackageJson(files)?.scripts?.postinstall).toBe("node install.js");
+    expect(files.find((file) => file.path === "install.js")?.flags).toEqual(["content-skipped"]);
+    expect(suspicious).toEqual([
+      expect.objectContaining({
+        kind: "content-skipped",
+        path: "install.js",
+      }),
+    ]);
+  });
+
   test("readTarStream parses chunked input identically to readTar", async () => {
     const tar = buildTar([
       { name: "package/index.js", body: "export const x = 1;\n" },

--- a/test/tar-parser.test.mjs
+++ b/test/tar-parser.test.mjs
@@ -542,6 +542,16 @@ describe("readTar limits and malformed archives", () => {
     ]);
   });
 
+  test("fails closed on an oversized non-regular entry instead of streaming its body", async () => {
+    // npm publish never emits non-regular entries, so a hand-crafted archive
+    // is the only source; unlike a regular file there is no retention/skip
+    // path for it, and it must be rejected before its body is streamed at all.
+    const limits = { maxFiles: 100, maxTarBytes: 1024 };
+    const big = new Uint8Array(2048).fill(0x42);
+    const tar = buildTar([{ name: "package/link", type: "2", body: big }]);
+    await expect(parse(tar, limits)).rejects.toThrow(/invalid tar entry size/);
+  });
+
   test("skips entries once the cumulative retention budget is exhausted", async () => {
     const limits = { maxFiles: 100, maxTarBytes: 1000 };
     const bodyA = new Uint8Array(600).fill(0x61);

--- a/test/tar-parser.test.mjs
+++ b/test/tar-parser.test.mjs
@@ -744,6 +744,30 @@ describe("readTar limits and malformed archives", () => {
     expect(manifest?.flags ?? []).not.toContain("content-skipped");
   });
 
+  test("always retains the root npm manifest even after nested manifests exhaust the headroom", async () => {
+    // Nested package.json files spend the shared 2×maxTarBytes manifest headroom,
+    // but the real root manifest must still be inspected or parsePackageJson goes
+    // null and every npm identity/script/dependency check is silently disabled.
+    const limits = { maxFiles: 100, maxTarBytes: 500 };
+    const tar = buildTar([
+      { name: "a/package.json", body: new Uint8Array(500).fill(0x61) },
+      { name: "b/package.json", body: new Uint8Array(500).fill(0x62) },
+      {
+        name: "package/package.json",
+        body: JSON.stringify({
+          name: "pkg",
+          version: "1.0.0",
+          scripts: { postinstall: "node x.js" },
+        }),
+      },
+    ]);
+    const { files } = await parseFull(tar, limits);
+    const root = files.find((f) => f.path === "package.json");
+    expect(root?.textSample).toContain("postinstall");
+    expect(root?.flags ?? []).not.toContain("content-skipped");
+    expect(parsePackageJson(files)?.name).toBe("pkg");
+  });
+
   test("bounds manifest retention headroom to twice the per-file cap", async () => {
     // Manifests bypass the shared budget but only up to a second maxTarBytes, so
     // a tar stuffed with manifest-named files cannot amplify retained memory.

--- a/test/tar-parser.test.mjs
+++ b/test/tar-parser.test.mjs
@@ -715,6 +715,49 @@ describe("readTar limits and malformed archives", () => {
     expect(tarParser.isRetainedManifestPath("")).toBe(false);
     expect(tarParser.isRetainedManifestPath(null)).toBe(false);
   });
+
+  test("skips a nested oversized manifest-named file instead of failing the scan", async () => {
+    // Only the exact root package.json fails closed when oversized; a vendored
+    // file that merely shares the basename is skipped, not fatal for the scan.
+    const limits = { maxFiles: 100, maxTarBytes: 1024 };
+    const tar = buildTar([
+      { name: "package/package.json", body: JSON.stringify({ name: "pkg", version: "1.0.0" }) },
+      { name: "package/vendor/dep/package.json", body: "x".repeat(2048) },
+    ]);
+    const { files, suspicious } = await parseFull(tar, limits);
+    expect(parsePackageJson(files)?.name).toBe("pkg");
+    expect(files.find((f) => f.path === "vendor/dep/package.json")?.flags).toEqual([
+      "content-skipped",
+    ]);
+    expect(suspicious.some((s) => s.path === "vendor/dep/package.json")).toBe(true);
+  });
+
+  test("retains a manifest via headroom once the shared budget is exhausted", async () => {
+    const limits = { maxFiles: 100, maxTarBytes: 500 };
+    const tar = buildTar([
+      { name: "package/filler.bin", body: new Uint8Array(500).fill(0x61) },
+      { name: "foo-1.0.0/PKG-INFO", body: "Metadata-Version: 2.1\nName: foo\nVersion: 1.0.0\n" },
+    ]);
+    const { files } = await parseFull(tar, limits);
+    const manifest = files.find((f) => f.path.endsWith("PKG-INFO"));
+    expect(manifest?.textSample).toContain("Name: foo");
+    expect(manifest?.flags ?? []).not.toContain("content-skipped");
+  });
+
+  test("bounds manifest retention headroom to twice the per-file cap", async () => {
+    // Manifests bypass the shared budget but only up to a second maxTarBytes, so
+    // a tar stuffed with manifest-named files cannot amplify retained memory.
+    const limits = { maxFiles: 100, maxTarBytes: 500 };
+    const tar = buildTar([
+      { name: "a/package.json", body: new Uint8Array(500).fill(0x61) },
+      { name: "b/package.json", body: new Uint8Array(400).fill(0x62) },
+      { name: "c/package.json", body: new Uint8Array(400).fill(0x63) },
+    ]);
+    const { files } = await parseFull(tar, limits);
+    expect(files.find((f) => f.path === "a/package.json")?.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(files.find((f) => f.path === "b/package.json")?.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(files.find((f) => f.path === "c/package.json")?.flags).toEqual(["content-skipped"]);
+  });
 });
 
 describe("parsePackageJson", () => {

--- a/test/tar-parser.test.mjs
+++ b/test/tar-parser.test.mjs
@@ -651,14 +651,22 @@ describe("readTar limits and malformed archives", () => {
     expect(files.map((f) => f.path)).toEqual(["a.js"]);
   });
 
-  test("fails closed on an oversized manifest instead of nulling the package identity", async () => {
-    // A package.json too large to inspect must fail the scan: skipping it would
-    // return packageJson:null and silently disable every manifest-derived rule.
-    const limits = { maxFiles: 100, maxTarBytes: 1024 };
-    const bigManifest = JSON.stringify({ name: "pkg", version: "1.0.0", _pad: "x".repeat(2000) });
-    const tar = buildTar([{ name: "package/package.json", body: bigManifest }]);
-    await expect(parse(tar, limits)).rejects.toThrow(/invalid tar entry size/);
-  });
+  test.each([
+    ["npm package.json", "package/package.json"],
+    ["PyPI sdist PKG-INFO", "foo-1.0.0/PKG-INFO"],
+    ["PyPI sdist pyproject.toml", "foo-1.0.0/pyproject.toml"],
+    ["root PKG-INFO", "PKG-INFO"],
+  ])(
+    "fails closed on an oversized root manifest (%s) instead of nulling the identity",
+    async (_name, path) => {
+      // A root manifest too large to inspect must fail the scan: skipping it
+      // would leave package identity/dependency metadata uninspected and only
+      // surface a finding, downgrading the trust-boundary failure.
+      const limits = { maxFiles: 100, maxTarBytes: 1024 };
+      const tar = buildTar([{ name: path, body: "x".repeat(2048) }]);
+      await expect(parse(tar, limits)).rejects.toThrow(/invalid tar entry size/);
+    },
+  );
 
   test("retains a PyPI sdist manifest (PKG-INFO) even under budget pressure", async () => {
     // The tgz path is shared with PyPI sdists, whose manifest is PKG-INFO under a
@@ -716,20 +724,37 @@ describe("readTar limits and malformed archives", () => {
     expect(tarParser.isRetainedManifestPath(null)).toBe(false);
   });
 
-  test("skips a nested oversized manifest-named file instead of failing the scan", async () => {
-    // Only the exact root package.json fails closed when oversized; a vendored
-    // file that merely shares the basename is skipped, not fatal for the scan.
+  test("isRootManifestPath anchors to the archive root, not the basename anywhere", () => {
+    expect(tarParser.isRootManifestPath("package.json")).toBe(true);
+    expect(tarParser.isRootManifestPath("PKG-INFO")).toBe(true);
+    expect(tarParser.isRootManifestPath("pyproject.toml")).toBe(true);
+    expect(tarParser.isRootManifestPath("foo-1.0.0/PKG-INFO")).toBe(true);
+    expect(tarParser.isRootManifestPath("foo-1.0.0/pyproject.toml")).toBe(true);
+    // Nested/vendored files that merely share the basename are not root manifests.
+    expect(tarParser.isRootManifestPath("vendor/dep/package.json")).toBe(false);
+    expect(tarParser.isRootManifestPath("foo-1.0.0/sub/PKG-INFO")).toBe(false);
+    expect(tarParser.isRootManifestPath("a/b/pyproject.toml")).toBe(false);
+    // package.json is only the root at the top level (npm strips the package/ prefix).
+    expect(tarParser.isRootManifestPath("foo-1.0.0/package.json")).toBe(false);
+    expect(tarParser.isRootManifestPath("")).toBe(false);
+    expect(tarParser.isRootManifestPath(null)).toBe(false);
+  });
+
+  test("skips a deeply-nested oversized manifest-named file instead of failing the scan", async () => {
+    // Only root manifests fail closed when oversized; a vendored file that merely
+    // shares the basename deeper in the tree is skipped, not fatal for the scan.
     const limits = { maxFiles: 100, maxTarBytes: 1024 };
     const tar = buildTar([
       { name: "package/package.json", body: JSON.stringify({ name: "pkg", version: "1.0.0" }) },
       { name: "package/vendor/dep/package.json", body: "x".repeat(2048) },
+      { name: "package/vendor/py/sub/PKG-INFO", body: "y".repeat(2048) },
     ]);
     const { files, suspicious } = await parseFull(tar, limits);
     expect(parsePackageJson(files)?.name).toBe("pkg");
-    expect(files.find((f) => f.path === "vendor/dep/package.json")?.flags).toEqual([
-      "content-skipped",
-    ]);
-    expect(suspicious.some((s) => s.path === "vendor/dep/package.json")).toBe(true);
+    for (const nested of ["vendor/dep/package.json", "vendor/py/sub/PKG-INFO"]) {
+      expect(files.find((f) => f.path === nested)?.flags).toEqual(["content-skipped"]);
+      expect(suspicious.some((s) => s.path === nested)).toBe(true);
+    }
   });
 
   test("retains a manifest via headroom once the shared budget is exhausted", async () => {
@@ -900,6 +925,7 @@ describe("rendered sandbox parser source", () => {
     "summarizeFile",
     "summarizeSkippedFile",
     "isRetainedManifestPath",
+    "isRootManifestPath",
     "tarError",
     "readTarStream",
     "parsePackageJson",

--- a/test/tar-parser.test.mjs
+++ b/test/tar-parser.test.mjs
@@ -515,6 +515,94 @@ describe("readTar limits and malformed archives", () => {
     );
   });
 
+  test("skips an oversized entry body but records its metadata", async () => {
+    const limits = { maxFiles: 100, maxTarBytes: 1024 };
+    const big = new Uint8Array(2048).fill(0x42);
+    const tar = buildTar([
+      { name: "package/index.js", body: "export const x = 1;\n" },
+      { name: "package/bin/native.node", body: big },
+      { name: "package/after.js", body: "// after\n" },
+    ]);
+    const { files, suspicious } = await parseFull(tar, limits);
+    expect(files.map((f) => f.path)).toEqual(["index.js", "bin/native.node", "after.js"]);
+    const skipped = files[1];
+    expect(skipped.size).toBe(2048);
+    expect(skipped.sha256).toBe("");
+    expect(skipped.flags).toEqual(["content-skipped"]);
+    expect(skipped.textSample).toBeUndefined();
+    // Entries after the skipped body are still fully parsed.
+    expect(files[2].textSample).toBe("// after\n");
+    expect(files[2].sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(suspicious).toEqual([
+      {
+        kind: "content-skipped",
+        path: "bin/native.node",
+        detail: expect.stringContaining("2048 bytes"),
+      },
+    ]);
+  });
+
+  test("skips entries once the cumulative retention budget is exhausted", async () => {
+    const limits = { maxFiles: 100, maxTarBytes: 1000 };
+    const bodyA = new Uint8Array(600).fill(0x61);
+    const bodyB = new Uint8Array(600).fill(0x62);
+    const tar = buildTar([
+      { name: "package/a.bin", body: bodyA },
+      { name: "package/b.bin", body: bodyB },
+    ]);
+    const { files, suspicious } = await parseFull(tar, limits);
+    expect(files[0].sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(files[1].sha256).toBe("");
+    expect(files[1].flags).toEqual(["content-skipped"]);
+    expect(suspicious.map((s) => s.kind)).toEqual(["content-skipped"]);
+  });
+
+  test("readTarStream parses chunked input identically to readTar", async () => {
+    const tar = buildTar([
+      { name: "package/index.js", body: "export const x = 1;\n" },
+      { name: "package/lib/util.js", body: "// util\n" },
+    ]);
+    const chunked = new ReadableStream({
+      start(controller) {
+        for (let i = 0; i < tar.length; i += 100) {
+          controller.enqueue(tar.subarray(i, Math.min(i + 100, tar.length)));
+        }
+        controller.close();
+      },
+    });
+    const streamed = await tarParser.readTarStream(
+      chunked,
+      PARSE_LIMITS.maxFiles,
+      PARSE_LIMITS.maxTarBytes,
+      Infinity,
+    );
+    const buffered = await parseFull(tar);
+    expect(streamed).toEqual(buffered);
+  });
+
+  test("readTarStream fails closed when the total stream exceeds its cap", async () => {
+    const tar = buildTar([{ name: "package/big.bin", body: new Uint8Array(4096) }]);
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(tar);
+        controller.close();
+      },
+    });
+    await expect(tarParser.readTarStream(stream, 100, 512, 2048)).rejects.toThrow(
+      /archive expands beyond safety limit/,
+    );
+  });
+
+  test("throws truncated when a skipped entry body overruns the archive", async () => {
+    const tar = buildTar([{ name: "package/x.bin", body: "abc" }]);
+    // Claim a body far beyond both the retention limit and the archive length:
+    // the skip path must still detect the overrun instead of succeeding.
+    tar.set(encoder.encode("00000010000\0"), 124);
+    await expect(parse(tar, { maxFiles: 100, maxTarBytes: 1024 })).rejects.toThrow(
+      /truncated tar entry/,
+    );
+  });
+
   test("stops at the end-of-archive marker even with trailing garbage", async () => {
     const tar = buildTar([{ name: "package/a.js", body: "// a\n" }]);
     // Append garbage after the zero blocks; readTar should not see it.
@@ -640,9 +728,9 @@ describe("rendered sandbox parser source", () => {
     "sha256Hex",
     "shouldSkipTextSample",
     "summarizeFile",
-    "readTar",
+    "summarizeSkippedFile",
+    "readTarStream",
     "parsePackageJson",
-    "gunzipBounded",
   ];
 
   test("every required parser export keeps its function name", () => {

--- a/test/tar-parser.test.mjs
+++ b/test/tar-parser.test.mjs
@@ -668,6 +668,20 @@ describe("readTar limits and malformed archives", () => {
     },
   );
 
+  test("fails closed when a root manifest is crowded out of the retention budget", async () => {
+    // Earlier manifest-named (non-root) entries fill the 2×maxTarBytes headroom,
+    // so the real root PKG-INFO cannot be retained. Skipping it would leave
+    // identity/dependency metadata unread, so the parse fails closed instead of
+    // degrading the trust-boundary failure to a content-skipped finding.
+    const limits = { maxFiles: 100, maxTarBytes: 500 };
+    const tar = buildTar([
+      { name: "a/b/METADATA", body: new Uint8Array(500).fill(0x61) },
+      { name: "c/d/METADATA", body: new Uint8Array(500).fill(0x62) },
+      { name: "foo-1.0.0/PKG-INFO", body: "Metadata-Version: 2.1\nName: foo\nVersion: 1.0.0\n" },
+    ]);
+    await expect(parse(tar, limits)).rejects.toThrow(/invalid tar entry size/);
+  });
+
   test("retains a PyPI sdist manifest (PKG-INFO) even under budget pressure", async () => {
     // The tgz path is shared with PyPI sdists, whose manifest is PKG-INFO under a
     // version directory. It must be force-retained the same way package.json is.
@@ -711,6 +725,24 @@ describe("readTar limits and malformed archives", () => {
     const other = files.find((file) => file.path === "other.bin");
     expect(other?.sha256).toMatch(/^[0-9a-f]{64}$/);
     expect(other?.flags ?? []).not.toContain("content-skipped");
+    expect(suspicious.map((s) => s.kind)).toContain("duplicate");
+  });
+
+  test("retains a duplicate that only fits once the earlier copy's bytes are released", async () => {
+    // maxTarBytes 1000, two 900-byte copies of one path. The last-write-wins copy
+    // is the bytes a consumer receives; it only fits if the budget check discounts
+    // the earlier copy it replaces, or that content goes uninspected.
+    const limits = { maxFiles: 100, maxTarBytes: 1000 };
+    const tar = buildTar([
+      { name: "package/a.js", body: new Uint8Array(900).fill(0x61) },
+      { name: "package/a.js", body: new Uint8Array(900).fill(0x62) },
+    ]);
+    const { files, suspicious } = await parseFull(tar, limits);
+    const a = files.filter((file) => file.path === "a.js");
+    expect(a).toHaveLength(1);
+    expect(a[0].flags ?? []).not.toContain("content-skipped");
+    // The retained bytes are the last-write-wins copy (0x62 → "b"), not the first.
+    expect(a[0].textSample).toBe("b".repeat(900));
     expect(suspicious.map((s) => s.kind)).toContain("duplicate");
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #445 for the `@apollo/rover` / esbuild-style prepackaged-binary packages: instead of failing the whole scan when a tarball blows the 25 MB cap, the sandbox now parses the tar as a stream, skips oversized entry bodies without buffering them, and persists what was skipped.

**Parser** (`server/lib/tar-parser.js`)
- New `readTarStream(body, maxFiles, maxTarBytes, maxStreamBytes)`: walks tar headers as decompressed bytes arrive. `maxTarBytes` is now a *retention* budget (per entry + cumulative) rather than a hard archive cap; `maxStreamBytes` bounds total bytes consumed (fail-closed `archive expands beyond safety limit`).
- A regular file whose body would exceed the retention budget is `discard()`ed instead of buffered, and recorded both ways:
  - in `files` as `{ path, size, sha256: "", flags: ["content-skipped"] }` (via `summarizeSkippedFile`) so the release manifest and diff stay complete;
  - in `suspicious` as `{ kind: "content-skipped", path, detail }`, which flows through `tarSuspiciousEntryFindings` into a persisted medium-severity finding ("content was never inspected").
- `readTar(buffer, ...)` is now a thin wrapper (`readTarStream(new Response(bytes).body, ...)`), so all existing regression/fuzz suites exercise the streaming code path. Metadata entries (`x`/`g`/`L`) still hard-fail if oversized; truncated bodies still throw.

**Sandbox** (`server/lib/sandbox.ts`)
- tgz path pipes `res.body → DecompressionStream("gzip") → readTarStream` — the archive is never fully buffered, replacing `gunzipBounded` + buffered `readTar`.
- The wire-size `content-length` 413 gate now applies only to zip (which still buffers); tgz has no wire cap.
- New `SANDBOX_MAX_STREAM_TAR_BYTES = 10 × SANDBOX_MAX_TAR_BYTES` (250 MB) bounds total decompressed streaming work.

**Baseline degrade** (`server/lib/adapters/npm/acquire.ts`)
- If the *previous published* tarball is too large to fetch (parent-worker fetch is still capped at 25 MB compressed), `acquireBaselineNpm` now degrades to a no-baseline scan (`reason: "<reason>:baseline-too-large"`) instead of failing the scan — otherwise every release after the first of a big binary package would still fail at the diff step.

Tests: streaming skip/cumulative-budget/stream-cap/truncation regressions plus a chunked-stream ≡ buffered equivalence check in `test/tar-parser.test.mjs`. Docs: `docs/architecture.md` sandbox-parser section updated.

Link to Devin session: https://app.devin.ai/sessions/d54f6486efc64c608697350770a4b367
Requested by: @JoviDeCroock