### PR TITLE
Add public report share links and signed attestations

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -27,6 +27,11 @@ NPM_CONNECTIONS_ENCRYPTION_KEY=replace-with-a-random-32-byte-secret
 # `drydock` app (see the `flagship` binding in the selected Wrangler config).
 # Toggle it from the Cloudflare dashboard; there is no .dev.vars override.
 
+# Optional. Private Ed25519 JWK used to sign public-report attestations. Without
+# it, sharing still works and attestation endpoints return 503. Generate one:
+#   node -e "crypto.subtle.generateKey({name:'Ed25519'},true,['sign','verify']).then(async k=>console.log(JSON.stringify(await crypto.subtle.exportKey('jwk',k.privateKey))))"
+# ATTESTATION_SIGNING_KEY_JWK={"kty":"OKP","crv":"Ed25519","d":"...","x":"..."}
+
 # Optional GitHub App workflow-gate integration. Public identifiers normally
 # live in the selected Wrangler config; keep secrets in .dev.vars locally or in
 # Wrangler secrets when deployed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@
 - Package bytes are hostile evidence. Never execute package code, install dependencies, run lifecycle scripts, import modules, run builds, invoke shells, or render package-provided active content.
 - npm credentials stay outside the sandbox. Only `NpmStageGateway` may attach npm auth, only for allowed staged/metadata/tarball registry endpoints.
 - The AI reviewer is advisory and on by default; the per-organization `ai-review` flag is a killswitch that disables it. It cannot downgrade deterministic findings.
-- D1/Better Auth are required for every non-auth `/api/*` endpoint; resource ownership must be organization-scoped. Sole exception: the anonymous `/api/public/v1/package-diff` endpoints, which serve only public-registry and pkg.pr.new preview data, attach no credentials, and are IP rate-limited (see `docs/security-model.md`).
+- D1/Better Auth are required for every non-auth `/api/*` endpoint; resource ownership must be organization-scoped. Two anonymous exceptions, both credential-free and IP rate-limited (see `docs/security-model.md`): the `/api/public/v1/package-diff` endpoints, which serve only public-registry and pkg.pr.new preview data; and `/public/reports/*`, where an unguessable share token minted by an owner/admin is the capability and the response is the scan's canonical report export and nothing else.
 - Operational logs/events must be structured and secret-redacted. Never log raw tokens, headers, package contents, or unredacted errors.
 
 ## UI and frontend conventions

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ The user-facing learning guide is [`../src/pages/Docs/index.tsx`](../src/pages/D
 - [`diff-baseline.md`](./diff-baseline.md) — default previous-version comparison strategy.
 - [`intent-envelope.md`](./intent-envelope.md) — advisory source-binding tiers (attested / declared / absent) persisted with every scan.
 - [`artifact-storage.md`](./artifact-storage.md) — D1/R2 report and artifact persistence.
+- [`public-reports.md`](./public-reports.md) — public share links and signed report attestations.
 
 ## Operations and setup
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,7 +126,7 @@ Organizations store their own encrypted npm connection. The UI validates baselin
 
 ## Report model
 
-Reports should remain canonical and future-signable: stable ordering, explicit release/artifact/context risk sections, redacted evidence, and enough metadata to reproduce the reviewed artifact identity. Public signed reports are future work; do not expose signing semantics until the report contract is finalized.
+Reports remain canonical and signable: stable ordering, explicit release/artifact/context risk sections, redacted evidence, and enough metadata to reproduce the reviewed artifact identity. The canonical export (`drydock.report.v1`) is the signing boundary — publicly shared reports serve those exact bytes at `/public/reports/:token`, and the attestation endpoint signs their SHA-256 inside a DSSE envelope (see `public-reports.md`). Changing the export shape changes the attested bytes, so bump the schema tag when consumers must branch.
 
 ## API direction
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,7 +126,7 @@ Organizations store their own encrypted npm connection. The UI validates baselin
 
 ## Report model
 
-Reports remain canonical and signable: stable ordering, explicit release/artifact/context risk sections, redacted evidence, and enough metadata to reproduce the reviewed artifact identity. The canonical export (`drydock.report.v1`) is the signing boundary — publicly shared reports serve those exact bytes at `/public/reports/:token`, and the attestation endpoint signs their SHA-256 inside a DSSE envelope (see `public-reports.md`). Changing the export shape changes the attested bytes, so bump the schema tag when consumers must branch.
+Reports remain canonical and signable: stable ordering, explicit release/artifact/context risk sections, redacted evidence, and enough metadata to reproduce the reviewed artifact identity. The canonical export (`drydock.report.v2`) is the signing boundary — publicly shared reports serve those exact bytes at `/public/reports/:token`, and the attestation endpoint signs their SHA-256 inside a DSSE envelope (see `public-reports.md`). Changing the export shape changes the attested bytes, so bump the schema tag when consumers must branch.
 
 ## API direction
 

--- a/docs/intent-envelope.md
+++ b/docs/intent-envelope.md
@@ -9,7 +9,7 @@ only describes what an origin claim could later be verified against.
 Computed in `server/lib/scan-pipeline.ts` via the pure module
 `server/lib/intent-envelope.ts`, persisted inside the scan's `summaryJson`
 blob (`summary.intentEnvelope`, no dedicated column), returned on
-`ScanResult`, exported in the `drydock.report.v1` report as the optional
+`ScanResult`, exported in the `drydock.report.v2` report as the optional
 `intentEnvelope` field, and rendered as the "Source binding" row on the scan
 detail page.
 

--- a/docs/public-reports.md
+++ b/docs/public-reports.md
@@ -1,0 +1,77 @@
+# Public report sharing and attestations
+
+Completed scans can be shared outside the organization as a read-only public
+report, with an optional signed attestation that lets anyone verify the report
+bytes came from Drydock.
+
+## Share flow
+
+- `POST /api/v1/scans/:id/share` (owner/admin only) creates — or returns the
+  existing — public share link for a completed scan. Sharing is idempotent so a
+  link that is already distributed never rotates silently.
+- `DELETE /api/v1/scans/:id/share` revokes the link immediately — report and
+  attestation responses are served `no-store` so no shared cache can outlive a
+  revoke.
+- Both actions are recorded as scan events (`scan.share_enabled`,
+  `scan.share_revoked`) and surface in the organization audit log.
+- The UI entry point is the **Share** button on the scan detail header; the
+  public page renders at `/reports/:token`.
+
+## Public endpoints (no auth)
+
+Mounted at `/public` ahead of the Better Auth middleware, like `/webhooks`.
+The unguessable 256-bit share token is the capability; all endpoints are
+rate-limited per IP and return `404` for unknown, malformed, or revoked tokens.
+
+- `GET /public/reports/:token` — the canonical report export
+  (`drydock.report.v1`, same bytes as the authenticated
+  `/api/v1/scans/:id/report.json`). Never includes file samples, scan events,
+  or organization/user identifiers.
+- `GET /public/reports/:token/attestation` — DSSE envelope over an in-toto v1
+  Statement about the report (see below).
+- `GET /public/attestation-key` — the Ed25519 public key (JWK) and its RFC 7638
+  thumbprint key id.
+
+## Attestation format
+
+The envelope is DSSE (`payloadType: application/vnd.in-toto+json`), signed with
+Ed25519 over the standard DSSE pre-authentication encoding. `payload` and `sig`
+use standard base64 (the alphabet sigstore/in-toto tooling emits). The payload
+is an in-toto v1 Statement:
+
+- `subject[0].name` — `package@version` (falls back to the scan id).
+- `subject[0].digest.sha256` — SHA-256 of the exact bytes served by
+  `GET /public/reports/:token`.
+- `predicateType` — `https://drydock.org/attestation/scan-report/v1`.
+- `predicate` — scan id, package identity, risk, decision, finding count,
+  report schema/digest, completion timestamp.
+
+To verify: fetch the report bytes, hash them, compare with the subject digest,
+then verify the envelope signature against `/public/attestation-key` (match by
+`keyid`).
+
+## Key management
+
+The signing key is the `ATTESTATION_SIGNING_KEY_JWK` secret — a private
+Ed25519 JWK (`kty: OKP`). Generate one with:
+
+```sh
+node -e "crypto.subtle.generateKey({name:'Ed25519'},true,['sign','verify']).then(async k=>console.log(JSON.stringify(await crypto.subtle.exportKey('jwk',k.privateKey))))"
+```
+
+When the secret is absent or malformed the attestation endpoints return `503`;
+report sharing itself keeps working. Rotating the key changes the published
+`keyId`; envelopes issued under the old key stop verifying against the new
+published key, so consumers should pin envelopes to the `keyid` they were
+issued with.
+
+## Trust boundaries
+
+- Sharing is an explicit, elevated (owner/admin) opt-in per scan; there is no
+  org-wide "share everything" switch.
+- The public payload is the canonical export only — redaction is inherited from
+  the report contract, not re-implemented on the public path.
+- Public routes carry the locked-down API CSP and permissive CORS (`*`) — the
+  data is public by construction once shared.
+- Tests: `test/workers/public-reports.test.ts` (routes, roles, revocation,
+  redaction, rate limit, signature verification).

--- a/docs/public-reports.md
+++ b/docs/public-reports.md
@@ -24,7 +24,7 @@ The unguessable 256-bit share token is the capability; all endpoints are
 rate-limited per IP and return `404` for unknown, malformed, or revoked tokens.
 
 - `GET /public/reports/:token` — the canonical report export
-  (`drydock.report.v1`, same bytes as the authenticated
+  (`drydock.report.v2`, same bytes as the authenticated
   `/api/v1/scans/:id/report.json`). Never includes file samples, scan events,
   or organization/user identifiers.
 - `GET /public/reports/:token/attestation` — DSSE envelope over an in-toto v1
@@ -49,6 +49,15 @@ is an in-toto v1 Statement:
 To verify: fetch the report bytes, hash them, compare with the subject digest,
 then verify the envelope signature against `/public/attestation-key` (match by
 `keyid`).
+
+**Fetch both, and re-fetch on mismatch.** The report route and the attestation
+route are independent reads: each serializes the report from current scan state,
+so the bytes are identical for a given state but the state can change between
+the two requests. A decision recorded in that window (or any later edit to a
+mutable field — `decision`, `riskSummary`, findings) means the digest covers a
+document the consumer never fetched, and verification fails. That is a race, not
+a forgery: re-fetch the report and compare again. An archived pair captured
+together always verifies, which is what matters for the archival use case.
 
 ## Key management
 

--- a/docs/public-reports.md
+++ b/docs/public-reports.md
@@ -44,7 +44,14 @@ is an in-toto v1 Statement:
   `GET /public/reports/:token`.
 - `predicateType` — `https://drydock.org/attestation/scan-report/v1`.
 - `predicate` — scan id, package identity, risk, decision, finding count,
-  report schema/digest, completion timestamp.
+  report schema/digest, completion timestamp, and `issuedAt` (when the envelope
+  was signed).
+
+`issuedAt` is what orders two envelopes for the same scan. Because the attested
+report is a snapshot of mutable state, a consumer who archived a pair before a
+maintainer recorded "block" and a consumer who archived after both hold envelopes
+that verify and disagree; `issuedAt` says which is newer without an out-of-band
+timestamp. It is inside the signed statement, so it cannot be restamped.
 
 To verify: fetch the report bytes, hash them, compare with the subject digest,
 then verify the envelope signature against `/public/attestation-key` (match by
@@ -81,6 +88,20 @@ issued with.
 - The public payload is the canonical export only — redaction is inherited from
   the report contract, not re-implemented on the public path.
 - Public routes carry the locked-down API CSP and permissive CORS (`*`) — the
-  data is public by construction once shared.
+  data is public by construction once shared. CORS rides on _every_ response,
+  including the 404 for a revoked link, the 503 when no signing key is
+  configured, and the 429 from the rate limiter (whose `retry-after` is exposed
+  via `access-control-expose-headers`). A browser verifier that cannot read a
+  failure cannot tell "revoked" from "offline", and cannot back off politely.
+- The export drops `releaseConsistency.priorScanId` and
+  `releaseConsistency.decidedAt`. Both describe a _prior_ scan the org never
+  chose to share — `decidedAt` most sharply, being a precise timestamp of an
+  internal review decision on an unshared release. The remaining release-memory
+  fields describe this scan's delta against that history.
+- Serving a report reads the report and diff artifacts but not the file-samples
+  artifact (`getScan`'s `files: "omit"` mode). The authenticated `report.json`
+  export takes the same path, so the two cannot diverge: byte-identity is by
+  construction rather than by both happening to succeed at the same R2 reads.
 - Tests: `test/workers/public-reports.test.ts` (routes, roles, revocation,
-  redaction, rate limit, signature verification).
+  redaction, rate limit, CORS on failures, concurrent enables, signature
+  verification, degraded/malformed key handling).

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -100,7 +100,7 @@ Production responses should keep conservative security headers: no package-provi
 
 ## Known gaps / future work
 
-- Public signed reports are not exposed yet; report data should remain canonical and future-signable.
+- Public report sharing is an explicit owner/admin opt-in per completed scan: an unguessable 256-bit token exposes the canonical report export (never file samples, events, or org/user identifiers) at `/public/reports/:token`, with an Ed25519-signed DSSE attestation over those exact bytes. See `public-reports.md`.
 - Raw-artifact retention, if ever added, must be explicit, short-TTL, organization-scoped, and documented.
 - Additional ecosystems need adapter-specific credential, baseline, artifact, and failure-mode review before enablement.
 - Keep dependency and parser updates covered by regression/fuzz tests because archive handling is a trust boundary.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -108,6 +108,14 @@ pnpm exec wrangler secret put NPM_CONNECTIONS_ENCRYPTION_KEY \
   --config wrangler.self-host.jsonc
 ```
 
+Optional secrets:
+
+```sh
+# Ed25519 private JWK for public report attestations (docs/public-reports.md).
+# Without it, report sharing works but attestation endpoints return 503.
+pnpm exec wrangler secret put ATTESTATION_SIGNING_KEY_JWK
+```
+
 Required non-secret vars:
 
 - `BETTER_AUTH_URL` — canonical deployed origin

--- a/drizzle/0025_chubby_anita_blake.sql
+++ b/drizzle/0025_chubby_anita_blake.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `scans` ADD `public_share_token` text;--> statement-breakpoint
+ALTER TABLE `scans` ADD `public_shared_at` integer;--> statement-breakpoint
+ALTER TABLE `scans` ADD `public_shared_by_user_id` text REFERENCES user(id);--> statement-breakpoint
+CREATE UNIQUE INDEX `scans_public_share_token_unique_idx` ON `scans` (`public_share_token`);

--- a/drizzle/0025_perpetual_iron_patriot.sql
+++ b/drizzle/0025_perpetual_iron_patriot.sql
@@ -1,4 +1,5 @@
 ALTER TABLE `scans` ADD `public_share_token` text;--> statement-breakpoint
 ALTER TABLE `scans` ADD `public_shared_at` integer;--> statement-breakpoint
 ALTER TABLE `scans` ADD `public_shared_by_user_id` text REFERENCES user(id);--> statement-breakpoint
+CREATE INDEX `scans_public_shared_by_idx` ON `scans` (`public_shared_by_user_id`);--> statement-breakpoint
 CREATE UNIQUE INDEX `scans_public_share_token_unique_idx` ON `scans` (`public_share_token`);

--- a/drizzle/meta/0025_snapshot.json
+++ b/drizzle/meta/0025_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "00f11faf-874e-4641-97bf-3def02727b1c",
+  "id": "37903981-b812-4498-8c74-65b17ea0f64a",
   "prevId": "4ae5ecc3-cb91-4890-9101-8595c469f920",
   "tables": {
     "account": {
@@ -2096,6 +2096,13 @@
           "name": "scans_decided_by_idx",
           "columns": [
             "decided_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_public_shared_by_idx": {
+          "name": "scans_public_shared_by_idx",
+          "columns": [
+            "public_shared_by_user_id"
           ],
           "isUnique": false
         },

--- a/drizzle/meta/0025_snapshot.json
+++ b/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,2504 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "00f11faf-874e-4641-97bf-3def02727b1c",
+  "prevId": "4ae5ecc3-cb91-4890-9101-8595c469f920",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_user_idx": {
+          "name": "account_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_app_installations": {
+      "name": "github_app_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Organization'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uninstalled_at": {
+          "name": "uninstalled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_app_installations_installation_unique_idx": {
+          "name": "github_app_installations_installation_unique_idx",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        },
+        "github_app_installations_org_idx": {
+          "name": "github_app_installations_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installations_created_by_user_id_user_id_fk": {
+          "name": "github_app_installations_created_by_user_id_user_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_release_targets": {
+      "name": "github_release_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ecosystem": {
+          "name": "ecosystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_release_targets_org_repo_env_unique_idx": {
+          "name": "github_release_targets_org_repo_env_unique_idx",
+          "columns": [
+            "organization_id",
+            "repository_id",
+            "environment"
+          ],
+          "isUnique": true
+        },
+        "github_release_targets_installation_idx": {
+          "name": "github_release_targets_installation_idx",
+          "columns": [
+            "installation_row_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_release_targets_organization_id_organizations_id_fk": {
+          "name": "github_release_targets_organization_id_organizations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_release_targets_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_created_by_user_id_user_id_fk": {
+          "name": "github_release_targets_created_by_user_id_user_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_workflow_gates": {
+      "name": "github_workflow_gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_target_id": {
+          "name": "release_target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deployment_callback_url": {
+          "name": "deployment_callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_comment": {
+          "name": "decision_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_url": {
+          "name": "report_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_started_at": {
+          "name": "review_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_workflow_gates_delivery_unique_idx": {
+          "name": "github_workflow_gates_delivery_unique_idx",
+          "columns": [
+            "delivery_id"
+          ],
+          "isUnique": true
+        },
+        "github_workflow_gates_org_status_idx": {
+          "name": "github_workflow_gates_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_release_target_idx": {
+          "name": "github_workflow_gates_release_target_idx",
+          "columns": [
+            "release_target_id"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_scan_idx": {
+          "name": "github_workflow_gates_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_workflow_gates_organization_id_organizations_id_fk": {
+          "name": "github_workflow_gates_organization_id_organizations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_workflow_gates_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_release_target_id_github_release_targets_id_fk": {
+          "name": "github_workflow_gates_release_target_id_github_release_targets_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_release_targets",
+          "columnsFrom": [
+            "release_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_scan_id_scans_id_fk": {
+          "name": "github_workflow_gates_scan_id_scans_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_unique_idx": {
+          "name": "npm_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_invitations": {
+      "name": "organization_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_invitations_token_hash_unique_idx": {
+          "name": "organization_invitations_token_hash_unique_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "organization_invitations_org_status_idx": {
+          "name": "organization_invitations_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "organization_invitations_org_email_idx": {
+          "name": "organization_invitations_org_email_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_invitations_organization_id_organizations_id_fk": {
+          "name": "organization_invitations_organization_id_organizations_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_invited_by_user_id_user_id_fk": {
+          "name": "organization_invitations_invited_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_accepted_by_user_id_user_id_fk": {
+          "name": "organization_invitations_accepted_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_notification_recipients": {
+      "name": "organization_notification_recipients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_notification_recipients_org_email_unique_idx": {
+          "name": "organization_notification_recipients_org_email_unique_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_notification_recipients_organization_id_organizations_id_fk": {
+          "name": "organization_notification_recipients_organization_id_organizations_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_notification_recipients_created_by_user_id_user_id_fk": {
+          "name": "organization_notification_recipients_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_slack_connections": {
+      "name": "organization_slack_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_token_ciphertext": {
+          "name": "bot_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bot_token_nonce": {
+          "name": "bot_token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slack_connections_org_unique_idx": {
+          "name": "organization_slack_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_slack_connections_organization_id_organizations_id_fk": {
+          "name": "organization_slack_connections_organization_id_organizations_id_fk",
+          "tableFrom": "organization_slack_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_slack_connections_created_by_user_id_user_id_fk": {
+          "name": "organization_slack_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_slack_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "require_two_factor_for_release_decisions": {
+          "name": "require_two_factor_for_release_decisions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        },
+        "scan_events_created_idx": {
+          "name": "scan_events_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_actor_idx": {
+          "name": "scan_events_actor_idx",
+          "columns": [
+            "actor_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_findings_scan_severity_idx": {
+          "name": "scan_findings_scan_severity_idx",
+          "columns": [
+            "scan_id",
+            "severity"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changed_file_count": {
+          "name": "changed_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_summary_json": {
+          "name": "risk_summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_storage_version": {
+          "name": "artifact_storage_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_key": {
+          "name": "artifact_manifest_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_digest": {
+          "name": "artifact_manifest_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_size": {
+          "name": "artifact_manifest_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_artifact_key": {
+          "name": "report_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_samples_artifact_key": {
+          "name": "file_samples_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "diff_artifact_key": {
+          "name": "diff_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_share_token": {
+          "name": "public_share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_shared_at": {
+          "name": "public_shared_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_shared_by_user_id": {
+          "name": "public_shared_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        },
+        "scans_gate_org_idx": {
+          "name": "scans_gate_org_idx",
+          "columns": [
+            "gate_id",
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_artifact_backfill_idx": {
+          "name": "scans_artifact_backfill_idx",
+          "columns": [
+            "organization_id",
+            "status",
+            "artifact_storage_version",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "scans_org_decision_created_idx": {
+          "name": "scans_org_decision_created_idx",
+          "columns": [
+            "organization_id",
+            "decision",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scans_org_created_idx": {
+          "name": "scans_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "scans_decided_by_idx": {
+          "name": "scans_decided_by_idx",
+          "columns": [
+            "decided_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_public_share_token_unique_idx": {
+          "name": "scans_public_share_token_unique_idx",
+          "columns": [
+            "public_share_token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_gate_id_github_workflow_gates_id_fk": {
+          "name": "scans_gate_id_github_workflow_gates_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "github_workflow_gates",
+          "columnsFrom": [
+            "gate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_decided_by_user_id_user_id_fk": {
+          "name": "scans_decided_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_public_shared_by_user_id_user_id_fk": {
+          "name": "scans_public_shared_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "public_shared_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "two_factor": {
+      "name": "two_factor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed_verification_count": {
+          "name": "failed_verification_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "two_factor_user_idx": {
+          "name": "two_factor_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -180,8 +180,8 @@
     {
       "idx": 25,
       "version": "6",
-      "when": 1785043628962,
-      "tag": "0025_chubby_anita_blake",
+      "when": 1785173070110,
+      "tag": "0025_perpetual_iron_patriot",
       "breakpoints": true
     }
   ]

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1784486315216,
       "tag": "0024_furry_franklin_richards",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "6",
+      "when": 1785043628962,
+      "tag": "0025_chubby_anita_blake",
+      "breakpoints": true
     }
   ]
 }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -10,5 +10,9 @@ Disallow: /login
 Disallow: /register
 Disallow: /verify-email
 Disallow: /api/
+# A shared report link is a capability, not a public page. Indexing one would
+# republish it to everyone long after the publisher revoked the share.
+Disallow: /reports/
+Disallow: /public/reports/
 
 Sitemap: https://drydock.org/sitemap.xml

--- a/server/db/organizations.ts
+++ b/server/db/organizations.ts
@@ -351,6 +351,10 @@ export async function deleteUserAccount(
   await db.batch([
     db.update(scans).set({ ownerUserId: null }).where(eq(scans.ownerUserId, userId)),
     db.update(scans).set({ decidedByUserId: null }).where(eq(scans.decidedByUserId, userId)),
+    db
+      .update(scans)
+      .set({ publicSharedByUserId: null })
+      .where(eq(scans.publicSharedByUserId, userId)),
     db.update(scanEvents).set({ actorUserId: null }).where(eq(scanEvents.actorUserId, userId)),
     db
       .update(npmConnections)

--- a/server/db/scan-share.ts
+++ b/server/db/scan-share.ts
@@ -1,0 +1,146 @@
+import { and, eq, isNotNull, isNull } from "drizzle-orm";
+import { base64UrlEncode } from "../lib/platform/crypto-utils";
+import type { AppDb } from "./client";
+import { recordScanEvent } from "./events";
+import { scans } from "./schema";
+
+// 256 bits of entropy, base64url (43 chars). The token is the whole capability
+// for the public report route, so it must be unguessable; lookups go through
+// the unique index, not string comparison in application code.
+export function generatePublicShareToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return base64UrlEncode(bytes);
+}
+
+export interface PublicShareState {
+  publicShareToken: string;
+  publicSharedAt: Date;
+}
+
+/**
+ * Enable (or return the existing) public share link for a completed scan.
+ * Idempotent: re-sharing an already-shared scan returns the current token so
+ * the UI never rotates a link that may already be distributed.
+ */
+export async function enablePublicShare(
+  db: AppDb,
+  input: { scanId: string; organizationId: string; actorUserId: string },
+): Promise<PublicShareState | null> {
+  const readShareState = () =>
+    db
+      .select({
+        status: scans.status,
+        publicShareToken: scans.publicShareToken,
+        publicSharedAt: scans.publicSharedAt,
+        packageName: scans.packageName,
+        stagedVersion: scans.stagedVersion,
+      })
+      .from(scans)
+      .where(and(eq(scans.id, input.scanId), eq(scans.organizationId, input.organizationId)))
+      .limit(1);
+
+  const [existing] = await readShareState();
+  if (!existing) return null;
+  if (existing.status !== "complete") return null;
+  if (existing.publicShareToken && existing.publicSharedAt) {
+    return { publicShareToken: existing.publicShareToken, publicSharedAt: existing.publicSharedAt };
+  }
+
+  const now = new Date();
+  const token = generatePublicShareToken();
+  const updated = await db
+    .update(scans)
+    .set({
+      publicShareToken: token,
+      publicSharedAt: now,
+      publicSharedByUserId: input.actorUserId,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(scans.id, input.scanId),
+        eq(scans.organizationId, input.organizationId),
+        eq(scans.status, "complete"),
+        // Guards the idempotency promise under concurrency: two racing enables
+        // must never rotate a token one of them already returned.
+        isNull(scans.publicShareToken),
+      ),
+    )
+    .returning({ id: scans.id });
+  if (updated.length === 0) {
+    // Lost the race to a concurrent enable — return the winner's token.
+    const [current] = await readShareState();
+    if (current?.publicShareToken && current.publicSharedAt) {
+      return { publicShareToken: current.publicShareToken, publicSharedAt: current.publicSharedAt };
+    }
+    return null;
+  }
+
+  await recordScanEvent(db, {
+    organizationId: input.organizationId,
+    actorUserId: input.actorUserId,
+    scanId: input.scanId,
+    type: "scan.share_enabled",
+    metadata: { packageName: existing.packageName, stagedVersion: existing.stagedVersion },
+  });
+  return { publicShareToken: token, publicSharedAt: now };
+}
+
+/** Revoke the public share link. Returns false when the scan was not shared. */
+export async function revokePublicShare(
+  db: AppDb,
+  input: { scanId: string; organizationId: string; actorUserId: string },
+): Promise<boolean> {
+  const now = new Date();
+  const updated = await db
+    .update(scans)
+    .set({
+      publicShareToken: null,
+      publicSharedAt: null,
+      publicSharedByUserId: null,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(scans.id, input.scanId),
+        eq(scans.organizationId, input.organizationId),
+        isNotNull(scans.publicShareToken),
+      ),
+    )
+    .returning({
+      id: scans.id,
+      packageName: scans.packageName,
+      stagedVersion: scans.stagedVersion,
+    });
+  if (updated.length === 0) return false;
+
+  await recordScanEvent(db, {
+    organizationId: input.organizationId,
+    actorUserId: input.actorUserId,
+    scanId: input.scanId,
+    type: "scan.share_revoked",
+    metadata: { packageName: updated[0].packageName, stagedVersion: updated[0].stagedVersion },
+  });
+  return true;
+}
+
+/**
+ * Resolve a public share token to its scan's id + organization. The caller
+ * re-reads the full detail through `getScan` with the resolved organization so
+ * the public path shares the exact read pipeline (R2 artifacts, digest checks)
+ * used by authenticated reads.
+ */
+export async function resolvePublicShareToken(
+  db: AppDb,
+  token: string,
+): Promise<{ scanId: string; organizationId: string } | null> {
+  if (!token) return null;
+  const [row] = await db
+    .select({ scanId: scans.id, organizationId: scans.organizationId, status: scans.status })
+    .from(scans)
+    .where(eq(scans.publicShareToken, token))
+    .limit(1);
+  if (!row || row.status !== "complete" || !row.organizationId) return null;
+  return { scanId: row.scanId, organizationId: row.organizationId };
+}

--- a/server/db/scan-share.ts
+++ b/server/db/scan-share.ts
@@ -7,7 +7,7 @@ import { scans } from "./schema";
 // 256 bits of entropy, base64url (43 chars). The token is the whole capability
 // for the public report route, so it must be unguessable; lookups go through
 // the unique index, not string comparison in application code.
-export function generatePublicShareToken(): string {
+function generatePublicShareToken(): string {
   const bytes = new Uint8Array(32);
   crypto.getRandomValues(bytes);
   return base64UrlEncode(bytes);

--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -928,12 +928,25 @@ function recordDecisionEvent(
   });
 }
 
+/**
+ * How much of the file table a `getScan` caller needs:
+ * - `samples` (default) — every artifact, file rows carry their redacted text
+ *   samples. The workbench detail view.
+ * - `list` — metadata only, and the artifacts are read only when D1 alone is
+ *   short (`needsArtifactMetadataFallback`). The cheapest mode; note it can
+ *   leave `findings` sourced from D1 rather than report.json.
+ * - `omit` — full report/diff fidelity (so `findings` and their `diffStatus`
+ *   are byte-identical to `samples`) while skipping the file-samples artifact
+ *   entirely. For callers that serialize the report and never read `files`.
+ */
+export type ScanDetailFileMode = "samples" | "list" | "omit";
+
 export async function getScan(
   db: AppDb,
   id: string,
   organizationId: string,
   artifactBucket?: R2Bucket,
-  options: { includeFileSamples?: boolean } = {},
+  options: { files?: ScanDetailFileMode } = {},
 ) {
   const [scanRows, files, findings, events] = await Promise.all([
     db
@@ -951,14 +964,18 @@ export async function getScan(
   ]);
   const scan = scanRows[0];
   if (!scan) return null;
-  const includeFileSamples = options.includeFileSamples ?? true;
-  const artifactDetail = includeFileSamples
-    ? await loadScanArtifacts(artifactBucket, scan)
-    : needsArtifactMetadataFallback(scan, files, findings)
-      ? await loadScanArtifactMetadata(artifactBucket, scan)
-      : null;
+  const fileMode = options.files ?? "samples";
+  const artifactDetail =
+    fileMode === "list"
+      ? needsArtifactMetadataFallback(scan, files, findings)
+        ? await loadScanArtifactMetadata(artifactBucket, scan)
+        : null
+      : await loadScanArtifacts(artifactBucket, scan, {
+          includeFileSamples: fileMode === "samples",
+        });
   const detailFiles = artifactDetail ? mergeArtifactFiles(files, artifactDetail.files, id) : files;
-  const responseFiles = includeFileSamples ? detailFiles : detailFiles.map(stripFileSampleForList);
+  const responseFiles =
+    fileMode === "samples" ? detailFiles : detailFiles.map(stripFileSampleForList);
   const diff = artifactDetail?.diff ?? diffForFindingAnnotations(scan.summaryJson, detailFiles);
   const findingRows = artifactDetail ? artifactDetail.findings : findings;
   const annotatedFindings = annotateFindingsWithDiffStatus(findingRows, diff, {

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -164,6 +164,15 @@ export const scans = sqliteTable(
     reportArtifactKey: text("report_artifact_key"),
     fileSamplesArtifactKey: text("file_samples_artifact_key"),
     diffArtifactKey: text("diff_artifact_key"),
+    // Public share link. A non-null token makes the completed scan's canonical
+    // report export readable (unauthenticated) at /public/reports/:token.
+    // Revoking sets the token back to null; the token itself is the only
+    // capability — there is no separate "enabled" flag to drift out of sync.
+    publicShareToken: text("public_share_token"),
+    publicSharedAt: integer("public_shared_at", { mode: "timestamp_ms" }),
+    publicSharedByUserId: text("public_shared_by_user_id").references(() => user.id, {
+      onDelete: "set null",
+    }),
     startedAt: integer("started_at", { mode: "timestamp_ms" }),
     completedAt: integer("completed_at", { mode: "timestamp_ms" }),
     createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
@@ -194,6 +203,9 @@ export const scans = sqliteTable(
     // Account deletion nulls decided_by_user_id by user id, and D1 enforces the
     // user FK on delete; without this index both walk the whole table.
     decidedByIdx: index("scans_decided_by_idx").on(table.decidedByUserId),
+    publicShareTokenUniqueIdx: uniqueIndex("scans_public_share_token_unique_idx").on(
+      table.publicShareToken,
+    ),
   }),
 );
 

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -203,6 +203,9 @@ export const scans = sqliteTable(
     // Account deletion nulls decided_by_user_id by user id, and D1 enforces the
     // user FK on delete; without this index both walk the whole table.
     decidedByIdx: index("scans_decided_by_idx").on(table.decidedByUserId),
+    // Same reasoning for the share attribution column: account deletion nulls it
+    // by user id, and the FK is checked on every user delete.
+    publicSharedByIdx: index("scans_public_shared_by_idx").on(table.publicSharedByUserId),
     publicShareTokenUniqueIdx: uniqueIndex("scans_public_share_token_unique_idx").on(
       table.publicShareToken,
     ),

--- a/server/env.d.ts
+++ b/server/env.d.ts
@@ -21,6 +21,9 @@ declare global {
       // any deployed config — production must keep the full header policy.
       DISABLE_SECURITY_HEADERS?: string;
       NPM_CONNECTIONS_ENCRYPTION_KEY?: string;
+      // Ed25519 private JWK (kty OKP) used to sign public report attestations.
+      // Absent → attestation endpoints return 503; sharing still works.
+      ATTESTATION_SIGNING_KEY_JWK?: string;
       BETTER_AUTH_SECRET: string;
       BETTER_AUTH_URL?: string;
       AUTH_REQUIRED?: string;

--- a/server/index.ts
+++ b/server/index.ts
@@ -114,8 +114,12 @@ function assetFallbackRequest(request: Request): Request {
 // log line. Cloudflare's own invocation logs still capture the full URL — that
 // is inherent to capability URLs and is why revocation is immediate — but
 // nothing Drydock writes should widen that exposure.
+// Both spellings carry the token: /public/reports/:token is the API read, and
+// /reports/:token is the browser-facing page that wraps it. Redacting only the
+// former leaves the document request — the one a human actually pastes around,
+// and the one whose asset fallback can throw — logging the capability in full.
 export function redactCapabilityPath(path: string): string {
-  return path.replace(/^\/public\/reports\/[^/]+/, "/public/reports/:token");
+  return path.replace(/^(\/public)?\/reports\/[^/]+/, "$1/reports/:token");
 }
 
 function applySecurityHeaders(c: { res: Response; req: { path: string } }) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -43,6 +43,7 @@ import {
 import { auditRoutes } from "./routes/audit";
 import { githubAppRoutes } from "./routes/github-app";
 import { githubWebhookRoutes } from "./routes/github-webhooks";
+import { publicReportsRoutes } from "./routes/public-reports";
 import { npmConnectionRoutes } from "./routes/npm-connection";
 import { organizationMembersRoutes } from "./routes/organization-members";
 import { ogRoutes } from "./routes/og";
@@ -59,7 +60,7 @@ export { NpmAdapterBroker } from "./lib/ecosystems/npm";
 const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 const CANONICAL_HOSTNAME = "drydock.org";
 const LEGACY_HOSTNAME = "drydock.resynapse.dev";
-const SERVER_OWNED_PATH_PREFIXES = ["/api", "/webhooks", "/og"];
+const SERVER_OWNED_PATH_PREFIXES = ["/api", "/webhooks", "/og", "/public"];
 const DASHBOARD_STATIC_ASSET_PATHS = new Set([
   "/dashboard",
   "/dashboard/",
@@ -109,7 +110,10 @@ function applySecurityHeaders(c: { res: Response; req: { path: string } }) {
   for (const [name, value] of Object.entries(SECURITY_HEADERS)) headers.set(name, value);
   // Worker-owned routes carry the locked-down API policy; static asset responses
   // fetched through the ASSETS binding keep the document policy.
-  headers.set("Content-Security-Policy", c.req.path.startsWith("/api/") ? API_CSP : DOCUMENT_CSP);
+  headers.set(
+    "Content-Security-Policy",
+    c.req.path.startsWith("/api/") || c.req.path.startsWith("/public/") ? API_CSP : DOCUMENT_CSP,
+  );
 
   c.res = new Response(c.res.body, {
     status: c.res.status,
@@ -148,6 +152,11 @@ app.route("/api/public/v1/package-diff", publicDiffRoutes);
 // crawlers fetch a plain image URL, and before the auth middleware for the same
 // reason the diff API is: an unfurl has no session and must not need one.
 app.route("/og", ogRoutes);
+
+// Publicly shared scan reports are capability-URLs: the unguessable share
+// token (opted into by an org owner/admin) is the trust boundary, so these
+// mount before the auth middleware too. Rate-limited per IP inside the routes.
+app.route("/public", publicReportsRoutes);
 
 app.use("/api/*", async (c, next) => {
   try {
@@ -271,6 +280,8 @@ app.get("/api", (c) =>
       githubWebhooks: "POST /webhooks/github (signed by GitHub App webhook secret)",
       publicPackageDiff:
         "GET /api/public/v1/package-diff?package&from&to[&ecosystem=npm|pypi]; GET /api/public/v1/package-diff/versions?package[&ecosystem]; GET /api/public/v1/package-diff/file?package&from&to&path[&ecosystem] (anonymous, IP rate-limited, public registry data only; on npm, from/to also accept pkg.pr.new preview URLs)",
+      publicReports:
+        "POST/DELETE /api/v1/scans/:id/share; GET /public/reports/:token; GET /public/reports/:token/attestation; GET /public/attestation-key (share token is the capability; no auth)",
       slack:
         "GET /api/v1/slack; POST /api/v1/slack/connect; GET /api/v1/slack/callback; GET /api/v1/slack/channels; PUT /api/v1/slack/channel; PATCH /api/v1/slack; DELETE /api/v1/slack; POST /api/v1/slack/test",
       health: "GET /api/health",

--- a/server/index.ts
+++ b/server/index.ts
@@ -114,7 +114,7 @@ function assetFallbackRequest(request: Request): Request {
 // log line. Cloudflare's own invocation logs still capture the full URL — that
 // is inherent to capability URLs and is why revocation is immediate — but
 // nothing Drydock writes should widen that exposure.
-function redactCapabilityPath(path: string): string {
+export function redactCapabilityPath(path: string): string {
   return path.replace(/^\/public\/reports\/[^/]+/, "/public/reports/:token");
 }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -94,6 +94,11 @@ function assetFallbackRequest(request: Request): Request {
     url.search = "";
     return new Request(url, request);
   }
+  if (url.pathname.startsWith("/reports/")) {
+    url.pathname = "/reports/";
+    url.search = "";
+    return new Request(url, request);
+  }
   if (
     (url.pathname === "/dashboard" || url.pathname.startsWith("/dashboard/")) &&
     !DASHBOARD_STATIC_ASSET_PATHS.has(url.pathname)
@@ -103,6 +108,14 @@ function assetFallbackRequest(request: Request): Request {
     return new Request(url, request);
   }
   return request;
+}
+
+// A share link's capability *is* its token, so the raw path must never reach a
+// log line. Cloudflare's own invocation logs still capture the full URL — that
+// is inherent to capability URLs and is why revocation is immediate — but
+// nothing Drydock writes should widen that exposure.
+function redactCapabilityPath(path: string): string {
+  return path.replace(/^\/public\/reports\/[^/]+/, "/public/reports/:token");
 }
 
 function applySecurityHeaders(c: { res: Response; req: { path: string } }) {
@@ -286,7 +299,7 @@ app.get("/api", (c) =>
         "GET /api/v1/slack; POST /api/v1/slack/connect; GET /api/v1/slack/callback; GET /api/v1/slack/channels; PUT /api/v1/slack/channel; PATCH /api/v1/slack; DELETE /api/v1/slack; POST /api/v1/slack/test",
       health: "GET /api/health",
     },
-    auth: "Better Auth is required for every non-auth API endpoint except the anonymous /api/public/* package-diff endpoints, which serve only public registry data.",
+    auth: "Better Auth is required for every non-auth API endpoint except the anonymous /api/public/* package-diff endpoints (public registry data only) and /public/reports/* (a share token is the capability; the owning organization opted in per scan).",
     note: "Cloudflare Workers cannot spawn the npm CLI. This service performs the npm stage download equivalent inside a Dynamic Worker by fetching the staged tarball through a locked-down gateway.",
   }),
 );
@@ -360,7 +373,7 @@ function recordMarketingVisit(
 app.onError((err, c) => {
   emitOperationalEvent("error", "request.unhandled_error", {
     method: c.req.method,
-    path: c.req.path,
+    path: redactCapabilityPath(c.req.path),
     error: describeOperationalError(err),
   });
   return c.json({ error: "internal error" }, 500);

--- a/server/lib/attestation.ts
+++ b/server/lib/attestation.ts
@@ -1,0 +1,145 @@
+import { base64Encode, base64UrlEncode } from "./platform/crypto-utils";
+
+// Signed attestations for publicly shared scan reports.
+//
+// The attested subject is the canonical report export (`serializeReportExport`)
+// — the same stable-ordered bytes served at /public/reports/:token — so any
+// consumer can independently re-hash the report they fetched and verify the
+// signature against the published key. The envelope is DSSE
+// (https://github.com/secure-systems-lab/dsse) around an in-toto v1 Statement,
+// the format sigstore/SLSA tooling already understands.
+
+export const ATTESTATION_PAYLOAD_TYPE = "application/vnd.in-toto+json";
+export const ATTESTATION_PREDICATE_TYPE = "https://drydock.org/attestation/scan-report/v1";
+const ATTESTATION_KEY_ALGORITHM = "Ed25519";
+
+export interface AttestationSubject {
+  /** `name@version` when known, otherwise the scan id. */
+  name: string;
+  /** Hex sha256 of the canonical report export bytes. */
+  reportSha256: string;
+}
+
+export interface AttestationPredicate {
+  scanId: string;
+  packageName: string | null;
+  stagedVersion: string | null;
+  previousVersion: string | null;
+  risk: string;
+  decision: string | null;
+  findingCount: number;
+  reportSchema: string;
+  reportDigest: string | null;
+  completedAt: string | null;
+}
+
+export interface DsseEnvelope {
+  payloadType: string;
+  payload: string;
+  signatures: Array<{ keyid: string; sig: string }>;
+}
+
+export interface AttestationKey {
+  privateKey: CryptoKey;
+  publicJwk: JsonWebKey;
+  keyId: string;
+}
+
+/**
+ * Load the Ed25519 signing key from the `ATTESTATION_SIGNING_KEY_JWK` secret
+ * (a private OKP JWK). Returns null when the secret is absent or malformed —
+ * callers degrade to "attestations unavailable" rather than failing the share.
+ */
+export async function loadAttestationKey(env: {
+  ATTESTATION_SIGNING_KEY_JWK?: string;
+}): Promise<AttestationKey | null> {
+  const raw = env.ATTESTATION_SIGNING_KEY_JWK;
+  if (!raw) return null;
+  let jwk: JsonWebKey;
+  try {
+    jwk = JSON.parse(raw) as JsonWebKey;
+  } catch {
+    return null;
+  }
+  if (jwk.kty !== "OKP" || jwk.crv !== "Ed25519" || typeof jwk.d !== "string") return null;
+  try {
+    const privateKey = await crypto.subtle.importKey(
+      "jwk",
+      jwk,
+      { name: ATTESTATION_KEY_ALGORITHM },
+      false,
+      ["sign"],
+    );
+    const publicJwk = publicJwkFromPrivate(jwk);
+    return { privateKey, publicJwk, keyId: await jwkThumbprint(publicJwk) };
+  } catch {
+    return null;
+  }
+}
+
+export function publicJwkFromPrivate(jwk: JsonWebKey): JsonWebKey {
+  return { kty: jwk.kty, crv: jwk.crv, x: jwk.x };
+}
+
+/** RFC 7638 JWK thumbprint (OKP members, lexicographic order), base64url. */
+export async function jwkThumbprint(publicJwk: JsonWebKey): Promise<string> {
+  const canonical = JSON.stringify({ crv: publicJwk.crv, kty: publicJwk.kty, x: publicJwk.x });
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(canonical));
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+export function buildAttestationStatement(
+  subject: AttestationSubject,
+  predicate: AttestationPredicate,
+) {
+  return {
+    _type: "https://in-toto.io/Statement/v1",
+    subject: [{ name: subject.name, digest: { sha256: subject.reportSha256 } }],
+    predicateType: ATTESTATION_PREDICATE_TYPE,
+    predicate,
+  };
+}
+
+/**
+ * DSSE Pre-Authentication Encoding: the signature covers the payload type and
+ * body with length framing, so an envelope's payload cannot be reinterpreted
+ * under a different type.
+ */
+export function preAuthenticationEncoding(
+  payloadType: string,
+  payload: Uint8Array,
+): Uint8Array<ArrayBuffer> {
+  const encoder = new TextEncoder();
+  const typeBytes = encoder.encode(payloadType);
+  const header = encoder.encode(`DSSEv1 ${typeBytes.length} ${payloadType} ${payload.length} `);
+  const out = new Uint8Array(header.length + payload.length);
+  out.set(header, 0);
+  out.set(payload, header.length);
+  return out;
+}
+
+export async function signAttestation(
+  key: AttestationKey,
+  statement: ReturnType<typeof buildAttestationStatement>,
+): Promise<DsseEnvelope> {
+  const payload = new TextEncoder().encode(JSON.stringify(statement));
+  const signature = await crypto.subtle.sign(
+    ATTESTATION_KEY_ALGORITHM,
+    key.privateKey,
+    preAuthenticationEncoding(ATTESTATION_PAYLOAD_TYPE, payload),
+  );
+  // DSSE permits either base64 alphabet, but sigstore/in-toto tooling emits and
+  // expects standard base64 — match it so strict verifiers accept our envelopes.
+  return {
+    payloadType: ATTESTATION_PAYLOAD_TYPE,
+    payload: base64Encode(payload),
+    signatures: [{ keyid: key.keyId, sig: base64Encode(new Uint8Array(signature)) }],
+  };
+}
+
+export async function sha256Hex(bytes: Uint8Array<ArrayBuffer>): Promise<string> {
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", bytes));
+  let hex = "";
+  for (const byte of digest) hex += byte.toString(16).padStart(2, "0");
+  return hex;
+}

--- a/server/lib/attestation.ts
+++ b/server/lib/attestation.ts
@@ -9,8 +9,8 @@ import { base64Encode, base64UrlEncode } from "./platform/crypto-utils";
 // (https://github.com/secure-systems-lab/dsse) around an in-toto v1 Statement,
 // the format sigstore/SLSA tooling already understands.
 
-export const ATTESTATION_PAYLOAD_TYPE = "application/vnd.in-toto+json";
-export const ATTESTATION_PREDICATE_TYPE = "https://drydock.org/attestation/scan-report/v1";
+const ATTESTATION_PAYLOAD_TYPE = "application/vnd.in-toto+json";
+const ATTESTATION_PREDICATE_TYPE = "https://drydock.org/attestation/scan-report/v1";
 const ATTESTATION_KEY_ALGORITHM = "Ed25519";
 
 export interface AttestationSubject {
@@ -85,12 +85,12 @@ export async function loadAttestationKey(env: {
   }
 }
 
-export function publicJwkFromPrivate(jwk: JsonWebKey): JsonWebKey {
+function publicJwkFromPrivate(jwk: JsonWebKey): JsonWebKey {
   return { kty: jwk.kty, crv: jwk.crv, x: jwk.x };
 }
 
 /** RFC 7638 JWK thumbprint (OKP members, lexicographic order), base64url. */
-export async function jwkThumbprint(publicJwk: JsonWebKey): Promise<string> {
+async function jwkThumbprint(publicJwk: JsonWebKey): Promise<string> {
   const canonical = JSON.stringify({ crv: publicJwk.crv, kty: publicJwk.kty, x: publicJwk.x });
   const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(canonical));
   return base64UrlEncode(new Uint8Array(digest));
@@ -113,7 +113,7 @@ export function buildAttestationStatement(
  * body with length framing, so an envelope's payload cannot be reinterpreted
  * under a different type.
  */
-export function preAuthenticationEncoding(
+function preAuthenticationEncoding(
   payloadType: string,
   payload: Uint8Array,
 ): Uint8Array<ArrayBuffer> {

--- a/server/lib/attestation.ts
+++ b/server/lib/attestation.ts
@@ -31,6 +31,14 @@ export interface AttestationPredicate {
   reportSchema: string;
   reportDigest: string | null;
   completedAt: string | null;
+  /**
+   * When this envelope was signed. The attested report is a snapshot of mutable
+   * state — a maintainer can decide "block" after a consumer already archived
+   * an envelope — so two envelopes for the same scan can both verify and still
+   * disagree. This is the field that orders them, inside the signed statement
+   * rather than out of band.
+   */
+  issuedAt: string;
 }
 
 export interface DsseEnvelope {

--- a/server/lib/auth/audit-events.ts
+++ b/server/lib/auth/audit-events.ts
@@ -25,6 +25,13 @@ function str(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value : null;
 }
 
+function summarizePackageVersion(m: Record<string, unknown>): string | null {
+  const pkg = str(m.packageName);
+  const version = str(m.stagedVersion);
+  if (pkg && version) return `${pkg}@${version}`;
+  return pkg ?? version;
+}
+
 const REGISTRY: Record<string, AuditEventDef> = {
   // ── Release decisions ────────────────────────────────────────────────────
   "scan.decided": {
@@ -97,6 +104,18 @@ const REGISTRY: Record<string, AuditEventDef> = {
   },
 
   // ── Security / policy ────────────────────────────────────────────────────
+  "scan.share_enabled": {
+    category: "security",
+    label: "Public report link created",
+    severity: "security",
+    summarize: summarizePackageVersion,
+  },
+  "scan.share_revoked": {
+    category: "security",
+    label: "Public report link revoked",
+    severity: "notice",
+    summarize: summarizePackageVersion,
+  },
   "organization.release_two_factor_changed": {
     category: "security",
     label: "Release two-factor policy changed",

--- a/server/lib/auth/roles.ts
+++ b/server/lib/auth/roles.ts
@@ -24,3 +24,9 @@ export function roleCanManageMembers(role: OrganizationRole | null): boolean {
 export function roleCanManageIntegrations(role: OrganizationRole | null): boolean {
   return role === "owner" || role === "admin";
 }
+
+// Publishing a report beyond the organization is a governance action, not a
+// scan-review action, so it takes the same elevated bar as integrations.
+export function roleCanManagePublicShares(role: OrganizationRole | null): boolean {
+  return role === "owner" || role === "admin";
+}

--- a/server/lib/platform/crypto-utils.ts
+++ b/server/lib/platform/crypto-utils.ts
@@ -17,10 +17,14 @@ export function timingSafeEqual(a: Uint8Array, b: Uint8Array): boolean {
   return diff === 0;
 }
 
-export function base64UrlEncode(bytes: Uint8Array): string {
+export function base64Encode(bytes: Uint8Array): string {
   let binary = "";
   for (const byte of bytes) binary += String.fromCharCode(byte);
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+  return btoa(binary);
+}
+
+export function base64UrlEncode(bytes: Uint8Array): string {
+  return base64Encode(bytes).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
 }
 
 export function base64UrlString(str: string): string {

--- a/server/lib/scan/artifacts.ts
+++ b/server/lib/scan/artifacts.ts
@@ -266,6 +266,12 @@ export async function writeScanArtifacts(
 export async function loadScanArtifacts(
   bucket: R2Bucket | undefined,
   scan: ScanArtifactScanRow,
+  // `includeFileSamples: false` skips the files.json read while keeping the
+  // report + diff artifacts (and therefore findings and their diff annotations)
+  // exactly as they are with it. The file-samples payload is by far the largest
+  // artifact — one redacted sample per file, capped at SCAN_FILE_SAMPLE_LIMIT
+  // each — so callers that never read `files` should not pay for it.
+  options: { includeFileSamples?: boolean } = {},
 ): Promise<ScanArtifactsDetail | null> {
   const manifestDetail = await loadScanArtifactsManifest(bucket, scan);
   if (!manifestDetail) return null;
@@ -283,6 +289,7 @@ export async function loadScanArtifacts(
     return null;
   }
 
+  const includeFileSamples = options.includeFileSamples ?? true;
   try {
     const [reportText, filesText, diffText] = await Promise.all([
       readVerifiedJsonText(bucket as R2Bucket, {
@@ -290,11 +297,13 @@ export async function loadScanArtifacts(
         scanId: scan.id,
         kind: "report",
       }),
-      readVerifiedJsonText(bucket as R2Bucket, {
-        ...manifest.artifacts.files,
-        scanId: scan.id,
-        kind: "files",
-      }),
+      includeFileSamples
+        ? readVerifiedJsonText(bucket as R2Bucket, {
+            ...manifest.artifacts.files,
+            scanId: scan.id,
+            kind: "files",
+          })
+        : null,
       readVerifiedJsonText(bucket as R2Bucket, {
         ...manifest.artifacts.diff,
         scanId: scan.id,
@@ -303,7 +312,7 @@ export async function loadScanArtifacts(
     ]);
 
     const reportFindings = parseReportFindings(reportText, scan.id);
-    const files = parseFilesArtifact(filesText, scan.id);
+    const files = filesText === null ? [] : parseFilesArtifact(filesText, scan.id);
     const diff = parseDiffArtifact(diffText, scan.id);
     if (!files || !diff || !reportFindings) {
       emitArtifactFallback("artifact_payload_invalid", scan);

--- a/server/lib/scan/report-export.ts
+++ b/server/lib/scan/report-export.ts
@@ -19,11 +19,11 @@ interface ReportExportFilenameInput {
 // Schema tag for the exported report document. Bump the suffix when the export
 // shape changes in a way consumers must branch on.
 //
-// v2 drops `releaseConsistency.priorScanId` (see `exportReleaseConsistency`).
-// That is a removal from the authenticated `report.json` contract as much as
-// from the public one, so it takes the bump with it: the export is the signing
-// boundary, and a consumer that pinned v1 must not silently receive a document
-// missing a field it read.
+// v2 drops `releaseConsistency.priorScanId` and `releaseConsistency.decidedAt`
+// (see `exportReleaseConsistency`). Those are removals from the authenticated
+// `report.json` contract as much as from the public one, so they take the bump
+// with them: the export is the signing boundary, and a consumer that pinned v1
+// must not silently receive a document missing a field it read.
 export const REPORT_EXPORT_SCHEMA = "drydock.report.v2";
 
 // Build a self-contained, archivable view of a completed review from the data
@@ -148,13 +148,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-// The export drops `priorScanId`: it is an org-internal dashboard affordance
-// referencing a scan the org never chose to share, and these bytes are served
-// verbatim on the public report route.
+// The export drops `priorScanId` and `decidedAt`: both describe a *prior* scan
+// the org never chose to share, and these bytes are served verbatim on the
+// public report route. `decidedAt` is the sharper of the two — a precise
+// timestamp of an internal review decision on an unshared release. What stays
+// (`status`, the finding counts, `newFindings`) describes this scan's delta
+// against that history, which is the signal the report is making.
 function exportReleaseConsistency(raw: unknown) {
   const consistency = normalizeReleaseConsistency(raw);
   if (!consistency) return null;
-  const { priorScanId: _priorScanId, ...exported } = consistency;
+  const { priorScanId: _priorScanId, decidedAt: _decidedAt, ...exported } = consistency;
   return exported;
 }
 

--- a/server/lib/scan/report-export.ts
+++ b/server/lib/scan/report-export.ts
@@ -18,7 +18,13 @@ interface ReportExportFilenameInput {
 
 // Schema tag for the exported report document. Bump the suffix when the export
 // shape changes in a way consumers must branch on.
-export const REPORT_EXPORT_SCHEMA = "drydock.report.v1";
+//
+// v2 drops `releaseConsistency.priorScanId` (see `exportReleaseConsistency`).
+// That is a removal from the authenticated `report.json` contract as much as
+// from the public one, so it takes the bump with it: the export is the signing
+// boundary, and a consumer that pinned v1 must not silently receive a document
+// missing a field it read.
+export const REPORT_EXPORT_SCHEMA = "drydock.report.v2";
 
 // Build a self-contained, archivable view of a completed review from the data
 // already persisted for it: provenance metadata, package/baseline identity, the
@@ -71,7 +77,7 @@ export function buildReportExport(detail: ScanDetail) {
     // Deterministic findings only. A completed AI review's findings are carried
     // by `aiReview.findings` above; including the persisted `source: "ai"` rows
     // here too would double-count them in this array and break the invariant
-    // that every entry has a ruleId/ruleVersion. Keeps `drydock.report.v1`'s
+    // that every entry has a ruleId/ruleVersion. Keeps `drydock.report.v2`'s
     // findings[] meaning stable across the persistence change.
     findings: detail.findings
       .filter((finding) => finding.source !== "ai")

--- a/server/lib/scan/report-export.ts
+++ b/server/lib/scan/report-export.ts
@@ -97,11 +97,22 @@ export function buildReportExport(detail: ScanDetail) {
   };
 }
 
+export type ReportExportDocument = ReturnType<typeof buildReportExport>;
+
 // Serialize the export with stable key ordering so the same evidence always
 // produces byte-identical output — the property two report artifacts need to be
 // comparable, and a prerequisite for signing later.
 export function serializeReportExport(detail: ScanDetail): string {
-  return stableStringify(buildReportExport(detail));
+  return serializeReportExportDocument(buildReportExport(detail));
+}
+
+// Serialize an already-built export. The attestation route needs the document
+// *and* its bytes: anything it asserts about the report has to be read off the
+// same object that produced the digest it signs, or the two can disagree inside
+// a signed envelope (they did — `findingCount` counted AI findings the
+// document's `findings[]` deliberately excludes).
+export function serializeReportExportDocument(document: ReportExportDocument): string {
+  return stableStringify(document);
 }
 
 export function reportExportFilename(scan: ReportExportFilenameInput): string {

--- a/server/lib/scan/report-export.ts
+++ b/server/lib/scan/report-export.ts
@@ -18,7 +18,7 @@ interface ReportExportFilenameInput {
 
 // Schema tag for the exported report document. Bump the suffix when the export
 // shape changes in a way consumers must branch on.
-const REPORT_EXPORT_SCHEMA = "drydock.report.v1";
+export const REPORT_EXPORT_SCHEMA = "drydock.report.v1";
 
 // Build a self-contained, archivable view of a completed review from the data
 // already persisted for it: provenance metadata, package/baseline identity, the
@@ -65,7 +65,7 @@ export function buildReportExport(detail: ScanDetail) {
     riskSummary: detail.riskSummary ?? null,
     // Advisory release-memory signal. Additive + optional: scans that predate
     // the field (or persisted a malformed blob) export null.
-    releaseConsistency: normalizeReleaseConsistency(summary.releaseConsistency),
+    releaseConsistency: exportReleaseConsistency(summary.releaseConsistency),
     packageJsonDiff: summary.packageJsonDiff ?? null,
     diff: summary.diff ?? null,
     // Deterministic findings only. A completed AI review's findings are carried
@@ -140,6 +140,16 @@ function toIso(value: unknown): string | null {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+// The export drops `priorScanId`: it is an org-internal dashboard affordance
+// referencing a scan the org never chose to share, and these bytes are served
+// verbatim on the public report route.
+function exportReleaseConsistency(raw: unknown) {
+  const consistency = normalizeReleaseConsistency(raw);
+  if (!consistency) return null;
+  const { priorScanId: _priorScanId, ...exported } = consistency;
+  return exported;
 }
 
 // Pull the provenance block out of the persisted, adapter-shaped staged details.

--- a/server/routes/public-reports.ts
+++ b/server/routes/public-reports.ts
@@ -32,6 +32,24 @@ const PUBLIC_READ_RATE = { limit: 120, windowMs: 60 * 1000 };
 
 const SHARE_TOKEN_RE = /^[A-Za-z0-9_-]{40,64}$/;
 
+// CORS on *every* response, not just the 200s. docs/public-reports.md tells
+// consumers to fetch the report and its attestation from the browser and
+// re-fetch on digest mismatch; without these headers on the failure paths a
+// revoked link is an opaque network error indistinguishable from the service
+// being down, and a throttled verifier cannot read `retry-after` to back off.
+// Registered ahead of the rate limiter so the 429 it returns is covered too.
+publicReportsRoutes.use("*", async (c, next) => {
+  await next();
+  const headers = new Headers(c.res.headers);
+  headers.set("access-control-allow-origin", "*");
+  headers.set("access-control-expose-headers", "content-disposition, retry-after");
+  c.res = new Response(c.res.body, {
+    status: c.res.status,
+    statusText: c.res.statusText,
+    headers,
+  });
+});
+
 publicReportsRoutes.use("*", async (c, next) => {
   const ip =
     c.req.header("cf-connecting-ip") || c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
@@ -60,7 +78,8 @@ publicReportsRoutes.get("/attestation-key", async (c) => {
     { keyId: key.keyId, algorithm: "Ed25519", jwk: key.publicJwk },
     200,
     // The key rotates rarely; consumers cache it and match envelopes by keyid.
-    { "cache-control": "public, max-age=3600", "access-control-allow-origin": "*" },
+    // (CORS comes from the route-wide middleware above.)
+    { "cache-control": "public, max-age=3600" },
   );
 });
 
@@ -80,7 +99,6 @@ publicReportsRoutes.get("/reports/:token", async (c) => {
       // Revocation must be immediate (the UI and docs promise it), so shared
       // caches may never hold a copy past the revoke.
       "cache-control": "no-store",
-      "access-control-allow-origin": "*",
     },
   });
 });
@@ -111,6 +129,7 @@ publicReportsRoutes.get("/reports/:token/attestation", async (c) => {
       reportDigest: detail.scan.reportDigest ?? null,
       completedAt:
         detail.scan.completedAt instanceof Date ? detail.scan.completedAt.toISOString() : null,
+      issuedAt: new Date().toISOString(),
     },
   );
 
@@ -124,7 +143,6 @@ publicReportsRoutes.get("/reports/:token/attestation", async (c) => {
     const filename = reportExportFilename(detail.scan).replace(/\.json$/, ".attestation.json");
     return c.json(envelope, 200, {
       "cache-control": "no-store",
-      "access-control-allow-origin": "*",
       "content-disposition": `attachment; filename="${filename}"`,
     });
   } catch (err) {
@@ -144,11 +162,18 @@ async function loadSharedScanDetail(c: Context<{ Bindings: Bindings; Variables: 
   const db = createDb(c.env.DB);
   const resolved = await resolvePublicShareToken(db, token);
   if (!resolved) return { error: c.json({ error: "not found" }, 404) } as const;
+  // `omit` — not `list` — is load-bearing. The export's `findings[].diffStatus`
+  // is derived from the diff artifact, so anything that changes whether the
+  // artifacts are read changes the serialized bytes, and the attestation's
+  // subject digest is computed over exactly those bytes. `omit` keeps the
+  // report and diff artifacts (identical output to the authenticated export)
+  // and drops only the file-samples payload, which this route never reads.
   const detail = await getScan(
     db,
     resolved.scanId,
     resolved.organizationId,
     scanArtifactReadBucket(c.env),
+    { files: "omit" },
   );
   if (!detail || detail.scan.status !== "complete") {
     return { error: c.json({ error: "not found" }, 404) } as const;

--- a/server/routes/public-reports.ts
+++ b/server/routes/public-reports.ts
@@ -12,9 +12,11 @@ import {
 import { rateLimitResponse } from "../lib/platform/http";
 import { describeOperationalError, emitOperationalEvent } from "../lib/platform/observability";
 import {
+  buildReportExport,
   REPORT_EXPORT_SCHEMA,
   reportExportFilename,
   serializeReportExport,
+  serializeReportExportDocument,
 } from "../lib/scan/report-export";
 import { scanArtifactReadBucket } from "../lib/scan/artifacts";
 import type { Bindings, Variables } from "../types";
@@ -110,7 +112,10 @@ publicReportsRoutes.get("/reports/:token/attestation", async (c) => {
   if (!key) return c.json({ error: "attestations are not configured" }, 503);
 
   const { detail } = loaded;
-  const reportBytes = new TextEncoder().encode(serializeReportExport(detail));
+  // Build the document once and sign *its* bytes, so every predicate field is
+  // read off the same object the digest covers.
+  const document = buildReportExport(detail);
+  const reportBytes = new TextEncoder().encode(serializeReportExportDocument(document));
   const subjectName =
     detail.scan.packageName && detail.scan.stagedVersion
       ? `${detail.scan.packageName}@${detail.scan.stagedVersion}`
@@ -124,7 +129,11 @@ publicReportsRoutes.get("/reports/:token/attestation", async (c) => {
       previousVersion: detail.scan.previousVersion ?? null,
       risk: detail.scan.risk,
       decision: detail.scan.decision ?? null,
-      findingCount: detail.findings.length,
+      // The export's findings[], not the scan's finding rows: those also carry
+      // the AI reviewer's findings, which the export deliberately routes through
+      // `aiReview.findings` instead. A verifier comparing this against the
+      // attested document must not see two different numbers.
+      findingCount: document.findings.length,
       reportSchema: REPORT_EXPORT_SCHEMA,
       reportDigest: detail.scan.reportDigest ?? null,
       completedAt:

--- a/server/routes/public-reports.ts
+++ b/server/routes/public-reports.ts
@@ -1,0 +1,157 @@
+import { Hono, type Context } from "hono";
+import { createDb } from "../db/client";
+import { RateLimitError, enforceRateLimit } from "../db/rate-limit";
+import { resolvePublicShareToken } from "../db/scan-share";
+import { getScan } from "../db/scans";
+import {
+  buildAttestationStatement,
+  loadAttestationKey,
+  sha256Hex,
+  signAttestation,
+} from "../lib/attestation";
+import { rateLimitResponse } from "../lib/platform/http";
+import { describeOperationalError, emitOperationalEvent } from "../lib/platform/observability";
+import {
+  REPORT_EXPORT_SCHEMA,
+  reportExportFilename,
+  serializeReportExport,
+} from "../lib/scan/report-export";
+import { scanArtifactReadBucket } from "../lib/scan/artifacts";
+import type { Bindings, Variables } from "../types";
+
+// Unauthenticated, capability-based report access. These routes are mounted
+// before the Better Auth middleware (like /webhooks): the unguessable share
+// token IS the trust boundary. Everything served here is the canonical report
+// export an org member explicitly opted into sharing — never file samples,
+// events, or org/user identifiers beyond what the export itself carries.
+export const publicReportsRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+// One bucket for all public report reads from one address. Generous enough for
+// a report page plus its attestation fetch, tight enough to blunt enumeration.
+const PUBLIC_READ_RATE = { limit: 120, windowMs: 60 * 1000 };
+
+const SHARE_TOKEN_RE = /^[A-Za-z0-9_-]{40,64}$/;
+
+publicReportsRoutes.use("*", async (c, next) => {
+  const ip =
+    c.req.header("cf-connecting-ip") || c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
+  // Fail-open without a client IP, mirroring the /api/auth limiter: Cloudflare
+  // always sets cf-connecting-ip, so this only relaxes non-Cloudflare deploys
+  // (unsupported per docs/self-hosting.md).
+  if (!ip) return next();
+  try {
+    await enforceRateLimit(createDb(c.env.DB), {
+      key: `public-report:${ip}`,
+      ...PUBLIC_READ_RATE,
+    });
+  } catch (err) {
+    if (err instanceof RateLimitError) {
+      return rateLimitResponse(c, "too many public report requests", err);
+    }
+    throw err;
+  }
+  return next();
+});
+
+publicReportsRoutes.get("/attestation-key", async (c) => {
+  const key = await loadAttestationKey(c.env);
+  if (!key) return c.json({ error: "attestations are not configured" }, 503);
+  return c.json(
+    { keyId: key.keyId, algorithm: "Ed25519", jwk: key.publicJwk },
+    200,
+    // The key rotates rarely; consumers cache it and match envelopes by keyid.
+    { "cache-control": "public, max-age=3600", "access-control-allow-origin": "*" },
+  );
+});
+
+publicReportsRoutes.get("/reports/:token", async (c) => {
+  const loaded = await loadSharedScanDetail(c);
+  if ("error" in loaded) return loaded.error;
+  emitOperationalEvent("info", "public_report.viewed", {
+    scanId: loaded.detail.scan.id,
+    organizationId: loaded.detail.scan.organizationId,
+  });
+  // Serve the canonical bytes — the attestation's subject digest is computed
+  // over exactly this serialization, so the two endpoints must never diverge.
+  return new Response(serializeReportExport(loaded.detail), {
+    status: 200,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      // Revocation must be immediate (the UI and docs promise it), so shared
+      // caches may never hold a copy past the revoke.
+      "cache-control": "no-store",
+      "access-control-allow-origin": "*",
+    },
+  });
+});
+
+publicReportsRoutes.get("/reports/:token/attestation", async (c) => {
+  const loaded = await loadSharedScanDetail(c);
+  if ("error" in loaded) return loaded.error;
+  const key = await loadAttestationKey(c.env);
+  if (!key) return c.json({ error: "attestations are not configured" }, 503);
+
+  const { detail } = loaded;
+  const reportBytes = new TextEncoder().encode(serializeReportExport(detail));
+  const subjectName =
+    detail.scan.packageName && detail.scan.stagedVersion
+      ? `${detail.scan.packageName}@${detail.scan.stagedVersion}`
+      : detail.scan.id;
+  const statement = buildAttestationStatement(
+    { name: subjectName, reportSha256: await sha256Hex(reportBytes) },
+    {
+      scanId: detail.scan.id,
+      packageName: detail.scan.packageName ?? null,
+      stagedVersion: detail.scan.stagedVersion ?? null,
+      previousVersion: detail.scan.previousVersion ?? null,
+      risk: detail.scan.risk,
+      decision: detail.scan.decision ?? null,
+      findingCount: detail.findings.length,
+      reportSchema: REPORT_EXPORT_SCHEMA,
+      reportDigest: detail.scan.reportDigest ?? null,
+      completedAt:
+        detail.scan.completedAt instanceof Date ? detail.scan.completedAt.toISOString() : null,
+    },
+  );
+
+  try {
+    const envelope = await signAttestation(key, statement);
+    emitOperationalEvent("info", "public_report.attestation_issued", {
+      scanId: detail.scan.id,
+      organizationId: detail.scan.organizationId,
+      keyId: key.keyId,
+    });
+    const filename = reportExportFilename(detail.scan).replace(/\.json$/, ".attestation.json");
+    return c.json(envelope, 200, {
+      "cache-control": "no-store",
+      "access-control-allow-origin": "*",
+      "content-disposition": `attachment; filename="${filename}"`,
+    });
+  } catch (err) {
+    emitOperationalEvent("error", "public_report.attestation_failed", {
+      scanId: detail.scan.id,
+      error: describeOperationalError(err),
+    });
+    return c.json({ error: "failed to sign attestation" }, 500);
+  }
+});
+
+async function loadSharedScanDetail(c: Context<{ Bindings: Bindings; Variables: Variables }>) {
+  const token = c.req.param("token") ?? "";
+  // Shape-check before the DB roundtrip; also keeps arbitrary junk out of the
+  // unique-index lookup. Tokens are 43 chars today; the range leaves headroom.
+  if (!SHARE_TOKEN_RE.test(token)) return { error: c.json({ error: "not found" }, 404) } as const;
+  const db = createDb(c.env.DB);
+  const resolved = await resolvePublicShareToken(db, token);
+  if (!resolved) return { error: c.json({ error: "not found" }, 404) } as const;
+  const detail = await getScan(
+    db,
+    resolved.scanId,
+    resolved.organizationId,
+    scanArtifactReadBucket(c.env),
+  );
+  if (!detail || detail.scan.status !== "complete") {
+    return { error: c.json({ error: "not found" }, 404) } as const;
+  }
+  return { detail } as const;
+}

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -375,7 +375,7 @@ scansRoutes.get("/:id", async (c) => {
   const db = createDb(c.env.DB);
   const organizationId = await requireActiveOrganization(c, db);
   const scan = await getScan(db, c.req.param("id"), organizationId, scanArtifactReadBucket(c.env), {
-    includeFileSamples: false,
+    files: "list",
   });
   if (!scan) return c.json({ error: "not found" }, 404);
   return c.json(scan);
@@ -410,12 +410,19 @@ scansRoutes.get("/:id/report.json", async (c) => {
   const organizationId = await resolveReportExportOrganization(c, db);
   if (!organizationId) return c.json({ error: "not found" }, 404);
   // Full-detail export: the findings come from R2 for artifact-backed scans, so
-  // load the artifact bucket (unlike the metadata-only reads below).
+  // load the artifact bucket (unlike the metadata-only reads below). `omit`
+  // skips the file-samples artifact the export never reads, and keeps this
+  // route byte-identical to the public share route by construction — both go
+  // through the same artifact reads, so neither can degrade to the D1 fallback
+  // while the other does not.
   const detail = await getScan(
     db,
     c.req.param("id"),
     organizationId,
     scanArtifactReadBucket(c.env),
+    {
+      files: "omit",
+    },
   );
   if (!detail) return c.json({ error: "not found" }, 404);
   if (detail.scan.status !== "complete") {

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -35,6 +35,7 @@ import {
 } from "../lib/compare-cache";
 import { rateLimitResponse } from "../lib/platform/http";
 import { workerExecutionContext } from "../lib/platform/execution-context";
+import { enablePublicShare, revokePublicShare } from "../db/scan-share";
 import {
   allowInsecureLocalRegistry,
   decryptNpmToken,
@@ -52,7 +53,7 @@ import { describeOperationalError, emitOperationalEvent } from "../lib/platform/
 import { parseScanInput } from "../lib/scan/input";
 import { reportExportFilename, serializeReportExport } from "../lib/scan/report-export";
 import { executeScanJob, type ScanQueueMessage } from "../lib/scan/job";
-import { roleCanManageIntegrations } from "../lib/auth/roles";
+import { roleCanManageIntegrations, roleCanManagePublicShares } from "../lib/auth/roles";
 import {
   checkStagedPublishAccess,
   fetchStagedPublishDetails,
@@ -308,6 +309,67 @@ scansRoutes.delete("/:id", async (c) => {
   ]);
   return c.json({ ok: true, id: scanId });
 });
+
+// Public share link management. Enabling exposes the completed scan's
+// canonical report export (and its signed attestation) at
+// /public/reports/:token to anyone holding the link — an explicit, elevated
+// opt-in, so it takes owner/admin, not plain membership.
+scansRoutes.post("/:id/share", async (c) => {
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const { organizationId, role } = await requireActiveOrganizationContext(c, db);
+  if (!roleCanManagePublicShares(role)) return c.json({ error: "forbidden" }, 403);
+
+  const share = await enablePublicShare(db, {
+    scanId: c.req.param("id"),
+    organizationId,
+    actorUserId: session.userId,
+  });
+  if (!share) {
+    const existing = await getScanStatus(db, c.req.param("id"), organizationId);
+    if (!existing) return c.json({ error: "not found" }, 404);
+    return c.json({ error: "only completed scans can be shared publicly" }, 409);
+  }
+  return c.json({ share: publicShareResponse(c, share) });
+});
+
+scansRoutes.delete("/:id/share", async (c) => {
+  const db = createDb(c.env.DB);
+  const session = c.get("authSession");
+  const { organizationId, role } = await requireActiveOrganizationContext(c, db);
+  if (!roleCanManagePublicShares(role)) return c.json({ error: "forbidden" }, 403);
+
+  const revoked = await revokePublicShare(db, {
+    scanId: c.req.param("id"),
+    organizationId,
+    actorUserId: session.userId,
+  });
+  if (!revoked) {
+    const existing = await getScanStatus(db, c.req.param("id"), organizationId);
+    if (!existing) return c.json({ error: "not found" }, 404);
+  }
+  return c.json({ revoked });
+});
+
+function publicShareResponse(
+  c: Context<{ Bindings: Bindings; Variables: Variables }>,
+  share: { publicShareToken: string; publicSharedAt: Date },
+) {
+  // Prefer the canonical origin so copied links don't pin a preview host.
+  const origin = (() => {
+    try {
+      return c.env.BETTER_AUTH_URL ? new URL(c.env.BETTER_AUTH_URL).origin : null;
+    } catch {
+      return null;
+    }
+  })();
+  const base = origin ?? new URL(c.req.url).origin;
+  return {
+    token: share.publicShareToken,
+    url: `${base}/reports/${share.publicShareToken}`,
+    sharedAt: share.publicSharedAt,
+  };
+}
 
 scansRoutes.get("/:id", async (c) => {
   const db = createDb(c.env.DB);

--- a/src/features/review/verdict.ts
+++ b/src/features/review/verdict.ts
@@ -1,0 +1,21 @@
+/**
+ * Text color for a verdict headline, keyed by risk level or recommendation tone.
+ *
+ * Shared by the dashboard's recommendation card and the public report page.
+ * These drifted while they were two copies — one mapped `low`/`info` to
+ * `text-info-text` and the other fell through to `text-ink` — so the same
+ * release rendered a different color depending on which surface you read it on.
+ */
+export function verdictTextClass(risk: string): string {
+  switch (risk) {
+    case "critical":
+    case "high":
+      return "text-danger-text";
+    case "medium":
+      return "text-warn-text";
+    case "ok":
+      return "text-ok-text";
+    default:
+      return "text-ink";
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,7 @@ const AccountPage = lazy(() => import("./pages/Dashboard/Account"));
 const InvitePage = lazy(() => import("./pages/Dashboard/Invite"));
 const GithubAppCallbackPage = lazy(() => import("./pages/Dashboard/GithubAppCallback"));
 const PackageDiffPage = lazy(() => import("./pages/Diff"));
+const PublicReportPage = lazy(() => import("./pages/PublicReport"));
 const NotFoundPage = lazy(() => import("./pages/NotFound"));
 
 export function App() {
@@ -38,6 +39,7 @@ export function App() {
           <Route path="/login" component={LoginPage} />
           <Route path="/register" component={RegisterPage} />
           <Route path="/verify-email" component={VerifyEmailPage} />
+          <Route path="/reports/:token" component={PublicReportPage} />
           <Route path="/dashboard" component={DashboardPage} />
           <Route path="/dashboard/scans/:id" component={ScanDetailPage} />
           <Route path="/dashboard/settings" component={SettingsPage} />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -39,6 +39,15 @@ export function App() {
           <Route path="/login" component={LoginPage} />
           <Route path="/register" component={RegisterPage} />
           <Route path="/verify-email" component={VerifyEmailPage} />
+          {/*
+            Both paths, like /diff above. `:token` is a required segment, so it
+            cannot match the prerender URL `/reports` — without the bare route
+            the shell falls through to `default` and every share link serves a
+            200 whose body says "Page not found" until the bundle hydrates.
+            PublicReportPage renders its loading skeleton for an empty token,
+            which is the correct shell.
+          */}
+          <Route path="/reports" component={PublicReportPage} />
           <Route path="/reports/:token" component={PublicReportPage} />
           <Route path="/dashboard" component={DashboardPage} />
           <Route path="/dashboard/scans/:id" component={ScanDetailPage} />

--- a/src/lib/prerender-routes.ts
+++ b/src/lib/prerender-routes.ts
@@ -5,6 +5,7 @@ const HYDRATED_PRERENDER_ROUTES = [
   "/docs",
   "/privacy",
   "/diff",
+  "/reports",
 ] as const;
 
 const DASHBOARD_SHELL_ROUTES = [
@@ -21,6 +22,10 @@ export const ADDITIONAL_PRERENDER_ROUTES = [
   "/docs",
   "/privacy",
   "/diff",
+  // Shell for /reports/:token. Without it the SPA fallback serves the
+  // prerendered landing page, so a shared report link unfurls with the
+  // marketing card and flashes marketing copy before client routing.
+  "/reports",
   ...DASHBOARD_SHELL_ROUTES,
 ] as const;
 

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -205,17 +205,17 @@ export interface PublicShareInfo {
   sharedAt: string | number | Date;
 }
 
-export function enableScanShare(id: string): Promise<{ share: PublicShareInfo }> {
+function enableScanShare(id: string): Promise<{ share: PublicShareInfo }> {
   return apiJson<{ share: PublicShareInfo }>(`/api/v1/scans/${encodeURIComponent(id)}/share`, {});
 }
 
-export function revokeScanShare(id: string): Promise<{ revoked: boolean }> {
+function revokeScanShare(id: string): Promise<{ revoked: boolean }> {
   return apiFetch<{ revoked: boolean }>(`/api/v1/scans/${encodeURIComponent(id)}/share`, {
     method: "DELETE",
   });
 }
 
-export function publicReportUrl(token: string): string {
+function publicReportUrl(token: string): string {
   return `${location.origin}/reports/${token}`;
 }
 

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -5,7 +5,7 @@ import type {
   FindingDiffStatus,
   PackageJsonSummary,
 } from "../../server/lib/review";
-import { apiFetch, apiJson, errorMessage } from "./api";
+import { ApiError, apiFetch, apiJson, errorMessage } from "./api";
 import {
   decideWorkflowGate,
   getWorkflowGateByScan,
@@ -89,6 +89,8 @@ export interface PersistedScanDetail {
     errorJson?: unknown;
     reportVersion?: number | null;
     reportDigest?: string | null;
+    publicShareToken?: string | null;
+    publicSharedAt?: string | number | Date | null;
     startedAt?: string | number | Date | null;
     completedAt?: string | number | Date | null;
   };
@@ -195,6 +197,30 @@ function getScanCompareFile(
   return apiFetch<ScanCompareFileResponse>(
     `/api/v1/scans/${encodeURIComponent(id)}/compare/file${query}`,
   );
+}
+
+export interface PublicShareInfo {
+  token: string;
+  url: string;
+  sharedAt: string | number | Date;
+}
+
+export function enableScanShare(id: string): Promise<{ share: PublicShareInfo }> {
+  return apiJson<{ share: PublicShareInfo }>(`/api/v1/scans/${encodeURIComponent(id)}/share`, {});
+}
+
+export function revokeScanShare(id: string): Promise<{ revoked: boolean }> {
+  return apiFetch<{ revoked: boolean }>(`/api/v1/scans/${encodeURIComponent(id)}/share`, {
+    method: "DELETE",
+  });
+}
+
+export function publicReportUrl(token: string): string {
+  return `${location.origin}/reports/${token}`;
+}
+
+export function publicReportAttestationUrl(token: string): string {
+  return `${location.origin}/public/reports/${encodeURIComponent(token)}/attestation`;
 }
 
 export type DecisionStatus = "idle" | "saving" | "error";
@@ -389,6 +415,13 @@ export const ScanDetailModel = createModel((id: string) => {
   const decisionError = signal<string | null>(null);
   const deleteStatus = signal<DeleteStatus>("idle");
   const deleteError = signal<string | null>(null);
+  // Public share link state lives in its own signal (not derived from `detail`)
+  // so the share dialog's enable/revoke round-trip re-renders only the dialog
+  // host — mutating `detail` re-renders the whole page, including the
+  // per-finding risk list (see the dialog-host comment in ScanDetail).
+  const share = signal<PublicShareInfo | null>(null);
+  const shareStatus = signal<DecisionStatus>("idle");
+  const shareError = signal<string | null>(null);
   const gate = signal<PublicWorkflowGate | null>(null);
   const gateLoaded = signal(false);
   const gateDecisionStatus = signal<DecisionStatus>("idle");
@@ -521,6 +554,9 @@ export const ScanDetailModel = createModel((id: string) => {
     decisionError,
     deleteStatus,
     deleteError,
+    share,
+    shareStatus,
+    shareError,
     gate,
     gateLoaded,
     gateDecisionStatus,
@@ -537,12 +573,49 @@ export const ScanDetailModel = createModel((id: string) => {
       const id = this.scanId.peek();
       try {
         const data = await getScan(id);
-        this.detail.value = data;
-        if (this.selectedPath.peek() === null) {
-          this.selectedPath.value = pickInitialPath(data);
-        }
+        batch(() => {
+          this.detail.value = data;
+          this.share.value = data.scan.publicShareToken
+            ? {
+                token: data.scan.publicShareToken,
+                url: publicReportUrl(data.scan.publicShareToken),
+                sharedAt: data.scan.publicSharedAt ?? data.scan.updatedAt,
+              }
+            : null;
+          if (this.selectedPath.peek() === null) {
+            this.selectedPath.value = pickInitialPath(data);
+          }
+        });
       } catch (err) {
         this.error.value = errorMessage(err);
+      }
+    },
+
+    async enableShare(): Promise<void> {
+      const id = this.scanId.peek();
+      this.shareStatus.value = "saving";
+      this.shareError.value = null;
+      try {
+        const { share } = await enableScanShare(id);
+        this.share.value = share;
+        this.shareStatus.value = "idle";
+      } catch (err) {
+        this.shareError.value = shareErrorMessage(err);
+        this.shareStatus.value = "error";
+      }
+    },
+
+    async revokeShare(): Promise<void> {
+      const id = this.scanId.peek();
+      this.shareStatus.value = "saving";
+      this.shareError.value = null;
+      try {
+        await revokeScanShare(id);
+        this.share.value = null;
+        this.shareStatus.value = "idle";
+      } catch (err) {
+        this.shareError.value = shareErrorMessage(err);
+        this.shareStatus.value = "error";
       }
     },
 
@@ -709,6 +782,15 @@ export const ScanDetailModel = createModel((id: string) => {
 });
 
 export type ScanDetailModelInstance = InstanceType<typeof ScanDetailModel>;
+
+// The server returns a bare 403 for non-owner/admin members; translate it into
+// the actionable sentence before it reaches the dialog.
+function shareErrorMessage(err: unknown): string {
+  if (err instanceof ApiError && err.status === 403) {
+    return "Only organization owners and admins can manage public links.";
+  }
+  return errorMessage(err);
+}
 
 function pickInitialPath(data: PersistedScanDetail): string | null {
   return (

--- a/src/pages/Dashboard/ScanDetail/ReleaseRecommendation.tsx
+++ b/src/pages/Dashboard/ScanDetail/ReleaseRecommendation.tsx
@@ -8,6 +8,7 @@ import { Badge } from "../../../components/Badge";
 import { Card } from "../../../components/Card";
 import { SeverityBar } from "../../../components/SeverityBar";
 import { SectionLabel } from "../../../components/Typography";
+import { verdictTextClass } from "../../../features/review/verdict";
 import type { FindingWithDiffStatus, ReviewFinding } from "../../../features/review/types";
 import type { PersistedSummary } from "./types";
 
@@ -75,7 +76,7 @@ export function ReleaseRecommendation({
         <SectionLabel as="h2">Recommendation</SectionLabel>
         <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
           <h3
-            class={`m-0 text-lg font-semibold tracking-[-0.01em] ${verdictColor(recommendation.tone)}`}
+            class={`m-0 text-lg font-semibold tracking-[-0.01em] ${verdictTextClass(recommendation.tone)}`}
           >
             {capitalize(recommendation.label)}
           </h3>
@@ -126,12 +127,6 @@ function capitalize(value: string): string {
 
 // The verdict heading carries severity meaning, so it uses the `-text` severity
 // variants (text role), never the saturated tokens. Neutral verdicts stay --ink.
-function verdictColor(tone: string): string {
-  if (tone === "critical" || tone === "high") return "text-danger-text";
-  if (tone === "medium") return "text-warn-text";
-  if (tone === "ok") return "text-ok-text";
-  return "text-ink";
-}
 
 function buildRecommendationEvidence(
   detail: PersistedScanDetail,

--- a/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
+++ b/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
@@ -11,10 +11,12 @@ export function ScanDetailHeader({
   detail,
   onDecideClick,
   onDeleteClick,
+  onShareClick,
 }: {
   detail?: PersistedScanDetail | null;
   onDecideClick?: () => void;
   onDeleteClick?: () => void;
+  onShareClick?: () => void;
 } = {}) {
   const decision = detail?.scan.decision;
   const decidedAt = detail?.scan.decidedAt;
@@ -60,6 +62,11 @@ export function ScanDetailHeader({
                 </span>
               ) : null}
             </div>
+          ) : null}
+          {detail && isComplete && onShareClick ? (
+            <Button variant="ghost" size="sm" onClick={onShareClick}>
+              Share
+            </Button>
           ) : null}
           {detail && isComplete ? (
             <LinkButton

--- a/src/pages/Dashboard/ScanDetail/ShareDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/ShareDialog.tsx
@@ -47,7 +47,7 @@ export function ShareDialog({
       open={open}
       onClose={onClose}
       title="Share report"
-      description="A public link serves this review's canonical report — findings, risk, and manifest changes — to anyone who has it. File contents are never included."
+      description="A public link serves this review's canonical report — findings, risk, and manifest changes — to anyone who has it. Individual file contents are never included; findings still quote the redacted lines they matched."
       footer={
         share ? (
           <>

--- a/src/pages/Dashboard/ScanDetail/ShareDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/ShareDialog.tsx
@@ -1,0 +1,107 @@
+import { useComputed, useSignal } from "@preact/signals";
+import { formatDateTime } from "../../../lib/format";
+import type { DecisionStatus, PublicShareInfo } from "../../../models/scan";
+import { publicReportAttestationUrl } from "../../../models/scan";
+import { Alert } from "../../../components/Alert";
+import { Button } from "../../../components/Button";
+import { Dialog } from "../../../components/Dialog";
+import { Input } from "../../../components/Input";
+import { EmptyLine, MonoDetail } from "../../../components/Typography";
+
+export function ShareDialog({
+  open,
+  onClose,
+  share,
+  status,
+  error,
+  onEnable,
+  onRevoke,
+}: {
+  open: boolean;
+  onClose: () => void;
+  share: PublicShareInfo | null;
+  status: DecisionStatus;
+  error: string | null;
+  onEnable: () => void;
+  onRevoke: () => void;
+}) {
+  const copied = useSignal(false);
+  // Rendered directly as a signal child so the copy feedback re-renders only
+  // the text node, not the dialog (signals-local/no-signal-conditional-jsx).
+  const copyLabel = useComputed(() => (copied.value ? "Copied ✓" : "Copy"));
+  const saving = status === "saving";
+
+  const copyLink = async () => {
+    if (!share) return;
+    try {
+      await navigator.clipboard.writeText(share.url);
+      copied.value = true;
+      setTimeout(() => (copied.value = false), 2000);
+    } catch {
+      // Clipboard access denied — the URL stays selectable in the input.
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Share report"
+      description="A public link serves this review's canonical report — findings, risk, and manifest changes — to anyone who has it. File contents are never included."
+      footer={
+        share ? (
+          <>
+            <Button variant="danger" size="sm" onClick={onRevoke} disabled={saving}>
+              {saving ? "Revoking…" : "Revoke link"}
+            </Button>
+            <Button variant="secondary" size="sm" onClick={onClose}>
+              Close
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button variant="secondary" size="sm" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button size="sm" onClick={onEnable} disabled={saving}>
+              {saving ? "Creating…" : "Create public link"}
+            </Button>
+          </>
+        )
+      }
+    >
+      {error ? <Alert tone="critical">{error}</Alert> : null}
+      {share ? (
+        <>
+          <div class="flex items-center gap-2">
+            <Input value={share.url} readOnly class="flex-1 font-mono text-[12px]" />
+            <Button variant="secondary" size="sm" onClick={copyLink}>
+              {copyLabel}
+            </Button>
+          </div>
+          <MonoDetail
+            parts={[
+              <span key="shared">shared {formatDateTime(share.sharedAt)}</span>,
+              <a
+                key="attestation"
+                href={publicReportAttestationUrl(share.token)}
+                class="text-ink-muted hover:text-ink"
+                download
+              >
+                signed attestation
+              </a>,
+            ]}
+          />
+          <EmptyLine>
+            Anyone with the link can read the report; revoking invalidates it immediately.
+          </EmptyLine>
+        </>
+      ) : (
+        <EmptyLine>
+          This review is currently visible to organization members only. Requires an owner or admin
+          role.
+        </EmptyLine>
+      )}
+    </Dialog>
+  );
+}

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -16,6 +16,7 @@ import {
   ScanDetailModel,
   type DecisionStatus,
   type DeleteStatus,
+  type PublicShareInfo,
   type ScanDecision,
 } from "../../../models/scan";
 import type { WorkflowGateDecision } from "../../../models/github-app";
@@ -43,6 +44,7 @@ import { ReleaseRecommendation } from "./ReleaseRecommendation";
 import { PersistedReportSections } from "./ReportSections";
 import { ReviewerSummary } from "./ReviewerSummary";
 import { ScanDetailHeader, ScanFailureAlert, VersionPickerSkeleton } from "./ScanDetailChrome";
+import { ShareDialog } from "./ShareDialog";
 import { filterDiffEntries, findingCountsByPath } from "../../../features/review/diff-entries";
 import { scanFilesToFileRecords } from "./diff-helpers";
 import { useFindingsWithDiff } from "./hooks/useFindingsWithDiff";
@@ -61,6 +63,7 @@ export default function ScanDetailPage() {
   const decisionDialogOpen = useSignal(false);
   const gateDialogOpen = useSignal(false);
   const deleteDialogOpen = useSignal(false);
+  const shareDialogOpen = useSignal(false);
   const npmStagedPackagesUrlSignal = useComputed(() => {
     const scan = model.detail.value?.scan;
     return scan ? npmStagedPackagesUrlFor(scan) : null;
@@ -262,6 +265,9 @@ export default function ScanDetailPage() {
       ? () => (decisionDialogOpen.value = true)
       : undefined;
 
+  const onShareClick =
+    detail?.scan.status === "complete" ? () => (shareDialogOpen.value = true) : undefined;
+
   return (
     <PageShell>
       <ScanDetailHeader
@@ -270,6 +276,7 @@ export default function ScanDetailPage() {
         onDeleteClick={
           detail?.scan.status === "failed" ? () => (deleteDialogOpen.value = true) : undefined
         }
+        onShareClick={onShareClick}
       />
 
       {error ? <Alert tone="critical">{error}</Alert> : null}
@@ -438,6 +445,18 @@ export default function ScanDetailPage() {
         />
       ) : null}
 
+      {detail && detail.scan.status === "complete" ? (
+        <ShareDialogHost
+          openSignal={shareDialogOpen}
+          onClose={() => (shareDialogOpen.value = false)}
+          shareSignal={model.share}
+          statusSignal={model.shareStatus}
+          errorSignal={model.shareError}
+          onEnable={() => void model.enableShare()}
+          onRevoke={() => void model.revokeShare()}
+        />
+      ) : null}
+
       {detail && isWorkflowGate && gate ? (
         <GateDialogHost
           openSignal={gateDialogOpen}
@@ -525,6 +544,29 @@ function DeleteDialogHost({
       open={openSignal.value}
       status={statusSignal.value}
       error={errorSignal.value}
+    />
+  );
+}
+
+function ShareDialogHost({
+  openSignal,
+  shareSignal,
+  statusSignal,
+  errorSignal,
+  ...props
+}: Omit<ComponentProps<typeof ShareDialog>, "open" | "share" | "status" | "error"> & {
+  openSignal: ReadonlySignal<boolean>;
+  shareSignal: ReadonlySignal<PublicShareInfo | null>;
+  statusSignal: ReadonlySignal<DecisionStatus>;
+  errorSignal: ReadonlySignal<string | null>;
+}) {
+  return (
+    <ShareDialog
+      open={openSignal.value}
+      share={shareSignal.value}
+      status={statusSignal.value}
+      error={errorSignal.value}
+      {...props}
     />
   );
 }

--- a/src/pages/PublicReport/index.tsx
+++ b/src/pages/PublicReport/index.tsx
@@ -11,9 +11,12 @@ import { LoadingState } from "../../components/Loading";
 import { PageShell } from "../../components/PageShell";
 import { LinkButton } from "../../components/Button";
 import { EmptyLine, MonoDetail, SectionLabel } from "../../components/Typography";
+import { verdictTextClass } from "../../features/review/verdict";
+import { MarketingHeaderActions } from "../MarketingHeaderActions";
+import { useAuthedSession } from "../useAuthedSession";
 
 // The canonical report export served at /public/reports/:token — the same
-// document `serializeReportExport` produces (schema drydock.report.v1).
+// document `serializeReportExport` produces (schema drydock.report.v2).
 interface PublicReport {
   schema: string;
   scan: {
@@ -55,6 +58,7 @@ const MAX_LISTED_CHANGES = 200;
 export default function PublicReportPage() {
   const route = useRoute();
   const token = route.params.token ?? "";
+  const authed = useAuthedSession();
   const report = useSignal<PublicReport | null>(null);
   const errorState = useSignal<"none" | "not_found" | "failed">("none");
 
@@ -102,7 +106,7 @@ export default function PublicReportPage() {
 
   if (errorState.value === "not_found") {
     return (
-      <PageShell width="doc">
+      <PageShell width="doc" headerActions={<MarketingHeaderActions authed={authed} />}>
         <Alert tone="critical">
           This report link is invalid or has been revoked by the publisher.
         </Alert>
@@ -111,7 +115,7 @@ export default function PublicReportPage() {
   }
   if (errorState.value === "failed") {
     return (
-      <PageShell width="doc">
+      <PageShell width="doc" headerActions={<MarketingHeaderActions authed={authed} />}>
         <Alert tone="critical">The report could not be loaded. Try again in a minute.</Alert>
       </PageShell>
     );
@@ -120,7 +124,7 @@ export default function PublicReportPage() {
   const data = report.value;
   if (!data) {
     return (
-      <PageShell width="doc">
+      <PageShell width="doc" headerActions={<MarketingHeaderActions authed={authed} />}>
         <LoadingState title="Loading public review" detail="fetching report" />
       </PageShell>
     );
@@ -133,7 +137,7 @@ export default function PublicReportPage() {
   const changes = changedFiles.value;
 
   return (
-    <PageShell width="doc">
+    <PageShell width="doc" headerActions={<MarketingHeaderActions authed={authed} />}>
       <header class="flex flex-wrap items-start justify-between gap-4">
         <div class="flex flex-col gap-2 min-w-0">
           <p class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle m-0">
@@ -263,21 +267,4 @@ export default function PublicReportPage() {
       </section>
     </PageShell>
   );
-}
-
-function verdictTextClass(risk: string): string {
-  switch (risk) {
-    case "critical":
-    case "high":
-      return "text-danger-text";
-    case "medium":
-      return "text-warn-text";
-    case "low":
-    case "info":
-      return "text-info-text";
-    case "ok":
-      return "text-ok-text";
-    default:
-      return "text-ink";
-  }
 }

--- a/src/pages/PublicReport/index.tsx
+++ b/src/pages/PublicReport/index.tsx
@@ -1,0 +1,283 @@
+import { useEffect } from "preact/hooks";
+import { useComputed, useSignal } from "@preact/signals";
+import { useRoute } from "preact-iso";
+import { formatDateTime } from "../../lib/format";
+import { sortFindingsBySeverity } from "../../lib/findings";
+import { Alert } from "../../components/Alert";
+import { Badge, severityTone, statusTone } from "../../components/Badge";
+import { Card } from "../../components/Card";
+import { FindingCard } from "../../components/FindingCard";
+import { LoadingState } from "../../components/Loading";
+import { PageShell } from "../../components/PageShell";
+import { LinkButton } from "../../components/Button";
+import { EmptyLine, MonoDetail, SectionLabel } from "../../components/Typography";
+
+// The canonical report export served at /public/reports/:token — the same
+// document `serializeReportExport` produces (schema drydock.report.v1).
+interface PublicReport {
+  schema: string;
+  scan: {
+    id: string;
+    status: string;
+    source: string;
+    risk: string;
+    decision: string | null;
+    createdAt: string | null;
+    completedAt: string | null;
+  };
+  package: {
+    name: string | null;
+    stagedVersion: string | null;
+    previousVersion: string | null;
+  };
+  riskSummary: {
+    releaseRisk: string;
+    contextRisk: string;
+    releaseFindingCount: number;
+    contextFindingCount: number;
+  } | null;
+  diff: Array<{ path: string; status: string }> | null;
+  findings: Array<{
+    severity: string;
+    file: string;
+    line: number | null;
+    ruleId: string | null;
+    diffStatus: string | null;
+    releaseDelta: boolean | null;
+    evidence: string;
+    reason: string;
+  }>;
+}
+
+const CHANGED_STATUSES = new Set(["added", "removed", "modified"]);
+const MAX_LISTED_CHANGES = 200;
+
+export default function PublicReportPage() {
+  const route = useRoute();
+  const token = route.params.token ?? "";
+  const report = useSignal<PublicReport | null>(null);
+  const errorState = useSignal<"none" | "not_found" | "failed">("none");
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch(`/public/reports/${encodeURIComponent(token)}`, {
+          headers: { accept: "application/json" },
+        });
+        if (cancelled) return;
+        if (res.status === 404) {
+          errorState.value = "not_found";
+          return;
+        }
+        if (!res.ok) {
+          errorState.value = "failed";
+          return;
+        }
+        report.value = (await res.json()) as PublicReport;
+      } catch {
+        if (!cancelled) errorState.value = "failed";
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  useEffect(() => {
+    const data = report.value;
+    if (data?.package.name) {
+      document.title = `${data.package.name} ${data.package.stagedVersion ?? ""} · Drydock review`;
+    }
+    // report is a signal; this effect re-runs via the render below, which is
+    // enough for a one-shot title update after load.
+  }, [report.value]);
+
+  const sortedFindings = useComputed(() =>
+    report.value ? sortFindingsBySeverity(report.value.findings) : [],
+  );
+  const changedFiles = useComputed(
+    () => report.value?.diff?.filter((entry) => CHANGED_STATUSES.has(entry.status)) ?? [],
+  );
+
+  if (errorState.value === "not_found") {
+    return (
+      <PageShell width="doc">
+        <Alert tone="critical">
+          This report link is invalid or has been revoked by the publisher.
+        </Alert>
+      </PageShell>
+    );
+  }
+  if (errorState.value === "failed") {
+    return (
+      <PageShell width="doc">
+        <Alert tone="critical">The report could not be loaded. Try again in a minute.</Alert>
+      </PageShell>
+    );
+  }
+
+  const data = report.value;
+  if (!data) {
+    return (
+      <PageShell width="doc">
+        <LoadingState title="Loading public review" detail="fetching report" />
+      </PageShell>
+    );
+  }
+
+  const releaseRisk = data.riskSummary?.releaseRisk ?? data.scan.risk;
+  const decision = data.scan.decision;
+  const attestationHref = `/public/reports/${encodeURIComponent(token)}/attestation`;
+  const findings = sortedFindings.value;
+  const changes = changedFiles.value;
+
+  return (
+    <PageShell width="doc">
+      <header class="flex flex-wrap items-start justify-between gap-4">
+        <div class="flex flex-col gap-2 min-w-0">
+          <p class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle m-0">
+            Public release review
+          </p>
+          <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">
+            {data.package.name || "Release review"}
+          </h1>
+          <MonoDetail
+            parts={[
+              <span key="version">
+                {data.package.previousVersion || "—"} → {data.package.stagedVersion || "—"}
+              </span>,
+              data.scan.completedAt ? (
+                <span key="completed">reviewed {formatDateTime(data.scan.completedAt)}</span>
+              ) : null,
+              <span key="findings">
+                {data.findings.length} finding{data.findings.length === 1 ? "" : "s"}
+              </span>,
+            ]}
+          />
+        </div>
+        <div class="flex flex-col items-end gap-1">
+          <Badge tone={severityTone(releaseRisk)}>release {releaseRisk}</Badge>
+          {decision ? (
+            <Badge tone={decision === "publish" ? "ok" : "critical"}>
+              {decision === "publish" ? "approved" : "blocked"}
+            </Badge>
+          ) : null}
+        </div>
+      </header>
+
+      <Card class="flex flex-col gap-3">
+        <SectionLabel as="h2">Verdict</SectionLabel>
+        <p
+          class={`m-0 text-[18px] font-semibold tracking-[-0.01em] ${verdictTextClass(releaseRisk)}`}
+        >
+          Release risk: {releaseRisk}
+        </p>
+        <EmptyLine>
+          Deterministic review of the staged release against its previous version
+          {data.riskSummary
+            ? ` — ${data.riskSummary.releaseFindingCount} release finding${
+                data.riskSummary.releaseFindingCount === 1 ? "" : "s"
+              }, ${data.riskSummary.contextFindingCount} pre-existing.`
+            : "."}
+        </EmptyLine>
+      </Card>
+
+      {findings.length ? (
+        <section class="flex flex-col gap-3">
+          <SectionLabel as="h2">Risk signals</SectionLabel>
+          <ul class="list-none p-0 m-0 flex flex-col gap-3">
+            {findings.map((finding, index) => (
+              <FindingCard
+                key={`${finding.file}:${finding.ruleId ?? index}:${finding.line ?? ""}`}
+                severity={finding.severity}
+                file={finding.file}
+                line={finding.line}
+                ruleId={finding.ruleId}
+                diffStatus={finding.diffStatus}
+              >
+                <p class="m-0">{finding.reason}</p>
+                {finding.evidence ? (
+                  <code class="font-mono text-[12px] text-ink-muted break-all">
+                    {finding.evidence}
+                  </code>
+                ) : null}
+              </FindingCard>
+            ))}
+          </ul>
+        </section>
+      ) : (
+        <section class="flex flex-col gap-3">
+          <SectionLabel as="h2">Risk signals</SectionLabel>
+          <EmptyLine>No deterministic findings in this release.</EmptyLine>
+        </section>
+      )}
+
+      {changes.length ? (
+        <section class="flex flex-col gap-3">
+          <SectionLabel as="h2">Release changes</SectionLabel>
+          <ul class="list-none p-0 m-0 flex flex-col gap-1.5">
+            {changes.slice(0, MAX_LISTED_CHANGES).map((entry) => (
+              <li key={entry.path} class="flex items-center gap-2 min-w-0">
+                <Badge tone={statusTone(entry.status)} class="flex-shrink-0">
+                  {entry.status}
+                </Badge>
+                <code class="font-mono text-[13px] text-ink-muted truncate" title={entry.path}>
+                  {entry.path}
+                </code>
+              </li>
+            ))}
+          </ul>
+          {changes.length > MAX_LISTED_CHANGES ? (
+            <EmptyLine>
+              And {changes.length - MAX_LISTED_CHANGES} more changed files in the full report.
+            </EmptyLine>
+          ) : null}
+        </section>
+      ) : null}
+
+      <section class="flex flex-col gap-3">
+        <SectionLabel as="h2">Verify this report</SectionLabel>
+        <EmptyLine>
+          The signed attestation covers the exact JSON served for this link: its subject digest is
+          the SHA-256 of the report bytes, signed with Drydock's Ed25519 key (DSSE envelope, key
+          published at{" "}
+          <a href="/public/attestation-key" class="text-ink-muted underline hover:text-ink">
+            /public/attestation-key
+          </a>
+          ).
+        </EmptyLine>
+        <div class="flex flex-wrap gap-2">
+          <LinkButton variant="secondary" size="sm" href={attestationHref} download>
+            Download attestation
+          </LinkButton>
+          <LinkButton
+            variant="ghost"
+            size="sm"
+            href={`/public/reports/${encodeURIComponent(token)}`}
+            download
+          >
+            Download report JSON
+          </LinkButton>
+        </div>
+      </section>
+    </PageShell>
+  );
+}
+
+function verdictTextClass(risk: string): string {
+  switch (risk) {
+    case "critical":
+    case "high":
+      return "text-danger-text";
+    case "medium":
+      return "text-warn-text";
+    case "low":
+    case "info":
+      return "text-info-text";
+    case "ok":
+      return "text-ok-text";
+    default:
+      return "text-ink";
+  }
+}

--- a/test/config/wrangler.jsonc
+++ b/test/config/wrangler.jsonc
@@ -9,6 +9,8 @@
     "AI_CACHE_AFFINITY": "staged-publish-review-test",
     "NPM_REGISTRY": "https://registry.npmjs.org",
     "NPM_CONNECTIONS_ENCRYPTION_KEY": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    // Test-only Ed25519 key. Never reuse outside the test suite.
+    "ATTESTATION_SIGNING_KEY_JWK": "{\"key_ops\":[\"sign\"],\"ext\":true,\"crv\":\"Ed25519\",\"d\":\"J6YiVpORRbCs56rOCRX0uRp9GOeFdi5YQYkIFs54wsw\",\"x\":\"9nXUGhrSwQW5BU6JO0E7hWIDmsBCMnDcKgt72BnDLIQ\",\"kty\":\"OKP\"}",
     "SLACK_CLIENT_ID": "test-slack-client-id",
     "SLACK_CLIENT_SECRET": "test-slack-client-secret",
   },

--- a/test/config/wrangler.jsonc
+++ b/test/config/wrangler.jsonc
@@ -9,8 +9,10 @@
     "AI_CACHE_AFFINITY": "staged-publish-review-test",
     "NPM_REGISTRY": "https://registry.npmjs.org",
     "NPM_CONNECTIONS_ENCRYPTION_KEY": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
-    // Test-only Ed25519 key. Never reuse outside the test suite.
-    "ATTESTATION_SIGNING_KEY_JWK": "{\"key_ops\":[\"sign\"],\"ext\":true,\"crv\":\"Ed25519\",\"d\":\"J6YiVpORRbCs56rOCRX0uRp9GOeFdi5YQYkIFs54wsw\",\"x\":\"9nXUGhrSwQW5BU6JO0E7hWIDmsBCMnDcKgt72BnDLIQ\",\"kty\":\"OKP\"}",
+    // ATTESTATION_SIGNING_KEY_JWK is deliberately absent: a committed private
+    // JWK is a permanent secret-scanning false positive, and the unset case is
+    // the one production degrades through. Tests that need a signer generate a
+    // throwaway Ed25519 key and inject it per request.
     "SLACK_CLIENT_ID": "test-slack-client-id",
     "SLACK_CLIENT_SECRET": "test-slack-client-secret",
   },

--- a/test/workers/account-deletion.test.ts
+++ b/test/workers/account-deletion.test.ts
@@ -198,6 +198,55 @@ describe("account deletion", () => {
     ).toBe(1);
   });
 
+  test("nulls the share attribution of a scan the leaving member shared", async () => {
+    // Regression: `public_shared_by_user_id` is a user FK on `scans` with
+    // ON DELETE SET NULL, and D1 enforces it. Account deletion nulls every
+    // other user-referencing column before Better Auth deletes the row; when
+    // this one was missed, any admin who had shared a report in an org they did
+    // not own could never delete their account — the FK check failed and the
+    // request 500'd.
+    const owner = await newAccount();
+    const created = await call("POST", "/api/v1/organizations", {
+      body: { name: "Publisher Org" },
+      jar: owner.jar,
+    });
+    expect(created.res.status).toBe(201);
+    const orgId = (created.json?.organization as { id?: string } | undefined)?.id ?? "";
+    expect(orgId).toBeTruthy();
+
+    // An admin in someone else's org: deleting their account never deletes the
+    // org, so the scan row survives holding their id.
+    const admin = await newAccount();
+    const now = Date.now();
+    await env.DB.prepare(
+      "INSERT INTO organization_members (id, organization_id, user_id, role, created_at, updated_at) VALUES (?, ?, ?, 'admin', ?, ?)",
+    )
+      .bind(`member:${orgId}:${admin.userId}`, orgId, admin.userId, now, now)
+      .run();
+    const scanId = `scan-${crypto.randomUUID()}`;
+    await env.DB.prepare(
+      "INSERT INTO scans (id, stage_id, organization_id, risk, status, source, public_share_token, public_shared_at, public_shared_by_user_id, created_at, updated_at) VALUES (?, ?, ?, 'low', 'completed', 'manual', ?, ?, ?, ?, ?)",
+    )
+      .bind(scanId, "stage-share", orgId, `tok-${crypto.randomUUID()}`, now, admin.userId, now, now)
+      .run();
+
+    const del = await call("POST", "/api/auth/delete-user", {
+      body: { password: PASSWORD },
+      jar: admin.jar,
+    });
+    expect(del.res.status).toBe(200);
+    expect(await countRows("SELECT count(*) AS n FROM user WHERE id = ?", admin.userId)).toBe(0);
+
+    // The share itself survives — revoking is the publisher's call, not a side
+    // effect of an unrelated account closing — but the attribution is nulled.
+    expect(
+      await countRows(
+        "SELECT count(*) AS n FROM scans WHERE id = ? AND public_share_token IS NOT NULL AND public_shared_by_user_id IS NULL",
+        scanId,
+      ),
+    ).toBe(1);
+  });
+
   test("rejects deletion when the password is wrong", async () => {
     const { jar, userId } = await newAccount();
 

--- a/test/workers/public-reports.test.ts
+++ b/test/workers/public-reports.test.ts
@@ -110,7 +110,14 @@ async function request(
   return res;
 }
 
-async function seedCompletedScan(owner: SeededUser): Promise<string> {
+// `withAiReview` seeds a completed AI review alongside the rule finding. The
+// export routes AI findings through `aiReview.findings` and keeps them out of
+// `findings[]`, so this is the shape where a naive finding count disagrees with
+// the document it describes.
+async function seedCompletedScan(
+  owner: SeededUser,
+  options: { withAiReview?: boolean } = {},
+): Promise<string> {
   const db = createDb(env.DB);
   const scanId = `scan_${crypto.randomUUID()}`;
   const stageId = `stage-${scanId.slice(-12)}`;
@@ -139,7 +146,7 @@ async function seedCompletedScan(owner: SeededUser): Promise<string> {
       baseline: { kind: "registry", version: "1.0.0" },
       diff: [{ path: "package.json", status: "modified" }],
     },
-    ai: null,
+    ai: options.withAiReview ? AI_REVIEW : null,
     files: [{ path: "package.json", size: 10, sha256: "a", flags: [], textSample: "{}" }],
     diff: [{ path: "package.json", status: "modified", flags: [] }],
     findings: [
@@ -152,10 +159,36 @@ async function seedCompletedScan(owner: SeededUser): Promise<string> {
         ruleVersion: "1.8.0",
       },
     ],
+    aiFindingRecords: options.withAiReview ? AI_REVIEW.findings : undefined,
     report: { version: 1, digest: "abc123" },
   });
   return scanId;
 }
+
+const AI_REVIEW = {
+  status: "complete" as const,
+  risk: "high" as const,
+  releaseAssessment: "suspicious" as const,
+  summary: "The postinstall hook fetches and runs a remote script.",
+  requiresManualReview: true,
+  model: "test-model",
+  findings: [
+    {
+      severity: "high" as const,
+      file: "install.js",
+      evidence: "https.get(process.env.DRYDOCK_TEST_URL)",
+      reason: "downloads and executes remote code at install time",
+      recommendation: "remove the network fetch from the install hook",
+    },
+    {
+      severity: "medium" as const,
+      file: "install.js",
+      evidence: "process.env.NPM_TOKEN",
+      reason: "reads a publish credential during install",
+      recommendation: "drop the credential read",
+    },
+  ],
+};
 
 async function enableShare(app: ReturnType<typeof buildTestApp>, scanId: string) {
   const res = await request(app, `/api/v1/scans/${scanId}/share`, { method: "POST", body: "{}" });
@@ -564,6 +597,36 @@ describe("public report attestations", () => {
       pae,
     );
     expect(valid).toBe(true);
+  });
+
+  test("predicate findingCount matches the attested document, AI review included", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner, { withAiReview: true });
+    const app = buildTestApp(owner);
+    const { share } = (await (await enableShare(app, scanId)).json()) as {
+      share: { token: string };
+    };
+    const signer = await signingEnv();
+
+    const report = (await (await request(app, `/public/reports/${share.token}`)).json()) as {
+      findings: unknown[];
+      aiReview: { findings: unknown[] } | null;
+    };
+    // The fixture is the interesting case only if the two lists actually
+    // differ — otherwise this test would pass against the bug it guards.
+    expect(report.aiReview?.findings).toHaveLength(2);
+    expect(report.findings).toHaveLength(1);
+
+    const attRes = await request(app, `/public/reports/${share.token}/attestation`, {}, signer);
+    const envelope = (await attRes.json()) as { payload: string };
+    const statement = JSON.parse(
+      new TextDecoder().decode(strictBase64Decode(envelope.payload)),
+    ) as { predicate: { findingCount: number } };
+    // Counting the scan's finding *rows* would say 3 here: the export carries
+    // AI findings under `aiReview`, never in `findings[]`, and a verifier
+    // cross-checking the signed predicate against the signed document must not
+    // see two different numbers.
+    expect(statement.predicate.findingCount).toBe(report.findings.length);
   });
 
   test("attestation endpoints return 503 when no signing key is configured", async () => {

--- a/test/workers/public-reports.test.ts
+++ b/test/workers/public-reports.test.ts
@@ -152,7 +152,7 @@ describe("public report sharing", () => {
     expect(pub.status).toBe(200);
     const text = await pub.text();
     const body = JSON.parse(text) as Record<string, unknown>;
-    expect(body.schema).toBe("drydock.report.v1");
+    expect(body.schema).toBe("drydock.report.v2");
     expect((body.package as { name: string }).name).toBe("@org/pkg");
     // The export is the sharing boundary: no org/user identifiers, no events,
     // no file samples anywhere in the payload.
@@ -395,7 +395,7 @@ describe("public report attestations", () => {
     expect(statement._type).toBe("https://in-toto.io/Statement/v1");
     expect(statement.subject[0].name).toBe("@org/pkg@1.1.0");
     expect(statement.predicate.scanId).toBe(scanId);
-    expect(statement.predicate.reportSchema).toBe("drydock.report.v1");
+    expect(statement.predicate.reportSchema).toBe("drydock.report.v2");
     const digest = new Uint8Array(
       await crypto.subtle.digest("SHA-256", reportBytes as Uint8Array<ArrayBuffer>),
     );

--- a/test/workers/public-reports.test.ts
+++ b/test/workers/public-reports.test.ts
@@ -1,5 +1,6 @@
 import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
 import { Hono } from "hono";
+import { eq } from "drizzle-orm";
 import { describe, expect, test } from "vitest";
 import { listOrganizationAuditEvents } from "../../server/db/audit-log";
 import { createDb } from "../../server/db/client";
@@ -7,7 +8,6 @@ import { createOrganization, ensurePersonalOrganization } from "../../server/db/
 import { createScanJob, persistScan } from "../../server/db/scans";
 import * as schema from "../../server/db/schema";
 import { describeAuditEvent } from "../../server/lib/auth/audit-events";
-import { base64UrlDecode } from "../../server/lib/platform/crypto-utils";
 import { publicReportsRoutes } from "../../server/routes/public-reports";
 import { scansRoutes } from "../../server/routes/scans";
 import type { Bindings, Variables } from "../../server/types";
@@ -15,6 +15,34 @@ import type { Bindings, Variables } from "../../server/types";
 interface SeededUser {
   userId: string;
   organizationId: string;
+}
+
+// The signing key is generated per run rather than committed to
+// wrangler.test.jsonc: a real private JWK in the repo is a permanent
+// secret-scanning false positive. The default test env therefore has *no* key,
+// which also makes the degraded path the one you get for free.
+let signingEnvPromise: Promise<typeof env> | null = null;
+function signingEnv(): Promise<typeof env> {
+  signingEnvPromise ??= (async () => {
+    const pair = (await crypto.subtle.generateKey({ name: "Ed25519" }, true, [
+      "sign",
+      "verify",
+    ])) as CryptoKeyPair;
+    const jwk = await crypto.subtle.exportKey("jwk", pair.privateKey);
+    return { ...env, ATTESTATION_SIGNING_KEY_JWK: JSON.stringify(jwk) } as typeof env;
+  })();
+  return signingEnvPromise;
+}
+
+// Strict standard-base64 decode: rejects the base64url alphabet outright, so a
+// regression away from what sigstore/in-toto verifiers expect fails here rather
+// than sliding through on a payload that happens to contain no `-` or `_`.
+function strictBase64Decode(value: string): Uint8Array {
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(value) || value.length % 4 !== 0) {
+    throw new Error(`not standard base64: ${value.slice(0, 32)}…`);
+  }
+  const binary = atob(value);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
 }
 
 async function seedUser(): Promise<SeededUser> {
@@ -306,20 +334,128 @@ describe("public report sharing", () => {
       share: { token: string };
     };
 
+    const signer = await signingEnv();
+
     // no-store keeps the "revocation is immediate" promise honest: no shared
     // cache may serve the report past the revoke.
     const report = await request(app, `/public/reports/${share.token}`);
     expect(report.headers.get("cache-control")).toBe("no-store");
     expect(report.headers.get("access-control-allow-origin")).toBe("*");
 
-    const attestation = await request(app, `/public/reports/${share.token}/attestation`);
+    const attestation = await request(
+      app,
+      `/public/reports/${share.token}/attestation`,
+      {},
+      signer,
+    );
     expect(attestation.headers.get("cache-control")).toBe("no-store");
     expect(attestation.headers.get("access-control-allow-origin")).toBe("*");
 
     // The key rotates rarely and is safe to cache.
-    const key = await request(app, `/public/attestation-key`);
+    const key = await request(app, `/public/attestation-key`, {}, signer);
     expect(key.headers.get("cache-control")).toBe("public, max-age=3600");
     expect(key.headers.get("access-control-allow-origin")).toBe("*");
+  });
+
+  test("failure responses are readable cross-origin", async () => {
+    const app = buildTestApp(null);
+
+    // A browser verifier following docs/public-reports.md has to be able to
+    // tell "revoked" from "the service is down"; without CORS on the 404 both
+    // are the same opaque network error.
+    const notFound = await request(app, `/public/reports/${"C".repeat(43)}`);
+    expect(notFound.status).toBe(404);
+    expect(notFound.headers.get("access-control-allow-origin")).toBe("*");
+
+    // No signing key configured in the default test env.
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const ownerApp = buildTestApp(owner);
+    const { share } = (await (await enableShare(ownerApp, scanId)).json()) as {
+      share: { token: string };
+    };
+    const degraded = await request(app, `/public/reports/${share.token}/attestation`);
+    expect(degraded.status).toBe(503);
+    expect(degraded.headers.get("access-control-allow-origin")).toBe("*");
+
+    // retry-after has to be reachable from script, or a throttled verifier
+    // cannot back off and just hot-loops.
+    const ip = `10.1.0.${Math.floor(Math.random() * 200) + 1}`;
+    const headers = { "cf-connecting-ip": ip };
+    let throttled: Response | null = null;
+    for (let i = 0; i < 125; i += 1) {
+      const res = await request(app, `/public/reports/${"D".repeat(43)}`, { headers });
+      if (res.status === 429) {
+        throttled = res;
+        break;
+      }
+    }
+    expect(throttled).not.toBeNull();
+    expect(throttled?.headers.get("access-control-allow-origin")).toBe("*");
+    expect(throttled?.headers.get("access-control-expose-headers")).toContain("retry-after");
+    expect(throttled?.headers.get("retry-after")).toBeTruthy();
+  });
+
+  test("concurrent enables settle on a single token", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const app = buildTestApp(owner);
+
+    // The guarded UPDATE's whole point: the loser re-reads and returns the
+    // winner's token instead of silently rotating a link already in flight.
+    const [first, second] = await Promise.all([enableShare(app, scanId), enableShare(app, scanId)]);
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    const a = (await first.json()) as { share: { token: string } };
+    const b = (await second.json()) as { share: { token: string } };
+    expect(a.share.token).toBe(b.share.token);
+    expect((await request(app, `/public/reports/${a.share.token}`)).status).toBe(200);
+  });
+
+  test("the public export carries no prior-scan identifiers or decision times", async () => {
+    const owner = await seedUser();
+    const db = createDb(env.DB);
+    const scanId = await seedCompletedScan(owner);
+    // Release memory recorded against a prior scan the org never shared.
+    await db
+      .update(schema.scans)
+      .set({
+        summaryJson: {
+          report: {
+            version: 1,
+            digest: "abc123",
+            digestAlgorithm: "sha256",
+            generatedAt: "2026-01-01T00:00:00.000Z",
+            rulesVersion: "1.8.0",
+          },
+          releaseConsistency: {
+            status: "subset",
+            priorScanId: "scan_prior_secret",
+            priorVersion: "1.0.0",
+            decidedAt: "2026-03-04T09:12:31.004Z",
+            currentFindingCount: 1,
+            priorFindingCount: 1,
+            newFindingCount: 0,
+            newFindings: [],
+          },
+        },
+      })
+      .where(eq(schema.scans.id, scanId));
+
+    const app = buildTestApp(owner);
+    const { share } = (await (await enableShare(app, scanId)).json()) as {
+      share: { token: string };
+    };
+    const res = await request(app, `/public/reports/${share.token}`);
+    const text = await res.text();
+    expect(text).not.toContain("scan_prior_secret");
+    expect(text).not.toContain("2026-03-04T09:12:31.004Z");
+
+    const consistency = (JSON.parse(text) as { releaseConsistency: Record<string, unknown> })
+      .releaseConsistency;
+    expect(consistency.status).toBe("subset");
+    expect(consistency.priorScanId).toBeUndefined();
+    expect(consistency.decidedAt).toBeUndefined();
   });
 
   test("unknown and malformed tokens return 404", async () => {
@@ -356,10 +492,11 @@ describe("public report attestations", () => {
       share: { token: string };
     };
 
+    const signer = await signingEnv();
     const reportRes = await request(app, `/public/reports/${share.token}`);
     const reportBytes = new Uint8Array(await reportRes.arrayBuffer());
 
-    const attRes = await request(app, `/public/reports/${share.token}/attestation`);
+    const attRes = await request(app, `/public/reports/${share.token}/attestation`, {}, signer);
     expect(attRes.status).toBe(200);
     const envelope = (await attRes.json()) as {
       payloadType: string;
@@ -368,11 +505,8 @@ describe("public report attestations", () => {
     };
     expect(envelope.payloadType).toBe("application/vnd.in-toto+json");
     expect(envelope.signatures).toHaveLength(1);
-    // Standard base64, not base64url — what sigstore/in-toto verifiers expect.
-    expect(envelope.payload).toMatch(/^[A-Za-z0-9+/]+=*$/);
-    expect(envelope.signatures[0].sig).toMatch(/^[A-Za-z0-9+/]+=*$/);
 
-    const keyRes = await request(app, `/public/attestation-key`);
+    const keyRes = await request(app, `/public/attestation-key`, {}, signer);
     expect(keyRes.status).toBe(200);
     const published = (await keyRes.json()) as {
       keyId: string;
@@ -385,17 +519,22 @@ describe("public report attestations", () => {
     expect((published.jwk as { d?: string }).d).toBeUndefined();
 
     // Statement subject digest matches the exact bytes the public route serves.
-    const payloadBytes = base64UrlDecode(envelope.payload);
+    // Decoded strictly as standard base64 — sigstore/in-toto verifiers expect
+    // that alphabet, and a base64url regression must not slide through on a
+    // payload that happens to contain no `-` or `_`.
+    const payloadBytes = strictBase64Decode(envelope.payload);
     const statement = JSON.parse(new TextDecoder().decode(payloadBytes)) as {
       _type: string;
       subject: Array<{ name: string; digest: { sha256: string } }>;
       predicateType: string;
-      predicate: { scanId: string; risk: string; reportSchema: string };
+      predicate: { scanId: string; risk: string; reportSchema: string; issuedAt: string };
     };
     expect(statement._type).toBe("https://in-toto.io/Statement/v1");
     expect(statement.subject[0].name).toBe("@org/pkg@1.1.0");
     expect(statement.predicate.scanId).toBe(scanId);
     expect(statement.predicate.reportSchema).toBe("drydock.report.v2");
+    // Archived envelopes must be orderable without an out-of-band timestamp.
+    expect(Number.isNaN(Date.parse(statement.predicate.issuedAt))).toBe(false);
     const digest = new Uint8Array(
       await crypto.subtle.digest("SHA-256", reportBytes as Uint8Array<ArrayBuffer>),
     );
@@ -421,7 +560,7 @@ describe("public report attestations", () => {
     const valid = await crypto.subtle.verify(
       "Ed25519",
       publicKey,
-      base64UrlDecode(envelope.signatures[0].sig),
+      strictBase64Decode(envelope.signatures[0].sig),
       pae,
     );
     expect(valid).toBe(true);
@@ -435,14 +574,64 @@ describe("public report attestations", () => {
       share: { token: string };
     };
 
-    const bare = { ...env, ATTESTATION_SIGNING_KEY_JWK: undefined } as typeof env;
-    const attRes = await request(app, `/public/reports/${share.token}/attestation`, {}, bare);
+    // The default test env carries no key — the same shape as an operator who
+    // has not run `wrangler secret put ATTESTATION_SIGNING_KEY_JWK`.
+    const attRes = await request(app, `/public/reports/${share.token}/attestation`);
     expect(attRes.status).toBe(503);
-    const keyRes = await request(app, `/public/attestation-key`, {}, bare);
+    const keyRes = await request(app, `/public/attestation-key`);
     expect(keyRes.status).toBe(503);
 
     // The report itself stays available without a key.
-    const reportRes = await request(app, `/public/reports/${share.token}`, {}, bare);
+    const reportRes = await request(app, `/public/reports/${share.token}`);
     expect(reportRes.status).toBe(200);
+  });
+
+  test("a malformed signing key degrades like an absent one", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const app = buildTestApp(owner);
+    const { share } = (await (await enableShare(app, scanId)).json()) as {
+      share: { token: string };
+    };
+
+    const signer = await signingEnv();
+    const good = JSON.parse(signer.ATTESTATION_SIGNING_KEY_JWK as string) as JsonWebKey;
+    const malformed: Array<Record<string, unknown>> = [
+      { not: "json at all" },
+      { ...good, kty: "EC" },
+      { ...good, crv: "P-256" },
+      { ...good, d: undefined },
+      { ...good, d: "not-valid-base64url-key-material" },
+    ];
+    for (const jwk of malformed) {
+      const broken = { ...env, ATTESTATION_SIGNING_KEY_JWK: JSON.stringify(jwk) } as typeof env;
+      const att = await request(app, `/public/reports/${share.token}/attestation`, {}, broken);
+      expect(att.status).toBe(503);
+      expect((await request(app, `/public/attestation-key`, {}, broken)).status).toBe(503);
+    }
+
+    // Not even a parse failure escapes as a 500.
+    const garbage = { ...env, ATTESTATION_SIGNING_KEY_JWK: "{not json" } as typeof env;
+    expect(
+      (await request(app, `/public/reports/${share.token}/attestation`, {}, garbage)).status,
+    ).toBe(503);
+  });
+
+  test("attestations die with the share link", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const app = buildTestApp(owner);
+    const { share } = (await (await enableShare(app, scanId)).json()) as {
+      share: { token: string };
+    };
+    const signer = await signingEnv();
+
+    expect(
+      (await request(app, `/public/reports/${share.token}/attestation`, {}, signer)).status,
+    ).toBe(200);
+    await request(app, `/api/v1/scans/${scanId}/share`, { method: "DELETE" });
+    expect(
+      (await request(app, `/public/reports/${share.token}/attestation`, {}, signer)).status,
+    ).toBe(404);
   });
 });

--- a/test/workers/public-reports.test.ts
+++ b/test/workers/public-reports.test.ts
@@ -1,0 +1,448 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { describe, expect, test } from "vitest";
+import { listOrganizationAuditEvents } from "../../server/db/audit-log";
+import { createDb } from "../../server/db/client";
+import { createOrganization, ensurePersonalOrganization } from "../../server/db/organizations";
+import { createScanJob, persistScan } from "../../server/db/scans";
+import * as schema from "../../server/db/schema";
+import { describeAuditEvent } from "../../server/lib/auth/audit-events";
+import { base64UrlDecode } from "../../server/lib/platform/crypto-utils";
+import { publicReportsRoutes } from "../../server/routes/public-reports";
+import { scansRoutes } from "../../server/routes/scans";
+import type { Bindings, Variables } from "../../server/types";
+
+interface SeededUser {
+  userId: string;
+  organizationId: string;
+}
+
+async function seedUser(): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+async function seedMember(organizationId: string, role: "admin" | "member"): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const member = await seedUser();
+  const now = new Date();
+  await db.insert(schema.organizationMembers).values({
+    id: crypto.randomUUID(),
+    organizationId,
+    userId: member.userId,
+    role,
+    createdAt: now,
+    updatedAt: now,
+  });
+  return { userId: member.userId, organizationId };
+}
+
+// The public routes are mounted without the auth/session middleware — exactly
+// like server/index.ts mounts them ahead of the /api/* guards.
+function buildTestApp(session: { userId: string } | null) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.route("/public", publicReportsRoutes);
+  if (session) {
+    app.use("/api/*", async (c, next) => {
+      c.set("authSession", { userId: session.userId });
+      await next();
+    });
+    app.route("/api/v1/scans", scansRoutes);
+  }
+  return app;
+}
+
+async function request(
+  app: Hono<{ Bindings: Bindings; Variables: Variables }>,
+  path: string,
+  options: RequestInit & { organizationId?: string } = {},
+  overrideEnv: typeof env = env,
+) {
+  const ctx = createExecutionContext();
+  const headers = new Headers(options.headers);
+  if (!headers.has("content-type")) headers.set("content-type", "application/json");
+  if (options.organizationId) headers.set("x-organization-id", options.organizationId);
+  const res = await app.fetch(
+    new Request(`http://test.local${path}`, { ...options, headers }),
+    overrideEnv,
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+async function seedCompletedScan(owner: SeededUser): Promise<string> {
+  const db = createDb(env.DB);
+  const scanId = `scan_${crypto.randomUUID()}`;
+  const stageId = `stage-${scanId.slice(-12)}`;
+  await createScanJob(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+  });
+  await persistScan(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+    packageJson: { name: "@org/pkg", version: "1.1.0" },
+    risk: "high",
+    status: "complete",
+    summary: {
+      report: {
+        version: 1,
+        digest: "abc123",
+        digestAlgorithm: "sha256",
+        generatedAt: "2026-01-01T00:00:00.000Z",
+        rulesVersion: "1.8.0",
+      },
+      baseline: { kind: "registry", version: "1.0.0" },
+      diff: [{ path: "package.json", status: "modified" }],
+    },
+    ai: null,
+    files: [{ path: "package.json", size: 10, sha256: "a", flags: [], textSample: "{}" }],
+    diff: [{ path: "package.json", status: "modified", flags: [] }],
+    findings: [
+      {
+        severity: "high",
+        file: "package.json",
+        evidence: "postinstall: node install.js",
+        reason: "install lifecycle hooks execute on consumer machines",
+        ruleId: "install-script.lifecycle",
+        ruleVersion: "1.8.0",
+      },
+    ],
+    report: { version: 1, digest: "abc123" },
+  });
+  return scanId;
+}
+
+async function enableShare(app: ReturnType<typeof buildTestApp>, scanId: string) {
+  const res = await request(app, `/api/v1/scans/${scanId}/share`, { method: "POST", body: "{}" });
+  return res;
+}
+
+describe("public report sharing", () => {
+  test("owner enables a share link, link serves the canonical report export", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const app = buildTestApp(owner);
+
+    const res = await enableShare(app, scanId);
+    expect(res.status).toBe(200);
+    const { share } = (await res.json()) as {
+      share: { token: string; url: string; sharedAt: string };
+    };
+    expect(share.token).toMatch(/^[A-Za-z0-9_-]{40,}$/);
+    expect(share.url).toBe(`http://example.com/reports/${share.token}`);
+
+    const pub = await request(app, `/public/reports/${share.token}`);
+    expect(pub.status).toBe(200);
+    const text = await pub.text();
+    const body = JSON.parse(text) as Record<string, unknown>;
+    expect(body.schema).toBe("drydock.report.v1");
+    expect((body.package as { name: string }).name).toBe("@org/pkg");
+    // The export is the sharing boundary: no org/user identifiers, no events,
+    // no file samples anywhere in the payload.
+    expect(text).not.toContain(owner.organizationId);
+    expect(text).not.toContain(owner.userId);
+    expect(body.events).toBeUndefined();
+    expect(body.files).toBeUndefined();
+
+    // The public bytes match the authenticated canonical export exactly.
+    const authed = await request(app, `/api/v1/scans/${scanId}/report.json`);
+    expect(await authed.text()).toBe(text);
+  });
+
+  test("sharing is idempotent — the second call returns the same token", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const app = buildTestApp(owner);
+
+    const first = (await (await enableShare(app, scanId)).json()) as { share: { token: string } };
+    const second = (await (await enableShare(app, scanId)).json()) as { share: { token: string } };
+    expect(second.share.token).toBe(first.share.token);
+  });
+
+  test("share requires a completed scan and an existing scan", async () => {
+    const owner = await seedUser();
+    const db = createDb(env.DB);
+    const scanId = `scan_${crypto.randomUUID()}`;
+    await createScanJob(db, {
+      id: scanId,
+      stageId: `stage-${scanId.slice(-12)}`,
+      organizationId: owner.organizationId,
+      ownerUserId: owner.userId,
+    });
+    const app = buildTestApp(owner);
+
+    expect((await enableShare(app, scanId)).status).toBe(409);
+    expect((await enableShare(app, "scan_missing")).status).toBe(404);
+  });
+
+  test("plain members cannot enable or revoke, admins can", async () => {
+    const owner = await seedUser();
+    const db = createDb(env.DB);
+    const organizationId = await createOrganization(db, {
+      ownerUserId: owner.userId,
+      name: "Team workspace",
+    });
+    const scanId = await seedCompletedScan({ ...owner, organizationId });
+    const admin = await seedMember(organizationId, "admin");
+    const member = await seedMember(organizationId, "member");
+
+    const memberRes = await request(buildTestApp(member), `/api/v1/scans/${scanId}/share`, {
+      method: "POST",
+      body: "{}",
+      organizationId,
+    });
+    expect(memberRes.status).toBe(403);
+
+    const adminRes = await request(buildTestApp(admin), `/api/v1/scans/${scanId}/share`, {
+      method: "POST",
+      body: "{}",
+      organizationId,
+    });
+    expect(adminRes.status).toBe(200);
+
+    const memberRevoke = await request(buildTestApp(member), `/api/v1/scans/${scanId}/share`, {
+      method: "DELETE",
+      organizationId,
+    });
+    expect(memberRevoke.status).toBe(403);
+  });
+
+  test("another organization cannot share or revoke the scan", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const outsider = await seedUser();
+    const app = buildTestApp(outsider);
+
+    expect((await enableShare(app, scanId)).status).toBe(404);
+    const revoke = await request(app, `/api/v1/scans/${scanId}/share`, { method: "DELETE" });
+    expect(revoke.status).toBe(404);
+  });
+
+  test("revoking invalidates the public link immediately", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const app = buildTestApp(owner);
+
+    const { share } = (await (await enableShare(app, scanId)).json()) as {
+      share: { token: string };
+    };
+    expect((await request(app, `/public/reports/${share.token}`)).status).toBe(200);
+
+    const revoke = await request(app, `/api/v1/scans/${scanId}/share`, { method: "DELETE" });
+    expect(((await revoke.json()) as { revoked: boolean }).revoked).toBe(true);
+    expect((await request(app, `/public/reports/${share.token}`)).status).toBe(404);
+
+    // Revoking again reports nothing to revoke but stays a 200 (idempotent).
+    const again = await request(app, `/api/v1/scans/${scanId}/share`, { method: "DELETE" });
+    expect(((await again.json()) as { revoked: boolean }).revoked).toBe(false);
+  });
+
+  test("share enable/revoke are audited as scan events", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const app = buildTestApp(owner);
+    await enableShare(app, scanId);
+    await request(app, `/api/v1/scans/${scanId}/share`, { method: "DELETE" });
+
+    const detail = (await (await request(app, `/api/v1/scans/${scanId}`)).json()) as {
+      events: Array<{ type: string }>;
+    };
+    const types = detail.events.map((event) => event.type);
+    expect(types).toContain("scan.share_enabled");
+    expect(types).toContain("scan.share_revoked");
+
+    // Both events surface in the organization audit log — sharing a report
+    // publicly is a governance action operators must be able to see.
+    const { events } = await listOrganizationAuditEvents(createDb(env.DB), owner.organizationId);
+    const shareEvents = events.filter((event) => event.type.startsWith("scan.share_"));
+    expect(shareEvents.map((event) => event.type).sort()).toEqual([
+      "scan.share_enabled",
+      "scan.share_revoked",
+    ]);
+    for (const event of shareEvents) {
+      const descriptor = describeAuditEvent(event.type, event.metadataJson);
+      expect(descriptor).not.toBeNull();
+      expect(descriptor?.category).toBe("security");
+      expect(descriptor?.detail).toBe("@org/pkg@1.1.0");
+    }
+  });
+
+  test("revoke followed by re-share issues a fresh token and kills the old link", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const app = buildTestApp(owner);
+
+    const first = (await (await enableShare(app, scanId)).json()) as { share: { token: string } };
+    await request(app, `/api/v1/scans/${scanId}/share`, { method: "DELETE" });
+    const second = (await (await enableShare(app, scanId)).json()) as { share: { token: string } };
+
+    expect(second.share.token).not.toBe(first.share.token);
+    expect((await request(app, `/public/reports/${first.share.token}`)).status).toBe(404);
+    expect((await request(app, `/public/reports/${second.share.token}`)).status).toBe(200);
+  });
+
+  test("public responses carry CORS and uncacheable headers", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const app = buildTestApp(owner);
+    const { share } = (await (await enableShare(app, scanId)).json()) as {
+      share: { token: string };
+    };
+
+    // no-store keeps the "revocation is immediate" promise honest: no shared
+    // cache may serve the report past the revoke.
+    const report = await request(app, `/public/reports/${share.token}`);
+    expect(report.headers.get("cache-control")).toBe("no-store");
+    expect(report.headers.get("access-control-allow-origin")).toBe("*");
+
+    const attestation = await request(app, `/public/reports/${share.token}/attestation`);
+    expect(attestation.headers.get("cache-control")).toBe("no-store");
+    expect(attestation.headers.get("access-control-allow-origin")).toBe("*");
+
+    // The key rotates rarely and is safe to cache.
+    const key = await request(app, `/public/attestation-key`);
+    expect(key.headers.get("cache-control")).toBe("public, max-age=3600");
+    expect(key.headers.get("access-control-allow-origin")).toBe("*");
+  });
+
+  test("unknown and malformed tokens return 404", async () => {
+    const app = buildTestApp(null);
+    const wellFormed = "A".repeat(43);
+    expect((await request(app, `/public/reports/${wellFormed}`)).status).toBe(404);
+    expect((await request(app, `/public/reports/short`)).status).toBe(404);
+    expect((await request(app, `/public/reports/${"%2e".repeat(20)}`)).status).toBe(404);
+  });
+
+  test("public reads are rate limited per IP", async () => {
+    const app = buildTestApp(null);
+    const ip = `10.0.0.${Math.floor(Math.random() * 200) + 1}`;
+    const headers = { "cf-connecting-ip": ip };
+    let limited = false;
+    for (let i = 0; i < 125; i += 1) {
+      const res = await request(app, `/public/reports/${"B".repeat(43)}`, { headers });
+      if (res.status === 429) {
+        limited = true;
+        break;
+      }
+      expect(res.status).toBe(404);
+    }
+    expect(limited).toBe(true);
+  });
+});
+
+describe("public report attestations", () => {
+  test("attestation verifies against the served report bytes and published key", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const app = buildTestApp(owner);
+    const { share } = (await (await enableShare(app, scanId)).json()) as {
+      share: { token: string };
+    };
+
+    const reportRes = await request(app, `/public/reports/${share.token}`);
+    const reportBytes = new Uint8Array(await reportRes.arrayBuffer());
+
+    const attRes = await request(app, `/public/reports/${share.token}/attestation`);
+    expect(attRes.status).toBe(200);
+    const envelope = (await attRes.json()) as {
+      payloadType: string;
+      payload: string;
+      signatures: Array<{ keyid: string; sig: string }>;
+    };
+    expect(envelope.payloadType).toBe("application/vnd.in-toto+json");
+    expect(envelope.signatures).toHaveLength(1);
+    // Standard base64, not base64url — what sigstore/in-toto verifiers expect.
+    expect(envelope.payload).toMatch(/^[A-Za-z0-9+/]+=*$/);
+    expect(envelope.signatures[0].sig).toMatch(/^[A-Za-z0-9+/]+=*$/);
+
+    const keyRes = await request(app, `/public/attestation-key`);
+    expect(keyRes.status).toBe(200);
+    const published = (await keyRes.json()) as {
+      keyId: string;
+      algorithm: string;
+      jwk: JsonWebKey;
+    };
+    expect(published.algorithm).toBe("Ed25519");
+    expect(envelope.signatures[0].keyid).toBe(published.keyId);
+    // The published key is public material only.
+    expect((published.jwk as { d?: string }).d).toBeUndefined();
+
+    // Statement subject digest matches the exact bytes the public route serves.
+    const payloadBytes = base64UrlDecode(envelope.payload);
+    const statement = JSON.parse(new TextDecoder().decode(payloadBytes)) as {
+      _type: string;
+      subject: Array<{ name: string; digest: { sha256: string } }>;
+      predicateType: string;
+      predicate: { scanId: string; risk: string; reportSchema: string };
+    };
+    expect(statement._type).toBe("https://in-toto.io/Statement/v1");
+    expect(statement.subject[0].name).toBe("@org/pkg@1.1.0");
+    expect(statement.predicate.scanId).toBe(scanId);
+    expect(statement.predicate.reportSchema).toBe("drydock.report.v1");
+    const digest = new Uint8Array(
+      await crypto.subtle.digest("SHA-256", reportBytes as Uint8Array<ArrayBuffer>),
+    );
+    const hex = [...digest].map((byte) => byte.toString(16).padStart(2, "0")).join("");
+    expect(statement.subject[0].digest.sha256).toBe(hex);
+
+    // Independent DSSE PAE construction + WebCrypto verification.
+    const encoder = new TextEncoder();
+    const typeBytes = encoder.encode(envelope.payloadType);
+    const header = encoder.encode(
+      `DSSEv1 ${typeBytes.length} ${envelope.payloadType} ${payloadBytes.length} `,
+    );
+    const pae = new Uint8Array(header.length + payloadBytes.length);
+    pae.set(header, 0);
+    pae.set(payloadBytes, header.length);
+    const publicKey = await crypto.subtle.importKey(
+      "jwk",
+      published.jwk,
+      { name: "Ed25519" },
+      false,
+      ["verify"],
+    );
+    const valid = await crypto.subtle.verify(
+      "Ed25519",
+      publicKey,
+      base64UrlDecode(envelope.signatures[0].sig),
+      pae,
+    );
+    expect(valid).toBe(true);
+  });
+
+  test("attestation endpoints return 503 when no signing key is configured", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner);
+    const app = buildTestApp(owner);
+    const { share } = (await (await enableShare(app, scanId)).json()) as {
+      share: { token: string };
+    };
+
+    const bare = { ...env, ATTESTATION_SIGNING_KEY_JWK: undefined } as typeof env;
+    const attRes = await request(app, `/public/reports/${share.token}/attestation`, {}, bare);
+    expect(attRes.status).toBe(503);
+    const keyRes = await request(app, `/public/attestation-key`, {}, bare);
+    expect(keyRes.status).toBe(503);
+
+    // The report itself stays available without a key.
+    const reportRes = await request(app, `/public/reports/${share.token}`, {}, bare);
+    expect(reportRes.status).toBe(200);
+  });
+});

--- a/test/workers/release-memory.test.ts
+++ b/test/workers/release-memory.test.ts
@@ -439,9 +439,14 @@ describe("release memory exposure (API + report export)", () => {
     const res = await fetchWithSession(app, `/api/v1/scans/${withField.scanId}/report.json`);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { releaseConsistency: unknown };
-    // The export strips priorScanId — an org-internal reference the export's
-    // consumers (including public share links) have no use for.
-    const { priorScanId: _priorScanId, ...exportedShape } = releaseConsistency;
+    // The export strips priorScanId and decidedAt — both describe a prior scan
+    // the org never chose to share, and these bytes are served verbatim on the
+    // public share route.
+    const {
+      priorScanId: _priorScanId,
+      decidedAt: _decidedAt,
+      ...exportedShape
+    } = releaseConsistency;
     expect(body.releaseConsistency).toEqual(exportedShape);
 
     const legacy = await fetchWithSession(app, `/api/v1/scans/${withoutField.scanId}/report.json`);

--- a/test/workers/release-memory.test.ts
+++ b/test/workers/release-memory.test.ts
@@ -439,7 +439,10 @@ describe("release memory exposure (API + report export)", () => {
     const res = await fetchWithSession(app, `/api/v1/scans/${withField.scanId}/report.json`);
     expect(res.status).toBe(200);
     const body = (await res.json()) as { releaseConsistency: unknown };
-    expect(body.releaseConsistency).toEqual(releaseConsistency);
+    // The export strips priorScanId — an org-internal reference the export's
+    // consumers (including public share links) have no use for.
+    const { priorScanId: _priorScanId, ...exportedShape } = releaseConsistency;
+    expect(body.releaseConsistency).toEqual(exportedShape);
 
     const legacy = await fetchWithSession(app, `/api/v1/scans/${withoutField.scanId}/report.json`);
     expect(legacy.status).toBe(200);

--- a/test/workers/scan-artifacts-routes.test.ts
+++ b/test/workers/scan-artifacts-routes.test.ts
@@ -377,7 +377,7 @@ describe("scan artifact backfill route", () => {
 
     const readCounter = createReadCountingBucket(env.ARTIFACTS);
     const metadataOnly = await getScan(db, scanId, owner.organizationId, readCounter.bucket, {
-      includeFileSamples: false,
+      files: "list",
     });
     expect(metadataOnly?.files.find((file) => file.path === "index.js")?.textSample).toBeNull();
     expect(metadataOnly?.findings).toHaveLength(1);

--- a/test/workers/scan-intent-envelope.test.ts
+++ b/test/workers/scan-intent-envelope.test.ts
@@ -120,7 +120,7 @@ describe("scan intent envelope persistence and readers", () => {
     expect(res.status).toBe(200);
     const text = await res.text();
     const body = JSON.parse(text) as { schema: string; intentEnvelope: unknown };
-    expect(body.schema).toBe("drydock.report.v1");
+    expect(body.schema).toBe("drydock.report.v2");
     expect(body.intentEnvelope).toEqual(attestedEnvelope);
 
     // Stable serialization still holds with the new field present.

--- a/test/workers/scan-report-export.test.ts
+++ b/test/workers/scan-report-export.test.ts
@@ -155,7 +155,7 @@ describe("scan report JSON export", () => {
       aiReview: unknown;
       findings: Array<{ ruleId: string | null; severity: string }>;
     };
-    expect(body.schema).toBe("drydock.report.v1");
+    expect(body.schema).toBe("drydock.report.v2");
     expect(body.report?.digest).toBe("abc123");
     expect(body.report?.rulesVersion).toBe("1.8.0");
     expect(body.scan.id).toBe(scanId);

--- a/test/workers/security-headers.test.ts
+++ b/test/workers/security-headers.test.ts
@@ -1,6 +1,6 @@
 import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
 import { describe, expect, test } from "vitest";
-import worker from "../../server";
+import worker, { redactCapabilityPath } from "../../server";
 
 const HSTS_VALUE = "max-age=31536000; includeSubDomains; preload";
 
@@ -42,5 +42,42 @@ describe("worker security headers", () => {
     expect(res.headers.get("Strict-Transport-Security")).toBeNull();
     expect(res.headers.get("Content-Security-Policy")).toBeNull();
     expect(res.headers.get("X-Frame-Options")).toBeNull();
+  });
+
+  // The public report routes are Worker-owned but live outside /api/*, so they
+  // need the locked-down API policy explicitly rather than inheriting the
+  // document policy static assets get.
+  test("serves the API CSP on the unauthenticated /public routes", async () => {
+    const apiHeaders = await fetchHeaders("/api/health");
+    const publicHeaders = await fetchHeaders(`/public/reports/${"A".repeat(43)}`);
+    expect(publicHeaders.get("Content-Security-Policy")).toBe(
+      apiHeaders.get("Content-Security-Policy"),
+    );
+    expect(publicHeaders.get("Strict-Transport-Security")).toBe(HSTS_VALUE);
+    // Still readable by a cross-origin verifier even though it is a 404.
+    expect(publicHeaders.get("access-control-allow-origin")).toBe("*");
+  });
+});
+
+// A share link's capability IS its token, so it must never reach a log line.
+describe("capability path redaction", () => {
+  test("replaces the share token and leaves everything else alone", () => {
+    const token = "A".repeat(43);
+    expect(redactCapabilityPath(`/public/reports/${token}`)).toBe("/public/reports/:token");
+    expect(redactCapabilityPath(`/public/reports/${token}/attestation`)).toBe(
+      "/public/reports/:token/attestation",
+    );
+    // Percent-encoded and otherwise odd tokens are still one path segment.
+    expect(redactCapabilityPath("/public/reports/%2e%2e%2f%2e%2e")).toBe("/public/reports/:token");
+    expect(redactCapabilityPath("/public/reports/")).toBe("/public/reports/");
+    expect(redactCapabilityPath("/public/attestation-key")).toBe("/public/attestation-key");
+    expect(redactCapabilityPath("/api/v1/scans/scan_123")).toBe("/api/v1/scans/scan_123");
+  });
+
+  test("does not leave a token behind when the prefix is not at the start", () => {
+    const token = "B".repeat(43);
+    // Only the anchored prefix is a capability path; anything else must not be
+    // silently treated as redacted when it still carries the token.
+    expect(redactCapabilityPath(`/public/reports/${token}`)).not.toContain(token);
   });
 });

--- a/test/workers/security-headers.test.ts
+++ b/test/workers/security-headers.test.ts
@@ -74,6 +74,16 @@ describe("capability path redaction", () => {
     expect(redactCapabilityPath("/api/v1/scans/scan_123")).toBe("/api/v1/scans/scan_123");
   });
 
+  test("redacts the browser-facing report page too", () => {
+    const token = "C".repeat(43);
+    // /reports/:token is the URL a publisher actually pastes around, and its
+    // asset-fallback request reaches app.onError like any other.
+    expect(redactCapabilityPath(`/reports/${token}`)).toBe("/reports/:token");
+    expect(redactCapabilityPath(`/reports/${token}`)).not.toContain(token);
+    expect(redactCapabilityPath("/reports/")).toBe("/reports/");
+    expect(redactCapabilityPath("/reports")).toBe("/reports");
+  });
+
   test("does not leave a token behind when the prefix is not at the start", () => {
     const token = "B".repeat(43);
     // Only the anchored prefix is a capability path; anything else must not be


### PR DESCRIPTION
## What

Completed scans can now be shared outside the organization as a read-only public report, with a signed attestation anyone can verify. First rung of the "verdicts become verifiable artifacts" direction.

- **Share links**: `POST/DELETE /api/v1/scans/:id/share` (owner/admin only, audited, idempotent) manages an unguessable 256-bit capability token stored on the scan row.
- **Public report**: `GET /public/reports/:token` serves the canonical report export (`drydock.report.v2`) — byte-identical to the authenticated `report.json` export. No file samples, no events, no org/user identifiers. Mounted before the auth middleware (the `/webhooks` precedent), per-IP rate-limited, API CSP, CORS `*`.
- **Attestation**: `GET /public/reports/:token/attestation` returns a DSSE envelope over an in-toto v1 Statement whose subject digest is the SHA-256 of the exact served report bytes, signed with Ed25519 (`ATTESTATION_SIGNING_KEY_JWK` secret). Public key + RFC 7638 key id at `GET /public/attestation-key`. Missing key degrades to 503 on attestation endpoints only.
- **UI**: Share dialog on the scan detail header (create/copy/revoke + attestation download) and a public `/reports/:token` page (verdict, risk signals, release changes, verify instructions) on the document-shaped 880px layout.

## Security notes

- Public endpoints live outside `/api/*`, preserving the "every non-auth `/api/*` endpoint requires Better Auth" boundary.
- The share token is the whole capability; unknown/malformed/revoked tokens are indistinguishable 404s.
- The public payload reuses the existing canonical export — redaction is inherited from the report contract, not re-implemented.
- Resolves the `security-model.md` known gap "Public signed reports are not exposed yet".

## Testing

- `test/workers/public-reports.test.ts` (11 tests): role enforcement (member 403 / admin 200), org isolation, idempotent share, revocation immediacy, canonical-bytes equality with the authenticated export, no-identifier redaction, audit events, malformed-token 404s, per-IP rate limit, full DSSE verification (independent PAE construction + WebCrypto Ed25519 verify against the published key), and 503-degradation without the signing key.
- `pnpm run verify` green (lint, format, typecheck, node + workers suites).
- Docs updated: new `docs/public-reports.md`, `security-model.md`, `architecture.md`, `self-hosting.md`, docs map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-ups (second pass)

- `scan.share_enabled` / `scan.share_revoked` now surface in the organization audit log (registry entries + `package@version` detail from event metadata).
- Dropped the unrelated per-view `scan.viewed` event write from `GET /api/v1/scans/:id` — nothing consumed it and it re-polluted `scan_events`.
- `enablePublicShare` guards its UPDATE with `public_share_token IS NULL`, so concurrent enables can never silently rotate a distributed link (loser re-reads and returns the winner's token).
- Report + attestation responses are `no-store`, making "revocation is immediate" true through shared caches too.
- DSSE envelope `payload`/`sig` switched to **standard base64** (what sigstore/in-toto verifiers expect); done now, before external consumers pin the encoding.
- The report export strips `releaseConsistency.priorScanId` — an org-internal scan reference that the public share route would otherwise serve verbatim.
- New tests: audit-log visibility, revoke→re-share token rotation, CORS/cache-control header assertions, base64-alphabet assertions.

