### PR TITLE
Add crates.io and Go module workflow-gate ecosystems

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ The user-facing learning guide is [`../src/pages/Docs/index.tsx`](../src/pages/D
 ## Product/runtime docs
 
 - [`architecture.md`](./architecture.md) — Worker, sandbox, adapters, storage, org model, and API shape.
-- [`workflow-gates.md`](./workflow-gates.md) — GitHub Environment gate flow for PyPI, npm, and VS Code workflow-gated releases.
+- [`workflow-gates.md`](./workflow-gates.md) — GitHub Environment gate flow for PyPI, npm, VS Code, crates.io, and Go module workflow-gated releases.
 - [`diff-baseline.md`](./diff-baseline.md) — default previous-version comparison strategy.
 - [`artifact-storage.md`](./artifact-storage.md) — D1/R2 report and artifact persistence.
 

--- a/docs/workflow-gates.md
+++ b/docs/workflow-gates.md
@@ -2,7 +2,7 @@
 
 Workflow gates are Drydock's review mode for releases whose registry cannot hold a private staged artifact. GitHub Actions builds the release, uploads the candidate artifacts, and a GitHub Environment custom deployment-protection rule pauses publishing while Drydock reviews the bytes.
 
-Supported gate ecosystems: **PyPI**, **npm**, and **VS Code extensions**. Shared GitHub plumbing lives in `server/lib/workflow-gates/`; artifact-specific behavior lives behind adapters.
+Supported gate ecosystems: **PyPI**, **npm**, **VS Code extensions**, **crates.io**, and **Go modules**. Shared GitHub plumbing lives in `server/lib/workflow-gates/`; artifact-specific behavior lives behind adapters.
 
 ## Core contract
 
@@ -143,6 +143,30 @@ jobs:
 ```
 
 The publish job must publish the reviewed VSIX bytes. Repacking after approval breaks the review boundary.
+
+## crates.io workflow-gate notes
+
+The candidate is whatever `cargo package` `.crate` archives (gzipped tars) the workflow uploads — `cargo publish` from GitHub Actions is paused by the deployment-protection rule between packaging and the registry upload.
+
+The crates adapter (`server/lib/adapters/crates/`):
+
+- reads crate identity from the normalized `Cargo.toml` inside each archive (content detection uses the root `Cargo.toml.orig` cargo writes next to it);
+- strips the `{name}-{version}/` archive root so staged/baseline diffs align across versions;
+- groups archives by crate name (a cargo workspace can release several crates from one run) and requires exactly one `.crate` per crate version;
+- selects the baseline from the crates.io sparse index (newest non-yanked published version) and downloads it through a credential-free broker restricted to `https://static.crates.io`;
+- reports build-script additions/changes, proc-macro introduction, `links` key changes, and new git/path dependencies, and scans changed lines with Rust code patterns.
+
+## Go modules workflow-gate notes
+
+Go has no publish step — the release is the tag plus the module proxy's first fetch — so the gate pauses the tag/release workflow. The candidate is the module zip the workflow builds (e.g. with `golang.org/x/mod/zip`).
+
+The Go adapter (`server/lib/adapters/gomod/`):
+
+- reads module identity from the zip's mandatory `{module}@{version}/` root and its `go.mod`, and fail-closes when they disagree;
+- strips that root so staged/baseline diffs align across versions;
+- groups zips by module path (multi-module repositories can tag several modules per release) and requires exactly one zip per module version;
+- selects the highest published semver from `proxy.golang.org/@v/list` as the baseline and downloads it through a credential-free broker restricted to `https://proxy.golang.org`;
+- reports `//go:generate` additions, cgo introduction, new `unsafe`/`syscall` imports, and `replace` directives in `go.mod`, and scans changed lines with Go code patterns.
 
 ## Trust and failure behavior
 

--- a/server/lib/adapters/artifact-input.ts
+++ b/server/lib/adapters/artifact-input.ts
@@ -1,0 +1,115 @@
+import type { FileRecord } from "../review";
+import type { TarSuspiciousEntry } from "../tar-parser.js";
+
+export interface ArtifactFilesInput {
+  path: string;
+  files: FileRecord[];
+  suspiciousEntries?: TarSuspiciousEntry[];
+}
+
+const SUSPICIOUS_ENTRY_KINDS = new Set([
+  "non-regular",
+  "duplicate",
+  "unicode-confusable",
+  "content-skipped",
+]);
+
+// The sandbox parser caps suspicious entries at maxFiles; this bounds the
+// re-validation on the adapter-input boundary so a hand-crafted input (not
+// straight from the sandbox) cannot materialize an unbounded array.
+const SUSPICIOUS_ENTRY_INPUT_LIMIT = 5_000;
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function isSafeManifestPath(path: string): boolean {
+  if (!path || path.length > 512 || path.includes("\0") || path.includes("\\")) return false;
+  if (path.startsWith("/") || path.startsWith("../") || path.includes("/../")) return false;
+  if (/^[A-Za-z]:/.test(path)) return false;
+  return path.split("/").every((part) => part && part !== "." && part !== "..");
+}
+
+/**
+ * Re-validate parsed artifact `{ path, files, suspiciousEntries }` inputs on the
+ * adapter-input boundary. Shared by ecosystem adapters whose pipeline input
+ * carries sandbox-parsed file records (crates, Go modules).
+ */
+export function parseArtifactFilesInputs(raw: unknown, field: string): ArtifactFilesInput[] {
+  if (!Array.isArray(raw) || !raw.length) {
+    throw new Error(`adapter input must include ${field}`);
+  }
+  return raw.map((artifact, index) => {
+    if (!isRecord(artifact)) throw new Error(`${field}[${index}] must be an object`);
+    const path = typeof artifact.path === "string" ? artifact.path : "";
+    if (!isSafeManifestPath(path)) throw new Error(`${field}[${index}] path is not safe`);
+    if (!Array.isArray(artifact.files))
+      throw new Error(`${field}[${index}] files must be an array`);
+    const suspiciousEntries = parseSuspiciousEntries(artifact.suspiciousEntries);
+    return {
+      path,
+      files: artifact.files.map((file, fileIndex) =>
+        parseFileRecord(file, field, index, fileIndex),
+      ),
+      ...(suspiciousEntries ? { suspiciousEntries } : {}),
+    };
+  });
+}
+
+// Preserve (and re-validate) the tar-parser's suspicious entries across the
+// adapter-input boundary so oversized content-skipped bodies still reach the
+// gate's findings instead of being silently dropped during input parsing.
+function parseSuspiciousEntries(raw: unknown): TarSuspiciousEntry[] | undefined {
+  if (!Array.isArray(raw) || !raw.length) return undefined;
+  const entries: TarSuspiciousEntry[] = [];
+  for (const item of raw.slice(0, SUSPICIOUS_ENTRY_INPUT_LIMIT)) {
+    if (!isRecord(item)) continue;
+    if (typeof item.kind !== "string" || !SUSPICIOUS_ENTRY_KINDS.has(item.kind)) continue;
+    entries.push({
+      kind: item.kind as TarSuspiciousEntry["kind"],
+      path: typeof item.path === "string" ? item.path : "",
+      detail: typeof item.detail === "string" ? item.detail : "",
+    });
+  }
+  return entries.length ? entries : undefined;
+}
+
+function parseFileRecord(
+  raw: unknown,
+  field: string,
+  artifactIndex: number,
+  fileIndex: number,
+): FileRecord {
+  if (!isRecord(raw)) {
+    throw new Error(`${field}[${artifactIndex}].files[${fileIndex}] must be an object`);
+  }
+  const path = typeof raw.path === "string" ? raw.path : "";
+  const size = typeof raw.size === "number" ? raw.size : 0;
+  const sha256 = typeof raw.sha256 === "string" ? raw.sha256 : "";
+  const flags = Array.isArray(raw.flags)
+    ? raw.flags.filter((flag): flag is string => typeof flag === "string")
+    : [];
+  return {
+    path,
+    size,
+    sha256,
+    flags,
+    ...(typeof raw.textSample === "string" ? { textSample: raw.textSample } : {}),
+  };
+}
+
+/**
+ * Strip the single shared top-level directory from an archive's file paths
+ * (a `.crate`'s `{name}-{version}/`), so staged/baseline diffs align across
+ * versions. Returns the files unchanged when there is no common root.
+ */
+export function stripCommonArchiveRoot(files: FileRecord[]): FileRecord[] {
+  const pathParts = files.map((file) => file.path.split("/"));
+  if (!pathParts.length || pathParts.some((parts) => parts.length < 2)) return files;
+  const root = pathParts[0][0];
+  if (!root || pathParts.some((parts) => parts[0] !== root)) return files;
+  return files.map((file) => ({
+    ...file,
+    path: file.path.split("/").slice(1).join("/"),
+  }));
+}

--- a/server/lib/adapters/crates/acquire.ts
+++ b/server/lib/adapters/crates/acquire.ts
@@ -1,0 +1,190 @@
+import type { FileRecord, PackageJsonSummary } from "../../review";
+import { stripCommonArchiveRoot } from "../artifact-input";
+import type { AcquiredArtifact, AdapterContext, BaselineInfo, StagedDetails } from "../types";
+import { cratesStaticArtifactUrl, type CratesBroker } from "./broker";
+import { summarizeCratesArtifact } from "./findings";
+import { inferCratesArtifactKind } from "./manifest";
+import type {
+  CratesAdapterDetails,
+  CratesAdapterInput,
+  CratesArtifactInput,
+  CratesIndexEntry,
+  CratesPreparedArtifact,
+  CratesReleaseManifest,
+} from "./types";
+
+export function prepareCratesArtifact(input: CratesArtifactInput): CratesPreparedArtifact {
+  const kind = inferCratesArtifactKind(input.path);
+  if (!kind) throw new Error("crates artifact must be a .crate archive");
+  // A `.crate` is a gzipped tar rooted at `{name}-{version}/`; strip that root
+  // so staged/baseline diffs align across versions.
+  const files = stripCommonArchiveRoot(input.files);
+  return {
+    path: input.path,
+    kind,
+    files,
+    summary: summarizeCratesArtifact(input.path, files),
+    ...(input.suspiciousEntries ? { suspiciousEntries: input.suspiciousEntries } : {}),
+  };
+}
+
+export function acquireStagedCrates(input: CratesAdapterInput): {
+  artifact: AcquiredArtifact;
+  details: StagedDetails;
+} {
+  assertManifestArtifactSet(input.manifest, input.artifacts);
+  const preparedArtifacts = input.artifacts.map(prepareCratesArtifact);
+  if (preparedArtifacts.length !== 1) {
+    // cargo publishes exactly one `.crate` per version; two archives claiming
+    // the same crate release is ambiguous and must not ship.
+    throw new Error("a crates release candidate must contain exactly one .crate artifact");
+  }
+  const [prepared] = preparedArtifacts;
+  return {
+    artifact: {
+      files: prepared.files,
+      manifest: manifestSummaryFor(input.manifest, prepared),
+    },
+    details: {
+      manifest: input.manifest,
+      artifacts: [prepared.summary],
+      preparedArtifacts,
+    } satisfies CratesAdapterDetails,
+  };
+}
+
+export async function acquireBaselineCrates(
+  ctx: AdapterContext,
+  input: CratesAdapterInput,
+  broker: CratesBroker,
+): Promise<{ artifact: AcquiredArtifact | null; baseline: BaselineInfo }> {
+  if (input.previousArtifacts?.length) {
+    return baselineFromPreviousCratesArtifacts(input);
+  }
+
+  const entries = input.metadata ?? (await broker.fetchIndexEntries(input.manifest.package));
+  if (!entries) return emptyCratesBaseline("index-unavailable");
+
+  const version = pickCratesBaselineVersion(entries, input.manifest.version);
+  if (!version) return emptyCratesBaseline("no-published-baseline");
+
+  const url = cratesStaticArtifactUrl(input.manifest.package, version);
+  const result = await broker.downloadPublicArtifact(url);
+  const prepared = prepareCratesArtifact({
+    path: `${input.manifest.package.toLowerCase()}-${version}.crate`,
+    files: result.files,
+  });
+  return {
+    artifact: {
+      files: prepared.files,
+      manifest: manifestSummaryFor(input.manifest, prepared),
+    },
+    baseline: {
+      version,
+      tag: null,
+      source: "latest-published",
+      distTagVersion: null,
+      reason: "index-newest-published",
+    },
+  };
+}
+
+export function baselineFromPreviousCratesArtifacts(input: CratesAdapterInput): {
+  artifact: AcquiredArtifact | null;
+  baseline: BaselineInfo;
+} {
+  if (!input.previousArtifacts?.length) return emptyCratesBaseline("no-previous-artifacts");
+  const prepared = prepareCratesArtifact(input.previousArtifacts[0]);
+  const manifest = manifestSummaryFor(input.manifest, prepared);
+  return {
+    artifact: { files: prepared.files, manifest },
+    baseline: {
+      version: manifest.version ?? null,
+      tag: null,
+      source: "latest-published",
+      distTagVersion: null,
+      reason: "provided-previous-artifacts",
+    },
+  };
+}
+
+/**
+ * The sparse index appends entries in publication order, so the newest
+ * published version is the last non-yanked entry that is not the candidate
+ * itself.
+ */
+export function pickCratesBaselineVersion(
+  entries: CratesIndexEntry[],
+  candidateVersion: string,
+): string | null {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry.yanked) continue;
+    const version = typeof entry.vers === "string" ? entry.vers : "";
+    if (!version || version === candidateVersion) continue;
+    if (!/^[0-9][A-Za-z0-9.+-]{0,127}$/.test(version)) continue;
+    return version;
+  }
+  return null;
+}
+
+function emptyCratesBaseline(reason: string): { artifact: null; baseline: BaselineInfo } {
+  return {
+    artifact: null,
+    baseline: {
+      version: null,
+      tag: null,
+      source: "none",
+      distTagVersion: null,
+      reason,
+    },
+  };
+}
+
+function assertManifestArtifactSet(
+  manifest: CratesReleaseManifest,
+  artifacts: CratesArtifactInput[],
+): void {
+  const manifestPaths = sortedUnique(manifest.artifacts.map((artifact) => artifact.path));
+  const artifactPaths = sortedUnique(artifacts.map((artifact) => artifact.path));
+  if (
+    manifestPaths.length !== manifest.artifacts.length ||
+    artifactPaths.length !== artifacts.length ||
+    manifestPaths.length !== artifactPaths.length ||
+    manifestPaths.some((path, index) => path !== artifactPaths[index])
+  ) {
+    throw new Error("review artifacts must exactly match manifest artifacts");
+  }
+}
+
+function sortedUnique(values: string[]): string[] {
+  return [...new Set(values)].sort();
+}
+
+export function pickCratesPackageIdentity(
+  manifest: CratesReleaseManifest,
+  artifacts: CratesPreparedArtifact[],
+): { name: string | null; version: string | null } {
+  const summary = artifacts.find(
+    (artifact) => artifact.summary.manifest.name && artifact.summary.manifest.version,
+  )?.summary;
+  return {
+    name: summary?.manifest.name ?? manifest.package ?? null,
+    version: summary?.manifest.version ?? manifest.version ?? null,
+  };
+}
+
+function manifestSummaryFor(
+  manifest: CratesReleaseManifest,
+  prepared: CratesPreparedArtifact,
+): PackageJsonSummary {
+  const identity = pickCratesPackageIdentity(manifest, [prepared]);
+  return {
+    name: identity.name ?? undefined,
+    version: identity.version ?? undefined,
+  };
+}
+
+export function cratesBaselineFiles(baseline: AcquiredArtifact | null): FileRecord[] | null {
+  return baseline?.files ?? null;
+}

--- a/server/lib/adapters/crates/broker.ts
+++ b/server/lib/adapters/crates/broker.ts
@@ -1,0 +1,80 @@
+import type { DownloadResult } from "../../sandbox";
+import type { AdapterBroker, AdapterConnectionRef, AdapterContext } from "../types";
+import type { CratesIndexEntry } from "./types";
+
+export interface CratesBroker extends AdapterBroker {
+  fetchIndexEntries(crateName: string): Promise<CratesIndexEntry[] | null>;
+  downloadPublicArtifact(url: string): Promise<DownloadResult>;
+}
+
+const CRATES_SPARSE_INDEX = "https://index.crates.io";
+const CRATES_STATIC_HOST = "static.crates.io";
+
+/** Sparse-index path for a crate: `1/a`, `2/ab`, `3/a/abc`, `ab/cd/abcd…`. */
+export function cratesIndexPath(crateName: string): string {
+  const name = crateName.toLowerCase();
+  if (name.length === 1) return `1/${name}`;
+  if (name.length === 2) return `2/${name}`;
+  if (name.length === 3) return `3/${name[0]}/${name}`;
+  return `${name.slice(0, 2)}/${name.slice(2, 4)}/${name}`;
+}
+
+export function cratesStaticArtifactUrl(crateName: string, version: string): string {
+  const name = crateName.toLowerCase();
+  return `https://${CRATES_STATIC_HOST}/crates/${name}/${name}-${version}.crate`;
+}
+
+export function isAllowedCratesArtifactUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" && parsed.hostname === CRATES_STATIC_HOST;
+  } catch {
+    return false;
+  }
+}
+
+// crates.io index metadata and published `.crate` archives are public, so like
+// the PyPI broker this holds no credential; it exists so the sandbox only ever
+// fetches a single pinned static.crates.io URL per download.
+export function createCratesBroker(ctx: AdapterContext, _ref: AdapterConnectionRef): CratesBroker {
+  return {
+    async fetchIndexEntries(crateName: string): Promise<CratesIndexEntry[] | null> {
+      try {
+        const res = await fetch(`${CRATES_SPARSE_INDEX}/${cratesIndexPath(crateName)}`, {
+          headers: { accept: "text/plain" },
+        });
+        if (!res.ok) return null;
+        const body = await res.text();
+        const entries: CratesIndexEntry[] = [];
+        for (const line of body.split("\n")) {
+          if (!line.trim()) continue;
+          try {
+            const parsed = JSON.parse(line) as CratesIndexEntry;
+            if (parsed && typeof parsed === "object") entries.push(parsed);
+          } catch {
+            // Skip unparseable index lines rather than failing the baseline.
+          }
+        }
+        return entries;
+      } catch {
+        return null;
+      }
+    },
+
+    async downloadPublicArtifact(url: string): Promise<DownloadResult> {
+      if (!isAllowedCratesArtifactUrl(url)) {
+        throw new Error("crates.io public artifact URL is not allowed");
+      }
+      const { downloadInSandbox } = await import("../../sandbox");
+      // No token is passed: the gateway sees only this single pinned URL on its
+      // public-artifact allowlist, so it forwards the request uncredentialed.
+      return downloadInSandbox(ctx.env, ctx.executionCtx, {
+        tarballUrl: url,
+        archiveFormat: "tgz",
+        publicArtifactUrls: [url],
+      });
+    },
+
+    dispose(): void {},
+  };
+}

--- a/server/lib/adapters/crates/findings.ts
+++ b/server/lib/adapters/crates/findings.ts
@@ -1,0 +1,208 @@
+import { type FileRecord, type Finding, tarSuspiciousEntryFindings } from "../../review";
+import { parseCargoManifest } from "./manifest";
+import {
+  CRATES_RULE_IDS,
+  CRATES_RULES_VERSION,
+  type CratesArtifactSummary,
+  type CratesManifestSummary,
+  type CratesPreparedArtifact,
+  type CratesReleaseManifest,
+} from "./types";
+
+export function summarizeCratesArtifact(
+  artifactPath: string,
+  files: FileRecord[],
+): CratesArtifactSummary {
+  const manifestFile = files.find((file) => file.path === "Cargo.toml");
+  const manifest: CratesManifestSummary = manifestFile?.textSample
+    ? parseCargoManifest(manifestFile.textSample)
+    : {
+        name: null,
+        version: null,
+        links: null,
+        buildValue: null,
+        procMacro: false,
+        nonRegistryDependencies: [],
+      };
+  return {
+    path: artifactPath,
+    kind: "crate",
+    manifestPath: manifestFile?.path ?? null,
+    manifest,
+    buildScriptPath: effectiveBuildScriptPath(manifest, files),
+  };
+}
+
+/**
+ * The build script cargo would compile and run at consumer build time:
+ * `build = false` disables it, a string names a custom path, and otherwise the
+ * conventional root `build.rs` applies when present.
+ */
+export function effectiveBuildScriptPath(
+  manifest: CratesManifestSummary,
+  files: FileRecord[],
+): string | null {
+  if (manifest.buildValue === false) return null;
+  if (typeof manifest.buildValue === "string") {
+    return manifest.buildValue.replace(/^\.\//, "");
+  }
+  return files.some((file) => file.path === "build.rs") ? "build.rs" : null;
+}
+
+export function cratesReleaseFindings(
+  manifest: CratesReleaseManifest,
+  artifacts: CratesPreparedArtifact[],
+  baselineFiles: FileRecord[] | null,
+): Finding[] {
+  const findings: Finding[] = [];
+  const baselineSummary = baselineFiles ? summarizeCratesArtifact("baseline", baselineFiles) : null;
+
+  for (const artifact of artifacts) {
+    const { summary } = artifact;
+    // Surface tar-parser evidence (oversized content-skipped bodies, non-regular
+    // entries, duplicates, confusable paths) the sandbox recorded for this
+    // artifact, so a crate whose oversized file was never inspected fails the
+    // review instead of passing silently.
+    findings.push(...tarSuspiciousEntryFindings(artifact.suspiciousEntries));
+
+    const manifestEvidencePath = summary.manifestPath ?? "Cargo.toml";
+    if (!summary.manifestPath || !summary.manifest.name || !summary.manifest.version) {
+      findings.push(
+        tag("metadataMissing", {
+          severity: "medium",
+          file: manifestEvidencePath,
+          evidence: `${artifact.path} does not expose a complete Cargo.toml name/version`,
+          reason:
+            "release gates need crate name and version metadata to prove the artifact matches the reviewed manifest",
+        }),
+      );
+    } else {
+      if (summary.manifest.name !== manifest.package) {
+        findings.push(
+          tag("metadataMismatch", {
+            severity: "critical",
+            file: manifestEvidencePath,
+            evidence: `${artifact.path} Cargo.toml name ${summary.manifest.name} != manifest package ${manifest.package}`,
+            reason: "the release artifact crate name does not match the reviewed manifest",
+          }),
+        );
+      }
+      if (summary.manifest.version !== manifest.version) {
+        findings.push(
+          tag("metadataMismatch", {
+            severity: "critical",
+            file: manifestEvidencePath,
+            evidence: `${artifact.path} Cargo.toml version ${summary.manifest.version} != manifest version ${manifest.version}`,
+            reason: "the release artifact version does not match the reviewed manifest",
+          }),
+        );
+      }
+    }
+
+    findings.push(...buildScriptFindings(artifact, baselineSummary, baselineFiles));
+
+    if (summary.manifest.procMacro && !baselineSummary?.manifest.procMacro) {
+      findings.push(
+        tag("procMacroIntroduced", {
+          severity: "high",
+          file: manifestEvidencePath,
+          evidence: baselineSummary
+            ? "crate became a proc-macro (`[lib] proc-macro = true`) in this release"
+            : "crate is a proc-macro (`[lib] proc-macro = true`)",
+          reason:
+            "proc-macro crates execute inside the compiler on every consumer build, a powerful code-execution surface",
+        }),
+      );
+    }
+
+    const links = summary.manifest.links;
+    const baselineLinks = baselineSummary?.manifest.links ?? null;
+    if (links !== baselineLinks && (links || baselineLinks) && baselineSummary) {
+      findings.push(
+        tag("linksChanged", {
+          severity: "high",
+          file: manifestEvidencePath,
+          evidence: `Cargo.toml links changed: ${baselineLinks ?? "(none)"} -> ${links ?? "(none)"}`,
+          reason:
+            "the `links` key changes native-library linkage and build-script coordination for every consumer build",
+        }),
+      );
+    }
+
+    for (const dep of summary.manifest.nonRegistryDependencies) {
+      const wasPresent = baselineSummary?.manifest.nonRegistryDependencies.some(
+        (baselineDep) =>
+          baselineDep.name === dep.name &&
+          baselineDep.source === dep.source &&
+          baselineDep.section === dep.section,
+      );
+      if (wasPresent) continue;
+      findings.push(
+        tag("nonRegistryDependency", {
+          severity: "high",
+          file: manifestEvidencePath,
+          evidence: `[${dep.section}] ${dep.name} uses a ${dep.source} source`,
+          reason:
+            "git/path dependencies bypass the crates.io registry and pull unreviewed code from an arbitrary location",
+        }),
+      );
+    }
+  }
+
+  return findings;
+}
+
+function buildScriptFindings(
+  artifact: CratesPreparedArtifact,
+  baselineSummary: CratesArtifactSummary | null,
+  baselineFiles: FileRecord[] | null,
+): Finding[] {
+  const buildScriptPath = artifact.summary.buildScriptPath;
+  if (!buildScriptPath) return [];
+
+  if (!baselineSummary || !baselineSummary.buildScriptPath) {
+    return [
+      tag("buildScriptAdded", {
+        severity: baselineSummary ? "high" : "medium",
+        file: buildScriptPath,
+        evidence: baselineSummary
+          ? `${buildScriptPath} is new in this release`
+          : `${buildScriptPath} runs at consumer build time`,
+        reason:
+          "cargo compiles and executes the build script on every consumer build, so it runs arbitrary code on consumer machines",
+      }),
+    ];
+  }
+
+  const staged = artifact.files.find((file) => file.path === buildScriptPath);
+  const baseline = baselineFiles?.find((file) => file.path === baselineSummary.buildScriptPath);
+  if (
+    baselineSummary.buildScriptPath !== buildScriptPath ||
+    (staged && baseline && staged.sha256 !== baseline.sha256)
+  ) {
+    return [
+      tag("buildScriptChanged", {
+        severity: "high",
+        file: buildScriptPath,
+        evidence:
+          baselineSummary.buildScriptPath !== buildScriptPath
+            ? `build script moved: ${baselineSummary.buildScriptPath} -> ${buildScriptPath}`
+            : `${buildScriptPath} changed since the previous release`,
+        reason:
+          "build-script changes alter code that executes on every consumer build and are a common crates.io attack vector",
+      }),
+    ];
+  }
+  return [];
+}
+
+function tag(
+  rule: keyof typeof CRATES_RULE_IDS,
+  finding: Omit<Finding, "ruleId" | "ruleVersion">,
+): Finding {
+  return {
+    ...finding,
+    ruleId: CRATES_RULE_IDS[rule],
+    ruleVersion: CRATES_RULES_VERSION,
+  };
+}

--- a/server/lib/adapters/crates/index.ts
+++ b/server/lib/adapters/crates/index.ts
@@ -1,0 +1,151 @@
+import {
+  computeRisk,
+  createPackageDiff,
+  deterministicFindings,
+  redactFindings,
+  summarizePackageJsonDiff,
+} from "../../review";
+import type { PackageAdapter, ReleaseProvenance } from "../types";
+import {
+  acquireBaselineCrates,
+  acquireStagedCrates,
+  baselineFromPreviousCratesArtifacts,
+  pickCratesPackageIdentity,
+} from "./acquire";
+import { createCratesBroker, type CratesBroker } from "./broker";
+import { cratesReleaseFindings } from "./findings";
+import { parseCratesAdapterInput } from "./manifest";
+import type {
+  CratesAdapterDetails,
+  CratesAdapterInput,
+  CratesArtifactInput,
+  CratesReleaseCandidateReview,
+  CratesReleaseManifest,
+} from "./types";
+
+export const cratesAdapter: PackageAdapter<CratesAdapterInput, CratesBroker> = {
+  id: "crates",
+  codePatternSet: "rust",
+
+  parseInput(raw: unknown): CratesAdapterInput {
+    return parseCratesAdapterInput(raw);
+  },
+
+  createBroker(ctx, ref) {
+    return createCratesBroker(ctx, ref);
+  },
+
+  async acquireStaged(_ctx, input, _broker) {
+    return acquireStagedCrates(input);
+  },
+
+  async acquireBaseline(ctx, input, broker, _staged) {
+    return acquireBaselineCrates(ctx, input, broker);
+  },
+
+  runFindings(args) {
+    const details = args.details as CratesAdapterDetails;
+    return [
+      ...deterministicFindings(args.staged.files, args.fileDiff, null, {
+        codePatternSet: "rust",
+      }),
+      ...cratesReleaseFindings(
+        details.manifest,
+        details.preparedArtifacts,
+        args.baseline?.files ?? null,
+      ),
+    ];
+  },
+
+  describe({ details, previous }) {
+    const d = details as CratesAdapterDetails;
+    const identity = pickCratesPackageIdentity(d.manifest, d.preparedArtifacts);
+    return {
+      name: identity.name,
+      stagedVersion: identity.version,
+      stagedTag: null,
+      previousVersion: previous?.manifest?.version ?? null,
+    };
+  },
+
+  summarizeDetails(details) {
+    const d = details as CratesAdapterDetails;
+    return {
+      manifest: d.manifest,
+      artifacts: d.artifacts,
+      provenance: {
+        // crates artifacts only reach review through the workflow gate; the
+        // manifest carries each `.crate` digest recomputed from the immutable
+        // bundle bytes, which the publish job re-verifies before upload.
+        ecosystem: "crates",
+        mode: "workflow_gate",
+        artifacts: d.manifest.artifacts.map((artifact) => ({
+          path: artifact.path,
+          kind: artifact.kind,
+          sha256: artifact.sha256,
+        })),
+      } satisfies ReleaseProvenance,
+    };
+  },
+};
+
+export function createCratesReleaseCandidateReview(input: {
+  manifest: CratesReleaseManifest;
+  artifacts: CratesArtifactInput[];
+  previousArtifacts?: CratesArtifactInput[];
+}): CratesReleaseCandidateReview {
+  const adapterInput = cratesAdapter.parseInput(input);
+  const staged = acquireStagedCrates(adapterInput);
+  const baseline = baselineFromPreviousCratesArtifacts(adapterInput);
+  const diff = createPackageDiff(baseline.artifact?.files ?? [], staged.artifact.files);
+  const ruleFindings = redactFindings(
+    cratesAdapter.runFindings({
+      staged: staged.artifact,
+      baseline: baseline.artifact,
+      details: staged.details,
+      fileDiff: diff,
+      manifestDiff: summarizePackageJsonDiff(baseline.artifact?.manifest, staged.artifact.manifest),
+      stagedManifestText: null,
+    }),
+  );
+  const packageIdentity = cratesAdapter.describe({
+    input: adapterInput,
+    staged: staged.artifact,
+    details: staged.details,
+    baseline: baseline.baseline,
+    previous: baseline.artifact,
+  });
+  const details = staged.details as CratesAdapterDetails;
+
+  return {
+    ecosystem: "crates",
+    manifest: adapterInput.manifest,
+    package: {
+      name: packageIdentity.name,
+      version: packageIdentity.stagedVersion,
+    },
+    fileCount: staged.artifact.files.length,
+    previousFileCount: baseline.artifact?.files.length ?? 0,
+    artifacts: details.artifacts,
+    diff,
+    ruleFindings,
+    risk: computeRisk(ruleFindings),
+  };
+}
+
+export { CRATES_RELEASE_MANIFEST_SCHEMA, CRATES_RULE_IDS, CRATES_RULES_VERSION } from "./types";
+export type {
+  CratesAdapterInput,
+  CratesArtifactInput,
+  CratesPreparedArtifact,
+  CratesReleaseCandidateReview,
+  CratesReleaseManifest,
+} from "./types";
+export {
+  inferCratesArtifactKind,
+  isValidCrateName,
+  parseCargoManifest,
+  parseCratesReleaseManifest,
+} from "./manifest";
+export { pickCratesBaselineVersion, prepareCratesArtifact } from "./acquire";
+export { cratesIndexPath, cratesStaticArtifactUrl, isAllowedCratesArtifactUrl } from "./broker";

--- a/server/lib/adapters/crates/manifest.ts
+++ b/server/lib/adapters/crates/manifest.ts
@@ -1,0 +1,173 @@
+import { isRecord, isSafeManifestPath, parseArtifactFilesInputs } from "../artifact-input";
+import {
+  CRATE_NAME_RE,
+  CRATES_ARTIFACT_LIMIT,
+  CRATES_RELEASE_MANIFEST_SCHEMA,
+  SAFE_VERSION_RE,
+  SHA256_RE,
+  type CratesAdapterInput,
+  type CratesArtifactKind,
+  type CratesIndexEntry,
+  type CratesManifestSummary,
+  type CratesReleaseManifest,
+} from "./types";
+
+export function isValidCrateName(name: string): boolean {
+  return typeof name === "string" && CRATE_NAME_RE.test(name);
+}
+
+export function inferCratesArtifactKind(path: string): CratesArtifactKind | null {
+  return path.toLowerCase().endsWith(".crate") ? "crate" : null;
+}
+
+export function parseCratesReleaseManifest(value: unknown): CratesReleaseManifest {
+  if (!isRecord(value)) throw new Error("manifest must be an object");
+  if (value.schema !== CRATES_RELEASE_MANIFEST_SCHEMA) {
+    throw new Error(`manifest schema must be ${CRATES_RELEASE_MANIFEST_SCHEMA}`);
+  }
+  if (value.ecosystem !== "crates") throw new Error("manifest ecosystem must be crates");
+  const packageName = String(value.package || "");
+  const version = String(value.version || "");
+  if (!isValidCrateName(packageName)) {
+    throw new Error("manifest package is not a valid crates.io package name");
+  }
+  if (!SAFE_VERSION_RE.test(version)) {
+    throw new Error("manifest version is not a safe crate version string");
+  }
+  if (!Array.isArray(value.artifacts) || !value.artifacts.length) {
+    throw new Error("manifest must include at least one artifact");
+  }
+  if (value.artifacts.length > CRATES_ARTIFACT_LIMIT) {
+    throw new Error(`manifest must include no more than ${CRATES_ARTIFACT_LIMIT} artifacts`);
+  }
+
+  const artifacts = value.artifacts.map((artifact, index) => {
+    if (!isRecord(artifact)) throw new Error(`artifact ${index + 1} must be an object`);
+    const path = String(artifact.path || "");
+    if (!isSafeManifestPath(path)) throw new Error(`artifact ${index + 1} path is not safe`);
+    const kind = inferCratesArtifactKind(path);
+    if (!kind) throw new Error(`artifact ${index + 1} must be a .crate archive`);
+    const sha256 = String(artifact.sha256 || "");
+    if (!SHA256_RE.test(sha256))
+      throw new Error(`artifact ${index + 1} sha256 must be a hex SHA-256 digest`);
+    return { path, sha256: sha256.toLowerCase(), kind };
+  });
+
+  return {
+    schema: CRATES_RELEASE_MANIFEST_SCHEMA,
+    ecosystem: "crates",
+    package: packageName,
+    version,
+    artifacts,
+  };
+}
+
+export function parseCratesAdapterInput(raw: unknown): CratesAdapterInput {
+  if (!isRecord(raw)) throw new Error("crates adapter input must be an object");
+  const manifest = parseCratesReleaseManifest(raw.manifest ?? raw);
+  return {
+    manifest,
+    artifacts: parseArtifactFilesInputs(raw.artifacts, "artifacts"),
+    previousArtifacts:
+      raw.previousArtifacts === undefined
+        ? undefined
+        : parseArtifactFilesInputs(raw.previousArtifacts, "previousArtifacts"),
+    metadata: Array.isArray(raw.metadata) ? (raw.metadata as CratesIndexEntry[]) : undefined,
+  };
+}
+
+const DEPENDENCY_SECTION_RE =
+  /^(?:dependencies|dev-dependencies|build-dependencies|target\.[^\]]+\.(?:dependencies|dev-dependencies|build-dependencies))$/;
+
+/**
+ * Extract the Cargo.toml facts the deterministic rules need with a
+ * line-oriented reader over the crate's normalized manifest text sample.
+ * This intentionally handles only the subset cargo itself emits for published
+ * crates (`cargo publish` normalizes the manifest); it never evaluates package
+ * bytes and treats unparseable input as absent metadata (fail toward
+ * `metadata-missing`, never a crash).
+ */
+export function parseCargoManifest(text: string): CratesManifestSummary {
+  const summary: CratesManifestSummary = {
+    name: null,
+    version: null,
+    links: null,
+    buildValue: null,
+    procMacro: false,
+    nonRegistryDependencies: [],
+  };
+  let section = "";
+  for (const rawLine of text.replace(/\r\n/g, "\n").split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const sectionMatch = /^\[\[?([^\]]+)\]\]?$/.exec(line);
+    if (sectionMatch) {
+      section = sectionMatch[1]
+        .trim()
+        .replace(/\s*\.\s*/g, ".")
+        .replace(/"/g, "");
+      continue;
+    }
+
+    const keyValue = /^([A-Za-z0-9_-]+|"[^"]+")\s*=\s*(.+)$/.exec(line);
+    if (!keyValue) continue;
+    const key = keyValue[1].replace(/^"|"$/g, "");
+    const value = keyValue[2].trim();
+
+    if (section === "package") {
+      if (key === "name") summary.name = parseTomlString(value);
+      else if (key === "version") summary.version = parseTomlString(value);
+      else if (key === "links") summary.links = parseTomlString(value);
+      else if (key === "build") {
+        if (value === "false") summary.buildValue = false;
+        else if (value === "true") summary.buildValue = true;
+        else summary.buildValue = parseTomlString(value);
+      }
+      continue;
+    }
+    if (section === "lib" && key === "proc-macro" && value.startsWith("true")) {
+      summary.procMacro = true;
+      continue;
+    }
+    if (DEPENDENCY_SECTION_RE.test(section)) {
+      const source = inlineDependencySource(value);
+      if (source) summary.nonRegistryDependencies.push({ name: key, source, section });
+      continue;
+    }
+    const subsection = matchDependencySubsection(section);
+    if (subsection && (key === "git" || key === "path")) {
+      const already = summary.nonRegistryDependencies.some(
+        (dep) => dep.name === subsection.name && dep.section === subsection.section,
+      );
+      if (!already) {
+        summary.nonRegistryDependencies.push({
+          name: subsection.name,
+          source: key,
+          section: subsection.section,
+        });
+      }
+    }
+  }
+  return summary;
+}
+
+/** `[dependencies.foo]` (or dev/build/target variants) → its parent section + dep name. */
+function matchDependencySubsection(section: string): { section: string; name: string } | null {
+  const match =
+    /^((?:dependencies|dev-dependencies|build-dependencies|target\.[^.]+(?:\.[^.]+)*?\.(?:dependencies|dev-dependencies|build-dependencies)))\.([A-Za-z0-9_-]+)$/.exec(
+      section,
+    );
+  return match ? { section: match[1], name: match[2] } : null;
+}
+
+function inlineDependencySource(value: string): "git" | "path" | null {
+  if (!value.startsWith("{")) return null;
+  if (/[{,]\s*git\s*=/.test(value)) return "git";
+  if (/[{,]\s*path\s*=/.test(value)) return "path";
+  return null;
+}
+
+function parseTomlString(value: string): string | null {
+  const match = /^"([^"]*)"/.exec(value);
+  return match ? match[1] : null;
+}

--- a/server/lib/adapters/crates/types.ts
+++ b/server/lib/adapters/crates/types.ts
@@ -1,0 +1,112 @@
+import type { DiffEntry, FileRecord, Finding, RiskLevel } from "../../review";
+import type { TarSuspiciousEntry } from "../../tar-parser.js";
+
+export const CRATES_RELEASE_MANIFEST_SCHEMA = "drydock.release-artifacts.v1";
+export const CRATES_RULES_VERSION = "0.1.0";
+
+export const CRATES_RULE_IDS = {
+  metadataMissing: "crates.metadata-missing",
+  metadataMismatch: "crates.metadata-mismatch",
+  buildScriptAdded: "crates.build-script-added",
+  buildScriptChanged: "crates.build-script-changed",
+  procMacroIntroduced: "crates.proc-macro-introduced",
+  linksChanged: "crates.links-changed",
+  nonRegistryDependency: "crates.non-registry-dependency",
+} as const;
+
+// crates.io package names: ASCII alphanumeric, `-`, `_`; must start with a
+// letter; max 64 characters.
+export const CRATE_NAME_RE = /^[A-Za-z][A-Za-z0-9_-]{0,63}$/;
+export const SAFE_VERSION_RE = /^[0-9][A-Za-z0-9.+-]{0,127}$/;
+export const SHA256_RE = /^[a-f0-9]{64}$/i;
+export const CRATES_ARTIFACT_LIMIT = 20;
+
+export type CratesArtifactKind = "crate";
+
+export interface CratesReleaseManifestArtifact {
+  path: string;
+  sha256: string;
+  kind: CratesArtifactKind;
+}
+
+export interface CratesReleaseManifest {
+  schema: typeof CRATES_RELEASE_MANIFEST_SCHEMA;
+  ecosystem: "crates";
+  package: string;
+  version: string;
+  artifacts: CratesReleaseManifestArtifact[];
+}
+
+export interface CratesArtifactInput {
+  path: string;
+  files: FileRecord[];
+  suspiciousEntries?: TarSuspiciousEntry[];
+}
+
+export interface CratesNonRegistryDependency {
+  name: string;
+  source: "git" | "path";
+  section: string;
+}
+
+// Cargo.toml facts the deterministic rules key off. Parsed from the crate's
+// normalized `Cargo.toml` text sample with a line-oriented reader — never by
+// evaluating package bytes.
+export interface CratesManifestSummary {
+  name: string | null;
+  version: string | null;
+  links: string | null;
+  /** `build = false` disables the build script; a string names a custom path. */
+  buildValue: string | boolean | null;
+  procMacro: boolean;
+  nonRegistryDependencies: CratesNonRegistryDependency[];
+}
+
+export interface CratesArtifactSummary {
+  path: string;
+  kind: CratesArtifactKind;
+  manifestPath: string | null;
+  manifest: CratesManifestSummary;
+  /** Path of the effective build script inside the crate, when present. */
+  buildScriptPath: string | null;
+}
+
+export interface CratesPreparedArtifact extends CratesArtifactInput {
+  kind: CratesArtifactKind;
+  summary: CratesArtifactSummary;
+}
+
+export interface CratesAdapterInput {
+  manifest: CratesReleaseManifest;
+  artifacts: CratesArtifactInput[];
+  previousArtifacts?: CratesArtifactInput[];
+  metadata?: CratesIndexEntry[];
+}
+
+export interface CratesAdapterDetails {
+  manifest: CratesReleaseManifest;
+  artifacts: CratesArtifactSummary[];
+  preparedArtifacts: CratesPreparedArtifact[];
+}
+
+/** One line of the crates.io sparse index file for a crate. */
+export interface CratesIndexEntry {
+  vers?: string;
+  cksum?: string;
+  yanked?: boolean;
+}
+
+export interface CratesReleaseCandidateReview {
+  ecosystem: "crates";
+  manifest: CratesReleaseManifest;
+  package: {
+    name: string | null;
+    version: string | null;
+  };
+  fileCount: number;
+  previousFileCount: number;
+  artifacts: CratesArtifactSummary[];
+  diff: DiffEntry[];
+  ruleFindings: Finding[];
+  risk: RiskLevel;
+}

--- a/server/lib/adapters/gomod/acquire.ts
+++ b/server/lib/adapters/gomod/acquire.ts
@@ -1,0 +1,233 @@
+import type { FileRecord, PackageJsonSummary } from "../../review";
+import type { AcquiredArtifact, AdapterContext, BaselineInfo, StagedDetails } from "../types";
+import { goProxyZipUrl, type GoBroker } from "./broker";
+import { summarizeGoArtifact } from "./findings";
+import { inferGoArtifactKind, isValidGoVersion, parseGoModuleZipRoot } from "./manifest";
+import type {
+  GoAdapterDetails,
+  GoAdapterInput,
+  GoArtifactInput,
+  GoPreparedArtifact,
+  GoReleaseManifest,
+} from "./types";
+
+export function prepareGoArtifact(input: GoArtifactInput): GoPreparedArtifact {
+  const kind = inferGoArtifactKind(input.path);
+  if (!kind) throw new Error("Go artifact must be a module .zip archive");
+  // Module zips are rooted at `{module}@{version}/`; strip that root so
+  // staged/baseline diffs align across versions. The parsed root feeds the
+  // identity rules.
+  const root = parseGoModuleZipRoot(input.files);
+  const files = root
+    ? input.files.map((file) => ({
+        ...file,
+        path: file.path.slice(`${root.modulePath}@${root.version}/`.length),
+      }))
+    : input.files;
+  return {
+    path: input.path,
+    kind,
+    files,
+    summary: summarizeGoArtifact(input.path, files, root),
+    ...(input.suspiciousEntries ? { suspiciousEntries: input.suspiciousEntries } : {}),
+  };
+}
+
+export function acquireStagedGo(input: GoAdapterInput): {
+  artifact: AcquiredArtifact;
+  details: StagedDetails;
+} {
+  assertManifestArtifactSet(input.manifest, input.artifacts);
+  const preparedArtifacts = input.artifacts.map(prepareGoArtifact);
+  if (preparedArtifacts.length !== 1) {
+    // A Go module version is exactly one zip; two archives claiming the same
+    // release is ambiguous and must not ship.
+    throw new Error("a Go release candidate must contain exactly one module zip artifact");
+  }
+  const [prepared] = preparedArtifacts;
+  return {
+    artifact: {
+      files: prepared.files,
+      manifest: manifestSummaryFor(input.manifest, prepared),
+    },
+    details: {
+      manifest: input.manifest,
+      artifacts: [prepared.summary],
+      preparedArtifacts,
+    } satisfies GoAdapterDetails,
+  };
+}
+
+export async function acquireBaselineGo(
+  ctx: AdapterContext,
+  input: GoAdapterInput,
+  broker: GoBroker,
+): Promise<{ artifact: AcquiredArtifact | null; baseline: BaselineInfo }> {
+  if (input.previousArtifacts?.length) {
+    return baselineFromPreviousGoArtifacts(input);
+  }
+
+  const versions = input.metadata ?? (await broker.fetchVersionList(input.manifest.package));
+  if (!versions) return emptyGoBaseline("proxy-unavailable");
+
+  const version = pickGoBaselineVersion(versions, input.manifest.version);
+  if (!version) return emptyGoBaseline("no-published-baseline");
+
+  const url = goProxyZipUrl(input.manifest.package, version);
+  const result = await broker.downloadPublicArtifact(url);
+  const prepared = prepareGoArtifact({
+    path: `${version}.zip`,
+    files: result.files,
+  });
+  return {
+    artifact: {
+      files: prepared.files,
+      manifest: manifestSummaryFor(input.manifest, prepared),
+    },
+    baseline: {
+      version,
+      tag: null,
+      source: "latest-published",
+      distTagVersion: null,
+      reason: "proxy-highest-semver",
+    },
+  };
+}
+
+export function baselineFromPreviousGoArtifacts(input: GoAdapterInput): {
+  artifact: AcquiredArtifact | null;
+  baseline: BaselineInfo;
+} {
+  if (!input.previousArtifacts?.length) return emptyGoBaseline("no-previous-artifacts");
+  const prepared = prepareGoArtifact(input.previousArtifacts[0]);
+  const manifest = manifestSummaryFor(input.manifest, prepared);
+  return {
+    artifact: { files: prepared.files, manifest },
+    baseline: {
+      version: prepared.summary.module.rootVersion ?? null,
+      tag: null,
+      source: "latest-published",
+      distTagVersion: null,
+      reason: "provided-previous-artifacts",
+    },
+  };
+}
+
+/**
+ * Highest canonical semver from the proxy `@v/list` that is not the candidate
+ * itself. `@v/list` order is unspecified, so versions are compared, not
+ * position-picked.
+ */
+export function pickGoBaselineVersion(versions: string[], candidateVersion: string): string | null {
+  let best: string | null = null;
+  for (const version of versions) {
+    if (!isValidGoVersion(version) || version === candidateVersion) continue;
+    if (best === null || compareGoVersions(version, best) > 0) best = version;
+  }
+  return best;
+}
+
+export function compareGoVersions(a: string, b: string): number {
+  const [coreA, preA] = splitPrerelease(a);
+  const [coreB, preB] = splitPrerelease(b);
+  const partsA = coreA.slice(1).split(".").map(Number);
+  const partsB = coreB.slice(1).split(".").map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    if (partsA[index] !== partsB[index]) return partsA[index] - partsB[index];
+  }
+  if (preA === null && preB === null) return 0;
+  if (preA === null) return 1;
+  if (preB === null) return -1;
+  return comparePrerelease(preA, preB);
+}
+
+function splitPrerelease(version: string): [string, string | null] {
+  const withoutBuild = version.split("+")[0];
+  const dash = withoutBuild.indexOf("-");
+  if (dash < 0) return [withoutBuild, null];
+  return [withoutBuild.slice(0, dash), withoutBuild.slice(dash + 1)];
+}
+
+function comparePrerelease(a: string, b: string): number {
+  const idsA = a.split(".");
+  const idsB = b.split(".");
+  for (let index = 0; index < Math.max(idsA.length, idsB.length); index += 1) {
+    const idA = idsA[index];
+    const idB = idsB[index];
+    if (idA === undefined) return -1;
+    if (idB === undefined) return 1;
+    const numA = /^\d+$/.test(idA) ? Number(idA) : null;
+    const numB = /^\d+$/.test(idB) ? Number(idB) : null;
+    if (numA !== null && numB !== null) {
+      if (numA !== numB) return numA - numB;
+    } else if (numA !== null) {
+      return -1;
+    } else if (numB !== null) {
+      return 1;
+    } else if (idA !== idB) {
+      return idA < idB ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+function emptyGoBaseline(reason: string): { artifact: null; baseline: BaselineInfo } {
+  return {
+    artifact: null,
+    baseline: {
+      version: null,
+      tag: null,
+      source: "none",
+      distTagVersion: null,
+      reason,
+    },
+  };
+}
+
+function assertManifestArtifactSet(
+  manifest: GoReleaseManifest,
+  artifacts: GoArtifactInput[],
+): void {
+  const manifestPaths = sortedUnique(manifest.artifacts.map((artifact) => artifact.path));
+  const artifactPaths = sortedUnique(artifacts.map((artifact) => artifact.path));
+  if (
+    manifestPaths.length !== manifest.artifacts.length ||
+    artifactPaths.length !== artifacts.length ||
+    manifestPaths.length !== artifactPaths.length ||
+    manifestPaths.some((path, index) => path !== artifactPaths[index])
+  ) {
+    throw new Error("review artifacts must exactly match manifest artifacts");
+  }
+}
+
+function sortedUnique(values: string[]): string[] {
+  return [...new Set(values)].sort();
+}
+
+export function pickGoPackageIdentity(
+  manifest: GoReleaseManifest,
+  artifacts: GoPreparedArtifact[],
+): { name: string | null; version: string | null } {
+  const summary = artifacts.find(
+    (artifact) => artifact.summary.module.rootModulePath && artifact.summary.module.rootVersion,
+  )?.summary;
+  return {
+    name: summary?.module.modulePath ?? summary?.module.rootModulePath ?? manifest.package ?? null,
+    version: summary?.module.rootVersion ?? manifest.version ?? null,
+  };
+}
+
+function manifestSummaryFor(
+  manifest: GoReleaseManifest,
+  prepared: GoPreparedArtifact,
+): PackageJsonSummary {
+  const identity = pickGoPackageIdentity(manifest, [prepared]);
+  return {
+    name: identity.name ?? undefined,
+    version: identity.version ?? undefined,
+  };
+}
+
+export function goBaselineFiles(baseline: AcquiredArtifact | null): FileRecord[] | null {
+  return baseline?.files ?? null;
+}

--- a/server/lib/adapters/gomod/broker.ts
+++ b/server/lib/adapters/gomod/broker.ts
@@ -1,0 +1,70 @@
+import type { DownloadResult } from "../../sandbox";
+import type { AdapterBroker, AdapterConnectionRef, AdapterContext } from "../types";
+
+export interface GoBroker extends AdapterBroker {
+  fetchVersionList(modulePath: string): Promise<string[] | null>;
+  downloadPublicArtifact(url: string): Promise<DownloadResult>;
+}
+
+const GO_PROXY_HOST = "proxy.golang.org";
+
+/**
+ * Case-encode a module path for proxy URLs: uppercase letters become
+ * `!lowercase` (module paths are case-sensitive but proxy paths are not).
+ */
+export function escapeGoModulePath(modulePath: string): string {
+  return modulePath.replace(/[A-Z]/g, (char) => `!${char.toLowerCase()}`);
+}
+
+export function goProxyZipUrl(modulePath: string, version: string): string {
+  return `https://${GO_PROXY_HOST}/${escapeGoModulePath(modulePath)}/@v/${encodeURIComponent(version)}.zip`;
+}
+
+export function isAllowedGoProxyArtifactUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" && parsed.hostname === GO_PROXY_HOST;
+  } catch {
+    return false;
+  }
+}
+
+// proxy.golang.org is a public, credential-free module proxy (checksums are
+// independently verifiable via sum.golang.org). Like the PyPI broker this is a
+// plain object; the sandbox only ever fetches a single pinned proxy URL.
+export function createGoBroker(ctx: AdapterContext, _ref: AdapterConnectionRef): GoBroker {
+  return {
+    async fetchVersionList(modulePath: string): Promise<string[] | null> {
+      try {
+        const res = await fetch(
+          `https://${GO_PROXY_HOST}/${escapeGoModulePath(modulePath)}/@v/list`,
+          { headers: { accept: "text/plain" } },
+        );
+        if (!res.ok) return null;
+        const body = await res.text();
+        return body
+          .split("\n")
+          .map((line) => line.trim())
+          .filter(Boolean);
+      } catch {
+        return null;
+      }
+    },
+
+    async downloadPublicArtifact(url: string): Promise<DownloadResult> {
+      if (!isAllowedGoProxyArtifactUrl(url)) {
+        throw new Error("Go module proxy artifact URL is not allowed");
+      }
+      const { downloadInSandbox } = await import("../../sandbox");
+      // No token is passed: the gateway sees only this single pinned URL on its
+      // public-artifact allowlist, so it forwards the request uncredentialed.
+      return downloadInSandbox(ctx.env, ctx.executionCtx, {
+        tarballUrl: url,
+        archiveFormat: "zip",
+        publicArtifactUrls: [url],
+      });
+    },
+
+    dispose(): void {},
+  };
+}

--- a/server/lib/adapters/gomod/findings.ts
+++ b/server/lib/adapters/gomod/findings.ts
@@ -1,0 +1,215 @@
+import { type FileRecord, type Finding, tarSuspiciousEntryFindings } from "../../review";
+import { firstMatchingLine } from "../../text-utils";
+import { parseGoModFile } from "./manifest";
+import {
+  GO_RULE_IDS,
+  GO_RULES_VERSION,
+  type GoArtifactSummary,
+  type GoPreparedArtifact,
+  type GoReleaseManifest,
+} from "./types";
+
+const GO_GENERATE_RE = /^\/\/go:generate\s/m;
+const CGO_IMPORT_RE = /^\s*import\s+"C"|^\s*"C"$/m;
+const UNSAFE_IMPORT_RE = /(?:^\s*import\s+(?:\w+\s+)?"unsafe"|^\s*(?:\w+\s+)?"unsafe"\s*$)/m;
+const SYSCALL_IMPORT_RE =
+  /(?:^\s*import\s+(?:\w+\s+)?"(?:syscall|golang\.org\/x\/sys\/[\w/]+)"|^\s*(?:\w+\s+)?"(?:syscall|golang\.org\/x\/sys\/[\w/]+)"\s*$)/m;
+
+export function summarizeGoArtifact(
+  artifactPath: string,
+  files: FileRecord[],
+  root: { modulePath: string; version: string } | null,
+): GoArtifactSummary {
+  const goModFile = files.find((file) => file.path === "go.mod");
+  const parsed = goModFile?.textSample
+    ? parseGoModFile(goModFile.textSample)
+    : { modulePath: null, replaceDirectives: [] };
+  return {
+    path: artifactPath,
+    kind: "module",
+    goModPath: goModFile?.path ?? null,
+    module: {
+      modulePath: parsed.modulePath,
+      rootModulePath: root?.modulePath ?? null,
+      rootVersion: root?.version ?? null,
+      replaceDirectives: parsed.replaceDirectives,
+    },
+  };
+}
+
+export function goReleaseFindings(
+  manifest: GoReleaseManifest,
+  artifacts: GoPreparedArtifact[],
+  baselineFiles: FileRecord[] | null,
+): Finding[] {
+  const findings: Finding[] = [];
+
+  for (const artifact of artifacts) {
+    const { summary } = artifact;
+    findings.push(...tarSuspiciousEntryFindings(artifact.suspiciousEntries));
+
+    const goModEvidencePath = summary.goModPath ?? "go.mod";
+    const identityPath = summary.module.modulePath ?? summary.module.rootModulePath;
+    if (!identityPath || !summary.module.rootVersion) {
+      findings.push(
+        tag("metadataMissing", {
+          severity: "medium",
+          file: goModEvidencePath,
+          evidence: `${artifact.path} does not expose a Go module path/version`,
+          reason:
+            "release gates need module path and version metadata to prove the artifact matches the reviewed manifest",
+        }),
+      );
+    } else {
+      if (identityPath !== manifest.package) {
+        findings.push(
+          tag("metadataMismatch", {
+            severity: "critical",
+            file: goModEvidencePath,
+            evidence: `${artifact.path} module path ${identityPath} != manifest package ${manifest.package}`,
+            reason: "the release artifact module path does not match the reviewed manifest",
+          }),
+        );
+      }
+      if (summary.module.rootVersion !== manifest.version) {
+        findings.push(
+          tag("metadataMismatch", {
+            severity: "critical",
+            file: goModEvidencePath,
+            evidence: `${artifact.path} zip version ${summary.module.rootVersion} != manifest version ${manifest.version}`,
+            reason: "the release artifact version does not match the reviewed manifest",
+          }),
+        );
+      }
+      if (
+        summary.module.modulePath &&
+        summary.module.rootModulePath &&
+        summary.module.modulePath !== summary.module.rootModulePath
+      ) {
+        findings.push(
+          tag("metadataMismatch", {
+            severity: "critical",
+            file: goModEvidencePath,
+            evidence: `go.mod module ${summary.module.modulePath} != zip root ${summary.module.rootModulePath}`,
+            reason: "the module zip root and its go.mod disagree on the module identity",
+          }),
+        );
+      }
+    }
+
+    for (const directive of summary.module.replaceDirectives) {
+      findings.push(
+        tag("replaceDirective", {
+          severity: "medium",
+          file: goModEvidencePath,
+          line: firstMatchingLine(
+            artifact.files.find((file) => file.path === summary.goModPath)?.textSample,
+            [/^\s*replace\b/],
+          ),
+          evidence: `go.mod replace directive: ${directive}`,
+          reason:
+            "replace directives redirect dependency resolution away from the module proxy; in a published module they signal untracked or local dependency sources",
+        }),
+      );
+    }
+
+    findings.push(...capabilityDeltaFindings(artifact, baselineFiles));
+  }
+
+  return findings;
+}
+
+interface CapabilityRule {
+  rule: keyof typeof GO_RULE_IDS;
+  pattern: RegExp;
+  severity: Finding["severity"];
+  evidence: string;
+  reason: string;
+  fileFilter: (path: string) => boolean;
+}
+
+const CAPABILITY_RULES: CapabilityRule[] = [
+  {
+    rule: "goGenerateAdded",
+    pattern: GO_GENERATE_RE,
+    severity: "medium",
+    evidence: "//go:generate directive added",
+    reason:
+      "go:generate directives run arbitrary commands on developer machines that invoke go generate",
+    fileFilter: isGoSourcePath,
+  },
+  {
+    rule: "cgoIntroduced",
+    pattern: CGO_IMPORT_RE,
+    severity: "high",
+    evidence: 'import "C" (cgo) added',
+    reason:
+      "cgo introduces native code compiled and linked into consumer builds, a hard-to-audit execution surface",
+    fileFilter: isGoSourcePath,
+  },
+  {
+    rule: "unsafeUsageAdded",
+    pattern: UNSAFE_IMPORT_RE,
+    severity: "medium",
+    evidence: 'import "unsafe" added',
+    reason:
+      "unsafe breaks Go memory safety and is a common building block for hiding malicious behavior",
+    fileFilter: isGoSourcePath,
+  },
+  {
+    rule: "syscallUsageAdded",
+    pattern: SYSCALL_IMPORT_RE,
+    severity: "medium",
+    evidence: "syscall import added",
+    reason:
+      "direct syscall access sidesteps the standard library and can perform low-level process/host operations",
+    fileFilter: isGoSourcePath,
+  },
+];
+
+/**
+ * Capability deltas: flag files that newly carry a capability relative to the
+ * baseline release. With no baseline every carrying file is flagged, so a first
+ * release still surfaces the capability inventory.
+ */
+function capabilityDeltaFindings(
+  artifact: GoPreparedArtifact,
+  baselineFiles: FileRecord[] | null,
+): Finding[] {
+  const findings: Finding[] = [];
+  const baselineByPath = new Map((baselineFiles ?? []).map((file) => [file.path, file]));
+  for (const capability of CAPABILITY_RULES) {
+    for (const file of artifact.files) {
+      if (!capability.fileFilter(file.path)) continue;
+      const sample = file.textSample ?? "";
+      if (!capability.pattern.test(sample)) continue;
+      const baselineFile = baselineByPath.get(file.path);
+      if (baselineFile && capability.pattern.test(baselineFile.textSample ?? "")) continue;
+      findings.push(
+        tag(capability.rule, {
+          severity: capability.severity,
+          file: file.path,
+          line: firstMatchingLine(sample, [capability.pattern]),
+          evidence: capability.evidence,
+          reason: capability.reason,
+        }),
+      );
+    }
+  }
+  return findings;
+}
+
+function isGoSourcePath(path: string): boolean {
+  return /\.go$/i.test(path);
+}
+
+function tag(
+  rule: keyof typeof GO_RULE_IDS,
+  finding: Omit<Finding, "ruleId" | "ruleVersion">,
+): Finding {
+  return {
+    ...finding,
+    ruleId: GO_RULE_IDS[rule],
+    ruleVersion: GO_RULES_VERSION,
+  };
+}

--- a/server/lib/adapters/gomod/index.ts
+++ b/server/lib/adapters/gomod/index.ts
@@ -1,0 +1,153 @@
+import {
+  computeRisk,
+  createPackageDiff,
+  deterministicFindings,
+  redactFindings,
+  summarizePackageJsonDiff,
+} from "../../review";
+import type { PackageAdapter, ReleaseProvenance } from "../types";
+import {
+  acquireBaselineGo,
+  acquireStagedGo,
+  baselineFromPreviousGoArtifacts,
+  pickGoPackageIdentity,
+} from "./acquire";
+import { createGoBroker, type GoBroker } from "./broker";
+import { goReleaseFindings } from "./findings";
+import { parseGoAdapterInput } from "./manifest";
+import type {
+  GoAdapterDetails,
+  GoAdapterInput,
+  GoArtifactInput,
+  GoReleaseCandidateReview,
+  GoReleaseManifest,
+} from "./types";
+
+export const goAdapter: PackageAdapter<GoAdapterInput, GoBroker> = {
+  id: "go",
+  codePatternSet: "go",
+
+  parseInput(raw: unknown): GoAdapterInput {
+    return parseGoAdapterInput(raw);
+  },
+
+  createBroker(ctx, ref) {
+    return createGoBroker(ctx, ref);
+  },
+
+  async acquireStaged(_ctx, input, _broker) {
+    return acquireStagedGo(input);
+  },
+
+  async acquireBaseline(ctx, input, broker, _staged) {
+    return acquireBaselineGo(ctx, input, broker);
+  },
+
+  runFindings(args) {
+    const details = args.details as GoAdapterDetails;
+    return [
+      ...deterministicFindings(args.staged.files, args.fileDiff, null, {
+        codePatternSet: "go",
+      }),
+      ...goReleaseFindings(
+        details.manifest,
+        details.preparedArtifacts,
+        args.baseline?.files ?? null,
+      ),
+    ];
+  },
+
+  describe({ details, previous }) {
+    const d = details as GoAdapterDetails;
+    const identity = pickGoPackageIdentity(d.manifest, d.preparedArtifacts);
+    return {
+      name: identity.name,
+      stagedVersion: identity.version,
+      stagedTag: null,
+      previousVersion: previous?.manifest?.version ?? null,
+    };
+  },
+
+  summarizeDetails(details) {
+    const d = details as GoAdapterDetails;
+    return {
+      manifest: d.manifest,
+      artifacts: d.artifacts,
+      provenance: {
+        // Go modules only reach review through the workflow gate; the manifest
+        // carries each module zip digest recomputed from the immutable bundle
+        // bytes, which the publish job re-verifies before the tag/proxy fetch.
+        ecosystem: "go",
+        mode: "workflow_gate",
+        artifacts: d.manifest.artifacts.map((artifact) => ({
+          path: artifact.path,
+          kind: artifact.kind,
+          sha256: artifact.sha256,
+        })),
+      } satisfies ReleaseProvenance,
+    };
+  },
+};
+
+export function createGoReleaseCandidateReview(input: {
+  manifest: GoReleaseManifest;
+  artifacts: GoArtifactInput[];
+  previousArtifacts?: GoArtifactInput[];
+}): GoReleaseCandidateReview {
+  const adapterInput = goAdapter.parseInput(input);
+  const staged = acquireStagedGo(adapterInput);
+  const baseline = baselineFromPreviousGoArtifacts(adapterInput);
+  const diff = createPackageDiff(baseline.artifact?.files ?? [], staged.artifact.files);
+  const ruleFindings = redactFindings(
+    goAdapter.runFindings({
+      staged: staged.artifact,
+      baseline: baseline.artifact,
+      details: staged.details,
+      fileDiff: diff,
+      manifestDiff: summarizePackageJsonDiff(baseline.artifact?.manifest, staged.artifact.manifest),
+      stagedManifestText: null,
+    }),
+  );
+  const packageIdentity = goAdapter.describe({
+    input: adapterInput,
+    staged: staged.artifact,
+    details: staged.details,
+    baseline: baseline.baseline,
+    previous: baseline.artifact,
+  });
+  const details = staged.details as GoAdapterDetails;
+
+  return {
+    ecosystem: "go",
+    manifest: adapterInput.manifest,
+    package: {
+      name: packageIdentity.name,
+      version: packageIdentity.stagedVersion,
+    },
+    fileCount: staged.artifact.files.length,
+    previousFileCount: baseline.artifact?.files.length ?? 0,
+    artifacts: details.artifacts,
+    diff,
+    ruleFindings,
+    risk: computeRisk(ruleFindings),
+  };
+}
+
+export { GO_RELEASE_MANIFEST_SCHEMA, GO_RULE_IDS, GO_RULES_VERSION } from "./types";
+export type {
+  GoAdapterInput,
+  GoArtifactInput,
+  GoPreparedArtifact,
+  GoReleaseCandidateReview,
+  GoReleaseManifest,
+} from "./types";
+export {
+  inferGoArtifactKind,
+  isValidGoModulePath,
+  isValidGoVersion,
+  parseGoModFile,
+  parseGoModuleZipRoot,
+  parseGoReleaseManifest,
+} from "./manifest";
+export { compareGoVersions, pickGoBaselineVersion, prepareGoArtifact } from "./acquire";
+export { escapeGoModulePath, goProxyZipUrl, isAllowedGoProxyArtifactUrl } from "./broker";

--- a/server/lib/adapters/gomod/manifest.ts
+++ b/server/lib/adapters/gomod/manifest.ts
@@ -1,0 +1,145 @@
+import type { FileRecord } from "../../review";
+import { isRecord, isSafeManifestPath, parseArtifactFilesInputs } from "../artifact-input";
+import {
+  GO_ARTIFACT_LIMIT,
+  GO_MODULE_PATH_RE,
+  GO_RELEASE_MANIFEST_SCHEMA,
+  GO_VERSION_RE,
+  SHA256_RE,
+  type GoAdapterInput,
+  type GoArtifactKind,
+  type GoModuleSummary,
+  type GoReleaseManifest,
+} from "./types";
+
+export function isValidGoModulePath(path: string): boolean {
+  return (
+    typeof path === "string" &&
+    path.length > 0 &&
+    path.length <= 512 &&
+    !path.includes("..") &&
+    GO_MODULE_PATH_RE.test(path)
+  );
+}
+
+export function isValidGoVersion(version: string): boolean {
+  return typeof version === "string" && GO_VERSION_RE.test(version);
+}
+
+export function inferGoArtifactKind(path: string): GoArtifactKind | null {
+  return path.toLowerCase().endsWith(".zip") ? "module" : null;
+}
+
+export function parseGoReleaseManifest(value: unknown): GoReleaseManifest {
+  if (!isRecord(value)) throw new Error("manifest must be an object");
+  if (value.schema !== GO_RELEASE_MANIFEST_SCHEMA) {
+    throw new Error(`manifest schema must be ${GO_RELEASE_MANIFEST_SCHEMA}`);
+  }
+  if (value.ecosystem !== "go") throw new Error("manifest ecosystem must be go");
+  const modulePath = String(value.package || "");
+  const version = String(value.version || "");
+  if (!isValidGoModulePath(modulePath)) {
+    throw new Error("manifest package is not a valid Go module path");
+  }
+  if (!isValidGoVersion(version)) {
+    throw new Error("manifest version is not a canonical Go semver version");
+  }
+  if (!Array.isArray(value.artifacts) || !value.artifacts.length) {
+    throw new Error("manifest must include at least one artifact");
+  }
+  if (value.artifacts.length > GO_ARTIFACT_LIMIT) {
+    throw new Error(`manifest must include no more than ${GO_ARTIFACT_LIMIT} artifacts`);
+  }
+
+  const artifacts = value.artifacts.map((artifact, index) => {
+    if (!isRecord(artifact)) throw new Error(`artifact ${index + 1} must be an object`);
+    const path = String(artifact.path || "");
+    if (!isSafeManifestPath(path)) throw new Error(`artifact ${index + 1} path is not safe`);
+    const kind = inferGoArtifactKind(path);
+    if (!kind) throw new Error(`artifact ${index + 1} must be a module .zip archive`);
+    const sha256 = String(artifact.sha256 || "");
+    if (!SHA256_RE.test(sha256))
+      throw new Error(`artifact ${index + 1} sha256 must be a hex SHA-256 digest`);
+    return { path, sha256: sha256.toLowerCase(), kind };
+  });
+
+  return {
+    schema: GO_RELEASE_MANIFEST_SCHEMA,
+    ecosystem: "go",
+    package: modulePath,
+    version,
+    artifacts,
+  };
+}
+
+export function parseGoAdapterInput(raw: unknown): GoAdapterInput {
+  if (!isRecord(raw)) throw new Error("Go adapter input must be an object");
+  const manifest = parseGoReleaseManifest(raw.manifest ?? raw);
+  return {
+    manifest,
+    artifacts: parseArtifactFilesInputs(raw.artifacts, "artifacts"),
+    previousArtifacts:
+      raw.previousArtifacts === undefined
+        ? undefined
+        : parseArtifactFilesInputs(raw.previousArtifacts, "previousArtifacts"),
+    metadata: Array.isArray(raw.metadata)
+      ? raw.metadata.filter((entry): entry is string => typeof entry === "string")
+      : undefined,
+  };
+}
+
+/**
+ * Parse the `{module}@{version}/` root every Go module zip carries. All files
+ * must share the same root; a zip with inconsistent roots yields `null` (fail
+ * toward `metadata-missing`).
+ */
+export function parseGoModuleZipRoot(
+  files: FileRecord[],
+): { modulePath: string; version: string } | null {
+  let root: string | null = null;
+  for (const file of files) {
+    const at = file.path.indexOf("@");
+    if (at <= 0) return null;
+    const slash = file.path.indexOf("/", at);
+    if (slash < 0) return null;
+    const candidate = file.path.slice(0, slash);
+    if (root === null) root = candidate;
+    else if (root !== candidate) return null;
+  }
+  if (!root) return null;
+  const at = root.lastIndexOf("@");
+  const modulePath = root.slice(0, at);
+  const version = root.slice(at + 1);
+  if (!isValidGoModulePath(modulePath) || !isValidGoVersion(version)) return null;
+  return { modulePath, version };
+}
+
+/** Line-oriented reader for the facts the rules need from `go.mod`. */
+export function parseGoModFile(text: string): Pick<GoModuleSummary, "modulePath"> & {
+  replaceDirectives: string[];
+} {
+  let modulePath: string | null = null;
+  const replaceDirectives: string[] = [];
+  let inReplaceBlock = false;
+  for (const rawLine of text.replace(/\r\n/g, "\n").split("\n")) {
+    const line = rawLine.replace(/\/\/.*$/, "").trim();
+    if (!line) continue;
+    if (inReplaceBlock) {
+      if (line === ")") inReplaceBlock = false;
+      else replaceDirectives.push(line);
+      continue;
+    }
+    const moduleMatch = /^module\s+("?)([^\s"]+)\1$/.exec(line);
+    if (moduleMatch && modulePath === null) {
+      modulePath = moduleMatch[2];
+      continue;
+    }
+    if (/^replace\s*\($/.test(line)) {
+      inReplaceBlock = true;
+      continue;
+    }
+    const replaceMatch = /^replace\s+(.+)$/.exec(line);
+    if (replaceMatch) replaceDirectives.push(replaceMatch[1].trim());
+  }
+  return { modulePath, replaceDirectives };
+}

--- a/server/lib/adapters/gomod/types.ts
+++ b/server/lib/adapters/gomod/types.ts
@@ -1,0 +1,97 @@
+import type { DiffEntry, FileRecord, Finding, RiskLevel } from "../../review";
+import type { TarSuspiciousEntry } from "../../tar-parser.js";
+
+export const GO_RELEASE_MANIFEST_SCHEMA = "drydock.release-artifacts.v1";
+export const GO_RULES_VERSION = "0.1.0";
+
+export const GO_RULE_IDS = {
+  metadataMissing: "go.metadata-missing",
+  metadataMismatch: "go.metadata-mismatch",
+  goGenerateAdded: "go.generate-directive-added",
+  cgoIntroduced: "go.cgo-introduced",
+  unsafeUsageAdded: "go.unsafe-usage-added",
+  syscallUsageAdded: "go.syscall-usage-added",
+  replaceDirective: "go.replace-directive",
+} as const;
+
+// Module paths: slash-separated segments of ASCII letters, digits, and
+// `-._~`; the first segment must look like a domain (contain a dot).
+export const GO_MODULE_PATH_RE = /^[a-z0-9][a-z0-9.-]*\.[a-z0-9.-]+(?:\/[A-Za-z0-9._~-]+)*$/i;
+// Canonical semver as Go requires for tagged module versions.
+export const GO_VERSION_RE = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]{1,64})?(?:\+[0-9A-Za-z.-]{1,64})?$/;
+export const SHA256_RE = /^[a-f0-9]{64}$/i;
+export const GO_ARTIFACT_LIMIT = 20;
+
+export type GoArtifactKind = "module";
+
+export interface GoReleaseManifestArtifact {
+  path: string;
+  sha256: string;
+  kind: GoArtifactKind;
+}
+
+export interface GoReleaseManifest {
+  schema: typeof GO_RELEASE_MANIFEST_SCHEMA;
+  ecosystem: "go";
+  /** Module path, e.g. `github.com/user/repo`. */
+  package: string;
+  /** Canonical semver version, e.g. `v1.2.3`. */
+  version: string;
+  artifacts: GoReleaseManifestArtifact[];
+}
+
+export interface GoArtifactInput {
+  path: string;
+  files: FileRecord[];
+  suspiciousEntries?: TarSuspiciousEntry[];
+}
+
+export interface GoModuleSummary {
+  /** `module` line from go.mod. */
+  modulePath: string | null;
+  /** Module path + version parsed from the zip's `{module}@{version}/` root. */
+  rootModulePath: string | null;
+  rootVersion: string | null;
+  replaceDirectives: string[];
+}
+
+export interface GoArtifactSummary {
+  path: string;
+  kind: GoArtifactKind;
+  goModPath: string | null;
+  module: GoModuleSummary;
+}
+
+export interface GoPreparedArtifact extends GoArtifactInput {
+  kind: GoArtifactKind;
+  summary: GoArtifactSummary;
+}
+
+export interface GoAdapterInput {
+  manifest: GoReleaseManifest;
+  artifacts: GoArtifactInput[];
+  previousArtifacts?: GoArtifactInput[];
+  /** Pre-fetched `proxy.golang.org` `@v/list` versions, for tests. */
+  metadata?: string[];
+}
+
+export interface GoAdapterDetails {
+  manifest: GoReleaseManifest;
+  artifacts: GoArtifactSummary[];
+  preparedArtifacts: GoPreparedArtifact[];
+}
+
+export interface GoReleaseCandidateReview {
+  ecosystem: "go";
+  manifest: GoReleaseManifest;
+  package: {
+    name: string | null;
+    version: string | null;
+  };
+  fileCount: number;
+  previousFileCount: number;
+  artifacts: GoArtifactSummary[];
+  diff: DiffEntry[];
+  ruleFindings: Finding[];
+  risk: RiskLevel;
+}

--- a/server/lib/adapters/types.ts
+++ b/server/lib/adapters/types.ts
@@ -36,7 +36,13 @@ export interface AcquiredArtifact {
 // Opaque to the pipeline — the adapter is the only thing that interprets it.
 export type StagedDetails = unknown;
 
-export type ReleaseProvenanceArtifactKind = "tarball" | "wheel" | "sdist" | "vsix";
+export type ReleaseProvenanceArtifactKind =
+  | "tarball"
+  | "wheel"
+  | "sdist"
+  | "vsix"
+  | "crate"
+  | "module";
 
 // One reviewed release artifact bound to the SHA-256 the control plane
 // recomputed from its immutable bytes.
@@ -53,7 +59,7 @@ export interface ReleaseProvenanceArtifact {
 // uniformly across ecosystems in the report "Provenance" section and surfaced in
 // the report export so a maintainer's CI can verify against it.
 export interface ReleaseProvenance {
-  ecosystem: "npm" | "pypi" | "vscode";
+  ecosystem: "npm" | "pypi" | "vscode" | "crates" | "go";
   mode: "workflow_gate";
   artifacts: ReleaseProvenanceArtifact[];
 }

--- a/server/lib/github-app/config.ts
+++ b/server/lib/github-app/config.ts
@@ -9,7 +9,7 @@ export interface GithubAppEnv {
   BETTER_AUTH_SECRET: string;
 }
 
-export const SUPPORTED_ECOSYSTEMS = ["pypi", "npm", "vscode"] as const;
+export const SUPPORTED_ECOSYSTEMS = ["pypi", "npm", "vscode", "crates", "go"] as const;
 export type SupportedEcosystem = (typeof SUPPORTED_ECOSYSTEMS)[number];
 
 export const INSTALLATION_STATUSES = ["active", "suspended", "uninstalled"] as const;

--- a/server/lib/report-export.ts
+++ b/server/lib/report-export.ts
@@ -142,7 +142,11 @@ function extractProvenance(stagedPublish: unknown): ReleaseProvenance | null {
   if (!isRecord(provenance)) return null;
   const { ecosystem, mode, artifacts } = provenance;
   if (
-    (ecosystem !== "npm" && ecosystem !== "pypi" && ecosystem !== "vscode") ||
+    (ecosystem !== "npm" &&
+      ecosystem !== "pypi" &&
+      ecosystem !== "vscode" &&
+      ecosystem !== "crates" &&
+      ecosystem !== "go") ||
     mode !== "workflow_gate"
   ) {
     return null;
@@ -153,7 +157,14 @@ function extractProvenance(stagedPublish: unknown): ReleaseProvenance | null {
     if (!isRecord(artifact)) return null;
     const { path, kind, sha256 } = artifact;
     if (typeof path !== "string" || typeof sha256 !== "string") return null;
-    if (kind === "tarball" || kind === "wheel" || kind === "sdist" || kind === "vsix") {
+    if (
+      kind === "tarball" ||
+      kind === "wheel" ||
+      kind === "sdist" ||
+      kind === "vsix" ||
+      kind === "crate" ||
+      kind === "module"
+    ) {
       mapped.push({ path, kind, sha256 });
       continue;
     }

--- a/server/lib/review-rules/patterns.ts
+++ b/server/lib/review-rules/patterns.ts
@@ -92,6 +92,76 @@ const PYTHON_CREDENTIAL_ACCESS_PATTERNS = [
   /\.ssh\/id_/,
   /\.netrc/,
 ];
+const RUST_PROCESS_EXECUTION_PATTERNS = [
+  /\bprocess::Command\b/,
+  /\bCommand::new\s*\(/,
+  /\bstd::process\b/,
+  /\bcurl\s/,
+  /\bwget\s/,
+  /\bbash\s+-c/,
+  /\bpowershell\s/,
+];
+const RUST_NETWORK_ACCESS_PATTERNS = [
+  /\bstd::net\b/,
+  /\bTcpStream::connect\s*\(/,
+  /\bUdpSocket::bind\s*\(/,
+  /\breqwest::/,
+  /\bureq::/,
+  /\bhyper::Client\b/,
+];
+const RUST_DYNAMIC_EVALUATION_PATTERNS = [
+  // Rust has no eval; the equivalent capability is loading native code at
+  // runtime or decoding an embedded payload before handing it to one of the
+  // process/network sinks above.
+  /\blibloading\b/,
+  /\bdlopen\b/,
+  /\bLibrary::new\s*\(/,
+  /\bbase64::decode\s*\(/,
+  /\bSTANDARD\.decode\s*\(/,
+  /\bfrom_hex\s*\(/,
+];
+const RUST_CREDENTIAL_ACCESS_PATTERNS = [
+  /\benv::var(?:_os)?\s*\(/,
+  /\bstd::env\b/,
+  /\bCARGO_REGISTRY_TOKEN\b/,
+  /\bGITHUB_TOKEN\b/,
+  /\bAWS_SECRET\b/,
+  /\.aws\/credentials/,
+  /\.ssh\/id_/,
+  /\.netrc/,
+];
+const GO_PROCESS_EXECUTION_PATTERNS = [
+  /"os\/exec"/,
+  /\bexec\.Command(?:Context)?\s*\(/,
+  /\bsyscall\.Exec\s*\(/,
+  /\bcurl\s/,
+  /\bwget\s/,
+  /\bbash\s+-c/,
+  /\bpowershell\s/,
+];
+const GO_NETWORK_ACCESS_PATTERNS = [
+  /"net\/http"/,
+  /\bhttp\.(?:Get|Post|PostForm|NewRequest)\s*\(/,
+  /\bnet\.(?:Dial|DialTimeout|Listen)\s*\(/,
+  /\bwebsocket\./,
+];
+const GO_DYNAMIC_EVALUATION_PATTERNS = [
+  // Go has no eval; the equivalent capability is loading code at runtime or
+  // decoding an embedded payload before handing it to a process/network sink.
+  /\bplugin\.Open\s*\(/,
+  /\bbase64\.(?:Std|URL|RawStd|RawURL)Encoding\.DecodeString\s*\(/,
+  /\bhex\.DecodeString\s*\(/,
+];
+const GO_CREDENTIAL_ACCESS_PATTERNS = [
+  /\bos\.Getenv\s*\(/,
+  /\bos\.LookupEnv\s*\(/,
+  /\bos\.Environ\s*\(/,
+  /\bGITHUB_TOKEN\b/,
+  /\bAWS_SECRET\b/,
+  /\.aws\/credentials/,
+  /\.ssh\/id_/,
+  /\.netrc/,
+];
 
 export const JS_PATTERN_SET = {
   processExecution: JS_PROCESS_EXECUTION_PATTERNS,
@@ -104,6 +174,18 @@ export const PYTHON_PATTERN_SET = {
   networkAccess: PYTHON_NETWORK_ACCESS_PATTERNS,
   dynamicEvaluation: PYTHON_DYNAMIC_EVALUATION_PATTERNS,
   credentialAccess: PYTHON_CREDENTIAL_ACCESS_PATTERNS,
+};
+export const RUST_PATTERN_SET = {
+  processExecution: RUST_PROCESS_EXECUTION_PATTERNS,
+  networkAccess: RUST_NETWORK_ACCESS_PATTERNS,
+  dynamicEvaluation: RUST_DYNAMIC_EVALUATION_PATTERNS,
+  credentialAccess: RUST_CREDENTIAL_ACCESS_PATTERNS,
+};
+export const GO_PATTERN_SET = {
+  processExecution: GO_PROCESS_EXECUTION_PATTERNS,
+  networkAccess: GO_NETWORK_ACCESS_PATTERNS,
+  dynamicEvaluation: GO_DYNAMIC_EVALUATION_PATTERNS,
+  credentialAccess: GO_CREDENTIAL_ACCESS_PATTERNS,
 };
 
 // Python process-execution, network, and dynamic-evaluation capability in one set.
@@ -152,5 +234,8 @@ function genericSecretPatterns(): Array<[RegExp, string]> {
 }
 
 export function codePatternsFor(codePatternSet: CodePatternSet | undefined): typeof JS_PATTERN_SET {
-  return codePatternSet === "python" ? PYTHON_PATTERN_SET : JS_PATTERN_SET;
+  if (codePatternSet === "python") return PYTHON_PATTERN_SET;
+  if (codePatternSet === "rust") return RUST_PATTERN_SET;
+  if (codePatternSet === "go") return GO_PATTERN_SET;
+  return JS_PATTERN_SET;
 }

--- a/server/lib/review-rules/scripts.ts
+++ b/server/lib/review-rules/scripts.ts
@@ -136,10 +136,10 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
     // `globalThis['re'+'quire']`) so the literal regex set sees them. Matching
     // both raw and normalized text means folding can only add detections, never
     // drop one a literal scan already finds. JavaScript only for now; the
-    // normalizer is JS-flavored and Python evasion is out of scope.
-    const normalized = ctx.codePatternSet === "python" ? sample : normalizeCodeForScanning(sample);
-    const packedObfuscation =
-      ctx.codePatternSet !== "python" && hasRotatingStringTableObfuscation(sample);
+    // normalizer is JS-flavored and evasion in other languages is out of scope.
+    const jsFlavored = ctx.codePatternSet === undefined || ctx.codePatternSet === "javascript";
+    const normalized = jsFlavored ? normalizeCodeForScanning(sample) : sample;
+    const packedObfuscation = jsFlavored && hasRotatingStringTableObfuscation(sample);
     const prefix = changedPrefix(ctx, file.path);
     const changed = ctx.diffByPath.get(file.path)?.status;
     const lifecycleScriptFile = isLifecycleScriptFile(ctx, file.path);
@@ -166,10 +166,10 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
       packedObfuscation,
       true,
     );
-    const credentialSample =
-      ctx.codePatternSet === "python" ? sample : omitCommonEnvironmentAccesses(sample);
-    const credentialNormalized =
-      ctx.codePatternSet === "python" ? normalized : omitCommonEnvironmentAccesses(normalized);
+    const credentialSample = jsFlavored ? omitCommonEnvironmentAccesses(sample) : sample;
+    const credentialNormalized = jsFlavored
+      ? omitCommonEnvironmentAccesses(normalized)
+      : normalized;
     const credentialAccess = matchCategory(
       ctx.patterns.credentialAccess,
       credentialSample,

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -41,7 +41,7 @@ export interface FindingDiffAnnotation {
   releaseDelta: boolean;
 }
 
-export type CodePatternSet = "javascript" | "python";
+export type CodePatternSet = "javascript" | "python" | "rust" | "go";
 
 export interface FindingAnnotationOptions {
   previousFiles?: Array<Pick<FileRecord, "path" | "textSample" | "flags">>;

--- a/server/lib/workflow-gates/crates.ts
+++ b/server/lib/workflow-gates/crates.ts
@@ -1,0 +1,146 @@
+import {
+  cratesAdapter,
+  CRATES_RELEASE_MANIFEST_SCHEMA,
+  inferCratesArtifactKind,
+  parseCratesReleaseManifest,
+  prepareCratesArtifact,
+  type CratesArtifactInput,
+  type CratesPreparedArtifact,
+  type CratesReleaseManifest,
+} from "../adapters/crates/index";
+import type { AdapterBroker, PackageAdapter } from "../adapters/types";
+import { WorkflowArtifactError } from "../github-app/artifacts";
+import type {
+  ArchiveContents,
+  ParsedGateArtifact,
+  PreparedReleaseCandidate,
+  WorkflowArtifactKind,
+  WorkflowGateAdapter,
+} from "./types";
+
+/**
+ * crates.io workflow-gate adapter.
+ *
+ * The release set is whatever `cargo package` `.crate` archives (gzipped tars)
+ * the workflow uploads. Identity (`package`/`version`) is read from each
+ * crate's normalized `Cargo.toml` after the bytes are parsed in the shared
+ * sandbox router. The deterministic review and baseline selection live in the
+ * shared `cratesAdapter` (`server/lib/adapters/crates`); this adapter only owns
+ * the gate-time artifact semantics.
+ */
+export const cratesWorkflowGateAdapter: WorkflowGateAdapter = {
+  ecosystem: "crates",
+  artifactName: "crates-release-candidate",
+  packageAdapter: cratesAdapter as PackageAdapter<unknown, AdapterBroker>,
+
+  classifyArtifact(path: string): WorkflowArtifactKind | null {
+    return inferCratesArtifactKind(path);
+  },
+
+  detectArtifact(contents: ArchiveContents): WorkflowArtifactKind | null {
+    // `cargo package` writes the pre-normalization manifest back as
+    // `Cargo.toml.orig` next to the normalized `Cargo.toml` under the single
+    // `{name}-{version}/` root. A vendored Cargo.toml deeper inside an npm
+    // tarball must not claim the archive, so only the root placement counts.
+    return contents.files.some((file) => isCrateRootManifestPath(file.path)) ? "crate" : null;
+  },
+
+  prepareReleaseCandidates(artifacts: ParsedGateArtifact[]): PreparedReleaseCandidate[] {
+    const entries: PreparedArtifactEntry[] = artifacts.map((artifact) => {
+      const input: CratesArtifactInput = {
+        path: artifact.path,
+        files: artifact.files,
+        ...(artifact.suspiciousEntries ? { suspiciousEntries: artifact.suspiciousEntries } : {}),
+      };
+      return { artifact, input, prepared: prepareCratesArtifact(input) };
+    });
+    return deriveReleaseCandidates(entries);
+  },
+};
+
+interface PreparedArtifactEntry {
+  artifact: ParsedGateArtifact;
+  input: CratesArtifactInput;
+  prepared: CratesPreparedArtifact;
+}
+
+/**
+ * Split the bundle's `.crate` archives into one candidate per distinct crate.
+ *
+ * A cargo workspace publishes several crates from one release, so archives are
+ * grouped by their `Cargo.toml` name and each group becomes its own candidate →
+ * its own scan against its own baseline. Every archive must expose a
+ * `name`/`version`, and a single crate version is exactly one archive, so a
+ * metadata-less or duplicated archive is rejected rather than silently shipped.
+ */
+function deriveReleaseCandidates(entries: PreparedArtifactEntry[]): PreparedReleaseCandidate[] {
+  const groups = new Map<string, { version: string; entries: PreparedArtifactEntry[] }>();
+  for (const entry of entries) {
+    const { manifest } = entry.prepared.summary;
+    if (!manifest.name || !manifest.version) {
+      throw new WorkflowArtifactError(
+        "artifact_identity_missing",
+        `${entry.artifact.path} does not expose a Cargo.toml name/version`,
+      );
+    }
+    const group = groups.get(manifest.name);
+    if (!group) {
+      groups.set(manifest.name, { version: manifest.version, entries: [entry] });
+      continue;
+    }
+    if (manifest.version !== group.version) {
+      throw new WorkflowArtifactError(
+        "artifact_identity_inconsistent",
+        `${entry.artifact.path} version ${manifest.version} disagrees with ${group.version} for ${manifest.name}`,
+      );
+    }
+    // A single published crate version maps to exactly one `.crate`; two
+    // archives claiming the same name+version is ambiguous and must not ship.
+    throw new WorkflowArtifactError(
+      "artifact_identity_inconsistent",
+      `crate ${manifest.name} has more than one .crate archive in this release`,
+    );
+  }
+
+  // `entries` is non-empty: the resolver throws `bundle_empty` for a bundle
+  // with no reviewable artifacts, so `groups` always has at least one crate.
+  return [...groups.entries()].map(([name, group]) => {
+    const manifest = buildReleaseManifest(
+      name,
+      group.version,
+      group.entries.map((entry) => entry.artifact),
+    );
+    return {
+      ecosystem: "crates",
+      pipelineInput: { manifest, artifacts: group.entries.map((entry) => entry.input) },
+      package: { name: manifest.package, version: manifest.version },
+    };
+  });
+}
+
+function buildReleaseManifest(
+  name: string,
+  version: string,
+  files: ParsedGateArtifact[],
+): CratesReleaseManifest {
+  const candidate = {
+    schema: CRATES_RELEASE_MANIFEST_SCHEMA,
+    ecosystem: "crates",
+    package: name,
+    version,
+    artifacts: files.map((file) => ({ path: file.path, sha256: file.sha256 })),
+  };
+  try {
+    return parseCratesReleaseManifest(candidate);
+  } catch (err) {
+    throw new WorkflowArtifactError(
+      "artifact_identity_missing",
+      err instanceof Error ? err.message : "derived release identity is not valid",
+    );
+  }
+}
+
+function isCrateRootManifestPath(path: string): boolean {
+  const parts = path.split("/");
+  return parts.length === 2 && parts[1] === "Cargo.toml.orig";
+}

--- a/server/lib/workflow-gates/go.ts
+++ b/server/lib/workflow-gates/go.ts
@@ -1,0 +1,143 @@
+import {
+  GO_RELEASE_MANIFEST_SCHEMA,
+  goAdapter,
+  inferGoArtifactKind,
+  parseGoModuleZipRoot,
+  parseGoReleaseManifest,
+  prepareGoArtifact,
+  type GoArtifactInput,
+  type GoPreparedArtifact,
+  type GoReleaseManifest,
+} from "../adapters/gomod/index";
+import type { AdapterBroker, PackageAdapter } from "../adapters/types";
+import { WorkflowArtifactError } from "../github-app/artifacts";
+import type {
+  ArchiveContents,
+  ParsedGateArtifact,
+  PreparedReleaseCandidate,
+  WorkflowArtifactKind,
+  WorkflowGateAdapter,
+} from "./types";
+
+/**
+ * Go modules workflow-gate adapter.
+ *
+ * Go has no publish step — the "release" is the tag plus the module proxy's
+ * first fetch — so the gate pauses the tag/release workflow instead of an
+ * upload. The reviewable artifact is the module zip the workflow builds (e.g.
+ * `go mod pack`-style zips produced with `golang.org/x/mod/zip`); identity
+ * comes from the zip's mandatory `{module}@{version}/` root and its `go.mod`.
+ * The deterministic review and proxy.golang.org baseline live in the shared
+ * `goAdapter` (`server/lib/adapters/gomod`); this adapter only owns the
+ * gate-time artifact semantics.
+ */
+export const goWorkflowGateAdapter: WorkflowGateAdapter = {
+  ecosystem: "go",
+  artifactName: "go-release-candidate",
+  packageAdapter: goAdapter as PackageAdapter<unknown, AdapterBroker>,
+
+  classifyArtifact(path: string): WorkflowArtifactKind | null {
+    return inferGoArtifactKind(path);
+  },
+
+  detectArtifact(contents: ArchiveContents): WorkflowArtifactKind | null {
+    // Every valid module zip roots all files under a single
+    // `{module}@{version}/` directory; nothing else produces that shape.
+    return parseGoModuleZipRoot(contents.files) ? "module" : null;
+  },
+
+  prepareReleaseCandidates(artifacts: ParsedGateArtifact[]): PreparedReleaseCandidate[] {
+    const entries: PreparedArtifactEntry[] = artifacts.map((artifact) => {
+      const input: GoArtifactInput = {
+        path: artifact.path,
+        files: artifact.files,
+        ...(artifact.suspiciousEntries ? { suspiciousEntries: artifact.suspiciousEntries } : {}),
+      };
+      return { artifact, input, prepared: prepareGoArtifact(input) };
+    });
+    return deriveReleaseCandidates(entries);
+  },
+};
+
+interface PreparedArtifactEntry {
+  artifact: ParsedGateArtifact;
+  input: GoArtifactInput;
+  prepared: GoPreparedArtifact;
+}
+
+/**
+ * Split the bundle's module zips into one candidate per distinct module.
+ *
+ * A multi-module repository can tag several modules from one release, so zips
+ * are grouped by the module path parsed from their `{module}@{version}/` root
+ * and each group becomes its own candidate → its own scan against its own
+ * baseline. Every zip must expose that root, and a single module version is
+ * exactly one zip, so an identity-less or duplicated zip is rejected rather
+ * than silently shipped.
+ */
+function deriveReleaseCandidates(entries: PreparedArtifactEntry[]): PreparedReleaseCandidate[] {
+  const groups = new Map<string, { version: string; entries: PreparedArtifactEntry[] }>();
+  for (const entry of entries) {
+    const { module } = entry.prepared.summary;
+    if (!module.rootModulePath || !module.rootVersion) {
+      throw new WorkflowArtifactError(
+        "artifact_identity_missing",
+        `${entry.artifact.path} does not expose a {module}@{version} zip root`,
+      );
+    }
+    const group = groups.get(module.rootModulePath);
+    if (!group) {
+      groups.set(module.rootModulePath, { version: module.rootVersion, entries: [entry] });
+      continue;
+    }
+    if (module.rootVersion !== group.version) {
+      throw new WorkflowArtifactError(
+        "artifact_identity_inconsistent",
+        `${entry.artifact.path} version ${module.rootVersion} disagrees with ${group.version} for ${module.rootModulePath}`,
+      );
+    }
+    // A single module version maps to exactly one zip; two zips claiming the
+    // same module+version is ambiguous and must not ship.
+    throw new WorkflowArtifactError(
+      "artifact_identity_inconsistent",
+      `module ${module.rootModulePath} has more than one zip in this release`,
+    );
+  }
+
+  // `entries` is non-empty: the resolver throws `bundle_empty` for a bundle
+  // with no reviewable artifacts, so `groups` always has at least one module.
+  return [...groups.entries()].map(([modulePath, group]) => {
+    const manifest = buildReleaseManifest(
+      modulePath,
+      group.version,
+      group.entries.map((entry) => entry.artifact),
+    );
+    return {
+      ecosystem: "go",
+      pipelineInput: { manifest, artifacts: group.entries.map((entry) => entry.input) },
+      package: { name: manifest.package, version: manifest.version },
+    };
+  });
+}
+
+function buildReleaseManifest(
+  modulePath: string,
+  version: string,
+  files: ParsedGateArtifact[],
+): GoReleaseManifest {
+  const candidate = {
+    schema: GO_RELEASE_MANIFEST_SCHEMA,
+    ecosystem: "go",
+    package: modulePath,
+    version,
+    artifacts: files.map((file) => ({ path: file.path, sha256: file.sha256 })),
+  };
+  try {
+    return parseGoReleaseManifest(candidate);
+  } catch (err) {
+    throw new WorkflowArtifactError(
+      "artifact_identity_missing",
+      err instanceof Error ? err.message : "derived release identity is not valid",
+    );
+  }
+}

--- a/server/lib/workflow-gates/registry.ts
+++ b/server/lib/workflow-gates/registry.ts
@@ -1,3 +1,5 @@
+import { cratesWorkflowGateAdapter } from "./crates";
+import { goWorkflowGateAdapter } from "./go";
 import { npmWorkflowGateAdapter } from "./npm";
 import { pypiWorkflowGateAdapter } from "./pypi";
 import { vscodeWorkflowGateAdapter } from "./vscode";
@@ -28,6 +30,8 @@ const WORKFLOW_GATE_ADAPTERS: Record<string, WorkflowGateAdapter> = {
   [pypiWorkflowGateAdapter.ecosystem]: pypiWorkflowGateAdapter,
   [npmWorkflowGateAdapter.ecosystem]: npmWorkflowGateAdapter,
   [vscodeWorkflowGateAdapter.ecosystem]: vscodeWorkflowGateAdapter,
+  [cratesWorkflowGateAdapter.ecosystem]: cratesWorkflowGateAdapter,
+  [goWorkflowGateAdapter.ecosystem]: goWorkflowGateAdapter,
 };
 
 /** Resolve the workflow-gate adapter for a release target's ecosystem. */

--- a/server/lib/workflow-gates/resolve.ts
+++ b/server/lib/workflow-gates/resolve.ts
@@ -30,9 +30,10 @@ export async function resolveBundleArtifacts(
     const lowerPath = file.path.toLowerCase();
     // Wheels stream through the zip reader; VSIX archives are yazl-packed
     // with data-descriptor entries and must take the buffered CD-first path.
+    // Go modules ship as .zip and take the same zip reader.
     const format = lowerPath.endsWith(".vsix")
       ? "vsix"
-      : lowerPath.endsWith(".whl")
+      : lowerPath.endsWith(".whl") || lowerPath.endsWith(".zip")
         ? "zip"
         : "tgz";
     const parsed = await downloadInSandboxInline(env, ctx, { bytes: file.bytes, format });
@@ -45,7 +46,7 @@ export async function resolveBundleArtifacts(
       if (claims.length === 0) {
         throw new WorkflowArtifactError(
           "artifact_identity_missing",
-          `${file.path} is not a recognizable npm or PyPI release artifact`,
+          `${file.path} is not a release artifact any registered ecosystem recognizes`,
         );
       }
       if (claims.length > 1) {

--- a/src/models/github-app.ts
+++ b/src/models/github-app.ts
@@ -16,7 +16,7 @@ export interface PublicGithubAppInstallation {
   updatedAt: string;
 }
 
-export type SupportedEcosystem = "pypi" | "npm" | "vscode";
+export type SupportedEcosystem = "pypi" | "npm" | "vscode" | "crates" | "go";
 
 export interface PublicReleaseTarget {
   id: string;

--- a/src/pages/Dashboard/ScanDetail/ReportSections.tsx
+++ b/src/pages/Dashboard/ScanDetail/ReportSections.tsx
@@ -82,12 +82,14 @@ function ReportSection({
 }
 
 function ProvenanceView({ provenance }: { provenance: ReleaseProvenance }) {
-  const ecosystem =
-    provenance.ecosystem === "pypi"
-      ? "PyPI"
-      : provenance.ecosystem === "vscode"
-        ? "VS Code"
-        : "npm";
+  const ecosystemLabels: Record<ReleaseProvenance["ecosystem"], string> = {
+    npm: "npm",
+    pypi: "PyPI",
+    vscode: "VS Code",
+    crates: "crates.io",
+    go: "Go module",
+  };
+  const ecosystem = ecosystemLabels[provenance.ecosystem] ?? provenance.ecosystem;
   return (
     <div class="flex flex-col gap-3">
       <p class="m-0 text-[13px] leading-[1.6] text-ink-muted">

--- a/test/crates.test.mjs
+++ b/test/crates.test.mjs
@@ -1,0 +1,290 @@
+import { describe, expect, test } from "vitest";
+import {
+  createCratesReleaseCandidateReview,
+  cratesAdapter,
+  cratesIndexPath,
+  cratesStaticArtifactUrl,
+  inferCratesArtifactKind,
+  isAllowedCratesArtifactUrl,
+  parseCargoManifest,
+  parseCratesReleaseManifest,
+  pickCratesBaselineVersion,
+  prepareCratesArtifact,
+} from "../server/lib/adapters/crates/index.ts";
+import { acquireBaselineCrates } from "../server/lib/adapters/crates/acquire.ts";
+
+function file(path, textSample, extra = {}) {
+  return {
+    path,
+    size: textSample.length,
+    sha256: `sha-${path}-${textSample.length}`,
+    flags: [],
+    textSample,
+    ...extra,
+  };
+}
+
+const adapterCtx = { env: {}, executionCtx: {}, db: {}, session: { userId: "user_1" } };
+
+function cargoToml(version, extra = "") {
+  return `[package]\nname = "demo-crate"\nversion = "${version}"\n${extra}`;
+}
+
+function crateFiles(version, { manifestExtra = "", extraFiles = [] } = {}) {
+  return [
+    file(`demo-crate-${version}/Cargo.toml`, cargoToml(version, manifestExtra)),
+    file(`demo-crate-${version}/src/lib.rs`, "pub fn value() -> u32 { 1 }\n"),
+    ...extraFiles.map((entry) => ({ ...entry, path: `demo-crate-${version}/${entry.path}` })),
+  ];
+}
+
+function manifestFor(version, path = `demo-crate-${version}.crate`) {
+  return {
+    schema: "drydock.release-artifacts.v1",
+    ecosystem: "crates",
+    package: "demo-crate",
+    version,
+    artifacts: [{ path, sha256: "a".repeat(64) }],
+  };
+}
+
+describe("crates release manifests", () => {
+  test("validates manifest shape and artifact kinds", () => {
+    const manifest = parseCratesReleaseManifest(manifestFor("1.2.0"));
+    expect(manifest.package).toBe("demo-crate");
+    expect(manifest.artifacts[0].kind).toBe("crate");
+    expect(inferCratesArtifactKind("demo-1.0.0.tar.gz")).toBeNull();
+    expect(inferCratesArtifactKind("demo-1.0.0.crate")).toBe("crate");
+  });
+
+  test("rejects unsafe paths and invalid names", () => {
+    expect(() =>
+      parseCratesReleaseManifest({
+        ...manifestFor("1.0.0"),
+        artifacts: [{ path: "../demo-1.0.0.crate", sha256: "a".repeat(64) }],
+      }),
+    ).toThrow(/path is not safe/);
+    expect(() => parseCratesReleaseManifest({ ...manifestFor("1.0.0"), package: "9bad" })).toThrow(
+      /valid crates.io package name/,
+    );
+  });
+});
+
+describe("Cargo.toml parsing", () => {
+  test("reads name, version, links, build, proc-macro, and non-registry deps", () => {
+    const summary = parseCargoManifest(
+      [
+        "[package]",
+        'name = "demo-crate"',
+        'version = "1.2.0"',
+        'links = "zlib"',
+        'build = "custom-build.rs"',
+        "",
+        "[lib]",
+        "proc-macro = true",
+        "",
+        "[dependencies]",
+        'evil = { git = "https://example.com/evil.git" }',
+        'local = { path = "../local" }',
+        'serde = "1"',
+        "",
+        "[dependencies.other]",
+        'git = "https://example.com/other.git"',
+      ].join("\n"),
+    );
+    expect(summary.name).toBe("demo-crate");
+    expect(summary.version).toBe("1.2.0");
+    expect(summary.links).toBe("zlib");
+    expect(summary.buildValue).toBe("custom-build.rs");
+    expect(summary.procMacro).toBe(true);
+    expect(summary.nonRegistryDependencies).toEqual([
+      { name: "evil", source: "git", section: "dependencies" },
+      { name: "local", source: "path", section: "dependencies" },
+      { name: "other", source: "git", section: "dependencies" },
+    ]);
+  });
+
+  test("build = false disables the conventional build script", () => {
+    const summary = parseCargoManifest('[package]\nname = "x"\nversion = "1.0.0"\nbuild = false\n');
+    expect(summary.buildValue).toBe(false);
+  });
+});
+
+describe("crates artifact preparation", () => {
+  test("strips the {name}-{version} root and summarizes the manifest", () => {
+    const prepared = prepareCratesArtifact({
+      path: "demo-crate-1.2.0.crate",
+      files: crateFiles("1.2.0"),
+    });
+    expect(prepared.files.map((entry) => entry.path)).toEqual(["Cargo.toml", "src/lib.rs"]);
+    expect(prepared.summary.manifest.name).toBe("demo-crate");
+    expect(prepared.summary.manifest.version).toBe("1.2.0");
+    expect(prepared.summary.buildScriptPath).toBeNull();
+  });
+
+  test("rejects non-.crate artifacts", () => {
+    expect(() => prepareCratesArtifact({ path: "demo.tgz", files: [] })).toThrow(/\.crate/);
+  });
+});
+
+describe("crates release review", () => {
+  test("flags build script, proc-macro, links, and non-registry dep changes vs baseline", () => {
+    const review = createCratesReleaseCandidateReview({
+      manifest: manifestFor("1.2.0"),
+      artifacts: [
+        {
+          path: "demo-crate-1.2.0.crate",
+          files: crateFiles("1.2.0", {
+            manifestExtra:
+              'links = "zlib"\n\n[lib]\nproc-macro = true\n\n[dependencies]\nevil = { git = "https://example.com/evil.git" }\n',
+            extraFiles: [file("build.rs", 'fn main() { println!("cargo:rerun"); }\n')],
+          }),
+        },
+      ],
+      previousArtifacts: [{ path: "demo-crate-1.1.0.crate", files: crateFiles("1.1.0") }],
+    });
+
+    const ruleIds = review.ruleFindings.map((finding) => finding.ruleId);
+    expect(ruleIds).toContain("crates.build-script-added");
+    expect(ruleIds).toContain("crates.proc-macro-introduced");
+    expect(ruleIds).toContain("crates.links-changed");
+    expect(ruleIds).toContain("crates.non-registry-dependency");
+    expect(review.package).toEqual({ name: "demo-crate", version: "1.2.0" });
+  });
+
+  test("flags a changed build script between releases", () => {
+    const review = createCratesReleaseCandidateReview({
+      manifest: manifestFor("1.2.0"),
+      artifacts: [
+        {
+          path: "demo-crate-1.2.0.crate",
+          files: crateFiles("1.2.0", {
+            extraFiles: [file("build.rs", 'fn main() { std::process::Command::new("sh"); }\n')],
+          }),
+        },
+      ],
+      previousArtifacts: [
+        {
+          path: "demo-crate-1.1.0.crate",
+          files: crateFiles("1.1.0", {
+            extraFiles: [file("build.rs", "fn main() {}\n")],
+          }),
+        },
+      ],
+    });
+    expect(review.ruleFindings.map((finding) => finding.ruleId)).toContain(
+      "crates.build-script-changed",
+    );
+  });
+
+  test("flags metadata mismatch against the reviewed manifest", () => {
+    const review = createCratesReleaseCandidateReview({
+      manifest: manifestFor("1.2.0"),
+      artifacts: [{ path: "demo-crate-1.2.0.crate", files: crateFiles("9.9.9") }],
+    });
+    const mismatch = review.ruleFindings.find(
+      (finding) => finding.ruleId === "crates.metadata-mismatch",
+    );
+    expect(mismatch).toBeTruthy();
+    expect(mismatch.severity).toBe("critical");
+  });
+
+  test("uses rust code patterns for changed-line findings", () => {
+    const review = createCratesReleaseCandidateReview({
+      manifest: manifestFor("1.2.0"),
+      artifacts: [
+        {
+          path: "demo-crate-1.2.0.crate",
+          files: [
+            file("demo-crate-1.2.0/Cargo.toml", cargoToml("1.2.0")),
+            file(
+              "demo-crate-1.2.0/src/lib.rs",
+              'pub fn run() { std::process::Command::new("curl"); }\n',
+            ),
+          ],
+        },
+      ],
+    });
+    expect(
+      review.ruleFindings.some(
+        (finding) => finding.file === "src/lib.rs" && /process/i.test(finding.evidence ?? ""),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("crates baseline selection", () => {
+  test("picks the newest non-yanked index entry that is not the candidate", () => {
+    expect(
+      pickCratesBaselineVersion(
+        [
+          { vers: "1.0.0" },
+          { vers: "1.1.0" },
+          { vers: "1.2.0-broken", yanked: true },
+          { vers: "1.2.0" },
+        ],
+        "1.2.0",
+      ),
+    ).toBe("1.1.0");
+    expect(pickCratesBaselineVersion([{ vers: "1.0.0" }], "1.0.0")).toBeNull();
+  });
+
+  test("downloads the baseline crate from static.crates.io via the broker", async () => {
+    const calls = [];
+    const broker = {
+      async fetchIndexEntries() {
+        return [{ vers: "1.1.0" }, { vers: "1.2.0" }];
+      },
+      async downloadPublicArtifact(url) {
+        calls.push(url);
+        return { files: crateFiles("1.1.0"), packageJson: null };
+      },
+      dispose() {},
+    };
+    const input = cratesAdapter.parseInput({
+      manifest: manifestFor("1.2.0"),
+      artifacts: [{ path: "demo-crate-1.2.0.crate", files: crateFiles("1.2.0") }],
+    });
+    const result = await acquireBaselineCrates(adapterCtx, input, broker);
+    expect(calls).toEqual(["https://static.crates.io/crates/demo-crate/demo-crate-1.1.0.crate"]);
+    expect(result.baseline.version).toBe("1.1.0");
+    expect(result.baseline.source).toBe("latest-published");
+    expect(result.artifact.files.map((entry) => entry.path)).toContain("Cargo.toml");
+  });
+
+  test("returns an empty baseline when the index is unavailable", async () => {
+    const broker = {
+      async fetchIndexEntries() {
+        return null;
+      },
+      async downloadPublicArtifact() {
+        throw new Error("unexpected download");
+      },
+      dispose() {},
+    };
+    const input = cratesAdapter.parseInput({
+      manifest: manifestFor("1.2.0"),
+      artifacts: [{ path: "demo-crate-1.2.0.crate", files: crateFiles("1.2.0") }],
+    });
+    const result = await acquireBaselineCrates(adapterCtx, input, broker);
+    expect(result.artifact).toBeNull();
+    expect(result.baseline.source).toBe("none");
+  });
+});
+
+describe("crates broker URL rules", () => {
+  test("sparse index paths follow the crates.io layout", () => {
+    expect(cratesIndexPath("a")).toBe("1/a");
+    expect(cratesIndexPath("ab")).toBe("2/ab");
+    expect(cratesIndexPath("abc")).toBe("3/a/abc");
+    expect(cratesIndexPath("Demo-Crate")).toBe("de/mo/demo-crate");
+  });
+
+  test("only https static.crates.io artifact URLs are allowed", () => {
+    expect(isAllowedCratesArtifactUrl(cratesStaticArtifactUrl("demo-crate", "1.1.0"))).toBe(true);
+    expect(isAllowedCratesArtifactUrl("https://example.com/demo-1.1.0.crate")).toBe(false);
+    expect(isAllowedCratesArtifactUrl("http://static.crates.io/crates/demo/demo-1.1.0.crate")).toBe(
+      false,
+    );
+  });
+});

--- a/test/gomod.test.mjs
+++ b/test/gomod.test.mjs
@@ -1,0 +1,272 @@
+import { describe, expect, test } from "vitest";
+import {
+  compareGoVersions,
+  createGoReleaseCandidateReview,
+  escapeGoModulePath,
+  goAdapter,
+  goProxyZipUrl,
+  inferGoArtifactKind,
+  isAllowedGoProxyArtifactUrl,
+  parseGoModFile,
+  parseGoModuleZipRoot,
+  parseGoReleaseManifest,
+  pickGoBaselineVersion,
+  prepareGoArtifact,
+} from "../server/lib/adapters/gomod/index.ts";
+import { acquireBaselineGo } from "../server/lib/adapters/gomod/acquire.ts";
+
+function file(path, textSample, extra = {}) {
+  return {
+    path,
+    size: textSample.length,
+    sha256: `sha-${path}-${textSample.length}`,
+    flags: [],
+    textSample,
+    ...extra,
+  };
+}
+
+const adapterCtx = { env: {}, executionCtx: {}, db: {}, session: { userId: "user_1" } };
+
+const MODULE = "github.com/octo/demo";
+
+function moduleFiles(version, { goMod, extraFiles = [] } = {}) {
+  const root = `${MODULE}@${version}`;
+  return [
+    file(`${root}/go.mod`, goMod ?? `module ${MODULE}\n\ngo 1.22\n`),
+    file(`${root}/main.go`, "package demo\n\nfunc Value() int { return 1 }\n"),
+    ...extraFiles.map((entry) => ({ ...entry, path: `${root}/${entry.path}` })),
+  ];
+}
+
+function manifestFor(version, path = `demo-${version}.zip`) {
+  return {
+    schema: "drydock.release-artifacts.v1",
+    ecosystem: "go",
+    package: MODULE,
+    version,
+    artifacts: [{ path, sha256: "a".repeat(64) }],
+  };
+}
+
+describe("Go release manifests", () => {
+  test("validates manifest shape and artifact kinds", () => {
+    const manifest = parseGoReleaseManifest(manifestFor("v1.2.0"));
+    expect(manifest.package).toBe(MODULE);
+    expect(manifest.artifacts[0].kind).toBe("module");
+    expect(inferGoArtifactKind("demo-v1.2.0.zip")).toBe("module");
+    expect(inferGoArtifactKind("demo-v1.2.0.tar.gz")).toBeNull();
+  });
+
+  test("rejects invalid module paths and non-canonical versions", () => {
+    expect(() => parseGoReleaseManifest({ ...manifestFor("v1.0.0"), package: "no-dot" })).toThrow(
+      /valid Go module path/,
+    );
+    expect(() => parseGoReleaseManifest({ ...manifestFor("v1.0.0"), version: "1.0.0" })).toThrow(
+      /canonical Go semver/,
+    );
+  });
+});
+
+describe("module zip root parsing", () => {
+  test("parses a consistent {module}@{version} root", () => {
+    expect(parseGoModuleZipRoot(moduleFiles("v1.2.0"))).toEqual({
+      modulePath: MODULE,
+      version: "v1.2.0",
+    });
+  });
+
+  test("returns null for inconsistent or missing roots", () => {
+    expect(
+      parseGoModuleZipRoot([
+        file(`${MODULE}@v1.2.0/go.mod`, `module ${MODULE}\n`),
+        file(`${MODULE}@v1.1.0/main.go`, "package demo\n"),
+      ]),
+    ).toBeNull();
+    expect(parseGoModuleZipRoot([file("go.mod", `module ${MODULE}\n`)])).toBeNull();
+  });
+});
+
+describe("go.mod parsing", () => {
+  test("reads the module path and replace directives (inline and block)", () => {
+    const parsed = parseGoModFile(
+      [
+        `module ${MODULE}`,
+        "",
+        "go 1.22",
+        "",
+        "replace example.com/a => ../local-a",
+        "",
+        "replace (",
+        "\texample.com/b => example.com/b-fork v1.0.0",
+        ")",
+      ].join("\n"),
+    );
+    expect(parsed.modulePath).toBe(MODULE);
+    expect(parsed.replaceDirectives).toEqual([
+      "example.com/a => ../local-a",
+      "example.com/b => example.com/b-fork v1.0.0",
+    ]);
+  });
+});
+
+describe("Go artifact preparation", () => {
+  test("strips the module zip root", () => {
+    const prepared = prepareGoArtifact({ path: "demo-v1.2.0.zip", files: moduleFiles("v1.2.0") });
+    expect(prepared.files.map((entry) => entry.path)).toEqual(["go.mod", "main.go"]);
+    expect(prepared.summary.module.rootModulePath).toBe(MODULE);
+    expect(prepared.summary.module.rootVersion).toBe("v1.2.0");
+  });
+});
+
+describe("Go release review", () => {
+  test("flags replace directives and capability additions vs baseline", () => {
+    const review = createGoReleaseCandidateReview({
+      manifest: manifestFor("v1.2.0"),
+      artifacts: [
+        {
+          path: "demo-v1.2.0.zip",
+          files: moduleFiles("v1.2.0", {
+            goMod: `module ${MODULE}\n\ngo 1.22\n\nreplace example.com/a => ../local-a\n`,
+            extraFiles: [
+              file(
+                "native.go",
+                'package demo\n\n//go:generate ./gen.sh\n\nimport "C"\n\nimport "unsafe"\n\nimport "syscall"\n',
+              ),
+            ],
+          }),
+        },
+      ],
+      previousArtifacts: [{ path: "demo-v1.1.0.zip", files: moduleFiles("v1.1.0") }],
+    });
+
+    const ruleIds = review.ruleFindings.map((finding) => finding.ruleId);
+    expect(ruleIds).toContain("go.replace-directive");
+    expect(ruleIds).toContain("go.generate-directive-added");
+    expect(ruleIds).toContain("go.cgo-introduced");
+    expect(ruleIds).toContain("go.unsafe-usage-added");
+    expect(ruleIds).toContain("go.syscall-usage-added");
+    expect(review.package).toEqual({ name: MODULE, version: "v1.2.0" });
+  });
+
+  test("does not re-flag capabilities already present in the baseline", () => {
+    const carrying = {
+      extraFiles: [file("sys.go", 'package demo\n\nimport "unsafe"\n')],
+    };
+    const review = createGoReleaseCandidateReview({
+      manifest: manifestFor("v1.2.0"),
+      artifacts: [{ path: "demo-v1.2.0.zip", files: moduleFiles("v1.2.0", carrying) }],
+      previousArtifacts: [{ path: "demo-v1.1.0.zip", files: moduleFiles("v1.1.0", carrying) }],
+    });
+    expect(review.ruleFindings.map((finding) => finding.ruleId)).not.toContain(
+      "go.unsafe-usage-added",
+    );
+  });
+
+  test("flags metadata mismatch when the zip root disagrees with the manifest", () => {
+    const review = createGoReleaseCandidateReview({
+      manifest: manifestFor("v1.2.0"),
+      artifacts: [{ path: "demo-v1.2.0.zip", files: moduleFiles("v9.9.9") }],
+    });
+    const mismatch = review.ruleFindings.find(
+      (finding) => finding.ruleId === "go.metadata-mismatch",
+    );
+    expect(mismatch).toBeTruthy();
+    expect(mismatch.severity).toBe("critical");
+  });
+
+  test("uses go code patterns for changed-line findings", () => {
+    const review = createGoReleaseCandidateReview({
+      manifest: manifestFor("v1.2.0"),
+      artifacts: [
+        {
+          path: "demo-v1.2.0.zip",
+          files: [
+            file(`${MODULE}@v1.2.0/go.mod`, `module ${MODULE}\n`),
+            file(
+              `${MODULE}@v1.2.0/run.go`,
+              'package demo\n\nimport "os/exec"\n\nfunc Run() { exec.Command("curl").Run() }\n',
+            ),
+          ],
+        },
+      ],
+    });
+    expect(
+      review.ruleFindings.some(
+        (finding) => finding.file === "run.go" && /process/i.test(finding.evidence ?? ""),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("Go baseline selection", () => {
+  test("picks the highest semver from the proxy list, skipping the candidate", () => {
+    expect(pickGoBaselineVersion(["v1.0.0", "v1.2.0", "v1.1.0", "v1.2.0-rc.1"], "v1.2.0")).toBe(
+      "v1.2.0-rc.1",
+    );
+    expect(pickGoBaselineVersion(["v1.0.0", "v1.1.0", "not-a-version"], "v1.2.0")).toBe("v1.1.0");
+    expect(pickGoBaselineVersion(["v1.0.0"], "v1.0.0")).toBeNull();
+  });
+
+  test("orders prereleases below releases", () => {
+    expect(compareGoVersions("v1.2.0-rc.1", "v1.2.0")).toBeLessThan(0);
+    expect(compareGoVersions("v1.2.0-rc.2", "v1.2.0-rc.1")).toBeGreaterThan(0);
+    expect(compareGoVersions("v1.10.0", "v1.9.0")).toBeGreaterThan(0);
+  });
+
+  test("downloads the baseline zip from proxy.golang.org via the broker", async () => {
+    const calls = [];
+    const broker = {
+      async fetchVersionList() {
+        return ["v1.1.0", "v1.2.0"];
+      },
+      async downloadPublicArtifact(url) {
+        calls.push(url);
+        return { files: moduleFiles("v1.1.0"), packageJson: null };
+      },
+      dispose() {},
+    };
+    const input = goAdapter.parseInput({
+      manifest: manifestFor("v1.2.0"),
+      artifacts: [{ path: "demo-v1.2.0.zip", files: moduleFiles("v1.2.0") }],
+    });
+    const result = await acquireBaselineGo(adapterCtx, input, broker);
+    expect(calls).toEqual(["https://proxy.golang.org/github.com/octo/demo/@v/v1.1.0.zip"]);
+    expect(result.baseline.version).toBe("v1.1.0");
+    expect(result.artifact.files.map((entry) => entry.path)).toContain("go.mod");
+  });
+
+  test("returns an empty baseline when the proxy is unavailable", async () => {
+    const broker = {
+      async fetchVersionList() {
+        return null;
+      },
+      async downloadPublicArtifact() {
+        throw new Error("unexpected download");
+      },
+      dispose() {},
+    };
+    const input = goAdapter.parseInput({
+      manifest: manifestFor("v1.2.0"),
+      artifacts: [{ path: "demo-v1.2.0.zip", files: moduleFiles("v1.2.0") }],
+    });
+    const result = await acquireBaselineGo(adapterCtx, input, broker);
+    expect(result.artifact).toBeNull();
+    expect(result.baseline.source).toBe("none");
+  });
+});
+
+describe("Go proxy URL rules", () => {
+  test("case-encodes module paths for proxy URLs", () => {
+    expect(escapeGoModulePath("github.com/Octo/Demo")).toBe("github.com/!octo/!demo");
+    expect(goProxyZipUrl("github.com/Octo/Demo", "v1.0.0")).toBe(
+      "https://proxy.golang.org/github.com/!octo/!demo/@v/v1.0.0.zip",
+    );
+  });
+
+  test("only https proxy.golang.org artifact URLs are allowed", () => {
+    expect(isAllowedGoProxyArtifactUrl(goProxyZipUrl(MODULE, "v1.1.0"))).toBe(true);
+    expect(isAllowedGoProxyArtifactUrl("https://example.com/demo-v1.1.0.zip")).toBe(false);
+    expect(isAllowedGoProxyArtifactUrl("http://proxy.golang.org/x/@v/v1.0.0.zip")).toBe(false);
+  });
+});

--- a/test/workers/workflow-gate-registry.test.ts
+++ b/test/workers/workflow-gate-registry.test.ts
@@ -7,13 +7,20 @@ import * as schema from "../../server/db/schema";
 import { readGithubAppConfig } from "../../server/lib/github-app/config";
 import { upsertInstallation } from "../../server/lib/github-app/persistence";
 import { getGateForOrganization } from "../../server/lib/github-app/webhook-gates";
+import { WorkflowArtifactError } from "../../server/lib/github-app/artifacts";
+import { cratesWorkflowGateAdapter } from "../../server/lib/workflow-gates/crates";
+import { goWorkflowGateAdapter } from "../../server/lib/workflow-gates/go";
 import { prepareReleaseCandidatesForGate } from "../../server/lib/workflow-gates/prepare";
 import { pypiWorkflowGateAdapter } from "../../server/lib/workflow-gates/pypi";
 import {
+  AMBIGUOUS_ARCHIVE_ECOSYSTEM,
   UnsupportedEcosystemError,
+  classifyBundleArtifact,
+  detectArchiveEcosystems,
   getWorkflowGateAdapter,
   supportedWorkflowGateEcosystems,
 } from "../../server/lib/workflow-gates/registry";
+import type { ParsedGateArtifact } from "../../server/lib/workflow-gates/types";
 
 // ── Pure adapter dispatch ────────────────────────────────────────────────────
 
@@ -36,7 +43,133 @@ describe("workflow-gate adapter registry", () => {
   });
 
   test("lists every registered ecosystem", () => {
-    expect(supportedWorkflowGateEcosystems()).toContain("pypi");
+    expect(supportedWorkflowGateEcosystems()).toEqual(
+      expect.arrayContaining(["pypi", "npm", "crates", "go"]),
+    );
+  });
+
+  test("resolves the crates and go adapters by ecosystem", () => {
+    expect(getWorkflowGateAdapter("crates")).toBe(cratesWorkflowGateAdapter);
+    expect(getWorkflowGateAdapter("go")).toBe(goWorkflowGateAdapter);
+  });
+});
+
+// ── crates/go: classification, content detection, candidate derivation ───────
+
+function gateFile(path: string, textSample: string) {
+  return { path, size: textSample.length, sha256: `sha-${path}`, flags: [], textSample };
+}
+
+function crateArtifact(name: string, version: string, path: string): ParsedGateArtifact {
+  return {
+    path,
+    sha256: "ab".repeat(32),
+    ecosystem: "crates",
+    kind: "crate",
+    files: [
+      gateFile(
+        `${name}-${version}/Cargo.toml`,
+        `[package]\nname = "${name}"\nversion = "${version}"\n`,
+      ),
+      gateFile(`${name}-${version}/src/lib.rs`, "pub fn v() {}\n"),
+    ],
+    packageJson: null,
+  };
+}
+
+function goArtifact(modulePath: string, version: string, path: string): ParsedGateArtifact {
+  return {
+    path,
+    sha256: "cd".repeat(32),
+    ecosystem: "go",
+    kind: "module",
+    files: [
+      gateFile(`${modulePath}@${version}/go.mod`, `module ${modulePath}\n\ngo 1.22\n`),
+      gateFile(`${modulePath}@${version}/main.go`, "package demo\n"),
+    ],
+    packageJson: null,
+  };
+}
+
+describe("workflow-gate registry with crates and go registered", () => {
+  test("classifies .crate as crates and .zip as go, keeping .tar.gz ambiguous", () => {
+    expect(classifyBundleArtifact("target/package/demo-1.0.0.crate")).toEqual({
+      ecosystem: "crates",
+      kind: "crate",
+    });
+    expect(classifyBundleArtifact("dist/demo-v1.0.0.zip")).toEqual({
+      ecosystem: "go",
+      kind: "module",
+    });
+    expect(classifyBundleArtifact("dist/pkg-1.0.0.tar.gz")).toEqual({
+      ecosystem: AMBIGUOUS_ARCHIVE_ECOSYSTEM,
+      kind: "archive",
+    });
+  });
+
+  test("content-detects a crate via its root Cargo.toml.orig and a module zip via its root", () => {
+    expect(
+      detectArchiveEcosystems({
+        files: [gateFile("demo-1.0.0/Cargo.toml.orig", "[package]")],
+        packageJson: null,
+      }),
+    ).toEqual([{ ecosystem: "crates", kind: "crate" }]);
+    expect(
+      detectArchiveEcosystems({
+        files: [gateFile("example.com/demo@v1.0.0/go.mod", "module example.com/demo\n")],
+        packageJson: null,
+      }),
+    ).toEqual([{ ecosystem: "go", kind: "module" }]);
+    // A vendored Cargo.toml deeper in the tree must not claim the archive.
+    expect(
+      detectArchiveEcosystems({
+        files: [gateFile("pkg/vendor/demo/Cargo.toml.orig", "[package]")],
+        packageJson: null,
+      }),
+    ).toEqual([]);
+  });
+
+  test("derives one crates candidate per crate name and rejects duplicates", () => {
+    const candidates = cratesWorkflowGateAdapter.prepareReleaseCandidates([
+      crateArtifact("demo-a", "1.0.0", "demo-a-1.0.0.crate"),
+      crateArtifact("demo-b", "2.0.0", "demo-b-2.0.0.crate"),
+    ]);
+    expect(candidates.map((candidate) => candidate.package)).toEqual([
+      { name: "demo-a", version: "1.0.0" },
+      { name: "demo-b", version: "2.0.0" },
+    ]);
+    expect(candidates.every((candidate) => candidate.ecosystem === "crates")).toBe(true);
+
+    expect(() =>
+      cratesWorkflowGateAdapter.prepareReleaseCandidates([
+        crateArtifact("demo-a", "1.0.0", "one.crate"),
+        crateArtifact("demo-a", "1.0.0", "two.crate"),
+      ]),
+    ).toThrow(WorkflowArtifactError);
+  });
+
+  test("derives one go candidate per module path and rejects identity-less zips", () => {
+    const candidates = goWorkflowGateAdapter.prepareReleaseCandidates([
+      goArtifact("example.com/demo", "v1.0.0", "demo-v1.0.0.zip"),
+      goArtifact("example.com/other", "v2.0.0", "other-v2.0.0.zip"),
+    ]);
+    expect(candidates.map((candidate) => candidate.package)).toEqual([
+      { name: "example.com/demo", version: "v1.0.0" },
+      { name: "example.com/other", version: "v2.0.0" },
+    ]);
+
+    expect(() =>
+      goWorkflowGateAdapter.prepareReleaseCandidates([
+        {
+          path: "bad.zip",
+          sha256: "ef".repeat(32),
+          ecosystem: "go",
+          kind: "module",
+          files: [gateFile("go.mod", "module example.com/demo\n")],
+          packageJson: null,
+        },
+      ]),
+    ).toThrow(WorkflowArtifactError);
   });
 });
 


### PR DESCRIPTION
## Summary

Implements #439: two new workflow-gate ecosystems following the existing PyPI/npm adapter pattern.

**crates.io** (`server/lib/adapters/crates/` + `server/lib/workflow-gates/crates.ts`)
- Candidate: `cargo package` `.crate` archives (gzipped tar). Content detection uses the root `Cargo.toml.orig`; identity comes from the normalized `Cargo.toml` (line-oriented reader, never evaluates package bytes). The `{name}-{version}/` root is stripped so staged/baseline diffs align.
- Workspace fan-out: archives are grouped by crate name → one candidate per crate; duplicate name+version fail-closes with `WorkflowArtifactError`.
- Baseline: newest non-yanked version from the crates.io sparse index, fetched by a credential-free broker pinned to `https://static.crates.io`.
- Rules: `crates.build-script-added/-changed`, `crates.proc-macro-introduced`, `crates.links-changed`, `crates.non-registry-dependency` (git/path deps), plus metadata missing/mismatch fail-closed checks.

**Go modules** (`server/lib/adapters/gomod/` + `server/lib/workflow-gates/go.ts`)
- Candidate: the module zip the tag/release workflow builds (Go has no publish step). Identity comes from the mandatory `{module}@{version}/` zip root cross-checked against `go.mod`; disagreement is a critical mismatch.
- Multi-module fan-out mirrors crates (grouped by module path).
- Baseline: highest published semver from `proxy.golang.org/@v/list` (proper semver compare incl. prereleases), broker pinned to `https://proxy.golang.org`.
- Rules: `go.generate-directive-added`, `go.cgo-introduced`, `go.unsafe-usage-added`, `go.syscall-usage-added` (capability deltas vs baseline), `go.replace-directive`.

**Shared wiring**
- `CodePatternSet` extended to `"rust" | "go"` with new pattern sets in `review-rules/patterns.ts`; JS-only code normalization is now gated on a `jsFlavored` check in `review-rules/scripts.ts`.
- New `adapters/artifact-input.ts`: shared `{ path, files, suspiciousEntries }` input validation + `stripCommonArchiveRoot`, preserving tar-parser suspicious entries across the adapter-input boundary.
- Registry/type plumbing: `SUPPORTED_ECOSYSTEMS = ["pypi", "npm", "crates", "go"]`, `ReleaseProvenance.ecosystem` + artifact kinds `crate`/`module`, report-export re-validation, workflow-gate resolver now parses `.zip` (not just `.whl`) as zip, UI provenance labels.

**Tests**: `test/crates.test.mjs`, `test/gomod.test.mjs` (manifests, artifact prep, rules vs baseline, baseline selection with stub brokers, broker URL allowlists) and gate registry/classification/candidate-derivation coverage in `test/workers/workflow-gate-registry.test.ts`.

Docs updated: `docs/workflow-gates.md` (new ecosystem sections), `docs/README.md`.

`pnpm run verify` passes (lint + format + typecheck + tests).

Link to Devin session: https://app.devin.ai/sessions/da4cdbfac5a64ede89fe92494f2001b3
Requested by: @JoviDeCroock