### PR TITLE
Render Slack scan link as mrkdwn, not an interactive button

### DIFF
--- a/server/lib/slack.ts
+++ b/server/lib/slack.ts
@@ -306,15 +306,14 @@ export function renderSlackMessage(payload: SlackNotificationPayload): SlackMess
   }
 
   if (payload.dashboardUrl) {
+    // Render as an mrkdwn link rather than an `actions` button. A button — even a
+    // pure `url` link button — is an interactive component to Slack, so it delivers
+    // a `block_actions` payload and requires the app to have an Interactivity
+    // Request URL configured. Drydock has no such endpoint, so a button would show
+    // a "not configured to handle interactive responses" warning in the message.
     blocks.push({
-      type: "actions",
-      elements: [
-        {
-          type: "button",
-          text: { type: "plain_text", text: "Open in Drydock", emoji: false },
-          url: payload.dashboardUrl,
-        },
-      ],
+      type: "section",
+      text: { type: "mrkdwn", text: `<${payload.dashboardUrl}|Open in Drydock>` },
     });
   }
 

--- a/test/slack.test.mjs
+++ b/test/slack.test.mjs
@@ -251,7 +251,7 @@ describe("renderSlackMessage", () => {
     expect(message.text).not.toContain("risk");
   });
 
-  test("adds an Open in Drydock action only when a dashboard URL is present", () => {
+  test("adds an Open in Drydock link only when a dashboard URL is present", () => {
     const message = renderSlackMessage({
       title: "Staged release scan complete",
       packageLabel: "demo-package",
@@ -259,8 +259,12 @@ describe("renderSlackMessage", () => {
       dashboardUrl: "https://drydock.test/dashboard/scans/scan_1",
     });
     const serialized = JSON.stringify(message.blocks);
-    expect(serialized).toContain("Open in Drydock");
-    expect(serialized).toContain("https://drydock.test/dashboard/scans/scan_1");
+    // Rendered as an mrkdwn link, not an interactive button. A button — even a
+    // `url` link button — would require the app to configure a Slack Interactivity
+    // Request URL, which Drydock does not have, surfacing a warning on the message.
+    expect(serialized).toContain("<https://drydock.test/dashboard/scans/scan_1|Open in Drydock>");
+    expect(serialized).not.toContain('"type":"actions"');
+    expect(serialized).not.toContain('"type":"button"');
   });
 });
 


### PR DESCRIPTION
The "Open in Drydock" button in scan notifications was an `actions`/`button` block, and Slack treats any button — even a pure `url` link button — as an interactive component that dispatches a `block_actions` payload and requires an Interactivity Request URL. Drydock has no such endpoint, so every notification showed a "not configured to handle interactive responses" warning. This renders it as an mrkdwn `<url|Open in Drydock>` link instead: same navigation, no interactivity, no warning, and no Slack app config needed. The render test now asserts the link markup and the absence of any `actions`/`button` block so the warning can't be reintroduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)