### PR TITLE
Surface VS Code workflow gate support across UI, docs, and AI review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,11 @@
 
 - `server/` — Hono Worker. `index.ts` mounts routes under `/api/*`. The Worker is the deploy target (`main` in `wrangler.jsonc`).
   - `routes/scans.ts` — `POST /api/v1/scans { stageId }`, `GET /api/v1/scans`, `GET /api/v1/scans/:id`.
-  - `routes/github-webhooks.ts` — public signed GitHub App webhook endpoint. Persists `deployment_protection_rule` deliveries into `github_workflow_gates`; see `docs/workflow-gates.md`, `docs/npm-workflow-gate.md`, and `docs/pypi-workflow-gate.md`.
+  - `routes/github-webhooks.ts` — public signed GitHub App webhook endpoint. Persists `deployment_protection_rule` deliveries into `github_workflow_gates`; see `docs/workflow-gates.md`, `docs/npm-workflow-gate.md`, `docs/pypi-workflow-gate.md`, and `docs/vscode-workflow-gate.md`.
   - `lib/sandbox.ts` — Dynamic Worker that downloads/parses package artifacts. `NpmStageGateway` is the only npm-token egress.
   - `lib/review.ts` — deterministic findings, package/package.json diffing, risk computation, and shared UI types.
   - `lib/ai-review.ts` — Workers AI reviewer, wired via `scan-pipeline.ts` and default-off behind the `ai-review` Flagship flag.
-  - `lib/adapters/` — ecosystem-specific registry/artifact behavior for npm, PyPI, and workflow gates.
+  - `lib/adapters/` — ecosystem-specific registry/artifact behavior for npm, PyPI, VS Code, and workflow gates.
   - `db/` — Drizzle schema and persistence helpers for scans, findings, artifacts, workflow gates, and Better Auth.
 - `src/` — Preact UI. `index.tsx` mounts `preact-iso`; `models/` re-use `server/` types.
 - `drizzle/` — D1 migrations generated from `server/db/schema.ts`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Approval stays outside Drydock: maintainers approve in npm, npmjs.com, or GitHub
 ## Modes
 
 - **npm registry staging** — `npm publish --stage` creates a private staged tarball. Drydock downloads it through a sandbox and leaves final approval in npm.
-- **Workflow gates** — for ecosystems where the registry cannot stage a candidate, GitHub Actions uploads built artifacts and a GitHub Environment custom deployment-protection rule blocks publishing until Drydock review is accepted or rejected. PyPI and npm workflow-gate artifacts are supported by the shared gate pipeline.
+- **Workflow gates** — for ecosystems where the registry cannot stage a candidate, GitHub Actions uploads built artifacts and a GitHub Environment custom deployment-protection rule blocks publishing until Drydock review is accepted or rejected. PyPI, npm, and VS Code workflow-gate artifacts are supported by the shared gate pipeline.
 
 ## Docs
 
@@ -16,7 +16,7 @@ Start with [`docs/README.md`](docs/README.md) to pick the smallest relevant refe
 - [`docs/self-hosting.md`](docs/self-hosting.md) — local setup, Cloudflare resources, deployment, GitHub App, and Slack setup.
 - [`docs/architecture.md`](docs/architecture.md) — runtime components, trust boundaries, adapters, storage, and API shape.
 - [`docs/security-model.md`](docs/security-model.md) — non-negotiable security posture.
-- [`docs/workflow-gates.md`](docs/workflow-gates.md) — GitHub Environment gate contract for PyPI and npm workflow-gated releases.
+- [`docs/workflow-gates.md`](docs/workflow-gates.md) — GitHub Environment gate contract for PyPI, npm, and VS Code workflow-gated releases.
 - [`docs/release-safety.md`](docs/release-safety.md), [`docs/security-detection-corpus.md`](docs/security-detection-corpus.md), [`docs/detection-eval.md`](docs/detection-eval.md), and [`docs/e2e-test-environment.md`](docs/e2e-test-environment.md) — verification and detection quality.
 
 ## Layout

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ Start here instead of reading every Markdown file. Pick the smallest set that ma
 ## Product/runtime docs
 
 - [`architecture.md`](./architecture.md) — Worker, sandbox, adapters, storage, org model, and API shape.
-- [`workflow-gates.md`](./workflow-gates.md) — GitHub Environment gate flow for PyPI and npm workflow-gated releases.
+- [`workflow-gates.md`](./workflow-gates.md) — GitHub Environment gate flow for PyPI, npm, and VS Code workflow-gated releases.
 - [`diff-baseline.md`](./diff-baseline.md) — default previous-version comparison strategy.
 - [`artifact-storage.md`](./artifact-storage.md) — D1/R2 report and artifact persistence.
 
@@ -36,3 +36,4 @@ Start here instead of reading every Markdown file. Pick the smallest set that ma
 ## Retired or compatibility pointers
 
 - [`npm-workflow-gate.md`](./npm-workflow-gate.md) — short pointer kept for old links; canonical npm workflow-gate details now live in [`workflow-gates.md`](./workflow-gates.md#npm-workflow-gate-notes).
+- [`vscode-workflow-gate.md`](./vscode-workflow-gate.md) — short pointer; canonical VS Code workflow-gate details live in [`workflow-gates.md`](./workflow-gates.md#vs-code-workflow-gate-notes).

--- a/docs/pypi-workflow-gate.md
+++ b/docs/pypi-workflow-gate.md
@@ -68,10 +68,11 @@ after parsing the archive in the credentials-free sandbox:
   → **pypi**;
 - an npm tarball carries a root `package.json` → **npm**.
 
-This lives in the shared router (`server/lib/workflow-gates/resolve.ts`). A
-single auto-detect gate therefore reviews npm, PyPI, or a mixed monorepo that
-publishes both. Pinning `ecosystem: "pypi"` on the release target is supported
-but optional.
+This lives in the shared router (`server/lib/workflow-gates/resolve.ts`), which
+also routes `.vsix` files to the VS Code adapter by extension (they are not
+byte-ambiguous with tarballs). A single auto-detect gate therefore reviews npm,
+PyPI, VS Code, or a mixed monorepo that publishes several. Pinning
+`ecosystem: "pypi"` on the release target is supported but optional.
 
 **Ambiguity fails closed.** Package contents are untrusted, and an archive that
 presents as more than one ecosystem is rejected

--- a/docs/vscode-workflow-gate.md
+++ b/docs/vscode-workflow-gate.md
@@ -1,0 +1,5 @@
+# VS Code workflow-gate mode
+
+This compatibility page is intentionally short. Canonical workflow-gate documentation now lives in [`workflow-gates.md`](./workflow-gates.md), including the [VS Code workflow-gate notes](./workflow-gates.md#vs-code-workflow-gate-notes).
+
+Use VS Code workflow gates when a GitHub Actions workflow packages an extension into a `.vsix` and should be paused by a GitHub Environment protection rule before it is published to the Marketplace. The workflow must upload the exact `vsce package` artifact that the publish job later publishes; repacking after approval breaks Drydock's review boundary. Identity comes from `extension/package.json` inside the VSIX (`publisher.name` plus `version`), and Drydock resolves a best-effort baseline from the public VS Code Marketplace as a diff aid only — see the [VS Code workflow-gate notes](./workflow-gates.md#vs-code-workflow-gate-notes) for the full shape.

--- a/server/lib/ai-review-contract.ts
+++ b/server/lib/ai-review-contract.ts
@@ -1,6 +1,6 @@
 import z from "zod";
 
-export type AiReviewEcosystem = "npm" | "pypi" | "generic";
+export type AiReviewEcosystem = "npm" | "pypi" | "vscode" | "generic";
 
 // We surface only the highest-signal findings: critical/high, most severe
 // first, capped at this count. Lower-severity context belongs in the summary.
@@ -19,7 +19,7 @@ Instruction boundary:
 
 Workflow:
 1. Read deterministicFindings first; preserve their seriousness.
-2. Read packageJsonDiff (legacy normalized manifest diff). npm: package.json. PyPI: normalized package identity; artifact metadata lives in METADATA, WHEEL, RECORD, PKG-INFO, pyproject.toml, setup.py.
+2. Read packageJsonDiff (legacy normalized manifest diff). npm: package.json. PyPI: normalized package identity; artifact metadata lives in METADATA, WHEEL, RECORD, PKG-INFO, pyproject.toml, setup.py. VS Code: the VSIX extension manifest package.json — publisher.name, name, version, engines.vscode, activationEvents, contributes, main/browser.
 3. Scan the changed-file manifest for suspicious new/modified artifacts.
 4. Pull targeted evidence with tools only when the manifest or findings make a file/search relevant.
 5. Cite concrete paths and exact snippets. Never invent line numbers, external package facts, or dependency reputation.
@@ -56,6 +56,23 @@ High-priority PyPI risks:
 
 PyPI evidence policy: don't assume a wheel/sdist is safe because metadata says so. Normal Python packaging files aren't suspicious by themselves; escalate when they introduce install/build execution, startup hooks, metadata inconsistency, native payloads, credential/network/process capability, obfuscation, or unexplained package-shape change.`;
 
+const VSCODE_REVIEW_PROMPT = `Ecosystem: VS Code extension (VSIX).
+
+The reviewed bytes are a packed .vsix (a ZIP) with the extension/ prefix stripped, so the extension manifest is package.json at the root. Extensions run in the Node.js extension host with the user's full privileges — process spawn, filesystem, network, environment, and VS Code's SecretStorage/authentication APIs — with no install sandbox, so the highest risk is code that runs automatically or reaches operator-controlled input.
+
+High-priority VS Code risks:
+- Startup/broad activation: activationEvents of "*" or "onStartupFinished", and workspaceContains globs that match ordinary repos, run extension code at launch or workspace open before the user invokes a feature. Treat new broad activation combined with network/process/dynamic-code capability as remote-command malware until evidence shows otherwise.
+- Entrypoint hijacking: changed main (Node extension host) or browser (web-extension worker) fields, or new files they load; trace what the activation entrypoint requires/imports.
+- Process/terminal execution: child_process, spawn/exec, window.createTerminal + terminal.sendText, tasks, or shell invocations run commands with no user prompt.
+- Network/staged payloads: fetch/http/https/net, downloading a language server, binary, or script after install and then executing it. A bundled or downloaded WebAssembly module (WebAssembly.instantiate/instantiateStreaming, wasm_exec, new Go()) can hide network/process behavior in an opaque payload.
+- Credential/secret/host access: SecretStorage, authentication.getSession, env.machineId/sessionId, process.env, reads of home/.ssh/.npmrc/.gitconfig, cloud or CI tokens, and telemetry that exfiltrates workspace contents or machine identifiers.
+- Undeclared configuration reads: workspace.getConfiguration keys not declared under contributes.configuration can be pre-seeded through a committed .vscode/settings.json and used as attacker-controlled input that never appears in the manifest.
+- Transitive install: extensionDependencies and extensionPack install and activate other extensions, a delivery path abused by malicious extension campaigns; confirm every referenced extension is intended.
+- Identity/metadata integrity: publisher.name, name, version, and engines.vscode must be present and match the reviewed release; a mismatch, or an unexpectedly broad engines.vscode, is tamper-like.
+- Obfuscation/native artifacts: eval, new Function, base64/hex decode then execute, packed/minified new bundles, and .node/.wasm/.dll/.so/.dylib/.exe payloads shipped in the VSIX.
+
+VS Code evidence policy: a VSIX ships already-built code, so the extension's own devDependencies and npm lifecycle scripts (prepare/postinstall/prepublish) usually do not run for consumers — don't treat them as consumer-install hooks without evidence they altered the packed output. Contributes, commands, and menus are ordinary; escalate when activation, entrypoints, transitive extensions, credential/network/process capability, undeclared configuration inputs, obfuscation, or native payloads change. When risk hinges on an asset downloaded at runtime that you cannot see, require manual review.`;
+
 const GENERIC_REVIEW_PROMPT = `Ecosystem: generic package release.
 
 High-priority risks:
@@ -82,18 +99,19 @@ Summary style:
 - Spend words only on what raises concern, citing concrete paths; stay terse even then.`;
 
 export function normalizeAiReviewEcosystem(ecosystem: string | undefined): AiReviewEcosystem {
-  if (ecosystem === "npm" || ecosystem === "pypi") return ecosystem;
+  if (ecosystem === "npm" || ecosystem === "pypi" || ecosystem === "vscode") return ecosystem;
   return "generic";
 }
 
+const ECOSYSTEM_REVIEW_PROMPTS: Record<AiReviewEcosystem, string> = {
+  npm: NPM_REVIEW_PROMPT,
+  pypi: PYPI_REVIEW_PROMPT,
+  vscode: VSCODE_REVIEW_PROMPT,
+  generic: GENERIC_REVIEW_PROMPT,
+};
+
 export function buildReviewerSystemPrompt(ecosystem: string | undefined): string {
-  const normalized = normalizeAiReviewEcosystem(ecosystem);
-  const ecosystemPrompt =
-    normalized === "npm"
-      ? NPM_REVIEW_PROMPT
-      : normalized === "pypi"
-        ? PYPI_REVIEW_PROMPT
-        : GENERIC_REVIEW_PROMPT;
+  const ecosystemPrompt = ECOSYSTEM_REVIEW_PROMPTS[normalizeAiReviewEcosystem(ecosystem)];
   return `${BASE_REVIEWER_SYSTEM_PROMPT}\n\n${ecosystemPrompt}\n\n${SEVERITY_GUIDANCE}`;
 }
 

--- a/server/lib/ai-review-evidence.ts
+++ b/server/lib/ai-review-evidence.ts
@@ -78,6 +78,8 @@ function reviewTaskFor(ecosystem: string): string {
       return "Review this staged npm release. Decide whether it looks ordinary or something is off and needs review before a maintainer approves it.";
     case "pypi":
       return "Review this PyPI release candidate. Decide whether the wheel/sdist changes look ordinary or something is off and needs review before the GitHub workflow gate allows publishing.";
+    case "vscode":
+      return "Review this VS Code extension release candidate. Decide whether the VSIX changes look ordinary or something is off and needs review before the GitHub workflow gate allows publishing to the Marketplace.";
     default:
       return "Review this staged package release. Decide whether it looks ordinary or something is off and needs review before a maintainer approves it.";
   }

--- a/src/components/PageShell.tsx
+++ b/src/components/PageShell.tsx
@@ -101,7 +101,7 @@ function SiteFooter({ maxWidth }: { maxWidth: string }) {
         <div class="flex flex-col gap-1">
           <BrandMark href="/" size="sm" />
           <p class="m-0 font-mono text-[11px] text-ink-subtle">
-            Pre-publish review for npm and PyPI · © 2026 Drydock
+            Pre-publish review for npm, PyPI, and VS Code · © 2026 Drydock
           </p>
         </div>
         <nav class="flex flex-wrap items-center gap-x-5 gap-y-2 text-[13px]" aria-label="Footer">

--- a/src/lib/seo.tsx
+++ b/src/lib/seo.tsx
@@ -3,7 +3,7 @@ import { toStatic, useHead, useLink, type MetaOptions } from "hoofd/preact";
 const SITE_NAME = "Drydock";
 const SITE_URL = "https://drydock.org";
 const OG_IMAGE_URL = `${SITE_URL}/og-image.png`;
-const OG_IMAGE_ALT = "Drydock — pre-publish package review for npm and PyPI maintainers";
+const OG_IMAGE_ALT = "Drydock — pre-publish package review for npm, PyPI, and VS Code maintainers";
 
 export interface PageSeoMetadata {
   title: string;
@@ -25,7 +25,7 @@ export interface PrerenderHead {
 export const homePageSeo: PageSeoMetadata = {
   title: "Drydock: pre-publish package review",
   description:
-    "Drydock lets npm and PyPI maintainers review the exact package artifact before a staged publish or gated release goes live.",
+    "Drydock lets npm, PyPI, and VS Code maintainers review the exact package artifact before a staged publish or gated release goes live.",
   path: "/",
 };
 

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -153,7 +153,7 @@ function DashboardHeader() {
       <Eyebrow>Review workspace</Eyebrow>
       <h1 class="text-3xl font-semibold tracking-[-0.02em] m-0">Ready for the next release</h1>
       <Muted class="text-[14px] leading-[1.55] m-0">
-        Review held npm and PyPI candidates before maintainers let them go live.
+        Review held npm, PyPI, and VS Code candidates before maintainers let them go live.
       </Muted>
     </header>
   );

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -41,7 +41,11 @@ export default function DocsPage() {
             Run <Code>npm publish --stage</Code>. npm holds a private candidate, Drydock reviews it,
             and you complete the publish in npm with your own 2FA.
           </ModeCard>
-          <ModeCard href="#workflow-gating" title="Workflow gating: PyPI & npm" badge="Preview">
+          <ModeCard
+            href="#workflow-gating"
+            title="Workflow gating: PyPI, npm & VS Code"
+            badge="Preview"
+          >
             GitHub Actions builds and uploads the release artifact. A GitHub Environment pauses
             publishing until a maintainer approves or rejects the Drydock review.
           </ModeCard>

--- a/src/pages/Landing/index.tsx
+++ b/src/pages/Landing/index.tsx
@@ -123,10 +123,11 @@ export default function LandingPage() {
             parks a private candidate. Drydock reviews that tarball and pins risk signals to the
             diff before the maintainer completes npm's 2FA confirmation.
           </RegistryCard>
-          <RegistryCard title="Workflow gating: PyPI & npm" badge="Preview">
-            For PyPI, or npm workflows that do not stage, a GitHub Environment pauses the publish
-            job after CI uploads the release artifact. Drydock reviews the upload, the maintainer
-            approves or rejects, and, if approved, the job continues with its own credential.
+          <RegistryCard title="Workflow gating: PyPI, npm & VS Code" badge="Preview">
+            For PyPI, VS Code extensions, or npm workflows that do not stage, a GitHub Environment
+            pauses the publish job after CI uploads the release artifact. Drydock reviews the
+            upload, the maintainer approves or rejects, and, if approved, the job continues with its
+            own credential.
           </RegistryCard>
         </div>
         <LinkButton href="/docs" variant="ghost" size="sm" class="self-start">

--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -123,6 +123,17 @@ describe("AI review prompt selection", () => {
     expect(prompt).not.toContain("optionalDependencies");
   });
 
+  test("routes the vscode ecosystem to the VS Code prompt without npm/PyPI leakage", () => {
+    expect(normalizeAiReviewEcosystem("vscode")).toBe("vscode");
+
+    const prompt = buildReviewerSystemPrompt("vscode");
+
+    expect(prompt).toContain("Ecosystem: VS Code extension (VSIX).");
+    expect(prompt).not.toContain("Ecosystem: npm.");
+    expect(prompt).not.toContain("Ecosystem: PyPI.");
+    expect(prompt).not.toContain("Ecosystem: generic package release.");
+  });
+
   test("falls back to generic package guidance for unknown adapters", () => {
     expect(normalizeAiReviewEcosystem("rubygems")).toBe("generic");
     expect(normalizeAiReviewEcosystem(undefined)).toBe("generic");


### PR DESCRIPTION
## Why

VS Code workflow gates are fully implemented in the backend — adapters (`server/lib/adapters/vscode/`), the shared gate pipeline, deterministic VSIX rules, Marketplace baselines, provenance, and comprehensive tests all handle them. But the support was **under-surfaced**: user-facing copy still enumerated only "npm and PyPI", and the AI reviewer fell back to the generic prompt for VSIX scans instead of reasoning about the VS Code extension threat model.

This PR closes both gaps. No gate/adapter logic changed.

## Surfacing (previously "npm and PyPI" only)

- **UI**: Landing + Docs workflow-gating cards, Dashboard header, `PageShell` footer tagline
- **SEO**: OG image alt + home page meta description (`src/lib/seo.tsx`)
- **Docs**: `README.md` + `docs/README.md` workflow-gate descriptions; new `docs/vscode-workflow-gate.md` compatibility pointer for parity with the npm/PyPI ones; auto-detect note in `docs/pypi-workflow-gate.md`
- **AGENTS.md**: adapters bullet + github-webhooks doc references

## AI review (VSIX scans were using the generic prompt)

- Add `"vscode"` to `AiReviewEcosystem`; route it to a new `VSCODE_REVIEW_PROMPT` grounded in the VS Code extension threat model — startup/broad activation, `main`/`browser` entrypoints, terminal/process execution, `SecretStorage`/`authentication` APIs, undeclared `workspace.getConfiguration` reads, `extensionDependencies`/`extensionPack`, WASM/native payloads — complementing (never downgrading) the deterministic VSIX rules
- Replace the prompt-routing ternary with an exhaustive `Record<AiReviewEcosystem, string>` map
- VS Code-specific evidence task string in `ai-review-evidence.ts`
- Test: `vscode` routes to the VS Code prompt without npm/PyPI/generic leakage

The AI reviewer stays advisory and default-off behind the per-org `ai-review` flag; it was already ecosystem-agnostic at the gate, so a VSIX scan with the flag on now gets an accurate prompt instead of the generic fallback. This aligns with the deterministic-vs-gated detection split (AI belongs to the gated-target mode).

## Testing

- `pnpm run typecheck` ✓
- `pnpm run format:check` ✓ · `oxlint` ✓
- `pnpm run test` ✓ — full Vitest suite (node 693 + workers 318) green, incl. the new prompt-routing test
- Docs checked: the AI-reviewer docs describe it ecosystem-agnostically (advisory/default-off), so no per-ecosystem enumeration needed updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)