### PR TITLE
[codex] Surface release gates earlier

### DIFF
--- a/docs/workflow-gates.md
+++ b/docs/workflow-gates.md
@@ -11,9 +11,10 @@ Supported gate ecosystems: **PyPI** and **npm**. Shared GitHub plumbing lives in
 3. GitHub sends a `deployment_protection_rule` webhook to `/webhooks/github`.
 4. Drydock resolves the installation, repository, run, environment, release target, and uploaded artifacts.
 5. The adapter derives one or more reviewable release candidates from those artifacts.
-6. A queue worker runs the shared scan pipeline for each candidate.
-7. A maintainer accepts or rejects the gate review in Drydock.
-8. Drydock posts the deployment-protection decision back to GitHub; the workflow either continues to publish or fails closed.
+6. The dashboard surfaces the pending gate immediately from the stored webhook row, even before package scans finish.
+7. A queue worker runs the shared scan pipeline for each candidate.
+8. A maintainer accepts or rejects the gate review in Drydock.
+9. Drydock posts the deployment-protection decision back to GitHub; the workflow either continues to publish or fails closed.
 
 The GitHub webhook is public but signed with `GITHUB_WEBHOOK_SECRET` and bypasses Better Auth only after signature verification. All stored gate state remains organization-scoped.
 
@@ -117,7 +118,9 @@ verification.
 
 ## Maintainer workbench
 
-The gate review workbench shows the release target, package identity/version, artifact set, scan status, findings, changed files, and accept/reject controls. Accept/reject actions require an authenticated maintainer in the owning organization. Step-up auth requirements should match other sensitive release decisions; see [`two-factor-auth.md`](./two-factor-auth.md).
+The dashboard lists pending release gates from `GET /api/v1/github-app/workflow-gates` as soon as GitHub's signed webhook has been persisted. Early rows may not have package scans yet; they show the repository, environment, workflow run, and queued/reviewing state until artifact resolution creates the package scan rows.
+
+The gate review workbench shows the release target, package identity/version, artifact set, scan status, findings, changed files, and accept/reject controls. It loads gate context for workflow-gate scans while the scan is still pending or running, but accept/reject actions remain disabled until the package reaches a reviewable terminal state. Accept/reject actions require an authenticated maintainer in the owning organization. Step-up auth requirements should match other sensitive release decisions; see [`two-factor-auth.md`](./two-factor-auth.md).
 
 ## Adding a new ecosystem
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -239,7 +239,7 @@ app.get("/api", (c) =>
       organizationMembers:
         "GET /api/v1/organizations/members; DELETE /api/v1/organizations/members/:userId; GET/POST /api/v1/organizations/invitations; DELETE /api/v1/organizations/invitations/:invitationId; POST /api/v1/organizations/invitations/accept",
       githubApp:
-        "GET /api/v1/github-app/config; POST /api/v1/github-app/install; POST /api/v1/github-app/install/callback; GET /api/v1/github-app/installations; GET/POST /api/v1/github-app/release-targets; DELETE /api/v1/github-app/release-targets/:id; GET /api/v1/github-app/workflow-gates/by-scan/:scanId; POST /api/v1/github-app/workflow-gates/:gateId/decision",
+        "GET /api/v1/github-app/config; POST /api/v1/github-app/install; POST /api/v1/github-app/install/callback; GET /api/v1/github-app/installations; GET/POST /api/v1/github-app/release-targets; DELETE /api/v1/github-app/release-targets/:id; GET /api/v1/github-app/workflow-gates; GET /api/v1/github-app/workflow-gates/by-scan/:scanId; POST /api/v1/github-app/workflow-gates/:gateId/decision",
       githubWebhooks: "POST /webhooks/github (signed by GitHub App webhook secret)",
       slack:
         "GET /api/v1/slack; POST /api/v1/slack/connect; GET /api/v1/slack/callback; GET /api/v1/slack/channels; PUT /api/v1/slack/channel; PATCH /api/v1/slack; DELETE /api/v1/slack; POST /api/v1/slack/test",

--- a/server/lib/github-app/webhook-gates.ts
+++ b/server/lib/github-app/webhook-gates.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, desc, eq, isNull, sql } from "drizzle-orm";
 import { type AppDb } from "../../db/client";
 import { githubWorkflowGates, scans } from "../../db/schema";
 import type { InstallationRecord, ReleaseTargetRecord } from "./persistence";
@@ -109,6 +109,31 @@ export async function getGateForOrganization(
     )
     .limit(1);
   return row ? readGateRow(row) : null;
+}
+
+export interface ListWorkflowGatesOptions {
+  status?: WorkflowGateStatus | "all";
+  limit?: number;
+}
+
+export async function listWorkflowGatesForOrganization(
+  db: AppDb,
+  organizationId: string,
+  options: ListWorkflowGatesOptions = {},
+): Promise<WorkflowGateRecord[]> {
+  const limit = Math.min(50, Math.max(1, Math.floor(options.limit ?? 10)));
+  const status = options.status ?? "pending";
+  const conditions = [eq(githubWorkflowGates.organizationId, organizationId)];
+  if (status !== "all") {
+    conditions.push(eq(githubWorkflowGates.status, status));
+  }
+  const rows = await db
+    .select()
+    .from(githubWorkflowGates)
+    .where(and(...conditions))
+    .orderBy(desc(githubWorkflowGates.requestedAt), desc(githubWorkflowGates.id))
+    .limit(limit);
+  return rows.map(readGateRow);
 }
 
 /**

--- a/server/routes/github-app.ts
+++ b/server/routes/github-app.ts
@@ -55,6 +55,7 @@ import {
   getGateByScanId,
   getGateForOrganization,
   listGatePackageScans,
+  listWorkflowGatesForOrganization,
   markGateDecidedForPackageAggregate,
   resetGateReviewForRetry,
 } from "../lib/github-app/webhook-gates";
@@ -402,6 +403,30 @@ const GATE_DECISIONS = ["approved", "rejected"] as const;
 type GateDecision = (typeof GATE_DECISIONS)[number];
 const GATE_DECISION_SET = new Set<GateDecision>(GATE_DECISIONS);
 const GATE_DECISION_COMMENT_MAX = 500;
+
+githubAppRoutes.get("/workflow-gates", async (c) => {
+  const db = createDb(c.env.DB);
+  const organizationId = await requireActiveOrganization(c, db);
+  const rawLimit = Number(c.req.query("limit"));
+  const limit = Number.isFinite(rawLimit) ? Math.min(50, Math.max(1, Math.floor(rawLimit))) : 10;
+  const gates = await listWorkflowGatesForOrganization(db, organizationId, {
+    status: "pending",
+    limit,
+  });
+  const orgRequiresTwoFactor = await organizationRequiresTwoFactorForReleaseDecisions(
+    db,
+    organizationId,
+  );
+  const packagesByGate = await Promise.all(
+    gates.map(async (gate) => listGatePackageScans(db, organizationId, gate.id)),
+  );
+  return c.json({
+    gates: gates.map((gate, index) =>
+      publicWorkflowGate(gate, packagesByGate[index] ?? [], orgRequiresTwoFactor),
+    ),
+    limit,
+  });
+});
 
 githubAppRoutes.get("/workflow-gates/by-scan/:scanId", async (c) => {
   const db = createDb(c.env.DB);

--- a/src/models/github-app.ts
+++ b/src/models/github-app.ts
@@ -87,6 +87,46 @@ export async function getWorkflowGateByScan(scanId: string): Promise<PublicWorkf
   }
 }
 
+export function listWorkflowGates(options: { limit?: number } = {}): Promise<{
+  gates: PublicWorkflowGate[];
+  limit: number;
+}> {
+  const params = new URLSearchParams();
+  if (options.limit) params.set("limit", String(options.limit));
+  const qs = params.toString();
+  return apiFetch<{ gates: PublicWorkflowGate[]; limit: number }>(
+    `/api/v1/github-app/workflow-gates${qs ? `?${qs}` : ""}`,
+  );
+}
+
+export const WorkflowGateListModel = createModel(() => {
+  const gates = signal<PublicWorkflowGate[]>([]);
+  const loaded = signal(false);
+  const refreshing = signal(false);
+  const error = signal<string | null>(null);
+
+  return {
+    gates,
+    loaded,
+    refreshing,
+    error,
+
+    async refresh(): Promise<void> {
+      refreshing.value = true;
+      try {
+        const data = await listWorkflowGates();
+        gates.value = data.gates;
+        error.value = null;
+      } catch (err) {
+        error.value = errorMessage(err);
+      } finally {
+        loaded.value = true;
+        refreshing.value = false;
+      }
+    },
+  };
+});
+
 // Records a decision for a single package of the gate (`scanId`). The gate only
 // finalizes — releasing or blocking the held GitHub job — once every package is
 // approved, or the moment any one is rejected.

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -96,12 +96,11 @@ export default function ScanDetailPage() {
 
   const versionsSignal = useScanVersions(model);
 
-  // Load the workflow gate once the review reaches a terminal state. Completed
-  // and failed scans may both be linked to the pending gate so the workbench can
-  // show the held GitHub job context.
+  // Load workflow-gate context as soon as the scan row exists. The gate row is
+  // created by the webhook before review finishes, and `scans.gate_id` lets the
+  // workbench show the held GitHub job while the package scan is still running.
   useSignalEffect(() => {
     if (!model.isWorkflowGate.value) return;
-    if (model.status.value !== "complete" && model.status.value !== "failed") return;
     if (model.gateLoaded.value) return;
     void model.loadGate();
     const retryTimer = window.setInterval(() => {

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -7,6 +7,11 @@ import { rememberDashboardReturnUrl, useQuerySignal } from "../../lib/query-stat
 import { npmStagedPackagesUrlFor } from "../../lib/npm-staged-url";
 import { pluralize } from "../../lib/format";
 import { sessionModel } from "../../models/auth";
+import {
+  WorkflowGateListModel,
+  type GatePackageScan,
+  type PublicWorkflowGate,
+} from "../../models/github-app";
 import { NpmConnectionModel } from "../../models/npm-connection";
 import { OrganizationModel } from "../../models/organization";
 import {
@@ -31,6 +36,7 @@ import { DecisionDialog } from "./ScanDetail/DecisionDialog";
 export default function DashboardPage() {
   const location = useLocation();
   const scans = useModel(ScanListModel);
+  const gates = useModel(WorkflowGateListModel);
   const npm = useModel(NpmConnectionModel);
   const organizations = useModel(OrganizationModel);
   const stagedPublishes = useModel(StagedPublishesModel);
@@ -59,7 +65,7 @@ export default function DashboardPage() {
         return;
       }
       sessionChecked.value = true;
-      await Promise.all([organizations.load(), scans.refresh(), npm.load()]);
+      await Promise.all([organizations.load(), scans.refresh(), gates.refresh(), npm.load()]);
     })();
     return () => {
       cancelled = true;
@@ -68,14 +74,14 @@ export default function DashboardPage() {
 
   const onSwitchOrganization = async (organizationId: string) => {
     if (organizations.activate(organizationId)) {
-      await Promise.all([scans.refresh(), npm.load()]);
+      await Promise.all([scans.refresh(), gates.refresh(), npm.load()]);
     }
   };
 
   const onCreateOrganization = async (name: string) => {
     const created = await organizations.create(name);
     if (created) {
-      await Promise.all([scans.refresh(), npm.load()]);
+      await Promise.all([scans.refresh(), gates.refresh(), npm.load()]);
     }
   };
 
@@ -102,8 +108,9 @@ export default function DashboardPage() {
 
   const user = sessionModel.user.value;
   const scansLoaded = scans.loaded.value;
+  const gatesLoaded = gates.loaded.value;
   const npmLoaded = npm.loaded.value;
-  const workspaceLoaded = scansLoaded && npmLoaded;
+  const workspaceLoaded = scansLoaded && gatesLoaded && npmLoaded;
 
   return (
     <PageShell
@@ -129,6 +136,7 @@ export default function DashboardPage() {
       {workspaceLoaded ? (
         <>
           {!npm.connection.value ? <NpmSetupCallout /> : null}
+          <ReleaseGatesSection gates={gates} />
           <RecentReviewsSection scans={scans} stagedPublishes={stagedPublishes} npm={npm} />
         </>
       ) : (
@@ -138,8 +146,10 @@ export default function DashboardPage() {
             npmLoaded
               ? "fetching recent reviews"
               : scansLoaded
-                ? "checking npm connection"
-                : "loading reviews · checking npm connection"
+                ? gatesLoaded
+                  ? "checking npm connection"
+                  : "checking release gates"
+                : "loading reviews · checking release gates · checking npm connection"
           }
         />
       )}
@@ -382,6 +392,180 @@ function NpmSetupCallout() {
         Open settings
       </LinkButton>
     </Card>
+  );
+}
+
+function ReleaseGatesSection({
+  gates,
+}: {
+  gates: ReturnType<typeof useModel<typeof WorkflowGateListModel.prototype>>;
+}) {
+  const activeGates = gates.gates.value;
+  const error = gates.error.value;
+  if (!activeGates.length && !error) return null;
+
+  return (
+    <Card as="section" padding="none" class="overflow-hidden">
+      <div class="px-5 py-4 flex flex-col gap-3 md:flex-row md:items-center">
+        <SectionLabel class="flex-1 min-w-0 after:hidden">Release gates</SectionLabel>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => void gates.refresh()}
+          disabled={gates.refreshing.value}
+          title="Reload pending release gates"
+        >
+          {gates.refreshing.value ? "Refreshing…" : "Refresh"}
+        </Button>
+      </div>
+      {error ? (
+        <div class="px-5 pb-4">
+          <Alert tone="critical">{error}</Alert>
+        </div>
+      ) : null}
+      {activeGates.length ? (
+        <ReleaseGateTable gates={activeGates} />
+      ) : (
+        <div class="border-t border-border p-5">
+          <EmptyLine>No release gates waiting on this organization.</EmptyLine>
+        </div>
+      )}
+    </Card>
+  );
+}
+
+function ReleaseGateTable({ gates }: { gates: PublicWorkflowGate[] }) {
+  return (
+    <div class="border-t border-border overflow-x-auto">
+      <table class="w-full border-collapse text-[13px]">
+        <thead>
+          <tr class="border-b border-border bg-surface-2">
+            <Th>Target</Th>
+            <Th>Packages</Th>
+            <Th>Review</Th>
+            <Th>Decision</Th>
+            <Th>Action</Th>
+          </tr>
+        </thead>
+        <tbody>
+          {gates.map((gate) => {
+            const review = gateReviewState(gate);
+            const href = gateReviewHref(gate);
+            const releaseRisk = highestReleaseRisk(gate.packages);
+            return (
+              <tr key={gate.id} class="border-b border-border last:border-b-0 hover:bg-surface-2">
+                <Td>
+                  <div class="flex flex-col gap-1 min-w-[220px]">
+                    <a
+                      href={githubRunUrl(gate)}
+                      target="_blank"
+                      rel="noreferrer"
+                      class="font-medium"
+                    >
+                      {gate.repositoryFullName}
+                    </a>
+                    <span class="font-mono text-[11px] text-ink-subtle">
+                      env {gate.environment} · run #{gate.runId}
+                    </span>
+                  </div>
+                </Td>
+                <Td>
+                  <span class="font-mono text-xs text-ink-muted whitespace-nowrap">
+                    {gatePackageProgressLabel(gate.packages)}
+                  </span>
+                </Td>
+                <Td>
+                  <div class="flex flex-wrap items-center gap-2">
+                    <Badge tone={review.tone}>{review.label}</Badge>
+                    {releaseRisk ? (
+                      <Badge tone={severityTone(releaseRisk)}>{releaseRisk}</Badge>
+                    ) : null}
+                  </div>
+                </Td>
+                <Td>
+                  <Badge tone={gateDecisionTone(gate)}>{gateDecisionLabel(gate)}</Badge>
+                </Td>
+                <Td>
+                  {href ? (
+                    <LinkButton variant="secondary" size="sm" href={href}>
+                      Open review
+                    </LinkButton>
+                  ) : (
+                    <Button variant="secondary" size="sm" disabled>
+                      Review pending
+                    </Button>
+                  )}
+                </Td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function githubRunUrl(gate: PublicWorkflowGate): string {
+  return `https://github.com/${gate.repositoryFullName}/actions/runs/${gate.runId}`;
+}
+
+function gateReviewHref(gate: PublicWorkflowGate): string | null {
+  const scanId = gate.scanId ?? gate.packages[0]?.scanId ?? null;
+  return scanId ? `/dashboard/scans/${encodeURIComponent(scanId)}` : null;
+}
+
+function gatePackageProgressLabel(packages: GatePackageScan[]): string {
+  if (!packages.length) return "resolving artifacts";
+  const reviewed = packages.filter((pkg) => pkg.status === "complete" || pkg.status === "failed");
+  return `${reviewed.length}/${packages.length} ${pluralize("package", packages.length)}`;
+}
+
+function gateReviewState(gate: PublicWorkflowGate): {
+  label: string;
+  tone: "info" | "medium" | "critical" | "ok";
+} {
+  if (gate.status === "approved") return { label: "released", tone: "ok" };
+  if (gate.status === "rejected") return { label: "blocked", tone: "critical" };
+  if (gate.failureReason) return { label: "artifact failed", tone: "critical" };
+  if (!gate.packages.length) return { label: "review queued", tone: "info" };
+  if (gate.packages.some((pkg) => pkg.status === "pending" || pkg.status === "running")) {
+    return { label: "reviewing", tone: "info" };
+  }
+  if (gate.packages.some((pkg) => pkg.status === "failed")) {
+    return { label: "needs review", tone: "critical" };
+  }
+  return { label: "ready", tone: "medium" };
+}
+
+function gateDecisionTone(gate: PublicWorkflowGate): "neutral" | "medium" | "critical" | "ok" {
+  if (gate.status === "approved") return "ok";
+  if (gate.status === "rejected" || gate.status === "errored") return "critical";
+  if (gate.packages.some((pkg) => pkg.decision === "publish")) return "medium";
+  return "neutral";
+}
+
+function gateDecisionLabel(gate: PublicWorkflowGate): string {
+  if (gate.status === "approved") return "approved";
+  if (gate.status === "rejected") return "rejected";
+  if (gate.status === "errored") return "errored";
+  const approved = gate.packages.filter((pkg) => pkg.decision === "publish").length;
+  return approved ? `${approved} approved` : "held";
+}
+
+const RISK_RANK: Record<string, number> = {
+  none: 0,
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 4,
+};
+
+function highestReleaseRisk(packages: GatePackageScan[]): string | null {
+  return (
+    packages
+      .map((pkg) => pkg.releaseRisk)
+      .filter((risk): risk is string => Boolean(risk))
+      .sort((a, b) => (RISK_RANK[b] ?? -1) - (RISK_RANK[a] ?? -1))[0] ?? null
   );
 }
 

--- a/test/workers/github-app.test.ts
+++ b/test/workers/github-app.test.ts
@@ -1242,7 +1242,47 @@ describe("github-app workflow-gate decision route", () => {
   });
 });
 
-describe("github-app workflow-gate by-scan route", () => {
+describe("github-app workflow-gate read routes", () => {
+  test("lists pending gates before a review scan is attached", async () => {
+    const { userId, organizationId } = await seedUser();
+    const { gateId, runId } = await seedGate(organizationId);
+
+    const res = await callGithubAppRoute(
+      buildTestApp(userId),
+      "GET",
+      "/api/v1/github-app/workflow-gates",
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { gates: Array<Record<string, unknown>> };
+    expect(body.gates).toHaveLength(1);
+    expect(body.gates[0]).toMatchObject({
+      id: gateId,
+      repositoryFullName: "octo/example",
+      runId,
+      status: "pending",
+      scanId: null,
+      packages: [],
+    });
+    expect(body.gates[0]).not.toHaveProperty("deploymentCallbackUrl");
+  });
+
+  test("lists only pending gates for the caller's organization", async () => {
+    const caller = await seedUser();
+    const other = await seedUser();
+    await seedGate(caller.organizationId, { status: "approved", decision: "approved" });
+    await seedGate(other.organizationId);
+
+    const res = await callGithubAppRoute(
+      buildTestApp(caller.userId),
+      "GET",
+      "/api/v1/github-app/workflow-gates",
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ gates: [] });
+  });
+
   test("returns 404 when no gate references the scan", async () => {
     const { userId } = await seedUser();
     const res = await callGithubAppRoute(


### PR DESCRIPTION
Surfaces pending GitHub workflow gates on the dashboard as soon as the signed webhook row exists, before review scans finish. Adds an org-scoped workflow gate list API and client model, while scan detail pages load gate context during pending/running workflow-gate scans. Keeps decisions blocked until a package reaches a reviewable terminal state, and updates workflow-gate docs and route tests for pre-scan listing plus org scoping. Validation: pnpm run verify.