### PR TITLE
Include advisory AI review in report.json export

### DIFF
--- a/docs/artifact-storage.md
+++ b/docs/artifact-storage.md
@@ -41,7 +41,7 @@ Path segments are URL-encoded with `%` replaced by `~` so object keys stay path-
 
 The manifest records each object key, SHA-256 digest, byte size, content type, and count where applicable. `report.json` is the canonical report JSON whose digest must equal `scans.report_digest`. `files.json` stores redacted staged file samples plus file metadata. `diff.json` stores the generated file diff.
 
-User-initiated report downloads serve the same canonical `report.json` bytes with a package-scoped filename: `drydock-{package-name}-{version}.json`. Package names are normalized to a path-safe filename segment for the `Content-Disposition` header. Dashboard download links include the active organization as a validated query parameter because native browser downloads cannot attach the dashboard's `x-organization-id` fetch header.
+User-initiated report downloads serve the same canonical `report.json` bytes with a package-scoped filename: `drydock-{package-name}-{version}.json`. The export also carries the persisted advisory AI review when one exists. Package names are normalized to a path-safe filename segment for the `Content-Disposition` header. Dashboard download links include the active organization as a validated query parameter because native browser downloads cannot attach the dashboard's `x-organization-id` fetch header.
 
 ## Write And Read Flow
 

--- a/server/lib/ai-review-contract.ts
+++ b/server/lib/ai-review-contract.ts
@@ -244,6 +244,46 @@ export function selectReportedFindings(
     .slice(0, MAX_AI_FINDINGS);
 }
 
+// Validation schema for a *persisted* AiReview (as stored in `scans.ai_json`),
+// as opposed to `aiReviewSubmissionSchema` which validates the model's raw
+// tool call. This one carries the reviewer envelope the pipeline adds after
+// normalization — `status`, `model`, the `not_assessed` release assessment used
+// by fallbacks, and per-finding `recommendation`. Unknown keys are dropped
+// rather than rejected so historical records stay parseable as the shape grows.
+const persistedAiFindingSchema = z.object({
+  severity: severitySchema,
+  file: z.string(),
+  evidence: z.string(),
+  reason: z.string(),
+  recommendation: z.string(),
+});
+
+export const persistedAiReviewSchema = z.object({
+  status: z.enum(["complete", "invalid", "unavailable"]),
+  risk: riskSchema,
+  releaseAssessment: z.enum([
+    "nothing_unusual",
+    "review_recommended",
+    "suspicious",
+    "blocked",
+    "not_assessed",
+  ]),
+  summary: z.string(),
+  findings: z.array(persistedAiFindingSchema),
+  requiresManualReview: z.boolean(),
+  model: z.string().nullable(),
+});
+
+export type PersistedAiReview = z.infer<typeof persistedAiReviewSchema>;
+
+// Re-validate an untrusted persisted AI review (a raw D1 `ai_json` value) before
+// a consumer reads it. Returns null for absent or malformed records so callers
+// degrade to "no AI review" instead of trusting a partial or legacy shape.
+export function parsePersistedAiReview(value: unknown): PersistedAiReview | null {
+  const parsed = persistedAiReviewSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
 const toolPathSchema = z
   .string()
   .min(1)

--- a/server/lib/report-export.ts
+++ b/server/lib/report-export.ts
@@ -1,4 +1,6 @@
 import type { getScan } from "../db/scans";
+import { parsePersistedAiReview } from "./ai-review-contract";
+import { displayedAiResult } from "./ai-review-types";
 import type { ReleaseProvenance, ReleaseProvenanceArtifact } from "./adapters/types";
 
 // A persisted scan detail, as returned by getScan (never null at the call site).
@@ -49,6 +51,7 @@ export function buildReportExport(detail: ScanDetail) {
     // wheel/sdist/tarball matches what Drydock reviewed. Workflow-gate reviews
     // only; null for staged-publish scans.
     provenance: extractProvenance(summary.stagedPublish),
+    aiReview: extractAiReview(scan.aiJson),
     riskSummary: detail.riskSummary ?? null,
     packageJsonDiff: summary.packageJsonDiff ?? null,
     diff: summary.diff ?? null,
@@ -146,6 +149,41 @@ function extractProvenance(stagedPublish: unknown): ReleaseProvenance | null {
   }
   if (!mapped.length) return null;
   return { ecosystem, mode, artifacts: mapped };
+}
+
+// Route through the display helper so invalid/unavailable fallbacks do not
+// leak the persisted `low` / `not_assessed` placeholders.
+function extractAiReview(aiJson: unknown) {
+  const review = parsePersistedAiReview(aiJson);
+  if (!review) return null;
+  const displayed = displayedAiResult(review);
+  if (!displayed) return null;
+  if (displayed.kind === "complete") {
+    return {
+      status: "complete",
+      model: displayed.model,
+      summary: displayed.summary,
+      risk: displayed.risk,
+      releaseAssessment: displayed.releaseAssessment,
+      requiresManualReview: displayed.requiresManualReview,
+      findings: displayed.findings.map((finding) => ({
+        severity: finding.severity,
+        file: finding.file,
+        evidence: finding.evidence,
+        reason: finding.reason,
+        recommendation: finding.recommendation,
+      })),
+    };
+  }
+  return {
+    status: displayed.status,
+    model: displayed.model,
+    summary: displayed.summary,
+    risk: null,
+    releaseAssessment: null,
+    requiresManualReview: false,
+    findings: [],
+  };
 }
 
 function filenameSegment(value: string | null | undefined): string | null {

--- a/test/workers/scan-report-export.test.ts
+++ b/test/workers/scan-report-export.test.ts
@@ -58,6 +58,10 @@ async function getReport(
 }
 
 async function seedCompletedScan(owner: SeededUser): Promise<string> {
+  return seedCompletedScanWithAi(owner, null);
+}
+
+async function seedCompletedScanWithAi(owner: SeededUser, ai: unknown): Promise<string> {
   const db = createDb(env.DB);
   const scanId = `scan_${crypto.randomUUID()}`;
   const stageId = `stage-${scanId.slice(-12)}`;
@@ -95,7 +99,7 @@ async function seedCompletedScan(owner: SeededUser): Promise<string> {
       },
       diff: [{ path: "package.json", status: "modified" }],
     },
-    ai: null,
+    ai,
     files: [{ path: "package.json", size: 10, sha256: "a", flags: [], textSample: "{}" }],
     diff: [{ path: "package.json", status: "modified", flags: [] }],
     findings: [
@@ -132,6 +136,7 @@ describe("scan report JSON export", () => {
       scan: { id: string; status: string };
       package: { name: string | null; stagedVersion: string | null };
       packageJsonDiff: unknown;
+      aiReview: unknown;
       findings: Array<{ ruleId: string | null; severity: string }>;
     };
     expect(body.schema).toBe("drydock.report.v1");
@@ -141,6 +146,7 @@ describe("scan report JSON export", () => {
     expect(body.package.name).toBe("@org/pkg");
     expect(body.package.stagedVersion).toBe("1.1.0");
     expect(body.packageJsonDiff).toBeTruthy();
+    expect(body.aiReview).toBeNull();
     expect(body.findings).toEqual([
       expect.objectContaining({ ruleId: "install-script.lifecycle", severity: "high" }),
     ]);
@@ -200,6 +206,108 @@ describe("scan report JSON export", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { provenance: typeof provenance | null };
     expect(body.provenance).toEqual(provenance);
+  });
+
+  test("exports a complete AI review with evidence and recommendations", async () => {
+    const owner = await seedUser();
+    const aiReview = {
+      status: "complete",
+      risk: "high",
+      releaseAssessment: "suspicious",
+      summary: "The release adds install-time execution and network access.",
+      findings: [
+        {
+          severity: "critical",
+          file: "package.json",
+          evidence: "postinstall runs node install.js",
+          reason: "consumer installs execute arbitrary code",
+          recommendation: "remove the install hook or gate it behind a manual step",
+        },
+      ],
+      requiresManualReview: true,
+      model: "ai-review-1",
+    } as const;
+
+    const scanId = await seedCompletedScanWithAi(owner, aiReview);
+    const res = await getReport(buildTestApp(owner), scanId);
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    const body = JSON.parse(text) as {
+      aiReview: {
+        status: string;
+        model: string | null;
+        summary: string;
+        risk: string | null;
+        releaseAssessment: string | null;
+        requiresManualReview: boolean;
+        findings: Array<{
+          severity: string;
+          file: string;
+          evidence: string;
+          reason: string;
+          recommendation: string;
+        }>;
+      } | null;
+    };
+
+    expect(body.aiReview).toEqual({
+      status: "complete",
+      model: "ai-review-1",
+      summary: "The release adds install-time execution and network access.",
+      risk: "high",
+      releaseAssessment: "suspicious",
+      requiresManualReview: true,
+      findings: [
+        {
+          severity: "critical",
+          file: "package.json",
+          evidence: "postinstall runs node install.js",
+          reason: "consumer installs execute arbitrary code",
+          recommendation: "remove the install hook or gate it behind a manual step",
+        },
+      ],
+    });
+
+    // Stable serialization: a re-export of the same evidence is byte-identical.
+    const again = await getReport(buildTestApp(owner), scanId);
+    expect(await again.text()).toBe(text);
+  });
+
+  test("exports unavailable AI reviews without surfacing fallback low risk", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScanWithAi(owner, {
+      status: "unavailable",
+      risk: "low",
+      releaseAssessment: "not_assessed",
+      summary: "AI review was unavailable.",
+      findings: [],
+      requiresManualReview: false,
+      model: null,
+    });
+
+    const res = await getReport(buildTestApp(owner), scanId);
+    expect(res.status).toBe(200);
+    const body = JSON.parse(await res.text()) as {
+      aiReview: {
+        status: string;
+        model: string | null;
+        summary: string;
+        risk: string | null;
+        releaseAssessment: string | null;
+        requiresManualReview: boolean;
+        findings: unknown[];
+      } | null;
+    };
+
+    expect(body.aiReview).toEqual({
+      status: "unavailable",
+      model: null,
+      summary: "AI review was unavailable.",
+      risk: null,
+      releaseAssessment: null,
+      requiresManualReview: false,
+      findings: [],
+    });
   });
 
   test("surfaces the reviewed VSIX digest for a VS Code gate review", async () => {


### PR DESCRIPTION
## Summary
The downloadable `report.json` export (`GET /api/v1/scans/:id/report.json`, built by `buildReportExport`) carried deterministic findings and provenance but omitted the AI reviewer's output entirely. This adds an `aiReview` field so the export includes the advisory AI evidence (per-finding `evidence`/`recommendation`, `summary`, `risk`, `releaseAssessment`).

The AI review is persisted untrusted on `scan.aiJson`, so it is re-validated and routed through the safe accessor before export:

```
aiReview: extractAiReview(scan.aiJson)

extractAiReview(aiJson):
  review = parsePersistedAiReview(aiJson)   // zod re-validate; null -> null (pre-AI / malformed)
  displayed = displayedAiResult(review)
  complete    -> { status, model, summary, risk, releaseAssessment,
                   requiresManualReview, findings:[{severity,file,evidence,reason,recommendation}] }
  unavailable -> { status, model, summary, risk:null, releaseAssessment:null,
                   requiresManualReview:false, findings:[] }
```

Routing through `displayedAiResult` matters for correctness: an `invalid`/`unavailable` fallback is persisted with `risk:"low"` / `releaseAssessment:"not_assessed"`, and exporting those raw would misrepresent "we couldn't review this" as "low risk / nothing unusual". Both branches emit the same keys so `stableStringify` output stays byte-identical across re-exports.

`parsePersistedAiReview` + `persistedAiReviewSchema` are added to `ai-review-contract.ts` (validates the persisted envelope: `status`, `model`, `not_assessed`, per-finding `recommendation`; drops unknown keys so historical records stay parseable).

## Testing
- `test/workers/scan-report-export.test.ts`: added a complete-review case (asserts evidence/recommendation/status/risk/assessment and byte-identical re-export) and an unavailable-review case (asserts `risk:null`, `releaseAssessment:null`, empty findings — no fallback low/nothing_unusual leak); existing pre-AI path now asserts `aiReview` is `null`.
- oxlint, oxfmt `--check`, `tsc --noEmit`, and `vitest run --project workers test/workers/scan-report-export.test.ts` (11 passed) all clean. (Direct `pnpm` unavailable in-env due to a Node/pnpm version pin mismatch; ran the repo's local binaries instead.)
- docs: updated `docs/artifact-storage.md` to note the export now carries the advisory AI review.


Link to Devin session: https://app.devin.ai/sessions/3f86201e0bff47a497c8b9ef7b5dcb09
Requested by: @JoviDeCroock