### PR TITLE
Add Workers Cache pilot for completed-scan reads

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,7 @@ Dynamic Worker sandbox
 
 The Worker is the trusted control plane; the sandbox treats package bytes as hostile evidence. Route handlers should stay thin and call shared pipeline/library code so HTTP routes, queue consumers, and local `waitUntil()` execution behave the same.
 
-Completed scan reads are split into a gateway handler and a `CachedScanReads` WorkerEntrypoint. The gateway keeps authentication, organization resolution, and scan-view event writes in the trusted worker, then forwards only the pure read to the cached entrypoint with `organizationId` in `ctx.props`. The cached entrypoint returns `Cache-Control`/`Cache-Tag` on completed scan detail, file, and report responses and exposes tag-based invalidation for decision mutations.
+Completed scan reads are split into a gateway handler and a `CachedScanReads` WorkerEntrypoint. The gateway keeps authentication, organization resolution, and scan-view event writes in the trusted worker, then forwards only the pure read to the cached entrypoint with `organizationId` in `ctx.props`. The tiered edge-cache dispatch is gated by `WORKERS_CACHE_PILOT` and is off by default; when the flag is off, or on runtimes that do not yet support the self-entrypoint `exports`/`props` binding, the reads stay in-process but still return the same `Cache-Control`/`Cache-Tag` headers. The cached entrypoint exposes tag-based invalidation for decision mutations, and enabling the pilot on a deployed Worker means setting `WORKERS_CACHE_PILOT=1`.
 
 ## Trust boundaries
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,6 +13,7 @@ Hono Worker
   ├─ D1 persistence and R2 report/artifact storage
   ├─ Queue-backed scan/gate orchestration
   ├─ Dynamic Worker loader for untrusted archive parsing
+  ├─ Cached inner entrypoints for immutable scan reads
   ├─ npm / PyPI / VS Code adapters and workflow-gate adapters
   └─ constrained brokers/gateways for registry/artifact downloads
         │
@@ -27,6 +28,8 @@ Dynamic Worker sandbox
 ```
 
 The Worker is the trusted control plane; the sandbox treats package bytes as hostile evidence. Route handlers should stay thin and call shared pipeline/library code so HTTP routes, queue consumers, and local `waitUntil()` execution behave the same.
+
+Completed scan reads are split into a gateway handler and a `CachedScanReads` WorkerEntrypoint. The gateway keeps authentication, organization resolution, and scan-view event writes in the trusted worker, then forwards only the pure read to the cached entrypoint with `organizationId` in `ctx.props`. The cached entrypoint returns `Cache-Control`/`Cache-Tag` on completed scan detail, file, and report responses and exposes tag-based invalidation for decision mutations.
 
 ## Trust boundaries
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.41.0",
     "@cloudflare/vitest-pool-workers": "0.16.17",
-    "@cloudflare/workers-types": "^4.20260617.1",
+    "@cloudflare/workers-types": "4.20260617.1",
     "@playwright/test": "^1.61.0",
     "@preact/eslint-plugin-signals": "^0.3.0",
     "@preact/preset-vite": "^2.10.5",
@@ -67,7 +67,7 @@
     "typescript": "^7.0.2",
     "vite": "^8.0.16",
     "vitest": "^4.1.9",
-    "wrangler": "4.102.0"
+    "wrangler": "4.107.0"
   },
   "packageManager": "pnpm@11.1.1+sha512.d1fdf5f73c617b64fa1a56a81c3c8dfe0e966e33a6010aa256b517ae77be21d93e05affc0de1a83b0e4f29d569f68b446ae8f068cd7247c0bb3df0fb4d7bdf9a"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,12 +64,12 @@ importers:
     devDependencies:
       '@cloudflare/vite-plugin':
         specifier: 1.41.0
-        version: 1.41.0(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))(workerd@1.20260617.1)(wrangler@4.102.0(@cloudflare/workers-types@4.20260617.1))
+        version: 1.41.0(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))(workerd@1.20260701.1)(wrangler@4.107.0(@cloudflare/workers-types@4.20260617.1))
       '@cloudflare/vitest-pool-workers':
         specifier: 0.16.17
         version: 0.16.17(@cloudflare/workers-types@4.20260617.1)(@vitest/runner@4.1.9)(@vitest/snapshot@4.1.9)(vitest@4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)))
       '@cloudflare/workers-types':
-        specifier: ^4.20260617.1
+        specifier: 4.20260617.1
         version: 4.20260617.1
       '@playwright/test':
         specifier: ^1.61.0
@@ -114,8 +114,8 @@ importers:
         specifier: ^4.1.9
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))
       wrangler:
-        specifier: 4.102.0
-        version: 4.102.0(@cloudflare/workers-types@4.20260617.1)
+        specifier: 4.107.0
+        version: 4.107.0(@cloudflare/workers-types@4.20260617.1)
 
 packages:
 
@@ -340,8 +340,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@cloudflare/workerd-darwin-64@1.20260701.1':
+    resolution: {integrity: sha512-Zd9Y1bah6DwwBN2RW8vJohffQrIUazb8UXnqSNecOxM+jJLhUuvv5IOG8dbHcV83TyZAubea6gsQXo2yH1lDdw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
   '@cloudflare/workerd-darwin-arm64@1.20260617.1':
     resolution: {integrity: sha512-LHH7b565g9znfCUOkwbec6FG2rmRbsgCy6aJiU9KN662mNheWl5sw/iKleiFSiljPKQQP3HkjnC/NSkdgi/aSA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260701.1':
+    resolution: {integrity: sha512-yBLsjS1qCWqFyCY37qRUrYfzHHvMGvjh8zRKJ6MvUivYDhkZTzqduppK38FoqYvayLJ5KbcxH7zo5rkxGqbsaA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
@@ -352,14 +364,32 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-64@1.20260701.1':
+    resolution: {integrity: sha512-vMfqSIMfoo4xmZXEuUVqLpSFS921YKjiR9q7kDXPi6Vld1PK74UHg9LZuBavT2KSyemHUCTpj9y/4JSYOEyQbQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
   '@cloudflare/workerd-linux-arm64@1.20260617.1':
     resolution: {integrity: sha512-MRoifFYcqbxxIIQy7PqO5tFY/qPFSnjXzakWl0sO93l+HLyG35jRAgOi6jfqa4kBxc7gKKtH861DcewjxUfkjA==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-arm64@1.20260701.1':
+    resolution: {integrity: sha512-HRfwbKU2pK44V2NhoM0+iH0JJSj7nQ9Wv13ifIiGYCmTtDL8/zKtEhX7kQ3D4Vy/Cpjhttl0FkfqXj1aqLDPPg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
   '@cloudflare/workerd-windows-64@1.20260617.1':
     resolution: {integrity: sha512-rgBV9wQrv0OSKgCTTbhFUFY3sLGNANZ88aqaLvtmEn2gmbFVb1J4PDGochVUdB7NSEp4D/ghHva6/8SZmbONpw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workerd-windows-64@1.20260701.1':
+    resolution: {integrity: sha512-ngxCiIN9s/fM2o1IBMD0o1/mcXrv2NJVdyznh51UH8sQuvrTrXvV2nM0Uj/qU2wMwF6prgNBcdcd7AZeZGiBQA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -2191,6 +2221,11 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
+  miniflare@4.20260701.0:
+    resolution: {integrity: sha512-L6eAAi6IKtyb/7J6L+YsH2vb1yBrJWKRXI293JYDiMl70+6nncdAgigex58w6WBd+CwvdMsqOyNyGs95Op5gWQ==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -2612,6 +2647,11 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  workerd@1.20260701.1:
+    resolution: {integrity: sha512-uF813NG09JwNRRUfJ0zBomyTslSPM810dMj9LVvkQ7RAkLrQLzAlPU8Xh/3dIqZDo2bfd7tChbf2PtqLRARRJQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   workers-ai-provider@3.2.0:
     resolution: {integrity: sha512-zw74Z5gfmF2i8wR+ORzGrTwY/6Ui24T6FpiNbzjqQJMMmUSIzZhCDyDIiRYIIxsFwvATITrsQLCWHZnxPNpQ4Q==}
     peerDependencies:
@@ -2634,6 +2674,16 @@ packages:
     hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^4.20260617.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  wrangler@4.107.0:
+    resolution: {integrity: sha512-fw69ThymNitZ0oIEBU2yNeq3kK59UKz/jyA3udwRrQIAIsxX57q5qLOpPTN7qc5t8n9pnUeofe0uxtMuhQZW8w==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260701.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -2899,13 +2949,19 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260617.1
 
-  '@cloudflare/vite-plugin@1.41.0(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))(workerd@1.20260617.1)(wrangler@4.102.0(@cloudflare/workers-types@4.20260617.1))':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260701.1)':
     dependencies:
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260617.1)
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260701.1
+
+  '@cloudflare/vite-plugin@1.41.0(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4))(workerd@1.20260701.1)(wrangler@4.107.0(@cloudflare/workers-types@4.20260617.1))':
+    dependencies:
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260701.1)
       miniflare: 4.20260617.0
       unenv: 2.0.0-rc.24
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)
-      wrangler: 4.102.0(@cloudflare/workers-types@4.20260617.1)
+      wrangler: 4.107.0(@cloudflare/workers-types@4.20260617.1)
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -2930,16 +2986,31 @@ snapshots:
   '@cloudflare/workerd-darwin-64@1.20260617.1':
     optional: true
 
+  '@cloudflare/workerd-darwin-64@1.20260701.1':
+    optional: true
+
   '@cloudflare/workerd-darwin-arm64@1.20260617.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260701.1':
     optional: true
 
   '@cloudflare/workerd-linux-64@1.20260617.1':
     optional: true
 
+  '@cloudflare/workerd-linux-64@1.20260701.1':
+    optional: true
+
   '@cloudflare/workerd-linux-arm64@1.20260617.1':
     optional: true
 
+  '@cloudflare/workerd-linux-arm64@1.20260701.1':
+    optional: true
+
   '@cloudflare/workerd-windows-64@1.20260617.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260701.1':
     optional: true
 
   '@cloudflare/workers-types@4.20260617.1': {}
@@ -4199,6 +4270,18 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  miniflare@4.20260701.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.28.0
+      workerd: 1.20260701.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   ms@2.1.3: {}
 
   nanoid@3.3.12: {}
@@ -4633,6 +4716,14 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260617.1
       '@cloudflare/workerd-windows-64': 1.20260617.1
 
+  workerd@1.20260701.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260701.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260701.1
+      '@cloudflare/workerd-linux-64': 1.20260701.1
+      '@cloudflare/workerd-linux-arm64': 1.20260701.1
+      '@cloudflare/workerd-windows-64': 1.20260701.1
+
   workers-ai-provider@3.2.0(@ai-sdk/provider@3.0.10)(ai@6.0.207(zod@4.4.3)):
     dependencies:
       '@ai-sdk/provider': 3.0.10
@@ -4648,6 +4739,23 @@ snapshots:
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
       workerd: 1.20260617.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260617.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  wrangler@4.107.0(@cloudflare/workers-types@4.20260617.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260701.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.1
+      miniflare: 4.20260701.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260701.1
     optionalDependencies:
       '@cloudflare/workers-types': 4.20260617.1
       fsevents: 2.3.3

--- a/server/env.d.ts
+++ b/server/env.d.ts
@@ -19,6 +19,7 @@ declare global {
       BETTER_AUTH_SECRET: string;
       BETTER_AUTH_URL?: string;
       AUTH_REQUIRED?: string;
+      WORKERS_CACHE_PILOT?: string;
       FLAGS?: Flagship;
       SEND_EMAIL?: SendEmailBinding;
       EMAIL_FROM_ADDRESS?: string;

--- a/server/index.ts
+++ b/server/index.ts
@@ -49,6 +49,7 @@ import type { Bindings, Variables } from "./types";
 
 export { NpmStageGateway } from "./lib/sandbox";
 export { NpmAdapterBroker } from "./lib/adapters/npm";
+export { CachedScanReads } from "./lib/cached-scan-reads";
 
 const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 const CANONICAL_HOSTNAME = "drydock.org";

--- a/server/lib/cached-scan-reads.ts
+++ b/server/lib/cached-scan-reads.ts
@@ -1,0 +1,145 @@
+import { WorkerEntrypoint } from "cloudflare:workers";
+import { createDb } from "../db/client";
+import { getScan, getScanFile, getScanStatus } from "../db/scans";
+import { reportExportFilename, serializeReportExport } from "./report-export";
+import { scanArtifactReadBucket } from "./scan-artifacts";
+
+const DETAIL_CACHE_MAX_AGE_SECONDS = 60;
+const DETAIL_STALE_WHILE_REVALIDATE_SECONDS = 60 * 60;
+const FILE_CACHE_MAX_AGE_SECONDS = 60 * 60 * 24;
+const FILE_STALE_WHILE_REVALIDATE_SECONDS = 60 * 60 * 24 * 30;
+const REPORT_CACHE_MAX_AGE_SECONDS = 60 * 5;
+const REPORT_STALE_WHILE_REVALIDATE_SECONDS = 60 * 60;
+
+interface CachedScanReadsProps {
+  organizationId: string;
+}
+
+interface CachePurgeContext {
+  purge?(options: {
+    tags?: string[];
+    pathPrefixes?: string[];
+    purgeEverything?: boolean;
+  }): Promise<unknown> | unknown;
+}
+
+type ScanDetail = Awaited<ReturnType<typeof getScan>>;
+
+function cacheHeaders(scanId: string, maxAgeSeconds: number, staleWhileRevalidateSeconds: number) {
+  return {
+    "cache-control": `public, max-age=${maxAgeSeconds}, stale-while-revalidate=${staleWhileRevalidateSeconds}`,
+    "cache-tag": `scan:${scanId}`,
+  };
+}
+
+function noStoreHeaders() {
+  return { "cache-control": "private, no-store" };
+}
+
+function jsonResponse(body: unknown, status = 200, headers: HeadersInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      ...headers,
+    },
+  });
+}
+
+function notFoundResponse(message: string) {
+  return jsonResponse({ error: message }, 404, noStoreHeaders());
+}
+
+function parseScanId(pathname: string) {
+  const match = /^\/api\/v1\/scans\/([^/]+)(?:\/(file|report\.json))?$/.exec(pathname);
+  return match ? { scanId: match[1], suffix: match[2] ?? null } : null;
+}
+
+function isCompletedScan(detail: ScanDetail) {
+  return detail?.scan.status === "complete";
+}
+
+export class CachedScanReads extends WorkerEntrypoint<Cloudflare.Env, CachedScanReadsProps> {
+  async fetch(request: Request): Promise<Response> {
+    if (request.method !== "GET") {
+      return jsonResponse({ error: "method not allowed" }, 405, noStoreHeaders());
+    }
+
+    const parsed = parseScanId(new URL(request.url).pathname);
+    if (!parsed) return notFoundResponse("not found");
+
+    const db = createDb(this.env.DB);
+    const organizationId = this.ctx.props.organizationId;
+    const bucket = scanArtifactReadBucket(this.env);
+
+    switch (parsed.suffix) {
+      case null: {
+        const detail = await getScan(db, parsed.scanId, organizationId, bucket, {
+          includeFileSamples: false,
+        });
+        if (!detail) return notFoundResponse("not found");
+        if (!isCompletedScan(detail)) {
+          return jsonResponse(detail, 200, noStoreHeaders());
+        }
+        return jsonResponse(
+          detail,
+          200,
+          cacheHeaders(
+            parsed.scanId,
+            DETAIL_CACHE_MAX_AGE_SECONDS,
+            DETAIL_STALE_WHILE_REVALIDATE_SECONDS,
+          ),
+        );
+      }
+      case "file": {
+        const scan = await getScanStatus(db, parsed.scanId, organizationId);
+        if (!scan) return notFoundResponse("file not found in scan");
+        const path = new URL(request.url).searchParams.get("path") || "";
+        if (!path) return jsonResponse({ error: "path is required" }, 400, noStoreHeaders());
+        const file = await getScanFile(db, parsed.scanId, organizationId, path, bucket);
+        if (!file) return jsonResponse({ error: "file not found in scan" }, 404, noStoreHeaders());
+        if (scan.status !== "complete") return jsonResponse({ file }, 200, noStoreHeaders());
+        return jsonResponse(
+          { file },
+          200,
+          cacheHeaders(
+            parsed.scanId,
+            FILE_CACHE_MAX_AGE_SECONDS,
+            FILE_STALE_WHILE_REVALIDATE_SECONDS,
+          ),
+        );
+      }
+      case "report.json": {
+        const detail = await getScan(db, parsed.scanId, organizationId, bucket);
+        if (!detail) return notFoundResponse("not found");
+        if (!isCompletedScan(detail)) {
+          return jsonResponse(
+            { error: "report export is only available for completed scans" },
+            409,
+            noStoreHeaders(),
+          );
+        }
+        return new Response(serializeReportExport(detail), {
+          status: 200,
+          headers: {
+            "content-type": "application/json; charset=utf-8",
+            "content-disposition": `attachment; filename="${reportExportFilename(detail.scan)}"`,
+            ...cacheHeaders(
+              parsed.scanId,
+              REPORT_CACHE_MAX_AGE_SECONDS,
+              REPORT_STALE_WHILE_REVALIDATE_SECONDS,
+            ),
+          },
+        });
+      }
+      default:
+        return notFoundResponse("not found");
+    }
+  }
+
+  async invalidate(scanId: string) {
+    const cache = (this.ctx as { cache?: CachePurgeContext }).cache;
+    if (!cache?.purge) return;
+    await cache.purge({ tags: [`scan:${scanId}`] });
+  }
+}

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -15,7 +15,6 @@ import {
   deleteFailedScan,
   getScan,
   getScanCompareData,
-  getScanFile,
   getScanStatus,
   listScans,
   recordScanDecision,
@@ -49,13 +48,60 @@ import {
 import { annotateFindingsWithDiffStatus, createPackageDiff, type FileRecord } from "../lib/review";
 import { describeOperationalError, emitOperationalEvent } from "../lib/observability";
 import { parseScanInput } from "../lib/scan-input";
-import { reportExportFilename, serializeReportExport } from "../lib/report-export";
+import { CachedScanReads } from "../lib/cached-scan-reads";
 import { executeScanJob, type ScanQueueMessage } from "../lib/scan-job";
 import { roleCanManageIntegrations } from "../lib/roles";
 import { checkStagedPublishAccess, fetchStagedPublishDetails } from "../lib/staged-publishes";
 import type { Bindings, ScanInput, Variables } from "../types";
 
 export const scansRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+interface CachedScanReadsEntrypoint {
+  fetch(request: Request, options: { props: { organizationId: string } }): Promise<Response>;
+  invalidate(scanId: string): Promise<void>;
+}
+
+function cachedScanReadsEntrypoint(
+  c: Context<{ Bindings: Bindings; Variables: Variables }>,
+  organizationId: string,
+) {
+  try {
+    const exports = (
+      c.executionCtx as ExecutionContext & {
+        exports?: { CachedScanReads?: CachedScanReadsEntrypoint };
+      }
+    ).exports;
+    if (exports?.CachedScanReads) return exports.CachedScanReads;
+  } catch {
+    // Fallback for local worker test runtimes that do not expose ctx.exports.
+  }
+
+  const entrypoint = Object.create(CachedScanReads.prototype) as CachedScanReads & {
+    env: Cloudflare.Env;
+    ctx: ExecutionContext & { props: { organizationId: string } };
+  };
+  entrypoint.env = c.env;
+  entrypoint.ctx = { props: { organizationId } } as ExecutionContext & {
+    props: { organizationId: string };
+  };
+  return entrypoint;
+}
+
+function buildCachedScanReadRequest(request: Request, allowedQueryKeys: string[]) {
+  const url = new URL(request.url);
+  for (const key of Array.from(url.searchParams.keys())) {
+    if (!allowedQueryKeys.includes(key)) url.searchParams.delete(key);
+  }
+
+  const headers = new Headers(request.headers);
+  headers.delete("authorization");
+  headers.delete("cookie");
+
+  return new Request(url, {
+    method: "GET",
+    headers,
+  });
+}
 
 scansRoutes.post("/", async (c) => {
   const body = (await c.req.json().catch(() => ({}))) as Partial<ScanInput>;
@@ -264,6 +310,15 @@ scansRoutes.post("/:id/decision", async (c) => {
     return c.json({ error: "decision can only be set on completed scans" }, 409);
   }
 
+  try {
+    await cachedScanReadsEntrypoint(c, organizationId).invalidate(c.req.param("id"));
+  } catch (err) {
+    emitOperationalEvent("warn", "cached_scan_reads.invalidate_failed", {
+      scanId: c.req.param("id"),
+      error: describeOperationalError(err),
+    });
+  }
+
   return c.json(updated);
 });
 
@@ -293,12 +348,33 @@ scansRoutes.delete("/:id", async (c) => {
 
 scansRoutes.get("/:id", async (c) => {
   const db = createDb(c.env.DB);
+  const session = c.get("authSession");
   const organizationId = await requireActiveOrganization(c, db);
-  const scan = await getScan(db, c.req.param("id"), organizationId, scanArtifactReadBucket(c.env), {
-    includeFileSamples: false,
-  });
+  const scan = await getScanStatus(db, c.req.param("id"), organizationId);
   if (!scan) return c.json({ error: "not found" }, 404);
-  return c.json(scan);
+
+  if (c.req.query("poll") !== "1") {
+    const response = await cachedScanReadsEntrypoint(c, organizationId).fetch(
+      buildCachedScanReadRequest(c.req.raw, []),
+      {
+        props: { organizationId },
+      },
+    );
+    await recordScanEvent(db, {
+      organizationId,
+      actorUserId: session.userId,
+      scanId: scan.id,
+      type: "scan.viewed",
+      metadata: { stageId: scan.stageId },
+    });
+    return response;
+  }
+  return cachedScanReadsEntrypoint(c, organizationId).fetch(
+    buildCachedScanReadRequest(c.req.raw, []),
+    {
+      props: { organizationId },
+    },
+  );
 });
 
 scansRoutes.get("/:id/status", async (c) => {
@@ -314,43 +390,19 @@ scansRoutes.get("/:id/file", async (c) => {
   if (!path) return c.json({ error: "path is required" }, 400);
   const db = createDb(c.env.DB);
   const organizationId = await requireActiveOrganization(c, db);
-  const file = await getScanFile(
-    db,
-    c.req.param("id"),
-    organizationId,
-    path,
-    scanArtifactReadBucket(c.env),
-  );
-  if (!file) return c.json({ error: "file not found in scan" }, 404);
-  return c.json({ file }, 200, { "cache-control": "private, max-age=300" });
+  const forwarded = buildCachedScanReadRequest(c.req.raw, ["path"]);
+  return cachedScanReadsEntrypoint(c, organizationId).fetch(forwarded, {
+    props: { organizationId },
+  });
 });
 
 scansRoutes.get("/:id/report.json", async (c) => {
   const db = createDb(c.env.DB);
   const organizationId = await resolveReportExportOrganization(c, db);
   if (!organizationId) return c.json({ error: "not found" }, 404);
-  // Full-detail export: the findings come from R2 for artifact-backed scans, so
-  // load the artifact bucket (unlike the metadata-only reads below).
-  const detail = await getScan(
-    db,
-    c.req.param("id"),
-    organizationId,
-    scanArtifactReadBucket(c.env),
-  );
-  if (!detail) return c.json({ error: "not found" }, 404);
-  if (detail.scan.status !== "complete") {
-    return c.json({ error: "report export is only available for completed scans" }, 409);
-  }
-  // Canonical, stable-ordered serialization so re-exports are byte-identical and
-  // two artifacts describing the same evidence compare equal. Served as a
-  // download; no scan.viewed event is recorded for a pure export.
-  return new Response(serializeReportExport(detail), {
-    status: 200,
-    headers: {
-      "content-type": "application/json; charset=utf-8",
-      "content-disposition": `attachment; filename="${reportExportFilename(detail.scan)}"`,
-      "cache-control": "private, no-store",
-    },
+  const forwarded = buildCachedScanReadRequest(c.req.raw, []);
+  return cachedScanReadsEntrypoint(c, organizationId).fetch(forwarded, {
+    props: { organizationId },
   });
 });
 

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -61,19 +61,25 @@ interface CachedScanReadsEntrypoint {
   invalidate(scanId: string): Promise<void>;
 }
 
+function isWorkersCachePilotEnabled(env: Pick<Cloudflare.Env, "WORKERS_CACHE_PILOT">) {
+  return env.WORKERS_CACHE_PILOT === "true" || env.WORKERS_CACHE_PILOT === "1";
+}
+
 function cachedScanReadsEntrypoint(
   c: Context<{ Bindings: Bindings; Variables: Variables }>,
   organizationId: string,
 ) {
-  try {
-    const exports = (
-      c.executionCtx as ExecutionContext & {
-        exports?: { CachedScanReads?: CachedScanReadsEntrypoint };
-      }
-    ).exports;
-    if (exports?.CachedScanReads) return exports.CachedScanReads;
-  } catch {
-    // Fallback for local worker test runtimes that do not expose ctx.exports.
+  if (isWorkersCachePilotEnabled(c.env)) {
+    try {
+      const exports = (
+        c.executionCtx as ExecutionContext & {
+          exports?: { CachedScanReads?: CachedScanReadsEntrypoint };
+        }
+      ).exports;
+      if (exports?.CachedScanReads) return exports.CachedScanReads;
+    } catch {
+      // Fallback for local worker test runtimes that do not expose ctx.exports.
+    }
   }
 
   const entrypoint = Object.create(CachedScanReads.prototype) as CachedScanReads & {

--- a/test/workers/cached-scan-reads.test.ts
+++ b/test/workers/cached-scan-reads.test.ts
@@ -224,6 +224,28 @@ describe("CachedScanReads", () => {
     expect(forwardedOptions.props.organizationId).toBe(owner.organizationId);
   });
 
+  test("gateway serves completed scan reads in-process when the pilot flag is off", async () => {
+    const owner = await seedUser();
+    const completed = await seedCompletedScan(owner);
+    const app = buildTestApp(owner);
+    const ctx = createExecutionContext();
+    const localEnv = { ...env, WORKERS_CACHE_PILOT: undefined } as typeof env;
+
+    const res = await app.fetch(
+      new Request(`http://test.local/api/v1/scans/${completed.scanId}`, { method: "GET" }),
+      localEnv,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toContain("public");
+    expect(res.headers.get("cache-tag")).toBe(`scan:${completed.scanId}`);
+    const body = (await res.json()) as { scan: { id: string; status: string } };
+    expect(body.scan.id).toBe(completed.scanId);
+    expect(body.scan.status).toBe("complete");
+  });
+
   test("gateway preserves file paths but strips organization and poll query params", async () => {
     const owner = await seedUser();
     const completed = await seedCompletedScan(owner);

--- a/test/workers/cached-scan-reads.test.ts
+++ b/test/workers/cached-scan-reads.test.ts
@@ -1,0 +1,307 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { createDb } from "../../server/db/client";
+import { ensurePersonalOrganization } from "../../server/db/organizations";
+import { createScanJob, persistScan } from "../../server/db/scans";
+import * as schema from "../../server/db/schema";
+import { CachedScanReads } from "../../server/lib/cached-scan-reads";
+import { scansRoutes } from "../../server/routes/scans";
+import type { Bindings, Variables } from "../../server/types";
+
+interface SeededUser {
+  userId: string;
+  organizationId: string;
+}
+
+async function seedUser(): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Cache Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+async function seedCompletedScan(owner: SeededUser, packageName = "@org/pkg") {
+  const db = createDb(env.DB);
+  const scanId = `scan_${crypto.randomUUID()}`;
+  const stageId = `stage-${scanId.slice(-12)}`;
+  await createScanJob(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+  });
+  await persistScan(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+    packageJson: { name: packageName, version: "1.2.3" },
+    risk: "high",
+    status: "complete",
+    summary: {
+      report: {
+        version: 1,
+        digest: "abc123",
+        digestAlgorithm: "sha256",
+        generatedAt: "2026-01-01T00:00:00.000Z",
+        rulesVersion: "1.8.0",
+      },
+      baseline: { kind: "registry", version: "1.0.0" },
+      safety: { outboundPolicy: "gateway-only" },
+      packageJsonDiff: {
+        name: packageName,
+        previousVersion: "1.0.0",
+        stagedVersion: "1.2.3",
+        scripts: [{ key: "postinstall", status: "added", staged: "node install.js" }],
+        dependencies: [],
+        entrypointsChanged: false,
+      },
+      diff: [{ path: "package.json", status: "modified" }],
+    },
+    ai: null,
+    files: [{ path: "package.json", size: 10, sha256: "a", flags: [], textSample: "{}" }],
+    diff: [{ path: "package.json", status: "modified", flags: [] }],
+    findings: [
+      {
+        severity: "high",
+        file: "package.json",
+        evidence: "postinstall: node install.js",
+        reason: "install lifecycle hooks execute on consumer machines",
+        ruleId: "install-script.lifecycle",
+        ruleVersion: "1.8.0",
+      },
+    ],
+    report: { version: 1, digest: "abc123" },
+  });
+  return { scanId, stageId };
+}
+
+async function seedPendingScan(owner: SeededUser) {
+  const db = createDb(env.DB);
+  const scanId = `scan_${crypto.randomUUID()}`;
+  const stageId = `stage-${scanId.slice(-12)}`;
+  await createScanJob(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+  });
+  return { scanId, stageId };
+}
+
+function buildTestApp(session: { userId: string }) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.use("*", async (c, next) => {
+    c.set("authSession", { userId: session.userId });
+    await next();
+  });
+  app.route("/api/v1/scans", scansRoutes);
+  return app;
+}
+
+function buildExecutionContext(exportsValue?: {
+  fetch?: ReturnType<typeof vi.fn>;
+  invalidate?: ReturnType<typeof vi.fn>;
+}) {
+  const ctx = createExecutionContext() as ExecutionContext & {
+    exports: {
+      CachedScanReads: {
+        fetch(request: Request, options: { props: { organizationId: string } }): Promise<Response>;
+        invalidate(scanId: string): Promise<void>;
+      };
+    };
+  };
+  const fetch = exportsValue?.fetch ?? vi.fn(async () => new Response("ok"));
+  const invalidate = exportsValue?.invalidate ?? vi.fn(async () => undefined);
+  ctx.exports = {
+    CachedScanReads: {
+      fetch,
+      invalidate,
+    },
+  };
+  return { ctx, fetch, invalidate };
+}
+
+function buildEntrypoint(organizationId: string, cache?: { purge: ReturnType<typeof vi.fn> }) {
+  const entrypoint = Object.create(CachedScanReads.prototype) as CachedScanReads & {
+    env: Cloudflare.Env;
+    ctx: {
+      props: { organizationId: string };
+      cache?: { purge?: ReturnType<typeof vi.fn> };
+    };
+  };
+  entrypoint.env = env;
+  entrypoint.ctx = { props: { organizationId }, cache };
+  return entrypoint;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("CachedScanReads", () => {
+  test("serves completed scan reads with cache headers and leaves pending scans private", async () => {
+    const owner = await seedUser();
+    const completed = await seedCompletedScan(owner);
+    const pending = await seedPendingScan(owner);
+
+    const entrypoint = buildEntrypoint(owner.organizationId);
+
+    const detailRes = await entrypoint.fetch(
+      new Request(`http://test.local/api/v1/scans/${completed.scanId}`, {
+        method: "GET",
+      }),
+    );
+    expect(detailRes.status).toBe(200);
+    expect(detailRes.headers.get("cache-control")).toContain("public");
+    expect(detailRes.headers.get("cache-control")).toContain("max-age=60");
+    expect(detailRes.headers.get("cache-tag")).toBe(`scan:${completed.scanId}`);
+
+    const fileRes = await entrypoint.fetch(
+      new Request(`http://test.local/api/v1/scans/${completed.scanId}/file?path=package.json`, {
+        method: "GET",
+      }),
+    );
+    expect(fileRes.status).toBe(200);
+    expect(fileRes.headers.get("cache-control")).toContain("public");
+    expect(fileRes.headers.get("cache-control")).toContain("max-age=86400");
+    expect(fileRes.headers.get("cache-tag")).toBe(`scan:${completed.scanId}`);
+
+    const reportRes = await entrypoint.fetch(
+      new Request(`http://test.local/api/v1/scans/${completed.scanId}/report.json`, {
+        method: "GET",
+      }),
+    );
+    expect(reportRes.status).toBe(200);
+    expect(reportRes.headers.get("cache-control")).toContain("public");
+    expect(reportRes.headers.get("cache-control")).toContain("max-age=300");
+    expect(reportRes.headers.get("cache-tag")).toBe(`scan:${completed.scanId}`);
+
+    const pendingRes = await entrypoint.fetch(
+      new Request(`http://test.local/api/v1/scans/${pending.scanId}`, { method: "GET" }),
+    );
+    expect(pendingRes.status).toBe(200);
+    expect(pendingRes.headers.get("cache-control")).toBe("private, no-store");
+    expect(pendingRes.headers.get("cache-tag")).toBeNull();
+  });
+
+  test("gateway delegates through a tenant-scoped export and strips auth-bearing headers", async () => {
+    const owner = await seedUser();
+    const completed = await seedCompletedScan(owner);
+    const app = buildTestApp(owner);
+    const { ctx, fetch } = buildExecutionContext();
+
+    const res = await app.fetch(
+      new Request(`http://test.local/api/v1/scans/${completed.scanId}?poll=1`, {
+        method: "GET",
+        headers: {
+          cookie: "session=secret",
+          authorization: "Bearer secret",
+        },
+      }),
+      env,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const forwardedRequest = fetch.mock.calls[0]?.[0] as Request;
+    const forwardedOptions = fetch.mock.calls[0]?.[1] as { props: { organizationId: string } };
+    expect(forwardedRequest.url).toBe(`http://test.local/api/v1/scans/${completed.scanId}`);
+    expect(forwardedRequest.headers.get("cookie")).toBeNull();
+    expect(forwardedRequest.headers.get("authorization")).toBeNull();
+    expect(forwardedOptions.props.organizationId).toBe(owner.organizationId);
+  });
+
+  test("gateway preserves file paths but strips organization and poll query params", async () => {
+    const owner = await seedUser();
+    const completed = await seedCompletedScan(owner);
+    const app = buildTestApp(owner);
+    const { ctx, fetch } = buildExecutionContext();
+
+    const res = await app.fetch(
+      new Request(
+        `http://test.local/api/v1/scans/${completed.scanId}/file?path=package.json&organizationId=${owner.organizationId}&poll=1`,
+        {
+          method: "GET",
+          headers: {
+            cookie: "session=secret",
+            authorization: "Bearer secret",
+          },
+        },
+      ),
+      env,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const forwardedRequest = fetch.mock.calls[0]?.[0] as Request;
+    expect(forwardedRequest.url).toBe(
+      `http://test.local/api/v1/scans/${completed.scanId}/file?path=package.json`,
+    );
+    expect(forwardedRequest.headers.get("cookie")).toBeNull();
+    expect(forwardedRequest.headers.get("authorization")).toBeNull();
+    const forwardedOptions = fetch.mock.calls[0]?.[1] as { props: { organizationId: string } };
+    expect(forwardedOptions.props.organizationId).toBe(owner.organizationId);
+  });
+
+  test("cross-tenant access still fails before delegation", async () => {
+    const owner = await seedUser();
+    const intruder = await seedUser();
+    const completed = await seedCompletedScan(owner);
+    const app = buildTestApp(intruder);
+    const { ctx, fetch } = buildExecutionContext();
+
+    const res = await app.fetch(
+      new Request(`http://test.local/api/v1/scans/${completed.scanId}`, { method: "GET" }),
+      env,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(404);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  test("POST /decision invalidates the cached scan tag", async () => {
+    const owner = await seedUser();
+    const completed = await seedCompletedScan(owner);
+    const app = buildTestApp(owner);
+    const invalidate = vi.fn(async () => undefined);
+    const { ctx } = buildExecutionContext({ invalidate });
+
+    const res = await app.fetch(
+      new Request(`http://test.local/api/v1/scans/${completed.scanId}/decision`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ decision: "publish" }),
+      }),
+      env,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    expect(invalidate).toHaveBeenCalledWith(completed.scanId);
+  });
+
+  test("invalidate no-ops safely when ctx.cache is unavailable", async () => {
+    const owner = await seedUser();
+    const entrypoint = buildEntrypoint(owner.organizationId);
+
+    await expect(entrypoint.invalidate("scan_123")).resolves.toBeUndefined();
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,6 +6,23 @@
 	"compatibility_flags": [
 		"nodejs_compat"
 	],
+	"cache": {
+		"enabled": true
+	},
+	"exports": {
+		"default": {
+			"type": "worker",
+			"cache": {
+				"enabled": false
+			}
+		},
+		"CachedScanReads": {
+			"type": "worker",
+			"cache": {
+				"enabled": true
+			}
+		}
+	},
 	"workers_dev": true,
 	"observability": {
 		"logs": {

--- a/wrangler.test.jsonc
+++ b/wrangler.test.jsonc
@@ -3,6 +3,23 @@
   "name": "staged-publish-review-test",
   "compatibility_date": "2026-05-20",
   "compatibility_flags": ["nodejs_compat"],
+  "cache": {
+    "enabled": true
+  },
+  "exports": {
+    "default": {
+      "type": "worker",
+      "cache": {
+        "enabled": false
+      }
+    },
+    "CachedScanReads": {
+      "type": "worker",
+      "cache": {
+        "enabled": true
+      }
+    }
+  },
   "vars": {
     "BETTER_AUTH_SECRET": "test-secret-that-is-long-enough-for-better-auth",
     "BETTER_AUTH_URL": "http://example.com",

--- a/wrangler.test.jsonc
+++ b/wrangler.test.jsonc
@@ -28,6 +28,7 @@
     "NPM_CONNECTIONS_ENCRYPTION_KEY": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
     "SLACK_CLIENT_ID": "test-slack-client-id",
     "SLACK_CLIENT_SECRET": "test-slack-client-secret",
+    "WORKERS_CACHE_PILOT": "1",
   },
   "d1_databases": [
     {


### PR DESCRIPTION
## Summary

Prototype of Cloudflare's new [Workers Cache](https://blog.cloudflare.com/workers-cache/) (a cache in front of Worker entrypoints, configured by wrangler `cache`/`exports` + standard `Cache-Control`/`Cache-Tag` headers) applied to the three immutable/expensive completed-scan read endpoints.

Scoped, safe pilot — **not** a blanket enable. It uses the blog's gateway + cached-inner-entrypoint pattern so a cache hit never skips auth, and per-org isolation comes from the cache key (`ctx.props`), not from URL/UUID secrecy.

### What changed
- **New `CachedScanReads` WorkerEntrypoint** (`server/lib/cached-scan-reads.ts`), exported from `server/index.ts`. It serves the pure reads for `GET /api/v1/scans/:id`, `/:id/file`, `/:id/report.json`, keyed by `this.ctx.props.organizationId`. It attaches `Cache-Control: public, max-age=…, stale-while-revalidate=…` + `Cache-Tag: scan:<id>` **only on a 200 for a `status === "complete"` scan**; running/failed/missing/non-complete responses stay `private, no-store` (so UI polling of a running scan always sees live status). Exposes `invalidate(scanId)` → `ctx.cache.purge({ tags: ["scan:<id>"] })`.
- **Gateway delegation** (`server/routes/scans.ts`): the Hono handlers keep auth, org resolution, and the `scan.viewed` event in the always-run gateway, then forward to the cached read. Cookie/Authorization are stripped (else Workers Cache auto-bypasses) and `poll`/`organizationId` are dropped from the URL (org travels via props).
- **Pilot gating** (`WORKERS_CACHE_PILOT`): the tiered edge-cache path — dispatching through `ctx.exports.CachedScanReads.fetch(req, { props })` — only engages when the flag is on. Otherwise the same read logic runs **in-process** (real `env` + `organizationId`), emitting the same cache headers but bypassing the edge cache tier:
  ```
  entrypoint = pilotEnabled(env) && ctx.exports?.CachedScanReads
    ? ctx.exports.CachedScanReads            // real cache tier (deployed CF)
    : inProcess(CachedScanReads, env, { props })  // correct on every runtime
  ```
  This is required because the self-entrypoint `exports`/`props` binding only works on deployed Cloudflare with the new runtime; the local dev / e2e / vitest runtime (bundled workerd in `@cloudflare/vite-plugin`) exposes a truthy-but-nonfunctional `ctx.exports.CachedScanReads` that drops `env` and `props`. The flag is left **unset in `wrangler.jsonc`** (dev + e2e use the in-process path) and set to `"1"` in `wrangler.test.jsonc` so the delegation unit tests still exercise the export path. Enable the pilot on a real deploy by setting `WORKERS_CACHE_PILOT=1` on the deployed Worker.
- **`GET /:id` avoids a double read**: it uses the cheap D1-only `getScanStatus` for the 404/org check (no R2 artifact load in the gateway), delegates, and records `scan.viewed` *after* delegation — a single artifact read, and the returned detail doesn't include the current view.
- **`POST /:id/decision`** calls `invalidate(scanId)` after recording the decision (best-effort; logged, never fails the request).
- **Config**: `cache.enabled` + an `exports` map in `wrangler.jsonc` / `wrangler.test.jsonc` — `default` (the gateway) has cache **disabled**; `CachedScanReads` has it **enabled**.
- **Toolchain**: bump `wrangler` 4.102.0 → 4.107.0 (needed for the `exports`/per-entrypoint `cache` config to validate). `@cloudflare/workers-types` pinned exactly to `4.20260617.1` (matching the repo's convention of pinning CF deps exactly) — a newer patch adds a required `ExecutionContext.tracing` field that breaks typecheck in unrelated files.

### Safety / correctness notes
- Tenant isolation is the cache key (`ctx.props.organizationId`), never scan-id unguessability. A hit skips the inner entrypoint but the gateway still authenticated the request.
- Only 200 + complete responses are cacheable; nothing else is stored.
- `ctx.cache`/`ctx.exports` are accessed defensively; on runtimes without them (or with the pilot flag off) reads fall back to the in-process path.

### Scope / follow-ups
- Real edge caching only happens on a deployed Worker with `WORKERS_CACHE_PILOT=1`; local `vitest`/e2e exercise the header/purge/delegation logic and the in-process path, not the tiered cache.
- Left out intentionally: caching `list`/`versions`/`compare` (compare/versions are already KV-cached), and adopting `@cloudflare/workers-types` v5 for first-class `ctx.cache`/`ctx.props`/`ctx.exports` types (currently local type shims) — v5 requires fixing the `ExecutionContext.tracing` ripple across the codebase, a separate change.
- Billing caveat from the blog: enabling `cache` worker-wide bills otherwise-free static-asset and worker-to-worker requests at the standard request rate.

### Testing
- `test/workers/cached-scan-reads.test.ts`: cache headers on completed reads vs `no-store` on pending; Cookie/Authorization stripped and `poll`/`organizationId` dropped on delegation; cross-tenant read still 404s before delegating; `POST /:id/decision` triggers tag invalidation; `invalidate` no-ops safely when `ctx.cache` is absent; and a flag-off gateway test proving `GET /:id` still returns the real body + cache headers via the in-process path.
- `pnpm run verify` (lint + format + typecheck + vitest) passes; `pnpm run test:e2e` passes (14/14); `pnpm run build` bundles the worker with the new entrypoint/config.
- docs: updated `docs/architecture.md` to describe the gateway + cached-entrypoint split and the pilot-gating.


Link to Devin session: https://app.devin.ai/sessions/839aa4260a5c4adfadfcf2ae84140b08
Requested by: @JoviDeCroock