### PR TITLE
perf(tar-parser): dequeue buffered chunks via head cursor instead of shift()

### DIFF
--- a/server/lib/tar-parser.js
+++ b/server/lib/tar-parser.js
@@ -229,6 +229,7 @@ export function createStreamCursor(body, maxStreamBytes) {
   const reader = body.getReader();
   const streamLimit = Number.isFinite(maxStreamBytes) ? maxStreamBytes : Infinity;
   const chunks = [];
+  let head = 0;
   let buffered = 0;
   let streamed = 0;
   let consumedBytes = 0;
@@ -252,20 +253,38 @@ export function createStreamCursor(body, maxStreamBytes) {
     return buffered >= target;
   }
 
+  function currentHead() {
+    return chunks[head];
+  }
+
+  function compact() {
+    if (head === 0) return;
+    if (head === chunks.length) {
+      chunks.length = 0;
+      head = 0;
+      return;
+    }
+    if (head > 64 && head * 2 >= chunks.length) {
+      chunks.splice(0, head);
+      head = 0;
+    }
+  }
+
   function take(count) {
     const out = new Uint8Array(count);
     let offset = 0;
     while (offset < count) {
-      const head = chunks[0];
+      const chunk = currentHead();
       const need = count - offset;
-      if (head.byteLength <= need) {
-        out.set(head, offset);
-        offset += head.byteLength;
-        buffered -= head.byteLength;
-        chunks.shift();
+      if (chunk.byteLength <= need) {
+        out.set(chunk, offset);
+        offset += chunk.byteLength;
+        buffered -= chunk.byteLength;
+        head += 1;
+        compact();
       } else {
-        out.set(head.subarray(0, need), offset);
-        chunks[0] = head.subarray(need);
+        out.set(chunk.subarray(0, need), offset);
+        chunks[head] = chunk.subarray(need);
         buffered -= need;
         offset = count;
       }
@@ -278,16 +297,17 @@ export function createStreamCursor(body, maxStreamBytes) {
     let remaining = count;
     while (remaining > 0) {
       if (!buffered && !(await fill(1))) return false;
-      const head = chunks[0];
-      if (head.byteLength <= remaining) {
-        if (sink) await sink(head);
-        remaining -= head.byteLength;
-        buffered -= head.byteLength;
-        consumedBytes += head.byteLength;
-        chunks.shift();
+      const chunk = currentHead();
+      if (chunk.byteLength <= remaining) {
+        if (sink) await sink(chunk);
+        remaining -= chunk.byteLength;
+        buffered -= chunk.byteLength;
+        consumedBytes += chunk.byteLength;
+        head += 1;
+        compact();
       } else {
-        if (sink) await sink(head.subarray(0, remaining));
-        chunks[0] = head.subarray(remaining);
+        if (sink) await sink(chunk.subarray(0, remaining));
+        chunks[head] = chunk.subarray(remaining);
         buffered -= remaining;
         consumedBytes += remaining;
         remaining = 0;

--- a/test/tar-parser.test.mjs
+++ b/test/tar-parser.test.mjs
@@ -632,6 +632,30 @@ describe("readTar limits and malformed archives", () => {
     expect(streamed).toEqual(buffered);
   });
 
+  test("readTarStream parses byte-at-a-time input identically to readTar", async () => {
+    const tar = buildTar([
+      { name: "package/index.js", body: "export const x = 1;\n" },
+      { name: "package/lib/util.js", body: "// util\n" },
+      { name: "package/readme.txt", body: "chunk cursor regression\n" },
+    ]);
+    const chunked = new ReadableStream({
+      start(controller) {
+        for (let i = 0; i < tar.length; i += 1) {
+          controller.enqueue(tar.subarray(i, i + 1));
+        }
+        controller.close();
+      },
+    });
+    const streamed = await tarParser.readTarStream(
+      chunked,
+      PARSE_LIMITS.maxFiles,
+      PARSE_LIMITS.maxTarBytes,
+      Infinity,
+    );
+    const buffered = await parseFull(tar);
+    expect(streamed).toEqual(buffered);
+  });
+
   test("readTarStream fails closed when the total stream exceeds its cap", async () => {
     const tar = buildTar([{ name: "package/big.bin", body: new Uint8Array(4096) }]);
     const stream = new ReadableStream({


### PR DESCRIPTION
## Summary
Stacked on #451. Removes an O(n²) micro-pattern in the streaming tar/zip reader's buffered-chunk queue (`createStreamCursor` in `server/lib/tar-parser.js`).

The reader buffers stream chunks in an array and drains them with `chunks.shift()`. `Array.shift()` re-indexes the whole array (O(n)), so when the underlying stream arrives as many small chunks the drain degrades to O(n²). This replaces the destructive shift with an O(1)-amortized head cursor:

```js
// before
const head = chunks[0];
... chunks.shift();            // O(n) per dequeue
chunks[0] = head.subarray(need);

// after
let head = 0;                  // cursor into chunks
const chunk = chunks[head];
... head += 1; compact();      // O(1) advance
chunks[head] = chunk.subarray(need);

function compact() {           // bound array growth
  if (head === chunks.length) { chunks.length = 0; head = 0; return; }
  if (head > 64 && head * 2 >= chunks.length) { chunks.splice(0, head); head = 0; }
}
```

Both `take()` and `discard()` go through the cursor; `fill()` still only appends to the tail. All `buffered` / `consumedBytes` accounting and partial-head handling (`subarray`) are byte-for-byte unchanged — this is purely an internal data-structure swap with no behavioral or API change.

## Testing
- Added a regression that drives a valid tar through `readTarStream()` delivered **one byte at a time** and asserts the result equals the single-buffer `readTar()` parse — this is exactly the fragmentation that stressed the old `shift()` path and exercises the cursor + compaction.
- `pnpm run verify` green (lint, format, typecheck, logic + workers suites); `test/tar-parser.test.mjs` (85), `test/zip-parser.test.mjs` (24), and `pnpm run fuzz` (14) all pass.
- Docs checked, no update needed.

Link to Devin session: https://app.devin.ai/sessions/86b738cd9fe5474aaaaa0d766fff37da
Requested by: @JoviDeCroock