### PR TITLE
Speed up the test suite by reusing workerd pool workers

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -14,7 +14,7 @@
 | `pnpm run lint:fix`     | Apply oxlint autofixes.                                                                                                                                                                                           |
 | `pnpm run format`       | Rewrite files with oxfmt.                                                                                                                                                                                         |
 | `pnpm run format:check` | Report files that would change without writing.                                                                                                                                                                   |
-| `pnpm run test`         | Node logic tests (`test/**`) plus D1-backed worker tests (`test/workers/**`) via `scripts/test.mjs`; the node project and four isolated worker shards run in parallel.                                            |
+| `pnpm run test`         | Node logic tests (`test/**`) plus D1-backed worker tests (`test/workers/**`) via `scripts/test.mjs`; the node and workers projects run as two parallel Vitest processes.                                          |
 | `pnpm run test:node`    | Just the node logic suite (`vitest run --project node`).                                                                                                                                                          |
 | `pnpm run test:workers` | Just the worker suite (`vitest run --project workers`; Miniflare D1 from `wrangler.test.jsonc` + `drizzle/`).                                                                                                     |
 | `pnpm run e2e:fixtures` | Pack local E2E fixture packages and generate `.context/e2e-registry/registry.json`.                                                                                                                               |
@@ -32,15 +32,24 @@ observability coverage by change type.
 
 ## Worker-suite performance
 
-The `workers` Vitest project runs every test file in its own Miniflare isolate,
-so every per-file startup cost is multiplied across the suite. Two deliberate
-choices keep it fast:
+Importing the server module graph into a fresh workerd isolate costs ~5s per
+test file (every module is fetched individually over the pool's module-fallback
+socket), so the suite's wall time is dominated by how often that import is
+repeated — not by the tests themselves. Deliberate choices that keep it fast:
 
-- **`pnpm run test` shards worker files across four Vitest processes.** Each
-  shard keeps default per-file isolation, so cross-file mocks and D1 fixtures do
-  not leak, while the expensive Worker import/transform work overlaps across
-  CPU cores. `pnpm run test:workers` remains the unsharded single-project
-  command for focused debugging.
+- **Pool workers are reused across test files.** `vitest.workers.config.ts`
+  sets `isolate: false` with `maxWorkers: 3`, so the module graph is imported
+  once per pool worker instead of once per file. More workers means more
+  redundant imports, so raising `maxWorkers` makes the suite _slower_. To keep
+  the per-file clean-database semantics tests are written against,
+  `test/workers/setup.ts` wipes all D1 tables and R2 objects in a `beforeAll`
+  before re-applying migrations — files on a worker run sequentially, so the
+  reset cannot race another file. Consequence: a worker test must not assert
+  against state it did not create _within its own file_, and tests that sweep
+  globally (e.g. the discovery cron) rely on that per-file reset.
+- **The node project uses the `threads` pool** (per-file isolation kept, since
+  several files `vi.mock` the same modules) to skip the default forks pool's
+  per-file process spawn.
 - **`wrangler.test.jsonc` has no `main`.** The worker tests don't use `SELF` —
   they `import worker from "../../server/index"` and call `worker.fetch(req, env, ctx)`
   directly. Setting `main` makes Miniflare eagerly evaluate the whole app graph

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -2,23 +2,16 @@ import { spawn } from "node:child_process";
 
 const forwardedArgs = process.argv.slice(2);
 const extraArgs = forwardedArgs[0] === "--" ? forwardedArgs.slice(1) : forwardedArgs;
-const workerShards = 4;
+// The workers project parallelizes internally (reused pool workers, see
+// vitest.workers.config.ts), so it needs no external sharding; running it in
+// one process keeps a single shared Vite transform cache. The node project
+// runs as a separate process so the two suites overlap fully.
 const checks =
   extraArgs.length > 0
     ? [{ name: "vitest", args: ["exec", "vitest", "run", ...extraArgs] }]
     : [
         { name: "node", args: ["exec", "vitest", "run", "--project", "node"] },
-        ...Array.from({ length: workerShards }, (_, index) => ({
-          name: `workers ${index + 1}/${workerShards}`,
-          args: [
-            "exec",
-            "vitest",
-            "run",
-            "--project",
-            "workers",
-            `--shard=${index + 1}/${workerShards}`,
-          ],
-        })),
+        { name: "workers", args: ["exec", "vitest", "run", "--project", "workers"] },
       ];
 
 function runCheck(check) {

--- a/test/workers/setup.ts
+++ b/test/workers/setup.ts
@@ -9,6 +9,38 @@ declare module "cloudflare:test" {
   }
 }
 
+// Pool workers are reused across test files (isolate: false in
+// vitest.workers.config.ts), so D1/R2 state persists between files that run on
+// the same worker. Files on a worker run sequentially, so resetting storage
+// here restores the per-file clean-database semantics the tests are written
+// against while keeping the (expensive) module graph warm.
+async function resetStorage(): Promise<void> {
+  const tables = await env.DB.prepare("SELECT name FROM sqlite_master WHERE type = 'table'").all<{
+    name: string;
+  }>();
+  const userTables = tables.results
+    .map((table) => table.name)
+    .filter(
+      (name) => !name.startsWith("sqlite_") && !name.startsWith("_cf") && name !== "d1_migrations",
+    );
+  if (userTables.length > 0) {
+    await env.DB.batch([
+      env.DB.prepare("PRAGMA defer_foreign_keys = true"),
+      ...userTables.map((name) => env.DB.prepare(`DELETE FROM "${name}"`)),
+    ]);
+  }
+
+  let cursor: string | undefined;
+  do {
+    const listed = await env.ARTIFACTS.list({ cursor });
+    if (listed.objects.length > 0) {
+      await env.ARTIFACTS.delete(listed.objects.map((object) => object.key));
+    }
+    cursor = listed.truncated ? listed.cursor : undefined;
+  } while (cursor !== undefined);
+}
+
 beforeAll(async () => {
+  await resetStorage();
   await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
 });

--- a/vitest.node.config.ts
+++ b/vitest.node.config.ts
@@ -7,5 +7,12 @@ export default defineConfig({
     exclude: ["test/workers/**/*.test.{ts,mjs}", "node_modules/**"],
     environment: "node",
     globals: false,
+    // Worker threads skip the per-file process spawn that the default forks
+    // pool pays. Isolation stays on: several files vi.mock the same modules.
+    pool: "threads",
+    // Distinct from the workers project: vitest refuses to schedule projects
+    // with different maxWorkers in the same group (matters when one `vitest
+    // run` invocation selects files from both projects).
+    sequence: { groupOrder: 1 },
   },
 });

--- a/vitest.workers.config.ts
+++ b/vitest.workers.config.ts
@@ -24,6 +24,18 @@ export default defineConfig(async () => {
       include: ["test/workers/**/*.test.ts"],
       globals: false,
       setupFiles: ["./test/workers/setup.ts"],
+      // Each pool worker boots its own workerd + imports the full server module
+      // graph through the module-fallback socket (~5s each), so more workers
+      // means more redundant importing. Reusing workers across files
+      // (isolate: false) pays that import once per worker instead of once per
+      // file; 3 workers balances import overhead against test parallelism.
+      isolate: false,
+      maxWorkers: 3,
+      minWorkers: 1,
+      // See the node project config: distinct groupOrder lets a single `vitest
+      // run` invocation mix files from both projects despite the different
+      // maxWorkers.
+      sequence: { groupOrder: 2 },
     },
   };
 });


### PR DESCRIPTION
Importing the server module graph into a fresh workerd isolate costs ~5s per worker test file, so the suite's wall time was dominated by repeated imports rather than by the tests themselves. The workers project now reuses pool workers across files (`isolate: false`, `maxWorkers: 3` — more workers means more redundant graph imports), while `test/workers/setup.ts` wipes D1 tables and R2 objects per file to keep the clean-database semantics tests are written against. `scripts/test.mjs` drops the external 4-way worker sharding (each shard duplicated the Vite transform work) in favour of one internally-parallel workers process alongside the node process, and the node project moves to the `threads` pool to skip per-file process spawns. Full suite locally: 21.3s → 13.4s wall and ~102s → ~36s CPU, so the ~2min CI test step should shrink roughly in proportion; verified with repeated and shuffled-order runs (all 1013 tests pass). Docs updated in `docs/tooling.md`, including the new rule that worker tests must only assert against state created within their own file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)