### PR TITLE
Fix agent tour copy drift and dev hydration crash on prerendered routes

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,7 +61,7 @@ function emptyAppShell() {
 if (typeof window !== "undefined") {
   const appElement = document.getElementById("app");
   if (!appElement) throw new Error("App element not found");
-  if (isPrerenderedRoute(location.pathname)) {
+  if (isPrerenderedRoute(location.pathname) && appElement.firstChild) {
     hydrate(<App />, appElement);
   } else {
     appElement.innerHTML = "";

--- a/test/agent-tour/drydock-agent-tour.spec.ts
+++ b/test/agent-tour/drydock-agent-tour.spec.ts
@@ -38,7 +38,7 @@ test("agent tour: local Drydock release review walkthrough", async ({
   try {
     await page.goto("/");
     await expect(
-      page.getByRole("heading", { name: "Review the package that will actually ship." }),
+      page.getByRole("heading", { name: "Review the package that will ship." }),
     ).toBeVisible();
     await tour.capture(page, "landing", "Marketing entry point and product promise.");
 

--- a/test/agent-tour/drydock-agent-tour.spec.ts
+++ b/test/agent-tour/drydock-agent-tour.spec.ts
@@ -44,7 +44,7 @@ test("agent tour: local Drydock release review walkthrough", async ({
 
     await page.goto("/docs");
     await expect(
-      page.getByRole("heading", { name: "Pick where Drydock pauses your release." }),
+      page.getByRole("heading", { name: "Pause releases where the real risk appears." }),
     ).toBeVisible();
     await tour.capture(page, "docs", "Setup documentation for staged publishing and gates.");
 


### PR DESCRIPTION
## Summary
Found while running the agent tour (`pnpm run agent:tour`) — it failed on `main`:

- `test/agent-tour/drydock-agent-tour.spec.ts` still asserted the pre-#447 landing/docs headings ("Review the package that will actually ship.", "Pick where Drydock pauses your release."). Updated to the current copy ("Review the package that will ship.", "Pause releases where the real risk appears.").
- Every prerendered-route load in dev threw `TypeError: Cannot read properties of null (reading 'length')` from `hydrate()` in `src/index.tsx`: the Vite dev server serves an empty `#app` (no prerendered HTML), but the client still hydrated. Now:
  ```diff
  - if (isPrerenderedRoute(location.pathname)) {
  + if (isPrerenderedRoute(location.pathname) && appElement.firstChild) {
      hydrate(<App />, appElement);
  ```
  Production behavior is unchanged (prerendered HTML is present there); dev/e2e now falls back to `render` and the tour's Browser Events section is clean.

Agent tour passes end-to-end after these fixes; `pnpm run verify` green. docs checked, no update needed.

Link to Devin session: https://app.devin.ai/sessions/1736040792574b178ca7f7ca306920e8
Requested by: @JoviDeCroock