### PR TITLE
Harden reusable components: Menu a11y/reactivity, ARIA roles, dedupe

### DIFF
--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -19,9 +19,10 @@ export function Alert({
   class?: string;
   children: ComponentChildren;
 }) {
+  const role = tone === "critical" || tone === "warn" ? "alert" : "status";
   return (
     <div
-      role="alert"
+      role={role}
       class={cn(
         "flex items-start gap-2.5 px-3.5 py-3 rounded-md border text-[13px]",
         toneStyles[tone],

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -10,6 +10,12 @@ const cardPaddingClass: Record<CardPadding, string> = {
   none: "",
 };
 
+function bodyLayoutClass(inset: "all" | "belowHeader", gap: "default" | "compact" | "none") {
+  const insetClass = inset === "belowHeader" ? "px-5 pb-5" : "p-5";
+  const gapClass = gap === "none" ? "" : gap === "compact" ? "gap-4" : "gap-5";
+  return cn(insetClass, "flex flex-col", gapClass);
+}
+
 export function Card({
   class: className,
   children,
@@ -57,9 +63,7 @@ export function SettingsCardBody({
   inset?: "all" | "belowHeader";
   gap?: "default" | "compact" | "none";
 }) {
-  const insetClass = inset === "belowHeader" ? "px-5 pb-5" : "p-5";
-  const gapClass = gap === "none" ? "" : gap === "compact" ? "gap-4" : "gap-5";
-  return <div class={cn(insetClass, "flex flex-col", gapClass, className)}>{children}</div>;
+  return <div class={cn(bodyLayoutClass(inset, gap), className)}>{children}</div>;
 }
 
 export function SettingsCardForm({
@@ -75,10 +79,8 @@ export function SettingsCardForm({
   inset?: "all" | "belowHeader";
   gap?: "default" | "compact" | "none";
 }) {
-  const insetClass = inset === "belowHeader" ? "px-5 pb-5" : "p-5";
-  const gapClass = gap === "none" ? "" : gap === "compact" ? "gap-4" : "gap-5";
   return (
-    <form class={cn(insetClass, "flex flex-col", gapClass, className)} onSubmit={onSubmit}>
+    <form class={cn(bodyLayoutClass(inset, gap), className)} onSubmit={onSubmit}>
       {children}
     </form>
   );

--- a/src/components/CloseButton.tsx
+++ b/src/components/CloseButton.tsx
@@ -1,0 +1,23 @@
+import type { JSX } from "preact";
+import { cn } from "./cn";
+
+type CloseButtonProps = Omit<JSX.ButtonHTMLAttributes<HTMLButtonElement>, "class" | "children"> & {
+  class?: string;
+  ariaLabel?: string;
+};
+
+const base =
+  "inline-flex items-center justify-center rounded-md leading-none text-ink-subtle transition-colors duration-150 ease-out cursor-pointer focus:outline-none disabled:cursor-not-allowed disabled:opacity-50";
+
+export function CloseButton({
+  class: className,
+  ariaLabel = "Close",
+  type = "button",
+  ...props
+}: CloseButtonProps) {
+  return (
+    <button type={type} aria-label={ariaLabel} class={cn(base, className)} {...props}>
+      ✕
+    </button>
+  );
+}

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,5 +1,6 @@
 import type { ComponentChildren } from "preact";
 import { useEffect, useId, useRef } from "preact/hooks";
+import { CloseButton } from "./CloseButton";
 import { cn } from "./cn";
 
 interface DialogProps {
@@ -60,14 +61,10 @@ export function Dialog({
       )}
     >
       <div class="relative flex flex-col gap-4 p-5">
-        <button
-          type="button"
+        <CloseButton
           onClick={onClose}
-          aria-label="Close"
-          class="absolute top-3 right-3 flex items-center justify-center w-7 h-7 rounded-md text-ink-subtle hover:text-ink hover:bg-surface-2 focus:outline-none focus:ring-2 focus:ring-accent leading-none text-[14px]"
-        >
-          ✕
-        </button>
+          class="absolute top-3 right-3 w-7 h-7 text-[14px] text-ink-subtle hover:text-ink hover:bg-surface-2 focus:ring-2 focus:ring-accent"
+        />
         <header class="flex flex-col gap-1 pr-7">
           <h2 id={titleId} class="text-[18px] font-medium tracking-[-0.01em] leading-[1.35] m-0">
             {title}

--- a/src/components/DiffView.tsx
+++ b/src/components/DiffView.tsx
@@ -569,7 +569,7 @@ function DiffOptionToggle({
       <input
         type="checkbox"
         class="sr-only peer"
-        checked={checked.value}
+        checked={checked}
         onChange={(event) => (checked.value = event.currentTarget.checked)}
         aria-label={description}
       />

--- a/src/components/FindingCard.tsx
+++ b/src/components/FindingCard.tsx
@@ -2,6 +2,37 @@ import type { ComponentChildren } from "preact";
 import { Badge, severityTone, statusTone } from "./Badge";
 import { cn } from "./cn";
 
+export function FileRef({
+  file,
+  onSelect,
+  class: className,
+}: {
+  file: string;
+  onSelect?: () => void;
+  class?: string;
+}) {
+  return onSelect ? (
+    <button
+      type="button"
+      onClick={onSelect}
+      title={`Open ${file} in the diff`}
+      class={cn(
+        "font-mono text-[13px] text-ink-muted hover:text-accent truncate text-left [direction:rtl] bg-transparent border-0 p-0 m-0 cursor-pointer transition-colors duration-150 ease-out",
+        className,
+      )}
+    >
+      <bdi>{file}</bdi>
+    </button>
+  ) : (
+    <code
+      class={cn("text-[13px] text-ink-muted truncate text-left [direction:rtl]", className)}
+      title={file}
+    >
+      <bdi>{file}</bdi>
+    </code>
+  );
+}
+
 export function FindingCard({
   severity,
   file,
@@ -37,23 +68,7 @@ export function FindingCard({
           <Badge tone={severityTone(severity)} dot>
             {severity}
           </Badge>
-          {onSelect ? (
-            <button
-              type="button"
-              onClick={onSelect}
-              title={`Open ${file} in the diff`}
-              class="font-mono text-[13px] text-ink-muted hover:text-accent truncate text-left [direction:rtl] bg-transparent border-0 p-0 m-0 cursor-pointer transition-colors duration-150 ease-out"
-            >
-              <bdi>{file}</bdi>
-            </button>
-          ) : (
-            <code
-              class="text-[13px] text-ink-muted truncate text-left [direction:rtl]"
-              title={file}
-            >
-              <bdi>{file}</bdi>
-            </code>
-          )}
+          <FileRef file={file} onSelect={onSelect} />
           {diffStatus ? (
             <Badge tone={statusTone(diffStatus)} class="flex-shrink-0">
               {diffLabel ?? diffStatus}
@@ -132,23 +147,7 @@ export function GroupedFindingCard({
       <ul class="list-none p-0 m-0 flex flex-col gap-1">
         {files.map((entry) => (
           <li key={`${entry.file}:${entry.line ?? ""}`} class="flex items-center gap-2 min-w-0">
-            {entry.onSelect ? (
-              <button
-                type="button"
-                onClick={entry.onSelect}
-                title={`Open ${entry.file} in the diff`}
-                class="font-mono text-[13px] text-ink-muted hover:text-accent truncate text-left [direction:rtl] bg-transparent border-0 p-0 m-0 cursor-pointer transition-colors duration-150 ease-out"
-              >
-                <bdi>{entry.file}</bdi>
-              </button>
-            ) : (
-              <code
-                class="text-[13px] text-ink-muted truncate text-left [direction:rtl]"
-                title={entry.file}
-              >
-                <bdi>{entry.file}</bdi>
-              </code>
-            )}
+            <FileRef file={entry.file} onSelect={entry.onSelect} />
             {entry.line ? (
               <span class="flex-shrink-0 font-mono text-[11px] text-ink-subtle">L{entry.line}</span>
             ) : null}

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,6 +1,7 @@
 import type { ComponentChildren, JSX } from "preact";
 import { useRef } from "preact/hooks";
-import { useSignal, useSignalEffect } from "@preact/signals";
+import { useComputed, useSignal, useSignalEffect } from "@preact/signals";
+import { Show } from "@preact/signals/utils";
 import { cn } from "./cn";
 
 interface MenuProps {
@@ -23,7 +24,24 @@ export function Menu({
   disabled,
 }: MenuProps) {
   const open = useSignal(false);
+  const focusFirstOnOpen = useSignal(false);
   const rootRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+
+  const triggerContent = useComputed(() => trigger(open.value));
+
+  const getEnabledMenuItems = () => {
+    const node = rootRef.current;
+    if (!node) return [];
+    return Array.from(node.querySelectorAll<HTMLElement>("[data-menu-item]:not([disabled])"));
+  };
+
+  const focusMenuItem = (index: number) => {
+    const items = getEnabledMenuItems();
+    if (!items.length) return;
+    const nextIndex = ((index % items.length) + items.length) % items.length;
+    items[nextIndex]?.focus();
+  };
 
   useSignalEffect(() => {
     if (!open.value) return;
@@ -35,7 +53,10 @@ export function Menu({
       }
     };
     const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") open.value = false;
+      if (event.key !== "Escape") return;
+      open.value = false;
+      focusFirstOnOpen.value = false;
+      triggerRef.current?.focus();
     };
     document.addEventListener("pointerdown", onPointer);
     document.addEventListener("keydown", onKey);
@@ -45,40 +66,100 @@ export function Menu({
     };
   });
 
+  useSignalEffect(() => {
+    if (!open.value || !focusFirstOnOpen.value) return;
+    const frame = requestAnimationFrame(() => {
+      focusMenuItem(0);
+      focusFirstOnOpen.value = false;
+    });
+    return () => {
+      cancelAnimationFrame(frame);
+    };
+  });
+
+  const onRootKeyDown = (event: KeyboardEvent) => {
+    const key = event.key;
+    if (disabled) return;
+
+    if (event.target === triggerRef.current && !open.value) {
+      if (key === "Enter" || key === " " || key === "ArrowDown") {
+        event.preventDefault();
+        open.value = true;
+        focusFirstOnOpen.value = true;
+      }
+      return;
+    }
+
+    if (!open.value) return;
+
+    if (key === "Escape") {
+      event.preventDefault();
+      open.value = false;
+      focusFirstOnOpen.value = false;
+      triggerRef.current?.focus();
+      return;
+    }
+
+    if (key === "ArrowDown" || key === "ArrowUp" || key === "Home" || key === "End") {
+      event.preventDefault();
+      const items = getEnabledMenuItems();
+      if (!items.length) return;
+      const active = document.activeElement;
+      const currentIndex = items.indexOf(active as HTMLElement);
+      let nextIndex = 0;
+      if (key === "Home") {
+        nextIndex = 0;
+      } else if (key === "End") {
+        nextIndex = items.length - 1;
+      } else if (currentIndex === -1) {
+        nextIndex = key === "ArrowUp" ? items.length - 1 : 0;
+      } else if (key === "ArrowDown") {
+        nextIndex = currentIndex + 1;
+      } else {
+        nextIndex = currentIndex - 1;
+      }
+      focusMenuItem(nextIndex);
+    }
+  };
+
   const onPanelClick = (event: MouseEvent) => {
     const target = event.target as HTMLElement | null;
     if (target?.closest("[data-menu-item]")) open.value = false;
   };
 
   return (
-    <div ref={rootRef} class="relative inline-block">
+    <div ref={rootRef} onKeyDown={onRootKeyDown} class="relative inline-block">
       <button
+        ref={triggerRef}
         type="button"
-        onClick={() => {
+        onClick={(event) => {
           if (disabled) return;
+          if (event.detail === 0) return;
           open.value = !open.value;
         }}
         disabled={disabled}
         aria-haspopup="menu"
-        aria-expanded={open.value}
+        aria-expanded={open}
         aria-label={triggerAriaLabel}
         class={cn("cursor-pointer disabled:cursor-not-allowed disabled:opacity-60", triggerClass)}
       >
-        {trigger(open.value)}
+        {triggerContent}
       </button>
-      {open.value ? (
-        <div
-          role="menu"
-          onClick={onPanelClick}
-          class={cn(
-            "absolute z-20 mt-1 min-w-[200px] bg-surface border border-border rounded-md shadow-md py-1",
-            align === "end" ? "right-0" : "left-0",
-            panelClass,
-          )}
-        >
-          {children}
-        </div>
-      ) : null}
+      <Show when={open}>
+        {() => (
+          <div
+            role="menu"
+            onClick={onPanelClick}
+            class={cn(
+              "absolute z-20 mt-1 min-w-[200px] bg-surface border border-border rounded-md shadow-md py-1",
+              align === "end" ? "right-0" : "left-0",
+              panelClass,
+            )}
+          >
+            {children}
+          </div>
+        )}
+      </Show>
     </div>
   );
 }

--- a/src/components/PageShell.tsx
+++ b/src/components/PageShell.tsx
@@ -4,15 +4,13 @@ import { sessionModel } from "../models/auth";
 import { cn } from "./cn";
 import { BrandMark } from "./BrandMark";
 import { LinkButton } from "./Button";
-import { AikidoFootnote, AikidoMark } from "./AikidoPartner";
+import { AikidoFootnote } from "./AikidoPartner";
 
 const FEEDBACK_MAILTO =
   "mailto:drydock@drydock.org?subject=Drydock%20feedback&body=Tell%20us%20what%27s%20broken%2C%20confusing%2C%20or%20missing%3A%0A%0A";
 
 const SECURITY_MAILTO =
   "mailto:drydock@drydock.org?subject=Drydock%20security%20report&body=Describe%20the%20issue%20and%20how%20to%20reproduce%20it%3A%0A%0A";
-
-const AIKIDO_URL = "https://www.aikido.dev";
 
 const WIDTH_CLASS = {
   narrow: "max-w-[640px]",
@@ -48,21 +46,6 @@ export function PageShell({
           <div class="flex flex-wrap items-center justify-between gap-3">
             <div class="flex items-center gap-2.5">
               <HeaderBrandMark />
-              {/* eslint-disable-next-line */}
-              {false && (
-                <>
-                  <span aria-hidden class="h-3.5 w-px bg-border-strong" />
-                  <a
-                    href={AIKIDO_URL}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="inline-flex items-center opacity-90 hover:opacity-100 transition-opacity duration-150 ease-out"
-                    title="Aikido Security"
-                  >
-                    <AikidoMark size="xs" />
-                  </a>
-                </>
-              )}
             </div>
             <div class="flex items-center gap-2">
               {feedbackPosition === "start" ? <FeedbackButton /> : null}

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -21,6 +21,7 @@ export function Select({
   onChange,
   children,
   size = "md",
+  class: className,
 }: {
   id?: string;
   value: string | Signal<string>;
@@ -28,6 +29,7 @@ export function Select({
   onChange: (value: string) => void;
   children: ComponentChildren;
   size?: SelectSize;
+  class?: string;
 }) {
   return (
     <div class="relative inline-block w-full">
@@ -39,6 +41,7 @@ export function Select({
         class={cn(
           "appearance-none w-full bg-bg border border-border rounded-md text-ink outline-none transition-[border-color,box-shadow] duration-150 ease-out focus:border-accent focus:shadow-[0_0_0_3px_var(--color-accent-soft)] disabled:opacity-60 disabled:cursor-not-allowed",
           sizeStyles[size],
+          className,
         )}
       >
         {children}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,5 +1,6 @@
 import { signal } from "@preact/signals";
 import { cn } from "./cn";
+import { CloseButton } from "./CloseButton";
 
 export type ToastTone = "ok" | "critical" | "info";
 
@@ -39,29 +40,23 @@ const toneDisc: Record<ToastTone, string> = {
 
 export function Toaster() {
   return (
-    <div
-      class="fixed bottom-4 right-4 z-50 flex flex-col gap-2 w-[min(92vw,360px)] pointer-events-none"
-      aria-live="polite"
-    >
+    <div class="fixed bottom-4 right-4 z-50 flex flex-col gap-2 w-[min(92vw,360px)] pointer-events-none">
       {items.value.map((item) => (
         <div
           key={item.id}
           class="pointer-events-auto flex items-start gap-2.5 bg-surface border border-border rounded-lg shadow-md px-3.5 py-3"
-          role="status"
+          role={item.tone === "critical" ? "alert" : "status"}
         >
           <span
             class={cn("w-4 h-4 rounded-full shrink-0 mt-0.5 opacity-90", toneDisc[item.tone])}
             aria-hidden
           />
           <span class="text-[13px] leading-[1.5] text-ink flex-1">{item.message}</span>
-          <button
-            type="button"
+          <CloseButton
             onClick={() => dismissToast(item.id)}
-            aria-label="Dismiss"
-            class="shrink-0 -mr-1 -mt-0.5 leading-none text-[13px] text-ink-subtle hover:text-ink"
-          >
-            ✕
-          </button>
+            ariaLabel="Dismiss"
+            class="shrink-0 -mr-1 -mt-0.5 text-[13px] text-ink-subtle hover:text-ink"
+          />
         </div>
       ))}
     </div>

--- a/src/components/VersionPicker.tsx
+++ b/src/components/VersionPicker.tsx
@@ -1,6 +1,5 @@
-import type { JSX } from "preact";
 import { Badge } from "./Badge";
-import { cn } from "./cn";
+import { Select } from "./Select";
 
 interface VersionOption {
   version: string;
@@ -25,48 +24,32 @@ export function VersionPicker({
 }) {
   const tagsForSelected = options.find((option) => option.version === selected)?.distTags ?? [];
 
-  const handleChange: JSX.GenericEventHandler<HTMLSelectElement> = (event) => {
-    const value = (event.currentTarget as HTMLSelectElement).value;
-    if (value) onChange(value);
-  };
-
   return (
     <div class="flex flex-wrap items-center gap-3">
       <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
         Compare against
       </span>
-      <div class="relative inline-block">
-        <select
-          value={selected ?? ""}
-          onChange={handleChange}
-          disabled={disabled || options.length === 0}
-          class={cn(
-            "appearance-none bg-bg border border-border rounded-md text-[13px] text-ink pl-3 pr-9 py-2 outline-none",
-            "focus:border-accent focus:shadow-[0_0_0_3px_var(--color-accent-soft)]",
-            "disabled:opacity-60 disabled:cursor-not-allowed",
-            "font-mono min-w-[200px] w-full",
-          )}
-        >
-          {!options.length ? <option value="">no published versions</option> : null}
-          {options.map((option) => {
-            const tagSuffix = option.distTags.length ? ` [${option.distTags.join(", ")}]` : "";
-            const defaultSuffix = option.version === defaultVersion ? " (default)" : "";
-            return (
-              <option key={option.version} value={option.version}>
-                {option.version}
-                {tagSuffix}
-                {defaultSuffix}
-              </option>
-            );
-          })}
-        </select>
-        <span
-          aria-hidden="true"
-          class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-[10px] text-ink-muted"
-        >
-          ▾
-        </span>
-      </div>
+      <Select
+        value={selected ?? ""}
+        onChange={(value) => {
+          if (value) onChange(value);
+        }}
+        disabled={disabled || options.length === 0}
+        class="font-mono min-w-[200px]"
+      >
+        {!options.length ? <option value="">no published versions</option> : null}
+        {options.map((option) => {
+          const tagSuffix = option.distTags.length ? ` [${option.distTags.join(", ")}]` : "";
+          const defaultSuffix = option.version === defaultVersion ? " (default)" : "";
+          return (
+            <option key={option.version} value={option.version}>
+              {option.version}
+              {tagSuffix}
+              {defaultSuffix}
+            </option>
+          );
+        })}
+      </Select>
       <span class="font-mono text-[11px] text-ink-muted">→ staged {stagedVersion || "—"}</span>
       {tagsForSelected.map((tag) => (
         <Badge key={tag} tone="info">

--- a/tooling/oxlint/signals-local/suppressions.json
+++ b/tooling/oxlint/signals-local/suppressions.json
@@ -1,5 +1,4 @@
 {
-  "src/components/Menu.tsx": [69],
   "src/pages/Auth/Login.tsx": [119, 120, 123, 143, 165, 168, 182, 220, 223],
   "src/pages/Auth/VerifyEmail.tsx": [111, 112, 117],
   "src/pages/Dashboard/Account/DeleteAccountSection.tsx": [83, 111],


### PR DESCRIPTION
## Summary
Audit-driven cleanup of `src/components/` primitives. Skips the `cn()`/tailwind-merge item (out of scope by request); implements the rest.

- **`Menu`** — remove eager signal unwraps (whole-menu re-render) and add keyboard support.
  - `aria-expanded={open}`, `{trigger(open.value)}` → `useComputed`, panel → `<Show when={open}>`; drops the last `src/components/*` entry from `tooling/oxlint/signals-local/suppressions.json`.
  - WAI-ARIA menu-button keys: Enter/Space/ArrowDown on trigger opens + focuses first item; ArrowUp/Down wrap; Home/End; Escape closes and returns focus to the trigger. Focus-first is deferred via `requestAnimationFrame` so it runs after the `<Show>` panel mounts.
- **`Alert`** — `role` by tone: `critical`/`warn` → `alert` (assertive), `info`/`ok` → `status` (polite), instead of always `alert`.
- **`Toast`** — remove the container `aria-live` so it no longer nests live regions with each item; item role is `critical ? "alert" : "status"`.
- **`VersionPicker`** — reuse `Select` instead of a hand-rolled `<select>` + arrow + focus-ring. `Select` gains an optional `class` merged onto the inner `<select>`.
- **Dedupe** — extract `FileRef` (shared filename affordance in `FindingCard`/`GroupedFindingCard`), `CloseButton` (Dialog/Toast `✕`), and a `bodyLayoutClass(inset, gap)` helper in `Card`. No visual change intended.
- **`PageShell`** — delete the dead `{false && (…)}` Aikido header block + now-unused `AikidoMark` import / `AIKIDO_URL`.
- **`DiffView`** — `checked={checked.value}` → `checked={checked}` (bind signal to the DOM input).

## Testing
- `oxlint`, `tsc --noEmit`, `oxfmt --check` all clean.
- `vitest run --project node`: 670 passed.
- No component-DOM (jsdom/happy-dom) test env is set up in the repo, so the new Menu keyboard behavior and role-by-tone changes aren't unit-covered; verified by types/lint + manual reasoning. Happy to add tests if you want the infra added.
- docs checked, no update needed (no documented behavior/API/UI contract changed).

Link to Devin session: https://app.devin.ai/sessions/45d300c6c44c437ea823a454da6816e9
Requested by: @JoviDeCroock