### PR TITLE
Resolve oxlint no-signal-conditional-jsx suppressions

### DIFF
--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "preact/hooks";
 import { useSignal } from "@preact/signals";
+import { Show } from "@preact/signals/utils";
 import { useLocation } from "preact-iso";
 import { normalizeAuthReturnTo } from "../../lib/auth-return";
 import { AuthError, sessionModel } from "../../models/auth";
@@ -116,11 +117,15 @@ export default function LoginPage() {
             Open the link to finish signing in. It expires in 24 hours.
           </Muted>
 
-          {error.value ? <Alert tone="critical">{error.value}</Alert> : null}
-          {resent.value ? <Alert tone="ok">We sent another verification link.</Alert> : null}
+          <Show when={error}>{(message) => <Alert tone="critical">{message}</Alert>}</Show>
+          <Show when={resent}>
+            <Alert tone="ok">We sent another verification link.</Alert>
+          </Show>
 
-          <Button variant="secondary" disabled={resending.value} onClick={onResend}>
-            {resending.value ? "Resending…" : "Resend verification email"}
+          <Button variant="secondary" disabled={resending} onClick={onResend}>
+            <Show when={resending} fallback="Resend verification email">
+              Resending…
+            </Show>
           </Button>
 
           <p class="text-[13px] text-ink-muted m-0">
@@ -140,9 +145,9 @@ export default function LoginPage() {
           <Eyebrow>Two-factor authentication</Eyebrow>
           <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">Verify it's you</h1>
           <Muted class="text-[13px] m-0">
-            {useBackup.value
-              ? "Enter one of your saved backup recovery codes."
-              : "Enter the 6-digit code from your authenticator app."}
+            <Show when={useBackup} fallback="Enter the 6-digit code from your authenticator app.">
+              Enter one of your saved backup recovery codes.
+            </Show>
           </Muted>
 
           <form class="flex flex-col gap-4 mt-2" onSubmit={onVerify}>
@@ -162,10 +167,12 @@ export default function LoginPage() {
               />
             </Field>
 
-            {error.value ? <Alert tone="critical">{error.value}</Alert> : null}
+            <Show when={error}>{(message) => <Alert tone="critical">{message}</Alert>}</Show>
 
-            <Button type="submit" disabled={loading.value}>
-              {loading.value ? "Verifying…" : "Verify"}
+            <Button type="submit" disabled={loading}>
+              <Show when={loading} fallback="Verify">
+                Verifying…
+              </Show>
             </Button>
           </form>
 
@@ -179,7 +186,9 @@ export default function LoginPage() {
               error.value = null;
             }}
           >
-            {useBackup.value ? "Use an authenticator code instead" : "Use a backup code instead"}
+            <Show when={useBackup} fallback="Use a backup code instead">
+              Use an authenticator code instead
+            </Show>
           </Button>
         </Card>
       </PageShell>
@@ -217,10 +226,12 @@ export default function LoginPage() {
             />
           </Field>
 
-          {error.value ? <Alert tone="critical">{error.value}</Alert> : null}
+          <Show when={error}>{(message) => <Alert tone="critical">{message}</Alert>}</Show>
 
-          <Button type="submit" disabled={loading.value}>
-            {loading.value ? "Signing in…" : "Sign in"}
+          <Button type="submit" disabled={loading}>
+            <Show when={loading} fallback="Sign in">
+              Signing in…
+            </Show>
           </Button>
         </form>
 

--- a/src/pages/Auth/VerifyEmail.tsx
+++ b/src/pages/Auth/VerifyEmail.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "preact/hooks";
 import { useSignal } from "@preact/signals";
+import { Show } from "@preact/signals/utils";
 import { useLocation } from "preact-iso";
 import { normalizeAuthReturnTo } from "../../lib/auth-return";
 import { sessionModel } from "../../models/auth";
@@ -108,13 +109,15 @@ export default function VerifyEmailPage() {
             />
           </Field>
 
-          {error.value ? <Alert tone="critical">{error.value}</Alert> : null}
-          {resent.value ? (
+          <Show when={error}>{(message) => <Alert tone="critical">{message}</Alert>}</Show>
+          <Show when={resent}>
             <Alert tone="ok">If that account needs verifying, a new link is on its way.</Alert>
-          ) : null}
+          </Show>
 
-          <Button type="submit" disabled={resending.value}>
-            {resending.value ? "Sending…" : "Send new link"}
+          <Button type="submit" disabled={resending}>
+            <Show when={resending} fallback="Send new link">
+              Sending…
+            </Show>
           </Button>
         </form>
 

--- a/src/pages/Dashboard/Account/DeleteAccountSection.tsx
+++ b/src/pages/Dashboard/Account/DeleteAccountSection.tsx
@@ -1,4 +1,5 @@
 import { useSignal } from "@preact/signals";
+import { Show } from "@preact/signals/utils";
 import { sessionModel } from "../../../models/auth";
 import { errorMessage } from "../../../models/api";
 import { Alert } from "../../../components/Alert";
@@ -80,7 +81,9 @@ export function DeleteAccountSection({ onDeleted }: { onDeleted: () => void }) {
               form="account-delete-form"
               disabled={!canSubmit}
             >
-              {busy.value ? "Deleting…" : "Delete account"}
+              <Show when={busy} fallback="Delete account">
+                Deleting…
+              </Show>
             </Button>
           </>
         }
@@ -108,7 +111,7 @@ export function DeleteAccountSection({ onDeleted }: { onDeleted: () => void }) {
               onInput={(e) => (confirmEmail.value = (e.target as HTMLInputElement).value)}
             />
           </Field>
-          {error.value ? <Alert tone="critical">{error.value}</Alert> : null}
+          <Show when={error}>{(message) => <Alert tone="critical">{message}</Alert>}</Show>
         </form>
       </Dialog>
     </SettingsCard>

--- a/src/pages/Dashboard/GithubAppCallback.tsx
+++ b/src/pages/Dashboard/GithubAppCallback.tsx
@@ -1,11 +1,13 @@
 import { useEffect } from "preact/hooks";
-import { useModel, useSignal } from "@preact/signals";
+import { useComputed, useModel, useSignal } from "@preact/signals";
+import { Show } from "@preact/signals/utils";
 import { useLocation } from "preact-iso";
 import { sessionModel } from "../../models/auth";
 import {
   GithubAppModel,
   type CallbackError,
   type GithubAppCallbackErrorCode,
+  type PublicGithubAppInstallation,
 } from "../../models/github-app";
 import { Alert } from "../../components/Alert";
 import { LinkButton } from "../../components/Button";
@@ -64,7 +66,17 @@ export default function GithubAppCallbackPage() {
 
   const user = sessionModel.user.value;
   const callbackError = githubApp.callbackError.value;
-  const lastLinked = githubApp.lastLinked.value;
+
+  const heading = useComputed(() =>
+    phase.value === "success"
+      ? "Installation linked"
+      : phase.value === "error"
+        ? "Installation could not be linked"
+        : "Finishing GitHub App install",
+  );
+  const linkedInstallation = useComputed(() =>
+    phase.value === "success" ? githubApp.lastLinked.value : null,
+  );
 
   const onSignOut = async () => {
     await sessionModel.signOut();
@@ -79,66 +91,66 @@ export default function GithubAppCallbackPage() {
     >
       <header class="flex flex-col gap-2 max-w-[640px]">
         <Eyebrow>GitHub App install</Eyebrow>
-        <h1 class="text-3xl font-semibold tracking-[-0.02em] m-0">
-          {phase.value === "success"
-            ? "Installation linked"
-            : phase.value === "error"
-              ? "Installation could not be linked"
-              : "Finishing GitHub App install"}
-        </h1>
+        <h1 class="text-3xl font-semibold tracking-[-0.02em] m-0">{heading}</h1>
         <Muted class="text-[14px] leading-[1.55] m-0">
           We're confirming the install with GitHub and storing the installation against your active
           organization.
         </Muted>
       </header>
 
-      {(phase.value === "checking-session" || phase.value === "verifying") && (
-        <LoadingState
-          title={
-            phase.value === "checking-session" ? "Confirming session" : "Verifying with GitHub"
-          }
-          detail={
-            phase.value === "checking-session"
-              ? "loading user"
-              : "exchanging code · linking installation"
-          }
-        />
-      )}
+      <Show when={() => phase.value === "checking-session" || phase.value === "verifying"}>
+        {() => (
+          <LoadingState
+            title={
+              phase.value === "checking-session" ? "Confirming session" : "Verifying with GitHub"
+            }
+            detail={
+              phase.value === "checking-session"
+                ? "loading user"
+                : "exchanging code · linking installation"
+            }
+          />
+        )}
+      </Show>
 
-      {phase.value === "success" && lastLinked ? (
-        <Card as="section" class="p-5 flex flex-col gap-4">
-          <SectionLabel>Linked installation</SectionLabel>
-          <div class="flex flex-col gap-2">
-            <span class="font-mono text-[16px] font-medium">{lastLinked.accountLogin}</span>
-            <MonoDetail
-              parts={[
-                <span key="installation">installation {lastLinked.installationId}</span>,
-                <span key="status">{lastLinked.status}</span>,
-                <span key="account">{lastLinked.accountType.toLowerCase()}</span>,
-              ]}
-            />
-          </div>
-          <Muted class="text-[13px] m-0">Returning you to settings…</Muted>
-          <div>
-            <LinkButton variant="secondary" size="sm" href={SETTINGS_PATH}>
-              Back to settings now
-            </LinkButton>
-          </div>
-        </Card>
-      ) : null}
+      <Show<PublicGithubAppInstallation | null> when={linkedInstallation}>
+        {(installation) => (
+          <Card as="section" class="p-5 flex flex-col gap-4">
+            <SectionLabel>Linked installation</SectionLabel>
+            <div class="flex flex-col gap-2">
+              <span class="font-mono text-[16px] font-medium">{installation.accountLogin}</span>
+              <MonoDetail
+                parts={[
+                  <span key="installation">installation {installation.installationId}</span>,
+                  <span key="status">{installation.status}</span>,
+                  <span key="account">{installation.accountType.toLowerCase()}</span>,
+                ]}
+              />
+            </div>
+            <Muted class="text-[13px] m-0">Returning you to settings…</Muted>
+            <div>
+              <LinkButton variant="secondary" size="sm" href={SETTINGS_PATH}>
+                Back to settings now
+              </LinkButton>
+            </div>
+          </Card>
+        )}
+      </Show>
 
-      {phase.value === "error" ? (
-        <Card as="section" class="p-5 flex flex-col gap-4">
-          <SectionLabel>What went wrong</SectionLabel>
-          <CallbackErrorView queryError={queryError.value} callbackError={callbackError} />
-          <div class="flex gap-2 flex-wrap">
-            <LinkButton href={SETTINGS_PATH}>Back to settings</LinkButton>
-            <LinkButton variant="ghost" href="/dashboard">
-              Go to dashboard
-            </LinkButton>
-          </div>
-        </Card>
-      ) : null}
+      <Show when={() => phase.value === "error"}>
+        {() => (
+          <Card as="section" class="p-5 flex flex-col gap-4">
+            <SectionLabel>What went wrong</SectionLabel>
+            <CallbackErrorView queryError={queryError.value} callbackError={callbackError} />
+            <div class="flex gap-2 flex-wrap">
+              <LinkButton href={SETTINGS_PATH}>Back to settings</LinkButton>
+              <LinkButton variant="ghost" href="/dashboard">
+                Go to dashboard
+              </LinkButton>
+            </div>
+          </Card>
+        )}
+      </Show>
     </PageShell>
   );
 }

--- a/src/pages/Dashboard/Invite/index.tsx
+++ b/src/pages/Dashboard/Invite/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "preact/hooks";
 import { useSignal } from "@preact/signals";
+import { Show } from "@preact/signals/utils";
 import { useLocation } from "preact-iso";
 import { sessionModel } from "../../../models/auth";
 import { ApiError, apiJson, errorMessage } from "../../../models/api";
@@ -66,7 +67,7 @@ export default function InvitePage() {
           <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">
             We couldn't accept this invite
           </h1>
-          {error.value ? <Alert tone="critical">{error.value}</Alert> : null}
+          <Show when={error}>{(message) => <Alert tone="critical">{message}</Alert>}</Show>
           <Muted class="text-[13px] m-0">
             Ask the person who invited you to send a fresh invitation, then open the new link.
           </Muted>

--- a/tooling/oxlint/signals-local/suppressions.json
+++ b/tooling/oxlint/signals-local/suppressions.json
@@ -1,7 +1,1 @@
-{
-  "src/pages/Auth/Login.tsx": [119, 120, 123, 143, 165, 168, 182, 220, 223],
-  "src/pages/Auth/VerifyEmail.tsx": [111, 112, 117],
-  "src/pages/Dashboard/Account/DeleteAccountSection.tsx": [83, 111],
-  "src/pages/Dashboard/GithubAppCallback.tsx": [83, 95, 108, 130],
-  "src/pages/Dashboard/Invite/index.tsx": [69]
-}
+{}


### PR DESCRIPTION
Burns the entire `signals-local/no-signal-conditional-jsx` baseline (`tooling/oxlint/signals-local/suppressions.json`) down from 19 grandfathered infractions to `{}`, so the rule now holds with no exceptions. Each suppressed site was conditional JSX whose condition eagerly read a local signal's `.value` (subscribing the whole component); these now render through `<Show>`, with two-way text toggles using `<Show … fallback>` and DOM attributes passing the signal directly. In `GithubAppCallback` the phase-driven heading and success card move to `useComputed`, and the loading/error branches use `<Show when={() => …}>` with function children so the inner signal reads stay reactive inside the boundary. Pure reactivity refactor with no behavior, API, or UI change. Verified: `oxlint` (baseline bypassed) reports 0 violations, `tsc --noEmit` clean, `oxfmt --check` clean, and 1010/1010 Vitest tests pass.