### PR TITLE
Revert Drydock-themed copy back to plain review wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Staged Publish Inspection
+# Staged Publish Review
 
-Drydock inspects package artifacts before a maintainer clears publication. It compares the candidate with a tag-aware published baseline, runs deterministic supply-chain checks, optionally sends changed-file evidence to Cloudflare Workers AI, and saves an inspection report.
+Drydock reviews package artifacts before a maintainer approves publication. It compares the candidate with a tag-aware published baseline, runs deterministic supply-chain checks, optionally sends changed-file evidence to Cloudflare Workers AI, and saves a review report.
 
-Publication clearance stays outside Drydock: maintainers clear the release in npm, npmjs.com, or GitHub with their own required 2FA/inspection step. Drydock never publishes and never collects 2FA codes.
+Approval stays outside Drydock: maintainers approve in npm, npmjs.com, or GitHub with their own required 2FA/review step. Drydock never publishes and never collects approval codes.
 
 ## Modes
 
-- **npm registry staging** — `npm publish --stage` creates a private staged tarball. Drydock downloads it through a sandbox and leaves final clearance in npm.
-- **Workflow gates** — for ecosystems where the registry cannot stage a candidate, GitHub Actions uploads built artifacts and a GitHub Environment custom deployment-protection rule pauses publishing until Drydock inspection is cleared or held. PyPI and npm workflow-gate artifacts are supported by the shared gate pipeline.
+- **npm registry staging** — `npm publish --stage` creates a private staged tarball. Drydock downloads it through a sandbox and leaves final approval in npm.
+- **Workflow gates** — for ecosystems where the registry cannot stage a candidate, GitHub Actions uploads built artifacts and a GitHub Environment custom deployment-protection rule blocks publishing until Drydock review is accepted or rejected. PyPI and npm workflow-gate artifacts are supported by the shared gate pipeline.
 
 ## Docs
 
@@ -71,7 +71,7 @@ The authenticated JSON API lives under `/api/v1`. The main resources are:
 
 - scans: create/list/read/export reports, compare published baselines, and fetch prior file samples;
 - npm connection: read public metadata, store/rotate, validate, and remove the current organization token;
-- release targets and workflow gates: map GitHub repositories/environments, inspect queued gate artifacts, and post clear/hold results;
+- release targets and workflow gates: map GitHub repositories/environments, review queued gate artifacts, and post accept/reject decisions;
 - auth/org/settings helpers for Better Auth-backed sessions and organization membership.
 
 Consult route definitions under `server/routes/` for exact request/response shapes; shared types are imported by the UI from `server/`.

--- a/docs/npm-workflow-gate.md
+++ b/docs/npm-workflow-gate.md
@@ -1,5 +1,5 @@
-# npm workflow-gate inspection
+# npm workflow-gate mode
 
 This compatibility page is intentionally short. Canonical workflow-gate documentation now lives in [`workflow-gates.md`](./workflow-gates.md), including the [npm workflow-gate notes](./workflow-gates.md#npm-workflow-gate-notes).
 
-Use npm workflow gates when the release is built in GitHub Actions and should be paused by a GitHub Environment protection rule instead of by npm registry staging. The workflow must upload the exact `npm pack` artifact that the publish job later publishes; rebuilding after clearance breaks Drydock's inspection boundary.
+Use npm workflow gates when the release is built in GitHub Actions and should be paused by a GitHub Environment protection rule instead of by npm registry staging. The workflow must upload the exact `npm pack` artifact that the publish job later publishes; rebuilding after approval breaks Drydock's review boundary.

--- a/docs/workflow-gates.md
+++ b/docs/workflow-gates.md
@@ -1,6 +1,6 @@
 # Workflow Gates
 
-Workflow gates are Drydock's inspection mode for releases whose registry cannot hold a private staged artifact. GitHub Actions builds the release, uploads the candidate artifacts, and a GitHub Environment custom deployment-protection rule pauses publishing while Drydock inspects the bytes.
+Workflow gates are Drydock's review mode for releases whose registry cannot hold a private staged artifact. GitHub Actions builds the release, uploads the candidate artifacts, and a GitHub Environment custom deployment-protection rule pauses publishing while Drydock reviews the bytes.
 
 Supported gate ecosystems: **PyPI** and **npm**. Shared GitHub plumbing lives in `server/lib/workflow-gates/`; artifact-specific behavior lives behind adapters.
 
@@ -10,10 +10,10 @@ Supported gate ecosystems: **PyPI** and **npm**. Shared GitHub plumbing lives in
 2. The publish workflow builds release artifacts and uploads them before the protected publish job starts.
 3. GitHub sends a `deployment_protection_rule` webhook to `/webhooks/github`.
 4. Drydock resolves the installation, repository, run, environment, release target, and uploaded artifacts.
-5. The adapter derives one or more inspectable release candidates from those artifacts.
+5. The adapter derives one or more reviewable release candidates from those artifacts.
 6. A queue worker runs the shared scan pipeline for each candidate.
-7. A maintainer clears or holds the gate inspection in Drydock.
-8. Drydock posts the deployment-protection clearance back to GitHub; the workflow either continues to publish or fails closed.
+7. A maintainer accepts or rejects the gate review in Drydock.
+8. Drydock posts the deployment-protection decision back to GitHub; the workflow either continues to publish or fails closed.
 
 The GitHub webhook is public but signed with `GITHUB_WEBHOOK_SECRET` and bypasses Better Auth only after signature verification. All stored gate state remains organization-scoped.
 
@@ -22,7 +22,7 @@ The GitHub webhook is public but signed with `GITHUB_WEBHOOK_SECRET` and bypasse
 - `server/routes/github-webhooks.ts` verifies GitHub webhook signatures and persists gate deliveries.
 - `server/routes/github-app.ts` handles App install/callback setup.
 - `server/routes/release-targets.ts` maps organizations to GitHub repositories/environments/ecosystems.
-- `server/routes/workflow-gates.ts` exposes pending/completed gate inspection APIs and clear/hold actions.
+- `server/routes/workflow-gates.ts` exposes pending/completed gate review APIs and accept/reject actions.
 - `server/lib/workflow-gates/` resolves workflow runs, artifacts, release targets, callback URLs, and gate lifecycle state.
 - `server/lib/scan-pipeline.ts` runs the same deterministic/AI/report pipeline used by npm registry-staged scans.
 
@@ -30,7 +30,7 @@ Required bindings/secrets include the GitHub App id/private key/client credentia
 
 ## Release set derivation
 
-A release set is the boundary between CI and Drydock. Drydock never trusts a maintainer-declared manifest as authority over inspected bytes; it recomputes identity and digest evidence from the uploaded artifacts themselves.
+A release set is the boundary between CI and Drydock. Drydock never trusts a maintainer-declared manifest as authority over reviewed bytes; it recomputes identity and digest evidence from the uploaded artifacts themselves.
 
 For every candidate artifact set, adapters must provide:
 
@@ -40,9 +40,9 @@ For every candidate artifact set, adapters must provide:
 - current candidate bytes;
 - previous-release baseline bytes when available;
 - deterministic findings specific to that ecosystem;
-- enough metadata to show the maintainer exactly what was inspected.
+- enough metadata to show the maintainer exactly what was reviewed.
 
-If a workflow uploads artifacts for several packages, Drydock fans out into separate gate inspections. Clearing one package must not clear another package's release.
+If a workflow uploads artifacts for several packages, Drydock fans out into separate gate reviews. Accepting one package must not approve another package's release.
 
 ## PyPI workflow-gate notes
 
@@ -85,20 +85,20 @@ jobs:
       - run: npm publish *.tgz
 ```
 
-Drydock should be the deployment-protection rule for the `production` environment. The publish job must consume the exact uploaded artifact inspected by Drydock; rebuilding after clearance breaks the inspection boundary.
+Drydock should be the deployment-protection rule for the `production` environment. The publish job must consume the exact uploaded artifact reviewed by Drydock; rebuilding after approval breaks the review boundary.
 
 ## Trust and failure behavior
 
 - The GitHub webhook signature is mandatory.
-- Gate clearances must resolve to the original installation, repository, workflow run, environment, and callback URL.
+- Gate decisions must resolve to the original installation, repository, workflow run, environment, and callback URL.
 - Artifact digests are recomputed by Drydock from downloaded bytes.
 - Package identity comes from artifact metadata, not GitHub paths or artifact names alone.
-- If artifact resolution, baseline acquisition, validation, scan, or callback fails, the gate remains held; do not fail open.
-- Drydock never publishes. It only posts the GitHub deployment-protection clearance.
+- If artifact resolution, baseline acquisition, validation, scan, or callback fails, the gate remains blocked or is rejected; do not fail open.
+- Drydock never publishes. It only posts the GitHub deployment-protection decision.
 
 ## Maintainer workbench
 
-The gate inspection workbench shows the release target, package identity/version, artifact set, scan status, findings, changed files, and clear/hold controls. Clear/hold actions require an authenticated maintainer in the owning organization. Step-up auth requirements should match other sensitive release clearances; see [`two-factor-auth.md`](./two-factor-auth.md).
+The gate review workbench shows the release target, package identity/version, artifact set, scan status, findings, changed files, and accept/reject controls. Accept/reject actions require an authenticated maintainer in the owning organization. Step-up auth requirements should match other sensitive release decisions; see [`two-factor-auth.md`](./two-factor-auth.md).
 
 ## Adding a new ecosystem
 
@@ -108,7 +108,7 @@ The gate inspection workbench shows the release target, package identity/version
 4. Add deterministic findings for ecosystem-specific risky behavior.
 5. Register the adapter with workflow-gate resolution.
 6. Add Worker-route tests for webhook/gate lifecycle and adapter tests for archive/metadata/baseline behavior.
-7. Add fake-registry or fake-artifact e2e coverage when the publish workflow or browser-visible inspection flow changes.
+7. Add fake-registry or fake-artifact e2e coverage when the publish workflow or browser-visible review flow changes.
 
 ## Remaining work
 

--- a/server/lib/adapters/pypi/findings.ts
+++ b/server/lib/adapters/pypi/findings.ts
@@ -37,7 +37,7 @@ export function pyPiReleaseFindings(
           file: metadataEvidencePath,
           evidence: `${artifact.path} does not expose complete PyPI metadata`,
           reason:
-            "release gates need package name and version metadata to prove the artifact matches the inspected manifest",
+            "release gates need package name and version metadata to prove the artifact matches the reviewed manifest",
         }),
       );
     } else if (normalizePyPiProjectName(summary.name) !== manifestName) {
@@ -46,7 +46,7 @@ export function pyPiReleaseFindings(
           severity: "critical",
           file: metadataEvidencePath,
           evidence: `${artifact.path} metadata Name ${summary.name} != manifest package ${manifest.package}`,
-          reason: "the release artifact package name does not match the inspected PyPI manifest",
+          reason: "the release artifact package name does not match the reviewed PyPI manifest",
         }),
       );
     }
@@ -56,7 +56,7 @@ export function pyPiReleaseFindings(
           severity: "critical",
           file: metadataEvidencePath,
           evidence: `${artifact.path} metadata Version ${summary.version} != manifest version ${manifest.version}`,
-          reason: "the release artifact version does not match the inspected PyPI manifest",
+          reason: "the release artifact version does not match the reviewed PyPI manifest",
         }),
       );
     }
@@ -81,7 +81,7 @@ export function pyPiReleaseFindings(
           file: metadataEvidencePath,
           evidence: `direct-reference dependency: ${directReferenceDeps.join(", ")}`,
           reason:
-            "PEP 508 direct-URL/VCS dependencies bypass the PyPI registry and pull uninspected code from an arbitrary location",
+            "PEP 508 direct-URL/VCS dependencies bypass the PyPI registry and pull unreviewed code from an arbitrary location",
         }),
       );
     }

--- a/server/lib/notify.ts
+++ b/server/lib/notify.ts
@@ -41,36 +41,33 @@ export async function notifyScanCompletion(input: NotifyScanCompletionInput): Pr
   const dashboardUrl = scanUrl(env, scanId);
   const subject =
     outcome === "complete"
-      ? `New version docked and ready for inspection — ${packageLabel}`
-      : `Version could not dock for inspection — ${packageLabel}`;
+      ? `Staged release scan complete — ${packageLabel}`
+      : `Staged release scan failed — ${packageLabel}`;
 
   const lines =
     outcome === "complete"
       ? [
           "Hi there,",
           "",
-          `New version docked and ready for inspection: ${packageLabel}.`,
+          `We finished scanning the staged release ${packageLabel}.`,
           scan?.risk ? `Overall risk: ${scan.risk}.` : null,
-          dashboardUrl ? `Inspect the report: ${dashboardUrl}` : null,
+          dashboardUrl ? `Review the report: ${dashboardUrl}` : null,
           "",
           "— Drydock",
         ]
       : [
           "Hi there,",
           "",
-          `We could not dock ${packageLabel} for inspection.`,
+          `We could not complete the staged release scan for ${packageLabel}.`,
           error?.message ? `Reason: ${error.message}` : null,
-          dashboardUrl ? `Open the inspection: ${dashboardUrl}` : null,
+          dashboardUrl ? `Review the scan: ${dashboardUrl}` : null,
           "",
           "— Drydock",
         ];
   const text = lines.filter((line): line is string => line !== null).join("\n");
 
   const slackPayload: SlackNotificationPayload = {
-    title:
-      outcome === "complete"
-        ? "New version docked and ready for inspection"
-        : "Version could not dock for inspection",
+    title: outcome === "complete" ? "Staged release scan complete" : "Staged release scan failed",
     packageLabel,
     source: "npm staged publish",
     risk: scan?.risk ?? null,
@@ -168,13 +165,13 @@ export async function notifyNpmConnectionExpired(
   const lines = [
     "Hi there,",
     "",
-    "Drydock can no longer reach the npm staging registry with your saved token, so staged-release inspections are paused for your organization.",
+    "Drydock can no longer reach the npm staging registry with your saved token, so staged-release reviews are paused for your organization.",
     "",
     `Registry: ${registryUrl}`,
     "",
     settingsLink
-      ? `Re-add a working token on Settings to resume inspections: ${settingsLink}`
-      : "Re-add a working token on the Settings page to resume inspections.",
+      ? `Re-add a working token on Settings to resume reviews: ${settingsLink}`
+      : "Re-add a working token on the Settings page to resume reviews.",
     "",
     "— Drydock",
   ];
@@ -252,38 +249,38 @@ export async function notifyWorkflowGateReview(
   // A monorepo release fans out into several per-package scans behind one gate;
   // the gate carries only its headline (highest-risk) package. Surface the bundle
   // size in every channel so the headline isn't mistaken for the whole release —
-  // each package must be cleared before the held deployment can publish.
+  // each package must be approved before the held deployment can publish.
   const packageDisplay = otherPackages
-    ? `${packageLabel} (+${otherPackages} more in this release; each must be cleared)`
+    ? `${packageLabel} (+${otherPackages} more in this release; each must be approved)`
     : packageLabel;
   const packageLine = `Package: ${packageDisplay}`;
-  const subject = `Release docked and waiting for inspection — ${packageLabel}`;
+  const subject = `Release gate needs your review — ${packageLabel}`;
   const lines = [
     "Hi there,",
     "",
-    `A release is docked in ${repositoryFullName} and is waiting for inspection before it can publish.`,
+    `A staged release is held in ${repositoryFullName} and is waiting for a decision before it can publish.`,
     "",
     packageLine,
     `Release risk: ${releaseRisk}`,
     `Repository: ${repositoryFullName}`,
     `Environment: ${environment}`,
     "",
-    dashboardUrl ? `Inspect and clear the release: ${dashboardUrl}` : null,
+    dashboardUrl ? `Approve or block the release: ${dashboardUrl}` : null,
     "",
-    "The held GitHub deployment stays docked until someone clears or holds it.",
+    "The held GitHub deployment stays blocked until someone approves or rejects it.",
     "",
     "— Drydock",
   ];
   const text = lines.filter((line): line is string => line !== null).join("\n");
 
   const slackPayload: SlackNotificationPayload = {
-    title: "Release docked for inspection",
+    title: "Release gate needs a decision",
     packageLabel: packageDisplay,
     source: "GitHub workflow gate",
     risk: releaseRisk,
     repository: repositoryFullName,
     environment,
-    statusLine: `Docked in ${repositoryFullName} — the deployment stays docked until someone clears or holds it.`,
+    statusLine: `Held in ${repositoryFullName} — the deployment stays blocked until someone approves or rejects it.`,
     dashboardUrl,
   };
 
@@ -386,19 +383,19 @@ export async function notifyWorkflowGateTimeout(
 
   const packageLabel = formatPackageLabel(packageName, version);
   const dashboardUrl = scanUrl(env, scanId);
-  const subject = `GitHub gate for ${packageLabel} timed out before inspection completed`;
+  const subject = `GitHub gate for ${packageLabel} timed out before scan completed`;
   const lines = [
     "Hi there,",
     "",
-    `The GitHub release gate for ${packageLabel} in ${repositoryFullName} timed out before Drydock finished inspecting it.`,
-    "GitHub may have already held the release because the inspection missed its clearance window.",
+    `The GitHub release gate for ${packageLabel} in ${repositoryFullName} timed out before Drydock finished scanning it.`,
+    "GitHub may have already blocked the release because the review did not return inside its decision window.",
     "",
     `Repository: ${repositoryFullName}`,
     `Environment: ${environment}`,
     "",
-    dashboardUrl ? `See the completed inspection: ${dashboardUrl}` : null,
+    dashboardUrl ? `See the completed review: ${dashboardUrl}` : null,
     "",
-    "Re-run the workflow to request a fresh inspection.",
+    "Re-run the workflow to request a fresh review.",
     "",
     "— Drydock",
   ];
@@ -586,7 +583,7 @@ function formatPackageLabel(
   version: string | null | undefined,
 ) {
   if (packageName && version) return `${packageName}@${version}`;
-  return packageName ?? "a docked release";
+  return packageName ?? "a staged release";
 }
 
 function scanUrl(env: Cloudflare.Env, scanId: string): string | null {

--- a/server/lib/slack.ts
+++ b/server/lib/slack.ts
@@ -311,7 +311,7 @@ export function renderSlackMessage(payload: SlackNotificationPayload): SlackMess
       elements: [
         {
           type: "button",
-          text: { type: "plain_text", text: "Inspect in Drydock", emoji: false },
+          text: { type: "plain_text", text: "Open in Drydock", emoji: false },
           url: payload.dashboardUrl,
         },
       ],

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -485,7 +485,7 @@ async function rejectGateForArtifactError(
   error: WorkflowArtifactError,
 ): Promise<void> {
   const comment =
-    "Drydock held this release: the published artifacts could not be verified against the inspected manifest.";
+    "Drydock blocked this release: the published artifacts could not be verified against the reviewed manifest.";
   const decided = await markGateDecided(db, {
     gateId: gate.id,
     decision: "rejected",
@@ -586,7 +586,7 @@ export function buildHumanDecisionComment(
   decision: "approved" | "rejected",
   reportUrl: string | null,
 ): string {
-  const verb = decision === "approved" ? "cleared" : "held";
+  const verb = decision === "approved" ? "approved" : "blocked";
   const head = `A Drydock maintainer ${verb} this release.`;
-  return reportUrl ? `${head} Inspection: ${reportUrl}` : head;
+  return reportUrl ? `${head} Review: ${reportUrl}` : head;
 }

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -186,7 +186,7 @@ export default function LoginPage() {
         <Eyebrow>Welcome back</Eyebrow>
         <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">Sign in</h1>
         <Muted class="text-[13px] m-0">
-          Sign in to inspect docked versions and revisit saved reports.
+          Sign in to review held releases and revisit saved reports.
         </Muted>
 
         <form class="flex flex-col gap-4 mt-2" onSubmit={onSubmit}>

--- a/src/pages/Auth/Register.tsx
+++ b/src/pages/Auth/Register.tsx
@@ -111,8 +111,8 @@ export default function RegisterPage() {
         <Eyebrow>Get started</Eyebrow>
         <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">Create account</h1>
         <Muted class="text-[13px] m-0">
-          Create a workspace, connect npm or a GitHub gate, and inspect docked versions before they
-          go live.
+          Create a workspace, connect npm or a GitHub gate, and review held releases before they go
+          live.
         </Muted>
 
         <form class="flex flex-col gap-4 mt-2" onSubmit={onSubmit}>

--- a/src/pages/Dashboard/ScanDetail/DecisionDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/DecisionDialog.tsx
@@ -59,14 +59,14 @@ export function DecisionDialog({
     <Dialog
       open={open}
       onClose={handleClose}
-      title="Release clearance"
-      description="Record whether this docked version is clear to release. This adds to the audit trail, but it does not publish or cancel anything on npm. You still confirm or cancel with 2FA there."
+      title="Publish decision"
+      description="Record whether this staged publish is safe to approve. This adds to the audit trail, but it does not publish or cancel anything on npm. You still confirm or cancel with 2FA there."
     >
       {decision ? (
         <div class="flex flex-col gap-2 border border-border rounded-md p-3">
           <div class="flex flex-wrap items-center gap-2">
             <Badge tone={decision === "publish" ? "ok" : "critical"}>
-              {decision === "publish" ? "currently cleared" : "currently held"}
+              {decision === "publish" ? "currently approved" : "currently blocked"}
             </Badge>
             {decidedAt ? (
               <span class="font-mono text-[11px] text-ink-subtle">{formatDateTime(decidedAt)}</span>
@@ -106,10 +106,10 @@ export function DecisionDialog({
 
       <div class="flex flex-wrap gap-2">
         <Button onClick={() => submit("publish")} disabled={saving}>
-          {saving ? "Saving…" : "Clear publish"}
+          {saving ? "Saving…" : "Approve publish"}
         </Button>
         <Button variant="danger" onClick={() => submit("no_publish")} disabled={saving}>
-          {saving ? "Saving…" : "Keep held"}
+          {saving ? "Saving…" : "Block publish"}
         </Button>
       </div>
       {error ? <Alert tone="critical">{error}</Alert> : null}

--- a/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/GateDecisionDialog.tsx
@@ -36,13 +36,13 @@ export function gateStatusTone(status: PublicWorkflowGate["status"]) {
 export function gateStatusLabel(status: PublicWorkflowGate["status"]): string {
   switch (status) {
     case "approved":
-      return "cleared · job released";
+      return "approved · job released";
     case "rejected":
-      return "held · job anchored";
+      return "rejected · job blocked";
     case "errored":
-      return "inspection errored";
+      return "review errored";
     default:
-      return "awaiting clearance";
+      return "awaiting decision";
   }
 }
 
@@ -55,11 +55,11 @@ function packageDecisionTone(pkg: GatePackageScan) {
 }
 
 function packageDecisionLabel(pkg: GatePackageScan): string {
-  if (pkg.decision === "publish") return "cleared";
-  if (pkg.decision === "no_publish") return "held";
-  if (pkg.status === "failed") return "inspection failed";
-  if (pkg.status !== "complete") return "inspecting";
-  return "awaiting clearance";
+  if (pkg.decision === "publish") return "approved";
+  if (pkg.decision === "no_publish") return "rejected";
+  if (pkg.status === "failed") return "review failed";
+  if (pkg.status !== "complete") return "reviewing";
+  return "awaiting decision";
 }
 
 function packageLabel(pkg: GatePackageScan): string {
@@ -70,9 +70,9 @@ function packageLabel(pkg: GatePackageScan): string {
 /**
  * Roster of every package the gated release publishes. A monorepo fans the gate
  * out into one scan per package and the held deployment only releases once all
- * of them are cleared — so this panel makes the sibling packages and their
- * per-package decision state visible from any one package's inspection page, with a
- * link to open each sibling's own inspection and an inline decide action on the row
+ * of them are approved — so this panel makes the sibling packages and their
+ * per-package decision state visible from any one package's review page, with a
+ * link to open each sibling's own review and an inline decide action on the row
  * for the package you're currently looking at.
  *
  * Renders nothing for a single-package gate, where the roster would just echo
@@ -85,7 +85,7 @@ export function GatePackagesPanel({
 }: {
   gate: PublicWorkflowGate;
   currentScanId: string;
-  /** Opens the decision dialog for the current package; absent until its inspection resolves. */
+  /** Opens the decision dialog for the current package; absent until its review resolves. */
   onDecide?: () => void;
 }) {
   const packages = gate.packages;
@@ -97,15 +97,15 @@ export function GatePackagesPanel({
   return (
     <section class="flex flex-col gap-3 border border-border rounded-lg p-4">
       <div class="flex flex-wrap items-center justify-between gap-2">
-        <SectionLabel>Docked packages</SectionLabel>
+        <SectionLabel>Release packages</SectionLabel>
         <span class="font-mono text-[11px] uppercase tracking-[0.08em] text-ink-subtle">
-          {approved} of {packages.length} cleared
-          {rejected ? ` · ${rejected} held` : ""}
+          {approved} of {packages.length} approved
+          {rejected ? ` · ${rejected} rejected` : ""}
         </span>
       </div>
       <p class="m-0 max-w-[760px] text-[13px] leading-[1.55] text-ink-muted">
-        This release publishes {packages.length} packages. Every one must be cleared before the held
-        deployment undocks; holding any single package anchors the whole release.
+        This release publishes {packages.length} packages. Every one must be approved before the
+        held deployment releases; rejecting any single package blocks the whole release.
       </p>
       <ul class="m-0 p-0 list-none flex flex-col">
         {packages.map((pkg) => {
@@ -131,7 +131,7 @@ export function GatePackagesPanel({
                       onClick={onDecide}
                       class="font-mono text-[11px] underline text-accent bg-transparent border-0 p-0 cursor-pointer"
                     >
-                      clear →
+                      decide →
                     </button>
                   ) : (
                     <span class="font-mono text-[11px] text-ink-subtle">shown here</span>
@@ -141,7 +141,7 @@ export function GatePackagesPanel({
                     class="font-mono text-[11px] underline text-accent"
                     href={`/dashboard/scans/${encodeURIComponent(pkg.scanId)}`}
                   >
-                    {pending && !pkg.decision ? "inspect →" : "open →"}
+                    {pending && !pkg.decision ? "review →" : "open →"}
                   </a>
                 )}
               </div>
@@ -172,7 +172,7 @@ export function GateContextPanel({
   return (
     <section class="flex flex-col gap-3 border border-border rounded-lg p-4">
       <div class="flex flex-wrap items-center justify-between gap-2">
-        <SectionLabel>Release gate</SectionLabel>
+        <SectionLabel>Deployment gate</SectionLabel>
         {gate ? (
           <Badge tone={gateStatusTone(gate.status)}>{gateStatusLabel(gate.status)}</Badge>
         ) : null}
@@ -200,17 +200,17 @@ export function GateContextPanel({
       )}
       {gate?.failureReason ? (
         <Alert tone="critical">
-          Drydock held this release automatically because the published artifacts could not be
-          verified against the inspected manifest ({gate.failureReason}).
+          Drydock blocked this release automatically because the published artifacts could not be
+          verified against the reviewed manifest ({gate.failureReason}).
         </Alert>
       ) : null}
       {canRetry && onRetry ? (
         <div class="flex flex-wrap items-center gap-3">
           <Button variant="secondary" onClick={onRetry} disabled={retrying}>
-            {retrying ? "Retrying…" : "Retry inspection"}
+            {retrying ? "Retrying…" : "Retry review"}
           </Button>
           <Muted class="m-0 text-[12px]">
-            Re-runs the gate inspection from the workflow artifacts and replaces the failed batch.
+            Re-runs the gate review from the workflow artifacts and replaces the failed batch.
           </Muted>
         </div>
       ) : null}
@@ -293,11 +293,11 @@ export function GateDecisionDialog({
     <Dialog
       open={open}
       onClose={handleClose}
-      title={multi ? "Package clearance" : "Release clearance"}
+      title={multi ? "Package decision" : "Release decision"}
       description={
         multi
-          ? "Clear this package. The held GitHub Actions job undocks only after every package is cleared; holding any one anchors the whole release. Publishing still runs through your workflow's own publish step, such as Trusted Publishing or OIDC. Drydock never holds your registry credentials."
-          : "Clear to undock the held GitHub Actions job. Hold to anchor it. Publishing still runs through your workflow's own publish step, such as Trusted Publishing or OIDC. Drydock never holds your registry credentials or uploads the package."
+          ? "Decide this package. The held GitHub Actions job releases only after every package is approved; rejecting any one blocks the whole release. Publishing still runs through your workflow's own publish step, such as Trusted Publishing or OIDC. Drydock never holds your registry credentials."
+          : "Approve to release the held GitHub Actions job. Reject to block it. Publishing still runs through your workflow's own publish step, such as Trusted Publishing or OIDC. Drydock never holds your registry credentials or uploads the package."
       }
     >
       <div class="flex flex-col gap-2 border border-border rounded-md p-3">
@@ -313,33 +313,33 @@ export function GateDecisionDialog({
           <Badge tone={gateStatusTone(gate.status)}>{gateStatusLabel(gate.status)}</Badge>
         ) : packageDecision ? (
           <Badge tone={packageDecision === "publish" ? "ok" : "critical"}>
-            this package {packageDecision === "publish" ? "cleared" : "held"}
+            this package {packageDecision === "publish" ? "approved" : "rejected"}
           </Badge>
         ) : null}
       </div>
 
       {multi && !gateDecided ? (
         <Muted class="m-0 text-[13px]">
-          {approvedCount} of {packages.length} packages cleared. All must be cleared before the held
-          deployment undocks.
+          {approvedCount} of {packages.length} packages approved. All must be approved before the
+          held deployment releases.
         </Muted>
       ) : null}
 
       {reviewFailed && !gateDecided && !packageAlreadyDecided ? (
         <Alert tone="warn">
-          This package inspection failed. Retry the inspection, or record human clearance based on
-          the release evidence you have inspected.
+          This package review failed. Retry the review, or record a human decision based on the
+          release evidence you have inspected.
         </Alert>
       ) : null}
 
       {mustEnroll ? (
         <Alert tone="warn">
-          Your organization requires two-factor authentication to clear or hold releases. Enable it
-          in{" "}
+          Your organization requires two-factor authentication to approve or block releases. Enable
+          it in{" "}
           <a class="underline text-accent" href="/dashboard/account">
             Account
           </a>
-          , then reopen this clearance.
+          , then reopen this decision.
         </Alert>
       ) : null}
 
@@ -348,7 +348,7 @@ export function GateDecisionDialog({
           id="gateComment"
           type="text"
           value={commentDraft.value}
-          placeholder="e.g. inspected changed files, no risk signals"
+          placeholder="e.g. reviewed changed files, no risk signals"
           onInput={(e) => (commentDraft.value = (e.target as HTMLInputElement).value)}
           disabled={saving || gateDecided || packageAlreadyDecided || mustEnroll}
           maxLength={500}
@@ -372,20 +372,19 @@ export function GateDecisionDialog({
             onInput={(e) => (codeDraft.value = (e.target as HTMLInputElement).value)}
           />
           <Muted class="m-0 mt-1 text-[12px]">
-            Confirm with the code from your authenticator app to clear or hold this deployment.
+            Confirm with the code from your authenticator app to release or block this deployment.
           </Muted>
         </Field>
       ) : null}
 
       {gateDecided ? (
         <Muted class="m-0 text-[13px]">
-          This gate has already been cleared or held. The clearance is final, and GitHub has been
-          notified.
+          This gate has already been decided. The decision is final, and GitHub has been notified.
         </Muted>
       ) : packageAlreadyDecided ? (
         <Muted class="m-0 text-[13px]">
-          This package clearance has been recorded. The held deployment stays pending until the
-          remaining packages receive clearance.
+          This package decision has been recorded. The held deployment stays pending until the
+          remaining packages are decided.
         </Muted>
       ) : (
         <div class="flex flex-wrap gap-2">
@@ -398,11 +397,11 @@ export function GateDecisionDialog({
                 ? "Submitting…"
                 : reviewFailed
                   ? multi
-                    ? "Ship package anyway"
-                    : "Ship anyway & release"
+                    ? "Approve package anyway"
+                    : "Approve anyway & release"
                   : multi
-                    ? "Ship package"
-                    : "Ship & release"}
+                    ? "Approve package"
+                    : "Approve & release"}
             </Button>
           ) : null}
           <Button
@@ -410,14 +409,14 @@ export function GateDecisionDialog({
             onClick={() => submit("rejected")}
             disabled={saving || blockedOnCode || mustEnroll}
           >
-            {saving ? "Submitting…" : "Hold release"}
+            {saving ? "Submitting…" : "Reject & block release"}
           </Button>
         </div>
       )}
       {!gateDecided && !canApprove ? (
         <Muted class="m-0 text-[13px]">
-          Clearance requires a completed inspection batch. Retry the inspection or hold the held
-          GitHub job at the dock.
+          Approval requires a completed review batch. Retry the review or reject to block the held
+          GitHub job.
         </Muted>
       ) : null}
       {error ? <Alert tone="critical">{error}</Alert> : null}

--- a/src/pages/Dashboard/ScanDetail/ReleaseRecommendation.tsx
+++ b/src/pages/Dashboard/ScanDetail/ReleaseRecommendation.tsx
@@ -58,12 +58,12 @@ export function ReleaseRecommendation({
   // The recommendation is the report's verdict, so it gets the only elevated
   // (carded) section among the supplementary bare sections below it, plus a
   // headline-scale verdict in the matching severity text color. Elevation +
-  // scale make it out-rank Risk signals / Manifest / Inspector notes, which all
+  // scale make it out-rank Risk signals / Manifest / Reviewer notes, which all
   // share the flat SectionLabel altitude.
   return (
     <Card class="p-5 sm:p-6 flex flex-col gap-4">
       <div class="flex flex-col gap-2">
-        <SectionLabel>Inspection recommendation</SectionLabel>
+        <SectionLabel>Recommendation</SectionLabel>
         <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
           <h2
             class={`m-0 text-lg font-semibold tracking-[-0.01em] ${verdictColor(recommendation.tone)}`}
@@ -78,7 +78,7 @@ export function ReleaseRecommendation({
               (ai.kind === "complete" ? (
                 <>
                   <Badge tone={ai.requiresManualReview ? "medium" : "ok"}>
-                    {ai.requiresManualReview ? "manual inspection" : "no extra inspection"}
+                    {ai.requiresManualReview ? "manual review" : "no extra review"}
                   </Badge>
                   <Badge tone="neutral">{ai.releaseAssessment.replaceAll("_", " ")}</Badge>
                 </>

--- a/src/pages/Dashboard/ScanDetail/ReportSections.tsx
+++ b/src/pages/Dashboard/ScanDetail/ReportSections.tsx
@@ -26,18 +26,18 @@ export function PersistedReportSections({
         {summary.packageJsonDiff ? (
           <PackageJsonDiffView diff={summary.packageJsonDiff} />
         ) : (
-          <EmptyLine>No manifest changes were saved for this inspection.</EmptyLine>
+          <EmptyLine>No manifest changes were saved for this review.</EmptyLine>
         )}
       </ReportSection>
 
       {ai != null && ai.model != null && (
-        <ReportSection title="Inspector notes">
+        <ReportSection title="Reviewer notes">
           {ai.kind === "complete" ? (
             <>
               <div class="flex flex-wrap gap-2">
                 <Badge tone={severityTone(ai.risk)}>{ai.risk}</Badge>
                 <Badge tone={ai.requiresManualReview ? "medium" : "ok"}>
-                  {ai.requiresManualReview ? "manual inspection" : "no extra inspection"}
+                  {ai.requiresManualReview ? "manual review" : "no extra review"}
                 </Badge>
                 <Badge tone="neutral">{ai.releaseAssessment.replaceAll("_", " ")}</Badge>
               </div>

--- a/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
+++ b/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
@@ -28,10 +28,10 @@ export function ScanDetailHeader({
     <header class="flex flex-wrap items-start justify-between gap-4">
       <div class="flex flex-col gap-2 min-w-0">
         <a href={dashboardHref} class="text-[13px] text-ink-muted hover:text-ink no-underline">
-          ← Inspections
+          ← Reviews
         </a>
         <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">
-          {detail?.scan.packageName || "Release inspection"}
+          {detail?.scan.packageName || "Release review"}
         </h1>
         {detail ? (
           <MonoDetail
@@ -47,7 +47,7 @@ export function ScanDetailHeader({
             ]}
           />
         ) : (
-          <LoadingLine size="inline">Loading saved inspection</LoadingLine>
+          <LoadingLine size="inline">Loading saved review</LoadingLine>
         )}
       </div>
       {decision || onDecideClick || (detail && isComplete) ? (
@@ -55,7 +55,7 @@ export function ScanDetailHeader({
           {decision ? (
             <div class="flex flex-col items-end gap-1">
               <Badge tone={decision === "publish" ? "ok" : "critical"}>
-                {decision === "publish" ? "cleared" : "held"}
+                {decision === "publish" ? "approved" : "blocked"}
               </Badge>
               {decidedAt ? (
                 <span class="font-mono text-[11px] text-ink-subtle">
@@ -76,7 +76,7 @@ export function ScanDetailHeader({
           ) : null}
           {onDecideClick ? (
             <Button variant={decision ? "secondary" : "primary"} onClick={onDecideClick}>
-              {decision ? "Update clearance" : "Ship"}
+              {decision ? "Update decision" : "Decide"}
             </Button>
           ) : null}
         </div>
@@ -124,7 +124,7 @@ export function ScanFailureAlert({ errorJson }: { errorJson: unknown }) {
   return (
     <Alert tone="critical">
       <div class="flex flex-col gap-1">
-        <strong>{typeof error?.message === "string" ? error.message : "Inspection failed."}</strong>
+        <strong>{typeof error?.message === "string" ? error.message : "Review failed."}</strong>
         {guidance ? (
           <span>
             {guidance.hint} <a href="/dashboard/settings?tab=integrations">{guidance.action}</a>

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -181,7 +181,7 @@ export default function ScanDetailPage() {
     return (
       <PageShell>
         <ScanDetailHeader />
-        <LoadingState title="Opening inspection" detail="confirming session · fetching report" />
+        <LoadingState title="Opening review" detail="confirming session · fetching report" />
       </PageShell>
     );
   }
@@ -250,9 +250,7 @@ export default function ScanDetailPage() {
       {pollingStalled ? (
         <Alert tone="warn">
           <div class="flex flex-wrap items-center justify-between gap-3">
-            <span>
-              Automatic refresh stopped after 10 minutes without the inspection finishing.
-            </span>
+            <span>Automatic refresh stopped after 10 minutes without the review finishing.</span>
             <Button variant="secondary" size="sm" onClick={() => model.resumePolling()}>
               Resume refresh
             </Button>
@@ -277,10 +275,7 @@ export default function ScanDetailPage() {
       ) : null}
 
       {!detail && !error ? (
-        <LoadingState
-          title="Loading saved inspection"
-          detail="fetching report · normalizing diff"
-        />
+        <LoadingState title="Loading saved review" detail="fetching report · normalizing diff" />
       ) : null}
 
       {detail ? (
@@ -386,12 +381,8 @@ export default function ScanDetailPage() {
           // auto-refresh; the warn Alert above carries the state instead.
           pollingStalled ? null : (
             <LoadingState
-              title={
-                detail.scan.status === "pending"
-                  ? "Version waiting to dock"
-                  : "Inspecting docked version"
-              }
-              detail="auto-refreshes when the inspection report is ready"
+              title={detail.scan.status === "pending" ? "Review queued" : "Reviewing release"}
+              detail="auto-refreshes when the report is ready"
             />
           )
         ) : null

--- a/src/pages/Dashboard/Settings/GithubAppSection.tsx
+++ b/src/pages/Dashboard/Settings/GithubAppSection.tsx
@@ -59,9 +59,9 @@ export function GithubAppSection({
           <div class="flex flex-col gap-1.5 max-w-[600px]">
             <Muted class="text-[13px] m-0">
               Install the Drydock GitHub App on your organization so releases gated by a GitHub
-              Actions environment can be cleared here. Drydock never asks for publish credentials.
-              Your workflow keeps its own OIDC/Trusted Publishing trust, and Drydock only grants
-              deployment-protection clearance.
+              Actions environment can be approved here. Drydock never asks for publish credentials.
+              Your workflow keeps its own OIDC/Trusted Publishing trust, and Drydock only acts as
+              the deployment-protection approver.
             </Muted>
             <MonoDetail
               parts={[

--- a/src/pages/Dashboard/Settings/NotificationRecipientsSection.tsx
+++ b/src/pages/Dashboard/Settings/NotificationRecipientsSection.tsx
@@ -48,9 +48,9 @@ export function NotificationRecipientsSection({
     >
       <SettingsCardBody>
         <Muted class="text-[13px] m-0 max-w-[760px]">
-          Choose who gets emailed when an auto-discovered scan finishes or a release gate needs
-          clearance. Add a shared inbox or teammates. When this list is empty, Drydock emails the
-          organization owner.
+          Choose who gets emailed when an auto-discovered scan finishes or a release gate needs a
+          review decision. Add a shared inbox or teammates. When this list is empty, Drydock emails
+          the organization owner.
         </Muted>
 
         {!loaded ? (

--- a/src/pages/Dashboard/Settings/NpmConnectionSection.tsx
+++ b/src/pages/Dashboard/Settings/NpmConnectionSection.tsx
@@ -53,14 +53,14 @@ export function NpmConnectionSection({
     >
       <SettingsCardBody>
         <Muted class="text-[13px] m-0 max-w-[760px]">
-          Add a read-only organization npm token so inspections can fetch staged packages securely.
-          We encrypt it, hide it after save, and use it only to retrieve release evidence.
+          Add a read-only organization npm token so reviews can fetch staged packages securely. We
+          encrypt it, hide it after save, and use it only to retrieve release evidence.
         </Muted>
 
         {connection && connection.validationStatus === "invalid" ? (
           <Alert tone="critical">
             Drydock can no longer reach the staging registry with this token, so staged-release
-            inspections are paused. Rotate the token below to resume.
+            reviews are paused. Rotate the token below to resume.
           </Alert>
         ) : null}
 
@@ -129,7 +129,7 @@ export function NpmConnectionSection({
         </form>
 
         <Muted class="text-xs">
-          After save, Drydock validates the token before any inspection uses it.
+          After save, Drydock validates the token before any review uses it.
         </Muted>
 
         {error ? <Alert tone="critical">{error}</Alert> : null}

--- a/src/pages/Dashboard/Settings/OrganizationMembersSection.tsx
+++ b/src/pages/Dashboard/Settings/OrganizationMembersSection.tsx
@@ -64,8 +64,8 @@ export function OrganizationMembersSection({
       <SettingsCardBody>
         <Muted class="text-[13px] m-0 max-w-[760px]">
           Invite teammates to collaborate on this organization's release targets, integrations, and
-          gate inspections. Owners and admins manage membership; members get read access to
-          org-scoped scans and can grant clearance.
+          gate reviews. Owners and admins manage membership; members get read access to org-scoped
+          scans and can act on releases.
         </Muted>
 
         {error ? <Alert tone="critical">{error}</Alert> : null}

--- a/src/pages/Dashboard/Settings/ReleaseSecuritySection.tsx
+++ b/src/pages/Dashboard/Settings/ReleaseSecuritySection.tsx
@@ -53,10 +53,11 @@ export function ReleaseSecuritySection({
       </div>
 
       <Muted class="text-[13px] m-0 max-w-[760px]">
-        Require two-factor authentication to clear or hold a release gate. Clearing a gate undocks
-        the held GitHub Actions job and publishing proceeds over Trusted Publishing/OIDC, which
-        cannot be undone — so when this is on, every member must confirm with a fresh authenticator
-        code, and a member who has not enabled 2FA cannot grant clearance until they do.
+        Require two-factor authentication to approve or block a release gate. Approving a gate
+        releases the held GitHub Actions job and publishing proceeds over Trusted Publishing/OIDC,
+        which cannot be undone — so when this is on, every member must confirm with a fresh
+        authenticator code, and a member who has not enabled 2FA cannot decide a release until they
+        do.
       </Muted>
 
       {active ? (
@@ -67,7 +68,7 @@ export function ReleaseSecuritySection({
               <a class="underline text-accent" href="/dashboard/account">
                 Account
               </a>{" "}
-              before you can require it for release clearances.
+              before you can require it for releases.
             </Alert>
           ) : enabled ? (
             // Relaxing the policy weakens a security control, so confirm with a
@@ -89,7 +90,7 @@ export function ReleaseSecuritySection({
                 />
                 <Muted class="m-0 mt-1 text-[12px]">
                   Enter the code from your authenticator app to stop requiring two-factor for
-                  release clearances.
+                  releases.
                 </Muted>
               </Field>
               <Button
@@ -111,13 +112,13 @@ export function ReleaseSecuritySection({
                 disabled={saving}
                 class="self-start"
               >
-                {saving ? "Saving…" : "Require two-factor for clearance"}
+                {saving ? "Saving…" : "Require two-factor for releases"}
               </Button>
             </div>
           )
         ) : (
           <Muted class="text-[13px] m-0">
-            Only the organization owner can change the release-clearance two-factor policy.
+            Only the organization owner can change the release two-factor policy.
           </Muted>
         )
       ) : (

--- a/src/pages/Dashboard/Settings/SlackConnectionSection.tsx
+++ b/src/pages/Dashboard/Settings/SlackConnectionSection.tsx
@@ -73,7 +73,7 @@ export function SlackConnectionSection({
       <SettingsCardBody>
         <Muted class="text-[13px] m-0 max-w-[760px]">
           Connect a Slack workspace and choose one public channel for Drydock to post scan
-          completions and release-gate inspections. The bot token is encrypted at rest and only ever
+          completions and release-gate reviews. The bot token is encrypted at rest and only ever
           posts to the channel you pick.
         </Muted>
 

--- a/src/pages/Dashboard/Settings/index.tsx
+++ b/src/pages/Dashboard/Settings/index.tsx
@@ -250,8 +250,8 @@ function SettingsHeader() {
       <Eyebrow>Organization settings</Eyebrow>
       <h1 class="text-3xl font-semibold tracking-[-0.02em] m-0">Settings</h1>
       <Muted class="text-[14px] leading-[1.55] m-0">
-        Manage members, notifications, and the npm or GitHub connections Drydock uses to dock
-        releases for inspection.
+        Manage members, notifications, and the npm or GitHub connections Drydock uses to hold
+        releases for review.
       </Muted>
     </header>
   );

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -229,16 +229,16 @@ function RecentReviewsSection({
             disabled={discoveryRefreshing || !ready}
             title="Find staged npm publishes and dock them for inspection"
           >
-            {discoveryRefreshing ? "Docking npm…" : "Dock npm"}
+            {discoveryRefreshing ? "Checking npm…" : "Check npm"}
           </Button>
           <Button
             variant="ghost"
             size="sm"
             onClick={() => void scans.refresh()}
             disabled={scans.refreshing.value}
-            title="Re-dock the inspections list"
+            title="Reload the inspections list"
           >
-            {scans.refreshing.value ? "Re-docking…" : "Re-dock"}
+            {scans.refreshing.value ? "Refreshing…" : "Refresh"}
           </Button>
         </div>
       </div>
@@ -366,7 +366,7 @@ function emptyStateMessage(filter: ScanDecisionFilter): string {
     case "no_publish":
       return "No held inspections yet.";
     default:
-      return "No versions docked yet. Dock npm or wait for auto-discovery to find a staged release.";
+      return "No versions docked yet. Check npm or wait for auto-discovery to find a staged release.";
   }
 }
 

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -102,7 +102,7 @@ export default function DashboardPage() {
     return (
       <PageShell>
         <DashboardHeader />
-        <LoadingState title="Opening workspace" detail="checking session · loading inspections" />
+        <LoadingState title="Opening workspace" detail="checking session · loading reviews" />
       </PageShell>
     );
   }
@@ -143,10 +143,10 @@ export default function DashboardPage() {
           title="Loading workspace"
           detail={
             npmLoaded
-              ? "fetching recent inspections"
+              ? "fetching recent reviews"
               : scansLoaded
                 ? "checking npm connection"
-                : "loading inspections · checking npm connection"
+                : "loading reviews · checking npm connection"
           }
         />
       )}
@@ -157,10 +157,11 @@ export default function DashboardPage() {
 function DashboardHeader() {
   return (
     <header class="flex flex-col gap-2 max-w-[640px]">
-      <Eyebrow>Inspection dock</Eyebrow>
-      <h1 class="text-3xl font-semibold tracking-[-0.02em] m-0">
-        New version docked and ready for inspection
-      </h1>
+      <Eyebrow>Review workspace</Eyebrow>
+      <h1 class="text-3xl font-semibold tracking-[-0.02em] m-0">Ready for the next release</h1>
+      <Muted class="text-[14px] leading-[1.55] m-0">
+        Review held npm and PyPI candidates before maintainers let them go live.
+      </Muted>
     </header>
   );
 }
@@ -215,7 +216,7 @@ function RecentReviewsSection({
   return (
     <Card as="section" padding="none" class="overflow-hidden">
       <div class="px-5 py-4 flex flex-col gap-3 md:flex-row md:items-center">
-        <SectionLabel class="flex-1 min-w-0 after:hidden">Recent inspections</SectionLabel>
+        <SectionLabel class="flex-1 min-w-0 after:hidden">Recent reviews</SectionLabel>
         <div class="flex flex-wrap items-center gap-2 shrink-0">
           <ScanStateSelect
             value={scans.filter.value}
@@ -227,7 +228,7 @@ function RecentReviewsSection({
             size="sm"
             onClick={() => void onDiscover()}
             disabled={discoveryRefreshing || !ready}
-            title="Find staged npm publishes and dock them for inspection"
+            title="Find staged npm publishes and start reviews"
           >
             {discoveryRefreshing ? "Checking npm…" : "Check npm"}
           </Button>
@@ -236,7 +237,7 @@ function RecentReviewsSection({
             size="sm"
             onClick={() => void scans.refresh()}
             disabled={scans.refreshing.value}
-            title="Reload the inspections list"
+            title="Reload the reviews list"
           >
             {scans.refreshing.value ? "Refreshing…" : "Refresh"}
           </Button>
@@ -248,13 +249,13 @@ function RecentReviewsSection({
           {showFreshness ? <ScanFreshnessIndicator at={discoveredAt} /> : null}
           {showStartedMessage && discovery ? (
             <Muted class="text-[13px] m-0">
-              {`${discovery.created === 1 ? "New version docked" : `${discovery.created} new versions docked`} and ready for inspection from npm${
+              {`Started ${discovery.created} new review${discovery.created === 1 ? "" : "s"} from npm${
                 startedLabels.length ? `: ${startedLabels.slice(0, 3).join(", ")}` : ""
               }${startedLabels.length > 3 ? `, +${startedLabels.length - 3} more` : ""}.`}
             </Muted>
           ) : null}
           {showNoOpenMessage ? (
-            <Muted class="text-[13px] m-0">No staged publishes waiting to dock.</Muted>
+            <Muted class="text-[13px] m-0">No open staged publishes found.</Muted>
           ) : null}
         </div>
       ) : null}
@@ -308,8 +309,8 @@ function RecentReviewsSection({
 
 const FILTER_OPTIONS: Array<{ value: ScanDecisionFilter; label: string }> = [
   { value: "undecided", label: "Undecided" },
-  { value: "publish", label: "Cleared" },
-  { value: "no_publish", label: "Held" },
+  { value: "publish", label: "Approved" },
+  { value: "no_publish", label: "Blocked" },
   { value: "all", label: "All" },
 ];
 
@@ -334,7 +335,7 @@ function ScanStateSelect({
 }) {
   return (
     <label class="flex items-center gap-2">
-      <span class="sr-only">Inspection state</span>
+      <span class="sr-only">Review state</span>
       <span aria-hidden class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
         State
       </span>
@@ -360,13 +361,13 @@ function ScanStateSelect({
 function emptyStateMessage(filter: ScanDecisionFilter): string {
   switch (filter) {
     case "undecided":
-      return "Nothing waiting in the dock. Switch to All to see earlier inspections.";
+      return "Nothing waiting on you. Switch to All to see earlier reviews.";
     case "publish":
-      return "No cleared inspections yet.";
+      return "No approved reviews yet.";
     case "no_publish":
-      return "No held inspections yet.";
+      return "No blocked reviews yet.";
     default:
-      return "No versions docked yet. Check npm or wait for auto-discovery to find a staged release.";
+      return "No reviews yet. Check npm or wait for auto-discovery to find a staged release.";
   }
 }
 
@@ -381,7 +382,7 @@ function NpmSetupCallout() {
       <div class="flex flex-col gap-1.5 min-w-0">
         <SectionLabel>npm not connected</SectionLabel>
         <Muted class="text-[13px] m-0">
-          Connect npm in settings so Drydock can bring staged tarballs into inspection.
+          Connect npm in settings so Drydock can fetch staged tarballs and run reviews.
         </Muted>
       </div>
       <LinkButton variant="primary" size="sm" href="/dashboard/settings?tab=integrations">
@@ -412,7 +413,7 @@ function ScanTable({
             <Th>Risk</Th>
             <Th>Changed</Th>
             <Th>Status</Th>
-            <Th>Clearance</Th>
+            <Th>Decision</Th>
           </tr>
         </thead>
         <tbody>
@@ -447,13 +448,13 @@ function ScanTable({
                       size="sm"
                       onClick={() => onQuickDecide(scan)}
                       disabled={decisionSaving}
-                      title="Record clearance without leaving the dashboard"
+                      title="Record a decision without leaving the dashboard"
                     >
                       {decisionSaving && quickDecisionScanId === scan.id
                         ? "Saving…"
                         : scan.decision
                           ? "Update"
-                          : "Ship"}
+                          : "Decide"}
                     </Button>
                   ) : null}
                 </div>
@@ -491,12 +492,12 @@ function ScanChangedCell({ scan }: { scan: ScanListItem }) {
 }
 
 function DecisionBadge({ decision }: { decision?: string | null }) {
-  if (decision === "publish") return <Badge tone="ok">cleared</Badge>;
-  if (decision === "no_publish") return <Badge tone="critical">held</Badge>;
-  return <Badge tone="neutral">awaiting inspection</Badge>;
+  if (decision === "publish") return <Badge tone="ok">approved</Badge>;
+  if (decision === "no_publish") return <Badge tone="critical">blocked</Badge>;
+  return <Badge tone="neutral">undecided</Badge>;
 }
 
-// Status and Clearance are both state columns, so both render as Badges (Status
+// Status and Decision are both state columns, so both render as Badges (Status
 // was previously raw mono text). Lifecycle status is not a severity: only a
 // failed run is critical; running is info; pending/complete stay neutral.
 function ScanStatusBadge({ status }: { status: string }) {

--- a/src/pages/Dashboard/recommendation.ts
+++ b/src/pages/Dashboard/recommendation.ts
@@ -8,7 +8,7 @@ export interface ReleaseRecommendationCopy {
 
 // `target` only shapes the trailing call-to-action copy: an npm scan ends in a
 // maintainer publishing with 2FA, while a workflow gate ends in the maintainer
-// clearing or blocking the held GitHub job (publishing then happens via PyPI
+// releasing or blocking the held GitHub job (publishing then happens via PyPI
 // Trusted Publishing). Labels and tones are identical either way.
 export function getReleaseRecommendation(
   artifactRisk: string,
@@ -19,20 +19,20 @@ export function getReleaseRecommendation(
   const isGate = target === "gate";
   if (releaseRisk === "critical" || releaseRisk === "high") {
     return {
-      label: "keep in drydock",
+      label: "block manual approval",
       tone: releaseRisk === "critical" ? "critical" : "high",
       copy: isGate
-        ? "Do not clear until you have inspected and resolved the highlighted release evidence."
-        : "Do not clear this staged publish until you have inspected and resolved the highlighted release evidence outside Drydock.",
+        ? "Do not approve until you have reviewed and resolved the highlighted release evidence."
+        : "Do not approve this staged publish until you have reviewed and resolved the highlighted release evidence outside Drydock.",
     };
   }
   if (releaseRisk === "medium") {
     return {
-      label: "inspect carefully",
+      label: "review carefully",
       tone: "medium",
       copy: isGate
         ? "Before releasing the job, inspect the most important findings, manifest changes, and changed files below."
-        : "Before clearing, inspect the most important findings, manifest changes, and changed files below.",
+        : "Before approving, inspect the most important findings, manifest changes, and changed files below.",
     };
   }
   if (
@@ -46,10 +46,10 @@ export function getReleaseRecommendation(
     };
   }
   return {
-    label: "cleared for release",
+    label: "likely safe",
     tone: "ok",
     copy: isGate
-      ? "No blocking deterministic signals were found. The held GitHub job is ready for clearance."
-      : "No blocking deterministic signals were found. A maintainer still clears the publish in npm.",
+      ? "No blocking deterministic signals were found. Your decision releases or blocks the held GitHub job."
+      : "No blocking deterministic signals were found. A maintainer still approves the publish in npm.",
   };
 }

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -71,7 +71,7 @@ export default function DocsPage() {
                 </>,
                 <>
                   That's it. Drydock picks up new staged publishes automatically, and{" "}
-                  <Code>Dock npm</Code> on the dashboard runs an on-demand check.
+                  <Code>Check npm</Code> on the dashboard runs an on-demand check.
                 </>,
               ]}
             />
@@ -87,7 +87,7 @@ export default function DocsPage() {
               items={[
                 <>
                   Drydock finds a new staged publish, either automatically or when you hit{" "}
-                  <Code>Dock npm</Code>, and queues a scan for it.
+                  <Code>Check npm</Code>, and queues a scan.
                 </>,
                 <>
                   Your npm token is stored encrypted and only decrypted at the moment Drydock needs

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -29,17 +29,17 @@ export default function DocsPage() {
         </p>
         <p class="m-0 max-w-[680px] text-[14px] text-ink-muted leading-[1.65]">
           Use registry staging when npm can hold the candidate. Use workflow gating when GitHub
-          Actions builds the release and a GitHub Environment can pause publication. Both paths
-          produce the same inspection report:
+          Actions builds the release and a GitHub Environment can pause the publish job. Both paths
+          produce the same review report:
         </p>
         <nav class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-1" aria-label="Integration modes">
           <ModeCard href="#staged-publishing" title="Staged publishing: npm">
-            Run <Code>npm publish --stage</Code>. npm holds a private candidate, Drydock inspects
-            it, and you finish the release in npm with your own 2FA.
+            Run <Code>npm publish --stage</Code>. npm holds a private candidate, Drydock reviews it,
+            and you complete the publish in npm with your own 2FA.
           </ModeCard>
           <ModeCard href="#workflow-gating" title="Workflow gating: PyPI & npm" badge="Preview">
-            GitHub Actions builds and uploads the release artifact. A GitHub Environment pauses the
-            publish job until a maintainer clears or blocks the Drydock inspection.
+            GitHub Actions builds and uploads the release artifact. A GitHub Environment pauses
+            publishing until a maintainer approves or rejects the Drydock review.
           </ModeCard>
         </nav>
       </header>
@@ -49,12 +49,12 @@ export default function DocsPage() {
           <div class="flex flex-col gap-3">
             <SectionLabel>Staged publishing: npm</SectionLabel>
             <h2 class="text-2xl font-semibold tracking-[-0.015em] m-0 max-w-[680px]">
-              npm holds the candidate; you clear the release.
+              npm holds the candidate; you keep the approval.
             </h2>
             <Prose>
               npm staged publishing gives Drydock a private release candidate to inspect. Run{" "}
               <Code>npm publish --stage</Code>; npm holds the new version until you confirm with
-              2FA; Drydock inspects the staged tarball before that confirmation.
+              2FA; Drydock reviews the staged tarball before that confirmation.
             </Prose>
           </div>
 
@@ -82,7 +82,7 @@ export default function DocsPage() {
             </div>
           </Subsection>
 
-          <Subsection title="Inspection lifecycle">
+          <Subsection title="Review lifecycle">
             <Steps
               items={[
                 <>
@@ -106,10 +106,9 @@ export default function DocsPage() {
                   packages, checks what changed, and saves the report.
                 </>,
                 <>
-                  You inspect the report on the dashboard, record your clearance, and can have
-                  Drydock open npm's staged-packages page filtered to that package. You still
-                  approve or decline in npm with your normal 2FA; Drydock never publishes on your
-                  behalf.
+                  You read the report on the dashboard, record your decision, and can have Drydock
+                  open npm's staged-packages page filtered to that package. You still approve or
+                  decline in npm with your normal 2FA; Drydock never publishes on your behalf.
                 </>,
               ]}
             />
@@ -128,8 +127,8 @@ export default function DocsPage() {
               PyPI has no staging step, and some npm workflows publish directly from CI. For those
               releases, the publish job becomes the checkpoint: CI builds wheels, sdists, or
               tarballs, uploads them as a workflow artifact, and enters a GitHub Environment
-              protected by Drydock. Drydock inspects the upload and records a recommendation; a
-              maintainer clears or blocks it in the workbench; if cleared, the job continues using
+              protected by Drydock. Drydock reviews the upload and records a recommendation; a
+              maintainer approves or rejects in the workbench; if approved, the job continues using
               its own credential.
             </Prose>
             <Prose>
@@ -137,7 +136,7 @@ export default function DocsPage() {
               uploaded files, so this walkthrough uses PyPI as the example. For npm, a workflow gate
               is the alternative to{" "}
               <a class="underline" href="#staged-publishing">
-                staged-publish inspection
+                staged-publish review
               </a>{" "}
               when a repository publishes without staging.
             </Prose>
@@ -165,8 +164,8 @@ export default function DocsPage() {
                 <>
                   Add the build and publish workflow below. The build job uploads the wheels and
                   sdists as a workflow artifact. The publish job runs in{" "}
-                  <Code>environment: pypi</Code>, downloads that same artifact, and stays held until
-                  the inspection is cleared in Drydock.
+                  <Code>environment: pypi</Code>, downloads that same artifact, and stays blocked
+                  until the review is approved in Drydock.
                 </>,
               ]}
             />
@@ -188,13 +187,13 @@ export default function DocsPage() {
             <Prose>
               Drydock reads each package's name and version out of the files themselves and
               recomputes SHA-256 digests from the bytes it fetched. The publish job only downloads
-              the inspected bundle and never rebuilds, so the bytes that were inspected are the
-              bytes that get published.
+              the reviewed bundle and never rebuilds, so the bytes that were reviewed are the bytes
+              that get published.
             </Prose>
             <Prose>
               You usually do not declare which ecosystem you're publishing. Drydock tells an npm
-              tarball from a PyPI sdist by looking inside it, so the same gate can inspect either
-              one or both at once in a mixed monorepo.
+              tarball from a PyPI sdist by looking inside it, so the same gate can review either one
+              or both at once in a mixed monorepo.
             </Prose>
           </Subsection>
 
@@ -202,13 +201,13 @@ export default function DocsPage() {
             <Prose>
               One workflow run can publish several packages at once, like a monorepo cutting many
               wheels and sdists in a single release. Drydock groups the uploads by package and opens
-              one inspection per package, each diffed against its own previously published version.
-              A single gate covers every package the environment publishes.
+              one review per package, each diffed against its own previously published version. A
+              single gate covers every package the environment publishes.
             </Prose>
             <Prose>
-              The held publish is released once every package is cleared, and holding any single
+              The held publish is released once every package is approved, and rejecting any single
               package blocks the whole release. The workbench lists the packages, tracks how many
-              are cleared, and links each one to its own inspection.
+              are approved, and links each one to its own review.
             </Prose>
           </Subsection>
 
@@ -241,13 +240,13 @@ export default function DocsPage() {
               No manifest or checksum step is required. CI builds and uploads <Code>dist/*</Code>.
               The <Code>environment: pypi</Code> line is the gate: configure that same environment
               as a PyPI Trusted Publisher and enable Drydock as a deployment protection rule on it.
-              The publish job stays held until the inspection is cleared in Drydock, then publishes
+              The publish job stays blocked until the review is approved in Drydock, then publishes
               the downloaded bundle with whatever tool you prefer.
             </Prose>
             <Prose>
               npm looks the same. <Code>npm pack</Code> the workspaces, upload{" "}
               <Code>dist/*.tgz</Code>, and gate the publish job on a GitHub Environment. The publish
-              job downloads the inspected tarballs and publishes them exactly as inspected, without
+              job downloads the reviewed tarballs and publishes them exactly as reviewed, without
               re-packing.
             </Prose>
             <CodeBlock name=".github/workflows/release.yml (npm)" lang="yaml">
@@ -273,7 +272,7 @@ export default function DocsPage() {
         with:
           name: npm-release-candidates
           path: dist
-      # no checkout, no re-pack: publish exactly the inspected bytes
+      # no checkout, no re-pack: publish exactly the reviewed bytes
       - run: |
           for tgz in dist/*.tgz; do
             npm publish "$tgz" --access public --provenance
@@ -281,7 +280,7 @@ export default function DocsPage() {
             </CodeBlock>
           </Subsection>
 
-          <Subsection title="Clearance flow">
+          <Subsection title="Decision flow">
             <Steps
               items={[
                 <>
@@ -294,23 +293,24 @@ export default function DocsPage() {
                   deliveries that don't match anything you configured are ignored.
                 </>,
                 <>
-                  Drydock fetches the uploaded bundle, recomputes artifact digests, and inspects
-                  each package against its own earlier version. The inspection records a
-                  recommendation and leaves the clearance to a human.
+                  Drydock fetches the uploaded bundle, recomputes artifact digests, and reviews each
+                  package against its own earlier version. The review records a recommendation and
+                  leaves the decision to a human.
                 </>,
                 <>
-                  A maintainer opens the inspection on the dashboard and clears or holds each
+                  A maintainer opens the review on the dashboard and approves or rejects each
                   package. If their Drydock account has 2FA enabled, this asks for a fresh TOTP
-                  code. The held job is released once every package is cleared and is blocked the
-                  moment any one is held. A bundle Drydock can't verify is blocked automatically.
+                  code. The held job is released once every package is approved and blocked the
+                  moment any one is rejected. A bundle Drydock can't verify is rejected
+                  automatically.
                 </>,
                 <>
-                  Drydock reports the final clearance back to GitHub over its own pinned connection,
+                  Drydock reports the final decision back to GitHub over its own pinned connection,
                   so a spoofed webhook can't redirect the callback.
                 </>,
                 <>
-                  Each gate is decided exactly once, even when a manual clearance and an automatic
-                  block race.
+                  Each gate is decided exactly once, even when a manual decision and an automatic
+                  rejection race.
                 </>,
               ]}
             />
@@ -318,7 +318,7 @@ export default function DocsPage() {
         </section>
 
         <section class="flex flex-col gap-4 border-t border-border pt-10">
-          <SectionLabel>Start inspecting releases</SectionLabel>
+          <SectionLabel>Start reviewing releases</SectionLabel>
           <div class="flex flex-wrap gap-3">
             <LinkButton href="/register">Create account</LinkButton>
             <LinkButton href="/login" variant="secondary">

--- a/src/pages/Privacy/index.tsx
+++ b/src/pages/Privacy/index.tsx
@@ -21,7 +21,7 @@ export default function PrivacyPage() {
         </p>
         <p class="text-[17px] text-ink-muted max-w-[620px] leading-[1.6] m-0">
           This policy explains what Drydock collects when you use the service, how that information
-          is used, and the choices you have. We collect the minimum needed to inspect your releases
+          is used, and the choices you have. We collect the minimum needed to review your releases
           and run your account.
         </p>
       </header>
@@ -38,8 +38,7 @@ export default function PrivacyPage() {
               </>,
               <>
                 <Strong>Organization data.</Strong> The organizations, members, and invitations you
-                create, and the repositories, registries, and environments you connect for
-                inspection.
+                create, and the repositories, registries, and environments you connect for review.
               </>,
               <>
                 <Strong>Integration credentials.</Strong> Tokens you provide to connect a registry
@@ -48,7 +47,7 @@ export default function PrivacyPage() {
               </>,
               <>
                 <Strong>Release metadata.</Strong> Package names, versions, file listings, diffs,
-                checksums, and the inspection findings we compute for the releases you submit.
+                checksums, and the review findings we compute for the releases you submit.
               </>,
               <>
                 <Strong>Operational data.</Strong> Logs and events generated as the service runs,
@@ -64,14 +63,12 @@ export default function PrivacyPage() {
           <List
             items={[
               <>operate your account, organizations, and sessions;</>,
-              <>inspect the releases you submit and show you the resulting report;</>,
+              <>review the releases you submit and show you the resulting report;</>,
               <>
-                connect to the registries and code hosts you authorize, and report clearances back;
+                connect to the registries and code hosts you authorize, and report decisions back;
               </>,
               <>keep the service secure, prevent abuse, and diagnose problems;</>,
-              <>
-                send you transactional messages such as verification and inspection notifications.
-              </>,
+              <>send you transactional messages such as verification and review notifications.</>,
             ]}
           />
           <Prose>
@@ -94,15 +91,15 @@ export default function PrivacyPage() {
           <Prose>
             We share information only as needed to run the service: with infrastructure providers
             that host and operate Drydock, with the registries and code hosts you explicitly connect
-            (to fetch the artifacts you ask us to inspect and report clearances back), and where we
+            (to fetch the artifacts you ask us to review and report decisions back), and where we
             are legally required to. We do not sell or rent your information to third parties.
           </Prose>
         </Section>
 
         <Section id="retention" label="Data retention">
           <Prose>
-            We keep account and organization data for as long as your account is active. Inspection
-            reports and release metadata are retained so you can refer back to past clearances.
+            We keep account and organization data for as long as your account is active. Review
+            reports and release metadata are retained so you can refer back to past decisions.
             Operational logs are kept for a limited period and then deleted. When you delete your
             account or an organization, we delete or anonymize the associated data, except where we
             must retain it to meet a legal obligation.

--- a/test/agent-tour/drydock-agent-tour.spec.ts
+++ b/test/agent-tour/drydock-agent-tour.spec.ts
@@ -49,18 +49,14 @@ test("agent tour: local Drydock release review walkthrough", async ({
     await tour.capture(page, "docs", "Setup documentation for staged publishing and gates.");
 
     await register(page);
-    await expect(
-      page.getByRole("heading", { name: "New version docked and ready for inspection" }),
-    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Ready for the next release" })).toBeVisible();
     await tour.capture(page, "dashboard-no-npm", "Fresh workspace before npm access is connected.");
 
     await connectNpmThroughSettings(page);
     await tour.capture(page, "settings-npm-connected", "Organization npm access saved and valid.");
 
     await page.goto("/dashboard");
-    await expect(
-      page.getByRole("heading", { name: "New version docked and ready for inspection" }),
-    ).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Ready for the next release" })).toBeVisible();
     const reviewScan = await createScan(page, "stage-implicit-node-gyp-000001");
     tour.note(`Started targeted review scan ${reviewScan.scan.id}.`);
     await tour.capture(
@@ -105,12 +101,12 @@ test("agent tour: local Drydock release review walkthrough", async ({
     await download.saveAs(exportedReportPath);
     tour.note(`Exported canonical report JSON to ${relative(exportedReportPath)}.`);
 
-    await page.getByRole("button", { name: "Ship" }).click();
-    await expect(page.getByRole("heading", { name: "Release clearance" })).toBeVisible();
+    await page.getByRole("button", { name: "Decide" }).click();
+    await expect(page.getByRole("heading", { name: "Publish decision" })).toBeVisible();
     await page.getByLabel("Reason (optional)").fill("Agent tour: high-risk implicit node-gyp.");
     await tour.capture(page, "decision-dialog", "Maintainer decision dialog before blocking.");
-    await page.getByRole("button", { name: "Keep held" }).click();
-    await expect(page.getByText("held").first()).toBeVisible({ timeout: 30_000 });
+    await page.getByRole("button", { name: "Block publish" }).click();
+    await expect(page.getByText("blocked").first()).toBeVisible({ timeout: 30_000 });
     await tour.capture(page, "decision-recorded", "Audit decision recorded on the report.");
 
     const failedScan = await createScan(page, "stage-registry-failure-000001");
@@ -128,9 +124,7 @@ test("agent tour: local Drydock release review walkthrough", async ({
     });
     await page.getByRole("button", { name: "Check npm" }).click();
     await expect(
-      page.getByText(
-        /(?:New version docked|\d+ new versions docked) and ready for inspection from npm|No open staged publishes found/,
-      ),
+      page.getByText(/Started \d+ new reviews? from npm|No open staged publishes found/),
     ).toBeVisible({ timeout: 60_000 });
     await tour.capture(page, "dashboard-discovery", "Manual npm discovery from the dashboard.");
 

--- a/test/agent-tour/drydock-agent-tour.spec.ts
+++ b/test/agent-tour/drydock-agent-tour.spec.ts
@@ -123,10 +123,10 @@ test("agent tour: local Drydock release review walkthrough", async ({
     await tour.capture(page, "failed-review", "Fail-closed review state for unavailable evidence.");
 
     await page.goto("/dashboard?filter=all");
-    await expect(page.getByRole("button", { name: "Dock npm" })).toBeEnabled({
+    await expect(page.getByRole("button", { name: "Check npm" })).toBeEnabled({
       timeout: 30_000,
     });
-    await page.getByRole("button", { name: "Dock npm" }).click();
+    await page.getByRole("button", { name: "Check npm" }).click();
     await expect(
       page.getByText(
         /(?:New version docked|\d+ new versions docked) and ready for inspection from npm|No open staged publishes found/,

--- a/test/e2e/local-registry.spec.ts
+++ b/test/e2e/local-registry.spec.ts
@@ -69,7 +69,7 @@ test("UI smoke: reviews the implicit node-gyp fixture", async ({ browser, baseUR
       timeout: 30_000,
     });
 
-    // Run the report assertions first via the async scan API. Dock npm fans out
+    // Run the report assertions first via the async scan API. Check npm fans
     // out nine concurrent background scans on the dev Worker, and CI's workerd
     // serializes them so badly that one scan can take minutes to surface a
     // report — waiting for this scan to finish before that contention starts
@@ -102,13 +102,13 @@ test("UI smoke: reviews the implicit node-gyp fixture", async ({ browser, baseUR
       fullPage: true,
     });
 
-    // Now exercise Dock npm as the live entry point. The button kicks off
+    // Now exercise Check npm as the live entry point. The button kicks off
     // discovery and we wait only for the "new versions docked" message —
     // the resulting background scans are exercised by the scenarios below.
     await page.goto("/dashboard");
-    const dockNpm = page.getByRole("button", { name: "Dock npm" });
-    await expect(dockNpm).toBeEnabled({ timeout: 30_000 });
-    await dockNpm.click();
+    const checkNpm = page.getByRole("button", { name: "Check npm" });
+    await expect(checkNpm).toBeEnabled({ timeout: 30_000 });
+    await checkNpm.click();
     await expect(
       page.getByText(
         /(?:New version docked|\d+ new versions docked) and ready for inspection from npm/,

--- a/test/e2e/local-registry.spec.ts
+++ b/test/e2e/local-registry.spec.ts
@@ -63,9 +63,7 @@ test("UI smoke: reviews the implicit node-gyp fixture", async ({ browser, baseUR
   const { context, page } = await openAuthenticatedPage(browser, baseURL);
   try {
     await page.goto("/dashboard");
-    await expect(
-      page.getByRole("heading", { name: "New version docked and ready for inspection" }),
-    ).toBeVisible({
+    await expect(page.getByRole("heading", { name: "Ready for the next release" })).toBeVisible({
       timeout: 30_000,
     });
 
@@ -103,17 +101,13 @@ test("UI smoke: reviews the implicit node-gyp fixture", async ({ browser, baseUR
     });
 
     // Now exercise Check npm as the live entry point. The button kicks off
-    // discovery and we wait only for the "new versions docked" message —
+    // discovery and we wait only for the "Started N new reviews" message —
     // the resulting background scans are exercised by the scenarios below.
     await page.goto("/dashboard");
     const checkNpm = page.getByRole("button", { name: "Check npm" });
     await expect(checkNpm).toBeEnabled({ timeout: 30_000 });
     await checkNpm.click();
-    await expect(
-      page.getByText(
-        /(?:New version docked|\d+ new versions docked) and ready for inspection from npm/,
-      ),
-    ).toBeVisible({
+    await expect(page.getByText(/Started \d+ new reviews? from npm/)).toBeVisible({
       timeout: 60_000,
     });
   } finally {
@@ -126,9 +120,7 @@ for (const scenario of scenarios.filter((item) => item.stageId !== uiStageId)) {
     const { context, page } = await openAuthenticatedPage(browser, baseURL);
     try {
       await page.goto("/dashboard");
-      await expect(
-        page.getByRole("heading", { name: "New version docked and ready for inspection" }),
-      ).toBeVisible({
+      await expect(page.getByRole("heading", { name: "Ready for the next release" })).toBeVisible({
         timeout: 30_000,
       });
 
@@ -187,9 +179,7 @@ async function registerAndConnect(page: Page) {
   await page.getByRole("button", { name: "Create account" }).click();
   await page.waitForURL(/\/dashboard$/, { timeout: 30_000 });
 
-  await expect(
-    page.getByRole("heading", { name: "New version docked and ready for inspection" }),
-  ).toBeVisible({
+  await expect(page.getByRole("heading", { name: "Ready for the next release" })).toBeVisible({
     timeout: 30_000,
   });
 

--- a/test/e2e/smoke.spec.ts
+++ b/test/e2e/smoke.spec.ts
@@ -16,19 +16,19 @@ test("renders and decides a workflow-gate review", async ({ page }) => {
     "href",
     "/dashboard",
   );
-  await expect(page.getByText("Release gate")).toBeVisible();
-  await expect(page.getByText("awaiting clearance").first()).toBeVisible();
+  await expect(page.getByText("Deployment gate")).toBeVisible();
+  await expect(page.getByText("awaiting decision").first()).toBeVisible();
   await expect(page.getByText("drydock/example").first()).toBeVisible();
-  await expect(page.getByText("Docked packages")).toBeVisible();
+  await expect(page.getByText("Release packages")).toBeVisible();
   await expect(page.getByText("@drydock/sidecar@0.4.0")).toBeVisible();
 
-  await page.getByRole("button", { name: "Ship", exact: true }).click();
-  await expect(page.getByRole("dialog", { name: "Package clearance" })).toBeVisible();
-  await expect(page.getByRole("button", { name: "Ship package" })).toBeVisible();
-  await page.getByRole("button", { name: "Hold release" }).click();
+  await page.getByRole("button", { name: "Decide", exact: true }).click();
+  await expect(page.getByRole("dialog", { name: "Package decision" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Approve package" })).toBeVisible();
+  await page.getByRole("button", { name: "Reject & block release" }).click();
 
-  await expect(page.getByText("held · job anchored").first()).toBeVisible();
-  await expect(page.getByText("held").first()).toBeVisible();
+  await expect(page.getByText("rejected · job blocked").first()).toBeVisible();
+  await expect(page.getByText("blocked").first()).toBeVisible();
 });
 
 async function installWorkflowGateMocks(page: Page) {

--- a/test/e2e/two-factor.spec.ts
+++ b/test/e2e/two-factor.spec.ts
@@ -69,9 +69,7 @@ test("enrolls in TOTP 2FA and signs in through the challenge", async ({ browser,
     await page.getByRole("button", { name: "Verify" }).click();
 
     await page.waitForURL(/\/dashboard$/, { timeout: 30_000 });
-    await expect(
-      page.getByRole("heading", { name: "New version docked and ready for inspection" }),
-    ).toBeVisible({
+    await expect(page.getByRole("heading", { name: "Ready for the next release" })).toBeVisible({
       timeout: 30_000,
     });
   } finally {

--- a/test/notify.test.mjs
+++ b/test/notify.test.mjs
@@ -163,12 +163,12 @@ describe("notifyWorkflowGateReview", () => {
     }
   });
 
-  test("flags a monorepo bundle so the owner knows every package needs clearance", async () => {
+  test("flags a monorepo bundle so the owner knows every package needs approval", async () => {
     await notifyWorkflowGateReview(gateInput({ packageCount: 3 }));
 
     const [, message] = emailMock.sendNotificationEmail.mock.calls[0];
     expect(message.text).toContain(
-      "demo-package@1.2.0 (+2 more in this release; each must be cleared)",
+      "demo-package@1.2.0 (+2 more in this release; each must be approved)",
     );
   });
 
@@ -277,7 +277,7 @@ describe("notifyScanCompletion", () => {
     );
 
     const [, message] = emailMock.sendNotificationEmail.mock.calls[0];
-    expect(message.subject).toContain("Version could not dock for inspection");
+    expect(message.subject).toContain("Staged release scan failed");
     expect(message.text).toContain("Reason: tarball unavailable");
     const [, event] = dbMock.recordScanEvent.mock.calls[0];
     expect(event.type).toBe("scan.notification_sent");
@@ -332,7 +332,7 @@ describe("Slack connection delivery", () => {
     expect(slackMock.renderSlackMessage).toHaveBeenCalledTimes(1);
     const [payload] = slackMock.renderSlackMessage.mock.calls[0];
     expect(payload.packageLabel).toBe(
-      "demo-package@1.2.0 (+1 more in this release; each must be cleared)",
+      "demo-package@1.2.0 (+1 more in this release; each must be approved)",
     );
   });
 

--- a/test/recommendation.test.ts
+++ b/test/recommendation.test.ts
@@ -4,7 +4,7 @@ import { getReleaseRecommendation } from "../src/pages/Dashboard/recommendation"
 describe("scan detail recommendation", () => {
   test("blocks when release risk is high even without deterministic release findings", () => {
     expect(getReleaseRecommendation("high", "high", 0)).toMatchObject({
-      label: "keep in drydock",
+      label: "block manual approval",
       tone: "high",
     });
   });

--- a/test/slack.test.mjs
+++ b/test/slack.test.mjs
@@ -208,7 +208,7 @@ describe("listSlackPublicChannels", () => {
 describe("renderSlackMessage", () => {
   test("includes package, source, and risk in the summary text and fields", () => {
     const message = renderSlackMessage({
-      title: "New version docked and ready for inspection",
+      title: "Staged release scan complete",
       packageLabel: "demo-package@1.2.0",
       source: "npm staged publish",
       risk: "high",
@@ -229,7 +229,7 @@ describe("renderSlackMessage", () => {
 
   test.each(["low", "medium", "high", "critical"])("renders the %s risk level", (risk) => {
     const message = renderSlackMessage({
-      title: "Release docked for inspection",
+      title: "Release gate needs a decision",
       packageLabel: "demo-package@2.0.0",
       source: "GitHub workflow gate",
       risk,
@@ -240,26 +240,26 @@ describe("renderSlackMessage", () => {
 
   test("omits optional fields when absent and adds no action button without a URL", () => {
     const message = renderSlackMessage({
-      title: "Version could not dock for inspection",
+      title: "Staged release scan failed",
       packageLabel: "demo-package",
       source: "npm staged publish",
       risk: null,
     });
     const serialized = JSON.stringify(message.blocks);
-    expect(serialized).not.toContain("Inspect in Drydock");
+    expect(serialized).not.toContain("Open in Drydock");
     expect(serialized).not.toContain("Risk");
     expect(message.text).not.toContain("risk");
   });
 
-  test("adds an Inspect in Drydock action only when a dashboard URL is present", () => {
+  test("adds an Open in Drydock action only when a dashboard URL is present", () => {
     const message = renderSlackMessage({
-      title: "New version docked and ready for inspection",
+      title: "Staged release scan complete",
       packageLabel: "demo-package",
       source: "npm staged publish",
       dashboardUrl: "https://drydock.test/dashboard/scans/scan_1",
     });
     const serialized = JSON.stringify(message.blocks);
-    expect(serialized).toContain("Inspect in Drydock");
+    expect(serialized).toContain("Open in Drydock");
     expect(serialized).toContain("https://drydock.test/dashboard/scans/scan_1");
   });
 });


### PR DESCRIPTION
## Summary
Undoes the Drydock'ified copy, restoring the original clearer wording:
- Reverts #418 ("Dock npm" / "Re-dock" → back to "Check npm" / "Refresh", incl. docs and browser test assertions).
- Reverts #413 ("Drydockify release copy"): inspection/clearance/hold wording across dashboard, settings, auth, server notifications, Slack messages, workflow-gate comments, and docs goes back to review/approve/reject/decide.
- The #413 revert also drops #414's follow-up "Ship" button labels (they built on #413's "Clear" wording), so buttons are back to `Approve package` / `Decide` / `Reject & block release`.

Conflicts from later PRs touching the same files were resolved to keep unrelated post-#413 changes (e.g. docs `CodeBlock lang="yaml"`) while restoring the pre-#413 copy.

`pnpm run verify` passes. Docs checked — reverted alongside the copy.

Link to Devin session: https://app.devin.ai/sessions/4af44e36d98a4554b306b1b41a6adaa2
Requested by: @JoviDeCroock