### PR TITLE
Fix OrgSwitcher showing "no organizations" until first click

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      testMatch: ["**/local-registry.spec.ts", "**/two-factor.spec.ts"],
+      testMatch: ["**/local-registry.spec.ts", "**/two-factor.spec.ts", "**/org-switcher.spec.ts"],
       use: { ...devices["Desktop Chrome"] },
     },
     {

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,7 +1,7 @@
 import type { ComponentChildren, JSX } from "preact";
 import { useRef } from "preact/hooks";
 import { useComputed, useSignal, useSignalEffect } from "@preact/signals";
-import { Show } from "@preact/signals/utils";
+import { Show, useLiveSignal } from "@preact/signals/utils";
 import { cn } from "./cn";
 
 interface MenuProps {
@@ -28,7 +28,11 @@ export function Menu({
   const rootRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
 
-  const triggerContent = useComputed(() => trigger(open.value));
+  // `trigger` is a plain prop whose closure can change (e.g. its label derives
+  // from parent state) without `open` changing. Track it via a live signal so
+  // the computed recomputes when the prop updates, not only on open toggles.
+  const triggerSignal = useLiveSignal(trigger);
+  const triggerContent = useComputed(() => triggerSignal.value(open.value));
 
   const getEnabledMenuItems = () => {
     const node = rootRef.current;

--- a/test/e2e/org-switcher.spec.ts
+++ b/test/e2e/org-switcher.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "@playwright/test";
+
+test("OrgSwitcher trigger updates after organizations load", async ({ page }) => {
+  let releaseOrganizations: (() => void) | null = null;
+
+  await page.route("**/api/auth/get-session", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        user: {
+          id: "user-org-switcher",
+          name: "Org Switcher Tester",
+          email: "org-switcher@example.test",
+          twoFactorEnabled: false,
+        },
+      }),
+    });
+  });
+
+  await page.route("**/api/v1/organizations", async (route) => {
+    await new Promise<void>((resolve) => {
+      releaseOrganizations = resolve;
+    });
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        organizations: [
+          {
+            id: "org-acme",
+            name: "Acme Widgets",
+            ownerUserId: "user-org-switcher",
+            role: "owner",
+            isPersonal: false,
+            npmConnectionConfigured: true,
+            requireTwoFactorForReleaseDecisions: false,
+            createdAt: "2026-06-15T12:00:00.000Z",
+            updatedAt: "2026-06-15T12:00:00.000Z",
+          },
+        ],
+      }),
+    });
+  });
+
+  await page.route("**/api/v1/scans**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        scans: [],
+        nextCursor: null,
+        filter: "undecided",
+        limit: 50,
+      }),
+    });
+  });
+
+  await page.route("**/api/v1/npm-connection", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        connection: {
+          id: "npm-connection-org-acme",
+          organizationId: "org-acme",
+          registryUrl: "https://registry.npmjs.org",
+          label: "npm registry",
+          tokenFingerprint: "sha256:abc123",
+          tokenLast4: "1234",
+          validationStatus: "valid",
+          capabilitiesJson: {
+            registryAuth: true,
+            stagedTarballAccess: true,
+            whoami: "org-switcher@example.test",
+            registryUrl: "https://registry.npmjs.org",
+          },
+          validatedAt: "2026-06-15T12:00:00.000Z",
+          lastUsedAt: null,
+          createdByUserId: "user-org-switcher",
+          createdAt: "2026-06-15T12:00:00.000Z",
+          updatedAt: "2026-06-15T12:00:00.000Z",
+        },
+      }),
+    });
+  });
+
+  await page.goto("/dashboard");
+
+  const switcher = page.getByRole("button", { name: "Switch organization" });
+  await expect(switcher).toBeVisible();
+  await expect(switcher).toContainText("no organizations");
+
+  releaseOrganizations?.();
+
+  await expect(switcher).toContainText("Acme Widgets");
+});


### PR DESCRIPTION
## Summary
The organizations dropdown trigger rendered `no organizations` until the user opened it once, even after the org list had loaded.

Root cause is in `src/components/Menu.tsx`. The trigger content was memoized as:

```ts
const triggerContent = useComputed(() => trigger(open.value));
```

`useComputed` only recomputes when a tracked *signal* changes — here just `open`. But `trigger` is a plain prop whose closure derives its label from parent state (in `OrgSwitcher`, `triggerLabel` comes from the `organizations` array). When organizations loaded asynchronously, `open` never changed, so the computed served its stale cached result (`no organizations`). Clicking toggled `open`, forcing a recompute with the now-current closure — hence "fixed after first click".

Fix: track the prop through a live signal so the computed recomputes when the prop identity changes, not only on open toggles:

```ts
const triggerSignal = useLiveSignal(trigger);
const triggerContent = useComputed(() => triggerSignal.value(open.value));
```

This is the anti-pattern called out in the `preact-signals-no-eager-unwrap` skill (a `useComputed` closing over a plain prop goes stale).

## Tests
Added a Playwright regression (`test/e2e/org-switcher.spec.ts`, wired into the chromium project) that holds the `/api/v1/organizations` response open, asserts the trigger shows `no organizations`, then releases it and asserts the trigger updates to the org name **without any click**. Fails before the fix, passes after. `pnpm run verify` green.

docs checked, no update needed.

Link to Devin session: https://app.devin.ai/sessions/e00715b5ac6040c387058059c9d2b412
Requested by: @JoviDeCroock