### PR TITLE
Add CI-native Drydock CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Approval stays outside Drydock: maintainers approve in npm, npmjs.com, or GitHub
 Start with [`docs/README.md`](docs/README.md) to pick the smallest relevant reference. Common entry points:
 
 - [`docs/self-hosting.md`](docs/self-hosting.md) — local setup, Cloudflare resources, deployment, GitHub App, and Slack setup.
+- [`docs/cli.md`](docs/cli.md) — CI-native scans and canonical report output with organization API tokens.
 - [`docs/architecture.md`](docs/architecture.md) — runtime components, trust boundaries, adapters, storage, and API shape.
 - [`docs/security-model.md`](docs/security-model.md) — non-negotiable security posture.
 - [`docs/workflow-gates.md`](docs/workflow-gates.md) — GitHub Environment gate contract for PyPI, npm, and VS Code workflow-gated releases.
@@ -24,6 +25,7 @@ Start with [`docs/README.md`](docs/README.md) to pick the smallest relevant refe
 ```text
 server/       Hono Worker, scan pipeline, adapters, persistence, webhooks
 src/          Preact UI and typed API models
+packages/cli/ Dependency-free npm CLI for CI scan checks and report export
 drizzle/      D1 migrations
 docs/         Architecture, security, workflow, setup, and test references
 test/         Vitest, Worker-runtime, security corpus, and fake-registry e2e

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Start here instead of reading every Markdown file. Pick the smallest set that ma
 ## Operations and setup
 
 - [`self-hosting.md`](./self-hosting.md) — local setup, Cloudflare resources, deploy, GitHub App, Slack.
+- [`cli.md`](./cli.md) — CI scan checks, organization-token auth, risk exit codes, and report output.
 - [`e2e-test-environment.md`](./e2e-test-environment.md) — fake registry and Playwright harness.
 - [`tooling.md`](./tooling.md) — oxlint/oxfmt/typecheck, signals lint rules, route/client helpers.
 - [`agent-tour.md`](./agent-tour.md) — portable product walkthrough artifacts.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,6 +52,8 @@ Archive parsing is shared by the sandbox and tests rather than copied as strings
 
 `POST /api/v1/scans` creates a queued scan record. A Queue consumer in production, or local `waitUntil()` execution in development, runs the pipeline. The UI polls `GET /api/v1/scans/:id` for status and report data.
 
+The dependency-free `drydock` npm CLI is a client of that same API surface. With an organization token it can create an npm staged-publish scan, poll a staged or workflow-gate scan to a terminal state, and fetch the canonical report export. Workflow-gate scans still originate from the signed GitHub webhook; the CLI cannot create or decide gates. See [`cli.md`](./cli.md).
+
 Baseline selection is tag-aware rather than simply highest-semver; see [`diff-baseline.md`](./diff-baseline.md).
 
 ## Workflow gates

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,66 @@
+# Drydock CLI
+
+The dependency-free `@resynapse/drydock` npm package (binary: `drydock`) is the CI-native client for
+the organization-token scan surface. It creates staged-publish scans, waits for existing
+workflow-gate scans, prints human summaries, and emits the canonical report JSON for other tools.
+
+## Authentication and configuration
+
+Create an organization API token in Settings and expose it to the job as a masked secret:
+
+```sh
+export DRYDOCK_TOKEN="drydock_..."
+```
+
+Creating a staged scan requires `scans:write`; polling and report export require `scans:read`. The
+CLI intentionally has no `--token` flag so secrets do not enter shell history or process listings.
+It sends the token only in the `Authorization: Bearer` header, refuses cross-origin redirects, and
+redacts it from surfaced API/network errors.
+
+The default API origin is `https://drydock.org`. Self-hosted jobs can set `DRYDOCK_API_URL` or pass
+`--api-url <origin>`.
+
+## Scan checks
+
+Create and await an npm staged-publish scan:
+
+```sh
+npx @resynapse/drydock scan --stage "$NPM_STAGE_ID" --fail-on high
+```
+
+GitHub workflow-gate scans are created by the signed deployment-protection webhook. The CLI does
+not create or decide a gate; it can await the scan ID already attached to one:
+
+```sh
+npx @resynapse/drydock scan --gate "$DRYDOCK_SCAN_ID" --fail-on high
+```
+
+Both forms poll `GET /api/v1/scans/:id?poll=1` until `complete` or `failed`. `--timeout` controls the
+overall wait and `--poll-interval` controls polling frequency.
+
+`--fail-on` accepts `low`, `medium`, `high`, `critical`, or `none` and defaults to `high`. It uses
+the primary artifact risk because deterministic evidence must not be hidden by diff context. Human
+output also reports the narrower release and context risks.
+
+Exit codes are stable for CI:
+
+- `0` — complete and below threshold;
+- `1` — configuration, API, timeout, or scan failure;
+- `2` — complete at or above the configured risk threshold.
+
+## Reports
+
+Print a compact summary:
+
+```sh
+npx @resynapse/drydock report <scan-id>
+```
+
+Emit the canonical `drydock.report.v1` document without re-deriving or reshaping its evidence:
+
+```sh
+npx @resynapse/drydock report <scan-id> --json > drydock-report.json
+```
+
+The CLI never requests package file bodies and never installs or executes package contents. It is
+only a client for the redacted scan and report APIs.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -82,6 +82,8 @@ Every non-auth `/api/*` endpoint requires authenticated organization resolution.
 
 Organization API tokens are the one non-cookie API auth path. They are scoped to exactly one organization, stored only as high-entropy SHA-256 hashes, returned only once at creation, and accepted only on the minimal programmatic scan surface (`scans:read` for scan reads/exports and `scans:write` for creating a scan). Tokens must not manage settings, rotate credentials, decide scans, decide workflow gates, or bypass any release-decision 2FA requirement. Each accepted token request is rate-limited per token and records a redacted `api_token.used` audit event.
 
+The npm CLI consumes those scopes as a thin API client. It accepts the secret only through `DRYDOCK_TOKEN`, never a command-line flag; sends it only in the authorization header; rejects redirects; and redacts it from surfaced failures. It requests scan/report JSON only and must never download, install, import, build, or execute package contents.
+
 ## Browser response headers
 
 Production responses should keep conservative security headers: no package-provided active content, no cross-origin credential leakage, and no relaxed CSP/CORS decisions for convenience.

--- a/packages/cli/LICENSE.md
+++ b/packages/cli/LICENSE.md
@@ -1,0 +1,6 @@
+# License
+
+This package is released under the Functional Source License, Version 1.1, Apache 2.0 Future
+License (`FSL-1.1-Apache-2.0`). The complete license terms are included in the Drydock repository:
+
+<https://github.com/JoviDeCroock/drydock/blob/main/LICENSE.md>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,34 @@
+# Drydock CLI
+
+Trigger and await Drydock package scans from CI, then consume the same canonical report used by
+the dashboard.
+
+```sh
+export DRYDOCK_TOKEN="drydock_..."
+npx @resynapse/drydock scan --stage "$NPM_STAGE_ID" --fail-on high
+npx @resynapse/drydock report <scan-id> --json > drydock-report.json
+```
+
+`scan --stage` needs a token with `scans:write`; polling and `report` need `scans:read`. Create an
+organization token in Drydock Settings. The CLI reads the secret only from `DRYDOCK_TOKEN` so it
+does not appear in shell history or process arguments.
+
+Workflow-gate scans are created by Drydock's signed GitHub webhook, not by the CLI. Await one with
+its scan ID:
+
+```sh
+npx @resynapse/drydock scan --gate <workflow-gate-scan-id> --fail-on high
+```
+
+The threshold is evaluated against artifact risk, Drydock's authoritative fail-closed scan risk.
+Human output also separates release and context risk. A completed scan at or above the threshold
+exits `2`; API/configuration/scan failures exit `1`; a pass exits `0`. Use `--fail-on none` when the
+command should report without enforcing a risk policy.
+
+Self-hosted deployments can set `DRYDOCK_API_URL` or pass `--api-url`. Run
+`npx @resynapse/drydock --help` for all options. The published package is scoped because the
+unscoped `drydock` npm name belongs to an unrelated project; installing it still provides the
+`drydock` executable for package scripts and global installs.
+
+The CLI is a dependency-free API client. It downloads report JSON only; it never downloads,
+installs, imports, builds, or executes package contents.

--- a/packages/cli/bin/drydock.js
+++ b/packages/cli/bin/drydock.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+import { runCli } from "../src/cli.js";
+
+process.exitCode = await runCli(process.argv.slice(2));

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@resynapse/drydock",
+  "version": "0.1.0",
+  "description": "CI-native client for Drydock package scans",
+  "license": "SEE LICENSE IN LICENSE.md",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JoviDeCroock/drydock.git",
+    "directory": "packages/cli"
+  },
+  "bin": {
+    "drydock": "./bin/drydock.js"
+  },
+  "files": [
+    "bin",
+    "src",
+    "README.md",
+    "LICENSE.md"
+  ],
+  "type": "module",
+  "exports": {
+    ".": "./src/cli.js"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "test": "node --test"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/cli/src/cli.js
+++ b/packages/cli/src/cli.js
@@ -1,0 +1,392 @@
+const DEFAULT_API_URL = "https://drydock.org";
+const DEFAULT_FAIL_ON = "high";
+const DEFAULT_POLL_INTERVAL_MS = 2_000;
+const DEFAULT_TIMEOUT_SECONDS = 15 * 60;
+const REQUEST_TIMEOUT_MS = 30_000;
+
+const RISK_ORDER = ["none", "low", "medium", "high", "critical"];
+const FAIL_ON_LEVELS = [...RISK_ORDER.slice(1), "none"];
+const TERMINAL_STATUSES = new Set(["complete", "failed"]);
+
+const HELP = `Drydock CLI
+
+Usage:
+  drydock scan --stage <stageId> [options]
+  drydock scan --gate <scanId> [options]
+  drydock report <scanId> [--json] [options]
+
+Commands:
+  scan      Create and await a staged-publish scan, or await a workflow-gate scan.
+  report    Print a completed scan report. --json emits the canonical report document.
+
+Options:
+  --fail-on <risk>       Exit 2 when artifact risk reaches low, medium, high, or critical
+                         (default: high; use none to disable).
+  --api-url <url>        Drydock origin (default: DRYDOCK_API_URL or https://drydock.org).
+  --poll-interval <ms>   Poll interval in milliseconds (default: 2000).
+  --timeout <seconds>    Overall scan wait timeout (default: 900).
+  --json                 Emit the canonical JSON document (report only).
+  -h, --help             Show help.
+  -v, --version          Show version.
+
+Environment:
+  DRYDOCK_TOKEN          Organization API token (required).
+  DRYDOCK_API_URL        Optional Drydock origin override.
+
+Exit codes:
+  0  Command succeeded and risk is below the configured threshold.
+  1  Configuration, API, timeout, or scan failure.
+  2  Completed scan reached the configured risk threshold.
+`;
+
+class CliError extends Error {
+  constructor(message, exitCode = 1) {
+    super(message);
+    this.name = "CliError";
+    this.exitCode = exitCode;
+  }
+}
+
+class DrydockApi {
+  constructor({ baseUrl, token, fetchImpl }) {
+    this.baseUrl = normalizeBaseUrl(baseUrl);
+    this.token = token;
+    this.fetchImpl = fetchImpl;
+  }
+
+  async json(path, init = {}) {
+    const response = await this.request(path, init);
+    try {
+      return await response.json();
+    } catch {
+      throw new CliError(`Drydock returned invalid JSON for ${init.method ?? "GET"} ${path}.`);
+    }
+  }
+
+  async text(path, init = {}) {
+    return (await this.request(path, init)).text();
+  }
+
+  async request(path, init) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    const headers = new Headers(init.headers);
+    headers.set("authorization", `Bearer ${this.token}`);
+    headers.set("accept", "application/json");
+    if (init.body !== undefined) headers.set("content-type", "application/json");
+
+    let response;
+    try {
+      response = await this.fetchImpl(new URL(path, `${this.baseUrl}/`), {
+        ...init,
+        headers,
+        redirect: "error",
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (error?.name === "AbortError") {
+        throw new CliError("Drydock API request timed out.");
+      }
+      throw new CliError(`Could not reach the Drydock API: ${safeErrorMessage(error, this.token)}`);
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (response.ok) return response;
+
+    const responseText = await response.text().catch(() => "");
+    const serverMessage = readServerError(responseText);
+    const suffix = serverMessage ? `: ${redact(serverMessage, this.token)}` : "";
+    throw new CliError(`Drydock API returned HTTP ${response.status}${suffix}`);
+  }
+}
+
+export async function runCli(argv, overrides = {}) {
+  const deps = {
+    env: overrides.env ?? process.env,
+    fetch: overrides.fetch ?? globalThis.fetch,
+    now: overrides.now ?? Date.now,
+    sleep:
+      overrides.sleep ??
+      ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds))),
+    stdout: overrides.stdout ?? process.stdout,
+    stderr: overrides.stderr ?? process.stderr,
+  };
+
+  try {
+    const parsed = parseArgs(argv);
+    if (parsed.kind === "help") {
+      deps.stdout.write(HELP);
+      return 0;
+    }
+    if (parsed.kind === "version") {
+      deps.stdout.write("drydock 0.1.0\n");
+      return 0;
+    }
+
+    const token = deps.env.DRYDOCK_TOKEN?.trim();
+    if (!token) throw new CliError("DRYDOCK_TOKEN is required.");
+
+    const api = new DrydockApi({
+      baseUrl: parsed.apiUrl ?? deps.env.DRYDOCK_API_URL ?? DEFAULT_API_URL,
+      token,
+      fetchImpl: deps.fetch,
+    });
+
+    if (parsed.kind === "report") {
+      await printReport(api, parsed, deps.stdout);
+      return 0;
+    }
+
+    const scanId = parsed.mode === "stage" ? await createScan(api, parsed.value) : parsed.value;
+    const detail = await pollScan(api, scanId, parsed, deps);
+
+    deps.stdout.write(`${formatScanSummary(detail)}\n`);
+    return riskReached(detail.scan?.risk, parsed.failOn) ? 2 : 0;
+  } catch (error) {
+    const cliError = error instanceof CliError ? error : new CliError(safeErrorMessage(error));
+    deps.stderr.write(`drydock: ${cliError.message}\n`);
+    return cliError.exitCode;
+  }
+}
+
+function parseArgs(argv) {
+  if (argv.length === 0 || argv[0] === "help" || argv[0] === "--help" || argv[0] === "-h") {
+    return { kind: "help" };
+  }
+  if (argv[0] === "--version" || argv[0] === "-v") return { kind: "version" };
+
+  const [command, ...tokens] = argv;
+  if (command === "scan") return parseScanArgs(tokens);
+  if (command === "report") return parseReportArgs(tokens);
+  throw new CliError(`Unknown command ${JSON.stringify(command)}. Run drydock --help.`);
+}
+
+function parseScanArgs(tokens) {
+  const options = {
+    kind: "scan",
+    mode: null,
+    value: null,
+    failOn: DEFAULT_FAIL_ON,
+    apiUrl: null,
+    pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
+    timeoutMs: DEFAULT_TIMEOUT_SECONDS * 1_000,
+  };
+
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === "--help" || token === "-h") return { kind: "help" };
+    if (token === "--stage" || token === "--gate") {
+      if (options.mode) throw new CliError("Use exactly one of --stage or --gate.");
+      options.mode = token.slice(2);
+      options.value = optionValue(tokens, ++index, token);
+      continue;
+    }
+    if (token === "--fail-on") {
+      const value = optionValue(tokens, ++index, token).toLowerCase();
+      if (!FAIL_ON_LEVELS.includes(value)) {
+        throw new CliError(`--fail-on must be one of ${FAIL_ON_LEVELS.join(", ")}.`);
+      }
+      options.failOn = value;
+      continue;
+    }
+    if (token === "--api-url") {
+      options.apiUrl = optionValue(tokens, ++index, token);
+      continue;
+    }
+    if (token === "--poll-interval") {
+      options.pollIntervalMs = positiveNumber(optionValue(tokens, ++index, token), token);
+      continue;
+    }
+    if (token === "--timeout") {
+      options.timeoutMs = positiveNumber(optionValue(tokens, ++index, token), token) * 1_000;
+      continue;
+    }
+    throw new CliError(`Unknown scan option ${JSON.stringify(token)}.`);
+  }
+
+  if (!options.mode || !options.value) {
+    throw new CliError("scan requires exactly one of --stage <stageId> or --gate <scanId>.");
+  }
+  return options;
+}
+
+function parseReportArgs(tokens) {
+  const options = { kind: "report", scanId: null, json: false, apiUrl: null };
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token === "--help" || token === "-h") return { kind: "help" };
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--api-url") {
+      options.apiUrl = optionValue(tokens, ++index, token);
+      continue;
+    }
+    if (token.startsWith("-"))
+      throw new CliError(`Unknown report option ${JSON.stringify(token)}.`);
+    if (options.scanId) throw new CliError("report accepts exactly one scan ID.");
+    options.scanId = token;
+  }
+  if (!options.scanId) throw new CliError("report requires a scan ID.");
+  return options;
+}
+
+function optionValue(tokens, index, option) {
+  const value = tokens[index];
+  if (!value || value.startsWith("-")) throw new CliError(`${option} requires a value.`);
+  return value;
+}
+
+function positiveNumber(value, option) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new CliError(`${option} must be a positive number.`);
+  }
+  return parsed;
+}
+
+async function createScan(api, stageId) {
+  const result = await api.json("/api/v1/scans", {
+    method: "POST",
+    body: JSON.stringify({ stageId }),
+  });
+  const scanId = result?.scan?.id;
+  if (typeof scanId !== "string" || !scanId) {
+    throw new CliError("Drydock create-scan response did not include a scan ID.");
+  }
+  return scanId;
+}
+
+async function pollScan(api, scanId, options, deps) {
+  const deadline = deps.now() + options.timeoutMs;
+  let lastStatus = null;
+  while (deps.now() <= deadline) {
+    const detail = await api.json(`/api/v1/scans/${encodeURIComponent(scanId)}?poll=1`);
+    const status = detail?.scan?.status;
+    if (typeof status !== "string") {
+      throw new CliError("Drydock scan response did not include a status.");
+    }
+    if (options.mode === "gate" && detail.scan?.source !== "workflow_gate") {
+      throw new CliError(`Scan ${scanId} is not a workflow-gate scan.`);
+    }
+    if (status !== lastStatus) {
+      deps.stderr.write(`Scan ${scanId}: ${status}\n`);
+      lastStatus = status;
+    }
+    if (TERMINAL_STATUSES.has(status)) {
+      if (status === "failed") {
+        const reason = detail.scan.error
+          ? `: ${redact(String(detail.scan.error).slice(0, 300), api.token)}`
+          : "";
+        throw new CliError(`Scan ${scanId} failed${reason}`);
+      }
+      return detail;
+    }
+    await deps.sleep(Math.min(options.pollIntervalMs, Math.max(0, deadline - deps.now())));
+  }
+  throw new CliError(`Timed out waiting for scan ${scanId}.`);
+}
+
+async function printReport(api, options, stdout) {
+  const raw = await api.text(`/api/v1/scans/${encodeURIComponent(options.scanId)}/report.json`);
+  if (options.json) {
+    stdout.write(raw.endsWith("\n") ? raw : `${raw}\n`);
+    return;
+  }
+
+  let report;
+  try {
+    report = JSON.parse(raw);
+  } catch {
+    throw new CliError("Drydock returned an invalid canonical report.");
+  }
+  const identity = packageIdentity(report.package);
+  const findings = Array.isArray(report.findings) ? report.findings.length : 0;
+  const risk = normalizeRisk(report.scan?.risk);
+  const releaseRisk = normalizeRisk(report.riskSummary?.releaseRisk);
+  const contextRisk = normalizeRisk(report.riskSummary?.contextRisk);
+  stdout.write(
+    [
+      `Drydock report ${report.scan?.id ?? options.scanId}`,
+      `Package: ${identity}`,
+      `Status: ${report.scan?.status ?? "unknown"}`,
+      `Artifact risk: ${risk}`,
+      `Release risk: ${releaseRisk}`,
+      `Context risk: ${contextRisk}`,
+      `Findings: ${findings}`,
+    ].join("\n") + "\n",
+  );
+}
+
+function formatScanSummary(detail) {
+  const scan = detail.scan ?? {};
+  const identity = packageIdentity({ name: scan.packageName, stagedVersion: scan.stagedVersion });
+  const artifactRisk = normalizeRisk(scan.risk);
+  const releaseRisk = normalizeRisk(detail.riskSummary?.releaseRisk);
+  const contextRisk = normalizeRisk(detail.riskSummary?.contextRisk);
+  const findings = Array.isArray(detail.findings)
+    ? detail.findings.length
+    : Number(scan.findingCount ?? 0);
+  return `Drydock scan ${scan.id}: ${identity} — artifact ${artifactRisk}, release ${releaseRisk}, context ${contextRisk}; ${findings} finding${findings === 1 ? "" : "s"}`;
+}
+
+function packageIdentity(pkg) {
+  const name = typeof pkg?.name === "string" && pkg.name ? pkg.name : "unknown package";
+  const version =
+    typeof pkg?.stagedVersion === "string" && pkg.stagedVersion ? pkg.stagedVersion : null;
+  return version ? `${name}@${version}` : name;
+}
+
+function riskReached(value, threshold) {
+  if (threshold === "none") return false;
+  const risk = normalizeRisk(value);
+  const rank = RISK_ORDER.indexOf(risk);
+  if (rank < 0)
+    throw new CliError(`Completed scan returned unknown risk ${JSON.stringify(value)}.`);
+  return rank >= RISK_ORDER.indexOf(threshold);
+}
+
+function normalizeRisk(value) {
+  return typeof value === "string" && RISK_ORDER.includes(value.toLowerCase())
+    ? value.toLowerCase()
+    : "unknown";
+}
+
+function normalizeBaseUrl(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new CliError(`Invalid Drydock API URL ${JSON.stringify(value)}.`);
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new CliError("Drydock API URL must use http or https.");
+  }
+  if (url.username || url.password || url.pathname !== "/" || url.search || url.hash) {
+    throw new CliError(
+      "Drydock API URL must be an origin without credentials, path, query, or fragment.",
+    );
+  }
+  return url.toString().replace(/\/$/, "");
+}
+
+function readServerError(value) {
+  if (!value) return "";
+  try {
+    const parsed = JSON.parse(value);
+    return typeof parsed?.error === "string" ? parsed.error.slice(0, 500) : "";
+  } catch {
+    return "";
+  }
+}
+
+function redact(value, secret) {
+  return String(value).split(secret).join("[redacted]");
+}
+
+function safeErrorMessage(error, secret = "") {
+  const message = error instanceof Error ? error.message : String(error ?? "unknown error");
+  return secret ? redact(message, secret) : message;
+}

--- a/packages/cli/test/cli.test.js
+++ b/packages/cli/test/cli.test.js
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runCli } from "../src/cli.js";
+
+const TOKEN = "drydock_test_secret_that_must_not_leak";
+
+test("scan creates, polls, authenticates, and exits 2 at the risk threshold", async () => {
+  const calls = [];
+  const responses = [
+    jsonResponse({ scan: { id: "scan-123", status: "pending" } }, 202),
+    jsonResponse({ scan: { id: "scan-123", status: "pending" } }),
+    jsonResponse({
+      scan: {
+        id: "scan-123",
+        status: "complete",
+        source: "manual",
+        packageName: "example-package",
+        stagedVersion: "1.2.3",
+        risk: "high",
+      },
+      riskSummary: { releaseRisk: "medium", contextRisk: "high" },
+      findings: [{ ruleId: "code.network" }],
+    }),
+  ];
+  const io = captureIo();
+
+  const exitCode = await runCli(
+    ["scan", "--stage", "stage-abc", "--poll-interval", "1", "--fail-on", "high"],
+    {
+      ...io,
+      env: { DRYDOCK_TOKEN: TOKEN, DRYDOCK_API_URL: "https://example.test" },
+      sleep: async () => {},
+      fetch: async (url, init) => {
+        calls.push({ url: String(url), init });
+        return responses.shift();
+      },
+    },
+  );
+
+  assert.equal(exitCode, 2);
+  assert.equal(calls[0].url, "https://example.test/api/v1/scans");
+  assert.equal(calls[0].init.method, "POST");
+  assert.deepEqual(JSON.parse(calls[0].init.body), { stageId: "stage-abc" });
+  assert.equal(new Headers(calls[0].init.headers).get("authorization"), `Bearer ${TOKEN}`);
+  assert.equal(calls[1].url, "https://example.test/api/v1/scans/scan-123?poll=1");
+  assert.match(io.stdout.text, /example-package@1\.2\.3/);
+  assert.match(io.stdout.text, /artifact high, release medium, context high/);
+  assert.equal(io.stderr.text.match(/pending/g)?.length, 1);
+  assert.match(io.stderr.text, /complete/);
+});
+
+test("scan --gate waits for an existing workflow-gate scan without creating one", async () => {
+  const calls = [];
+  const io = captureIo();
+  const exitCode = await runCli(["scan", "--gate", "gate-scan", "--fail-on", "none"], {
+    ...io,
+    env: { DRYDOCK_TOKEN: TOKEN, DRYDOCK_API_URL: "https://example.test" },
+    fetch: async (url, init) => {
+      calls.push({ url: String(url), init });
+      return jsonResponse({
+        scan: {
+          id: "gate-scan",
+          status: "complete",
+          source: "workflow_gate",
+          risk: "critical",
+        },
+        riskSummary: { releaseRisk: "critical", contextRisk: "none" },
+        findings: [],
+      });
+    },
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].init.method, undefined);
+  assert.match(calls[0].url, /gate-scan\?poll=1$/);
+});
+
+test("report --json writes the canonical report document", async () => {
+  const report = {
+    schema: "drydock.report.v1",
+    scan: { id: "scan-json", status: "complete", risk: "low" },
+    findings: [],
+  };
+  const canonical = JSON.stringify(report);
+  const io = captureIo();
+  const exitCode = await runCli(["report", "scan-json", "--json"], {
+    ...io,
+    env: { DRYDOCK_TOKEN: TOKEN, DRYDOCK_API_URL: "https://example.test" },
+    fetch: async (url, init) => {
+      assert.equal(String(url), "https://example.test/api/v1/scans/scan-json/report.json");
+      assert.equal(new Headers(init.headers).get("authorization"), `Bearer ${TOKEN}`);
+      return new Response(canonical, { status: 200 });
+    },
+  });
+
+  assert.equal(exitCode, 0);
+  assert.equal(io.stdout.text, `${canonical}\n`);
+  assert.equal(io.stderr.text, "");
+});
+
+test("human report separates artifact, release, and context risk", async () => {
+  const io = captureIo();
+  const exitCode = await runCli(["report", "scan-report"], {
+    ...io,
+    env: { DRYDOCK_TOKEN: TOKEN },
+    fetch: async () =>
+      new Response(
+        JSON.stringify({
+          scan: { id: "scan-report", status: "complete", risk: "high" },
+          package: { name: "@scope/pkg", stagedVersion: "3.0.0" },
+          riskSummary: { releaseRisk: "medium", contextRisk: "high" },
+          findings: [{}, {}],
+        }),
+        { status: 200 },
+      ),
+  });
+
+  assert.equal(exitCode, 0);
+  assert.match(io.stdout.text, /Package: @scope\/pkg@3\.0\.0/);
+  assert.match(io.stdout.text, /Artifact risk: high/);
+  assert.match(io.stdout.text, /Release risk: medium/);
+  assert.match(io.stdout.text, /Context risk: high/);
+  assert.match(io.stdout.text, /Findings: 2/);
+});
+
+test("configuration and API failures never print the token", async () => {
+  const io = captureIo();
+  const exitCode = await runCli(["report", "scan-error"], {
+    ...io,
+    env: { DRYDOCK_TOKEN: TOKEN },
+    fetch: async () =>
+      new Response(JSON.stringify({ error: `invalid token ${TOKEN}` }), { status: 401 }),
+  });
+
+  assert.equal(exitCode, 1);
+  assert.doesNotMatch(io.stderr.text, new RegExp(TOKEN));
+  assert.match(io.stderr.text, /\[redacted\]/);
+});
+
+test("scan requires one source and rejects invalid thresholds before making a request", async () => {
+  const io = captureIo();
+  let fetched = false;
+  const exitCode = await runCli(
+    ["scan", "--stage", "stage", "--gate", "scan", "--fail-on", "severe"],
+    {
+      ...io,
+      env: { DRYDOCK_TOKEN: TOKEN },
+      fetch: async () => {
+        fetched = true;
+        throw new Error("unexpected request");
+      },
+    },
+  );
+
+  assert.equal(exitCode, 1);
+  assert.equal(fetched, false);
+  assert.match(io.stderr.text, /exactly one/);
+});
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function captureIo() {
+  const stdout = stringWriter();
+  const stderr = stringWriter();
+  return { stdout, stderr };
+}
+
+function stringWriter() {
+  return {
+    text: "",
+    write(value) {
+      this.text += String(value);
+    },
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,8 @@ importers:
         specifier: 4.102.0
         version: 4.102.0(@cloudflare/workers-types@4.20260617.1)
 
+  packages/cli: {}
+
 packages:
 
   '@ai-sdk/gateway@3.0.133':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - .
+  - packages/*
 
 # kysely 0.29.x dropped DEFAULT_MIGRATION_TABLE / DEFAULT_MIGRATION_LOCK_TABLE from its
 # root export; @better-auth/kysely-adapter still imports them from "kysely", so rolldown

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -7,6 +7,7 @@ const checks =
   extraArgs.length > 0
     ? [{ name: "vitest", args: ["exec", "vitest", "run", ...extraArgs] }]
     : [
+        { name: "cli", args: ["--filter", "@resynapse/drydock", "test"] },
         { name: "node", args: ["exec", "vitest", "run", "--project", "node"] },
         ...Array.from({ length: workerShards }, (_, index) => ({
           name: `workers ${index + 1}/${workerShards}`,


### PR DESCRIPTION
Depends on #456. Closes #441.

Adds the dependency-free `@resynapse/drydock` CLI for creating or awaiting scans, enforcing configurable artifact-risk thresholds, and emitting canonical reports for CI tooling.

Workflow-gate scans remain webhook-created, and the CLI cannot make release decisions or execute package contents.

Validated with `pnpm run verify`, six native CLI tests, and an npm package dry run.