### PR TITLE
DB perf: collapse findCoOwnedOrganizations N+1 and parallelize gate artifact deletes

### DIFF
--- a/server/db/organizations.ts
+++ b/server/db/organizations.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, ne, sql } from "drizzle-orm";
 import { personalOrganizationId } from "../lib/ownership";
 import { deleteOrganizationArtifacts } from "../lib/scan-artifacts";
 import type { AppDb, WorkspaceSession } from "./client";
@@ -288,22 +288,23 @@ export async function findCoOwnedOrganizations(
   userId: string,
 ): Promise<CoOwnedOrganization[]> {
   const personalId = personalOrganizationId(userId);
-  const owned = await db
-    .select({ id: organizations.id, name: organizations.name })
+  const rows = await db
+    .select({
+      id: organizations.id,
+      name: organizations.name,
+      otherMemberCount: sql<number>`count(${organizationMembers.userId})`,
+    })
     .from(organizations)
-    .where(eq(organizations.ownerUserId, userId));
-
-  const conflicts: CoOwnedOrganization[] = [];
-  for (const org of owned) {
-    if (org.id === personalId) continue;
-    const members = await db
-      .select({ userId: organizationMembers.userId })
-      .from(organizationMembers)
-      .where(eq(organizationMembers.organizationId, org.id));
-    const otherMemberCount = members.filter((member) => member.userId !== userId).length;
-    if (otherMemberCount > 0) conflicts.push({ id: org.id, name: org.name, otherMemberCount });
-  }
-  return conflicts;
+    .innerJoin(
+      organizationMembers,
+      and(
+        eq(organizationMembers.organizationId, organizations.id),
+        ne(organizationMembers.userId, userId),
+      ),
+    )
+    .where(and(eq(organizations.ownerUserId, userId), ne(organizations.id, personalId)))
+    .groupBy(organizations.id, organizations.name);
+  return rows;
 }
 
 /**

--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -191,9 +191,9 @@ export async function discardGateScans(
     ? await db.select({ id: scans.id }).from(scans).where(condition)
     : [];
   await db.delete(scans).where(condition);
-  for (const { id } of discarded) {
-    await deleteScanArtifacts(artifactBucket, organizationId, id);
-  }
+  await Promise.all(
+    discarded.map(({ id }) => deleteScanArtifacts(artifactBucket, organizationId, id)),
+  );
 }
 
 export async function persistScan(db: AppDb, input: PersistedScanInput) {


### PR DESCRIPTION
## Summary
Two small D1/R2 hot-path improvements:

- `findCoOwnedOrganizations` issued one members query per owned org (N+1, on the account-deletion path). Now a single joined aggregate:
  ```sql
  select org.id, org.name, count(m.user_id) as otherMemberCount
  from organizations org
  join organization_members m
    on m.organization_id = org.id and m.user_id != :userId
  where org.owner_user_id = :userId and org.id != :personalId
  group by org.id, org.name
  ```
  Same result shape (`CoOwnedOrganization[]`); the inner join drops sole-owned orgs, matching the old `otherMemberCount > 0` filter.
- `discardGateScans` deleted per-scan R2 artifact prefixes sequentially; now `Promise.all` — the deletes are independent per scan id.

No behavior change. Covered by the existing account-deletion and scan-artifact-cleanup workers tests; `pnpm run verify` green. docs checked, no update needed.

Link to Devin session: https://app.devin.ai/sessions/1736040792574b178ca7f7ca306920e8
Requested by: @JoviDeCroock