### PR TITLE
Add shields badge endpoint and opt-in public threat feed

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ The user-facing learning guide is [`../src/pages/Docs/index.tsx`](../src/pages/D
 - [`diff-baseline.md`](./diff-baseline.md) — default previous-version comparison strategy.
 - [`intent-envelope.md`](./intent-envelope.md) — advisory source-binding tiers (attested / declared / absent) persisted with every scan.
 - [`artifact-storage.md`](./artifact-storage.md) — D1/R2 report and artifact persistence.
-- [`public-reports.md`](./public-reports.md) — public share links and signed report attestations.
+- [`public-reports.md`](./public-reports.md) — public share links, signed report attestations, badges, and the threat feed.
 
 ## Operations and setup
 

--- a/docs/account-deletion.md
+++ b/docs/account-deletion.md
@@ -35,7 +35,8 @@ of it cascades on its own (the same reason `deleteOrganization` deletes children
    member. That clears the org's scans, findings, npm connection, GitHub install/targets/gates,
    Slack connection, invitations, notification recipients, and membership rows.
 2. **References in surviving orgs** — in organizations owned by _other_ people, the departing user
-   may have created or decided on rows (`scans.owner_user_id` / `decided_by_user_id`,
+   may have created, decided on, or publicly shared rows (`scans.owner_user_id` /
+   `decided_by_user_id` / `public_shared_by_user_id`,
    `scan_events.actor_user_id`, `npm_connections.created_by_user_id`, the GitHub/Slack/notification
    `created_by_user_id` columns, and `organization_invitations.invited_by_user_id` /
    `accepted_by_user_id`). These are all `ON DELETE SET NULL`, so we null them by hand — otherwise a

--- a/docs/public-reports.md
+++ b/docs/public-reports.md
@@ -1,8 +1,9 @@
-# Public report sharing and attestations
+# Public report sharing, attestations, badges, and the threat feed
 
 Completed scans can be shared outside the organization as a read-only public
 report, with an optional signed attestation that lets anyone verify the report
-bytes came from Drydock.
+bytes came from Drydock. Shared reports also power two discoverable surfaces:
+a shields.io badge per package and an opt-in public threat feed.
 
 ## Share flow
 
@@ -65,6 +66,66 @@ mutable field — `decision`, `riskSummary`, findings) means the digest covers a
 document the consumer never fetched, and verification fails. That is a race, not
 a forgery: re-fetch the report and compare again. An archived pair captured
 together always verifies, which is what matters for the archival use case.
+
+## Badge endpoint
+
+`GET /public/badge/:ecosystem/:package` (ecosystems: `npm`, `pypi`, `vscode`;
+npm names may contain `@scope/` slashes) returns a
+[shields.io endpoint-badge](https://shields.io/badges/endpoint-badge) payload
+for the package's most recent **feed-listed** review:
+
+- Not listed / unknown → `not reviewed` (lightgrey). Always `200` so badge
+  proxies never render an error.
+- Listed → `<version> reviewed · <release risk> risk`, colored green / yellow /
+  red by risk; a `no_publish` decision renders `<version> blocked` (red).
+
+The badge is a name-discoverable index, so it takes the same second opt-in as
+the threat feed — a report shared privately by link never becomes queryable by
+package name. Among listed candidates the newest **registry-verified** review
+wins (see package identity below), so a workflow-gate scan claiming someone
+else's npm name cannot override the real maintainer's badge.
+
+Embed via
+`https://img.shields.io/endpoint?url=<origin>/public/badge/npm/<package>`
+(URL-encode the badge URL).
+
+## Threat feed
+
+`GET /public/threat-feed.json` is a discoverable index (schema
+`drydock.threat-feed.v1`, capped at 100 entries, newest listings first) meant
+for security partners — Aikido and other ecosystem-intel consumers can poll it.
+Each entry carries package identity, ecosystem, release/artifact risk,
+decision, finding count, timestamps, and a `reportUrl` to the full public
+report.
+
+Listing is a **second explicit opt-in** on top of sharing (the checkbox in the
+share dialog, or `POST /api/v1/scans/:id/share { "threatFeed": true|false }`):
+holding a link is capability, appearing in an index is publication, and the two
+must never be conflated. Revoking the share link always unlists the report;
+re-sharing later starts unlisted. Listing changes are audited
+(`scan.feed_listed`, `scan.feed_unlisted`).
+
+### Package identity
+
+Each feed entry carries `packageIdentity`:
+
+- `registry-verified` — staged-publish reviews. The artifact was fetched from
+  the registry with the org's npm token, so the registry proved the org can
+  publish under that name.
+- `manifest-claimed` — workflow-gate reviews. The reviewed artifact is
+  repo-built and its manifest claims the name; nothing verifies ownership yet.
+  Consumers should weigh these accordingly. (Known limitation: post-publish
+  digest verification against the registry would upgrade gate claims; not
+  built yet.)
+
+### Caching
+
+Badge and feed responses read through the per-colo Workers cache
+(`caches.default`, keyed on the path with any query string ignored) and declare
+`max-age=300`, so listing or revocation changes can take up to ~5 minutes to
+propagate to these two surfaces. Report and attestation responses are
+deliberately uncached (`no-store`): revoking a share link takes effect
+immediately.
 
 ## Key management
 

--- a/docs/public-reports.md
+++ b/docs/public-reports.md
@@ -81,9 +81,18 @@ for the package's most recent **feed-listed** review:
 
 The badge is a name-discoverable index, so it takes the same second opt-in as
 the threat feed — a report shared privately by link never becomes queryable by
-package name. Among listed candidates the newest **registry-verified** review
-wins (see package identity below), so a workflow-gate scan claiming someone
-else's npm name cannot override the real maintainer's badge.
+package name.
+
+**Verified and unverified badges are visibly different.** Among listed
+candidates the newest **registry-verified** review wins (see package identity
+below), so on npm a workflow-gate scan claiming someone else's name cannot
+displace the real maintainer's staged review. That preference is only a
+tiebreak, and it does not generalize: only npm has a staged adapter, so every
+PyPI and VS Code review is a workflow gate and is _always_ manifest-claimed —
+there is never a registry-verified row to prefer. A manifest-claimed pick
+therefore renders as `drydock (unverified)` and never takes the clean green
+low-risk color, because anyone can build an artifact whose manifest claims any
+name, and a badge is read by people who will not open the report behind it.
 
 Embed via
 `https://img.shields.io/endpoint?url=<origin>/public/badge/npm/<package>`
@@ -121,11 +130,17 @@ Each feed entry carries `packageIdentity`:
 ### Caching
 
 Badge and feed responses read through the per-colo Workers cache
-(`caches.default`, keyed on the path with any query string ignored) and declare
-`max-age=300`, so listing or revocation changes can take up to ~5 minutes to
-propagate to these two surfaces. Report and attestation responses are
-deliberately uncached (`no-store`): revoking a share link takes effect
-immediately. Badge cache misses use a rate-limit bucket separate from report
+(`caches.default`) and declare `max-age=300`. The cache key is the canonical
+path with any query string ignored, and badge URLs collapse onto their package
+lookup key, so one package has exactly one entry however an embedder cased or
+encoded the name.
+
+Revoking a share or unlisting a report **purges both entries** rather than
+waiting out the TTL: a withdrawn review must stop being asserted, and a cached
+feed body embeds a now-dead share token. Report and attestation responses are
+uncached (`no-store`) for the same reason. What the TTL still bounds is
+staleness from changes that are not revocations — a decision recorded after the
+badge was cached can take up to ~5 minutes to show as `blocked`. Badge cache misses use a rate-limit bucket separate from report
 reads; a throttled badge still returns an uncached valid shields.io payload so
 shared badge-proxy traffic cannot produce an error badge or exhaust report
 access.

--- a/docs/public-reports.md
+++ b/docs/public-reports.md
@@ -104,8 +104,15 @@ Embed via
 `drydock.threat-feed.v1`, 100 entries per page, newest listings first) meant
 for security partners — Aikido and other ecosystem-intel consumers can poll it.
 Each entry carries package identity, ecosystem, release/artifact risk,
-decision, finding count, timestamps, and a `reportUrl` to the full public
+decision, `totalFindingCount`, timestamps, and a `reportUrl` to the full public
 report.
+
+`totalFindingCount` counts deterministic _and_ advisory AI findings. It is
+deliberately not `report.findings.length`: the export routes AI findings
+through `aiReview.findings` and keeps `findings[]` deterministic-only, so the
+two numbers differ by design and the field is named for what it counts. (The
+attestation's `predicate.findingCount` is the other one — it is read off the
+attested document, so it always equals that document's `findings.length`.)
 
 **Page one is not the whole feed.** The response carries `nextCursor` whenever
 more listings exist behind it; pass it back as `?after=<cursor>` to continue.

--- a/docs/public-reports.md
+++ b/docs/public-reports.md
@@ -101,11 +101,23 @@ Embed via
 ## Threat feed
 
 `GET /public/threat-feed.json` is a discoverable index (schema
-`drydock.threat-feed.v1`, capped at 100 entries, newest listings first) meant
+`drydock.threat-feed.v1`, 100 entries per page, newest listings first) meant
 for security partners — Aikido and other ecosystem-intel consumers can poll it.
 Each entry carries package identity, ecosystem, release/artifact risk,
 decision, finding count, timestamps, and a `reportUrl` to the full public
 report.
+
+**Page one is not the whole feed.** The response carries `nextCursor` whenever
+more listings exist behind it; pass it back as `?after=<cursor>` to continue.
+`?limit=` shrinks the page (capped at 100); a malformed `after` or `limit` is
+ignored rather than erroring.
+`(listedAt, scanId)` is a total order over the listed set, so paging is stable
+and nothing is unreachable — which matters because listings are not
+rate-limited: one organization listing a batch of its own scans displaces
+everything older off page one, including other organizations' `no_publish`
+releases. A poller that reads only page one after such a burst silently misses
+them. Read until you reach a listing you have already seen, not until the first
+response ends.
 
 Listing is a **second explicit opt-in** on top of sharing (the checkbox in the
 share dialog, or `POST /api/v1/scans/:id/share { "threatFeed": true|false }`):
@@ -113,6 +125,11 @@ holding a link is capability, appearing in an index is publication, and the two
 must never be conflated. Revoking the share link always unlists the report;
 re-sharing later starts unlisted. Listing changes are audited
 (`scan.feed_listed`, `scan.feed_unlisted`).
+
+`{ "threatFeed": false }` is a _withdrawal_ and never creates a share link. On
+a scan whose link was revoked in the meantime it returns `409` (the dialog
+drops its stale share state and falls back to "create link") rather than
+quietly minting a fresh token and republishing the report.
 
 ### Package identity
 
@@ -131,19 +148,41 @@ Each feed entry carries `packageIdentity`:
 
 Badge and feed responses read through the per-colo Workers cache
 (`caches.default`) and declare `max-age=300`. The cache key is the canonical
-path with any query string ignored, and badge URLs collapse onto their package
-lookup key, so one package has exactly one entry however an embedder cased or
-encoded the name.
+origin plus path, query string ignored, and badge URLs collapse onto their
+package lookup key, so one package has one entry per colo however an embedder
+encoded the name. Case is part of that key for npm — the registry treats
+existing names case-sensitively, so `JSONStream` and `jsonstream` are different
+packages and must not share a badge — while PyPI (PEP 503) and VS Code fold, as
+`publicPackageLookupKey` documents. Two consequences: `/badge/npm/React` is its
+own entry and resolves to "not reviewed", and the origin must be the _canonical_
+one on both the write and the purge, or a second bound hostname builds entries
+the purge never visits.
 
-Revoking a share or unlisting a report **purges both entries** rather than
-waiting out the TTL: a withdrawn review must stop being asserted, and a cached
-feed body embeds a now-dead share token. Report and attestation responses are
-uncached (`no-store`) for the same reason. What the TTL still bounds is
-staleness from changes that are not revocations — a decision recorded after the
-badge was cached can take up to ~5 minutes to show as `blocked`. Badge cache misses use a rate-limit bucket separate from report
-reads; a throttled badge still returns an uncached valid shields.io payload so
-shared badge-proxy traffic cannot produce an error badge or exhaust report
-access.
+Badge **misses** are deliberately not written to the colo cache. The "not
+reviewed" body is identical for every package, so a per-name entry buys nothing
+the downstream `max-age` doesn't already absorb, while every invented name would
+add an entry to the namespace that also holds published-tarball bytes. Cursored
+feed pages (`?after=`) are uncached too, since the key ignores the query.
+
+Revoking a share or unlisting a report purges both entries. **That purge is
+colo-local and best effort**: `caches.default.delete()` clears the entry in the
+colo that handled the revoking request and nowhere else, so other regions keep
+serving the withdrawn badge until `max-age` expires — and shields.io's own cache
+(a ≥300s floor it enforces regardless of what we send) sits in front of that.
+Plan for a withdrawal to take effect on the derived surfaces within roughly ten
+minutes, not instantly. Only the report and attestation routes are immediate,
+via `no-store` plus a D1 lookup on every request; they are the authority, and
+the badge links to them.
+
+The same TTL bounds non-revocation staleness: a decision recorded after the
+badge was cached can take ~5 minutes to render as `blocked`.
+
+Badge reads use a rate-limit bucket separate from report reads, because badge
+proxies multiplex unrelated packages through a handful of egress addresses. A
+throttled badge returns an uncached, valid shields.io payload reading
+`unavailable` — never `not reviewed`, which is an assertion _about the package_
+that shields would cache for minutes, potentially over a review that says
+`blocked`.
 
 ## Key management
 

--- a/docs/public-reports.md
+++ b/docs/public-reports.md
@@ -125,7 +125,10 @@ Badge and feed responses read through the per-colo Workers cache
 `max-age=300`, so listing or revocation changes can take up to ~5 minutes to
 propagate to these two surfaces. Report and attestation responses are
 deliberately uncached (`no-store`): revoking a share link takes effect
-immediately.
+immediately. Badge cache misses use a rate-limit bucket separate from report
+reads; a throttled badge still returns an uncached valid shields.io payload so
+shared badge-proxy traffic cannot produce an error badge or exhaust report
+access.
 
 ## Key management
 

--- a/docs/public-reports.md
+++ b/docs/public-reports.md
@@ -127,9 +127,11 @@ re-sharing later starts unlisted. Listing changes are audited
 (`scan.feed_listed`, `scan.feed_unlisted`).
 
 `{ "threatFeed": false }` is a _withdrawal_ and never creates a share link. On
-a scan whose link was revoked in the meantime it returns `409` (the dialog
-drops its stale share state and falls back to "create link") rather than
-quietly minting a fresh token and republishing the report.
+a scan that is not currently shared it returns `409` (the dialog drops its
+stale share state and falls back to "create link") rather than quietly minting
+a fresh token and republishing the report. Revoking nulls the share token and
+its timestamp together, so "revoked a moment ago" and "never shared" are the
+same persisted state and the 409 does not claim to tell them apart.
 
 ### Package identity
 
@@ -143,6 +145,14 @@ Each feed entry carries `packageIdentity`:
   Consumers should weigh these accordingly. (Known limitation: post-publish
   digest verification against the registry would upgrade gate claims; not
   built yet.)
+
+`ecosystem` is `null` when a gate scan's provenance snapshot never established
+one — a legacy pre-provenance record, or a redaction that failed. Such a scan
+can still be feed-listed, but it is not badge-discoverable under any ecosystem:
+defaulting an unknown to npm would let a PyPI or VS Code release take the npm
+badge for its own name, in the one ecosystem where a registry-verified review
+exists to be displaced. Partners should treat a null `ecosystem` as unknown
+rather than assuming npm.
 
 ### Caching
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -92,6 +92,14 @@ The `/og/diff/**/card.png` share cards are part of the same anonymous surface an
 
 Marketing attribution is a `marketing_page.viewed` Analytics Engine event. The only public surfaces recorded are the landing page, the docs page, and the package diff; authenticated routes are never recorded. A request is reduced to `(surface, channel bucket)` where the bucket comes from a closed allowlist — no IP, no full referrer URL, no user agent, no session identifier, package name, or version is written. An unrecognized `utm_source` collapses to `other` rather than creating unbounded analytics dimension cardinality.
 
+Three further anonymous endpoints exist, all under `/public`, all serving only data an organization owner/admin explicitly opted into publishing:
+
+- `GET /public/reports/:token` and `GET /public/reports/:token/attestation` — capability URLs. The unguessable 256-bit share token _is_ the authorization; unknown, malformed, and revoked tokens are indistinguishable 404s. They serve the canonical report export (never file samples, events, or org/user identifiers), attach no credentials, persist nothing, are `no-store` so revocation is immediate, and are per-IP rate limited. `GET /public/attestation-key` returns public key material only.
+- `GET /public/badge/:ecosystem/*` — a shields.io endpoint payload for a package's latest review. Reflects only scans whose org took the _second_ opt-in (feed listing) on top of sharing, so a private share link never makes a scan name-queryable. The response carries no package name, no org identity, and no share token; an unlisted-but-scanned package and a never-scanned package return byte-identical bodies, so there is no enumeration oracle. Separate per-IP rate-limit bucket (badge proxies multiplex unrelated packages through shared egress addresses), and a throttled response says `unavailable` rather than impersonating `not reviewed`.
+- `GET /public/threat-feed.json` — the listed set, newest first, keyset-paginated. Entries carry package identity, risk, decision, counts, and the public report URL; no organization id, user id, or internal scan id.
+
+Both derived surfaces are colo-cached for 300s and purged on revoke/unlist. That purge is **colo-local and best effort** — it clears the region that served the revoking request, and every other region serves the withdrawn body until the TTL expires (longer still behind a badge proxy's own cache). The report itself has no such window. Treat the badge and feed as eventually consistent; the report route is the authority.
+
 The `pkg.pr.new` egress (npm only) is bounded by a shared strict URL parser (`src/lib/pkg-pr-new.ts`): only `https://pkg.pr.new` (exact host, no port, no credentials, no query/fragment) with a canonical `owner/repo/name@ref`-shaped path is ever fetched, the fetch path is structurally anonymous (`fetchPkgPrNewTarballStream` accepts no token option), and preview bytes are never written to the shared colo tarball cache because preview refs are mutable. Diff results that involve a preview side are cached for at most 15 minutes.
 
 ## Browser response headers
@@ -100,7 +108,7 @@ Production responses should keep conservative security headers: no package-provi
 
 ## Known gaps / future work
 
-- Public report sharing is an explicit owner/admin opt-in per completed scan: an unguessable 256-bit token exposes the canonical report export (never file samples, events, or org/user identifiers) at `/public/reports/:token`, with an Ed25519-signed DSSE attestation over those exact bytes. See `public-reports.md`.
+- Public report sharing is an explicit owner/admin opt-in per completed scan; the badge and threat feed are a second opt-in on top of it. See `public-reports.md` and the authorization posture section above.
 - Raw-artifact retention, if ever added, must be explicit, short-TTL, organization-scoped, and documented.
 - Additional ecosystems need adapter-specific credential, baseline, artifact, and failure-mode review before enablement.
 - Keep dependency and parser updates covered by regression/fuzz tests because archive handling is a trust boundary.

--- a/drizzle/0026_brave_banshee.sql
+++ b/drizzle/0026_brave_banshee.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `scans` ADD `public_feed_listed_at` integer;--> statement-breakpoint
+ALTER TABLE `scans` ADD `public_package_key` text;--> statement-breakpoint
+CREATE INDEX `scans_public_package_key_completed_idx` ON `scans` (`public_package_key`,`completed_at`);--> statement-breakpoint
+CREATE INDEX `scans_public_feed_listed_idx` ON `scans` (`public_feed_listed_at`);

--- a/drizzle/0026_mixed_meltdown.sql
+++ b/drizzle/0026_mixed_meltdown.sql
@@ -1,5 +1,0 @@
-ALTER TABLE `scans` ADD `public_feed_listed_at` integer;--> statement-breakpoint
-ALTER TABLE `scans` ADD `public_package_key` text;--> statement-breakpoint
-CREATE INDEX `scans_package_completed_idx` ON `scans` (`package_name`,`completed_at`);--> statement-breakpoint
-CREATE INDEX `scans_public_feed_listed_idx` ON `scans` (`public_feed_listed_at`);--> statement-breakpoint
-CREATE INDEX `scans_public_package_key_idx` ON `scans` (`public_package_key`);

--- a/drizzle/0026_mixed_meltdown.sql
+++ b/drizzle/0026_mixed_meltdown.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `scans` ADD `public_feed_listed_at` integer;--> statement-breakpoint
+ALTER TABLE `scans` ADD `public_package_key` text;--> statement-breakpoint
+CREATE INDEX `scans_package_completed_idx` ON `scans` (`package_name`,`completed_at`);--> statement-breakpoint
+CREATE INDEX `scans_public_feed_listed_idx` ON `scans` (`public_feed_listed_at`);--> statement-breakpoint
+CREATE INDEX `scans_public_package_key_idx` ON `scans` (`public_package_key`);

--- a/drizzle/0026_strong_ares.sql
+++ b/drizzle/0026_strong_ares.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `scans` ADD `public_package_key` text;--> statement-breakpoint
+CREATE INDEX `scans_public_package_key_idx` ON `scans` (`public_package_key`);

--- a/drizzle/0026_strong_ares.sql
+++ b/drizzle/0026_strong_ares.sql
@@ -1,2 +1,0 @@
-ALTER TABLE `scans` ADD `public_package_key` text;--> statement-breakpoint
-CREATE INDEX `scans_public_package_key_idx` ON `scans` (`public_package_key`);

--- a/drizzle/meta/0026_snapshot.json
+++ b/drizzle/meta/0026_snapshot.json
@@ -1,8 +1,8 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "bde138e4-f987-45b9-bfd1-a2459f7e0af0",
-  "prevId": "ad493616-10bf-429c-8e90-fd492730628c",
+  "id": "82b955aa-1e43-4038-95c1-8ac7482e1a17",
+  "prevId": "00f11faf-874e-4641-97bf-3def02727b1c",
   "tables": {
     "account": {
       "name": "account",
@@ -1507,6 +1507,20 @@
             "scan_id"
           ],
           "isUnique": false
+        },
+        "scan_events_created_idx": {
+          "name": "scan_events_created_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_actor_idx": {
+          "name": "scan_events_actor_idx",
+          "columns": [
+            "actor_user_id"
+          ],
+          "isUnique": false
         }
       },
       "foreignKeys": {
@@ -2100,6 +2114,13 @@
           ],
           "isUnique": false
         },
+        "scans_decided_by_idx": {
+          "name": "scans_decided_by_idx",
+          "columns": [
+            "decided_by_user_id"
+          ],
+          "isUnique": false
+        },
         "scans_public_share_token_unique_idx": {
           "name": "scans_public_share_token_unique_idx",
           "columns": [
@@ -2491,7 +2512,15 @@
           "autoincrement": false
         }
       },
-      "indexes": {},
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},

--- a/drizzle/meta/0026_snapshot.json
+++ b/drizzle/meta/0026_snapshot.json
@@ -1,8 +1,8 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "82b955aa-1e43-4038-95c1-8ac7482e1a17",
-  "prevId": "00f11faf-874e-4641-97bf-3def02727b1c",
+  "id": "3e6e53aa-9934-48a5-b804-47b2723d0387",
+  "prevId": "37903981-b812-4498-8c74-65b17ea0f64a",
   "tables": {
     "account": {
       "name": "account",
@@ -2070,10 +2070,10 @@
           ],
           "isUnique": false
         },
-        "scans_package_completed_idx": {
-          "name": "scans_package_completed_idx",
+        "scans_public_package_key_completed_idx": {
+          "name": "scans_public_package_key_completed_idx",
           "columns": [
-            "package_name",
+            "public_package_key",
             "completed_at"
           ],
           "isUnique": false
@@ -2121,6 +2121,13 @@
           ],
           "isUnique": false
         },
+        "scans_public_shared_by_idx": {
+          "name": "scans_public_shared_by_idx",
+          "columns": [
+            "public_shared_by_user_id"
+          ],
+          "isUnique": false
+        },
         "scans_public_share_token_unique_idx": {
           "name": "scans_public_share_token_unique_idx",
           "columns": [
@@ -2132,13 +2139,6 @@
           "name": "scans_public_feed_listed_idx",
           "columns": [
             "public_feed_listed_at"
-          ],
-          "isUnique": false
-        },
-        "scans_public_package_key_idx": {
-          "name": "scans_public_package_key_idx",
-          "columns": [
-            "public_package_key"
           ],
           "isUnique": false
         }

--- a/drizzle/meta/0026_snapshot.json
+++ b/drizzle/meta/0026_snapshot.json
@@ -1,0 +1,2511 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "bde138e4-f987-45b9-bfd1-a2459f7e0af0",
+  "prevId": "ad493616-10bf-429c-8e90-fd492730628c",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_user_idx": {
+          "name": "account_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_app_installations": {
+      "name": "github_app_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Organization'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uninstalled_at": {
+          "name": "uninstalled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_app_installations_installation_unique_idx": {
+          "name": "github_app_installations_installation_unique_idx",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        },
+        "github_app_installations_org_idx": {
+          "name": "github_app_installations_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installations_created_by_user_id_user_id_fk": {
+          "name": "github_app_installations_created_by_user_id_user_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_release_targets": {
+      "name": "github_release_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ecosystem": {
+          "name": "ecosystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_release_targets_org_repo_env_unique_idx": {
+          "name": "github_release_targets_org_repo_env_unique_idx",
+          "columns": [
+            "organization_id",
+            "repository_id",
+            "environment"
+          ],
+          "isUnique": true
+        },
+        "github_release_targets_installation_idx": {
+          "name": "github_release_targets_installation_idx",
+          "columns": [
+            "installation_row_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_release_targets_organization_id_organizations_id_fk": {
+          "name": "github_release_targets_organization_id_organizations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_release_targets_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_created_by_user_id_user_id_fk": {
+          "name": "github_release_targets_created_by_user_id_user_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_workflow_gates": {
+      "name": "github_workflow_gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_target_id": {
+          "name": "release_target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deployment_callback_url": {
+          "name": "deployment_callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_comment": {
+          "name": "decision_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_url": {
+          "name": "report_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_started_at": {
+          "name": "review_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_workflow_gates_delivery_unique_idx": {
+          "name": "github_workflow_gates_delivery_unique_idx",
+          "columns": [
+            "delivery_id"
+          ],
+          "isUnique": true
+        },
+        "github_workflow_gates_org_status_idx": {
+          "name": "github_workflow_gates_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_release_target_idx": {
+          "name": "github_workflow_gates_release_target_idx",
+          "columns": [
+            "release_target_id"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_scan_idx": {
+          "name": "github_workflow_gates_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_workflow_gates_organization_id_organizations_id_fk": {
+          "name": "github_workflow_gates_organization_id_organizations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_workflow_gates_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_release_target_id_github_release_targets_id_fk": {
+          "name": "github_workflow_gates_release_target_id_github_release_targets_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_release_targets",
+          "columnsFrom": [
+            "release_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_scan_id_scans_id_fk": {
+          "name": "github_workflow_gates_scan_id_scans_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_unique_idx": {
+          "name": "npm_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_invitations": {
+      "name": "organization_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_invitations_token_hash_unique_idx": {
+          "name": "organization_invitations_token_hash_unique_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "organization_invitations_org_status_idx": {
+          "name": "organization_invitations_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "organization_invitations_org_email_idx": {
+          "name": "organization_invitations_org_email_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_invitations_organization_id_organizations_id_fk": {
+          "name": "organization_invitations_organization_id_organizations_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_invited_by_user_id_user_id_fk": {
+          "name": "organization_invitations_invited_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_accepted_by_user_id_user_id_fk": {
+          "name": "organization_invitations_accepted_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_notification_recipients": {
+      "name": "organization_notification_recipients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_notification_recipients_org_email_unique_idx": {
+          "name": "organization_notification_recipients_org_email_unique_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_notification_recipients_organization_id_organizations_id_fk": {
+          "name": "organization_notification_recipients_organization_id_organizations_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_notification_recipients_created_by_user_id_user_id_fk": {
+          "name": "organization_notification_recipients_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_slack_connections": {
+      "name": "organization_slack_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_token_ciphertext": {
+          "name": "bot_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bot_token_nonce": {
+          "name": "bot_token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slack_connections_org_unique_idx": {
+          "name": "organization_slack_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_slack_connections_organization_id_organizations_id_fk": {
+          "name": "organization_slack_connections_organization_id_organizations_id_fk",
+          "tableFrom": "organization_slack_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_slack_connections_created_by_user_id_user_id_fk": {
+          "name": "organization_slack_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_slack_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "require_two_factor_for_release_decisions": {
+          "name": "require_two_factor_for_release_decisions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_findings_scan_severity_idx": {
+          "name": "scan_findings_scan_severity_idx",
+          "columns": [
+            "scan_id",
+            "severity"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changed_file_count": {
+          "name": "changed_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_summary_json": {
+          "name": "risk_summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_storage_version": {
+          "name": "artifact_storage_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_key": {
+          "name": "artifact_manifest_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_digest": {
+          "name": "artifact_manifest_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_size": {
+          "name": "artifact_manifest_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_artifact_key": {
+          "name": "report_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_samples_artifact_key": {
+          "name": "file_samples_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "diff_artifact_key": {
+          "name": "diff_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_share_token": {
+          "name": "public_share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_shared_at": {
+          "name": "public_shared_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_shared_by_user_id": {
+          "name": "public_shared_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_feed_listed_at": {
+          "name": "public_feed_listed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_package_key": {
+          "name": "public_package_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        },
+        "scans_package_completed_idx": {
+          "name": "scans_package_completed_idx",
+          "columns": [
+            "package_name",
+            "completed_at"
+          ],
+          "isUnique": false
+        },
+        "scans_gate_org_idx": {
+          "name": "scans_gate_org_idx",
+          "columns": [
+            "gate_id",
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_artifact_backfill_idx": {
+          "name": "scans_artifact_backfill_idx",
+          "columns": [
+            "organization_id",
+            "status",
+            "artifact_storage_version",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "scans_org_decision_created_idx": {
+          "name": "scans_org_decision_created_idx",
+          "columns": [
+            "organization_id",
+            "decision",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scans_org_created_idx": {
+          "name": "scans_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "scans_public_share_token_unique_idx": {
+          "name": "scans_public_share_token_unique_idx",
+          "columns": [
+            "public_share_token"
+          ],
+          "isUnique": true
+        },
+        "scans_public_feed_listed_idx": {
+          "name": "scans_public_feed_listed_idx",
+          "columns": [
+            "public_feed_listed_at"
+          ],
+          "isUnique": false
+        },
+        "scans_public_package_key_idx": {
+          "name": "scans_public_package_key_idx",
+          "columns": [
+            "public_package_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_gate_id_github_workflow_gates_id_fk": {
+          "name": "scans_gate_id_github_workflow_gates_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "github_workflow_gates",
+          "columnsFrom": [
+            "gate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_decided_by_user_id_user_id_fk": {
+          "name": "scans_decided_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_public_shared_by_user_id_user_id_fk": {
+          "name": "scans_public_shared_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "public_shared_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "two_factor": {
+      "name": "two_factor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed_verification_count": {
+          "name": "failed_verification_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "two_factor_user_idx": {
+          "name": "two_factor_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1785173070110,
       "tag": "0025_perpetual_iron_patriot",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "6",
+      "when": 1784152882196,
+      "tag": "0026_strong_ares",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -187,8 +187,8 @@
     {
       "idx": 26,
       "version": "6",
-      "when": 1784152882196,
-      "tag": "0026_strong_ares",
+      "when": 1785043845230,
+      "tag": "0026_mixed_meltdown",
       "breakpoints": true
     }
   ]

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -187,8 +187,8 @@
     {
       "idx": 26,
       "version": "6",
-      "when": 1785043845230,
-      "tag": "0026_mixed_meltdown",
+      "when": 1785173461659,
+      "tag": "0026_brave_banshee",
       "breakpoints": true
     }
   ]

--- a/server/db/scan-share.ts
+++ b/server/db/scan-share.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNotNull, isNull } from "drizzle-orm";
+import { and, desc, eq, isNotNull, isNull, or, sql } from "drizzle-orm";
 import { base64UrlEncode } from "../lib/platform/crypto-utils";
 import type { AppDb } from "./client";
 import { recordScanEvent } from "./events";
@@ -16,6 +16,7 @@ function generatePublicShareToken(): string {
 export interface PublicShareState {
   publicShareToken: string;
   publicSharedAt: Date;
+  publicFeedListedAt: Date | null;
 }
 
 /**
@@ -33,6 +34,7 @@ export async function enablePublicShare(
         status: scans.status,
         publicShareToken: scans.publicShareToken,
         publicSharedAt: scans.publicSharedAt,
+        publicFeedListedAt: scans.publicFeedListedAt,
         packageName: scans.packageName,
         stagedVersion: scans.stagedVersion,
       })
@@ -44,7 +46,11 @@ export async function enablePublicShare(
   if (!existing) return null;
   if (existing.status !== "complete") return null;
   if (existing.publicShareToken && existing.publicSharedAt) {
-    return { publicShareToken: existing.publicShareToken, publicSharedAt: existing.publicSharedAt };
+    return {
+      publicShareToken: existing.publicShareToken,
+      publicSharedAt: existing.publicSharedAt,
+      publicFeedListedAt: existing.publicFeedListedAt,
+    };
   }
 
   const now = new Date();
@@ -72,7 +78,11 @@ export async function enablePublicShare(
     // Lost the race to a concurrent enable — return the winner's token.
     const [current] = await readShareState();
     if (current?.publicShareToken && current.publicSharedAt) {
-      return { publicShareToken: current.publicShareToken, publicSharedAt: current.publicSharedAt };
+      return {
+        publicShareToken: current.publicShareToken,
+        publicSharedAt: current.publicSharedAt,
+        publicFeedListedAt: current.publicFeedListedAt,
+      };
     }
     return null;
   }
@@ -84,10 +94,14 @@ export async function enablePublicShare(
     type: "scan.share_enabled",
     metadata: { packageName: existing.packageName, stagedVersion: existing.stagedVersion },
   });
-  return { publicShareToken: token, publicSharedAt: now };
+  return { publicShareToken: token, publicSharedAt: now, publicFeedListedAt: null };
 }
 
-/** Revoke the public share link. Returns false when the scan was not shared. */
+/**
+ * Revoke the public share link. Returns false when the scan was not shared.
+ * Also drops any threat-feed listing — an unreachable report must never stay
+ * indexed in the public feed.
+ */
 export async function revokePublicShare(
   db: AppDb,
   input: { scanId: string; organizationId: string; actorUserId: string },
@@ -99,6 +113,7 @@ export async function revokePublicShare(
       publicShareToken: null,
       publicSharedAt: null,
       publicSharedByUserId: null,
+      publicFeedListedAt: null,
       updatedAt: now,
     })
     .where(
@@ -123,6 +138,139 @@ export async function revokePublicShare(
     metadata: { packageName: updated[0].packageName, stagedVersion: updated[0].stagedVersion },
   });
   return true;
+}
+
+/**
+ * Toggle the threat-feed listing for an already-shared scan. Listing requires
+ * an active share link (the feed entry links to the public report); unlisting
+ * keeps the link itself intact. Returns the new state, or null when the scan
+ * is missing, not complete, or (for listing) not currently shared.
+ */
+export async function setThreatFeedListing(
+  db: AppDb,
+  input: { scanId: string; organizationId: string; actorUserId: string; listed: boolean },
+): Promise<PublicShareState | null> {
+  const now = new Date();
+  const scoped = and(
+    eq(scans.id, input.scanId),
+    eq(scans.organizationId, input.organizationId),
+    eq(scans.status, "complete"),
+    isNotNull(scans.publicShareToken),
+  );
+  const updated = await db
+    .update(scans)
+    .set({ publicFeedListedAt: input.listed ? now : null, updatedAt: now })
+    .where(scoped)
+    .returning({
+      publicShareToken: scans.publicShareToken,
+      publicSharedAt: scans.publicSharedAt,
+      publicFeedListedAt: scans.publicFeedListedAt,
+    });
+  const row = updated[0];
+  if (!row?.publicShareToken || !row.publicSharedAt) return null;
+
+  await recordScanEvent(db, {
+    organizationId: input.organizationId,
+    actorUserId: input.actorUserId,
+    scanId: input.scanId,
+    type: input.listed ? "scan.feed_listed" : "scan.feed_unlisted",
+  });
+  return {
+    publicShareToken: row.publicShareToken,
+    publicSharedAt: row.publicSharedAt,
+    publicFeedListedAt: row.publicFeedListedAt,
+  };
+}
+
+export const THREAT_FEED_MAX_ENTRIES = 100;
+
+export interface SharedScanRow {
+  scanId: string;
+  source: string;
+  packageName: string | null;
+  stagedVersion: string | null;
+  previousVersion: string | null;
+  risk: string;
+  decision: string | null;
+  findingCount: number | null;
+  riskSummaryJson: unknown;
+  summaryJson: unknown;
+  publicShareToken: string | null;
+  publicFeedListedAt: Date | null;
+  completedAt: Date | null;
+}
+
+const SHARED_SCAN_COLUMNS = {
+  scanId: scans.id,
+  source: scans.source,
+  packageName: scans.packageName,
+  stagedVersion: scans.stagedVersion,
+  previousVersion: scans.previousVersion,
+  risk: scans.risk,
+  decision: scans.decision,
+  findingCount: scans.findingCount,
+  riskSummaryJson: scans.riskSummaryJson,
+  summaryJson: scans.summaryJson,
+  publicShareToken: scans.publicShareToken,
+  publicFeedListedAt: scans.publicFeedListedAt,
+  completedAt: scans.completedAt,
+} as const;
+
+/** Feed-listed shared scans, newest listing first. */
+export async function listThreatFeedScans(
+  db: AppDb,
+  limit = THREAT_FEED_MAX_ENTRIES,
+): Promise<SharedScanRow[]> {
+  return db
+    .select(SHARED_SCAN_COLUMNS)
+    .from(scans)
+    .where(
+      and(
+        isNotNull(scans.publicFeedListedAt),
+        isNotNull(scans.publicShareToken),
+        eq(scans.status, "complete"),
+      ),
+    )
+    .orderBy(desc(scans.publicFeedListedAt), desc(scans.id))
+    .limit(limit);
+}
+
+/**
+ * Recent badge-eligible reviews for one package name. The badge is a
+ * discoverable index keyed by package name, so — exactly like the threat
+ * feed — it only ever reflects scans whose org explicitly opted into feed
+ * listing; a privately shared link never becomes name-queryable.
+ *
+ * Ecosystem is filtered in SQL over the persisted provenance snapshot
+ * (staged-publish scans carry no snapshot and are npm by construction), so a
+ * package that is busy in one ecosystem can never crowd another ecosystem's
+ * review out of the bounded page.
+ */
+export async function listBadgeCandidateScans(
+  db: AppDb,
+  packageName: string,
+  ecosystem: "npm" | "pypi" | "vscode",
+  limit = 20,
+): Promise<SharedScanRow[]> {
+  const provenanceEcosystem = sql`json_extract(${scans.summaryJson}, '$.stagedPublish.provenance.ecosystem')`;
+  const ecosystemMatches =
+    ecosystem === "npm"
+      ? or(sql`${provenanceEcosystem} = 'npm'`, sql`${provenanceEcosystem} IS NULL`)
+      : sql`${provenanceEcosystem} = ${ecosystem}`;
+  return db
+    .select(SHARED_SCAN_COLUMNS)
+    .from(scans)
+    .where(
+      and(
+        eq(scans.packageName, packageName),
+        isNotNull(scans.publicShareToken),
+        isNotNull(scans.publicFeedListedAt),
+        eq(scans.status, "complete"),
+        ecosystemMatches,
+      ),
+    )
+    .orderBy(desc(scans.completedAt), desc(scans.id))
+    .limit(limit);
 }
 
 /**

--- a/server/db/scan-share.ts
+++ b/server/db/scan-share.ts
@@ -1,5 +1,6 @@
 import { and, desc, eq, isNotNull, isNull, or, sql } from "drizzle-orm";
 import { base64UrlEncode } from "../lib/platform/crypto-utils";
+import { publicPackageLookupKey, scanEcosystem } from "../lib/public-feed";
 import type { AppDb } from "./client";
 import { recordScanEvent } from "./events";
 import { scans } from "./schema";
@@ -114,6 +115,7 @@ export async function revokePublicShare(
       publicSharedAt: null,
       publicSharedByUserId: null,
       publicFeedListedAt: null,
+      publicPackageKey: null,
       updatedAt: now,
     })
     .where(
@@ -157,9 +159,23 @@ export async function setThreatFeedListing(
     eq(scans.status, "complete"),
     isNotNull(scans.publicShareToken),
   );
+  const [candidate] = await db
+    .select({ packageName: scans.packageName, summaryJson: scans.summaryJson })
+    .from(scans)
+    .where(scoped)
+    .limit(1);
+  if (!candidate) return null;
+  const publicPackageKey =
+    input.listed && candidate.packageName
+      ? publicPackageLookupKey(scanEcosystem(candidate.summaryJson), candidate.packageName)
+      : null;
   const updated = await db
     .update(scans)
-    .set({ publicFeedListedAt: input.listed ? now : null, updatedAt: now })
+    .set({
+      publicFeedListedAt: input.listed ? now : null,
+      publicPackageKey,
+      updatedAt: now,
+    })
     .where(scoped)
     .returning({
       publicShareToken: scans.publicShareToken,
@@ -255,6 +271,7 @@ export async function listBadgeCandidateScans(
   ecosystem: "npm" | "pypi" | "vscode",
   limit = 20,
 ): Promise<SharedScanRow[]> {
+  const packageKey = publicPackageLookupKey(ecosystem, packageName);
   const provenanceEcosystem = sql`json_extract(${scans.summaryJson}, '$.stagedPublish.provenance.ecosystem')`;
   const ecosystemMatches =
     ecosystem === "npm"
@@ -269,7 +286,7 @@ export async function listBadgeCandidateScans(
     .from(scans)
     .where(
       and(
-        eq(scans.packageName, packageName),
+        eq(scans.publicPackageKey, packageKey),
         isNotNull(scans.publicShareToken),
         isNotNull(scans.publicFeedListedAt),
         eq(scans.status, "complete"),

--- a/server/db/scan-share.ts
+++ b/server/db/scan-share.ts
@@ -18,6 +18,13 @@ export interface PublicShareState {
   publicShareToken: string;
   publicSharedAt: Date;
   publicFeedListedAt: Date | null;
+  /**
+   * Canonical badge key this scan occupies, so a caller can purge the colo-
+   * cached badge after a listing change. Present whether or not the scan is
+   * currently listed — an *un*listing is exactly when the cached body goes
+   * stale.
+   */
+  publicPackageKey?: string | null;
 }
 
 /**
@@ -106,7 +113,7 @@ export async function enablePublicShare(
 export async function revokePublicShare(
   db: AppDb,
   input: { scanId: string; organizationId: string; actorUserId: string },
-): Promise<boolean> {
+): Promise<{ revoked: boolean; publicPackageKey: string | null }> {
   const now = new Date();
   const updated = await db
     .update(scans)
@@ -129,8 +136,11 @@ export async function revokePublicShare(
       id: scans.id,
       packageName: scans.packageName,
       stagedVersion: scans.stagedVersion,
+      // `public_package_key` is nulled by this same UPDATE, so the key that
+      // just went stale is recomputed from the (untouched) package name.
+      summaryJson: scans.summaryJson,
     });
-  if (updated.length === 0) return false;
+  if (updated.length === 0) return { revoked: false, publicPackageKey: null };
 
   await recordScanEvent(db, {
     organizationId: input.organizationId,
@@ -139,7 +149,12 @@ export async function revokePublicShare(
     type: "scan.share_revoked",
     metadata: { packageName: updated[0].packageName, stagedVersion: updated[0].stagedVersion },
   });
-  return true;
+  return {
+    revoked: true,
+    publicPackageKey: updated[0].packageName
+      ? publicPackageLookupKey(scanEcosystem(updated[0].summaryJson), updated[0].packageName)
+      : null,
+  };
 }
 
 /**
@@ -195,6 +210,11 @@ export async function setThreatFeedListing(
     metadata: { packageName: row.packageName, stagedVersion: row.stagedVersion },
   });
   return {
+    publicPackageKey:
+      publicPackageKey ??
+      (row.packageName
+        ? publicPackageLookupKey(scanEcosystem(candidate.summaryJson), row.packageName)
+        : null),
     publicShareToken: row.publicShareToken,
     publicSharedAt: row.publicSharedAt,
     publicFeedListedAt: row.publicFeedListedAt,

--- a/server/db/scan-share.ts
+++ b/server/db/scan-share.ts
@@ -28,6 +28,35 @@ export interface PublicShareState {
 }
 
 /**
+ * Read the current share state without creating one. Callers acting on an
+ * *existing* share — notably unlisting from the threat feed — must go through
+ * this rather than `enablePublicShare`, or a withdrawal turns into a
+ * publication when the link was revoked in the meantime.
+ */
+export async function readPublicShare(
+  db: AppDb,
+  input: { scanId: string; organizationId: string },
+): Promise<PublicShareState | null> {
+  const [row] = await db
+    .select({
+      publicShareToken: scans.publicShareToken,
+      publicSharedAt: scans.publicSharedAt,
+      publicFeedListedAt: scans.publicFeedListedAt,
+      publicPackageKey: scans.publicPackageKey,
+    })
+    .from(scans)
+    .where(and(eq(scans.id, input.scanId), eq(scans.organizationId, input.organizationId)))
+    .limit(1);
+  if (!row?.publicShareToken || !row.publicSharedAt) return null;
+  return {
+    publicShareToken: row.publicShareToken,
+    publicSharedAt: row.publicSharedAt,
+    publicFeedListedAt: row.publicFeedListedAt,
+    publicPackageKey: row.publicPackageKey,
+  };
+}
+
+/**
  * Enable (or return the existing) public share link for a completed scan.
  * Idempotent: re-sharing an already-shared scan returns the current token so
  * the UI never rotates a link that may already be distributed.
@@ -255,11 +284,42 @@ const SHARED_SCAN_COLUMNS = {
   completedAt: scans.completedAt,
 } as const;
 
-/** Feed-listed shared scans, newest listing first. */
+export interface ThreatFeedCursor {
+  listedAtMs: number;
+  scanId: string;
+}
+
+/** `<listedAtMs>:<scanId>` — the same shape as the scan list cursor. */
+export function parseThreatFeedCursor(raw: string | undefined): ThreatFeedCursor | null {
+  if (!raw) return null;
+  const sep = raw.indexOf(":");
+  if (sep <= 0) return null;
+  const listedAtMs = Number(raw.slice(0, sep));
+  const scanId = raw.slice(sep + 1);
+  if (!Number.isFinite(listedAtMs) || !scanId) return null;
+  return { listedAtMs, scanId };
+}
+
+export function encodeThreatFeedCursor(cursor: ThreatFeedCursor | null): string | null {
+  return cursor ? `${cursor.listedAtMs}:${cursor.scanId}` : null;
+}
+
+/**
+ * Feed-listed shared scans, newest listing first, keyset-paginated.
+ *
+ * The page is bounded, and without a cursor the bound is the whole story a
+ * consumer can see: one organization listing a batch of its own scans pushes
+ * everything older — including other organizations' `no_publish` releases —
+ * off the end, and a poller that only ever reads page one silently misses
+ * them. `(publicFeedListedAt, id)` is a total order over the listed set, so
+ * `after` walks backwards through it and nothing is ever unreachable.
+ */
 export async function listThreatFeedScans(
   db: AppDb,
-  limit = THREAT_FEED_MAX_ENTRIES,
+  options: { limit?: number; after?: ThreatFeedCursor | null } = {},
 ): Promise<SharedScanRow[]> {
+  const limit = Math.min(options.limit ?? THREAT_FEED_MAX_ENTRIES, THREAT_FEED_MAX_ENTRIES);
+  const after = options.after ?? null;
   return db
     .select(SHARED_SCAN_COLUMNS)
     .from(scans)
@@ -268,10 +328,30 @@ export async function listThreatFeedScans(
         isNotNull(scans.publicFeedListedAt),
         isNotNull(scans.publicShareToken),
         eq(scans.status, "complete"),
+        after
+          ? or(
+              sql`${scans.publicFeedListedAt} < ${after.listedAtMs}`,
+              and(
+                sql`${scans.publicFeedListedAt} = ${after.listedAtMs}`,
+                sql`${scans.id} < ${after.scanId}`,
+              ),
+            )
+          : undefined,
       ),
     )
     .orderBy(desc(scans.publicFeedListedAt), desc(scans.id))
     .limit(limit);
+}
+
+/** The cursor that continues a page, or null when the feed is exhausted. */
+export function threatFeedNextCursor(
+  rows: SharedScanRow[],
+  limit: number,
+): ThreatFeedCursor | null {
+  if (rows.length < limit) return null;
+  const last = rows[rows.length - 1];
+  if (!last?.publicFeedListedAt) return null;
+  return { listedAtMs: last.publicFeedListedAt.getTime(), scanId: last.scanId };
 }
 
 /**

--- a/server/db/scan-share.ts
+++ b/server/db/scan-share.ts
@@ -166,7 +166,8 @@ export async function revokePublicShare(
       packageName: scans.packageName,
       stagedVersion: scans.stagedVersion,
       // `public_package_key` is nulled by this same UPDATE, so the key that
-      // just went stale is recomputed from the (untouched) package name.
+      // just went stale is recomputed from the (untouched) source + snapshot.
+      source: scans.source,
       summaryJson: scans.summaryJson,
     });
   if (updated.length === 0) return { revoked: false, publicPackageKey: null };
@@ -180,10 +181,24 @@ export async function revokePublicShare(
   });
   return {
     revoked: true,
-    publicPackageKey: updated[0].packageName
-      ? publicPackageLookupKey(scanEcosystem(updated[0].summaryJson), updated[0].packageName)
-      : null,
+    publicPackageKey: badgeLookupKey(updated[0]),
   };
+}
+
+/**
+ * The badge cache key a row occupies, or null when it can never occupy one —
+ * no package name, or a gate scan whose provenance never established an
+ * ecosystem. Same rule as the key written on listing, so a purge always
+ * addresses the entry the write created.
+ */
+function badgeLookupKey(row: {
+  source: string;
+  packageName: string | null;
+  summaryJson: unknown;
+}): string | null {
+  if (!row.packageName) return null;
+  const ecosystem = scanEcosystem(row.source, row.summaryJson);
+  return ecosystem ? publicPackageLookupKey(ecosystem, row.packageName) : null;
 }
 
 /**
@@ -204,15 +219,19 @@ export async function setThreatFeedListing(
     isNotNull(scans.publicShareToken),
   );
   const [candidate] = await db
-    .select({ packageName: scans.packageName, summaryJson: scans.summaryJson })
+    .select({
+      source: scans.source,
+      packageName: scans.packageName,
+      summaryJson: scans.summaryJson,
+    })
     .from(scans)
     .where(scoped)
     .limit(1);
   if (!candidate) return null;
-  const publicPackageKey =
-    input.listed && candidate.packageName
-      ? publicPackageLookupKey(scanEcosystem(candidate.summaryJson), candidate.packageName)
-      : null;
+  // Null here means "listed in the feed but not badge-discoverable" — the scan
+  // has no name, or is a gate scan whose ecosystem was never established.
+  const badgeKey = badgeLookupKey(candidate);
+  const publicPackageKey = input.listed ? badgeKey : null;
   const updated = await db
     .update(scans)
     .set({
@@ -239,11 +258,9 @@ export async function setThreatFeedListing(
     metadata: { packageName: row.packageName, stagedVersion: row.stagedVersion },
   });
   return {
-    publicPackageKey:
-      publicPackageKey ??
-      (row.packageName
-        ? publicPackageLookupKey(scanEcosystem(candidate.summaryJson), row.packageName)
-        : null),
+    // Always the key, listing or unlisting: an *un*listing is exactly when the
+    // cached badge body goes stale, so the caller needs the entry to purge.
+    publicPackageKey: badgeKey,
     publicShareToken: row.publicShareToken,
     publicSharedAt: row.publicSharedAt,
     publicFeedListedAt: row.publicFeedListedAt,

--- a/server/db/scan-share.ts
+++ b/server/db/scan-share.ts
@@ -165,6 +165,8 @@ export async function setThreatFeedListing(
       publicShareToken: scans.publicShareToken,
       publicSharedAt: scans.publicSharedAt,
       publicFeedListedAt: scans.publicFeedListedAt,
+      packageName: scans.packageName,
+      stagedVersion: scans.stagedVersion,
     });
   const row = updated[0];
   if (!row?.publicShareToken || !row.publicSharedAt) return null;
@@ -174,6 +176,7 @@ export async function setThreatFeedListing(
     actorUserId: input.actorUserId,
     scanId: input.scanId,
     type: input.listed ? "scan.feed_listed" : "scan.feed_unlisted",
+    metadata: { packageName: row.packageName, stagedVersion: row.stagedVersion },
   });
   return {
     publicShareToken: row.publicShareToken,
@@ -257,6 +260,10 @@ export async function listBadgeCandidateScans(
     ecosystem === "npm"
       ? or(sql`${provenanceEcosystem} = 'npm'`, sql`${provenanceEcosystem} IS NULL`)
       : sql`${provenanceEcosystem} = ${ecosystem}`;
+  // Rank registry-backed scans before applying the bounded page. Otherwise a
+  // burst of newer manifest-claimed gate scans could crowd the verified review
+  // out of the result set before pickBadgeScan gets a chance to prefer it.
+  const packageIdentityPriority = sql<number>`CASE WHEN ${scans.source} = 'workflow_gate' THEN 1 ELSE 0 END`;
   return db
     .select(SHARED_SCAN_COLUMNS)
     .from(scans)
@@ -269,7 +276,7 @@ export async function listBadgeCandidateScans(
         ecosystemMatches,
       ),
     )
-    .orderBy(desc(scans.completedAt), desc(scans.id))
+    .orderBy(packageIdentityPriority, desc(scans.completedAt), desc(scans.id))
     .limit(limit);
 }
 

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -173,6 +173,11 @@ export const scans = sqliteTable(
     publicSharedByUserId: text("public_shared_by_user_id").references(() => user.id, {
       onDelete: "set null",
     }),
+    // Public threat-feed listing is a second, separate opt-in on top of the
+    // share link: a shared report is reachable by anyone holding the link,
+    // but only feed-listed scans appear in the discoverable
+    // /public/threat-feed.json index. Cleared whenever the share is revoked.
+    publicFeedListedAt: integer("public_feed_listed_at", { mode: "timestamp_ms" }),
     startedAt: integer("started_at", { mode: "timestamp_ms" }),
     completedAt: integer("completed_at", { mode: "timestamp_ms" }),
     createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
@@ -183,6 +188,12 @@ export const scans = sqliteTable(
     ownerIdx: index("scans_owner_idx").on(table.ownerUserId),
     stageIdx: index("scans_stage_id_idx").on(table.stageId),
     packageIdx: index("scans_package_idx").on(table.packageName),
+    // Serves the badge lookup's ORDER BY completed_at over one package name
+    // without sorting every row that ever carried the name.
+    packageCompletedIdx: index("scans_package_completed_idx").on(
+      table.packageName,
+      table.completedAt,
+    ),
     gateIdx: index("scans_gate_org_idx").on(table.gateId, table.organizationId),
     artifactBackfillIdx: index("scans_artifact_backfill_idx").on(
       table.organizationId,
@@ -209,6 +220,7 @@ export const scans = sqliteTable(
     publicShareTokenUniqueIdx: uniqueIndex("scans_public_share_token_unique_idx").on(
       table.publicShareToken,
     ),
+    publicFeedListedIdx: index("scans_public_feed_listed_idx").on(table.publicFeedListedAt),
   }),
 );
 

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -178,6 +178,10 @@ export const scans = sqliteTable(
     // but only feed-listed scans appear in the discoverable
     // /public/threat-feed.json index. Cleared whenever the share is revoked.
     publicFeedListedAt: integer("public_feed_listed_at", { mode: "timestamp_ms" }),
+    // Ecosystem-prefixed canonical package identity used by the public badge.
+    // Populated only while feed-listed, so private shares stay unqueryable by
+    // package name and PyPI/VS Code aliases resolve through one indexed key.
+    publicPackageKey: text("public_package_key"),
     startedAt: integer("started_at", { mode: "timestamp_ms" }),
     completedAt: integer("completed_at", { mode: "timestamp_ms" }),
     createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
@@ -221,6 +225,7 @@ export const scans = sqliteTable(
       table.publicShareToken,
     ),
     publicFeedListedIdx: index("scans_public_feed_listed_idx").on(table.publicFeedListedAt),
+    publicPackageKeyIdx: index("scans_public_package_key_idx").on(table.publicPackageKey),
   }),
 );
 

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -192,10 +192,11 @@ export const scans = sqliteTable(
     ownerIdx: index("scans_owner_idx").on(table.ownerUserId),
     stageIdx: index("scans_stage_id_idx").on(table.stageId),
     packageIdx: index("scans_package_idx").on(table.packageName),
-    // Serves the badge lookup's ORDER BY completed_at over one package name
-    // without sorting every row that ever carried the name.
-    packageCompletedIdx: index("scans_package_completed_idx").on(
-      table.packageName,
+    // Serves the badge lookup, which filters on the canonical public key (not
+    // package_name) and orders by completed_at. Keyed on the wrong column this
+    // index covered nothing and taxed every write to the busiest table.
+    publicPackageKeyCompletedIdx: index("scans_public_package_key_completed_idx").on(
+      table.publicPackageKey,
       table.completedAt,
     ),
     gateIdx: index("scans_gate_org_idx").on(table.gateId, table.organizationId),
@@ -225,7 +226,8 @@ export const scans = sqliteTable(
       table.publicShareToken,
     ),
     publicFeedListedIdx: index("scans_public_feed_listed_idx").on(table.publicFeedListedAt),
-    publicPackageKeyIdx: index("scans_public_package_key_idx").on(table.publicPackageKey),
+    // No standalone public_package_key index: the composite above has it as a
+    // leading column, so it already serves an equality lookup on the key alone.
   }),
 );
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -299,6 +299,8 @@ app.get("/api", (c) =>
         "GET /api/public/v1/package-diff?package&from&to[&ecosystem=npm|pypi]; GET /api/public/v1/package-diff/versions?package[&ecosystem]; GET /api/public/v1/package-diff/file?package&from&to&path[&ecosystem] (anonymous, IP rate-limited, public registry data only; on npm, from/to also accept pkg.pr.new preview URLs)",
       publicReports:
         "POST/DELETE /api/v1/scans/:id/share; GET /public/reports/:token; GET /public/reports/:token/attestation; GET /public/attestation-key (share token is the capability; no auth)",
+      publicFeed:
+        "GET /public/threat-feed.json (feed-listed shared reviews); GET /public/badge/:ecosystem/:package (shields.io endpoint badge)",
       slack:
         "GET /api/v1/slack; POST /api/v1/slack/connect; GET /api/v1/slack/callback; GET /api/v1/slack/channels; PUT /api/v1/slack/channel; PATCH /api/v1/slack; DELETE /api/v1/slack; POST /api/v1/slack/test",
       health: "GET /api/health",

--- a/server/lib/auth/audit-events.ts
+++ b/server/lib/auth/audit-events.ts
@@ -116,6 +116,18 @@ const REGISTRY: Record<string, AuditEventDef> = {
     severity: "notice",
     summarize: summarizePackageVersion,
   },
+  "scan.feed_listed": {
+    category: "security",
+    label: "Report listed in public threat feed",
+    severity: "security",
+    summarize: summarizePackageVersion,
+  },
+  "scan.feed_unlisted": {
+    category: "security",
+    label: "Report removed from public threat feed",
+    severity: "notice",
+    summarize: summarizePackageVersion,
+  },
   "organization.release_two_factor_changed": {
     category: "security",
     label: "Release two-factor policy changed",

--- a/server/lib/platform/colo-cache.ts
+++ b/server/lib/platform/colo-cache.ts
@@ -15,7 +15,7 @@
 // The runtime exposes the colo cache as `caches.default`, but the DOM lib wins
 // the global CacheStorage type in this repo's single tsconfig and doesn't know
 // the property.
-export function coloCache(): Cache {
+function coloCache(): Cache {
   return (caches as unknown as { default: Cache }).default;
 }
 

--- a/server/lib/platform/colo-cache.ts
+++ b/server/lib/platform/colo-cache.ts
@@ -1,0 +1,47 @@
+/**
+ * The Workers per-colo cache (`caches.default`).
+ *
+ * Two things to keep in mind at every call site, because neither is obvious
+ * from the API:
+ *
+ * - It is **per colo**, not global. A `delete()` drops the entry in the colo
+ *   that handled *that* request and nowhere else, so a purge is an optimization
+ *   for the requester's region — never a correctness mechanism. Anything that
+ *   must be withdrawn everywhere has to be either uncached or short-TTL'd.
+ * - The key is a `Request`, so it includes the origin. Two hostnames bound to
+ *   the same Worker are two cache namespaces; a write and its purge must derive
+ *   the origin the same way or they will never meet.
+ */
+// The runtime exposes the colo cache as `caches.default`, but the DOM lib wins
+// the global CacheStorage type in this repo's single tsconfig and doesn't know
+// the property.
+export function coloCache(): Cache {
+  return (caches as unknown as { default: Cache }).default;
+}
+
+/** Cache lookup that treats any cache failure as a miss. */
+export async function coloCacheMatch(key: Request): Promise<Response | undefined> {
+  try {
+    return await coloCache().match(key);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Best-effort background write; a failure only costs a later read-through. */
+export function coloCachePut(ctx: ExecutionContext, key: Request, response: Response): void {
+  ctx.waitUntil(
+    coloCache()
+      .put(key, response)
+      .catch(() => {}),
+  );
+}
+
+/** Best-effort background delete. Colo-local — see the note above. */
+export function coloCacheDelete(ctx: ExecutionContext, key: Request): void {
+  ctx.waitUntil(
+    coloCache()
+      .delete(key)
+      .catch(() => {}),
+  );
+}

--- a/server/lib/platform/colo-cache.ts
+++ b/server/lib/platform/colo-cache.ts
@@ -28,9 +28,13 @@ export async function coloCacheMatch(key: Request): Promise<Response | undefined
   }
 }
 
+// Both entry points take a nullable context and no-op without one. Everything
+// here is background work behind `waitUntil`, so a request with no execution
+// context should lose the cache write — never the request.
+
 /** Best-effort background write; a failure only costs a later read-through. */
-export function coloCachePut(ctx: ExecutionContext, key: Request, response: Response): void {
-  ctx.waitUntil(
+export function coloCachePut(ctx: ExecutionContext | null, key: Request, response: Response): void {
+  ctx?.waitUntil(
     coloCache()
       .put(key, response)
       .catch(() => {}),
@@ -38,8 +42,8 @@ export function coloCachePut(ctx: ExecutionContext, key: Request, response: Resp
 }
 
 /** Best-effort background delete. Colo-local — see the note above. */
-export function coloCacheDelete(ctx: ExecutionContext, key: Request): void {
-  ctx.waitUntil(
+export function coloCacheDelete(ctx: ExecutionContext | null, key: Request): void {
+  ctx?.waitUntil(
     coloCache()
       .delete(key)
       .catch(() => {}),

--- a/server/lib/platform/execution-context.ts
+++ b/server/lib/platform/execution-context.ts
@@ -8,3 +8,22 @@ type HonoExecutionContext = import("hono").Context["executionCtx"];
 export function workerExecutionContext(ctx: HonoExecutionContext): ExecutionContext {
   return ctx as unknown as ExecutionContext;
 }
+
+/**
+ * The Worker ExecutionContext when the request has one, otherwise null.
+ *
+ * Hono's `executionCtx` getter *throws* when there is no execution context, so
+ * reading it on a best-effort path turns a request that already did its real
+ * work into a 500 — a revoke that committed to D1 would report failure while
+ * the link is in fact dead. Background-only callers (cache writes, purges,
+ * telemetry) take the null and skip the work instead.
+ */
+export function optionalWorkerExecutionContext(c: {
+  executionCtx: HonoExecutionContext;
+}): ExecutionContext | null {
+  try {
+    return workerExecutionContext(c.executionCtx);
+  } catch {
+    return null;
+  }
+}

--- a/server/lib/platform/http.ts
+++ b/server/lib/platform/http.ts
@@ -16,3 +16,14 @@ export function rateLimitResponse(c: AppContext, error: string, err: RateLimitEr
 export function coloCache(): Cache {
   return (caches as unknown as { default: Cache }).default;
 }
+
+// Origin for links we hand out (share URLs, feed report links). Prefer the
+// canonical configured origin so copied links never pin a preview host.
+export function canonicalOrigin(c: AppContext): string {
+  try {
+    if (c.env.BETTER_AUTH_URL) return new URL(c.env.BETTER_AUTH_URL).origin;
+  } catch {
+    // fall through to the request origin
+  }
+  return new URL(c.req.url).origin;
+}

--- a/server/lib/public-feed.ts
+++ b/server/lib/public-feed.ts
@@ -1,0 +1,157 @@
+import type { SharedScanRow } from "../db/scan-share";
+
+// Shaping helpers for the two discoverable public surfaces: the shields.io
+// badge endpoint and the threat feed. Both are name-discoverable indexes, so
+// both only ever reflect scans whose org explicitly opted into feed listing
+// on top of sharing — a privately shared link never appears in either.
+
+export const THREAT_FEED_SCHEMA = "drydock.threat-feed.v1";
+
+export const PUBLIC_ECOSYSTEMS = ["npm", "pypi", "vscode"] as const;
+export type PublicEcosystem = (typeof PUBLIC_ECOSYSTEMS)[number];
+
+/**
+ * The reviewed ecosystem lives in the persisted adapter snapshot
+ * (`summaryJson.stagedPublish.provenance.ecosystem`) for workflow-gate scans;
+ * staged-publish scans are npm by construction.
+ */
+export function scanEcosystem(summaryJson: unknown): PublicEcosystem {
+  if (summaryJson && typeof summaryJson === "object" && !Array.isArray(summaryJson)) {
+    const stagedPublish = (summaryJson as { stagedPublish?: unknown }).stagedPublish;
+    if (stagedPublish && typeof stagedPublish === "object" && !Array.isArray(stagedPublish)) {
+      const provenance = (stagedPublish as { provenance?: unknown }).provenance;
+      if (provenance && typeof provenance === "object" && !Array.isArray(provenance)) {
+        const ecosystem = (provenance as { ecosystem?: unknown }).ecosystem;
+        if (ecosystem === "pypi" || ecosystem === "vscode" || ecosystem === "npm") {
+          return ecosystem;
+        }
+      }
+    }
+  }
+  return "npm";
+}
+
+// How trustworthy the package-name claim is. Staged-publish scans fetched the
+// artifact from the registry with the org's npm token, so the registry proved
+// the org can publish under that name. Workflow-gate scans review a repo-built
+// artifact whose manifest claims the name — nothing verifies ownership yet, so
+// consumers must be able to discount those claims.
+export type PackageIdentity = "registry-verified" | "manifest-claimed";
+
+export function scanPackageIdentity(source: string): PackageIdentity {
+  return source === "workflow_gate" ? "manifest-claimed" : "registry-verified";
+}
+
+/**
+ * Pick the badge's scan among the (already listed + ecosystem-scoped)
+ * candidates: the newest registry-verified review wins over any
+ * manifest-claimed one, so a workflow-gate scan claiming someone else's npm
+ * name can never override the real maintainer's badge.
+ */
+export function pickBadgeScan(rows: SharedScanRow[]): SharedScanRow | null {
+  return (
+    rows.find((row) => scanPackageIdentity(row.source) === "registry-verified") ?? rows[0] ?? null
+  );
+}
+
+/** The release-scoped risk when persisted, falling back to the artifact risk. */
+export function sharedScanReleaseRisk(row: SharedScanRow): string {
+  const breakdown = row.riskSummaryJson;
+  if (breakdown && typeof breakdown === "object" && !Array.isArray(breakdown)) {
+    const releaseRisk = (breakdown as { releaseRisk?: unknown }).releaseRisk;
+    if (typeof releaseRisk === "string" && releaseRisk) return releaseRisk;
+  }
+  return row.risk;
+}
+
+export interface ThreatFeedEntry {
+  package: string | null;
+  version: string | null;
+  previousVersion: string | null;
+  ecosystem: PublicEcosystem;
+  packageIdentity: PackageIdentity;
+  releaseRisk: string;
+  artifactRisk: string;
+  decision: string | null;
+  findingCount: number;
+  completedAt: string | null;
+  listedAt: string | null;
+  reportUrl: string;
+}
+
+export function buildThreatFeedEntry(row: SharedScanRow, origin: string): ThreatFeedEntry {
+  return {
+    package: row.packageName,
+    version: row.stagedVersion,
+    previousVersion: row.previousVersion,
+    ecosystem: scanEcosystem(row.summaryJson),
+    packageIdentity: scanPackageIdentity(row.source),
+    releaseRisk: sharedScanReleaseRisk(row),
+    artifactRisk: row.risk,
+    decision: row.decision,
+    findingCount: row.findingCount ?? 0,
+    completedAt: row.completedAt ? row.completedAt.toISOString() : null,
+    listedAt: row.publicFeedListedAt ? row.publicFeedListedAt.toISOString() : null,
+    reportUrl: `${origin}/reports/${row.publicShareToken}`,
+  };
+}
+
+// shields.io endpoint-badge schema:
+// https://shields.io/badges/endpoint-badge
+export interface BadgePayload {
+  schemaVersion: 1;
+  label: string;
+  message: string;
+  color: string;
+  cacheSeconds: number;
+}
+
+const BADGE_LABEL = "drydock";
+const BADGE_CACHE_SECONDS = 300;
+
+// Version strings originate in package manifests (attacker-shaped for gate
+// scans); clamp so a hostile version can't balloon the badge message.
+const BADGE_VERSION_MAX = 64;
+
+function badgeVersion(stagedVersion: string | null): string {
+  if (!stagedVersion) return "release";
+  return stagedVersion.length > BADGE_VERSION_MAX
+    ? `${stagedVersion.slice(0, BADGE_VERSION_MAX)}…`
+    : stagedVersion;
+}
+
+const RISK_BADGE_COLOR: Record<string, string> = {
+  low: "brightgreen",
+  medium: "yellow",
+  high: "red",
+  critical: "red",
+};
+
+export function buildBadgePayload(row: SharedScanRow | null): BadgePayload {
+  if (!row) {
+    return {
+      schemaVersion: 1,
+      label: BADGE_LABEL,
+      message: "not reviewed",
+      color: "lightgrey",
+      cacheSeconds: BADGE_CACHE_SECONDS,
+    };
+  }
+  if (row.decision === "no_publish") {
+    return {
+      schemaVersion: 1,
+      label: BADGE_LABEL,
+      message: `${badgeVersion(row.stagedVersion)} blocked`,
+      color: "red",
+      cacheSeconds: BADGE_CACHE_SECONDS,
+    };
+  }
+  const risk = sharedScanReleaseRisk(row);
+  return {
+    schemaVersion: 1,
+    label: BADGE_LABEL,
+    message: `${badgeVersion(row.stagedVersion)} reviewed · ${risk} risk`,
+    color: RISK_BADGE_COLOR[risk] ?? "lightgrey",
+    cacheSeconds: BADGE_CACHE_SECONDS,
+  };
+}

--- a/server/lib/public-feed.ts
+++ b/server/lib/public-feed.ts
@@ -10,6 +10,27 @@ export const THREAT_FEED_SCHEMA = "drydock.threat-feed.v1";
 export const PUBLIC_ECOSYSTEMS = ["npm", "pypi", "vscode"] as const;
 export type PublicEcosystem = (typeof PUBLIC_ECOSYSTEMS)[number];
 
+const PUBLIC_PACKAGE_NAME_MAX: Record<PublicEcosystem, number> = {
+  npm: 214,
+  pypi: 214,
+  // publisher (128) + "." + extension name (128).
+  vscode: 257,
+};
+
+export function publicPackageNameMax(ecosystem: PublicEcosystem): number {
+  return PUBLIC_PACKAGE_NAME_MAX[ecosystem];
+}
+
+export function publicPackageLookupKey(ecosystem: PublicEcosystem, packageName: string): string {
+  const normalized =
+    ecosystem === "pypi"
+      ? packageName.toLowerCase().replace(/[-_.]+/g, "-")
+      : ecosystem === "vscode"
+        ? packageName.toLowerCase()
+        : packageName;
+  return `${ecosystem}:${normalized}`;
+}
+
 /**
  * The reviewed ecosystem lives in the persisted adapter snapshot
  * (`summaryJson.stagedPublish.provenance.ecosystem`) for workflow-gate scans;

--- a/server/lib/public-feed.ts
+++ b/server/lib/public-feed.ts
@@ -124,9 +124,9 @@ export function scanEcosystem(summaryJson: unknown): PublicEcosystem {
 // the org can publish under that name. Workflow-gate scans review a repo-built
 // artifact whose manifest claims the name — nothing verifies ownership yet, so
 // consumers must be able to discount those claims.
-export type PackageIdentity = "registry-verified" | "manifest-claimed";
+type PackageIdentity = "registry-verified" | "manifest-claimed";
 
-export function scanPackageIdentity(source: string): PackageIdentity {
+function scanPackageIdentity(source: string): PackageIdentity {
   return source === "workflow_gate" ? "manifest-claimed" : "registry-verified";
 }
 
@@ -149,7 +149,7 @@ export function pickBadgeScan(rows: SharedScanRow[]): SharedScanRow | null {
 }
 
 /** The release-scoped risk when persisted, falling back to the artifact risk. */
-export function sharedScanReleaseRisk(row: SharedScanRow): string {
+function sharedScanReleaseRisk(row: SharedScanRow): string {
   const breakdown = row.riskSummaryJson;
   if (breakdown && typeof breakdown === "object" && !Array.isArray(breakdown)) {
     const releaseRisk = (breakdown as { releaseRisk?: unknown }).releaseRisk;

--- a/server/lib/public-feed.ts
+++ b/server/lib/public-feed.ts
@@ -21,6 +21,17 @@ export function publicPackageNameMax(ecosystem: PublicEcosystem): number {
   return PUBLIC_PACKAGE_NAME_MAX[ecosystem];
 }
 
+/**
+ * Canonical lookup key for a package name, per that ecosystem's own identity
+ * rules. The ecosystem prefix makes a cross-ecosystem collision impossible.
+ *
+ * npm is deliberately *not* case-folded, unlike the other two. Its registry
+ * treats names case-sensitively for existing packages — `JSONStream` and
+ * `jsonstream` are different packages — so folding would merge two real
+ * packages onto one badge. PyPI folds per PEP 503 and the VS Code marketplace
+ * treats extension ids case-insensitively, so for those, *not* folding would
+ * fragment one package across several keys.
+ */
 export function publicPackageLookupKey(ecosystem: PublicEcosystem, packageName: string): string {
   const normalized =
     ecosystem === "pypi"
@@ -66,8 +77,14 @@ export function scanPackageIdentity(source: string): PackageIdentity {
 /**
  * Pick the badge's scan among the (already listed + ecosystem-scoped)
  * candidates: the newest registry-verified review wins over any
- * manifest-claimed one, so a workflow-gate scan claiming someone else's npm
- * name can never override the real maintainer's badge.
+ * manifest-claimed one, so on npm a workflow-gate scan claiming someone else's
+ * name cannot displace the real maintainer's staged review.
+ *
+ * That preference is only a *tiebreak*, and it does not generalize: only npm has
+ * a staged adapter, so every PyPI and VS Code scan is a workflow gate and is
+ * therefore always `manifest-claimed`. There is never a registry-verified row to
+ * prefer. `buildBadgePayload` is what closes the gap — a manifest-claimed pick
+ * is labelled as unverified rather than presented as a plain review.
  */
 export function pickBadgeScan(rows: SharedScanRow[]): SharedScanRow | null {
   return (
@@ -133,12 +150,22 @@ const BADGE_CACHE_SECONDS = 300;
 // Version strings originate in package manifests (attacker-shaped for gate
 // scans); clamp so a hostile version can't balloon the badge message.
 const BADGE_VERSION_MAX = 64;
+// Zero-width and bidirectional-override code points. The badge is rendered into
+// SVG text by shields, so an RLO in a version string reverses the visible run
+// and can make the message read as something it does not say. Same set the tar
+// parser strips from entry names, and the same reasoning.
+const BADGE_INVISIBLE_CHARS = /[\u200B-\u200F\u2028-\u202E\u2060-\u206F\uFEFF\u180E]/g;
+// eslint-disable-next-line no-control-regex -- stripping C0/C1 is the point
+const BADGE_CONTROL_CHARS = /[\u0000-\u001F\u007F-\u009F]/g;
 
 function badgeVersion(stagedVersion: string | null): string {
   if (!stagedVersion) return "release";
-  return stagedVersion.length > BADGE_VERSION_MAX
-    ? `${stagedVersion.slice(0, BADGE_VERSION_MAX)}…`
-    : stagedVersion;
+  const cleaned = stagedVersion
+    .replace(BADGE_INVISIBLE_CHARS, "")
+    .replace(BADGE_CONTROL_CHARS, "")
+    .trim();
+  if (!cleaned) return "release";
+  return cleaned.length > BADGE_VERSION_MAX ? `${cleaned.slice(0, BADGE_VERSION_MAX)}…` : cleaned;
 }
 
 const RISK_BADGE_COLOR: Record<string, string> = {
@@ -147,6 +174,21 @@ const RISK_BADGE_COLOR: Record<string, string> = {
   high: "red",
   critical: "red",
 };
+
+/**
+ * A badge is read as an assertion about a package name, by people who will never
+ * open the report behind it. Only a registry-verified review proves the
+ * publisher controls that name; a workflow-gate review proves only that some
+ * organization built an artifact whose manifest claims it. Anyone can do the
+ * latter for any name, and for PyPI and VS Code it is the *only* kind of review
+ * that exists — so the distinction has to be visible on the badge, not just in
+ * the feed entry that a badge viewer never sees.
+ */
+function badgeLabel(row: SharedScanRow): string {
+  return scanPackageIdentity(row.source) === "registry-verified"
+    ? BADGE_LABEL
+    : `${BADGE_LABEL} (unverified)`;
+}
 
 export function buildBadgePayload(row: SharedScanRow | null): BadgePayload {
   if (!row) {
@@ -161,7 +203,7 @@ export function buildBadgePayload(row: SharedScanRow | null): BadgePayload {
   if (row.decision === "no_publish") {
     return {
       schemaVersion: 1,
-      label: BADGE_LABEL,
+      label: badgeLabel(row),
       message: `${badgeVersion(row.stagedVersion)} blocked`,
       color: "red",
       cacheSeconds: BADGE_CACHE_SECONDS,
@@ -170,9 +212,16 @@ export function buildBadgePayload(row: SharedScanRow | null): BadgePayload {
   const risk = sharedScanReleaseRisk(row);
   return {
     schemaVersion: 1,
-    label: BADGE_LABEL,
+    label: badgeLabel(row),
     message: `${badgeVersion(row.stagedVersion)} reviewed · ${risk} risk`,
-    color: RISK_BADGE_COLOR[risk] ?? "lightgrey",
+    // An unverified claim never renders as a clean green pass: the color is the
+    // only thing most readers take from a badge.
+    color:
+      scanPackageIdentity(row.source) === "registry-verified"
+        ? (RISK_BADGE_COLOR[risk] ?? "lightgrey")
+        : risk === "low"
+          ? "lightgrey"
+          : (RISK_BADGE_COLOR[risk] ?? "lightgrey"),
     cacheSeconds: BADGE_CACHE_SECONDS,
   };
 }

--- a/server/lib/public-feed.ts
+++ b/server/lib/public-feed.ts
@@ -183,7 +183,16 @@ export interface ThreatFeedEntry {
   releaseRisk: string;
   artifactRisk: string;
   decision: string | null;
-  findingCount: number;
+  /**
+   * Deterministic *and* advisory AI findings — the scan's persisted total, not
+   * `report.findings.length`. The report export routes AI findings through
+   * `aiReview.findings` and keeps `findings[]` deterministic-only, so the two
+   * numbers legitimately differ. Named for what it counts so a partner walking
+   * feed → report doesn't read the difference as a discrepancy. The per-entry
+   * deterministic count is not carried here: deriving it means reading each
+   * scan's report artifact, and this is a 100-entry page.
+   */
+  totalFindingCount: number;
   completedAt: string | null;
   listedAt: string | null;
   reportUrl: string;
@@ -199,7 +208,7 @@ export function buildThreatFeedEntry(row: SharedScanRow, origin: string): Threat
     releaseRisk: sharedScanReleaseRisk(row),
     artifactRisk: row.risk,
     decision: row.decision,
-    findingCount: row.findingCount ?? 0,
+    totalFindingCount: row.findingCount ?? 0,
     completedAt: row.completedAt ? row.completedAt.toISOString() : null,
     listedAt: row.publicFeedListedAt ? row.publicFeedListedAt.toISOString() : null,
     reportUrl: `${origin}/reports/${row.publicShareToken}`,

--- a/server/lib/public-feed.ts
+++ b/server/lib/public-feed.ts
@@ -1,4 +1,5 @@
 import type { SharedScanRow } from "../db/scan-share";
+import { coloCacheDelete } from "./platform/colo-cache";
 
 // Shaping helpers for the two discoverable public surfaces: the shields.io
 // badge endpoint and the threat feed. Both are name-discoverable indexes, so
@@ -40,6 +41,61 @@ export function publicPackageLookupKey(ecosystem: PublicEcosystem, packageName: 
         ? packageName.toLowerCase()
         : packageName;
   return `${ecosystem}:${normalized}`;
+}
+
+// Colo-cache keys for the two cacheable public surfaces. These live here, next
+// to `publicPackageLookupKey`, rather than in a route module: the write side
+// (the badge/feed GETs) and the purge side (the dashboard's share and listing
+// mutations) are different routes, and a route importing another route is how
+// the two drifted onto different origins in the first place.
+function badgeCacheKey(origin: string, packageKey: string): Request {
+  return new Request(`${origin}/public/badge-key/${encodeURIComponent(packageKey)}`);
+}
+
+function threatFeedCacheKey(origin: string): Request {
+  return new Request(`${origin}/public/threat-feed.json`);
+}
+
+/**
+ * Colo-cache key for a cacheable public path. Badge paths collapse to their
+ * canonical package key, so every encoding of one package shares one entry and
+ * `purgePublicFeedCache` can delete it by key after a revoke or unlist.
+ */
+export function publicFeedCacheKey(origin: string, routePath: string): Request {
+  const badge = /^\/badge\/([^/]+)\/(.+)$/.exec(routePath);
+  if (badge) {
+    const ecosystem = badge[1] as PublicEcosystem;
+    if (PUBLIC_ECOSYSTEMS.includes(ecosystem)) {
+      let name = badge[2];
+      try {
+        name = decodeURIComponent(name);
+      } catch {
+        // Undecodable name: fall through and key on the raw path.
+      }
+      return badgeCacheKey(origin, publicPackageLookupKey(ecosystem, name));
+    }
+  }
+  return new Request(origin + "/public" + routePath);
+}
+
+/**
+ * Drop the colo-cached badge and threat feed after a share is revoked or a
+ * listing is turned off, so the withdrawal is not delayed by the TTL.
+ *
+ * **This is colo-local.** It clears the entries in the colo that served the
+ * revoking admin's request and nowhere else; every other region keeps serving
+ * the withdrawn badge until `max-age` expires, and shields.io's own cache
+ * (≥300s) sits in front of that. Revocation of the *report* is immediate —
+ * `no-store` plus a D1 lookup on every request. These two derived surfaces are
+ * eventually consistent by construction, which is why their TTLs are short.
+ */
+export function purgePublicFeedCache(
+  executionCtx: ExecutionContext,
+  origin: string,
+  publicPackageKey: string | null,
+): void {
+  coloCacheDelete(executionCtx, threatFeedCacheKey(origin));
+  if (publicPackageKey) coloCacheDelete(executionCtx, badgeCacheKey(origin, publicPackageKey));
 }
 
 /**
@@ -146,6 +202,10 @@ export interface BadgePayload {
 
 const BADGE_LABEL = "drydock";
 const BADGE_CACHE_SECONDS = 300;
+// Short, because this payload is a statement about Drydock's availability, not
+// about the package. shields enforces a 300s floor of its own, so it cannot be
+// honoured exactly — but nothing here should ask to be remembered.
+const BADGE_UNAVAILABLE_CACHE_SECONDS = 30;
 
 // Version strings originate in package manifests (attacker-shaped for gate
 // scans); clamp so a hostile version can't balloon the badge message.
@@ -188,6 +248,28 @@ function badgeLabel(row: SharedScanRow): string {
   return scanPackageIdentity(row.source) === "registry-verified"
     ? BADGE_LABEL
     : `${BADGE_LABEL} (unverified)`;
+}
+
+/**
+ * The badge for "Drydock could not answer" — throttling, mostly.
+ *
+ * This must never be `buildBadgePayload(null)`. That payload asserts *nobody
+ * reviewed this package*, and shields would cache the assertion for at least
+ * five minutes. Every Drydock badge in the world reaches us through a handful
+ * of shields egress addresses against a per-IP limiter with no per-package
+ * dimension, so an unrelated burst can throttle the request for a package
+ * whose review says `blocked` — and every README rendering that badge would
+ * quietly show neutral grey instead. "We don't know" and "nobody reviewed
+ * this" have to be distinguishable.
+ */
+export function buildUnavailableBadgePayload(): BadgePayload {
+  return {
+    schemaVersion: 1,
+    label: BADGE_LABEL,
+    message: "unavailable",
+    color: "lightgrey",
+    cacheSeconds: BADGE_UNAVAILABLE_CACHE_SECONDS,
+  };
 }
 
 export function buildBadgePayload(row: SharedScanRow | null): BadgePayload {

--- a/server/lib/public-feed.ts
+++ b/server/lib/public-feed.ts
@@ -90,7 +90,7 @@ export function publicFeedCacheKey(origin: string, routePath: string): Request {
  * eventually consistent by construction, which is why their TTLs are short.
  */
 export function purgePublicFeedCache(
-  executionCtx: ExecutionContext,
+  executionCtx: ExecutionContext | null,
   origin: string,
   publicPackageKey: string | null,
 ): void {
@@ -98,12 +98,7 @@ export function purgePublicFeedCache(
   if (publicPackageKey) coloCacheDelete(executionCtx, badgeCacheKey(origin, publicPackageKey));
 }
 
-/**
- * The reviewed ecosystem lives in the persisted adapter snapshot
- * (`summaryJson.stagedPublish.provenance.ecosystem`) for workflow-gate scans;
- * staged-publish scans are npm by construction.
- */
-export function scanEcosystem(summaryJson: unknown): PublicEcosystem {
+function provenanceEcosystem(summaryJson: unknown): PublicEcosystem | null {
   if (summaryJson && typeof summaryJson === "object" && !Array.isArray(summaryJson)) {
     const stagedPublish = (summaryJson as { stagedPublish?: unknown }).stagedPublish;
     if (stagedPublish && typeof stagedPublish === "object" && !Array.isArray(stagedPublish)) {
@@ -116,7 +111,26 @@ export function scanEcosystem(summaryJson: unknown): PublicEcosystem {
       }
     }
   }
-  return "npm";
+  return null;
+}
+
+/**
+ * The reviewed ecosystem, or null when it cannot be established.
+ *
+ * It lives in the persisted adapter snapshot
+ * (`summaryJson.stagedPublish.provenance.ecosystem`) for workflow-gate scans.
+ * Staged-publish scans carry no snapshot and are npm by construction — only npm
+ * has a staged adapter.
+ *
+ * A gate scan whose snapshot is missing or malformed (a legacy pre-provenance
+ * record, or a redaction that failed) resolves to null rather than falling back
+ * to npm. Defaulting is what turns "we don't know" into a claim: a PyPI or VS
+ * Code release would take the npm badge for its own name, in the one ecosystem
+ * where a real registry-verified review exists to be displaced. Null means the
+ * scan can still be feed-listed — it just isn't badge-discoverable.
+ */
+export function scanEcosystem(source: string, summaryJson: unknown): PublicEcosystem | null {
+  return provenanceEcosystem(summaryJson) ?? (source === "workflow_gate" ? null : "npm");
 }
 
 // How trustworthy the package-name claim is. Staged-publish scans fetched the
@@ -162,7 +176,9 @@ export interface ThreatFeedEntry {
   package: string | null;
   version: string | null;
   previousVersion: string | null;
-  ecosystem: PublicEcosystem;
+  // Null when a gate scan's provenance snapshot never established one — the
+  // feed says "unknown" rather than guessing on a partner's behalf.
+  ecosystem: PublicEcosystem | null;
   packageIdentity: PackageIdentity;
   releaseRisk: string;
   artifactRisk: string;
@@ -178,7 +194,7 @@ export function buildThreatFeedEntry(row: SharedScanRow, origin: string): Threat
     package: row.packageName,
     version: row.stagedVersion,
     previousVersion: row.previousVersion,
-    ecosystem: scanEcosystem(row.summaryJson),
+    ecosystem: scanEcosystem(row.source, row.summaryJson),
     packageIdentity: scanPackageIdentity(row.source),
     releaseRisk: sharedScanReleaseRisk(row),
     artifactRisk: row.risk,

--- a/server/routes/public-reports.ts
+++ b/server/routes/public-reports.ts
@@ -12,6 +12,7 @@ import {
   buildThreatFeedEntry,
   pickBadgeScan,
   PUBLIC_ECOSYSTEMS,
+  publicPackageNameMax,
   scanEcosystem,
   THREAT_FEED_SCHEMA,
   type PublicEcosystem,
@@ -193,7 +194,7 @@ publicReportsRoutes.get("/badge/:ecosystem/*", async (c) => {
   } catch {
     return c.json({ error: "invalid package name" }, 400);
   }
-  if (!packageName || packageName.length > 214) {
+  if (!packageName || packageName.length > publicPackageNameMax(ecosystem)) {
     return c.json({ error: "invalid package name" }, 400);
   }
 

--- a/server/routes/public-reports.ts
+++ b/server/routes/public-reports.ts
@@ -12,6 +12,7 @@ import {
   buildThreatFeedEntry,
   pickBadgeScan,
   PUBLIC_ECOSYSTEMS,
+  publicPackageLookupKey,
   publicPackageNameMax,
   scanEcosystem,
   THREAT_FEED_SCHEMA,
@@ -82,6 +83,58 @@ function coloCache(): Cache {
   return (caches as unknown as { default: Cache }).default;
 }
 
+/**
+ * Colo-cache key for a cacheable public path. Badge paths collapse to their
+ * canonical package key so `/badge/npm/Foo` and `/badge/npm/Foo` reached via a
+ * different encoding share one entry — and so `purgePublicFeedCache` can delete
+ * that entry by key after a revoke or unlist.
+ */
+export function publicCacheKey(origin: string, routePath: string): Request {
+  const badge = /^\/badge\/([^/]+)\/(.+)$/.exec(routePath);
+  if (badge) {
+    const ecosystem = badge[1] as PublicEcosystem;
+    if (PUBLIC_ECOSYSTEMS.includes(ecosystem)) {
+      let name = badge[2];
+      try {
+        name = decodeURIComponent(name);
+      } catch {
+        // Undecodable name: fall through and key on the raw path.
+      }
+      const key = publicPackageLookupKey(ecosystem, name);
+      return new Request(`${origin}/public/badge-key/${encodeURIComponent(key)}`);
+    }
+  }
+  return new Request(origin + "/public" + routePath);
+}
+
+/**
+ * Drop the colo-cached badge and threat feed after a share is revoked or a
+ * listing is turned off.
+ *
+ * Without this the cached bodies keep asserting "<version> reviewed · low risk"
+ * for up to the cache TTL after the publisher withdrew the report, and the
+ * cached feed still embeds a now-dead share token. The report itself is
+ * `no-store` and 404s immediately; this closes the same window on the two
+ * derived surfaces. Best effort: a failure here only means the old TTL applies.
+ */
+export function purgePublicFeedCache(
+  executionCtx: ExecutionContext,
+  origin: string,
+  publicPackageKey: string | null,
+): void {
+  const keys = [new Request(`${origin}/public/threat-feed.json`)];
+  if (publicPackageKey) {
+    keys.push(new Request(`${origin}/public/badge-key/${encodeURIComponent(publicPackageKey)}`));
+  }
+  for (const key of keys) {
+    executionCtx.waitUntil(
+      coloCache()
+        .delete(key)
+        .catch(() => {}),
+    );
+  }
+}
+
 publicReportsRoutes.use("*", async (c, next) => {
   if (c.req.method !== "GET") return next();
   const routePath = new URL(c.req.url).pathname.replace(/^\/public/, "");
@@ -91,9 +144,12 @@ publicReportsRoutes.use("*", async (c, next) => {
   // of a request-derived origin would be a Host-header poisoning vector, so
   // only cache the feed when the origin is pinned by config.
   if (routePath.startsWith("/threat-feed") && !c.env.BETTER_AUTH_URL) return next();
-  // Key on the path only: responses never vary by query, so a cache-busting
-  // query string can never force a D1 read-through.
-  const cacheKey = new Request(new URL(c.req.path, c.req.url).origin + c.req.path);
+  // Key on the *canonical* path only: responses never vary by query, so a
+  // cache-busting query string can never force a D1 read-through, and folding
+  // badge URLs onto their lookup key means one package has exactly one cache
+  // entry no matter how the embedder cased or encoded the name. That is what
+  // makes the purge below exact rather than best-effort.
+  const cacheKey = publicCacheKey(new URL(c.req.url).origin, routePath);
   let cached: Response | undefined;
   try {
     cached = await coloCache().match(cacheKey);
@@ -178,12 +234,17 @@ publicReportsRoutes.get("/threat-feed.json", async (c) => {
 });
 
 // shields.io endpoint badge for a package's latest publicly shared review.
+// Badge errors are fetched cross-origin by the same proxies as the 200s, so
+// they carry the same CORS header; without it the proxy reports an opaque
+// network failure instead of the actual status.
+const BADGE_ERROR_HEADERS = { "access-control-allow-origin": "*" } as const;
+
 // npm names contain slashes (@scope/name), so the route is a wildcard and the
 // name is everything after the ecosystem segment.
 publicReportsRoutes.get("/badge/:ecosystem/*", async (c) => {
   const ecosystem = c.req.param("ecosystem") as PublicEcosystem;
   if (!PUBLIC_ECOSYSTEMS.includes(ecosystem)) {
-    return c.json({ error: "unknown ecosystem" }, 404);
+    return c.json({ error: "unknown ecosystem" }, 404, BADGE_ERROR_HEADERS);
   }
   const marker = `/badge/${ecosystem}/`;
   const markerIndex = c.req.path.indexOf(marker);
@@ -192,10 +253,10 @@ publicReportsRoutes.get("/badge/:ecosystem/*", async (c) => {
   try {
     packageName = decodeURIComponent(rawName);
   } catch {
-    return c.json({ error: "invalid package name" }, 400);
+    return c.json({ error: "invalid package name" }, 400, BADGE_ERROR_HEADERS);
   }
   if (!packageName || packageName.length > publicPackageNameMax(ecosystem)) {
-    return c.json({ error: "invalid package name" }, 400);
+    return c.json({ error: "invalid package name" }, 400, BADGE_ERROR_HEADERS);
   }
 
   const db = createDb(c.env.DB);

--- a/server/routes/public-reports.ts
+++ b/server/routes/public-reports.ts
@@ -2,22 +2,28 @@ import { Hono, type Context } from "hono";
 import { createDb } from "../db/client";
 import { RateLimitError, enforceRateLimit } from "../db/rate-limit";
 import {
+  encodeThreatFeedCursor,
   listBadgeCandidateScans,
   listThreatFeedScans,
+  parseThreatFeedCursor,
   resolvePublicShareToken,
+  threatFeedNextCursor,
+  THREAT_FEED_MAX_ENTRIES,
 } from "../db/scan-share";
 import { getScan } from "../db/scans";
 import {
   buildBadgePayload,
   buildThreatFeedEntry,
+  buildUnavailableBadgePayload,
   pickBadgeScan,
   PUBLIC_ECOSYSTEMS,
-  publicPackageLookupKey,
+  publicFeedCacheKey,
   publicPackageNameMax,
   scanEcosystem,
   THREAT_FEED_SCHEMA,
   type PublicEcosystem,
 } from "../lib/public-feed";
+import { coloCacheMatch, coloCachePut } from "../lib/platform/colo-cache";
 import {
   buildAttestationStatement,
   loadAttestationKey,
@@ -70,102 +76,52 @@ publicReportsRoutes.use("*", async (c, next) => {
 });
 
 // The badge and feed are hot, anonymous, and staleness-tolerant (both already
-// declare max-age=300), so they read through the colo cache (caches.default) —
-// the same pattern as the published-tarball byte cache. Report/attestation
-// reads are deliberately NOT cached: revocation must be immediate. Runs before
-// the rate limiter so cache hits never cost a D1 round trip.
+// declare max-age=300), so they read through the colo cache — the same pattern
+// as the published-tarball byte cache. Report/attestation reads are
+// deliberately NOT cached: revocation must be immediate. Runs before the rate
+// limiter so cache hits never cost a D1 round trip.
 const COLO_CACHED_PATHS = [/^\/badge\//, /^\/threat-feed\.json$/];
 
-// The Workers runtime exposes the colo cache as `caches.default`, but the DOM
-// lib wins the global CacheStorage type in this repo's single tsconfig and
-// doesn't know the property.
-function coloCache(): Cache {
-  return (caches as unknown as { default: Cache }).default;
-}
-
-/**
- * Colo-cache key for a cacheable public path. Badge paths collapse to their
- * canonical package key so `/badge/npm/Foo` and `/badge/npm/Foo` reached via a
- * different encoding share one entry — and so `purgePublicFeedCache` can delete
- * that entry by key after a revoke or unlist.
- */
-export function publicCacheKey(origin: string, routePath: string): Request {
-  const badge = /^\/badge\/([^/]+)\/(.+)$/.exec(routePath);
-  if (badge) {
-    const ecosystem = badge[1] as PublicEcosystem;
-    if (PUBLIC_ECOSYSTEMS.includes(ecosystem)) {
-      let name = badge[2];
-      try {
-        name = decodeURIComponent(name);
-      } catch {
-        // Undecodable name: fall through and key on the raw path.
-      }
-      const key = publicPackageLookupKey(ecosystem, name);
-      return new Request(`${origin}/public/badge-key/${encodeURIComponent(key)}`);
-    }
-  }
-  return new Request(origin + "/public" + routePath);
-}
-
-/**
- * Drop the colo-cached badge and threat feed after a share is revoked or a
- * listing is turned off.
- *
- * Without this the cached bodies keep asserting "<version> reviewed · low risk"
- * for up to the cache TTL after the publisher withdrew the report, and the
- * cached feed still embeds a now-dead share token. The report itself is
- * `no-store` and 404s immediately; this closes the same window on the two
- * derived surfaces. Best effort: a failure here only means the old TTL applies.
- */
-export function purgePublicFeedCache(
-  executionCtx: ExecutionContext,
-  origin: string,
-  publicPackageKey: string | null,
-): void {
-  const keys = [new Request(`${origin}/public/threat-feed.json`)];
-  if (publicPackageKey) {
-    keys.push(new Request(`${origin}/public/badge-key/${encodeURIComponent(publicPackageKey)}`));
-  }
-  for (const key of keys) {
-    executionCtx.waitUntil(
-      coloCache()
-        .delete(key)
-        .catch(() => {}),
-    );
-  }
-}
+// Internal marker: a handler sets it to opt one response out of the colo cache
+// while keeping its downstream `cache-control`. Stripped before the response
+// leaves the Worker.
+const COLO_CACHE_SKIP_HEADER = "x-drydock-colo-cache-skip";
 
 publicReportsRoutes.use("*", async (c, next) => {
   if (c.req.method !== "GET") return next();
   const routePath = new URL(c.req.url).pathname.replace(/^\/public/, "");
   if (!COLO_CACHED_PATHS.some((re) => re.test(routePath))) return next();
-  // The feed body embeds report URLs built from canonicalOrigin, which falls
-  // back to the request origin when BETTER_AUTH_URL is unset — a cached copy
-  // of a request-derived origin would be a Host-header poisoning vector, so
-  // only cache the feed when the origin is pinned by config.
-  if (routePath.startsWith("/threat-feed") && !c.env.BETTER_AUTH_URL) return next();
-  // Key on the *canonical* path only: responses never vary by query, so a
-  // cache-busting query string can never force a D1 read-through, and folding
-  // badge URLs onto their lookup key means one package has exactly one cache
-  // entry no matter how the embedder cased or encoded the name. That is what
-  // makes the purge below exact rather than best-effort.
-  const cacheKey = publicCacheKey(new URL(c.req.url).origin, routePath);
-  let cached: Response | undefined;
-  try {
-    cached = await coloCache().match(cacheKey);
-  } catch {
-    cached = undefined;
+  if (routePath.startsWith("/threat-feed")) {
+    // The feed body embeds report URLs built from canonicalOrigin, which falls
+    // back to the request origin when BETTER_AUTH_URL is unset — a cached copy
+    // of a request-derived origin would be a Host-header poisoning vector, so
+    // only cache the feed when the origin is pinned by config.
+    if (!c.env.BETTER_AUTH_URL) return next();
+    // The cache key is the path alone, and the feed *does* vary by `?after=`.
+    // Only the first page is cacheable; a cursored page must never be served
+    // from, or written into, the entry that page one occupies. Backfill pages
+    // are rare by nature — a consumer walks them once to catch up.
+    if (new URL(c.req.url).search) return next();
   }
+  // Key on the *canonical* origin and path only. Everything still cacheable at
+  // this point ignores its query string, so a cache-busting query can't force a
+  // D1 read-through, and folding badge URLs onto their lookup key means one
+  // package has one entry per colo however the embedder encoded the name. The
+  // origin has to be canonicalOrigin — the same value purgePublicFeedCache uses
+  // from a *dashboard* request — or a deploy bound to a second hostname
+  // (workers.dev, a preview alias) writes entries the purge never visits.
+  const cacheKey = publicFeedCacheKey(canonicalOrigin(c), routePath);
+  const cached = await coloCacheMatch(cacheKey);
   if (cached) return cached;
   await next();
-  if (c.res?.status === 200 && !c.res.headers.get("cache-control")?.includes("no-store")) {
-    const copy = c.res.clone();
-    c.executionCtx.waitUntil(
-      coloCache()
-        .put(cacheKey, copy)
-        .catch(() => {}),
-    );
+  const skip = c.res?.headers.has(COLO_CACHE_SKIP_HEADER);
+  if (c.res?.status === 200 && !skip && !c.res.headers.get("cache-control")?.includes("no-store")) {
+    coloCachePut(c.executionCtx, cacheKey, c.res.clone());
   }
+  // Mutate in place rather than rebuilding: Hono's `c.res` setter copies the
+  // previous response's headers onto the replacement, so a delete-then-reassign
+  // would put the marker straight back.
+  if (skip) c.res.headers.delete(COLO_CACHE_SKIP_HEADER);
 });
 
 publicReportsRoutes.use("*", async (c, next) => {
@@ -187,10 +143,13 @@ publicReportsRoutes.use("*", async (c, next) => {
   } catch (err) {
     if (err instanceof RateLimitError) {
       // Shields proxies many unrelated package badges through shared egress
-      // addresses. Preserve the endpoint-badge contract under throttling and
-      // keep this fallback out of the colo cache so it cannot mask a real review.
+      // addresses. Preserve the endpoint-badge contract under throttling (200,
+      // or proxies render an error) but say "unavailable", never "not
+      // reviewed" — the latter is an assertion about the package that shields
+      // would cache for minutes over a review that may say "blocked". Kept out
+      // of the colo cache for the same reason.
       if (isBadgeRequest) {
-        return c.json(buildBadgePayload(null), 200, {
+        return c.json(buildUnavailableBadgePayload(), 200, {
           "cache-control": "no-store",
           "access-control-allow-origin": "*",
           "retry-after": String(err.retryAfterSeconds),
@@ -220,13 +179,23 @@ publicReportsRoutes.get("/attestation-key", async (c) => {
 // isn't already reachable through those links.
 publicReportsRoutes.get("/threat-feed.json", async (c) => {
   const db = createDb(c.env.DB);
-  const rows = await listThreatFeedScans(db);
+  const after = parseThreatFeedCursor(c.req.query("after"));
+  const requested = Number(c.req.query("limit"));
+  const limit = Number.isFinite(requested)
+    ? Math.min(THREAT_FEED_MAX_ENTRIES, Math.max(1, Math.floor(requested)))
+    : THREAT_FEED_MAX_ENTRIES;
+  const rows = await listThreatFeedScans(db, { limit, after });
   const origin = canonicalOrigin(c);
   return c.json(
     {
       schema: THREAT_FEED_SCHEMA,
       generatedAt: new Date().toISOString(),
       entries: rows.map((row) => buildThreatFeedEntry(row, origin)),
+      // Present whenever more listings exist behind this page. A poller that
+      // reads only page one after a burst of listings misses everything the
+      // burst displaced, so the continuation has to be in the payload rather
+      // than something a consumer has to know to ask for.
+      nextCursor: encodeThreatFeedCursor(threatFeedNextCursor(rows, limit)),
     },
     200,
     { "cache-control": "public, max-age=300", "access-control-allow-origin": "*" },
@@ -270,6 +239,13 @@ publicReportsRoutes.get("/badge/:ecosystem/*", async (c) => {
   return c.json(buildBadgePayload(match), 200, {
     "cache-control": "public, max-age=300",
     "access-control-allow-origin": "*",
+    // Misses stay out of the colo cache. The "not reviewed" body is identical
+    // for every package, so a per-name entry buys nothing on a repeat view that
+    // the downstream `max-age` would not already absorb — while every distinct
+    // name an anonymous client invents writes another entry into the same
+    // `caches.default` namespace that holds the published-tarball bytes. Hits
+    // are the ones worth keeping.
+    ...(match ? {} : { [COLO_CACHE_SKIP_HEADER]: "1" }),
   });
 });
 

--- a/server/routes/public-reports.ts
+++ b/server/routes/public-reports.ts
@@ -24,6 +24,7 @@ import {
   type PublicEcosystem,
 } from "../lib/public-feed";
 import { coloCacheMatch, coloCachePut } from "../lib/platform/colo-cache";
+import { optionalWorkerExecutionContext } from "../lib/platform/execution-context";
 import {
   buildAttestationStatement,
   loadAttestationKey,
@@ -116,7 +117,7 @@ publicReportsRoutes.use("*", async (c, next) => {
   await next();
   const skip = c.res?.headers.has(COLO_CACHE_SKIP_HEADER);
   if (c.res?.status === 200 && !skip && !c.res.headers.get("cache-control")?.includes("no-store")) {
-    coloCachePut(c.executionCtx, cacheKey, c.res.clone());
+    coloCachePut(optionalWorkerExecutionContext(c), cacheKey, c.res.clone());
   }
   // Mutate in place rather than rebuilding: Hono's `c.res` setter copies the
   // previous response's headers onto the replacement, so a delete-then-reassign
@@ -233,7 +234,9 @@ publicReportsRoutes.get("/badge/:ecosystem/*", async (c) => {
   // name-queryable), the SQL pre-filter re-checked through scanEcosystem, and
   // registry-verified identity preferred over manifest claims.
   const rows = await listBadgeCandidateScans(db, packageName, ecosystem);
-  const match = pickBadgeScan(rows.filter((row) => scanEcosystem(row.summaryJson) === ecosystem));
+  const match = pickBadgeScan(
+    rows.filter((row) => scanEcosystem(row.source, row.summaryJson) === ecosystem),
+  );
   // Always 200: shields renders the payload either way, and "not reviewed"
   // must not read as an error to badge proxies.
   return c.json(buildBadgePayload(match), 200, {

--- a/server/routes/public-reports.ts
+++ b/server/routes/public-reports.ts
@@ -1,15 +1,28 @@
 import { Hono, type Context } from "hono";
 import { createDb } from "../db/client";
 import { RateLimitError, enforceRateLimit } from "../db/rate-limit";
-import { resolvePublicShareToken } from "../db/scan-share";
+import {
+  listBadgeCandidateScans,
+  listThreatFeedScans,
+  resolvePublicShareToken,
+} from "../db/scan-share";
 import { getScan } from "../db/scans";
+import {
+  buildBadgePayload,
+  buildThreatFeedEntry,
+  pickBadgeScan,
+  PUBLIC_ECOSYSTEMS,
+  scanEcosystem,
+  THREAT_FEED_SCHEMA,
+  type PublicEcosystem,
+} from "../lib/public-feed";
 import {
   buildAttestationStatement,
   loadAttestationKey,
   sha256Hex,
   signAttestation,
 } from "../lib/attestation";
-import { rateLimitResponse } from "../lib/platform/http";
+import { canonicalOrigin, rateLimitResponse } from "../lib/platform/http";
 import { describeOperationalError, emitOperationalEvent } from "../lib/platform/observability";
 import {
   buildReportExport,
@@ -52,6 +65,50 @@ publicReportsRoutes.use("*", async (c, next) => {
   });
 });
 
+// The badge and feed are hot, anonymous, and staleness-tolerant (both already
+// declare max-age=300), so they read through the colo cache (caches.default) —
+// the same pattern as the published-tarball byte cache. Report/attestation
+// reads are deliberately NOT cached: revocation must be immediate. Runs before
+// the rate limiter so cache hits never cost a D1 round trip.
+const COLO_CACHED_PATHS = [/^\/badge\//, /^\/threat-feed\.json$/];
+
+// The Workers runtime exposes the colo cache as `caches.default`, but the DOM
+// lib wins the global CacheStorage type in this repo's single tsconfig and
+// doesn't know the property.
+function coloCache(): Cache {
+  return (caches as unknown as { default: Cache }).default;
+}
+
+publicReportsRoutes.use("*", async (c, next) => {
+  if (c.req.method !== "GET") return next();
+  const routePath = new URL(c.req.url).pathname.replace(/^\/public/, "");
+  if (!COLO_CACHED_PATHS.some((re) => re.test(routePath))) return next();
+  // The feed body embeds report URLs built from canonicalOrigin, which falls
+  // back to the request origin when BETTER_AUTH_URL is unset — a cached copy
+  // of a request-derived origin would be a Host-header poisoning vector, so
+  // only cache the feed when the origin is pinned by config.
+  if (routePath.startsWith("/threat-feed") && !c.env.BETTER_AUTH_URL) return next();
+  // Key on the path only: responses never vary by query, so a cache-busting
+  // query string can never force a D1 read-through.
+  const cacheKey = new Request(new URL(c.req.path, c.req.url).origin + c.req.path);
+  let cached: Response | undefined;
+  try {
+    cached = await coloCache().match(cacheKey);
+  } catch {
+    cached = undefined;
+  }
+  if (cached) return cached;
+  await next();
+  if (c.res?.status === 200) {
+    const copy = c.res.clone();
+    c.executionCtx.waitUntil(
+      coloCache()
+        .put(cacheKey, copy)
+        .catch(() => {}),
+    );
+  }
+});
+
 publicReportsRoutes.use("*", async (c, next) => {
   const ip =
     c.req.header("cf-connecting-ip") || c.req.header("x-forwarded-for")?.split(",")[0]?.trim();
@@ -83,6 +140,59 @@ publicReportsRoutes.get("/attestation-key", async (c) => {
     // (CORS comes from the route-wide middleware above.)
     { "cache-control": "public, max-age=3600" },
   );
+});
+
+// Discoverable index of reports whose org opted into feed listing on top of
+// sharing. Entries link back to the public report; nothing here is served that
+// isn't already reachable through those links.
+publicReportsRoutes.get("/threat-feed.json", async (c) => {
+  const db = createDb(c.env.DB);
+  const rows = await listThreatFeedScans(db);
+  const origin = canonicalOrigin(c);
+  return c.json(
+    {
+      schema: THREAT_FEED_SCHEMA,
+      generatedAt: new Date().toISOString(),
+      entries: rows.map((row) => buildThreatFeedEntry(row, origin)),
+    },
+    200,
+    { "cache-control": "public, max-age=300", "access-control-allow-origin": "*" },
+  );
+});
+
+// shields.io endpoint badge for a package's latest publicly shared review.
+// npm names contain slashes (@scope/name), so the route is a wildcard and the
+// name is everything after the ecosystem segment.
+publicReportsRoutes.get("/badge/:ecosystem/*", async (c) => {
+  const ecosystem = c.req.param("ecosystem") as PublicEcosystem;
+  if (!PUBLIC_ECOSYSTEMS.includes(ecosystem)) {
+    return c.json({ error: "unknown ecosystem" }, 404);
+  }
+  const marker = `/badge/${ecosystem}/`;
+  const markerIndex = c.req.path.indexOf(marker);
+  const rawName = markerIndex >= 0 ? c.req.path.slice(markerIndex + marker.length) : "";
+  let packageName: string;
+  try {
+    packageName = decodeURIComponent(rawName);
+  } catch {
+    return c.json({ error: "invalid package name" }, 400);
+  }
+  if (!packageName || packageName.length > 214) {
+    return c.json({ error: "invalid package name" }, 400);
+  }
+
+  const db = createDb(c.env.DB);
+  // Feed-listed scans only (a share link alone never makes a scan
+  // name-queryable), the SQL pre-filter re-checked through scanEcosystem, and
+  // registry-verified identity preferred over manifest claims.
+  const rows = await listBadgeCandidateScans(db, packageName, ecosystem);
+  const match = pickBadgeScan(rows.filter((row) => scanEcosystem(row.summaryJson) === ecosystem));
+  // Always 200: shields renders the payload either way, and "not reviewed"
+  // must not read as an error to badge proxies.
+  return c.json(buildBadgePayload(match), 200, {
+    "cache-control": "public, max-age=300",
+    "access-control-allow-origin": "*",
+  });
 });
 
 publicReportsRoutes.get("/reports/:token", async (c) => {

--- a/server/routes/public-reports.ts
+++ b/server/routes/public-reports.ts
@@ -41,9 +41,11 @@ import type { Bindings, Variables } from "../types";
 // events, or org/user identifiers beyond what the export itself carries.
 export const publicReportsRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
-// One bucket for all public report reads from one address. Generous enough for
-// a report page plus its attestation fetch, tight enough to blunt enumeration.
-const PUBLIC_READ_RATE = { limit: 120, windowMs: 60 * 1000 };
+// Report/key reads share a bucket per address. Badge misses use a separate
+// bucket because shields.io multiplexes unrelated packages through its egress.
+// Both remain tight enough to blunt enumeration and cache-busting traffic.
+const PUBLIC_READ_RATE = { bucket: "public-report", limit: 120, windowMs: 60 * 1000 };
+const PUBLIC_BADGE_READ_RATE = { bucket: "public-badge", limit: 120, windowMs: 60 * 1000 };
 
 const SHARE_TOKEN_RE = /^[A-Za-z0-9_-]{40,64}$/;
 
@@ -99,7 +101,7 @@ publicReportsRoutes.use("*", async (c, next) => {
   }
   if (cached) return cached;
   await next();
-  if (c.res?.status === 200) {
+  if (c.res?.status === 200 && !c.res.headers.get("cache-control")?.includes("no-store")) {
     const copy = c.res.clone();
     c.executionCtx.waitUntil(
       coloCache()
@@ -116,13 +118,27 @@ publicReportsRoutes.use("*", async (c, next) => {
   // always sets cf-connecting-ip, so this only relaxes non-Cloudflare deploys
   // (unsupported per docs/self-hosting.md).
   if (!ip) return next();
+  const routePath = new URL(c.req.url).pathname.replace(/^\/public/, "");
+  const isBadgeRequest = routePath.startsWith("/badge/");
+  const rate = isBadgeRequest ? PUBLIC_BADGE_READ_RATE : PUBLIC_READ_RATE;
   try {
     await enforceRateLimit(createDb(c.env.DB), {
-      key: `public-report:${ip}`,
-      ...PUBLIC_READ_RATE,
+      key: `${rate.bucket}:${ip}`,
+      limit: rate.limit,
+      windowMs: rate.windowMs,
     });
   } catch (err) {
     if (err instanceof RateLimitError) {
+      // Shields proxies many unrelated package badges through shared egress
+      // addresses. Preserve the endpoint-badge contract under throttling and
+      // keep this fallback out of the colo cache so it cannot mask a real review.
+      if (isBadgeRequest) {
+        return c.json(buildBadgePayload(null), 200, {
+          "cache-control": "no-store",
+          "access-control-allow-origin": "*",
+          "retry-after": String(err.retryAfterSeconds),
+        });
+      }
       return rateLimitResponse(c, "too many public report requests", err);
     }
     throw err;

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -35,8 +35,13 @@ import {
 } from "../lib/compare-cache";
 import { canonicalOrigin, rateLimitResponse } from "../lib/platform/http";
 import { workerExecutionContext } from "../lib/platform/execution-context";
-import { enablePublicShare, revokePublicShare, setThreatFeedListing } from "../db/scan-share";
-import { purgePublicFeedCache } from "./public-reports";
+import { purgePublicFeedCache } from "../lib/public-feed";
+import {
+  enablePublicShare,
+  readPublicShare,
+  revokePublicShare,
+  setThreatFeedListing,
+} from "../db/scan-share";
 import {
   allowInsecureLocalRegistry,
   decryptNpmToken,
@@ -323,14 +328,25 @@ scansRoutes.post("/:id/share", async (c) => {
   const { organizationId, role } = await requireActiveOrganizationContext(c, db);
   if (!roleCanManagePublicShares(role)) return c.json({ error: "forbidden" }, 403);
 
-  let share = await enablePublicShare(db, {
-    scanId: c.req.param("id"),
-    organizationId,
-    actorUserId: session.userId,
-  });
+  // `threatFeed: false` is a *withdrawal*. Routing it through
+  // enablePublicShare would mint a fresh token whenever the scan has none, so
+  // an admin unchecking "List publicly" on a dialog whose link another admin
+  // just revoked would republish the report — the wrong failure direction, and
+  // invisible, because the response then hands back a live URL. Read the
+  // existing share instead and let the 409 below tell the stale dialog to
+  // refresh (the UI drops its share state on 409).
+  const unlisting = body.threatFeed === false;
+  let share = unlisting
+    ? await readPublicShare(db, { scanId: c.req.param("id"), organizationId })
+    : await enablePublicShare(db, {
+        scanId: c.req.param("id"),
+        organizationId,
+        actorUserId: session.userId,
+      });
   if (!share) {
     const existing = await getScanStatus(db, c.req.param("id"), organizationId);
     if (!existing) return c.json({ error: "not found" }, 404);
+    if (unlisting) return c.json({ error: "the share link was just revoked" }, 409);
     return c.json({ error: "only completed scans can be shared publicly" }, 409);
   }
   // Threat-feed listing is a second opt-in layered on the link: only flip it
@@ -348,12 +364,11 @@ scansRoutes.post("/:id/share", async (c) => {
       // toggle; the stale pre-revoke state must not be reported as current.
       if (!updated) return c.json({ error: "the share link was just revoked" }, 409);
       // Unlisting (and re-listing) changes what the cached badge and feed
-      // assert; drop both so the change is not delayed by the colo TTL.
-      purgePublicFeedCache(
-        c.executionCtx,
-        new URL(c.req.url).origin,
-        updated.publicPackageKey ?? null,
-      );
+      // assert; drop both so the change is not delayed by the colo TTL in at
+      // least this region. canonicalOrigin, not the request origin: the badge
+      // writes its entry under the same value, and this request arrives at the
+      // dashboard, which may be a different hostname than the one embedders hit.
+      purgePublicFeedCache(c.executionCtx, canonicalOrigin(c), updated.publicPackageKey ?? null);
       share = updated;
     }
   }
@@ -375,7 +390,7 @@ scansRoutes.delete("/:id/share", async (c) => {
     const existing = await getScanStatus(db, c.req.param("id"), organizationId);
     if (!existing) return c.json({ error: "not found" }, 404);
   } else {
-    purgePublicFeedCache(c.executionCtx, new URL(c.req.url).origin, publicPackageKey);
+    purgePublicFeedCache(c.executionCtx, canonicalOrigin(c), publicPackageKey);
   }
   return c.json({ revoked });
 });

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -389,7 +389,15 @@ scansRoutes.get("/:id", async (c) => {
     files: "list",
   });
   if (!scan) return c.json({ error: "not found" }, 404);
-  return c.json(scan);
+  return c.json({
+    ...scan,
+    scan: {
+      ...scan.scan,
+      publicShareUrl: scan.scan.publicShareToken
+        ? `${canonicalOrigin(c)}/reports/${scan.scan.publicShareToken}`
+        : null,
+    },
+  });
 });
 
 scansRoutes.get("/:id/status", async (c) => {

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -34,7 +34,10 @@ import {
   writeCompareMetadataCache,
 } from "../lib/compare-cache";
 import { canonicalOrigin, rateLimitResponse } from "../lib/platform/http";
-import { workerExecutionContext } from "../lib/platform/execution-context";
+import {
+  optionalWorkerExecutionContext,
+  workerExecutionContext,
+} from "../lib/platform/execution-context";
 import { purgePublicFeedCache } from "../lib/public-feed";
 import {
   enablePublicShare,
@@ -346,7 +349,11 @@ scansRoutes.post("/:id/share", async (c) => {
   if (!share) {
     const existing = await getScanStatus(db, c.req.param("id"), organizationId);
     if (!existing) return c.json({ error: "not found" }, 404);
-    if (unlisting) return c.json({ error: "the share link was just revoked" }, 409);
+    // Revoking nulls the token *and* its timestamp, so "revoked a moment ago"
+    // and "never shared" are the same persisted state — there is nothing to
+    // tell them apart with. Say the part that is true either way; the UI drops
+    // its stale share state on 409 regardless.
+    if (unlisting) return c.json({ error: "this report is not shared publicly" }, 409);
     return c.json({ error: "only completed scans can be shared publicly" }, 409);
   }
   // Threat-feed listing is a second opt-in layered on the link: only flip it
@@ -368,7 +375,11 @@ scansRoutes.post("/:id/share", async (c) => {
       // least this region. canonicalOrigin, not the request origin: the badge
       // writes its entry under the same value, and this request arrives at the
       // dashboard, which may be a different hostname than the one embedders hit.
-      purgePublicFeedCache(c.executionCtx, canonicalOrigin(c), updated.publicPackageKey ?? null);
+      purgePublicFeedCache(
+        optionalWorkerExecutionContext(c),
+        canonicalOrigin(c),
+        updated.publicPackageKey ?? null,
+      );
       share = updated;
     }
   }
@@ -390,7 +401,7 @@ scansRoutes.delete("/:id/share", async (c) => {
     const existing = await getScanStatus(db, c.req.param("id"), organizationId);
     if (!existing) return c.json({ error: "not found" }, 404);
   } else {
-    purgePublicFeedCache(c.executionCtx, canonicalOrigin(c), publicPackageKey);
+    purgePublicFeedCache(optionalWorkerExecutionContext(c), canonicalOrigin(c), publicPackageKey);
   }
   return c.json({ revoked });
 });

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -36,6 +36,7 @@ import {
 import { canonicalOrigin, rateLimitResponse } from "../lib/platform/http";
 import { workerExecutionContext } from "../lib/platform/execution-context";
 import { enablePublicShare, revokePublicShare, setThreatFeedListing } from "../db/scan-share";
+import { purgePublicFeedCache } from "./public-reports";
 import {
   allowInsecureLocalRegistry,
   decryptNpmToken,
@@ -346,6 +347,13 @@ scansRoutes.post("/:id/share", async (c) => {
       // A concurrent revoke can void the share between the enable and the
       // toggle; the stale pre-revoke state must not be reported as current.
       if (!updated) return c.json({ error: "the share link was just revoked" }, 409);
+      // Unlisting (and re-listing) changes what the cached badge and feed
+      // assert; drop both so the change is not delayed by the colo TTL.
+      purgePublicFeedCache(
+        c.executionCtx,
+        new URL(c.req.url).origin,
+        updated.publicPackageKey ?? null,
+      );
       share = updated;
     }
   }
@@ -358,7 +366,7 @@ scansRoutes.delete("/:id/share", async (c) => {
   const { organizationId, role } = await requireActiveOrganizationContext(c, db);
   if (!roleCanManagePublicShares(role)) return c.json({ error: "forbidden" }, 403);
 
-  const revoked = await revokePublicShare(db, {
+  const { revoked, publicPackageKey } = await revokePublicShare(db, {
     scanId: c.req.param("id"),
     organizationId,
     actorUserId: session.userId,
@@ -366,6 +374,8 @@ scansRoutes.delete("/:id/share", async (c) => {
   if (!revoked) {
     const existing = await getScanStatus(db, c.req.param("id"), organizationId);
     if (!existing) return c.json({ error: "not found" }, 404);
+  } else {
+    purgePublicFeedCache(c.executionCtx, new URL(c.req.url).origin, publicPackageKey);
   }
   return c.json({ revoked });
 });

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -33,9 +33,9 @@ import {
   stripTextSamples,
   writeCompareMetadataCache,
 } from "../lib/compare-cache";
-import { rateLimitResponse } from "../lib/platform/http";
+import { canonicalOrigin, rateLimitResponse } from "../lib/platform/http";
 import { workerExecutionContext } from "../lib/platform/execution-context";
-import { enablePublicShare, revokePublicShare } from "../db/scan-share";
+import { enablePublicShare, revokePublicShare, setThreatFeedListing } from "../db/scan-share";
 import {
   allowInsecureLocalRegistry,
   decryptNpmToken,
@@ -315,12 +315,14 @@ scansRoutes.delete("/:id", async (c) => {
 // /public/reports/:token to anyone holding the link — an explicit, elevated
 // opt-in, so it takes owner/admin, not plain membership.
 scansRoutes.post("/:id/share", async (c) => {
+  // `?? {}` also covers a literal `null` body, which json() parses successfully.
+  const body = ((await c.req.json().catch(() => ({}))) ?? {}) as Partial<{ threatFeed: boolean }>;
   const db = createDb(c.env.DB);
   const session = c.get("authSession");
   const { organizationId, role } = await requireActiveOrganizationContext(c, db);
   if (!roleCanManagePublicShares(role)) return c.json({ error: "forbidden" }, 403);
 
-  const share = await enablePublicShare(db, {
+  let share = await enablePublicShare(db, {
     scanId: c.req.param("id"),
     organizationId,
     actorUserId: session.userId,
@@ -329,6 +331,23 @@ scansRoutes.post("/:id/share", async (c) => {
     const existing = await getScanStatus(db, c.req.param("id"), organizationId);
     if (!existing) return c.json({ error: "not found" }, 404);
     return c.json({ error: "only completed scans can be shared publicly" }, 409);
+  }
+  // Threat-feed listing is a second opt-in layered on the link: only flip it
+  // when the caller states an intent, so a plain re-share never (un)lists.
+  if (typeof body.threatFeed === "boolean") {
+    const listedNow = share.publicFeedListedAt !== null;
+    if (body.threatFeed !== listedNow) {
+      const updated = await setThreatFeedListing(db, {
+        scanId: c.req.param("id"),
+        organizationId,
+        actorUserId: session.userId,
+        listed: body.threatFeed,
+      });
+      // A concurrent revoke can void the share between the enable and the
+      // toggle; the stale pre-revoke state must not be reported as current.
+      if (!updated) return c.json({ error: "the share link was just revoked" }, 409);
+      share = updated;
+    }
   }
   return c.json({ share: publicShareResponse(c, share) });
 });
@@ -353,21 +372,13 @@ scansRoutes.delete("/:id/share", async (c) => {
 
 function publicShareResponse(
   c: Context<{ Bindings: Bindings; Variables: Variables }>,
-  share: { publicShareToken: string; publicSharedAt: Date },
+  share: { publicShareToken: string; publicSharedAt: Date; publicFeedListedAt: Date | null },
 ) {
-  // Prefer the canonical origin so copied links don't pin a preview host.
-  const origin = (() => {
-    try {
-      return c.env.BETTER_AUTH_URL ? new URL(c.env.BETTER_AUTH_URL).origin : null;
-    } catch {
-      return null;
-    }
-  })();
-  const base = origin ?? new URL(c.req.url).origin;
   return {
     token: share.publicShareToken,
-    url: `${base}/reports/${share.publicShareToken}`,
+    url: `${canonicalOrigin(c)}/reports/${share.publicShareToken}`,
     sharedAt: share.publicSharedAt,
+    threatFeedListedAt: share.publicFeedListedAt,
   };
 }
 

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -91,6 +91,7 @@ export interface PersistedScanDetail {
     reportDigest?: string | null;
     publicShareToken?: string | null;
     publicSharedAt?: string | number | Date | null;
+    publicFeedListedAt?: string | number | Date | null;
     startedAt?: string | number | Date | null;
     completedAt?: string | number | Date | null;
   };
@@ -203,10 +204,17 @@ export interface PublicShareInfo {
   token: string;
   url: string;
   sharedAt: string | number | Date;
+  threatFeedListedAt: string | number | Date | null;
 }
 
-function enableScanShare(id: string): Promise<{ share: PublicShareInfo }> {
-  return apiJson<{ share: PublicShareInfo }>(`/api/v1/scans/${encodeURIComponent(id)}/share`, {});
+function enableScanShare(
+  id: string,
+  options: { threatFeed?: boolean } = {},
+): Promise<{ share: PublicShareInfo }> {
+  return apiJson<{ share: PublicShareInfo }>(
+    `/api/v1/scans/${encodeURIComponent(id)}/share`,
+    options,
+  );
 }
 
 function revokeScanShare(id: string): Promise<{ revoked: boolean }> {
@@ -580,6 +588,7 @@ export const ScanDetailModel = createModel((id: string) => {
                 token: data.scan.publicShareToken,
                 url: publicReportUrl(data.scan.publicShareToken),
                 sharedAt: data.scan.publicSharedAt ?? data.scan.updatedAt,
+                threatFeedListedAt: data.scan.publicFeedListedAt ?? null,
               }
             : null;
           if (this.selectedPath.peek() === null) {
@@ -600,6 +609,23 @@ export const ScanDetailModel = createModel((id: string) => {
         this.share.value = share;
         this.shareStatus.value = "idle";
       } catch (err) {
+        this.shareError.value = shareErrorMessage(err);
+        this.shareStatus.value = "error";
+      }
+    },
+
+    async setFeedListing(listed: boolean): Promise<void> {
+      const id = this.scanId.peek();
+      this.shareStatus.value = "saving";
+      this.shareError.value = null;
+      try {
+        const { share } = await enableScanShare(id, { threatFeed: listed });
+        this.share.value = share;
+        this.shareStatus.value = "idle";
+      } catch (err) {
+        // 409 means the link was revoked while the toggle was in flight — drop
+        // the dead share state so the dialog falls back to "create link".
+        if (err instanceof ApiError && err.status === 409) this.share.value = null;
         this.shareError.value = shareErrorMessage(err);
         this.shareStatus.value = "error";
       }

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -231,6 +231,18 @@ export function publicReportAttestationUrl(token: string): string {
   return `${location.origin}/public/reports/${encodeURIComponent(token)}/attestation`;
 }
 
+export async function publicAttestationAvailable(): Promise<boolean> {
+  try {
+    const response = await fetch("/public/attestation-key", {
+      credentials: "same-origin",
+      headers: { accept: "application/json" },
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
 export type DecisionStatus = "idle" | "saving" | "error";
 export type DeleteStatus = "idle" | "deleting" | "error";
 
@@ -430,6 +442,7 @@ export const ScanDetailModel = createModel((id: string) => {
   const share = signal<PublicShareInfo | null>(null);
   const shareStatus = signal<DecisionStatus>("idle");
   const shareError = signal<string | null>(null);
+  const attestationAvailable = signal<boolean | null>(null);
   const gate = signal<PublicWorkflowGate | null>(null);
   const gateLoaded = signal(false);
   const gateDecisionStatus = signal<DecisionStatus>("idle");
@@ -565,6 +578,7 @@ export const ScanDetailModel = createModel((id: string) => {
     share,
     shareStatus,
     shareError,
+    attestationAvailable,
     gate,
     gateLoaded,
     gateDecisionStatus,
@@ -612,6 +626,11 @@ export const ScanDetailModel = createModel((id: string) => {
         this.shareError.value = shareErrorMessage(err);
         this.shareStatus.value = "error";
       }
+    },
+
+    async loadAttestationAvailability(): Promise<void> {
+      this.attestationAvailable.value = null;
+      this.attestationAvailable.value = await publicAttestationAvailable();
     },
 
     async setFeedListing(listed: boolean): Promise<void> {

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -232,7 +232,7 @@ export function publicReportAttestationUrl(token: string): string {
   return `${location.origin}/public/reports/${encodeURIComponent(token)}/attestation`;
 }
 
-export async function publicAttestationAvailable(): Promise<boolean> {
+async function publicAttestationAvailable(): Promise<boolean> {
   try {
     const response = await fetch("/public/attestation-key", {
       credentials: "same-origin",

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -90,6 +90,7 @@ export interface PersistedScanDetail {
     reportVersion?: number | null;
     reportDigest?: string | null;
     publicShareToken?: string | null;
+    publicShareUrl?: string | null;
     publicSharedAt?: string | number | Date | null;
     publicFeedListedAt?: string | number | Date | null;
     startedAt?: string | number | Date | null;
@@ -600,7 +601,7 @@ export const ScanDetailModel = createModel((id: string) => {
           this.share.value = data.scan.publicShareToken
             ? {
                 token: data.scan.publicShareToken,
-                url: publicReportUrl(data.scan.publicShareToken),
+                url: data.scan.publicShareUrl ?? publicReportUrl(data.scan.publicShareToken),
                 sharedAt: data.scan.publicSharedAt ?? data.scan.updatedAt,
                 threatFeedListedAt: data.scan.publicFeedListedAt ?? null,
               }

--- a/src/pages/Dashboard/ScanDetail/ShareDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/ShareDialog.tsx
@@ -16,6 +16,7 @@ export function ShareDialog({
   error,
   onEnable,
   onRevoke,
+  onSetFeedListing,
 }: {
   open: boolean;
   onClose: () => void;
@@ -24,6 +25,7 @@ export function ShareDialog({
   error: string | null;
   onEnable: () => void;
   onRevoke: () => void;
+  onSetFeedListing: (listed: boolean) => void;
 }) {
   const copied = useSignal(false);
   // Rendered directly as a signal child so the copy feedback re-renders only
@@ -95,6 +97,23 @@ export function ShareDialog({
           <EmptyLine>
             Anyone with the link can read the report; revoking invalidates it immediately.
           </EmptyLine>
+          <label class="flex items-start gap-2 text-[13px] text-ink-muted cursor-pointer">
+            <input
+              type="checkbox"
+              class="mt-0.5"
+              checked={share.threatFeedListedAt !== null}
+              disabled={saving}
+              onChange={(e) => onSetFeedListing((e.target as HTMLInputElement).checked)}
+            />
+            <span>
+              List publicly — the report appears in the discoverable{" "}
+              <a href="/public/threat-feed.json" class="text-ink-muted underline hover:text-ink">
+                threat-feed.json
+              </a>{" "}
+              index that security partners consume and powers the package&apos;s status badge, not
+              just behind this link.
+            </span>
+          </label>
         </>
       ) : (
         <EmptyLine>

--- a/src/pages/Dashboard/ScanDetail/ShareDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/ShareDialog.tsx
@@ -14,6 +14,7 @@ export function ShareDialog({
   share,
   status,
   error,
+  attestationAvailable,
   onEnable,
   onRevoke,
   onSetFeedListing,
@@ -23,6 +24,7 @@ export function ShareDialog({
   share: PublicShareInfo | null;
   status: DecisionStatus;
   error: string | null;
+  attestationAvailable: boolean | null;
   onEnable: () => void;
   onRevoke: () => void;
   onSetFeedListing: (listed: boolean) => void;
@@ -84,16 +86,21 @@ export function ShareDialog({
           <MonoDetail
             parts={[
               <span key="shared">shared {formatDateTime(share.sharedAt)}</span>,
-              <a
-                key="attestation"
-                href={publicReportAttestationUrl(share.token)}
-                class="text-ink-muted hover:text-ink"
-                download
-              >
-                signed attestation
-              </a>,
+              attestationAvailable ? (
+                <a
+                  key="attestation"
+                  href={publicReportAttestationUrl(share.token)}
+                  class="text-ink-muted hover:text-ink"
+                  download
+                >
+                  signed attestation
+                </a>
+              ) : null,
             ]}
           />
+          {attestationAvailable === false ? (
+            <EmptyLine>Signed attestations are not configured for this deployment.</EmptyLine>
+          ) : null}
           <EmptyLine>
             Anyone with the link can read the report; revoking invalidates it immediately.
           </EmptyLine>

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -266,7 +266,12 @@ export default function ScanDetailPage() {
       : undefined;
 
   const onShareClick =
-    detail?.scan.status === "complete" ? () => (shareDialogOpen.value = true) : undefined;
+    detail?.scan.status === "complete"
+      ? () => {
+          shareDialogOpen.value = true;
+          void model.loadAttestationAvailability();
+        }
+      : undefined;
 
   return (
     <PageShell>
@@ -452,6 +457,7 @@ export default function ScanDetailPage() {
           shareSignal={model.share}
           statusSignal={model.shareStatus}
           errorSignal={model.shareError}
+          attestationAvailableSignal={model.attestationAvailable}
           onEnable={() => void model.enableShare()}
           onRevoke={() => void model.revokeShare()}
           onSetFeedListing={(listed) => void model.setFeedListing(listed)}
@@ -554,12 +560,17 @@ function ShareDialogHost({
   shareSignal,
   statusSignal,
   errorSignal,
+  attestationAvailableSignal,
   ...props
-}: Omit<ComponentProps<typeof ShareDialog>, "open" | "share" | "status" | "error"> & {
+}: Omit<
+  ComponentProps<typeof ShareDialog>,
+  "open" | "share" | "status" | "error" | "attestationAvailable"
+> & {
   openSignal: ReadonlySignal<boolean>;
   shareSignal: ReadonlySignal<PublicShareInfo | null>;
   statusSignal: ReadonlySignal<DecisionStatus>;
   errorSignal: ReadonlySignal<string | null>;
+  attestationAvailableSignal: ReadonlySignal<boolean | null>;
 }) {
   return (
     <ShareDialog
@@ -567,6 +578,7 @@ function ShareDialogHost({
       share={shareSignal.value}
       status={statusSignal.value}
       error={errorSignal.value}
+      attestationAvailable={attestationAvailableSignal.value}
       {...props}
     />
   );

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -454,6 +454,7 @@ export default function ScanDetailPage() {
           errorSignal={model.shareError}
           onEnable={() => void model.enableShare()}
           onRevoke={() => void model.revokeShare()}
+          onSetFeedListing={(listed) => void model.setFeedListing(listed)}
         />
       ) : null}
 

--- a/src/pages/PublicReport/index.tsx
+++ b/src/pages/PublicReport/index.tsx
@@ -52,6 +52,11 @@ interface PublicReport {
   }>;
 }
 
+interface LoadedPublicReport {
+  data: PublicReport;
+  attestationAvailable: boolean;
+}
+
 const CHANGED_STATUSES = new Set(["added", "removed", "modified"]);
 const MAX_LISTED_CHANGES = 200;
 
@@ -59,12 +64,17 @@ export default function PublicReportPage() {
   const route = useRoute();
   const token = route.params.token ?? "";
   const authed = useAuthedSession();
-  const report = useSignal<PublicReport | null>(null);
+  const report = useSignal<LoadedPublicReport | null>(null);
   const errorState = useSignal<"none" | "not_found" | "failed">("none");
 
   useEffect(() => {
     let cancelled = false;
+    report.value = null;
+    errorState.value = "none";
     void (async () => {
+      const keyRequest = fetch("/public/attestation-key", {
+        headers: { accept: "application/json" },
+      }).catch(() => null);
       try {
         const res = await fetch(`/public/reports/${encodeURIComponent(token)}`, {
           headers: { accept: "application/json" },
@@ -78,7 +88,11 @@ export default function PublicReportPage() {
           errorState.value = "failed";
           return;
         }
-        report.value = (await res.json()) as PublicReport;
+        const data = (await res.json()) as PublicReport;
+        const keyResponse = await keyRequest;
+        if (!cancelled) {
+          report.value = { data, attestationAvailable: keyResponse?.ok ?? false };
+        }
       } catch {
         if (!cancelled) errorState.value = "failed";
       }
@@ -89,7 +103,7 @@ export default function PublicReportPage() {
   }, [token]);
 
   useEffect(() => {
-    const data = report.value;
+    const data = report.value?.data;
     if (data?.package.name) {
       document.title = `${data.package.name} ${data.package.stagedVersion ?? ""} · Drydock review`;
     }
@@ -98,10 +112,10 @@ export default function PublicReportPage() {
   }, [report.value]);
 
   const sortedFindings = useComputed(() =>
-    report.value ? sortFindingsBySeverity(report.value.findings) : [],
+    report.value ? sortFindingsBySeverity(report.value.data.findings) : [],
   );
   const changedFiles = useComputed(
-    () => report.value?.diff?.filter((entry) => CHANGED_STATUSES.has(entry.status)) ?? [],
+    () => report.value?.data.diff?.filter((entry) => CHANGED_STATUSES.has(entry.status)) ?? [],
   );
 
   if (errorState.value === "not_found") {
@@ -121,14 +135,16 @@ export default function PublicReportPage() {
     );
   }
 
-  const data = report.value;
-  if (!data) {
+  const loaded = report.value;
+  if (!loaded) {
     return (
       <PageShell width="doc" headerActions={<MarketingHeaderActions authed={authed} />}>
         <LoadingState title="Loading public review" detail="fetching report" />
       </PageShell>
     );
   }
+
+  const { data, attestationAvailable } = loaded;
 
   const releaseRisk = data.riskSummary?.releaseRisk ?? data.scan.risk;
   const decision = data.scan.decision;
@@ -242,19 +258,25 @@ export default function PublicReportPage() {
 
       <section class="flex flex-col gap-3">
         <SectionLabel as="h2">Verify this report</SectionLabel>
-        <EmptyLine>
-          The signed attestation covers the exact JSON served for this link: its subject digest is
-          the SHA-256 of the report bytes, signed with Drydock's Ed25519 key (DSSE envelope, key
-          published at{" "}
-          <a href="/public/attestation-key" class="text-ink-muted underline hover:text-ink">
-            /public/attestation-key
-          </a>
-          ).
-        </EmptyLine>
+        {attestationAvailable ? (
+          <EmptyLine>
+            The signed attestation covers the exact JSON served for this link: its subject digest is
+            the SHA-256 of the report bytes, signed with Drydock's Ed25519 key (DSSE envelope, key
+            published at{" "}
+            <a href="/public/attestation-key" class="text-ink-muted underline hover:text-ink">
+              /public/attestation-key
+            </a>
+            ).
+          </EmptyLine>
+        ) : (
+          <EmptyLine>Signed attestations are not configured for this deployment.</EmptyLine>
+        )}
         <div class="flex flex-wrap gap-2">
-          <LinkButton variant="secondary" size="sm" href={attestationHref} download>
-            Download attestation
-          </LinkButton>
+          {attestationAvailable ? (
+            <LinkButton variant="secondary" size="sm" href={attestationHref} download>
+              Download attestation
+            </LinkButton>
+          ) : null}
           <LinkButton
             variant="ghost"
             size="sm"

--- a/test/workers/account-deletion.test.ts
+++ b/test/workers/account-deletion.test.ts
@@ -161,9 +161,9 @@ describe("account deletion", () => {
     // ...and a scan they triggered inside that surviving org.
     const scanId = `scan-${crypto.randomUUID()}`;
     await env.DB.prepare(
-      "INSERT INTO scans (id, stage_id, organization_id, owner_user_id, risk, status, source, created_at, updated_at) VALUES (?, ?, ?, ?, 'unknown', 'completed', 'manual', ?, ?)",
+      "INSERT INTO scans (id, stage_id, organization_id, owner_user_id, public_shared_by_user_id, risk, status, source, created_at, updated_at) VALUES (?, ?, ?, ?, ?, 'unknown', 'completed', 'manual', ?, ?)",
     )
-      .bind(scanId, "stage-1", orgId, member.userId, now, now)
+      .bind(scanId, "stage-1", orgId, member.userId, member.userId, now, now)
       .run();
 
     const del = await call("POST", "/api/auth/delete-user", {
@@ -192,7 +192,7 @@ describe("account deletion", () => {
     expect(await countRows("SELECT count(*) AS n FROM scans WHERE id = ?", scanId)).toBe(1);
     expect(
       await countRows(
-        "SELECT count(*) AS n FROM scans WHERE id = ? AND owner_user_id IS NULL",
+        "SELECT count(*) AS n FROM scans WHERE id = ? AND owner_user_id IS NULL AND public_shared_by_user_id IS NULL",
         scanId,
       ),
     ).toBe(1);

--- a/test/workers/public-reports.test.ts
+++ b/test/workers/public-reports.test.ts
@@ -209,6 +209,11 @@ describe("public report sharing", () => {
     expect(share.token).toMatch(/^[A-Za-z0-9_-]{40,}$/);
     expect(share.url).toBe(`http://example.com/reports/${share.token}`);
 
+    const detail = (await (await request(app, `/api/v1/scans/${scanId}`)).json()) as {
+      scan: { publicShareUrl: string };
+    };
+    expect(detail.scan.publicShareUrl).toBe(share.url);
+
     const pub = await request(app, `/public/reports/${share.token}`);
     expect(pub.status).toBe(200);
     const text = await pub.text();

--- a/test/workers/threat-feed-badge.test.ts
+++ b/test/workers/threat-feed-badge.test.ts
@@ -7,7 +7,7 @@ import { ensurePersonalOrganization } from "../../server/db/organizations";
 import { createScanJob, persistScan } from "../../server/db/scans";
 import * as schema from "../../server/db/schema";
 import { describeAuditEvent } from "../../server/lib/auth/audit-events";
-import { publicReportsRoutes } from "../../server/routes/public-reports";
+import { publicCacheKey, publicReportsRoutes } from "../../server/routes/public-reports";
 import { scansRoutes } from "../../server/routes/scans";
 import type { Bindings, Variables } from "../../server/types";
 
@@ -168,8 +168,11 @@ interface FeedBody {
 // Badge and feed responses read through the colo cache (caches.default), so
 // lifecycle tests that assert on fresh state purge the entry first. Tests that
 // exercise the caching itself skip the purge.
+// Mirrors the route module's keying so the helper purges the entry the Worker
+// actually wrote: badge paths collapse onto their canonical package key.
 function coloCacheKey(path: string): Request {
-  return new Request(`http://test.local${path.split("?")[0]}`);
+  const bare = path.split("?")[0];
+  return publicCacheKey("http://test.local", bare.replace(/^\/public/, ""));
 }
 
 async function purgeColoCache(path: string): Promise<void> {
@@ -271,9 +274,56 @@ describe("shields badge endpoint", () => {
       source: "workflow_gate",
     });
     await share(buildTestApp(spoofer), gateOnly, { threatFeed: true });
-    expect((await fetchBadge(app, "npm", gateOnlyName)).body.message).toBe(
-      "2.0.0 reviewed · low risk",
-    );
+    // A gate-only claim still answers the badge — but says so. The registry
+    // never proved this org can publish under that name.
+    expect((await fetchBadge(app, "npm", gateOnlyName)).body).toMatchObject({
+      label: "drydock (unverified)",
+      message: "2.0.0 reviewed · low risk",
+      color: "lightgrey",
+    });
+  });
+
+  test("PyPI and VS Code badges are always labelled unverified", async () => {
+    // Only npm has a staged adapter, so every PyPI and VS Code review is a
+    // workflow gate and can never be registry-verified. The "verified wins"
+    // tiebreak has nothing to prefer there, which makes the label the only
+    // thing separating a maintainer's review from anyone's claim on the name.
+    for (const ecosystem of ["pypi", "vscode"] as const) {
+      const claimant = await seedUser();
+      const claimantApp = buildTestApp(claimant);
+      const packageName = `pkg-${crypto.randomUUID().slice(0, 8)}`;
+      const scanId = await seedCompletedScan(claimant, {
+        packageName,
+        version: "2.99.0",
+        ecosystem,
+        source: "workflow_gate",
+      });
+      await share(claimantApp, scanId, { threatFeed: true });
+
+      const badge = await fetchBadge(claimantApp, ecosystem, packageName);
+      expect(badge.body.label).toBe("drydock (unverified)");
+      expect(badge.body.color).toBe("lightgrey");
+    }
+  });
+
+  test("a hostile version string cannot reshape the rendered badge", async () => {
+    // Versions come from a package manifest, and for gate scans that manifest
+    // is attacker-shaped. shields renders the message into SVG text, so a
+    // right-to-left override would reverse the visible run.
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `pkg-${crypto.randomUUID().slice(0, 8)}`;
+    const scanId = await seedCompletedScan(owner, {
+      packageName,
+      version: "1.0.0\u202E ksir hgih\u0007",
+    });
+    await share(app, scanId, { threatFeed: true });
+
+    const badge = await fetchBadge(app, "npm", packageName);
+    expect(badge.body.message).toBe("1.0.0 ksir hgih reviewed · low risk");
+    expect(badge.body.message).not.toMatch(/[\u200B-\u200F\u2028-\u202E\uFEFF]/);
+    // eslint-disable-next-line no-control-regex -- asserting control chars are gone
+    expect(badge.body.message).not.toMatch(/[\u0000-\u001F\u007F-\u009F]/);
   });
 
   test("manifest-claimed scans cannot crowd a verified review out of the candidate page", async () => {
@@ -310,19 +360,15 @@ describe("shields badge endpoint", () => {
     const first = await fetchBadge(app, "npm", packageName);
     expect(first.body.message).toBe("5.0.0 reviewed · low risk");
 
-    // Revoke, then read without purging: the colo cache still serves the old
-    // payload (staleness is bounded by max-age=300 and documented).
-    await request(app, `/api/v1/scans/${scanId}/share`, { method: "DELETE" });
-    const cachedRead = await fetchBadge(app, "npm", packageName, { cached: true });
-    expect(cachedRead.body.message).toBe("5.0.0 reviewed · low risk");
-
-    // Query strings never bypass the cache — the key is the bare path.
+    // Query strings never bypass the cache — the key is the canonical path.
     const busted = await request(app, `/public/badge/npm/${packageName}?bust=${Math.random()}`);
     expect(((await busted.json()) as BadgeBody).message).toBe("5.0.0 reviewed · low risk");
 
-    // A purged (expired) entry recomputes from the database.
-    const fresh = await fetchBadge(app, "npm", packageName);
-    expect(fresh.body.message).toBe("not reviewed");
+    // Revoking purges both derived surfaces, so the withdrawn review stops
+    // being asserted immediately rather than lingering for the cache TTL.
+    await request(app, `/api/v1/scans/${scanId}/share`, { method: "DELETE" });
+    const afterRevoke = await fetchBadge(app, "npm", packageName, { cached: true });
+    expect(afterRevoke.body.message).toBe("not reviewed");
   });
 
   test("hostile version strings are clamped in the badge message", async () => {

--- a/test/workers/threat-feed-badge.test.ts
+++ b/test/workers/threat-feed-badge.test.ts
@@ -6,7 +6,7 @@ import { createDb } from "../../server/db/client";
 import { ensurePersonalOrganization } from "../../server/db/organizations";
 import { createScanJob, persistScan } from "../../server/db/scans";
 import * as schema from "../../server/db/schema";
-import { describeAuditEvent } from "../../server/lib/audit-events";
+import { describeAuditEvent } from "../../server/lib/auth/audit-events";
 import { publicReportsRoutes } from "../../server/routes/public-reports";
 import { scansRoutes } from "../../server/routes/scans";
 import type { Bindings, Variables } from "../../server/types";

--- a/test/workers/threat-feed-badge.test.ts
+++ b/test/workers/threat-feed-badge.test.ts
@@ -72,6 +72,9 @@ async function seedCompletedScan(
     releaseRisk?: string;
     ecosystem?: "npm" | "pypi" | "vscode";
     source?: "manual" | "workflow_gate";
+    // A gate scan with no provenance snapshot at all: a legacy pre-provenance
+    // record, or one whose redaction failed. Its ecosystem is unknowable.
+    withoutProvenance?: boolean;
   } = {},
 ): Promise<string> {
   const db = createDb(env.DB);
@@ -81,8 +84,9 @@ async function seedCompletedScan(
   const version = options.version ?? "1.1.0";
   const risk = options.risk ?? "low";
   // Gate scans persist a provenance snapshot; staged-publish scans do not.
-  const gateEcosystem =
-    options.ecosystem && options.ecosystem !== "npm"
+  const gateEcosystem = options.withoutProvenance
+    ? null
+    : options.ecosystem && options.ecosystem !== "npm"
       ? options.ecosystem
       : options.source === "workflow_gate"
         ? "npm"
@@ -158,7 +162,7 @@ interface FeedBody {
   entries: Array<{
     package: string | null;
     version: string | null;
-    ecosystem: string;
+    ecosystem: string | null;
     packageIdentity: string;
     releaseRisk: string;
     decision: string | null;
@@ -441,6 +445,32 @@ describe("shields badge endpoint", () => {
 
     expect((await fetchBadge(app, "pypi", packageName)).body.message).toContain("reviewed");
     expect((await fetchBadge(app, "npm", packageName)).body.message).toBe("not reviewed");
+  });
+
+  test("a gate scan with no provenance snapshot claims no ecosystem's badge", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `demo-${crypto.randomUUID().slice(0, 8)}`;
+    const scanId = await seedCompletedScan(owner, {
+      packageName,
+      source: "workflow_gate",
+      withoutProvenance: true,
+    });
+    await share(app, scanId, { threatFeed: true });
+
+    // Defaulting an unknowable ecosystem to npm would hand a PyPI or VS Code
+    // release the npm badge for its own name — the one ecosystem where a real
+    // registry-verified review exists to be displaced.
+    for (const ecosystem of ["npm", "pypi", "vscode"] as const) {
+      expect((await fetchBadge(app, ecosystem, packageName)).body.message).toBe("not reviewed");
+    }
+
+    // Listing still works; it is only the name-keyed badge that abstains, and
+    // the feed reports the unknown rather than inventing a value.
+    const feed = await fetchFeed(app);
+    const entry = feed.entries.find((item) => item.package === packageName);
+    expect(entry).toBeDefined();
+    expect(entry?.ecosystem).toBeNull();
   });
 
   test("canonical ecosystem aliases resolve to the same public badge", async () => {

--- a/test/workers/threat-feed-badge.test.ts
+++ b/test/workers/threat-feed-badge.test.ts
@@ -1,10 +1,12 @@
 import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
 import { Hono } from "hono";
 import { describe, expect, test } from "vitest";
+import { listOrganizationAuditEvents } from "../../server/db/audit-log";
 import { createDb } from "../../server/db/client";
 import { ensurePersonalOrganization } from "../../server/db/organizations";
 import { createScanJob, persistScan } from "../../server/db/scans";
 import * as schema from "../../server/db/schema";
+import { describeAuditEvent } from "../../server/lib/audit-events";
 import { publicReportsRoutes } from "../../server/routes/public-reports";
 import { scansRoutes } from "../../server/routes/scans";
 import type { Bindings, Variables } from "../../server/types";
@@ -274,6 +276,30 @@ describe("shields badge endpoint", () => {
     );
   });
 
+  test("manifest-claimed scans cannot crowd a verified review out of the candidate page", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `pkg-${crypto.randomUUID().slice(0, 8)}`;
+    const staged = await seedCompletedScan(owner, { packageName, version: "1.0.0", risk: "low" });
+    await share(app, staged, { threatFeed: true });
+    await env.DB.prepare("UPDATE scans SET completed_at = 1 WHERE id = ?").bind(staged).run();
+
+    const spoofer = await seedUser();
+    const spooferApp = buildTestApp(spoofer);
+    for (let index = 0; index < 21; index += 1) {
+      const gate = await seedCompletedScan(spoofer, {
+        packageName,
+        version: `9.9.${index}`,
+        risk: "high",
+        source: "workflow_gate",
+      });
+      await share(spooferApp, gate, { threatFeed: true });
+    }
+
+    const badge = await fetchBadge(app, "npm", packageName);
+    expect(badge.body.message).toBe("1.0.0 reviewed · low risk");
+  });
+
   test("badge and feed responses are served from the colo cache", async () => {
     const owner = await seedUser();
     const app = buildTestApp(owner);
@@ -370,22 +396,24 @@ describe("shields badge endpoint", () => {
     expect((await request(app, `/public/badge/npm/${"a".repeat(300)}`)).status).toBe(400);
   });
 
-  test("badge cache misses are rate limited per IP", async () => {
+  test("badge throttling preserves the shields payload contract", async () => {
     const app = buildTestApp(null);
     const ip = `10.1.0.${Math.floor(Math.random() * 200) + 1}`;
     const headers = { "cf-connecting-ip": ip };
-    let limited = false;
+    let throttled = false;
     // Distinct package names so every request misses the colo cache and pays
     // the D1 lookup the limiter protects.
     for (let i = 0; i < 125; i += 1) {
       const res = await request(app, `/public/badge/npm/miss-${i}`, { headers });
-      if (res.status === 429) {
-        limited = true;
+      expect(res.status).toBe(200);
+      if (res.headers.has("retry-after")) {
+        throttled = true;
+        expect(res.headers.get("cache-control")).toBe("no-store");
+        expect(((await res.json()) as BadgeBody).message).toBe("not reviewed");
         break;
       }
-      expect(res.status).toBe(200);
     }
-    expect(limited).toBe(true);
+    expect(throttled).toBe(true);
   });
 });
 
@@ -473,6 +501,18 @@ describe("public threat feed", () => {
     const types = detail.events.map((event) => event.type);
     expect(types).toContain("scan.feed_listed");
     expect(types).toContain("scan.feed_unlisted");
+
+    const { events } = await listOrganizationAuditEvents(createDb(env.DB), owner.organizationId);
+    const feedEvents = events.filter((event) => event.type.startsWith("scan.feed_"));
+    expect(feedEvents.map((event) => event.type).sort()).toEqual([
+      "scan.feed_listed",
+      "scan.feed_unlisted",
+    ]);
+    for (const event of feedEvents) {
+      const descriptor = describeAuditEvent(event.type, event.metadataJson);
+      expect(descriptor?.category).toBe("security");
+      expect(descriptor?.detail).toMatch(/^feed-.+@1\.1\.0$/);
+    }
   });
 
   test("gate scans are labeled manifest-claimed and the feed orders newest listing first", async () => {

--- a/test/workers/threat-feed-badge.test.ts
+++ b/test/workers/threat-feed-badge.test.ts
@@ -1,0 +1,537 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { describe, expect, test } from "vitest";
+import { createDb } from "../../server/db/client";
+import { ensurePersonalOrganization } from "../../server/db/organizations";
+import { createScanJob, persistScan } from "../../server/db/scans";
+import * as schema from "../../server/db/schema";
+import { publicReportsRoutes } from "../../server/routes/public-reports";
+import { scansRoutes } from "../../server/routes/scans";
+import type { Bindings, Variables } from "../../server/types";
+
+interface SeededUser {
+  userId: string;
+  organizationId: string;
+}
+
+async function seedUser(): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+function buildTestApp(session: { userId: string } | null) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.route("/public", publicReportsRoutes);
+  if (session) {
+    app.use("/api/*", async (c, next) => {
+      c.set("authSession", { userId: session.userId });
+      await next();
+    });
+    app.route("/api/v1/scans", scansRoutes);
+  }
+  return app;
+}
+
+async function request(
+  app: Hono<{ Bindings: Bindings; Variables: Variables }>,
+  path: string,
+  options: RequestInit = {},
+) {
+  const ctx = createExecutionContext();
+  const headers = new Headers(options.headers);
+  if (!headers.has("content-type")) headers.set("content-type", "application/json");
+  const res = await app.fetch(
+    new Request(`http://test.local${path}`, { ...options, headers }),
+    env,
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+async function seedCompletedScan(
+  owner: SeededUser,
+  options: {
+    packageName?: string;
+    version?: string;
+    risk?: string;
+    releaseRisk?: string;
+    ecosystem?: "npm" | "pypi" | "vscode";
+    source?: "manual" | "workflow_gate";
+  } = {},
+): Promise<string> {
+  const db = createDb(env.DB);
+  const scanId = `scan_${crypto.randomUUID()}`;
+  const stageId = `stage-${scanId.slice(-12)}`;
+  const packageName = options.packageName ?? "@org/pkg";
+  const version = options.version ?? "1.1.0";
+  const risk = options.risk ?? "low";
+  // Gate scans persist a provenance snapshot; staged-publish scans do not.
+  const gateEcosystem =
+    options.ecosystem && options.ecosystem !== "npm"
+      ? options.ecosystem
+      : options.source === "workflow_gate"
+        ? "npm"
+        : null;
+  await createScanJob(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+    source: options.source ?? (gateEcosystem ? "workflow_gate" : "manual"),
+  });
+  await persistScan(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+    packageJson: { name: packageName, version },
+    risk,
+    status: "complete",
+    summary: {
+      report: { version: 1, digest: "abc123", digestAlgorithm: "sha256" },
+      ...(gateEcosystem
+        ? {
+            stagedPublish: {
+              provenance: {
+                ecosystem: gateEcosystem,
+                mode: "workflow_gate",
+                artifacts: [
+                  gateEcosystem === "npm"
+                    ? { path: "pkg.tgz", kind: "tarball", sha256: "a".repeat(64) }
+                    : { path: "dist/a.whl", kind: "wheel", sha256: "a".repeat(64) },
+                ],
+              },
+            },
+          }
+        : {}),
+    },
+    ai: null,
+    files: [],
+    diff: [],
+    findings: [],
+    riskSummary: {
+      artifactRisk: risk,
+      releaseRisk: options.releaseRisk ?? risk,
+      contextRisk: "low",
+      releaseFindingCount: 0,
+      contextFindingCount: 0,
+      unknownFindingCount: 0,
+    },
+    report: { version: 1, digest: "abc123" },
+  });
+  return scanId;
+}
+
+async function share(
+  app: ReturnType<typeof buildTestApp>,
+  scanId: string,
+  body: Record<string, unknown> = {},
+) {
+  const res = await request(app, `/api/v1/scans/${scanId}/share`, {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+  expect(res.status).toBe(200);
+  return (await res.json()) as {
+    share: { token: string; url: string; threatFeedListedAt: string | null };
+  };
+}
+
+interface FeedBody {
+  schema: string;
+  entries: Array<{
+    package: string | null;
+    version: string | null;
+    ecosystem: string;
+    packageIdentity: string;
+    releaseRisk: string;
+    decision: string | null;
+    reportUrl: string;
+    listedAt: string | null;
+  }>;
+}
+
+// Badge and feed responses read through the colo cache (caches.default), so
+// lifecycle tests that assert on fresh state purge the entry first. Tests that
+// exercise the caching itself skip the purge.
+function coloCacheKey(path: string): Request {
+  return new Request(`http://test.local${path.split("?")[0]}`);
+}
+
+async function purgeColoCache(path: string): Promise<void> {
+  const cache = (caches as unknown as { default: Cache }).default;
+  await cache.delete(coloCacheKey(path));
+}
+
+async function fetchFeed(
+  app: ReturnType<typeof buildTestApp>,
+  options: { cached?: boolean } = {},
+): Promise<FeedBody> {
+  if (!options.cached) await purgeColoCache("/public/threat-feed.json");
+  const res = await request(app, "/public/threat-feed.json");
+  expect(res.status).toBe(200);
+  return (await res.json()) as FeedBody;
+}
+
+interface BadgeBody {
+  schemaVersion: number;
+  label: string;
+  message: string;
+  color: string;
+}
+
+async function fetchBadge(
+  app: ReturnType<typeof buildTestApp>,
+  ecosystem: string,
+  name: string,
+  options: { cached?: boolean } = {},
+): Promise<{ status: number; body: BadgeBody }> {
+  const path = `/public/badge/${ecosystem}/${name}`;
+  if (!options.cached) await purgeColoCache(path);
+  const res = await request(app, path);
+  return { status: res.status, body: (await res.json()) as BadgeBody };
+}
+
+describe("shields badge endpoint", () => {
+  test("only feed-listed reviews surface; sharing alone stays not reviewed", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `pkg-${crypto.randomUUID().slice(0, 8)}`;
+
+    const before = await fetchBadge(app, "npm", packageName);
+    expect(before.status).toBe(200);
+    expect(before.body).toMatchObject({
+      schemaVersion: 1,
+      label: "drydock",
+      message: "not reviewed",
+      color: "lightgrey",
+    });
+
+    const scanId = await seedCompletedScan(owner, { packageName, version: "2.0.0", risk: "low" });
+    // Not shared yet — still not reviewed publicly.
+    expect((await fetchBadge(app, "npm", packageName)).body.message).toBe("not reviewed");
+
+    // Shared but not listed: the link is a capability, the badge is a
+    // name-discoverable index — a private share must not surface here.
+    await share(app, scanId);
+    expect((await fetchBadge(app, "npm", packageName)).body.message).toBe("not reviewed");
+
+    await share(app, scanId, { threatFeed: true });
+    const after = await fetchBadge(app, "npm", packageName);
+    expect(after.body.message).toBe("2.0.0 reviewed · low risk");
+    expect(after.body.color).toBe("brightgreen");
+
+    // Unlisting removes the badge again even though the link stays live.
+    await share(app, scanId, { threatFeed: false });
+    expect((await fetchBadge(app, "npm", packageName)).body.message).toBe("not reviewed");
+  });
+
+  test("registry-verified reviews outrank newer manifest-claimed gate scans", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `pkg-${crypto.randomUUID().slice(0, 8)}`;
+
+    const staged = await seedCompletedScan(owner, { packageName, version: "1.0.0", risk: "low" });
+    await share(app, staged, { threatFeed: true });
+
+    // A later workflow-gate scan claims the same npm name (manifest-claimed
+    // identity) — it must not override the registry-verified badge.
+    const spoofer = await seedUser();
+    const gate = await seedCompletedScan(spoofer, {
+      packageName,
+      version: "9.9.9",
+      risk: "high",
+      releaseRisk: "high",
+      source: "workflow_gate",
+    });
+    await share(buildTestApp(spoofer), gate, { threatFeed: true });
+
+    const badge = await fetchBadge(app, "npm", packageName);
+    expect(badge.body.message).toBe("1.0.0 reviewed · low risk");
+
+    // With no verified review, the gate scan is what the org published — shown.
+    const gateOnlyName = `pkg-${crypto.randomUUID().slice(0, 8)}`;
+    const gateOnly = await seedCompletedScan(spoofer, {
+      packageName: gateOnlyName,
+      version: "2.0.0",
+      source: "workflow_gate",
+    });
+    await share(buildTestApp(spoofer), gateOnly, { threatFeed: true });
+    expect((await fetchBadge(app, "npm", gateOnlyName)).body.message).toBe(
+      "2.0.0 reviewed · low risk",
+    );
+  });
+
+  test("badge and feed responses are served from the colo cache", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `pkg-${crypto.randomUUID().slice(0, 8)}`;
+    const scanId = await seedCompletedScan(owner, { packageName, version: "5.0.0" });
+    await share(app, scanId, { threatFeed: true });
+
+    const first = await fetchBadge(app, "npm", packageName);
+    expect(first.body.message).toBe("5.0.0 reviewed · low risk");
+
+    // Revoke, then read without purging: the colo cache still serves the old
+    // payload (staleness is bounded by max-age=300 and documented).
+    await request(app, `/api/v1/scans/${scanId}/share`, { method: "DELETE" });
+    const cachedRead = await fetchBadge(app, "npm", packageName, { cached: true });
+    expect(cachedRead.body.message).toBe("5.0.0 reviewed · low risk");
+
+    // Query strings never bypass the cache — the key is the bare path.
+    const busted = await request(app, `/public/badge/npm/${packageName}?bust=${Math.random()}`);
+    expect(((await busted.json()) as BadgeBody).message).toBe("5.0.0 reviewed · low risk");
+
+    // A purged (expired) entry recomputes from the database.
+    const fresh = await fetchBadge(app, "npm", packageName);
+    expect(fresh.body.message).toBe("not reviewed");
+  });
+
+  test("hostile version strings are clamped in the badge message", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `pkg-${crypto.randomUUID().slice(0, 8)}`;
+    const longVersion = `1.0.0-${"x".repeat(200)}`;
+    const scanId = await seedCompletedScan(owner, { packageName, version: longVersion });
+    await share(app, scanId, { threatFeed: true });
+
+    const badge = await fetchBadge(app, "npm", packageName);
+    expect(badge.body.message.length).toBeLessThan(100);
+    expect(badge.body.message).toContain("reviewed · low risk");
+  });
+
+  test("scoped npm names with slashes resolve through the wildcard route", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `@scope-${crypto.randomUUID().slice(0, 6)}/pkg`;
+    const scanId = await seedCompletedScan(owner, { packageName });
+    await share(app, scanId, { threatFeed: true });
+
+    const badge = await fetchBadge(app, "npm", packageName);
+    expect(badge.body.message).toContain("reviewed");
+
+    const encoded = await fetchBadge(app, "npm", encodeURIComponent(packageName));
+    expect(encoded.body.message).toContain("reviewed");
+  });
+
+  test("high risk and blocked releases surface as red badges", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `pkg-${crypto.randomUUID().slice(0, 8)}`;
+    const scanId = await seedCompletedScan(owner, {
+      packageName,
+      version: "3.0.0",
+      risk: "high",
+      releaseRisk: "high",
+    });
+    await share(app, scanId, { threatFeed: true });
+    expect((await fetchBadge(app, "npm", packageName)).body).toMatchObject({
+      message: "3.0.0 reviewed · high risk",
+      color: "red",
+    });
+
+    const decide = await request(app, `/api/v1/scans/${scanId}/decision`, {
+      method: "POST",
+      body: JSON.stringify({ decision: "no_publish", reason: "malicious" }),
+    });
+    expect(decide.status).toBe(200);
+    expect((await fetchBadge(app, "npm", packageName)).body).toMatchObject({
+      message: "3.0.0 blocked",
+      color: "red",
+    });
+  });
+
+  test("the badge is ecosystem-scoped", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `demo-${crypto.randomUUID().slice(0, 8)}`;
+    const scanId = await seedCompletedScan(owner, { packageName, ecosystem: "pypi" });
+    await share(app, scanId, { threatFeed: true });
+
+    expect((await fetchBadge(app, "pypi", packageName)).body.message).toContain("reviewed");
+    expect((await fetchBadge(app, "npm", packageName)).body.message).toBe("not reviewed");
+  });
+
+  test("rejects unknown ecosystems and malformed names", async () => {
+    const app = buildTestApp(null);
+    expect((await request(app, "/public/badge/cargo/serde")).status).toBe(404);
+    expect((await request(app, `/public/badge/npm/${"a".repeat(300)}`)).status).toBe(400);
+  });
+
+  test("badge cache misses are rate limited per IP", async () => {
+    const app = buildTestApp(null);
+    const ip = `10.1.0.${Math.floor(Math.random() * 200) + 1}`;
+    const headers = { "cf-connecting-ip": ip };
+    let limited = false;
+    // Distinct package names so every request misses the colo cache and pays
+    // the D1 lookup the limiter protects.
+    for (let i = 0; i < 125; i += 1) {
+      const res = await request(app, `/public/badge/npm/miss-${i}`, { headers });
+      if (res.status === 429) {
+        limited = true;
+        break;
+      }
+      expect(res.status).toBe(200);
+    }
+    expect(limited).toBe(true);
+  });
+});
+
+describe("public threat feed", () => {
+  test("sharing alone does not list; the feed opt-in does", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `feed-${crypto.randomUUID().slice(0, 8)}`;
+    const scanId = await seedCompletedScan(owner, {
+      packageName,
+      version: "9.9.9",
+      risk: "high",
+      releaseRisk: "high",
+    });
+
+    const shared = await share(app, scanId);
+    expect(shared.share.threatFeedListedAt).toBeNull();
+    let feed = await fetchFeed(app);
+    expect(feed.entries.find((entry) => entry.package === packageName)).toBeUndefined();
+
+    const listed = await share(app, scanId, { threatFeed: true });
+    expect(listed.share.threatFeedListedAt).not.toBeNull();
+    // Re-sharing without stating feed intent must not unlist.
+    const resharedAgain = await share(app, scanId);
+    expect(resharedAgain.share.threatFeedListedAt).not.toBeNull();
+
+    feed = await fetchFeed(app);
+    expect(feed.schema).toBe("drydock.threat-feed.v1");
+    const entry = feed.entries.find((item) => item.package === packageName);
+    expect(entry).toMatchObject({
+      package: packageName,
+      version: "9.9.9",
+      ecosystem: "npm",
+      packageIdentity: "registry-verified",
+      releaseRisk: "high",
+    });
+    expect(entry?.reportUrl).toBe(`http://example.com/reports/${listed.share.token}`);
+
+    // No org/user identifiers anywhere in the public feed.
+    const rawFeed = JSON.stringify(feed);
+    expect(rawFeed).not.toContain(owner.organizationId);
+    expect(rawFeed).not.toContain(owner.userId);
+  });
+
+  test("unlisting and revoking both drop the entry", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `feed-${crypto.randomUUID().slice(0, 8)}`;
+    const scanId = await seedCompletedScan(owner, { packageName });
+    await share(app, scanId, { threatFeed: true });
+    expect((await fetchFeed(app)).entries.some((entry) => entry.package === packageName)).toBe(
+      true,
+    );
+
+    const unlisted = await share(app, scanId, { threatFeed: false });
+    expect(unlisted.share.threatFeedListedAt).toBeNull();
+    expect((await fetchFeed(app)).entries.some((entry) => entry.package === packageName)).toBe(
+      false,
+    );
+
+    await share(app, scanId, { threatFeed: true });
+    const revoke = await request(app, `/api/v1/scans/${scanId}/share`, { method: "DELETE" });
+    expect(revoke.status).toBe(200);
+    expect((await fetchFeed(app)).entries.some((entry) => entry.package === packageName)).toBe(
+      false,
+    );
+
+    // Re-sharing after a revoke starts unlisted again.
+    const reshared = await share(app, scanId);
+    expect(reshared.share.threatFeedListedAt).toBeNull();
+  });
+
+  test("feed listing changes are audited as scan events", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const scanId = await seedCompletedScan(owner, {
+      packageName: `feed-${crypto.randomUUID().slice(0, 8)}`,
+    });
+    await share(app, scanId, { threatFeed: true });
+    await share(app, scanId, { threatFeed: false });
+
+    const detail = (await (await request(app, `/api/v1/scans/${scanId}`)).json()) as {
+      events: Array<{ type: string }>;
+    };
+    const types = detail.events.map((event) => event.type);
+    expect(types).toContain("scan.feed_listed");
+    expect(types).toContain("scan.feed_unlisted");
+  });
+
+  test("gate scans are labeled manifest-claimed and the feed orders newest listing first", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const first = `feed-${crypto.randomUUID().slice(0, 8)}`;
+    const second = `feed-${crypto.randomUUID().slice(0, 8)}`;
+    const gateScan = await seedCompletedScan(owner, {
+      packageName: first,
+      source: "workflow_gate",
+    });
+    await share(app, gateScan, { threatFeed: true });
+    // Ensure a strictly later listing timestamp for a deterministic order.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    const stagedScan = await seedCompletedScan(owner, { packageName: second });
+    await share(app, stagedScan, { threatFeed: true });
+
+    const feed = await fetchFeed(app);
+    const gateIndex = feed.entries.findIndex((entry) => entry.package === first);
+    const stagedIndex = feed.entries.findIndex((entry) => entry.package === second);
+    expect(feed.entries[gateIndex]?.packageIdentity).toBe("manifest-claimed");
+    expect(feed.entries[stagedIndex]?.packageIdentity).toBe("registry-verified");
+    // Listed later → appears first.
+    expect(stagedIndex).toBeLessThan(gateIndex);
+  });
+
+  test("a null JSON body shares without touching the listing", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const scanId = await seedCompletedScan(owner, {
+      packageName: `feed-${crypto.randomUUID().slice(0, 8)}`,
+    });
+    const res = await request(app, `/api/v1/scans/${scanId}/share`, {
+      method: "POST",
+      body: "null",
+    });
+    expect(res.status).toBe(200);
+    const { share: state } = (await res.json()) as {
+      share: { token: string; threatFeedListedAt: string | null };
+    };
+    expect(state.token).toBeTruthy();
+    expect(state.threatFeedListedAt).toBeNull();
+  });
+
+  test("another organization cannot list a scan it does not own", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `feed-${crypto.randomUUID().slice(0, 8)}`;
+    const scanId = await seedCompletedScan(owner, { packageName });
+    await share(app, scanId);
+
+    const outsider = await seedUser();
+    const res = await request(buildTestApp(outsider), `/api/v1/scans/${scanId}/share`, {
+      method: "POST",
+      body: JSON.stringify({ threatFeed: true }),
+    });
+    expect(res.status).toBe(404);
+    expect((await fetchFeed(app)).entries.some((entry) => entry.package === packageName)).toBe(
+      false,
+    );
+  });
+});

--- a/test/workers/threat-feed-badge.test.ts
+++ b/test/workers/threat-feed-badge.test.ts
@@ -7,7 +7,8 @@ import { ensurePersonalOrganization } from "../../server/db/organizations";
 import { createScanJob, persistScan } from "../../server/db/scans";
 import * as schema from "../../server/db/schema";
 import { describeAuditEvent } from "../../server/lib/auth/audit-events";
-import { publicCacheKey, publicReportsRoutes } from "../../server/routes/public-reports";
+import { publicFeedCacheKey } from "../../server/lib/public-feed";
+import { publicReportsRoutes } from "../../server/routes/public-reports";
 import { scansRoutes } from "../../server/routes/scans";
 import type { Bindings, Variables } from "../../server/types";
 
@@ -153,6 +154,7 @@ async function share(
 
 interface FeedBody {
   schema: string;
+  nextCursor: string | null;
   entries: Array<{
     package: string | null;
     version: string | null;
@@ -170,9 +172,14 @@ interface FeedBody {
 // exercise the caching itself skip the purge.
 // Mirrors the route module's keying so the helper purges the entry the Worker
 // actually wrote: badge paths collapse onto their canonical package key.
+// The canonical origin, not the request origin: the Worker keys cache entries
+// off canonicalOrigin so the badge write and the dashboard-side purge land on
+// the same entry even when the two arrive on different hostnames.
+const CANONICAL_TEST_ORIGIN = new URL(env.BETTER_AUTH_URL as string).origin;
+
 function coloCacheKey(path: string): Request {
   const bare = path.split("?")[0];
-  return publicCacheKey("http://test.local", bare.replace(/^\/public/, ""));
+  return publicFeedCacheKey(CANONICAL_TEST_ORIGIN, bare.replace(/^\/public/, ""));
 }
 
 async function purgeColoCache(path: string): Promise<void> {
@@ -477,24 +484,68 @@ describe("shields badge endpoint", () => {
     expect((await request(app, `/public/badge/npm/${"a".repeat(300)}`)).status).toBe(400);
   });
 
-  test("badge throttling preserves the shields payload contract", async () => {
-    const app = buildTestApp(null);
+  test("a throttled badge says unavailable, never not-reviewed", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    // A package Drydock explicitly blocked. Its badge must never be throttled
+    // into the same payload as a package nobody reviewed: shields honours the
+    // `cacheSeconds` field and enforces a 300s floor of its own, so a "not
+    // reviewed" fallback would render neutral grey over a blocked release in
+    // every README embedding it — and badge proxies multiplex unrelated
+    // packages through shared egress addresses, so an unrelated burst is
+    // enough to trigger it.
+    const packageName = `blocked-${crypto.randomUUID().slice(0, 8)}`;
+    const scanId = await seedCompletedScan(owner, { packageName, version: "3.0.0", risk: "high" });
+    await share(app, scanId, { threatFeed: true });
+    await request(app, `/api/v1/scans/${scanId}/decision`, {
+      method: "POST",
+      body: JSON.stringify({ decision: "no_publish", reason: "malicious" }),
+    });
+    expect((await fetchBadge(app, "npm", packageName)).body.message).toBe("3.0.0 blocked");
+
     const ip = `10.1.0.${Math.floor(Math.random() * 200) + 1}`;
     const headers = { "cf-connecting-ip": ip };
-    let throttled = false;
+    let throttled: BadgeBody | null = null;
     // Distinct package names so every request misses the colo cache and pays
     // the D1 lookup the limiter protects.
     for (let i = 0; i < 125; i += 1) {
       const res = await request(app, `/public/badge/npm/miss-${i}`, { headers });
       expect(res.status).toBe(200);
       if (res.headers.has("retry-after")) {
-        throttled = true;
         expect(res.headers.get("cache-control")).toBe("no-store");
-        expect(((await res.json()) as BadgeBody).message).toBe("not reviewed");
+        throttled = (await res.json()) as BadgeBody;
         break;
       }
     }
-    expect(throttled).toBe(true);
+    expect(throttled).not.toBeNull();
+    // Still a valid shields payload — proxies must not render an error badge.
+    expect(throttled?.schemaVersion).toBe(1);
+    expect(throttled?.message).toBe("unavailable");
+    expect(throttled?.message).not.toBe("not reviewed");
+
+    // And the throttled fallback for the blocked package is distinguishable
+    // from its real badge rather than silently replacing it.
+    const blockedUnderThrottle = await request(
+      app,
+      `/public/badge/npm/${encodeURIComponent(packageName)}`,
+      { headers },
+    );
+    expect(((await blockedUnderThrottle.json()) as BadgeBody).message).not.toBe("not reviewed");
+  });
+
+  test("badge misses are not written to the colo cache", async () => {
+    const app = buildTestApp(null);
+    // Every invented name would otherwise add an entry to the same
+    // caches.default namespace that holds published-tarball bytes.
+    const missName = `never-scanned-${crypto.randomUUID().slice(0, 8)}`;
+    const res = await request(app, `/public/badge/npm/${missName}`);
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as BadgeBody).message).toBe("not reviewed");
+    // The internal opt-out marker must not leak to clients.
+    expect(res.headers.get("x-drydock-colo-cache-skip")).toBeNull();
+
+    const cache = (caches as unknown as { default: Cache }).default;
+    expect(await cache.match(coloCacheKey(`/public/badge/npm/${missName}`))).toBeUndefined();
   });
 });
 
@@ -654,5 +705,88 @@ describe("public threat feed", () => {
     expect((await fetchFeed(app)).entries.some((entry) => entry.package === packageName)).toBe(
       false,
     );
+  });
+
+  test("unlisting a revoked share does not republish it", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `feed-${crypto.randomUUID().slice(0, 8)}`;
+    const scanId = await seedCompletedScan(owner, { packageName });
+    await share(app, scanId, { threatFeed: true });
+
+    // Another admin (or the same user in another tab) revokes the link.
+    const revoke = await request(app, `/api/v1/scans/${scanId}/share`, { method: "DELETE" });
+    expect(revoke.status).toBe(200);
+
+    // The stale dialog still shows the checkbox; unchecking it must not turn a
+    // withdrawal into a fresh publication.
+    const unlist = await request(app, `/api/v1/scans/${scanId}/share`, {
+      method: "POST",
+      body: JSON.stringify({ threatFeed: false }),
+    });
+    expect(unlist.status).toBe(409);
+    expect(await unlist.text()).not.toContain("/reports/");
+
+    // Still revoked: no token was minted on the way through.
+    const detail = (await (await request(app, `/api/v1/scans/${scanId}`)).json()) as {
+      scan: { publicShareUrl: string | null; publicShareToken: string | null };
+    };
+    expect(detail.scan.publicShareUrl).toBeNull();
+    expect(detail.scan.publicShareToken).toBeNull();
+    expect((await fetchFeed(app)).entries.some((entry) => entry.package === packageName)).toBe(
+      false,
+    );
+  });
+
+  test("unlisting a live share still works and leaves the link alone", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `feed-${crypto.randomUUID().slice(0, 8)}`;
+    const scanId = await seedCompletedScan(owner, { packageName });
+    const { share: listed } = await share(app, scanId, { threatFeed: true });
+
+    const { share: unlisted } = await share(app, scanId, { threatFeed: false });
+    expect(unlisted.token).toBe(listed.token);
+    expect(unlisted.threatFeedListedAt).toBeNull();
+    expect((await fetchFeed(app)).entries.some((entry) => entry.package === packageName)).toBe(
+      false,
+    );
+  });
+
+  test("the feed pages backwards so a burst of listings cannot hide older entries", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageNames = [] as string[];
+    for (let i = 0; i < 3; i += 1) {
+      const packageName = `page-${crypto.randomUUID().slice(0, 8)}`;
+      packageNames.push(packageName);
+      const scanId = await seedCompletedScan(owner, { packageName });
+      await share(app, scanId, { threatFeed: true });
+    }
+
+    // One entry per page, so the cursor is exercised rather than everything
+    // fitting in the first response.
+    const seen = new Set<string>();
+    let cursor: string | null = null;
+    let pages = 0;
+    for (let page = 0; page < 50; page += 1) {
+      const suffix: string = cursor ? `&after=${encodeURIComponent(cursor)}` : "";
+      const res = await request(app, `/public/threat-feed.json?limit=1${suffix}`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as FeedBody;
+      expect(body.entries.length).toBeLessThanOrEqual(1);
+      pages += 1;
+      for (const entry of body.entries) if (entry.package) seen.add(entry.package);
+      cursor = body.nextCursor;
+      if (!cursor) break;
+    }
+    expect(pages).toBeGreaterThan(1);
+    // Every listing is reachable by walking the cursor, in order.
+    for (const packageName of packageNames) expect(seen.has(packageName)).toBe(true);
+
+    // A malformed cursor is ignored rather than erroring or emptying the feed.
+    const malformed = await request(app, "/public/threat-feed.json?after=not-a-cursor");
+    expect(malformed.status).toBe(200);
+    expect(((await malformed.json()) as FeedBody).entries.length).toBeGreaterThan(0);
   });
 });

--- a/test/workers/threat-feed-badge.test.ts
+++ b/test/workers/threat-feed-badge.test.ts
@@ -390,6 +390,41 @@ describe("shields badge endpoint", () => {
     expect((await fetchBadge(app, "npm", packageName)).body.message).toBe("not reviewed");
   });
 
+  test("canonical ecosystem aliases resolve to the same public badge", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+
+    const pypiScan = await seedCompletedScan(owner, {
+      packageName: "Demo_Package.Name",
+      ecosystem: "pypi",
+    });
+    await share(app, pypiScan, { threatFeed: true });
+    expect((await fetchBadge(app, "pypi", "demo-package-name")).body.message).toContain("reviewed");
+
+    const vscodeScan = await seedCompletedScan(owner, {
+      packageName: "Publisher.PowerShell",
+      ecosystem: "vscode",
+    });
+    await share(app, vscodeScan, { threatFeed: true });
+    expect((await fetchBadge(app, "vscode", "publisher.powershell")).body.message).toContain(
+      "reviewed",
+    );
+  });
+
+  test("accepts valid VS Code identities beyond the npm and PyPI length limit", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `${"p".repeat(120)}.${"e".repeat(120)}`;
+    expect(packageName.length).toBeGreaterThan(214);
+
+    const scanId = await seedCompletedScan(owner, { packageName, ecosystem: "vscode" });
+    await share(app, scanId, { threatFeed: true });
+
+    const badge = await fetchBadge(app, "vscode", packageName);
+    expect(badge.status).toBe(200);
+    expect(badge.body.message).toContain("reviewed");
+  });
+
   test("rejects unknown ecosystems and malformed names", async () => {
     const app = buildTestApp(null);
     expect((await request(app, "/public/badge/cargo/serde")).status).toBe(404);


### PR DESCRIPTION
## What

Stacked on #469 (public report share links). Adds the two discoverable surfaces on top of shared reports:

- **Badge**: `GET /public/badge/:ecosystem/:package` returns a [shields.io endpoint-badge](https://shields.io/badges/endpoint-badge) payload for the package's latest **feed-listed** review — `2.0.0 reviewed · low risk` (green/yellow/red by release risk), `3.0.0 blocked` for a `no_publish` decision, `not reviewed` (lightgrey) otherwise. Wildcard route handles scoped npm names; ecosystem (npm/pypi/vscode) derives from the persisted provenance snapshot. Always 200 so badge proxies never render errors. Embed: `https://img.shields.io/endpoint?url=<origin>/public/badge/npm/<pkg>`.
- **Threat feed**: `GET /public/threat-feed.json` (`drydock.threat-feed.v1`, 100 entries, newest first) indexes reports whose org **explicitly opted into listing**. Holding a share link is capability; appearing in a discoverable index is publication — so listing is a second opt-in (`POST /api/v1/scans/:id/share { threatFeed: true|false }` + a checkbox in the share dialog), never inferred from sharing alone. Revoking the share always unlists; re-shares never silently flip the listing. Built for partner consumption (Aikido and other ecosystem-intel feeds); entries link to the full public report.

## Design notes

- No new trust surface: both endpoints serve only data already public through share links; the feed adds discoverability only with the extra opt-in.
- One additive migration (`public_feed_listed_at` + index); badge queries filter ecosystem in SQL over the persisted provenance snapshot (staged scans are npm by construction) with a JS re-check, ordered via a new `(package_name, completed_at)` index.
- Listing changes audited as `scan.feed_listed` / `scan.feed_unlisted`.

## Testing

- `test/workers/threat-feed-badge.test.ts` (8 tests): badge lifecycle (unshared → shared → risk colors → blocked), scoped-name wildcard + URL-encoded form, ecosystem scoping, unknown-ecosystem/oversized-name rejection, feed opt-in semantics (share alone ≠ listed, re-share preserves listing, unlist and revoke both drop entries, re-share starts unlisted), no org/user identifiers in feed output, audit events.
- `pnpm run verify` green.
- Docs: `docs/public-reports.md` extended with badge + feed sections (incl. partner-consumption note), docs map updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-ups (second pass)

- **Badge takes the same second opt-in as the feed**: it only reflects feed-listed reviews, so a privately shared link is never name-discoverable — the "capability vs publication" line holds across all discoverable surfaces.
- **Identity spoofing mitigations**: `packageName` on workflow-gate scans is manifest-claimed (repo-controlled), so a gate scan claiming `react` could previously control react's public badge. Now registry-verified reviews (staged-publish, name proven by the org's npm token) always outrank manifest-claimed gate scans in the badge pick, and every feed entry carries `packageIdentity: "registry-verified" | "manifest-claimed"` so partners can weigh claims. Residual limitation (gate-only names) documented in `docs/public-reports.md`; post-publish registry digest verification is the roadmap fix.
- **Colo caching**: badge + feed reads go through `caches.default` (keyed on the bare path, query stripped) ahead of the rate limiter — shields traffic mostly never touches D1. Reports/attestations stay `no-store` (revocation immediacy). Staleness ≤ `max-age=300`, documented.
- Ecosystem crowd-out fixed: SQL `json_extract` ecosystem filter instead of JS-filtering a 20-row page; composite `(package_name, completed_at)` index for the badge sort.
- `POST /share`: literal-`null` JSON body no longer 500s; a listing toggle racing a concurrent revoke returns 409 instead of stale share state.
- Badge message clamps manifest-controlled version strings to 64 chars.
- Migration 0025 regenerated cleanly; removed a phantom `0024_black_moondragon` journal entry left over from an earlier branch state.
- New tests: listing-gates-badge lifecycle, verified-vs-manifest preference, cache behavior (stale-after-revoke, no query-string busting, purge-recompute), badge rate limiting on cache misses, `packageIdentity` + feed ordering, null body, cross-org listing negative.
