### PR TITLE
Add intent envelope tiers: advisory source-binding classification per scan

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ The user-facing learning guide is [`../src/pages/Docs/index.tsx`](../src/pages/D
 - [`architecture.md`](./architecture.md) — Worker, sandbox, adapters, storage, org model, and API shape.
 - [`workflow-gates.md`](./workflow-gates.md) — GitHub Environment gate flow for PyPI, npm, and VS Code workflow-gated releases.
 - [`diff-baseline.md`](./diff-baseline.md) — default previous-version comparison strategy.
+- [`intent-envelope.md`](./intent-envelope.md) — advisory source-binding tiers (attested / declared / absent) persisted with every scan.
 - [`artifact-storage.md`](./artifact-storage.md) — D1/R2 report and artifact persistence.
 
 ## Operations and setup

--- a/docs/intent-envelope.md
+++ b/docs/intent-envelope.md
@@ -1,0 +1,63 @@
+# Intent envelope
+
+Every completed scan carries an **intent envelope**: a deterministic,
+advisory classification of how strongly the reviewed artifact is bound to a
+source repository and a release intent. It is groundwork for a future
+"Release Contract" feature and **never changes risk levels or findings** — it
+only describes what an origin claim could later be verified against.
+
+Computed in `server/lib/scan-pipeline.ts` via the pure module
+`server/lib/intent-envelope.ts`, persisted inside the scan's `summaryJson`
+blob (`summary.intentEnvelope`, no dedicated column), returned on
+`ScanResult`, exported in the `drydock.report.v1` report as the optional
+`intentEnvelope` field, and rendered as the "Source binding" row on the scan
+detail page.
+
+## Shape
+
+```ts
+interface IntentEnvelope {
+  tier: "attested" | "declared" | "absent";
+  repository: string | null; // normalized https://github.com/owner/repo (or gitlab/…)
+  signals: Array<{ kind: string; detail: string }>; // human-readable evidence
+}
+```
+
+## Tiers
+
+| Tier       | Meaning                                                                                                                                                                                                                           |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `attested` | The scan came through a GitHub workflow gate: the signed `deployment_protection_rule` webhook binds repository + workflow run + environment, and the reviewed artifact bytes were downloaded from that run.                       |
+| `declared` | Not attested, but the staged manifest (package.json / PyPI core metadata / VSIX manifest) declares a parseable repository URL (`repository` as string or `{url}`, `git+https://`, `github:owner/repo`, …). Claimed, not verified. |
+| `absent`   | No repository binding at all — the artifact cannot be tied to reviewed source.                                                                                                                                                    |
+
+Repository URLs are normalized to `https://host/owner/repo` for the known
+forges (GitHub, GitLab, Bitbucket); unknown hosts keep their sanitized full
+path. Garbage never partially parses — it reads as `absent`.
+
+## Claim ceiling
+
+The tier is a ceiling on the strength of origin claims a future Release
+Contract could make about the scan:
+
+- `attested` can later support **proven** claims ("this artifact was built
+  from run N of owner/repo") because the binding is machine-verified by the
+  signed webhook plus the artifact download from that exact run.
+- `declared` caps at **consistent** claims ("the artifact's contents are
+  consistent with what the declared repository publishes") — the manifest is
+  package-controlled, so the binding itself is unverifiable evidence.
+- `absent` caps at **not verifiable**: with no binding there is nothing to
+  check a claim against.
+
+## v1 constraints
+
+- A staged npm publish cannot reach `attested`: the staged registry metadata
+  Drydock receives (`StagedPublishDetails`) exposes package identity, actor,
+  and shasum but no provenance attestation. If npm later surfaces provenance
+  for staged versions, that signal can promote staged scans without changing
+  the tier model.
+- Scans persisted before the feature have no envelope. Every reader
+  re-validates through `normalizeIntentEnvelope` (same pattern as
+  `normalizeScanRiskBreakdown`): missing or malformed data reads as
+  `null` — the UI hides the row and the report export carries
+  `"intentEnvelope": null`.

--- a/docs/intent-envelope.md
+++ b/docs/intent-envelope.md
@@ -31,9 +31,10 @@ interface IntentEnvelope {
 | `declared` | Not attested, but the staged manifest (package.json / PyPI core metadata / VSIX manifest) declares a parseable repository URL (`repository` as string or `{url}`, `git+https://`, `github:owner/repo`, …). Claimed, not verified. |
 | `absent`   | No repository binding at all — the artifact cannot be tied to reviewed source.                                                                                                                                                    |
 
-Repository URLs are normalized to `https://host/owner/repo` for the known
-forges (GitHub, GitLab, Bitbucket); unknown hosts keep their sanitized full
-path. Garbage never partially parses — it reads as `absent`.
+Repository URLs are normalized to `https://host/owner/repo` for GitHub and
+Bitbucket. GitLab keeps nested group namespaces
+(`https://gitlab.com/group/subgroup/project`), and unknown hosts keep their
+sanitized full path. Garbage never partially parses — it reads as `absent`.
 
 ## Claim ceiling
 

--- a/server/lib/intent-envelope.ts
+++ b/server/lib/intent-envelope.ts
@@ -1,0 +1,269 @@
+// Intent envelope: a deterministic classification of how strongly a reviewed
+// artifact is bound to a source repository / release intent. Groundwork for a
+// future "Release Contract" feature.
+//
+// The envelope is advisory metadata only. It must never change risk levels or
+// findings — it describes what a claim about the artifact's origin could later
+// be verified against (the "claim ceiling"):
+//
+//  - `attested` — the binding is machine-verified. The scan came through a
+//    GitHub workflow gate: the signed `deployment_protection_rule` webhook
+//    binds repository + workflow run + environment, and the reviewed artifact
+//    bytes were downloaded from that run.
+//  - `declared` — the staged manifest (package.json / PyPI metadata / VSIX
+//    manifest) declares a parseable repository URL. The binding is claimed by
+//    the package, not verified.
+//  - `absent` — no repository binding at all.
+//
+// v1 constraint: a staged npm publish cannot reach `attested`. The staged
+// registry metadata Drydock receives (`StagedPublishDetails`, populated from
+// the staged publishes endpoints) exposes package identity, actor, and shasum —
+// but no provenance attestation. If npm later surfaces provenance for staged
+// versions, that signal can promote staged scans here without touching tiers.
+
+import type { FileRecord } from "./review";
+import { safeJson } from "./review/rules/helpers";
+
+export type IntentEnvelopeTier = "attested" | "declared" | "absent";
+
+export interface IntentEnvelopeSignal {
+  kind: string;
+  detail: string;
+}
+
+export interface IntentEnvelope {
+  tier: IntentEnvelopeTier;
+  /** Normalized https://github.com/owner/repo (or gitlab/…) when known. */
+  repository: string | null;
+  /** Human-readable evidence for the tier, in stable order. */
+  signals: IntentEnvelopeSignal[];
+}
+
+/** Gate-bound release context, threaded from the workflow-gate job. */
+export interface WorkflowGateIntent {
+  repositoryFullName: string;
+  runId: number | string;
+  environment: string;
+}
+
+export interface IntentEnvelopeInput {
+  /** Present only for scans reviewed through a GitHub workflow gate. */
+  workflowGate?: WorkflowGateIntent | null;
+  /** Raw manifest `repository` value (string, `{url}` object, shorthand, …). */
+  declaredRepository?: unknown;
+}
+
+const INTENT_ENVELOPE_TIERS: ReadonlySet<string> = new Set(["attested", "declared", "absent"]);
+
+// Hosts whose canonical repository identity is exactly `owner/repo`; extra
+// path segments (tree/…, monorepo directories) are trimmed to that identity.
+const OWNER_REPO_HOSTS: ReadonlySet<string> = new Set([
+  "github.com",
+  "gitlab.com",
+  "bitbucket.org",
+]);
+
+const SHORTHAND_HOSTS: Record<string, string> = {
+  github: "github.com",
+  gitlab: "gitlab.com",
+  bitbucket: "bitbucket.org",
+};
+
+const MAX_REPOSITORY_INPUT_LENGTH = 512;
+const REPO_SEGMENT_RE = /^[A-Za-z0-9_][A-Za-z0-9_.-]*$/;
+const BARE_OWNER_REPO_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const MAX_SIGNALS = 20;
+const MAX_SIGNAL_TEXT_LENGTH = 512;
+
+/**
+ * Normalize a manifest `repository` declaration to a canonical https URL.
+ * Handles the shapes npm/PyPI manifests carry in the wild: a plain string, a
+ * `{ url }` object, `git+https://`/`git://`/`ssh://` schemes, scp-like
+ * `git@host:owner/repo.git`, and `github:owner/repo` (plus bare `owner/repo`)
+ * shorthands. Returns null for anything that does not parse.
+ */
+export function normalizeRepositoryUrl(raw: unknown): string | null {
+  if (raw !== null && typeof raw === "object" && !Array.isArray(raw)) {
+    return normalizeRepositoryUrl((raw as { url?: unknown }).url);
+  }
+  if (typeof raw !== "string") return null;
+  let value = raw.trim();
+  if (!value || value.length > MAX_REPOSITORY_INPUT_LENGTH) return null;
+
+  const shorthand = /^(github|gitlab|bitbucket):(.+)$/i.exec(value);
+  if (shorthand) {
+    return hostPathToUrl(SHORTHAND_HOSTS[shorthand[1].toLowerCase()], shorthand[2]);
+  }
+  // npm treats a bare `owner/repo` string as a GitHub shorthand.
+  if (BARE_OWNER_REPO_RE.test(value)) return hostPathToUrl("github.com", value);
+
+  if (value.startsWith("git+")) value = value.slice("git+".length);
+
+  const scpLike = /^git@([A-Za-z0-9.-]+):(.+)$/.exec(value);
+  if (scpLike) return hostPathToUrl(scpLike[1], scpLike[2]);
+
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return null;
+  }
+  if (!["https:", "http:", "git:", "ssh:"].includes(parsed.protocol)) return null;
+  return hostPathToUrl(parsed.hostname, parsed.pathname);
+}
+
+function hostPathToUrl(host: string, path: string): string | null {
+  const normalizedHost = host.trim().toLowerCase();
+  if (!normalizedHost || !normalizedHost.includes(".")) return null;
+  const segments = path
+    .replace(/^\/+/, "")
+    .replace(/\/+$/, "")
+    .split("/")
+    .map((segment) => segment.replace(/\.git$/i, ""))
+    .filter(Boolean);
+  if (segments.length < 2) return null;
+  const [owner, repo] = segments;
+  if (!REPO_SEGMENT_RE.test(owner) || !REPO_SEGMENT_RE.test(repo)) return null;
+  if (OWNER_REPO_HOSTS.has(normalizedHost)) {
+    return `https://${normalizedHost}/${owner}/${repo}`;
+  }
+  // Unknown hosts keep their full (sanitized) path so self-hosted forges with
+  // group nesting (e.g. GitLab subgroups) are not truncated to two segments.
+  if (!segments.every((segment) => REPO_SEGMENT_RE.test(segment))) return null;
+  return `https://${normalizedHost}/${segments.join("/")}`;
+}
+
+/**
+ * Pull the raw repository declaration out of staged artifact evidence:
+ * `repository` from the staged package.json text (npm, VSIX after payload
+ * normalization), or Project-URL/Home-page headers from PyPI core metadata
+ * (`PKG-INFO` / `*.dist-info/METADATA`) when no package.json is present.
+ * Returns the raw declared value; callers normalize via
+ * `normalizeRepositoryUrl`.
+ */
+export function extractDeclaredRepository(input: {
+  manifestText: string | null;
+  files: ReadonlyArray<Pick<FileRecord, "path" | "textSample">>;
+}): unknown {
+  const manifest = input.manifestText ? safeJson(input.manifestText) : null;
+  if (manifest !== null && typeof manifest === "object" && !Array.isArray(manifest)) {
+    const repository = (manifest as { repository?: unknown }).repository;
+    if (repository !== undefined && repository !== null) return repository;
+  }
+
+  const metadataFile = input.files.find(
+    (file) =>
+      (file.path === "PKG-INFO" ||
+        file.path.endsWith("/PKG-INFO") ||
+        (file.path.endsWith("/METADATA") && file.path.includes(".dist-info"))) &&
+      typeof file.textSample === "string",
+  );
+  if (metadataFile?.textSample) {
+    return repositoryFromPyPiMetadata(metadataFile.textSample);
+  }
+  return null;
+}
+
+// Project-URL labels that conventionally point at the source repository, in
+// preference order. Comparison is case-insensitive on the trimmed label.
+const PYPI_REPOSITORY_LABELS = ["repository", "source", "source code", "code", "github"];
+
+function repositoryFromPyPiMetadata(text: string): string | null {
+  const projectUrls = new Map<string, string>();
+  let homePage: string | null = null;
+  for (const line of text.split(/\r?\n/)) {
+    // Core-metadata headers end at the first blank line; the description body
+    // that follows is package-controlled prose and must not be scanned.
+    if (line.trim() === "") break;
+    const projectUrl = /^Project-URL:\s*([^,]+),\s*(\S.*)$/i.exec(line);
+    if (projectUrl) {
+      projectUrls.set(projectUrl[1].trim().toLowerCase(), projectUrl[2].trim());
+      continue;
+    }
+    const home = /^Home-page:\s*(\S.*)$/i.exec(line);
+    if (home) homePage = home[1].trim();
+  }
+  for (const label of PYPI_REPOSITORY_LABELS) {
+    const url = projectUrls.get(label);
+    if (url) return url;
+  }
+  return homePage;
+}
+
+/**
+ * Pure tier computation. Advisory only: the result is persisted alongside the
+ * scan and rendered in the report, and never feeds risk or findings.
+ */
+export function computeIntentEnvelope(input: IntentEnvelopeInput): IntentEnvelope {
+  const declared = normalizeRepositoryUrl(input.declaredRepository);
+  const gate = validWorkflowGateIntent(input.workflowGate);
+
+  if (gate) {
+    const gateRepository = normalizeRepositoryUrl(`https://github.com/${gate.repositoryFullName}`);
+    const signals: IntentEnvelopeSignal[] = [
+      {
+        kind: "workflow-gate",
+        detail: `repo ${gate.repositoryFullName}, run ${gate.runId}, environment ${gate.environment}`,
+      },
+    ];
+    if (declared) {
+      signals.push({ kind: "manifest-repository", detail: `manifest declares ${declared}` });
+    }
+    return { tier: "attested", repository: gateRepository ?? declared, signals };
+  }
+
+  // Staged publishes: no attestation signal exists in staged registry metadata
+  // today (see the module comment), so the manifest declaration is the
+  // strongest available binding.
+  if (declared) {
+    return {
+      tier: "declared",
+      repository: declared,
+      signals: [
+        {
+          kind: "manifest-repository",
+          detail: `manifest declares ${declared} — claimed by the package, not verified`,
+        },
+      ],
+    };
+  }
+
+  return { tier: "absent", repository: null, signals: [] };
+}
+
+function validWorkflowGateIntent(value: WorkflowGateIntent | null | undefined) {
+  if (!value) return null;
+  const { repositoryFullName, runId, environment } = value;
+  if (typeof repositoryFullName !== "string" || !repositoryFullName.trim()) return null;
+  if (typeof environment !== "string" || !environment.trim()) return null;
+  if (typeof runId !== "number" && typeof runId !== "string") return null;
+  return { repositoryFullName: repositoryFullName.trim(), runId, environment: environment.trim() };
+}
+
+/**
+ * Re-validate a persisted envelope from an untyped summary blob. Scans created
+ * before this feature have no envelope; malformed data reads as null rather
+ * than a partial envelope. Follows the `normalizeScanRiskBreakdown` pattern.
+ */
+export function normalizeIntentEnvelope(value: unknown): IntentEnvelope | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const item = value as Partial<Record<keyof IntentEnvelope, unknown>>;
+  if (typeof item.tier !== "string" || !INTENT_ENVELOPE_TIERS.has(item.tier)) return null;
+  const repository =
+    typeof item.repository === "string" && item.repository.length <= MAX_REPOSITORY_INPUT_LENGTH
+      ? item.repository
+      : null;
+  const signals: IntentEnvelopeSignal[] = [];
+  if (Array.isArray(item.signals)) {
+    for (const signal of item.signals.slice(0, MAX_SIGNALS)) {
+      if (!signal || typeof signal !== "object" || Array.isArray(signal)) continue;
+      const { kind, detail } = signal as { kind?: unknown; detail?: unknown };
+      if (typeof kind !== "string" || typeof detail !== "string") continue;
+      signals.push({
+        kind: kind.slice(0, MAX_SIGNAL_TEXT_LENGTH),
+        detail: detail.slice(0, MAX_SIGNAL_TEXT_LENGTH),
+      });
+    }
+  }
+  return { tier: item.tier as IntentEnvelopeTier, repository, signals };
+}

--- a/server/lib/intent-envelope.ts
+++ b/server/lib/intent-envelope.ts
@@ -70,6 +70,11 @@ const SHORTHAND_HOSTS: Record<string, string> = {
 };
 
 const MAX_REPOSITORY_INPUT_LENGTH = 512;
+// PyPI core-metadata header lines are short by construction (a label plus a
+// URL); a multi-kilobyte "line" is only ever hostile padding. Bounding line
+// length before any per-line regex runs keeps this parser linear even though
+// `textSample` is the whole decoded metadata file, not a fixed-size head.
+const MAX_METADATA_LINE_LENGTH = 2048;
 const REPO_SEGMENT_RE = /^[A-Za-z0-9_][A-Za-z0-9_.-]*$/;
 const BARE_OWNER_REPO_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
 const MAX_SIGNALS = 20;
@@ -168,6 +173,15 @@ export function extractDeclaredRepository(input: {
 // preference order. Comparison is case-insensitive on the trimmed label.
 const PYPI_REPOSITORY_LABELS = ["repository", "source", "source code", "code", "github"];
 
+// Case-insensitive header-prefix match without regex backtracking. Returns the
+// text after the header name (e.g. everything past `Project-URL:`), or null
+// when the line is not that header. Callers trim the remainder themselves.
+function matchHeader(line: string, header: string): string | null {
+  if (line.length < header.length) return null;
+  if (line.slice(0, header.length).toLowerCase() !== header.toLowerCase()) return null;
+  return line.slice(header.length);
+}
+
 function repositoryFromPyPiMetadata(text: string): string | null {
   const projectUrls = new Map<string, string>();
   let homePage: string | null = null;
@@ -175,13 +189,24 @@ function repositoryFromPyPiMetadata(text: string): string | null {
     // Core-metadata headers end at the first blank line; the description body
     // that follows is package-controlled prose and must not be scanned.
     if (line.trim() === "") break;
-    const projectUrl = /^Project-URL:\s*([^,]+),\s*(\S.*)$/i.exec(line);
-    if (projectUrl) {
-      projectUrls.set(projectUrl[1].trim().toLowerCase(), projectUrl[2].trim());
+    // Hostile padding guard: a header line this long is never legitimate, and
+    // skipping it keeps the parser bounded on adversarial metadata.
+    if (line.length > MAX_METADATA_LINE_LENGTH) continue;
+    const projectUrl = matchHeader(line, "Project-URL:");
+    if (projectUrl !== null) {
+      // Split on the first comma with `indexOf` rather than a regex: a pattern
+      // that lets `\s*` and the label class both match spaces backtracks
+      // quadratically on a comma-less padded line (ReDoS). `indexOf` is linear.
+      const comma = projectUrl.indexOf(",");
+      if (comma !== -1) {
+        const label = projectUrl.slice(0, comma).trim().toLowerCase();
+        const url = projectUrl.slice(comma + 1).trim();
+        if (label && url) projectUrls.set(label, url);
+      }
       continue;
     }
-    const home = /^Home-page:\s*(\S.*)$/i.exec(line);
-    if (home) homePage = home[1].trim();
+    const home = matchHeader(line, "Home-page:");
+    if (home !== null && home.trim()) homePage = home.trim();
   }
   for (const label of PYPI_REPOSITORY_LABELS) {
     const url = projectUrls.get(label);

--- a/server/lib/intent-envelope.ts
+++ b/server/lib/intent-envelope.ts
@@ -57,11 +57,9 @@ const INTENT_ENVELOPE_TIERS: ReadonlySet<string> = new Set(["attested", "declare
 
 // Hosts whose canonical repository identity is exactly `owner/repo`; extra
 // path segments (tree/…, monorepo directories) are trimmed to that identity.
-const OWNER_REPO_HOSTS: ReadonlySet<string> = new Set([
-  "github.com",
-  "gitlab.com",
-  "bitbucket.org",
-]);
+// GitLab is handled separately because nested groups are part of a project's
+// canonical identity (`group/subgroup/project`).
+const OWNER_REPO_HOSTS: ReadonlySet<string> = new Set(["github.com", "bitbucket.org"]);
 
 const SHORTHAND_HOSTS: Record<string, string> = {
   github: "github.com",
@@ -120,20 +118,20 @@ export function normalizeRepositoryUrl(raw: unknown): string | null {
 function hostPathToUrl(host: string, path: string): string | null {
   const normalizedHost = host.trim().toLowerCase();
   if (!normalizedHost || !normalizedHost.includes(".")) return null;
-  const segments = path
-    .replace(/^\/+/, "")
-    .replace(/\/+$/, "")
-    .split("/")
-    .map((segment) => segment.replace(/\.git$/i, ""))
-    .filter(Boolean);
-  if (segments.length < 2) return null;
-  const [owner, repo] = segments;
-  if (!REPO_SEGMENT_RE.test(owner) || !REPO_SEGMENT_RE.test(repo)) return null;
+  let segments = path.replace(/^\/+/, "").replace(/\/+$/, "").split("/").filter(Boolean);
   if (OWNER_REPO_HOSTS.has(normalizedHost)) {
-    return `https://${normalizedHost}/${owner}/${repo}`;
+    segments = segments.slice(0, 2);
+  } else if (normalizedHost === "gitlab.com") {
+    // GitLab browser URLs put revision/file paths after `/-/`; everything
+    // before that marker is the namespace + project identity.
+    const browserSuffix = segments.indexOf("-");
+    if (browserSuffix !== -1) segments = segments.slice(0, browserSuffix);
   }
-  // Unknown hosts keep their full (sanitized) path so self-hosted forges with
-  // group nesting (e.g. GitLab subgroups) are not truncated to two segments.
+
+  if (segments.length < 2) return null;
+  segments[segments.length - 1] = segments.at(-1)!.replace(/\.git$/i, "");
+  // GitLab and unknown hosts keep their full (sanitized) namespace path so
+  // subgroup projects are not collapsed to the wrong repository.
   if (!segments.every((segment) => REPO_SEGMENT_RE.test(segment))) return null;
   return `https://${normalizedHost}/${segments.join("/")}`;
 }
@@ -274,10 +272,7 @@ export function normalizeIntentEnvelope(value: unknown): IntentEnvelope | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const item = value as Partial<Record<keyof IntentEnvelope, unknown>>;
   if (typeof item.tier !== "string" || !INTENT_ENVELOPE_TIERS.has(item.tier)) return null;
-  const repository =
-    typeof item.repository === "string" && item.repository.length <= MAX_REPOSITORY_INPUT_LENGTH
-      ? item.repository
-      : null;
+  const repository = normalizeRepositoryUrl(item.repository);
   const signals: IntentEnvelopeSignal[] = [];
   if (Array.isArray(item.signals)) {
     for (const signal of item.signals.slice(0, MAX_SIGNALS)) {
@@ -290,5 +285,27 @@ export function normalizeIntentEnvelope(value: unknown): IntentEnvelope | null {
       });
     }
   }
+
+  // Do not let a persisted tier outlive the evidence that justified it. In
+  // particular, an object containing only `{ tier: "attested" }` must not be
+  // rendered or exported as a machine-verified source binding.
+  if (item.tier === "attested") {
+    if (
+      !repository?.startsWith("https://github.com/") ||
+      !signals.some((signal) => signal.kind === "workflow-gate" && signal.detail.trim())
+    ) {
+      return null;
+    }
+  } else if (item.tier === "declared") {
+    if (
+      !repository ||
+      !signals.some((signal) => signal.kind === "manifest-repository" && signal.detail.trim())
+    ) {
+      return null;
+    }
+  } else if (repository || signals.length) {
+    return null;
+  }
+
   return { tier: item.tier as IntentEnvelopeTier, repository, signals };
 }

--- a/server/lib/scan/pipeline-phases.ts
+++ b/server/lib/scan/pipeline-phases.ts
@@ -10,6 +10,7 @@ import type {
   PackageAdapter,
   StagedDetails,
 } from "../ecosystems/package-adapter";
+import type { IntentEnvelope } from "../intent-envelope";
 import {
   describeOperationalError,
   durationMsSince,
@@ -258,6 +259,9 @@ export interface PersistResultsArgs<TInput, TBroker extends AdapterBroker> {
   mergedAiFindings?: MergedAiFindings;
   riskSummary: ScanRiskBreakdown;
   releaseConsistency: ReleaseConsistency;
+  // Advisory source-binding classification computed by the pipeline; persisted
+  // with the scan but never allowed to influence risk or findings.
+  intentEnvelope: IntentEnvelope;
 }
 
 export interface PersistedScanOutcome {
@@ -299,6 +303,7 @@ export async function persistResults<TInput, TBroker extends AdapterBroker>(
     risk,
     riskSummary: args.riskSummary,
     releaseConsistency: args.releaseConsistency,
+    intentEnvelope: args.intentEnvelope,
     safety,
   };
 
@@ -332,6 +337,7 @@ export async function persistResults<TInput, TBroker extends AdapterBroker>(
     aiFindings: args.aiFindings,
     risk: args.riskSummary,
     releaseConsistency: args.releaseConsistency,
+    intentEnvelope: args.intentEnvelope,
     safety,
   };
   const reportJson = stableJson(reportPayload);
@@ -370,6 +376,7 @@ export async function persistResults<TInput, TBroker extends AdapterBroker>(
       stagedPublish: findings.redactedDetails,
       baseline: baseline.baseline,
       releaseConsistency: args.releaseConsistency,
+      intentEnvelope: args.intentEnvelope,
       safety: result.safety,
     },
     ai: args.aiFindings,

--- a/server/lib/scan/pipeline.ts
+++ b/server/lib/scan/pipeline.ts
@@ -7,6 +7,11 @@ import type {
   PackageAdapter,
 } from "../ecosystems/package-adapter";
 import {
+  computeIntentEnvelope,
+  extractDeclaredRepository,
+  type WorkflowGateIntent,
+} from "../intent-envelope";
+import {
   describeOperationalError,
   durationMsSince,
   emitOperationalEvent,
@@ -32,6 +37,13 @@ export interface ScanPipelineOptions extends ScanInput {
   organizationId: string;
   /** `manual` | `auto_discovery` | `workflow_gate`; recorded on the product counter. */
   source?: string;
+  /**
+   * Gate-bound release context, set only by the workflow-gate job. Its
+   * presence marks the scan as attested in the intent envelope: the signed
+   * `deployment_protection_rule` webhook binds repository + run + environment,
+   * and the reviewed artifact bytes were downloaded from that run.
+   */
+  gateContext?: WorkflowGateIntent;
   // Adapters parse their own input shape off this object (e.g. the PyPI adapter
   // reads `manifest`/`artifacts`), so allow extra keys to flow through untyped.
   [key: string]: unknown;
@@ -107,6 +119,17 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
       { baselineComparisonSkipped: Boolean(resolved.baseline.baseline.comparisonSkipped) },
     );
 
+    // Advisory source-binding classification. Computed from the gate context
+    // (when the workflow-gate job placed this scan) and the staged manifest's
+    // repository declaration; it never influences risk or findings.
+    const intentEnvelope = computeIntentEnvelope({
+      workflowGate: input.gateContext ?? null,
+      declaredRepository: extractDeclaredRepository({
+        manifestText: diff.stagedManifestText,
+        files: resolved.staged.artifact.files,
+      }),
+    });
+
     const { result, persisted } = await persistResults({
       env,
       db,
@@ -121,6 +144,7 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
       mergedAiFindings,
       riskSummary,
       releaseConsistency,
+      intentEnvelope,
     });
 
     await recordCompletion({

--- a/server/lib/scan/report-export.ts
+++ b/server/lib/scan/report-export.ts
@@ -1,6 +1,7 @@
 import type { getScan } from "../../db/scans";
 import { parsePersistedAiReview } from "../ai-review/contract";
 import { displayedAiResult } from "../ai-review/types";
+import { normalizeIntentEnvelope } from "../intent-envelope";
 import { normalizeReleaseConsistency } from "./release-memory";
 import type { ReleaseProvenance, ReleaseProvenanceArtifact } from "../ecosystems/package-adapter";
 import { isEcosystemId } from "../ecosystems/labels";
@@ -53,6 +54,9 @@ export function buildReportExport(detail: ScanDetail) {
     // wheel/sdist/tarball matches what Drydock reviewed. Workflow-gate reviews
     // only; null for staged-publish scans.
     provenance: extractProvenance(summary.stagedPublish),
+    // Advisory source-binding tier (attested / declared / absent). Additive and
+    // optional: scans persisted before the envelope existed export `null`.
+    intentEnvelope: normalizeIntentEnvelope(summary.intentEnvelope),
     aiReview: extractAiReview(scan.aiJson),
     riskSummary: detail.riskSummary ?? null,
     // Advisory release-memory signal. Additive + optional: scans that predate

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -467,10 +467,24 @@ async function reviewGatePackages(
       const result = await runScanPipeline(
         { env, executionCtx, db, session: { userId: ownerUserId } },
         packageAdapter,
-        // `source` matches the `workflow_gate` value the D1 row already
-        // carries; without it the product counter files every gated scan as
-        // "unknown" and the npm/gate split is unreadable.
-        { scanId, stageId, organizationId, source: "workflow_gate", ...candidate.pipelineInput },
+        {
+          scanId,
+          stageId,
+          organizationId,
+          // `source` matches the `workflow_gate` value the D1 row already
+          // carries; without it the product counter files every gated scan as
+          // "unknown" and the npm/gate split is unreadable.
+          source: "workflow_gate",
+          // Marks the scan as gate-attested in the intent envelope: the signed
+          // webhook bound repository + run + environment, and the reviewed
+          // bytes came from that run.
+          gateContext: {
+            repositoryFullName: gate.repositoryFullName,
+            runId: gate.runId,
+            environment: gate.environment,
+          },
+          ...candidate.pipelineInput,
+        },
       );
       return {
         scanId,

--- a/server/types.ts
+++ b/server/types.ts
@@ -4,6 +4,7 @@ import type { BaselineInfo } from "./lib/ecosystems/package-adapter";
 export type { ReleaseProvenance } from "./lib/ecosystems/package-adapter";
 import type { AiReview } from "./lib/ai-review";
 import type { ReleaseConsistency } from "./lib/scan/release-memory";
+import type { IntentEnvelope } from "./lib/intent-envelope";
 import type { ScanRiskBreakdown } from "./lib/review/risk";
 import type {
   DiffEntry,
@@ -14,6 +15,11 @@ import type {
 } from "./lib/review";
 
 export type { PackageJsonDiff, PackageJsonDiffEntry } from "./lib/review";
+export type {
+  IntentEnvelope,
+  IntentEnvelopeSignal,
+  IntentEnvelopeTier,
+} from "./lib/intent-envelope";
 
 export type Bindings = Cloudflare.Env;
 
@@ -49,6 +55,8 @@ export interface ScanResult {
   // Advisory prior-release consistency signal (release memory). Display-only:
   // it never feeds risk or findings.
   releaseConsistency: ReleaseConsistency;
+  // Advisory source-binding classification; never feeds risk or findings.
+  intentEnvelope: IntentEnvelope;
   safety: {
     tokenExposedToSandbox: boolean;
     directSandboxNetwork: boolean;

--- a/src/pages/Dashboard/ScanDetail/IntentEnvelopeSection.tsx
+++ b/src/pages/Dashboard/ScanDetail/IntentEnvelopeSection.tsx
@@ -1,0 +1,65 @@
+import type { IntentEnvelope, IntentEnvelopeTier } from "../../../../server/types";
+import { Badge, type BadgeTone } from "../../../components/Badge";
+import { SectionLabel } from "../../../components/Typography";
+
+// Advisory source-binding row rendered under the recommendation. The envelope
+// never changes risk, so tier tones stay informational (ok / info / neutral)
+// rather than borrowing severity colors. Scans persisted before the envelope
+// existed render nothing (the parent passes null).
+export function IntentEnvelopeSection({ envelope }: { envelope: IntentEnvelope }) {
+  return (
+    <section class="flex flex-col gap-3 min-w-0">
+      <SectionLabel as="h2">Source binding</SectionLabel>
+      <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <Badge tone={tierTone(envelope.tier)}>{envelope.tier}</Badge>
+        <span class="text-[13px] leading-[1.55] text-ink-muted min-w-0">
+          {tierDescription(envelope)}
+        </span>
+      </div>
+      {envelope.signals.length ? (
+        <ul class="list-none p-0 m-0 flex flex-col gap-2">
+          {envelope.signals.map((signal, index) => (
+            <li
+              key={`${signal.kind}-${index}`}
+              class="grid grid-cols-[132px_minmax(0,1fr)] gap-3 text-[13px]"
+            >
+              <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
+                {signal.kind}
+              </span>
+              <span class="min-w-0 text-ink-muted break-words">{signal.detail}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+}
+
+function tierTone(tier: IntentEnvelopeTier): BadgeTone {
+  if (tier === "attested") return "ok";
+  if (tier === "declared") return "info";
+  return "neutral";
+}
+
+function tierDescription(envelope: IntentEnvelope): string {
+  if (envelope.tier === "attested") {
+    const repoName = repositoryDisplayName(envelope.repository);
+    return repoName
+      ? `Built and held by a GitHub workflow gate for ${repoName}.`
+      : "Built and held by a GitHub workflow gate.";
+  }
+  if (envelope.tier === "declared") {
+    return envelope.repository
+      ? `Package declares repository ${envelope.repository} — binding is unverified.`
+      : "Package declares a repository — binding is unverified.";
+  }
+  return "No repository binding — the artifact cannot be tied to reviewed source.";
+}
+
+// "https://github.com/owner/repo" → "owner/repo" for the one-liner; other
+// hosts keep the full URL so the forge stays visible.
+function repositoryDisplayName(repository: string | null): string | null {
+  if (!repository) return null;
+  const match = /^https:\/\/github\.com\/(.+)$/.exec(repository);
+  return match ? match[1] : repository;
+}

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -20,6 +20,7 @@ import {
 } from "../../../models/scan";
 import type { WorkflowGateDecision } from "../../../models/github-app";
 import { displayedAiResult, type AiReview } from "../../../../server/lib/ai-review/types";
+import { normalizeIntentEnvelope } from "../../../../server/lib/intent-envelope";
 import { createPackageDiff, type DiffEntry } from "../../../../server/lib/review";
 import { Alert } from "../../../components/Alert";
 import { Button } from "../../../components/Button";
@@ -35,6 +36,7 @@ import { DecisionDialog } from "./DecisionDialog";
 import { GateContextPanel, GateDecisionDialog, GatePackagesPanel } from "./GateDecisionDialog";
 import { DiffWorkbench } from "./DiffWorkbench";
 import { RiskSignalsSection } from "../../../features/review/RiskSignalsSection";
+import { IntentEnvelopeSection } from "./IntentEnvelopeSection";
 import { ReleaseConsistencyNotice } from "./ReleaseConsistencyNotice";
 import { ReleaseRecommendation } from "./ReleaseRecommendation";
 import { PersistedReportSections } from "./ReportSections";
@@ -122,6 +124,9 @@ export default function ScanDetailPage() {
 
   const summary = useComputed(() => asPersistedSummary(model.detail.value?.scan.summaryJson));
   const ai = useComputed(() => displayedAiResult(asAiReview(model.detail.value?.scan.aiJson)));
+  // Older scans have no envelope; the normalizer returns null and the section
+  // is simply not rendered.
+  const intentEnvelope = useComputed(() => normalizeIntentEnvelope(summary.value.intentEnvelope));
 
   const diffEntries = useComputed<DiffEntry[]>(() => {
     const detail = model.detail.value;
@@ -206,6 +211,7 @@ export default function ScanDetailPage() {
 
   const isWorkflowGate = model.isWorkflowGate.value;
   const gate = model.gate.value;
+  const envelope = intentEnvelope.value;
 
   const handleDecisionSubmit = async (decision: ScanDecision, reason: string | null) => {
     await model.setDecision(decision, reason);
@@ -316,6 +322,8 @@ export default function ScanDetailPage() {
               value={summary.value.releaseConsistency}
               approvedContextCount={detail.riskSummary?.priorApprovedContextFindingCount ?? 0}
             />
+
+            {envelope ? <IntentEnvelopeSection envelope={envelope} /> : null}
 
             {detail.scan.packageName ? (
               <div class="flex flex-col gap-2 border-t border-border pt-3">

--- a/src/pages/Dashboard/ScanDetail/types.ts
+++ b/src/pages/Dashboard/ScanDetail/types.ts
@@ -24,6 +24,10 @@ export interface PersistedSummary {
   // Advisory release-memory blob. Old scans lack it and its shape is only
   // trusted after normalizeReleaseConsistency, so it stays unknown here.
   releaseConsistency?: unknown;
+  // Advisory source-binding envelope. Untyped here because persisted blobs
+  // predate the feature or may be malformed; readers re-validate through
+  // `normalizeIntentEnvelope`.
+  intentEnvelope?: unknown;
 }
 
 export type PersistedFinding = PersistedScanDetail["findings"][number];

--- a/test/intent-envelope.test.mjs
+++ b/test/intent-envelope.test.mjs
@@ -1,0 +1,262 @@
+import { describe, expect, test } from "vitest";
+import {
+  computeIntentEnvelope,
+  extractDeclaredRepository,
+  normalizeIntentEnvelope,
+  normalizeRepositoryUrl,
+} from "../server/lib/intent-envelope.ts";
+
+describe("normalizeRepositoryUrl", () => {
+  test("normalizes plain https URLs and strips .git", () => {
+    expect(normalizeRepositoryUrl("https://github.com/owner/repo")).toBe(
+      "https://github.com/owner/repo",
+    );
+    expect(normalizeRepositoryUrl("https://github.com/owner/repo.git")).toBe(
+      "https://github.com/owner/repo",
+    );
+    expect(normalizeRepositoryUrl("https://gitlab.com/owner/repo.git/")).toBe(
+      "https://gitlab.com/owner/repo",
+    );
+  });
+
+  test("truncates known-forge URLs to owner/repo", () => {
+    expect(normalizeRepositoryUrl("https://github.com/owner/repo/tree/main/packages/core")).toBe(
+      "https://github.com/owner/repo",
+    );
+  });
+
+  test("keeps the full path for unknown hosts (self-hosted forges)", () => {
+    expect(normalizeRepositoryUrl("https://git.example.com/group/subgroup/repo")).toBe(
+      "https://git.example.com/group/subgroup/repo",
+    );
+  });
+
+  test("handles git+https, git, ssh, and http schemes", () => {
+    expect(normalizeRepositoryUrl("git+https://github.com/owner/repo.git")).toBe(
+      "https://github.com/owner/repo",
+    );
+    expect(normalizeRepositoryUrl("git://github.com/owner/repo.git")).toBe(
+      "https://github.com/owner/repo",
+    );
+    expect(normalizeRepositoryUrl("git+ssh://git@gitlab.com/owner/repo.git")).toBe(
+      "https://gitlab.com/owner/repo",
+    );
+    expect(normalizeRepositoryUrl("http://github.com/owner/repo")).toBe(
+      "https://github.com/owner/repo",
+    );
+  });
+
+  test("handles scp-like git@host:owner/repo.git", () => {
+    expect(normalizeRepositoryUrl("git@github.com:owner/repo.git")).toBe(
+      "https://github.com/owner/repo",
+    );
+  });
+
+  test("expands github:/gitlab:/bitbucket: and bare owner/repo shorthands", () => {
+    expect(normalizeRepositoryUrl("github:owner/repo")).toBe("https://github.com/owner/repo");
+    expect(normalizeRepositoryUrl("gitlab:owner/repo")).toBe("https://gitlab.com/owner/repo");
+    expect(normalizeRepositoryUrl("bitbucket:owner/repo")).toBe("https://bitbucket.org/owner/repo");
+    expect(normalizeRepositoryUrl("owner/repo")).toBe("https://github.com/owner/repo");
+  });
+
+  test("unwraps { url } objects (including nested type field)", () => {
+    expect(
+      normalizeRepositoryUrl({ type: "git", url: "git+https://github.com/owner/repo.git" }),
+    ).toBe("https://github.com/owner/repo");
+    expect(normalizeRepositoryUrl({ url: "github:owner/repo" })).toBe(
+      "https://github.com/owner/repo",
+    );
+  });
+
+  test("rejects garbage, unsupported schemes, and oversized input", () => {
+    expect(normalizeRepositoryUrl(undefined)).toBeNull();
+    expect(normalizeRepositoryUrl(null)).toBeNull();
+    expect(normalizeRepositoryUrl(42)).toBeNull();
+    expect(normalizeRepositoryUrl([])).toBeNull();
+    expect(normalizeRepositoryUrl("")).toBeNull();
+    expect(normalizeRepositoryUrl("   ")).toBeNull();
+    expect(normalizeRepositoryUrl("not a url at all")).toBeNull();
+    expect(normalizeRepositoryUrl("ftp://github.com/owner/repo")).toBeNull();
+    expect(normalizeRepositoryUrl("javascript:alert(1)")).toBeNull();
+    expect(normalizeRepositoryUrl({ url: 42 })).toBeNull();
+    expect(normalizeRepositoryUrl("https://github.com/owner-only")).toBeNull();
+    expect(normalizeRepositoryUrl(`https://github.com/${"a".repeat(600)}/repo`)).toBeNull();
+  });
+
+  test("rejects owner/repo segments with unsafe characters", () => {
+    expect(normalizeRepositoryUrl("https://github.com/ow ner/repo")).toBeNull();
+    expect(normalizeRepositoryUrl("github:owner/repo?x=1")).toBeNull();
+  });
+});
+
+describe("extractDeclaredRepository", () => {
+  test("reads a string repository from the staged package.json text", () => {
+    const declared = extractDeclaredRepository({
+      manifestText: JSON.stringify({ name: "pkg", repository: "github:owner/repo" }),
+      files: [],
+    });
+    expect(declared).toBe("github:owner/repo");
+  });
+
+  test("reads an object repository from the staged package.json text", () => {
+    const declared = extractDeclaredRepository({
+      manifestText: JSON.stringify({
+        name: "pkg",
+        repository: { type: "git", url: "git+https://github.com/owner/repo.git" },
+      }),
+      files: [],
+    });
+    expect(declared).toEqual({ type: "git", url: "git+https://github.com/owner/repo.git" });
+  });
+
+  test("falls back to PyPI PKG-INFO Project-URL headers", () => {
+    const declared = extractDeclaredRepository({
+      manifestText: null,
+      files: [
+        {
+          path: "demo-1.0.0/PKG-INFO",
+          textSample:
+            "Metadata-Version: 2.1\nName: demo\nProject-URL: Homepage, https://example.com\nProject-URL: Source, https://github.com/owner/repo\n\nBody text with Project-URL: Fake, https://evil.example\n",
+        },
+      ],
+    });
+    expect(declared).toBe("https://github.com/owner/repo");
+  });
+
+  test("falls back to Home-page when no repository-like Project-URL exists", () => {
+    const declared = extractDeclaredRepository({
+      manifestText: null,
+      files: [
+        {
+          path: "demo.dist-info/METADATA",
+          textSample:
+            "Metadata-Version: 2.1\nName: demo\nHome-page: https://github.com/owner/repo\n",
+        },
+      ],
+    });
+    expect(declared).toBe("https://github.com/owner/repo");
+  });
+
+  test("returns null for malformed manifest text and missing metadata", () => {
+    expect(extractDeclaredRepository({ manifestText: "{not json", files: [] })).toBeNull();
+    expect(
+      extractDeclaredRepository({ manifestText: JSON.stringify({ name: "pkg" }), files: [] }),
+    ).toBeNull();
+    expect(extractDeclaredRepository({ manifestText: null, files: [] })).toBeNull();
+  });
+});
+
+describe("computeIntentEnvelope", () => {
+  test("workflow gate context yields attested with gate signals", () => {
+    const envelope = computeIntentEnvelope({
+      workflowGate: { repositoryFullName: "owner/repo", runId: 123, environment: "release" },
+    });
+    expect(envelope.tier).toBe("attested");
+    expect(envelope.repository).toBe("https://github.com/owner/repo");
+    expect(envelope.signals).toEqual([
+      { kind: "workflow-gate", detail: "repo owner/repo, run 123, environment release" },
+    ]);
+  });
+
+  test("attested keeps the manifest declaration as a secondary signal", () => {
+    const envelope = computeIntentEnvelope({
+      workflowGate: { repositoryFullName: "owner/repo", runId: 7, environment: "release" },
+      declaredRepository: "git+https://github.com/owner/repo.git",
+    });
+    expect(envelope.tier).toBe("attested");
+    expect(envelope.signals).toHaveLength(2);
+    expect(envelope.signals[1]).toEqual({
+      kind: "manifest-repository",
+      detail: "manifest declares https://github.com/owner/repo",
+    });
+  });
+
+  test("a parseable manifest repository yields declared", () => {
+    const envelope = computeIntentEnvelope({
+      declaredRepository: { url: "git://gitlab.com/owner/repo.git" },
+    });
+    expect(envelope.tier).toBe("declared");
+    expect(envelope.repository).toBe("https://gitlab.com/owner/repo");
+    expect(envelope.signals).toEqual([
+      {
+        kind: "manifest-repository",
+        detail:
+          "manifest declares https://gitlab.com/owner/repo — claimed by the package, not verified",
+      },
+    ]);
+  });
+
+  test("no gate and no parseable repository yields absent", () => {
+    expect(computeIntentEnvelope({})).toEqual({ tier: "absent", repository: null, signals: [] });
+    expect(computeIntentEnvelope({ declaredRepository: "///nope" })).toEqual({
+      tier: "absent",
+      repository: null,
+      signals: [],
+    });
+  });
+
+  test("a malformed gate context degrades to the declared/absent path", () => {
+    expect(
+      computeIntentEnvelope({
+        workflowGate: { repositoryFullName: "", runId: 1, environment: "release" },
+      }).tier,
+    ).toBe("absent");
+    expect(
+      computeIntentEnvelope({
+        workflowGate: { repositoryFullName: "owner/repo", runId: 1, environment: " " },
+        declaredRepository: "github:owner/repo",
+      }).tier,
+    ).toBe("declared");
+  });
+});
+
+describe("normalizeIntentEnvelope", () => {
+  test("round-trips a computed envelope", () => {
+    const envelope = computeIntentEnvelope({
+      workflowGate: { repositoryFullName: "owner/repo", runId: 9, environment: "release" },
+    });
+    expect(normalizeIntentEnvelope(JSON.parse(JSON.stringify(envelope)))).toEqual(envelope);
+  });
+
+  test("returns null for missing or malformed values", () => {
+    expect(normalizeIntentEnvelope(undefined)).toBeNull();
+    expect(normalizeIntentEnvelope(null)).toBeNull();
+    expect(normalizeIntentEnvelope("attested")).toBeNull();
+    expect(normalizeIntentEnvelope([])).toBeNull();
+    expect(normalizeIntentEnvelope({})).toBeNull();
+    expect(normalizeIntentEnvelope({ tier: "verified" })).toBeNull();
+  });
+
+  test("drops malformed repository values and signal entries", () => {
+    expect(
+      normalizeIntentEnvelope({
+        tier: "declared",
+        repository: 42,
+        signals: [
+          { kind: "manifest-repository", detail: "ok" },
+          "garbage",
+          { kind: 1, detail: "no" },
+          { kind: "missing-detail" },
+        ],
+      }),
+    ).toEqual({
+      tier: "declared",
+      repository: null,
+      signals: [{ kind: "manifest-repository", detail: "ok" }],
+    });
+  });
+
+  test("tolerates absent signals and caps oversized arrays", () => {
+    expect(normalizeIntentEnvelope({ tier: "absent" })).toEqual({
+      tier: "absent",
+      repository: null,
+      signals: [],
+    });
+    const flooded = normalizeIntentEnvelope({
+      tier: "attested",
+      repository: "https://github.com/owner/repo",
+      signals: Array.from({ length: 100 }, (_, i) => ({ kind: "k", detail: `d${i}` })),
+    });
+    expect(flooded?.signals).toHaveLength(20);
+  });
+});

--- a/test/intent-envelope.test.mjs
+++ b/test/intent-envelope.test.mjs
@@ -144,6 +144,28 @@ describe("extractDeclaredRepository", () => {
     ).toBeNull();
     expect(extractDeclaredRepository({ manifestText: null, files: [] })).toBeNull();
   });
+
+  test("stays linear on a pathologically long comma-less Project-URL line (ReDoS guard)", () => {
+    // `textSample` is the whole decoded metadata file, so a hostile PKG-INFO can
+    // pack a header line with hundreds of KB of padding and no comma. The old
+    // `\s*([^,]+),` split backtracked quadratically on that (tens of seconds of
+    // Worker CPU per scan). Parsing must stay linear, the over-long line must be
+    // skipped, and it must not shadow a later valid header in the same file.
+    const padding = " ".repeat(200_000);
+    const textSample =
+      `Metadata-Version: 2.1\nName: demo\nProject-URL:${padding}no-comma-here\n` +
+      "Project-URL: Source, https://github.com/owner/repo\n";
+    const startedAt = performance.now();
+    const declared = extractDeclaredRepository({
+      manifestText: null,
+      files: [{ path: "demo-1.0.0/PKG-INFO", textSample }],
+    });
+    const elapsedMs = performance.now() - startedAt;
+    expect(declared).toBe("https://github.com/owner/repo");
+    // The quadratic version took ~60s on this input; linear parsing is single
+    // digit ms. A generous bound keeps the regression signal without flaking.
+    expect(elapsedMs).toBeLessThan(2000);
+  });
 });
 
 describe("computeIntentEnvelope", () => {

--- a/test/intent-envelope.test.mjs
+++ b/test/intent-envelope.test.mjs
@@ -25,6 +25,18 @@ describe("normalizeRepositoryUrl", () => {
     );
   });
 
+  test("preserves GitLab subgroup paths and trims browser suffixes", () => {
+    expect(normalizeRepositoryUrl("https://gitlab.com/group/subgroup/project.git")).toBe(
+      "https://gitlab.com/group/subgroup/project",
+    );
+    expect(normalizeRepositoryUrl("gitlab:group/subgroup/project")).toBe(
+      "https://gitlab.com/group/subgroup/project",
+    );
+    expect(normalizeRepositoryUrl("https://gitlab.com/group/subgroup/project/-/tree/main")).toBe(
+      "https://gitlab.com/group/subgroup/project",
+    );
+  });
+
   test("keeps the full path for unknown hosts (self-hosted forges)", () => {
     expect(normalizeRepositoryUrl("https://git.example.com/group/subgroup/repo")).toBe(
       "https://git.example.com/group/subgroup/repo",
@@ -249,7 +261,7 @@ describe("normalizeIntentEnvelope", () => {
     expect(normalizeIntentEnvelope({ tier: "verified" })).toBeNull();
   });
 
-  test("drops malformed repository values and signal entries", () => {
+  test("rejects a declared tier after its repository evidence becomes malformed", () => {
     expect(
       normalizeIntentEnvelope({
         tier: "declared",
@@ -261,14 +273,28 @@ describe("normalizeIntentEnvelope", () => {
           { kind: "missing-detail" },
         ],
       }),
-    ).toEqual({
-      tier: "declared",
-      repository: null,
-      signals: [{ kind: "manifest-repository", detail: "ok" }],
-    });
+    ).toBeNull();
   });
 
-  test("tolerates absent signals and caps oversized arrays", () => {
+  test("rejects evidence-free attested tiers", () => {
+    expect(normalizeIntentEnvelope({ tier: "attested" })).toBeNull();
+    expect(
+      normalizeIntentEnvelope({
+        tier: "attested",
+        repository: "https://github.com/owner/repo",
+        signals: [],
+      }),
+    ).toBeNull();
+    expect(
+      normalizeIntentEnvelope({
+        tier: "attested",
+        repository: "javascript:alert(1)",
+        signals: [{ kind: "workflow-gate", detail: "repo owner/repo, run 1" }],
+      }),
+    ).toBeNull();
+  });
+
+  test("tolerates absent signals and caps oversized valid arrays", () => {
     expect(normalizeIntentEnvelope({ tier: "absent" })).toEqual({
       tier: "absent",
       repository: null,
@@ -277,7 +303,10 @@ describe("normalizeIntentEnvelope", () => {
     const flooded = normalizeIntentEnvelope({
       tier: "attested",
       repository: "https://github.com/owner/repo",
-      signals: Array.from({ length: 100 }, (_, i) => ({ kind: "k", detail: `d${i}` })),
+      signals: [
+        { kind: "workflow-gate", detail: "repo owner/repo, run 1" },
+        ...Array.from({ length: 99 }, (_, i) => ({ kind: "k", detail: `d${i}` })),
+      ],
     });
     expect(flooded?.signals).toHaveLength(20);
   });

--- a/test/scan-pipeline-phases.test.mjs
+++ b/test/scan-pipeline-phases.test.mjs
@@ -91,6 +91,8 @@ const disabledAi = {
   model: null,
 };
 
+const absentIntentEnvelope = { tier: "absent", repository: null, signals: [] };
+
 function makeAdapter(overrides = {}) {
   return {
     id: "fake",
@@ -422,6 +424,7 @@ describe("persistResults", () => {
       aiFindings: disabledAi,
       riskSummary,
       releaseConsistency: noneConsistency,
+      intentEnvelope: absentIntentEnvelope,
     });
 
     expect(persisted).toBe(true);
@@ -453,6 +456,9 @@ describe("persistResults", () => {
     // Release memory rides the result + persisted summary, advisory only.
     expect(result.releaseConsistency).toEqual(noneConsistency);
     expect(persistArg.summary.releaseConsistency).toEqual(noneConsistency);
+    // The advisory envelope rides the summary blob and the scan result verbatim.
+    expect(persistArg.summary.intentEnvelope).toEqual(absentIntentEnvelope);
+    expect(result.intentEnvelope).toEqual(absentIntentEnvelope);
   });
 
   test("persists AI finding records after the rule findings with combined annotations", async () => {
@@ -507,6 +513,7 @@ describe("persistResults", () => {
       aiFindings: disabledAi,
       riskSummary,
       releaseConsistency: noneConsistency,
+      intentEnvelope: absentIntentEnvelope,
     });
 
     expect(persisted).toBe(false);

--- a/test/scan-pipeline.test.mjs
+++ b/test/scan-pipeline.test.mjs
@@ -258,6 +258,76 @@ describe("scan pipeline baseline selection", () => {
     });
   });
 
+  test("computes a declared intent envelope from the staged manifest repository", async () => {
+    sandboxMock.downloadInSandbox.mockResolvedValue({
+      files: [
+        {
+          path: "package.json",
+          size: 96,
+          sha256: "staged-pkg",
+          flags: [],
+          textSample: JSON.stringify({
+            name: "@scope/pkg",
+            version: "2.0.0-beta.3",
+            repository: { type: "git", url: "git+https://github.com/scope/pkg.git" },
+          }),
+        },
+      ],
+      packageJson: { name: "@scope/pkg", version: "2.0.0-beta.3" },
+    });
+
+    const result = await runScanPipeline(baseContext, npmAdapter, {
+      scanId: "scan_envelope_declared",
+      stageId: "stage-beta-123",
+      organizationId: "org_1",
+    });
+
+    expect(result.intentEnvelope).toEqual({
+      tier: "declared",
+      repository: "https://github.com/scope/pkg",
+      signals: [
+        {
+          kind: "manifest-repository",
+          detail:
+            "manifest declares https://github.com/scope/pkg — claimed by the package, not verified",
+        },
+      ],
+    });
+    expect(dbMock.persistScan.mock.calls[0]?.[1].summary.intentEnvelope).toEqual(
+      result.intentEnvelope,
+    );
+  });
+
+  test("marks scans placed with a gate context as attested", async () => {
+    const result = await runScanPipeline(baseContext, npmAdapter, {
+      scanId: "scan_envelope_attested",
+      stageId: "stage-beta-123",
+      organizationId: "org_1",
+      gateContext: { repositoryFullName: "scope/pkg", runId: 4242, environment: "release" },
+    });
+
+    expect(result.intentEnvelope).toEqual({
+      tier: "attested",
+      repository: "https://github.com/scope/pkg",
+      signals: [{ kind: "workflow-gate", detail: "repo scope/pkg, run 4242, environment release" }],
+    });
+    expect(dbMock.persistScan.mock.calls[0]?.[1].summary.intentEnvelope).toEqual(
+      result.intentEnvelope,
+    );
+  });
+
+  test("staged scans without a manifest repository read as absent", async () => {
+    const result = await runScanPipeline(baseContext, npmAdapter, {
+      scanId: "scan_envelope_absent",
+      stageId: "stage-beta-123",
+      organizationId: "org_1",
+    });
+
+    // Staged registry metadata carries no provenance attestation today, so a
+    // staged publish can never reach "attested" (see server/lib/intent-envelope.ts).
+    expect(result.intentEnvelope).toEqual({ tier: "absent", repository: null, signals: [] });
+  });
+
   test("persists deterministic results when enabled AI review fails", async () => {
     aiReviewMock.runSelectiveAiReview.mockRejectedValue(new Error("workers ai unavailable"));
     const context = {

--- a/test/workers/scan-intent-envelope.test.ts
+++ b/test/workers/scan-intent-envelope.test.ts
@@ -1,0 +1,162 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { describe, expect, test } from "vitest";
+import { createDb } from "../../server/db/client";
+import { ensurePersonalOrganization } from "../../server/db/organizations";
+import { createScanJob, persistScan } from "../../server/db/scans";
+import * as schema from "../../server/db/schema";
+import type { IntentEnvelope } from "../../server/lib/intent-envelope";
+import { scansRoutes } from "../../server/routes/scans";
+import type { Bindings, Variables } from "../../server/types";
+
+interface SeededUser {
+  userId: string;
+  organizationId: string;
+}
+
+async function seedUser(): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+function buildTestApp(session: { userId: string }) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.use("*", async (c, next) => {
+    c.set("authSession", { userId: session.userId });
+    await next();
+  });
+  app.route("/api/v1/scans", scansRoutes);
+  return app;
+}
+
+async function fetchJson(
+  app: Hono<{ Bindings: Bindings; Variables: Variables }>,
+  path: string,
+): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await app.fetch(new Request(`http://test.local${path}`, { method: "GET" }), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+async function seedCompletedScan(
+  owner: SeededUser,
+  intentEnvelope: IntentEnvelope | undefined,
+): Promise<string> {
+  const db = createDb(env.DB);
+  const scanId = `scan_${crypto.randomUUID()}`;
+  const stageId = `stage-${scanId.slice(-12)}`;
+  await createScanJob(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+  });
+  await persistScan(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+    packageJson: { name: "@org/pkg", version: "1.1.0" },
+    risk: "low",
+    status: "complete",
+    summary: {
+      report: {
+        version: 1,
+        digest: "abc123",
+        digestAlgorithm: "sha256",
+        generatedAt: "2026-01-01T00:00:00.000Z",
+        rulesVersion: "1.8.0",
+      },
+      diff: [{ path: "package.json", status: "modified" }],
+      // Scans persisted before the envelope existed simply omit the key.
+      ...(intentEnvelope ? { intentEnvelope } : {}),
+    },
+    ai: null,
+    files: [{ path: "package.json", size: 10, sha256: "a", flags: [], textSample: "{}" }],
+    diff: [{ path: "package.json", status: "modified", flags: [] }],
+    findings: [],
+    report: { version: 1, digest: "abc123" },
+  });
+  return scanId;
+}
+
+describe("scan intent envelope persistence and readers", () => {
+  const attestedEnvelope: IntentEnvelope = {
+    tier: "attested",
+    repository: "https://github.com/owner/repo",
+    signals: [{ kind: "workflow-gate", detail: "repo owner/repo, run 123, environment release" }],
+  };
+
+  test("the scan detail endpoint returns the persisted envelope in summaryJson", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner, attestedEnvelope);
+
+    const res = await fetchJson(buildTestApp(owner), `/api/v1/scans/${scanId}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      scan: { summaryJson: { intentEnvelope?: unknown } };
+    };
+    expect(body.scan.summaryJson.intentEnvelope).toEqual(attestedEnvelope);
+  });
+
+  test("the report export includes the envelope as an additive field", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner, attestedEnvelope);
+
+    const app = buildTestApp(owner);
+    const res = await fetchJson(app, `/api/v1/scans/${scanId}/report.json`);
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    const body = JSON.parse(text) as { schema: string; intentEnvelope: unknown };
+    expect(body.schema).toBe("drydock.report.v1");
+    expect(body.intentEnvelope).toEqual(attestedEnvelope);
+
+    // Stable serialization still holds with the new field present.
+    const again = await fetchJson(app, `/api/v1/scans/${scanId}/report.json`);
+    expect(await again.text()).toBe(text);
+  });
+
+  test("readers tolerate scans persisted before the envelope existed", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner, undefined);
+    const app = buildTestApp(owner);
+
+    const detail = await fetchJson(app, `/api/v1/scans/${scanId}`);
+    expect(detail.status).toBe(200);
+    const detailBody = (await detail.json()) as {
+      scan: { summaryJson: { intentEnvelope?: unknown } };
+    };
+    expect(detailBody.scan.summaryJson.intentEnvelope).toBeUndefined();
+
+    const report = await fetchJson(app, `/api/v1/scans/${scanId}/report.json`);
+    expect(report.status).toBe(200);
+    const reportBody = (await report.json()) as { intentEnvelope: unknown };
+    expect(reportBody.intentEnvelope).toBeNull();
+  });
+
+  test("a malformed persisted envelope exports as null instead of partial data", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner, {
+      tier: "verified",
+      repository: 42,
+      signals: "nope",
+    } as unknown as IntentEnvelope);
+
+    const report = await fetchJson(buildTestApp(owner), `/api/v1/scans/${scanId}/report.json`);
+    expect(report.status).toBe(200);
+    const body = (await report.json()) as { intentEnvelope: unknown };
+    expect(body.intentEnvelope).toBeNull();
+  });
+});

--- a/test/workers/scan-intent-envelope.test.ts
+++ b/test/workers/scan-intent-envelope.test.ts
@@ -159,4 +159,16 @@ describe("scan intent envelope persistence and readers", () => {
     const body = (await report.json()) as { intentEnvelope: unknown };
     expect(body.intentEnvelope).toBeNull();
   });
+
+  test("an evidence-free persisted attested tier exports as null", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner, {
+      tier: "attested",
+    } as unknown as IntentEnvelope);
+
+    const report = await fetchJson(buildTestApp(owner), `/api/v1/scans/${scanId}/report.json`);
+    expect(report.status).toBe(200);
+    const body = (await report.json()) as { intentEnvelope: unknown };
+    expect(body.intentEnvelope).toBeNull();
+  });
 });


### PR DESCRIPTION
## What

Every completed scan now carries an **intent envelope**: a deterministic, advisory classification of how strongly the reviewed artifact is bound to a source repository / release intent. Groundwork for a future "Release Contract" feature. It is metadata only — it never changes risk levels or findings.

```ts
interface IntentEnvelope {
  tier: "attested" | "declared" | "absent";
  repository: string | null; // normalized https://github.com/owner/repo (or gitlab/…)
  signals: Array<{ kind: string; detail: string }>;
}
```

### Tier rules

- **attested** — the scan came through a GitHub workflow gate: the signed `deployment_protection_rule` webhook binds repository + workflow run + environment, and the reviewed bytes were downloaded from that run. Signals carry repo full name, run id, and environment.
- **declared** — the staged manifest (package.json / PyPI core metadata / VSIX manifest) declares a parseable repository URL (`repository` as string or `{url}`, `git+https://`, `git://`, scp-like `git@host:owner/repo.git`, `github:owner/repo` and bare shorthands), normalized to https. Claimed by the package, not verified.
- **absent** — otherwise.

### How it's wired

- `server/lib/intent-envelope.ts` (new, pure): `computeIntentEnvelope`, `normalizeRepositoryUrl`, `extractDeclaredRepository`, and a `normalizeIntentEnvelope` guard following the `normalizeScanRiskBreakdown` pattern.
- Computed in `runScanPipeline`; the gate job threads an explicit typed `gateContext` option (`repositoryFullName`, `runId`, `environment`) instead of sniffing untyped keys.
- Persisted inside `summary.intentEnvelope` (summaryJson blob — **no schema migration**), added to `ScanResult`, and exported in `drydock.report.v1` as an additive optional `intentEnvelope` field (stable ordering preserved).
- UI: compact "Source binding" row under the recommendation on the scan detail page (tier badge + plain-language one-liner + signal rows). Informational tones only (ok / info / neutral) so it never reads as a risk change.
- Every reader tolerates absence: pre-feature scans normalize to `null` (UI hides the row; report export carries `"intentEnvelope": null`).

### Constraint discovered

A staged npm publish cannot reach `attested` in v1: the staged registry metadata Drydock receives (`StagedPublishDetails`) exposes package identity, actor, and shasum but **no provenance attestation**. Documented in the module comment and `docs/intent-envelope.md` rather than fabricated.

## Tests

- `test/intent-envelope.test.mjs` — tier computation, repository URL normalization (string/object, all shorthands/schemes, garbage, oversized), declared-repository extraction (package.json + PKG-INFO/METADATA headers, description-body injection ignored), and `normalizeIntentEnvelope` edge cases.
- `test/scan-pipeline.test.mjs` — pipeline-level declared / attested (gateContext) / absent envelopes persisted in the summary blob.
- `test/workers/scan-intent-envelope.test.ts` — envelope persisted on a scan and returned by `GET /api/v1/scans/:id`, included in the report export (byte-stable re-export), legacy scans tolerate absence, malformed persisted data exports as null.

## Docs

- New `docs/intent-envelope.md` (tiers + claim-ceiling idea) and an index line in `docs/README.md`. `docs/release-safety.md` checked — it covers verification layers, not report contents, so no update needed there.

## Verification

`pnpm run verify` passes (lint, format:check, typecheck, node + workers test suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)