### PR TITLE
Add release memory: advisory prior-release finding-profile consistency

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ Start here instead of reading every Markdown file. Pick the smallest set that ma
 
 - [`security-detection-corpus.md`](./security-detection-corpus.md) — rule/eval fixture layout and expected findings.
 - [`detection-eval.md`](./detection-eval.md) — eval harness, metrics, and gates.
+- [`release-memory.md`](./release-memory.md) — advisory prior-release finding-profile consistency; never changes risk.
 - [`organization-members.md`](./organization-members.md) — organization invitation/membership behavior.
 - [`audit-log.md`](./audit-log.md) — organization audit log surface, visible-event allowlist, and retention.
 - [`two-factor-auth.md`](./two-factor-auth.md) — step-up auth and sensitive actions.

--- a/docs/release-memory.md
+++ b/docs/release-memory.md
@@ -1,0 +1,59 @@
+# Release memory (prior-release consistency)
+
+Release memory tells a reviewer when the scan they are looking at has the same
+deterministic finding profile as a release the organization already reviewed
+and approved. It exists to cut alert fatigue: benign packages like `tape`
+trigger the same high-severity capability findings on every release (test
+runners legitimately spawn processes), and without context each new scan
+presents those findings as if they were novel.
+
+## What it does
+
+During a scan, after deterministic findings and risk are computed, the
+pipeline looks up the most recent scan in the **same organization**, for the
+**same `packageName`**, with `status = 'complete'` and `decision = 'publish'`
+(the in-flight scan id is excluded). Both scans are reduced to a **finding
+profile**: the multiset of `(ruleId, severity, file)` over rule findings.
+`line` and `evidence` are ignored — a finding that moved lines is the same
+profile entry — and findings without a `ruleId` participate as `"unknown"`.
+
+The profiles are compared as multisets:
+
+| Status     | Meaning                                                                                                                                                       |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `match`    | Identical multisets — the approved release had exactly this finding profile.                                                                                  |
+| `subset`   | Strict multiset subset — every current finding (duplicates included) was in the approved profile, plus more.                                                  |
+| `diverged` | Something is present now that the approved profile lacked; `newFindings` lists the difference (capped at 25 entries; `newFindingCount` keeps the true count). |
+| `none`     | No prior approved scan for this package in this organization (or the lookup was skipped/failed).                                                              |
+
+The result is persisted as `summary.releaseConsistency` on the scan (no schema
+migration; it lives in `summaryJson`), returned on `ScanResult`, included in
+the digested report payload, and exported by `report.json` as an additive
+optional field (`null` for scans that predate it).
+
+## It never changes risk
+
+Release memory is **advisory display context only**. It does not modify
+`risk`, the risk breakdown, or any finding — deterministic findings stay
+authoritative, exactly like the AI reviewer cannot downgrade them. The UI
+renders it as a positive banner (`match`/`subset`) or a quiet "N findings are
+new since the last approved release" line (`diverged`) next to the
+recommendation; `none` renders nothing.
+
+## Failure and compatibility behavior
+
+- The lookup is wrapped: a database or artifact-read error degrades to `none`
+  and emits a structured `scan.release_memory.lookup_failed` operational event
+  instead of failing the scan.
+- The prior scan's rule findings are read from the digest-verified R2
+  `report.json` for artifact-backed scans (they are no longer duplicated into
+  `scan_findings`); legacy/degraded scans fall back to the D1 rows.
+- Old scans lack the field entirely; every reader goes through
+  `normalizeReleaseConsistency`, which tolerates absence and malformed blobs.
+- The query is organization-scoped (`scans_org_decision_created_idx` covers
+  it); one organization's review history is never visible to another.
+
+Code: `server/lib/release-memory.ts` (profile building + comparison),
+`server/db/release-memory.ts` (prior-approved-scan lookup),
+`resolveReleaseConsistency` in `server/lib/scan-pipeline-phases.ts` (pipeline
+phase), `src/pages/Dashboard/ScanDetail/ReleaseConsistencyNotice.tsx` (UI).

--- a/server/db/release-memory.ts
+++ b/server/db/release-memory.ts
@@ -1,0 +1,89 @@
+import { and, desc, eq, ne } from "drizzle-orm";
+import { loadScanArtifacts } from "../lib/scan-artifacts";
+import type { ProfileFindingInput } from "../lib/release-memory";
+import type { AppDb } from "./client";
+import { scanFindings, scans } from "./schema";
+
+export interface PriorApprovedScanQuery {
+  organizationId: string;
+  packageName: string;
+  /** The in-flight scan; excluded so a re-run never compares against itself. */
+  excludeScanId: string;
+}
+
+export interface PriorApprovedScanFindings {
+  scanId: string;
+  stagedVersion: string | null;
+  decidedAt: Date | null;
+  findings: ProfileFindingInput[];
+}
+
+/**
+ * Fetch the most recent completed scan in the SAME organization for the SAME
+ * package that a maintainer decided "publish", plus its deterministic rule
+ * findings. Organization scoping is mandatory: release memory must never leak
+ * another organization's review history.
+ *
+ * Findings for artifact-backed scans live in the digest-verified R2 report.json
+ * (persistScan stopped duplicating them into `scan_findings`), so pass the
+ * artifact bucket to read those; legacy/degraded scans fall back to the D1 rows.
+ */
+export async function getPriorApprovedScanFindings(
+  db: AppDb,
+  query: PriorApprovedScanQuery,
+  artifactBucket?: R2Bucket,
+): Promise<PriorApprovedScanFindings | null> {
+  const rows = await db
+    .select({
+      id: scans.id,
+      organizationId: scans.organizationId,
+      stagedVersion: scans.stagedVersion,
+      decidedAt: scans.decidedAt,
+      reportDigest: scans.reportDigest,
+      artifactStorageVersion: scans.artifactStorageVersion,
+      artifactManifestKey: scans.artifactManifestKey,
+      artifactManifestDigest: scans.artifactManifestDigest,
+      artifactManifestSize: scans.artifactManifestSize,
+      reportArtifactKey: scans.reportArtifactKey,
+      fileSamplesArtifactKey: scans.fileSamplesArtifactKey,
+      diffArtifactKey: scans.diffArtifactKey,
+    })
+    .from(scans)
+    .where(
+      and(
+        eq(scans.organizationId, query.organizationId),
+        eq(scans.packageName, query.packageName),
+        eq(scans.status, "complete"),
+        eq(scans.decision, "publish"),
+        ne(scans.id, query.excludeScanId),
+      ),
+    )
+    .orderBy(desc(scans.createdAt), desc(scans.id))
+    .limit(1);
+
+  const prior = rows[0];
+  if (!prior) return null;
+
+  const artifactDetail = await loadScanArtifacts(artifactBucket, prior);
+  const findingRows = artifactDetail
+    ? artifactDetail.findings
+    : await db
+        .select({
+          ruleId: scanFindings.ruleId,
+          severity: scanFindings.severity,
+          file: scanFindings.file,
+        })
+        .from(scanFindings)
+        .where(and(eq(scanFindings.scanId, prior.id), eq(scanFindings.source, "rule")));
+
+  return {
+    scanId: prior.id,
+    stagedVersion: prior.stagedVersion,
+    decidedAt: prior.decidedAt,
+    findings: findingRows.map((finding) => ({
+      ruleId: finding.ruleId,
+      severity: finding.severity,
+      file: finding.file,
+    })),
+  };
+}

--- a/server/lib/release-memory.ts
+++ b/server/lib/release-memory.ts
@@ -1,0 +1,220 @@
+// Release memory: advisory prior-release consistency for a scan.
+//
+// When a maintainer already reviewed and decided "publish" for a version of a
+// package whose deterministic finding profile matches the current scan, the new
+// scan says so instead of presenting the same capability findings as if they
+// were novel (test runners legitimately spawn processes on every release).
+//
+// This signal is display-only context. It never modifies `risk`, the risk
+// breakdown, or any finding — deterministic findings stay authoritative.
+
+export type ReleaseConsistencyStatus = "match" | "subset" | "diverged" | "none";
+
+export interface FindingProfileEntry {
+  ruleId: string;
+  severity: string;
+  file: string;
+}
+
+export interface ReleaseConsistency {
+  status: ReleaseConsistencyStatus;
+  /** The prior approved scan this scan was compared against; null for "none". */
+  priorScanId: string | null;
+  /** The prior approved scan's staged version, when it recorded one. */
+  priorVersion: string | null;
+  /** ISO timestamp of the prior scan's publish decision. */
+  decidedAt: string | null;
+  currentFindingCount: number;
+  priorFindingCount: number;
+  /** Total findings present now but absent from the approved profile. */
+  newFindingCount: number;
+  /** The new findings themselves, capped at NEW_FINDINGS_CAP entries. */
+  newFindings: FindingProfileEntry[];
+}
+
+export const RELEASE_CONSISTENCY_NEW_FINDINGS_CAP = 25;
+
+const STATUSES = new Set<ReleaseConsistencyStatus>(["match", "subset", "diverged", "none"]);
+
+export interface ProfileFindingInput {
+  ruleId?: string | null;
+  severity: string;
+  file: string;
+}
+
+/**
+ * Build the finding profile: the multiset of (ruleId, severity, file) over rule
+ * findings. `line` and `evidence` are deliberately ignored — a finding that
+ * moved lines or re-rendered its evidence is still the same profile entry.
+ * Findings without a ruleId participate as ruleId "unknown". Sorted stably by
+ * (ruleId, severity, file) so equal multisets serialize identically.
+ */
+export function buildFindingProfile(findings: ProfileFindingInput[]): FindingProfileEntry[] {
+  return findings
+    .map((finding) => ({
+      ruleId: finding.ruleId ?? "unknown",
+      severity: finding.severity,
+      file: finding.file,
+    }))
+    .sort(compareProfileEntries);
+}
+
+export interface ProfileComparison {
+  status: "match" | "subset" | "diverged";
+  newFindings: FindingProfileEntry[];
+  newFindingCount: number;
+}
+
+/**
+ * Compare two finding profiles as multisets:
+ * - identical multisets → "match";
+ * - current is a strict subset of the approved profile → "subset";
+ * - anything present now that the approved profile lacked → "diverged", with
+ *   the multiset difference (current − prior) reported as `newFindings`.
+ */
+export function compareFindingProfiles(
+  current: FindingProfileEntry[],
+  prior: FindingProfileEntry[],
+): ProfileComparison {
+  const priorCounts = countEntries(prior);
+
+  const newFindings: FindingProfileEntry[] = [];
+  for (const entry of [...current].sort(compareProfileEntries)) {
+    const key = entryKey(entry);
+    const remaining = priorCounts.get(key) ?? 0;
+    if (remaining > 0) {
+      priorCounts.set(key, remaining - 1);
+    } else {
+      newFindings.push(entry);
+    }
+  }
+
+  if (newFindings.length > 0) {
+    return {
+      status: "diverged",
+      newFindingCount: newFindings.length,
+      newFindings: newFindings.slice(0, RELEASE_CONSISTENCY_NEW_FINDINGS_CAP),
+    };
+  }
+  const status = current.length === prior.length ? "match" : "subset";
+  return { status, newFindings: [], newFindingCount: 0 };
+}
+
+export interface PriorApprovedProfile {
+  scanId: string;
+  stagedVersion: string | null;
+  decidedAt: Date | string | null;
+  findings: ProfileFindingInput[];
+}
+
+/**
+ * Fold a prior approved scan (or its absence) and the current scan's rule
+ * findings into the persisted ReleaseConsistency object.
+ */
+export function computeReleaseConsistency(
+  currentFindings: ProfileFindingInput[],
+  prior: PriorApprovedProfile | null,
+): ReleaseConsistency {
+  const currentProfile = buildFindingProfile(currentFindings);
+  if (!prior) return noneReleaseConsistency(currentProfile.length);
+
+  const priorProfile = buildFindingProfile(prior.findings);
+  const comparison = compareFindingProfiles(currentProfile, priorProfile);
+  return {
+    status: comparison.status,
+    priorScanId: prior.scanId,
+    priorVersion: prior.stagedVersion,
+    decidedAt: toIsoOrNull(prior.decidedAt),
+    currentFindingCount: currentProfile.length,
+    priorFindingCount: priorProfile.length,
+    newFindingCount: comparison.newFindingCount,
+    newFindings: comparison.newFindings,
+  };
+}
+
+export function noneReleaseConsistency(currentFindingCount = 0): ReleaseConsistency {
+  return {
+    status: "none",
+    priorScanId: null,
+    priorVersion: null,
+    decidedAt: null,
+    currentFindingCount,
+    priorFindingCount: 0,
+    newFindingCount: 0,
+    newFindings: [],
+  };
+}
+
+/**
+ * Tolerant reader for the persisted `summary.releaseConsistency` blob. Old
+ * scans predate the field entirely and malformed values must never break a
+ * reader, so anything unusable normalizes to null (treated as "none"). Follows
+ * the normalizeScanRiskBreakdown pattern in `risk.ts`.
+ */
+export function normalizeReleaseConsistency(value: unknown): ReleaseConsistency | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const item = value as Partial<Record<keyof ReleaseConsistency, unknown>>;
+  if (typeof item.status !== "string" || !STATUSES.has(item.status as ReleaseConsistencyStatus)) {
+    return null;
+  }
+  return {
+    status: item.status as ReleaseConsistencyStatus,
+    priorScanId: typeof item.priorScanId === "string" ? item.priorScanId : null,
+    priorVersion: typeof item.priorVersion === "string" ? item.priorVersion : null,
+    decidedAt: typeof item.decidedAt === "string" ? item.decidedAt : null,
+    currentFindingCount: normalizeCount(item.currentFindingCount),
+    priorFindingCount: normalizeCount(item.priorFindingCount),
+    newFindingCount: normalizeCount(item.newFindingCount),
+    newFindings: normalizeNewFindings(item.newFindings),
+  };
+}
+
+function normalizeCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function normalizeNewFindings(value: unknown): FindingProfileEntry[] {
+  if (!Array.isArray(value)) return [];
+  const entries: FindingProfileEntry[] = [];
+  for (const entry of value) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+    const item = entry as Partial<FindingProfileEntry>;
+    if (
+      typeof item.ruleId !== "string" ||
+      typeof item.severity !== "string" ||
+      typeof item.file !== "string"
+    ) {
+      continue;
+    }
+    entries.push({ ruleId: item.ruleId, severity: item.severity, file: item.file });
+    if (entries.length >= RELEASE_CONSISTENCY_NEW_FINDINGS_CAP) break;
+  }
+  return entries;
+}
+
+function compareProfileEntries(a: FindingProfileEntry, b: FindingProfileEntry): number {
+  return cmp(a.ruleId, b.ruleId) || cmp(a.severity, b.severity) || cmp(a.file, b.file);
+}
+
+function entryKey(entry: FindingProfileEntry): string {
+  return `${entry.ruleId}\u0000${entry.severity}\u0000${entry.file}`;
+}
+
+function countEntries(entries: FindingProfileEntry[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const entry of entries) {
+    const key = entryKey(entry);
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function cmp(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function toIsoOrNull(value: Date | string | null): string | null {
+  if (value == null) return null;
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value.toISOString();
+  return value;
+}

--- a/server/lib/report-export.ts
+++ b/server/lib/report-export.ts
@@ -1,6 +1,7 @@
 import type { getScan } from "../db/scans";
 import { parsePersistedAiReview } from "./ai-review-contract";
 import { displayedAiResult } from "./ai-review-types";
+import { normalizeReleaseConsistency } from "./release-memory";
 import type { ReleaseProvenance, ReleaseProvenanceArtifact } from "./adapters/types";
 
 // A persisted scan detail, as returned by getScan (never null at the call site).
@@ -53,6 +54,9 @@ export function buildReportExport(detail: ScanDetail) {
     provenance: extractProvenance(summary.stagedPublish),
     aiReview: extractAiReview(scan.aiJson),
     riskSummary: detail.riskSummary ?? null,
+    // Advisory release-memory signal. Additive + optional: scans that predate
+    // the field (or persisted a malformed blob) export null.
+    releaseConsistency: normalizeReleaseConsistency(summary.releaseConsistency),
     packageJsonDiff: summary.packageJsonDiff ?? null,
     diff: summary.diff ?? null,
     findings: [...detail.findings].sort(compareFindings).map((finding) => ({

--- a/server/lib/scan-pipeline-phases.ts
+++ b/server/lib/scan-pipeline-phases.ts
@@ -1,4 +1,5 @@
 import { type AppDb, type WorkspaceSession } from "../db/client";
+import { getPriorApprovedScanFindings } from "../db/release-memory";
 import { persistScan } from "../db/scans";
 import type { AiReview } from "./ai-review";
 import type {
@@ -9,7 +10,12 @@ import type {
   PackageAdapter,
   StagedDetails,
 } from "./adapters/types";
-import { durationMsSince, emitOperationalEvent } from "./observability";
+import { describeOperationalError, durationMsSince, emitOperationalEvent } from "./observability";
+import {
+  computeReleaseConsistency,
+  noneReleaseConsistency,
+  type ReleaseConsistency,
+} from "./release-memory";
 import {
   annotateFindingsWithDiffStatus,
   createPackageDiff,
@@ -26,7 +32,7 @@ import {
   type PackageJsonSummary,
 } from "./review";
 import { computeScanRiskBreakdown, type ScanRiskBreakdown } from "./risk";
-import { maybeWriteScanArtifacts } from "./scan-artifacts";
+import { maybeWriteScanArtifacts, scanArtifactReadBucket } from "./scan-artifacts";
 import { sha256Hex, stableJson } from "./stable-json";
 import type { ScanResult } from "../types";
 
@@ -153,6 +159,47 @@ export function scoreRisk(
   return computeScanRiskBreakdown(annotatedFindings, aiFindings);
 }
 
+export interface ResolveReleaseConsistencyArgs {
+  db: AppDb;
+  env?: Cloudflare.Env;
+  identity: PipelineIdentity;
+  /** The staged manifest name — the same value persistScan records as `scans.packageName`. */
+  packageName: string | null;
+  /** The current scan's deterministic rule findings (redacted set that gets persisted). */
+  ruleFindings: Finding[];
+}
+
+// Side-effecting (db read): release memory. Compare the current deterministic
+// finding profile against the most recent completed scan of the same package,
+// in the same organization, that a maintainer decided "publish". Advisory only:
+// the outcome never feeds risk, the risk breakdown, or any finding — and a
+// lookup failure degrades to "none" instead of failing the scan.
+export async function resolveReleaseConsistency(
+  args: ResolveReleaseConsistencyArgs,
+): Promise<ReleaseConsistency> {
+  if (!args.packageName) return noneReleaseConsistency(args.ruleFindings.length);
+  try {
+    const prior = await getPriorApprovedScanFindings(
+      args.db,
+      {
+        organizationId: args.identity.organizationId,
+        packageName: args.packageName,
+        excludeScanId: args.identity.scanId,
+      },
+      args.env ? scanArtifactReadBucket(args.env) : undefined,
+    );
+    return computeReleaseConsistency(args.ruleFindings, prior);
+  } catch (err) {
+    emitOperationalEvent("warn", "scan.release_memory.lookup_failed", {
+      scanId: args.identity.scanId,
+      organizationId: args.identity.organizationId,
+      packageName: args.packageName,
+      error: describeOperationalError(err),
+    });
+    return noneReleaseConsistency(args.ruleFindings.length);
+  }
+}
+
 export interface PersistResultsArgs<TInput, TBroker extends AdapterBroker> {
   env?: Cloudflare.Env;
   db: AppDb;
@@ -165,6 +212,7 @@ export interface PersistResultsArgs<TInput, TBroker extends AdapterBroker> {
   findings: DeterministicFindings;
   aiFindings: AiReview;
   riskSummary: ScanRiskBreakdown;
+  releaseConsistency: ReleaseConsistency;
 }
 
 export interface PersistedScanOutcome {
@@ -204,6 +252,7 @@ export async function persistResults<TInput, TBroker extends AdapterBroker>(
     aiFindings: args.aiFindings,
     risk,
     riskSummary: args.riskSummary,
+    releaseConsistency: args.releaseConsistency,
     safety,
   };
 
@@ -223,6 +272,7 @@ export async function persistResults<TInput, TBroker extends AdapterBroker>(
     findingAnnotations: findings.findingAnnotations,
     aiFindings: args.aiFindings,
     risk: args.riskSummary,
+    releaseConsistency: args.releaseConsistency,
     safety,
   };
   const reportJson = stableJson(reportPayload);
@@ -260,6 +310,7 @@ export async function persistResults<TInput, TBroker extends AdapterBroker>(
       risk: args.riskSummary,
       stagedPublish: findings.redactedDetails,
       baseline: baseline.baseline,
+      releaseConsistency: args.releaseConsistency,
       safety: result.safety,
     },
     ai: args.aiFindings,

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -12,6 +12,7 @@ import {
   persistResults,
   recordCompletion,
   resolveBaseline,
+  resolveReleaseConsistency,
   runDeterministicFindings,
   scoreRisk,
   type ComputedDiff,
@@ -67,6 +68,17 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
     });
     const riskSummary = scoreRisk(findings.annotatedFindings, aiFindings);
 
+    // Advisory release-memory lookup (db read) before persistence. It compares
+    // finding profiles only; it never touches risk or findings, and a lookup
+    // failure degrades to "none" inside the phase instead of failing the scan.
+    const releaseConsistency = await resolveReleaseConsistency({
+      db,
+      env,
+      identity,
+      packageName: findings.redactedStagedManifest?.name ?? null,
+      ruleFindings: findings.ruleFindings,
+    });
+
     const { result, persisted } = await persistResults({
       env,
       db,
@@ -79,6 +91,7 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
       findings,
       aiFindings,
       riskSummary,
+      releaseConsistency,
     });
 
     await recordCompletion({

--- a/server/types.ts
+++ b/server/types.ts
@@ -7,6 +7,7 @@ export type {
   ReleaseProvenanceArtifactKind,
 } from "./lib/adapters/types";
 import type { AiReview } from "./lib/ai-review";
+import type { ReleaseConsistency } from "./lib/release-memory";
 import type { ScanRiskBreakdown } from "./lib/risk";
 import type {
   DiffEntry,
@@ -49,6 +50,9 @@ export interface ScanResult {
   aiFindings: AiReview;
   risk: RiskLevel;
   riskSummary: ScanRiskBreakdown;
+  // Advisory prior-release consistency signal (release memory). Display-only:
+  // it never feeds risk or findings.
+  releaseConsistency: ReleaseConsistency;
   safety: {
     tokenExposedToSandbox: boolean;
     directSandboxNetwork: boolean;

--- a/src/pages/Dashboard/ScanDetail/ReleaseConsistencyNotice.tsx
+++ b/src/pages/Dashboard/ScanDetail/ReleaseConsistencyNotice.tsx
@@ -1,0 +1,62 @@
+import {
+  normalizeReleaseConsistency,
+  type ReleaseConsistency,
+} from "../../../../server/lib/release-memory";
+import { formatDateTime, pluralize } from "../../../lib/format";
+import { Alert } from "../../../components/Alert";
+
+// Advisory release-memory notice, rendered directly under the Recommendation.
+// match/subset: a prominent positive banner — the maintainer already reviewed
+// and published a release with this exact finding profile, so the same
+// capability findings are not news. diverged: a quiet one-liner pointing at the
+// count of genuinely new findings. It never changes risk and renders nothing
+// when there is no approved prior scan (or the scan predates the field).
+export function ReleaseConsistencyNotice({ value }: { value: unknown }) {
+  const consistency = normalizeReleaseConsistency(value);
+  if (!consistency || consistency.status === "none") return null;
+
+  if (consistency.status === "diverged") {
+    const count = consistency.newFindingCount;
+    return (
+      <p class="m-0 text-[13px] text-ink-muted">
+        {count} {pluralize("finding", count)} {count === 1 ? "is" : "are"} new since the last
+        approved release
+        {consistency.priorVersion || consistency.priorScanId ? (
+          <> ({priorScanLink(consistency)})</>
+        ) : null}
+        .
+      </p>
+    );
+  }
+
+  const approvedOn = consistency.decidedAt
+    ? `, approved on ${formatDateTime(consistency.decidedAt)}`
+    : "";
+  return (
+    <Alert tone="ok">
+      {consistency.status === "match" ? (
+        <>
+          Finding profile matches {priorScanLink(consistency)}
+          {approvedOn}. The same deterministic findings were already reviewed and published.
+        </>
+      ) : (
+        <>
+          No new findings since {priorScanLink(consistency)}
+          {approvedOn}. Every current finding was already reviewed and published.
+        </>
+      )}
+    </Alert>
+  );
+}
+
+function priorScanLink(consistency: ReleaseConsistency) {
+  const label = consistency.priorVersion
+    ? `v${consistency.priorVersion}`
+    : "the last approved release";
+  if (!consistency.priorScanId) return <>{label}</>;
+  return (
+    <a href={`/dashboard/scans/${encodeURIComponent(consistency.priorScanId)}`} class="underline">
+      {label}
+    </a>
+  );
+}

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -35,6 +35,7 @@ import { DecisionDialog } from "./DecisionDialog";
 import { GateContextPanel, GateDecisionDialog, GatePackagesPanel } from "./GateDecisionDialog";
 import { DiffWorkbench } from "./DiffWorkbench";
 import { RiskSignalsSection } from "./FindingsSection";
+import { ReleaseConsistencyNotice } from "./ReleaseConsistencyNotice";
 import { ReleaseRecommendation } from "./ReleaseRecommendation";
 import { PersistedReportSections } from "./ReportSections";
 import { ScanDetailHeader, ScanFailureAlert, VersionPickerSkeleton } from "./ScanDetailChrome";
@@ -306,6 +307,8 @@ export default function ScanDetailPage() {
               usePersistedRiskSummary={model.isDefaultComparison.value || !compare}
               isWorkflowGate={isWorkflowGate}
             />
+
+            <ReleaseConsistencyNotice value={summary.value.releaseConsistency} />
 
             {detail.scan.packageName ? (
               <div class="flex flex-col gap-2 border-t border-border pt-3">

--- a/src/pages/Dashboard/ScanDetail/types.ts
+++ b/src/pages/Dashboard/ScanDetail/types.ts
@@ -17,6 +17,9 @@ export interface PersistedSummary {
   stagedPublish?: {
     provenance?: ReleaseProvenance;
   };
+  // Advisory release-memory blob. Old scans lack it and its shape is only
+  // trusted after normalizeReleaseConsistency, so it stays unknown here.
+  releaseConsistency?: unknown;
 }
 
 export type PersistedFinding = PersistedScanDetail["findings"][number];

--- a/test/release-memory.test.ts
+++ b/test/release-memory.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "vitest";
+import {
+  RELEASE_CONSISTENCY_NEW_FINDINGS_CAP,
+  buildFindingProfile,
+  compareFindingProfiles,
+  computeReleaseConsistency,
+  noneReleaseConsistency,
+  normalizeReleaseConsistency,
+} from "../server/lib/release-memory";
+
+const spawn = (file: string, severity = "high") => ({
+  ruleId: "code.child-process",
+  severity,
+  file,
+  evidence: "spawn('node')",
+  reason: "spawns a process",
+  line: 3,
+});
+
+describe("buildFindingProfile", () => {
+  test("keeps only (ruleId, severity, file), sorted stably", () => {
+    const profile = buildFindingProfile([
+      { ruleId: "code.network", severity: "medium", file: "lib/b.js" },
+      spawn("lib/a.js"),
+      { ruleId: "code.network", severity: "medium", file: "lib/a.js" },
+    ]);
+
+    expect(profile).toEqual([
+      { ruleId: "code.child-process", severity: "high", file: "lib/a.js" },
+      { ruleId: "code.network", severity: "medium", file: "lib/a.js" },
+      { ruleId: "code.network", severity: "medium", file: "lib/b.js" },
+    ]);
+    // line/evidence never survive into the profile.
+    expect(profile[0]).not.toHaveProperty("line");
+    expect(profile[0]).not.toHaveProperty("evidence");
+  });
+
+  test("findings without a ruleId participate as 'unknown'", () => {
+    const profile = buildFindingProfile([
+      { severity: "low", file: "x.js" },
+      { ruleId: null, severity: "low", file: "y.js" },
+    ]);
+    expect(profile.map((entry) => entry.ruleId)).toEqual(["unknown", "unknown"]);
+  });
+});
+
+describe("compareFindingProfiles", () => {
+  test("identical multisets match regardless of input order", () => {
+    const current = buildFindingProfile([spawn("a.js"), spawn("b.js")]);
+    const prior = buildFindingProfile([spawn("b.js"), spawn("a.js")]);
+    expect(compareFindingProfiles(current, prior)).toEqual({
+      status: "match",
+      newFindings: [],
+      newFindingCount: 0,
+    });
+  });
+
+  test("duplicate rule hits are compared as a multiset, not a set", () => {
+    // Two identical (ruleId, severity, file) hits now vs one before is NOT a
+    // subset — the extra occurrence is a new finding.
+    const current = buildFindingProfile([spawn("a.js"), spawn("a.js")]);
+    const prior = buildFindingProfile([spawn("a.js")]);
+    const out = compareFindingProfiles(current, prior);
+    expect(out.status).toBe("diverged");
+    expect(out.newFindingCount).toBe(1);
+    expect(out.newFindings).toEqual([
+      { ruleId: "code.child-process", severity: "high", file: "a.js" },
+    ]);
+  });
+
+  test("strict multiset subset (including duplicates) reports subset", () => {
+    const current = buildFindingProfile([spawn("a.js")]);
+    const prior = buildFindingProfile([spawn("a.js"), spawn("a.js"), spawn("b.js")]);
+    expect(compareFindingProfiles(current, prior).status).toBe("subset");
+  });
+
+  test("severity changes on the same rule/file diverge", () => {
+    const current = buildFindingProfile([spawn("a.js", "critical")]);
+    const prior = buildFindingProfile([spawn("a.js", "high")]);
+    const out = compareFindingProfiles(current, prior);
+    expect(out.status).toBe("diverged");
+    expect(out.newFindings).toEqual([
+      { ruleId: "code.child-process", severity: "critical", file: "a.js" },
+    ]);
+  });
+
+  test("empty vs empty matches; empty vs non-empty is a subset", () => {
+    expect(compareFindingProfiles([], []).status).toBe("match");
+    expect(compareFindingProfiles([], buildFindingProfile([spawn("a.js")])).status).toBe("subset");
+  });
+
+  test("caps reported new findings while keeping the true count", () => {
+    const current = buildFindingProfile(
+      Array.from({ length: 30 }, (_, i) => spawn(`file-${String(i).padStart(2, "0")}.js`)),
+    );
+    const out = compareFindingProfiles(current, []);
+    expect(out.status).toBe("diverged");
+    expect(out.newFindingCount).toBe(30);
+    expect(out.newFindings).toHaveLength(RELEASE_CONSISTENCY_NEW_FINDINGS_CAP);
+  });
+});
+
+describe("computeReleaseConsistency", () => {
+  test("returns none when there is no prior approved scan", () => {
+    expect(computeReleaseConsistency([spawn("a.js")], null)).toEqual({
+      status: "none",
+      priorScanId: null,
+      priorVersion: null,
+      decidedAt: null,
+      currentFindingCount: 1,
+      priorFindingCount: 0,
+      newFindingCount: 0,
+      newFindings: [],
+    });
+  });
+
+  test("carries the prior scan identity and counts on a match", () => {
+    const decidedAt = new Date("2026-07-01T12:00:00.000Z");
+    const out = computeReleaseConsistency([spawn("a.js")], {
+      scanId: "scan-prior",
+      stagedVersion: "5.7.4",
+      decidedAt,
+      findings: [spawn("a.js")],
+    });
+    expect(out).toEqual({
+      status: "match",
+      priorScanId: "scan-prior",
+      priorVersion: "5.7.4",
+      decidedAt: "2026-07-01T12:00:00.000Z",
+      currentFindingCount: 1,
+      priorFindingCount: 1,
+      newFindingCount: 0,
+      newFindings: [],
+    });
+  });
+});
+
+describe("normalizeReleaseConsistency", () => {
+  test("round-trips a computed value", () => {
+    const value = computeReleaseConsistency([spawn("a.js"), { severity: "low", file: "b.js" }], {
+      scanId: "scan-prior",
+      stagedVersion: "1.0.0",
+      decidedAt: "2026-07-01T12:00:00.000Z",
+      findings: [],
+    });
+    expect(normalizeReleaseConsistency(JSON.parse(JSON.stringify(value)))).toEqual(value);
+  });
+
+  test("tolerates absence and garbage from old scans", () => {
+    expect(normalizeReleaseConsistency(undefined)).toBeNull();
+    expect(normalizeReleaseConsistency(null)).toBeNull();
+    expect(normalizeReleaseConsistency("match")).toBeNull();
+    expect(normalizeReleaseConsistency([])).toBeNull();
+    expect(normalizeReleaseConsistency({})).toBeNull();
+    expect(normalizeReleaseConsistency({ status: "sideways" })).toBeNull();
+  });
+
+  test("defaults malformed fields instead of rejecting the whole value", () => {
+    expect(
+      normalizeReleaseConsistency({
+        status: "diverged",
+        priorScanId: 42,
+        decidedAt: {},
+        currentFindingCount: -3,
+        newFindingCount: 2.9,
+        newFindings: [{ ruleId: "r", severity: "high", file: "a.js" }, { ruleId: "broken" }, "x"],
+      }),
+    ).toEqual({
+      status: "diverged",
+      priorScanId: null,
+      priorVersion: null,
+      decidedAt: null,
+      currentFindingCount: 0,
+      priorFindingCount: 0,
+      newFindingCount: 2,
+      newFindings: [{ ruleId: "r", severity: "high", file: "a.js" }],
+    });
+  });
+
+  test("noneReleaseConsistency normalizes to itself", () => {
+    const none = noneReleaseConsistency(2);
+    expect(normalizeReleaseConsistency(none)).toEqual(none);
+  });
+});

--- a/test/scan-pipeline-phases.test.mjs
+++ b/test/scan-pipeline-phases.test.mjs
@@ -13,6 +13,7 @@ const {
   computeDiff,
   runDeterministicFindings,
   scoreRisk,
+  resolveReleaseConsistency,
   persistResults,
   recordCompletion,
 } = await import("../server/lib/scan-pipeline-phases.ts");
@@ -240,6 +241,41 @@ describe("scoreRisk", () => {
   });
 });
 
+const noneConsistency = {
+  status: "none",
+  priorScanId: null,
+  priorVersion: null,
+  decidedAt: null,
+  currentFindingCount: 1,
+  priorFindingCount: 0,
+  newFindingCount: 0,
+  newFindings: [],
+};
+
+describe("resolveReleaseConsistency", () => {
+  test("degrades to none (never throws) when the db lookup fails", async () => {
+    const out = await resolveReleaseConsistency({
+      db: {},
+      identity: { scanId: "scan-1", stageId: "stage-1", organizationId: "org-1" },
+      packageName: "pkg",
+      ruleFindings: [{ severity: "high", file: "index.js", evidence: "", reason: "" }],
+    });
+
+    expect(out).toEqual(noneConsistency);
+  });
+
+  test("returns none without a db read when the scan has no package name", async () => {
+    const out = await resolveReleaseConsistency({
+      db: {},
+      identity: { scanId: "scan-1", stageId: "stage-1", organizationId: "org-1" },
+      packageName: null,
+      ruleFindings: [{ severity: "high", file: "index.js", evidence: "", reason: "" }],
+    });
+
+    expect(out).toEqual(noneConsistency);
+  });
+});
+
 describe("persistResults", () => {
   test("assembles the scan result and persists a completed scan", async () => {
     const adapter = makeAdapter();
@@ -259,6 +295,7 @@ describe("persistResults", () => {
       findings,
       aiFindings: disabledAi,
       riskSummary,
+      releaseConsistency: noneConsistency,
     });
 
     expect(persisted).toBe(true);
@@ -286,6 +323,10 @@ describe("persistResults", () => {
     });
     expect(persistArg.summary.report.digest).toMatch(/^[0-9a-f]{64}$/);
     expect(persistArg.summary.report.rulesVersion).toBeDefined();
+
+    // Release memory rides the result + persisted summary, advisory only.
+    expect(result.releaseConsistency).toEqual(noneConsistency);
+    expect(persistArg.summary.releaseConsistency).toEqual(noneConsistency);
   });
 
   test("propagates a non-persisted outcome from persistScan", async () => {
@@ -306,6 +347,7 @@ describe("persistResults", () => {
       findings,
       aiFindings: disabledAi,
       riskSummary,
+      releaseConsistency: noneConsistency,
     });
 
     expect(persisted).toBe(false);

--- a/test/workers/release-memory.test.ts
+++ b/test/workers/release-memory.test.ts
@@ -1,0 +1,370 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { describe, expect, test } from "vitest";
+import { createDb } from "../../server/db/client";
+import { ensurePersonalOrganization } from "../../server/db/organizations";
+import { getPriorApprovedScanFindings } from "../../server/db/release-memory";
+import { createScanJob, persistScan, recordScanDecision } from "../../server/db/scans";
+import * as schema from "../../server/db/schema";
+import {
+  computeReleaseConsistency,
+  type ReleaseConsistency,
+} from "../../server/lib/release-memory";
+import { writeScanArtifacts } from "../../server/lib/scan-artifacts";
+import { resolveReleaseConsistency } from "../../server/lib/scan-pipeline-phases";
+import { sha256Hex, stableJson } from "../../server/lib/stable-json";
+import type { Finding } from "../../server/lib/review";
+import { scansRoutes } from "../../server/routes/scans";
+import type { Bindings, Variables } from "../../server/types";
+
+interface SeededUser {
+  userId: string;
+  organizationId: string;
+}
+
+async function seedUser(): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Release Memory Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+function buildTestApp(session: { userId: string }) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.use("*", async (c, next) => {
+    c.set("authSession", { userId: session.userId });
+    await next();
+  });
+  app.route("/api/v1/scans", scansRoutes);
+  return app;
+}
+
+async function fetchWithSession(
+  app: Hono<{ Bindings: Bindings; Variables: Variables }>,
+  path: string,
+) {
+  const ctx = createExecutionContext();
+  const res = await app.fetch(new Request(`http://test.local${path}`), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+// The `tape` shape from prod ops data: a test runner whose suite legitimately
+// spawns processes, flagged identically on every release.
+const spawnFinding = (file: string, severity: Finding["severity"] = "high"): Finding => ({
+  severity,
+  file,
+  evidence: "spawn('node', [bin])",
+  reason: "spawns a child process",
+  line: 12,
+  ruleId: "code.child-process",
+  ruleVersion: "1.0.0",
+});
+
+interface SeedScanOptions {
+  packageName?: string;
+  version?: string;
+  findings?: Finding[];
+  decision?: "publish" | "no_publish" | null;
+  summaryExtra?: Record<string, unknown>;
+}
+
+async function seedCompletedScan(owner: SeededUser, options: SeedScanOptions = {}) {
+  const db = createDb(env.DB);
+  const scanId = `scan_${crypto.randomUUID()}`;
+  const stageId = `stage-${scanId.slice(-12)}`;
+  const packageName = options.packageName ?? "tape";
+  const version = options.version ?? "5.7.4";
+  await createScanJob(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+  });
+  await persistScan(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+    packageJson: { name: packageName, version },
+    risk: "high",
+    status: "complete",
+    summary: {
+      diff: [{ path: "index.js", status: "modified" }],
+      ...options.summaryExtra,
+    },
+    ai: null,
+    files: [{ path: "index.js", size: 10, sha256: "a", flags: [], textSample: "x" }],
+    diff: [{ path: "index.js", status: "modified", flags: [] }],
+    findings: options.findings ?? [spawnFinding("test/spawn.js")],
+    report: { version: 1, digest: `digest-${scanId}` },
+  });
+  if (options.decision) {
+    await recordScanDecision(db, {
+      scanId,
+      organizationId: owner.organizationId,
+      actorUserId: owner.userId,
+      decision: options.decision,
+    });
+  }
+  return { scanId, stageId, packageName, version };
+}
+
+async function setScanCreatedAt(scanId: string, createdAt: Date) {
+  const db = createDb(env.DB);
+  await db.update(schema.scans).set({ createdAt }).where(eq(schema.scans.id, scanId));
+}
+
+function consistencyFor(
+  owner: SeededUser,
+  packageName: string,
+  ruleFindings: Finding[],
+): Promise<ReleaseConsistency> {
+  return resolveReleaseConsistency({
+    db: createDb(env.DB),
+    env: env as unknown as Cloudflare.Env,
+    identity: {
+      scanId: `scan_${crypto.randomUUID()}`,
+      stageId: "stage-current",
+      organizationId: owner.organizationId,
+    },
+    packageName,
+    ruleFindings,
+  });
+}
+
+describe("release memory (prior-release consistency)", () => {
+  test("matches the prior approved scan for the same org + package", async () => {
+    const owner = await seedUser();
+    const prior = await seedCompletedScan(owner, {
+      findings: [spawnFinding("test/spawn.js"), spawnFinding("bin/tape.js")],
+      decision: "publish",
+    });
+
+    // Same profile, different line/evidence — those never enter the profile.
+    const current = [
+      { ...spawnFinding("bin/tape.js"), line: 99, evidence: "spawn('node')" },
+      spawnFinding("test/spawn.js"),
+    ];
+    const out = await consistencyFor(owner, "tape", current);
+
+    expect(out.status).toBe("match");
+    expect(out.priorScanId).toBe(prior.scanId);
+    expect(out.priorVersion).toBe("5.7.4");
+    expect(out.decidedAt).toEqual(expect.any(String));
+    expect(out.currentFindingCount).toBe(2);
+    expect(out.priorFindingCount).toBe(2);
+    expect(out.newFindings).toEqual([]);
+  });
+
+  test("does not match another organization's identical package history", async () => {
+    const ownerA = await seedUser();
+    await seedCompletedScan(ownerA, { decision: "publish" });
+
+    const ownerB = await seedUser();
+    const out = await consistencyFor(ownerB, "tape", [spawnFinding("test/spawn.js")]);
+
+    expect(out.status).toBe("none");
+    expect(out.priorScanId).toBeNull();
+  });
+
+  test("returns none without an approved prior (undecided or no_publish)", async () => {
+    const owner = await seedUser();
+    await seedCompletedScan(owner, { decision: null });
+    await seedCompletedScan(owner, { decision: "no_publish" });
+
+    const out = await consistencyFor(owner, "tape", [spawnFinding("test/spawn.js")]);
+    expect(out.status).toBe("none");
+  });
+
+  test("diverges with the new findings when the profile grew", async () => {
+    const owner = await seedUser();
+    await seedCompletedScan(owner, {
+      findings: [spawnFinding("test/spawn.js")],
+      decision: "publish",
+    });
+
+    const out = await consistencyFor(owner, "tape", [
+      spawnFinding("test/spawn.js"),
+      { ...spawnFinding("lib/exfil.js"), ruleId: "code.network" },
+    ]);
+
+    expect(out.status).toBe("diverged");
+    expect(out.newFindingCount).toBe(1);
+    expect(out.newFindings).toEqual([
+      { ruleId: "code.network", severity: "high", file: "lib/exfil.js" },
+    ]);
+  });
+
+  test("compares against the most recent approved scan", async () => {
+    const owner = await seedUser();
+    const older = await seedCompletedScan(owner, {
+      version: "5.7.3",
+      findings: [spawnFinding("test/spawn.js")],
+      decision: "publish",
+    });
+    const newer = await seedCompletedScan(owner, {
+      version: "5.7.4",
+      findings: [spawnFinding("test/spawn.js"), spawnFinding("bin/tape.js")],
+      decision: "publish",
+    });
+    await setScanCreatedAt(older.scanId, new Date("2026-06-01T00:00:00.000Z"));
+    await setScanCreatedAt(newer.scanId, new Date("2026-07-01T00:00:00.000Z"));
+
+    const out = await consistencyFor(owner, "tape", [spawnFinding("test/spawn.js")]);
+    expect(out.priorScanId).toBe(newer.scanId);
+    expect(out.priorVersion).toBe("5.7.4");
+    // One of the two approved findings is gone → strict multiset subset.
+    expect(out.status).toBe("subset");
+  });
+
+  test("reads the prior profile from R2 for artifact-backed scans", async () => {
+    const owner = await seedUser();
+    const db = createDb(env.DB);
+    const scanId = `scan_${crypto.randomUUID()}`;
+    const stageId = `stage-${scanId.slice(-12)}`;
+    const ruleFindings = [spawnFinding("test/spawn.js")];
+    const reportPayload = {
+      version: 1,
+      stageId,
+      ruleFindings,
+      findingAnnotations: [{ findingIndex: 0, diffStatus: "modified", releaseDelta: true }],
+    };
+    const reportJson = stableJson(reportPayload);
+    const reportDigest = await sha256Hex(reportJson);
+    const artifacts = await writeScanArtifacts(env.ARTIFACTS, {
+      organizationId: owner.organizationId,
+      scanId,
+      reportJson,
+      reportDigest,
+      files: [{ path: "index.js", size: 10, sha256: "a", flags: [], textSample: "x" }],
+      diff: [{ path: "index.js", status: "modified", flags: [] }],
+      generatedAt: "2026-07-01T00:00:00.000Z",
+    });
+    await createScanJob(db, {
+      id: scanId,
+      stageId,
+      organizationId: owner.organizationId,
+      ownerUserId: owner.userId,
+    });
+    // Artifact-backed persist: findings are NOT duplicated into scan_findings.
+    await persistScan(db, {
+      id: scanId,
+      stageId,
+      organizationId: owner.organizationId,
+      ownerUserId: owner.userId,
+      packageJson: { name: "tape", version: "5.7.4" },
+      risk: "high",
+      status: "complete",
+      summary: {},
+      ai: null,
+      files: [{ path: "index.js", size: 10, sha256: "a", flags: [], textSample: "x" }],
+      diff: [{ path: "index.js", status: "modified", flags: [] }],
+      findings: ruleFindings,
+      report: { version: 1, digest: reportDigest },
+      artifacts,
+    });
+    const d1Findings = await db
+      .select()
+      .from(schema.scanFindings)
+      .where(eq(schema.scanFindings.scanId, scanId));
+    expect(d1Findings).toEqual([]);
+    await recordScanDecision(db, {
+      scanId,
+      organizationId: owner.organizationId,
+      actorUserId: owner.userId,
+      decision: "publish",
+    });
+
+    const out = await consistencyFor(owner, "tape", [spawnFinding("test/spawn.js")]);
+    expect(out.status).toBe("match");
+    expect(out.priorScanId).toBe(scanId);
+    expect(out.priorFindingCount).toBe(1);
+  });
+
+  test("db helper is org-scoped and feeds computeReleaseConsistency", async () => {
+    const owner = await seedUser();
+    const prior = await seedCompletedScan(owner, { decision: "publish" });
+    const db = createDb(env.DB);
+
+    const found = await getPriorApprovedScanFindings(db, {
+      organizationId: owner.organizationId,
+      packageName: "tape",
+      excludeScanId: "scan_current",
+    });
+    expect(found?.scanId).toBe(prior.scanId);
+    expect(found?.findings).toEqual([
+      { ruleId: "code.child-process", severity: "high", file: "test/spawn.js" },
+    ]);
+
+    // Excluding the prior scan's own id (a re-run of the same scan) hides it.
+    const excluded = await getPriorApprovedScanFindings(db, {
+      organizationId: owner.organizationId,
+      packageName: "tape",
+      excludeScanId: prior.scanId,
+    });
+    expect(excluded).toBeNull();
+
+    const out = computeReleaseConsistency([spawnFinding("test/spawn.js")], found);
+    expect(out.status).toBe("match");
+  });
+});
+
+describe("release memory exposure (API + report export)", () => {
+  test("the scan detail API returns the persisted summary blob", async () => {
+    const owner = await seedUser();
+    const releaseConsistency = {
+      status: "match",
+      priorScanId: "scan_prior",
+      priorVersion: "5.7.3",
+      decidedAt: "2026-07-01T00:00:00.000Z",
+      currentFindingCount: 1,
+      priorFindingCount: 1,
+      newFindingCount: 0,
+      newFindings: [],
+    };
+    const seeded = await seedCompletedScan(owner, { summaryExtra: { releaseConsistency } });
+
+    const res = await fetchWithSession(buildTestApp(owner), `/api/v1/scans/${seeded.scanId}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { scan: { summaryJson: Record<string, unknown> } };
+    expect(body.scan.summaryJson.releaseConsistency).toEqual(releaseConsistency);
+  });
+
+  test("report export exposes releaseConsistency, null for scans that predate it", async () => {
+    const owner = await seedUser();
+    const releaseConsistency = {
+      status: "diverged",
+      priorScanId: "scan_prior",
+      priorVersion: "5.7.3",
+      decidedAt: "2026-07-01T00:00:00.000Z",
+      currentFindingCount: 2,
+      priorFindingCount: 1,
+      newFindingCount: 1,
+      newFindings: [{ ruleId: "code.network", severity: "high", file: "lib/exfil.js" }],
+    };
+    const withField = await seedCompletedScan(owner, { summaryExtra: { releaseConsistency } });
+    const withoutField = await seedCompletedScan(owner, { packageName: "other-pkg" });
+
+    const app = buildTestApp(owner);
+    const res = await fetchWithSession(app, `/api/v1/scans/${withField.scanId}/report.json`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { releaseConsistency: unknown };
+    expect(body.releaseConsistency).toEqual(releaseConsistency);
+
+    const legacy = await fetchWithSession(app, `/api/v1/scans/${withoutField.scanId}/report.json`);
+    expect(legacy.status).toBe(200);
+    const legacyBody = (await legacy.json()) as { releaseConsistency: unknown };
+    expect(legacyBody.releaseConsistency).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

When a maintainer already reviewed and published a release with a given deterministic finding profile, the next scan with the same profile now says so prominently instead of presenting the same capability findings as novel. Motivated by prod ops data: benign packages like `tape` trigger identical high-severity capability findings on every release (test runners legitimately spawn processes), causing alert fatigue.

## How

- **Lookup (org-scoped)**: during a scan, fetch the most recent scan in the same organization, same `packageName`, with `status = 'complete'` and `decision = 'publish'` (current scan id excluded). Covered by the existing `scans_org_decision_created_idx`. `server/db/release-memory.ts`.
- **Finding profile**: the multiset of `(ruleId, severity, file)` over rule findings — `line`/`evidence` ignored, missing ruleIds participate as `"unknown"`, sorted stably. Compared as multisets: equal → `match`; strict multiset subset of the approved profile → `subset`; otherwise `diverged` with `newFindings` (multiset difference, capped at 25 entries; `newFindingCount` keeps the true count); no approved prior → `none`. Pure module: `server/lib/release-memory.ts`.
- **Pipeline**: new `resolveReleaseConsistency` phase (db read) before persistence; the result rides `ScanResult`, the digested report payload, and `summary.releaseConsistency` in `summaryJson` — **no schema migration**. The lookup can never fail a scan: errors degrade to `none` and emit a structured `scan.release_memory.lookup_failed` event.
- **Artifact-backed priors**: rule findings for R2-backed scans are no longer duplicated into `scan_findings`, so the prior profile is read from the digest-verified `report.json` (via `loadScanArtifacts`) with a D1 fallback for legacy/degraded scans.
- **Hard constraint honored**: this signal never modifies `risk`, `riskSummary`, or any finding. Advisory display only.
- **Compatibility**: every reader goes through `normalizeReleaseConsistency` (same pattern as `normalizeScanRiskBreakdown`); old scans export `releaseConsistency: null` from `report.json`.
- **UI**: `ReleaseConsistencyNotice` under the Recommendation — `match`/`subset` render a positive `Alert tone="ok"` banner ("Finding profile matches v5.7.4, approved on <date>", linking the approved scan); `diverged` renders a quiet "N findings are new since the last approved release (vX.Y.Z)" line; `none` renders nothing. No signals state needed (plain props), no SVG icons.

## Tests

- `test/release-memory.test.ts` — profile building + multiset comparison (equal, duplicate rule hits, strict subset, diverged, empty profiles, unknown ruleIds, cap).
- `test/workers/release-memory.test.ts` — approved prior → `match`; org isolation (identical package in another org does NOT match); no approved prior → `none`; diverged with new findings; most-recent-approved selection; R2 artifact-backed prior read; API + report export expose the field (null for legacy scans).
- `test/scan-pipeline-phases.test.mjs` — degrade-to-none on db failure, no-package skip, and result/summary wiring.

`pnpm run verify` passes (lint, format, typecheck, node + workers suites).

Docs: added `docs/release-memory.md` + index line in `docs/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)