### PR TITLE
Add organization audit log built on scan_events

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ Start here instead of reading every Markdown file. Pick the smallest set that ma
 - [`security-detection-corpus.md`](./security-detection-corpus.md) — rule/eval fixture layout and expected findings.
 - [`detection-eval.md`](./detection-eval.md) — eval harness, metrics, and gates.
 - [`organization-members.md`](./organization-members.md) — organization invitation/membership behavior.
+- [`audit-log.md`](./audit-log.md) — organization audit log surface, visible-event allowlist, and retention.
 - [`two-factor-auth.md`](./two-factor-auth.md) — step-up auth and sensitive actions.
 - [`slack-notifications.md`](./slack-notifications.md) — Slack install and notification flow.
 - [`account-deletion.md`](./account-deletion.md) — account deletion lifecycle.

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -1,0 +1,77 @@
+# Organization audit log
+
+The `scan_events` table doubles as the per-organization audit log. Owners and
+admins read it from **Settings → Audit log**; it records who changed what across
+release decisions, membership, security policy, and integrations.
+
+## Data
+
+`scan_events` (`server/db/schema.ts`) is the store. Every row is org-scoped
+(`organizationId` NOT NULL, cascade-delete with the org), carries an optional
+`actorUserId` (SET NULL on user delete), an event `type`, JSON `metadataJson`,
+and `createdAt`. The `scan_events_org_created_idx` index backs the newest-first,
+org-scoped read.
+
+Writes go through `recordScanEvent` (`server/db/events.ts`). The table is
+append-only in normal operation — the only delete paths are org/scan cascade and
+retention (below).
+
+## What is and isn't recorded
+
+Scan **lifecycle** churn (`scan.started`, `scan.queued`, `scan.backgrounded`,
+`scan.completed`, `scan.failed`, `scan.skipped`, `scan.retryable_failed`,
+`scan.viewed`) and **discovery** churn (`npm_connection.used`,
+`staged_publishes.scans_started`) are **no longer recorded** — they were ~97% of
+all rows and carried no audit value. Operational visibility for those still lives
+in Workers Logs via `emitOperationalEvent`.
+
+Everything else is still written: `scan.decided`, `github_workflow_gate.*`,
+`npm_connection.{upserted,validated,deleted,token_expired}`, `github_app_*`,
+`organization.*`, and notification-delivery events.
+
+## Visible allowlist
+
+`server/lib/audit-events.ts` is the single source of truth for the audit view. It
+maps each surfaced `type` to a category (`release_decision`, `member`,
+`security`, `integration`, `organization`), a human label, a severity, and a
+redaction-safe `summarize()` that derives a short detail line from metadata.
+
+Types not in the registry are hidden from the view even though they are persisted
+— notification-delivery and internal gate-processing events are intentionally
+excluded as noise. `AUDIT_VISIBLE_TYPES` scopes the query so hidden types never
+leave the Worker.
+
+## API
+
+`GET /api/v1/audit-events` (`server/routes/audit.ts`), owner/admin only
+(`roleCanManageMembers`), org resolved from the active-organization header like
+the other org-scoped routes. Query params: `limit` (default 50, max 100) and
+`cursor` (`<createdAtMs>:<id>`, keyset pagination, newest first).
+
+Metadata never leaves the Worker: each row is reduced to
+`{ id, type, category, label, severity, detail, createdAt, scanId, actor }`. Raw
+`metadataJson` is dropped, and `redactScanEventForClient`'s sensitive-key set
+still applies to anything the summarizer reads.
+
+## Retention
+
+Flat 90-day window (`AUDIT_LOG_RETENTION_DAYS`). `pruneAuditEventsOlderThan`
+(`server/db/audit-log.ts`) runs each scheduled tick from the Worker's `scheduled`
+handler, after the discovery sweep. Because lifecycle/discovery churn is no
+longer written, retention is a single age sweep across all rows rather than a
+type-restricted one.
+
+## UI
+
+The **Audit log** tab in organization settings
+(`src/pages/Dashboard/Settings/AuditLogSection.tsx`, model
+`src/models/audit-log.ts`) is rendered only for owners/admins; members never see
+the tab and the endpoint 403s them. The tab shows a paginated, newest-first
+timeline with a category badge, label, detail, actor, timestamp, and a deep-link
+to the originating scan when present.
+
+## Tests
+
+`test/workers/audit-events-route.test.ts` covers visible-only filtering, metadata
+non-leakage, org scoping, cursor pagination, and the member-403 / admin-200 role
+gate.

--- a/server/db/audit-log.ts
+++ b/server/db/audit-log.ts
@@ -1,0 +1,100 @@
+import { and, desc, eq, inArray, lt, or } from "drizzle-orm";
+import type { AppDb } from "./client";
+import { scanEvents, user } from "./schema";
+import { AUDIT_VISIBLE_TYPES } from "../lib/audit-events";
+
+export const AUDIT_LOG_DEFAULT_LIMIT = 50;
+export const AUDIT_LOG_MAX_LIMIT = 100;
+
+// Audit events older than this are pruned by the scheduled sweep. Everything
+// still recorded here is audit-relevant (scan lifecycle/discovery churn is no
+// longer written), so retention is a flat window across all rows.
+export const AUDIT_LOG_RETENTION_DAYS = 90;
+
+export interface AuditLogCursor {
+  createdAtMs: number;
+  id: string;
+}
+
+export interface ListAuditEventsOptions {
+  cursor?: AuditLogCursor | null;
+  limit?: number;
+}
+
+export interface AuditEventRow {
+  id: string;
+  type: string;
+  createdAt: Date;
+  scanId: string | null;
+  actorUserId: string | null;
+  actorName: string | null;
+  actorEmail: string | null;
+  metadataJson: unknown;
+}
+
+export interface ListAuditEventsResult {
+  events: AuditEventRow[];
+  nextCursor: AuditLogCursor | null;
+}
+
+// Keyset-paginated read of an organization's audit log, newest first. Scoped to
+// the visible allowlist and to `organizationId` (backed by the
+// scan_events_org_created_idx index) — no cross-org leakage possible. Metadata
+// is returned raw here; the route maps it through the registry summarizer and
+// never ships raw metadata to the client.
+export async function listOrganizationAuditEvents(
+  db: AppDb,
+  organizationId: string,
+  options: ListAuditEventsOptions = {},
+): Promise<ListAuditEventsResult> {
+  const limit = Math.min(
+    AUDIT_LOG_MAX_LIMIT,
+    Math.max(1, Math.floor(options.limit ?? AUDIT_LOG_DEFAULT_LIMIT)),
+  );
+
+  const conditions = [
+    eq(scanEvents.organizationId, organizationId),
+    inArray(scanEvents.type, [...AUDIT_VISIBLE_TYPES]),
+  ];
+
+  if (options.cursor) {
+    const cursorDate = new Date(options.cursor.createdAtMs);
+    conditions.push(
+      or(
+        lt(scanEvents.createdAt, cursorDate),
+        and(eq(scanEvents.createdAt, cursorDate), lt(scanEvents.id, options.cursor.id)),
+      )!,
+    );
+  }
+
+  const rows = await db
+    .select({
+      id: scanEvents.id,
+      type: scanEvents.type,
+      createdAt: scanEvents.createdAt,
+      scanId: scanEvents.scanId,
+      actorUserId: scanEvents.actorUserId,
+      actorName: user.name,
+      actorEmail: user.email,
+      metadataJson: scanEvents.metadataJson,
+    })
+    .from(scanEvents)
+    .leftJoin(user, eq(scanEvents.actorUserId, user.id))
+    .where(and(...conditions))
+    .orderBy(desc(scanEvents.createdAt), desc(scanEvents.id))
+    .limit(limit + 1);
+
+  const hasMore = rows.length > limit;
+  const page = hasMore ? rows.slice(0, limit) : rows;
+  const last = page[page.length - 1];
+  const nextCursor =
+    hasMore && last ? { createdAtMs: new Date(last.createdAt).getTime(), id: last.id } : null;
+
+  return { events: page, nextCursor };
+}
+
+// Delete audit events recorded before `cutoff`. The only delete path for the
+// table besides org/scan cascade, and it is a flat age sweep.
+export async function pruneAuditEventsOlderThan(db: AppDb, cutoff: Date): Promise<void> {
+  await db.delete(scanEvents).where(lt(scanEvents.createdAt, cutoff));
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import { createDb } from "./db/client";
+import { AUDIT_LOG_RETENTION_DAYS, pruneAuditEventsOlderThan } from "./db/audit-log";
 import { listAutoDiscoveryNpmConnections } from "./db/npm-connections";
 import { getOrganizationOwnerUserId } from "./db/organizations";
 import { RateLimitError, enforceRateLimit } from "./db/rate-limit";
@@ -33,6 +34,7 @@ import {
   recordExpiredNpmConnection,
   StagedPublishesFetchError,
 } from "./lib/staged-publishes-discovery";
+import { auditRoutes } from "./routes/audit";
 import { githubAppRoutes } from "./routes/github-app";
 import { githubWebhookRoutes } from "./routes/github-webhooks";
 import { npmConnectionRoutes } from "./routes/npm-connection";
@@ -264,6 +266,7 @@ app.route("/api/v1/organizations", organizationMembersRoutes);
 app.route("/api/v1/scans", scansRoutes);
 app.route("/api/v1/slack", slackRoutes);
 app.route("/api/v1/staged-publishes", stagedPublishesRoutes);
+app.route("/api/v1/audit-events", auditRoutes);
 
 app.notFound((c) => {
   if (!isServerOwnedPath(c.req.path) && c.env.ASSETS) {
@@ -397,10 +400,29 @@ async function runStagedPublishesDiscoveryCron(env: Cloudflare.Env, ctx: Executi
   });
 }
 
+// Flat-window retention for the organization audit log. Runs each tick; a
+// bounded DELETE keeps the sweep cheap. Never let pruning failures abort the
+// discovery cron.
+async function pruneStaleAuditEvents(env: Cloudflare.Env) {
+  const cutoff = new Date(Date.now() - AUDIT_LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000);
+  try {
+    await pruneAuditEventsOlderThan(createDb(env.DB), cutoff);
+    emitOperationalEvent("info", "audit_events.pruned", {
+      retentionDays: AUDIT_LOG_RETENTION_DAYS,
+      cutoff: cutoff.toISOString(),
+    });
+  } catch (err) {
+    emitOperationalEvent("error", "audit_events.prune_failed", {
+      error: describeOperationalError(err),
+    });
+  }
+}
+
 export default {
   fetch: app.fetch,
   async scheduled(_event: ScheduledController, env: Cloudflare.Env, ctx: ExecutionContext) {
     await runStagedPublishesDiscoveryCron(env, ctx);
+    await pruneStaleAuditEvents(env);
   },
   async queue(batch: MessageBatch<QueueMessage>, env: Cloudflare.Env, ctx: ExecutionContext) {
     for (const message of batch.messages) {

--- a/server/lib/audit-events.ts
+++ b/server/lib/audit-events.ts
@@ -1,0 +1,238 @@
+// Registry that turns raw `scan_events` rows into the organization audit log
+// the settings UI renders. It is the single source of truth for:
+//   - which event `type`s are surfaced to owners/admins (the visible allowlist),
+//   - their human label, category, and severity,
+//   - a short, redaction-safe detail line derived from event metadata.
+//
+// Anything not listed here is intentionally hidden from the audit view — scan
+// lifecycle churn is no longer recorded at all, and notification-delivery and
+// internal gate-processing events are persisted but excluded here as noise.
+
+export type AuditCategory =
+  | "release_decision"
+  | "member"
+  | "security"
+  | "integration"
+  | "organization";
+
+export type AuditSeverity = "info" | "notice" | "security";
+
+interface AuditEventDef {
+  category: AuditCategory;
+  label: string;
+  severity: AuditSeverity;
+  // Pure, redaction-safe: only reads known non-sensitive metadata keys. Returns
+  // a short human string or null when there is nothing extra worth showing.
+  summarize?: (metadata: Record<string, unknown>) => string | null;
+}
+
+function str(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+const REGISTRY: Record<string, AuditEventDef> = {
+  // ── Release decisions ────────────────────────────────────────────────────
+  "scan.decided": {
+    category: "release_decision",
+    label: "Release decision recorded",
+    severity: "notice",
+    summarize: (m) => {
+      const decision = m.decision === "publish" ? "approved publish" : "blocked publish";
+      const reason = str(m.reason);
+      return reason ? `${decision} · ${reason}` : decision;
+    },
+  },
+  "github_workflow_gate.requested": {
+    category: "release_decision",
+    label: "Release gate opened",
+    severity: "info",
+    summarize: (m) => str(m.repositoryFullName) ?? str(m.environment),
+  },
+  "github_workflow_gate.reviewed": {
+    category: "release_decision",
+    label: "Release gate reviewed",
+    severity: "notice",
+    summarize: (m) => str(m.recommendation),
+  },
+  "github_workflow_gate.approved": {
+    category: "release_decision",
+    label: "Release gate approved",
+    severity: "notice",
+    summarize: (m) => str(m.decidedBy),
+  },
+  "github_workflow_gate.rejected": {
+    category: "release_decision",
+    label: "Release gate rejected",
+    severity: "notice",
+    summarize: (m) => str(m.decidedBy),
+  },
+  "github_workflow_gate.timeout_missed": {
+    category: "release_decision",
+    label: "Release gate expired without a decision",
+    severity: "security",
+  },
+
+  // ── Members ──────────────────────────────────────────────────────────────
+  "organization.member_invited": {
+    category: "member",
+    label: "Member invited",
+    severity: "notice",
+    summarize: (m) => str(m.invitedEmail),
+  },
+  "organization.member_joined": {
+    category: "member",
+    label: "Member joined",
+    severity: "notice",
+    summarize: (m) => {
+      const email = str(m.email);
+      const role = str(m.role);
+      return email && role ? `${email} as ${role}` : (email ?? role);
+    },
+  },
+  "organization.member_removed": {
+    category: "member",
+    label: "Member removed",
+    severity: "notice",
+    summarize: (m) => str(m.email),
+  },
+  "organization.member_invitation_revoked": {
+    category: "member",
+    label: "Invitation revoked",
+    severity: "info",
+  },
+
+  // ── Security / policy ────────────────────────────────────────────────────
+  "organization.release_two_factor_changed": {
+    category: "security",
+    label: "Release two-factor policy changed",
+    severity: "security",
+    summarize: (m) => (m.enabled ? "required" : "not required"),
+  },
+  "npm_connection.token_expired": {
+    category: "security",
+    label: "npm token stopped working",
+    severity: "security",
+    summarize: (m) => str(m.registryUrl),
+  },
+
+  // ── Integrations ─────────────────────────────────────────────────────────
+  "npm_connection.upserted": {
+    category: "integration",
+    label: "npm connection saved",
+    severity: "notice",
+    summarize: (m) => str(m.label) ?? str(m.registryUrl),
+  },
+  "npm_connection.validated": {
+    category: "integration",
+    label: "npm connection validated",
+    severity: "info",
+    summarize: (m) => str(m.registryUrl),
+  },
+  "npm_connection.deleted": {
+    category: "integration",
+    label: "npm connection removed",
+    severity: "notice",
+    summarize: (m) => str(m.label) ?? str(m.registryUrl),
+  },
+  "github_app_installation.linked": {
+    category: "integration",
+    label: "GitHub App installed",
+    severity: "notice",
+    summarize: (m) => str(m.accountLogin),
+  },
+  "github_app_release_target.created": {
+    category: "integration",
+    label: "Release target added",
+    severity: "notice",
+    summarize: (m) => str(m.artifactName) ?? str(m.repositoryFullName),
+  },
+  "github_app_release_target.deleted": {
+    category: "integration",
+    label: "Release target removed",
+    severity: "notice",
+  },
+  "organization.slack_connected": {
+    category: "integration",
+    label: "Slack connected",
+    severity: "notice",
+    summarize: (m) => str(m.teamName),
+  },
+  "organization.slack_channel_set": {
+    category: "integration",
+    label: "Slack channel set",
+    severity: "info",
+    summarize: (m) => str(m.channelName),
+  },
+  "organization.slack_enabled": {
+    category: "integration",
+    label: "Slack notifications enabled",
+    severity: "info",
+  },
+  "organization.slack_disabled": {
+    category: "integration",
+    label: "Slack notifications disabled",
+    severity: "info",
+  },
+  "organization.slack_disconnected": {
+    category: "integration",
+    label: "Slack disconnected",
+    severity: "notice",
+  },
+
+  // ── Organization ─────────────────────────────────────────────────────────
+  "organization.created": {
+    category: "organization",
+    label: "Organization created",
+    severity: "info",
+    summarize: (m) => str(m.name),
+  },
+  "organization.renamed": {
+    category: "organization",
+    label: "Organization renamed",
+    severity: "info",
+    summarize: (m) => str(m.name),
+  },
+  "organization.notification_recipient_added": {
+    category: "organization",
+    label: "Notification recipient added",
+    severity: "info",
+    summarize: (m) => str(m.recipient),
+  },
+  "organization.notification_recipient_removed": {
+    category: "organization",
+    label: "Notification recipient removed",
+    severity: "info",
+    summarize: (m) => str(m.recipient),
+  },
+};
+
+// The allowlist of event types the audit log surfaces. Used to scope the query
+// so hidden/operational events never leave the Worker.
+export const AUDIT_VISIBLE_TYPES: readonly string[] = Object.keys(REGISTRY);
+
+export interface AuditEventDescriptor {
+  category: AuditCategory;
+  label: string;
+  severity: AuditSeverity;
+  detail: string | null;
+}
+
+// Returns the display descriptor for a visible event, or null when the type is
+// not part of the audit view (defense-in-depth against a type slipping through).
+export function describeAuditEvent(type: string, metadata: unknown): AuditEventDescriptor | null {
+  const def = REGISTRY[type];
+  if (!def) return null;
+  const bag =
+    metadata && typeof metadata === "object" && !Array.isArray(metadata)
+      ? (metadata as Record<string, unknown>)
+      : {};
+  let detail: string | null = null;
+  if (def.summarize) {
+    try {
+      detail = def.summarize(bag);
+    } catch {
+      detail = null;
+    }
+  }
+  return { category: def.category, label: def.label, severity: def.severity, detail };
+}

--- a/server/lib/scan-job.ts
+++ b/server/lib/scan-job.ts
@@ -1,5 +1,4 @@
 import { type AppDb, type WorkspaceSession, createDb } from "../db/client";
-import { recordScanEvent } from "../db/events";
 import { getNpmConnection, markNpmConnectionUsed } from "../db/npm-connections";
 import { type ScanSource, claimScanForRun, discardScanAttempt, markScanFailed } from "../db/scans";
 import { npmAdapter } from "./adapters/npm";
@@ -71,13 +70,6 @@ export async function executeScanJob(
     });
     return null;
   }
-  await recordScanEvent(db, {
-    organizationId: message.organizationId,
-    actorUserId: message.actorUserId,
-    scanId: message.scanId,
-    type: "scan.started",
-    metadata: { stageId: message.stageId, attempt },
-  });
 
   try {
     const npmConnection = await getNpmConnection(db, message.organizationId);
@@ -88,20 +80,7 @@ export async function executeScanJob(
       throw new Error("Validate the organization npm token before scanning staged publishes.");
     }
 
-    await Promise.all([
-      markNpmConnectionUsed(db, message.organizationId),
-      recordScanEvent(db, {
-        organizationId: message.organizationId,
-        actorUserId: message.actorUserId,
-        scanId: message.scanId,
-        type: "npm_connection.used",
-        metadata: {
-          stageId: message.stageId,
-          registryUrl: npmConnection.registryUrl,
-          tokenFingerprint: npmConnection.tokenFingerprint,
-        },
-      }),
-    ]);
+    await markNpmConnectionUsed(db, message.organizationId);
 
     const result = await runScanPipeline({ env, executionCtx, db, session }, npmAdapter, {
       scanId: message.scanId,
@@ -139,17 +118,6 @@ export async function executeScanJob(
       const skip =
         message.source === "auto_discovery" && safe.code === "staged_tarball_unavailable";
       if (skip) {
-        await recordScanEvent(db, {
-          organizationId: message.organizationId,
-          actorUserId: message.actorUserId,
-          type: "scan.skipped",
-          metadata: {
-            scanId: message.scanId,
-            stageId: message.stageId,
-            attempt,
-            error: safe,
-          },
-        });
         await discardScanAttempt(db, message.scanId, message.organizationId);
         emitOperationalEvent("warn", "scan.job.skipped", {
           scanId: message.scanId,
@@ -162,16 +130,7 @@ export async function executeScanJob(
           error: safe,
         });
       } else {
-        await Promise.all([
-          markScanFailed(db, message.scanId, message.organizationId, safe),
-          recordScanEvent(db, {
-            organizationId: message.organizationId,
-            actorUserId: message.actorUserId,
-            scanId: message.scanId,
-            type: "scan.failed",
-            metadata: { stageId: message.stageId, attempt, error: safe },
-          }),
-        ]);
+        await markScanFailed(db, message.scanId, message.organizationId, safe);
         emitOperationalEvent("error", "scan.job.failed", {
           scanId: message.scanId,
           organizationId: message.organizationId,
@@ -197,13 +156,6 @@ export async function executeScanJob(
         }
       }
     } else {
-      await recordScanEvent(db, {
-        organizationId: message.organizationId,
-        actorUserId: message.actorUserId,
-        scanId: message.scanId,
-        type: "scan.retryable_failed",
-        metadata: { stageId: message.stageId, attempt, error: safe },
-      });
       emitOperationalEvent("warn", "scan.job.retryable_failed", {
         scanId: message.scanId,
         organizationId: message.organizationId,

--- a/server/lib/scan-pipeline-phases.ts
+++ b/server/lib/scan-pipeline-phases.ts
@@ -1,5 +1,4 @@
 import { type AppDb, type WorkspaceSession } from "../db/client";
-import { recordScanEvent } from "../db/events";
 import { persistScan } from "../db/scans";
 import type { AiReview } from "./ai-review";
 import type {
@@ -288,34 +287,11 @@ export interface RecordCompletionArgs {
   pipelineStartedAtMs: number;
 }
 
-// Side-effecting: write the completion audit event (only when this attempt won
-// the persistence claim) and emit the structured completion observability
-// event.
+// Side-effecting: emit the structured completion observability event.
 export async function recordCompletion(args: RecordCompletionArgs): Promise<void> {
-  const { result, identity, baseline } = args;
+  const { result, identity } = args;
   const riskSummary = result.riskSummary;
   const risk = result.risk;
-
-  if (args.persisted) {
-    await recordScanEvent(args.db, {
-      organizationId: identity.organizationId,
-      actorUserId: args.session.userId,
-      scanId: identity.scanId,
-      type: "scan.completed",
-      metadata: {
-        stageId: identity.stageId,
-        packageName: result.package.name,
-        stagedVersion: result.package.stagedVersion,
-        stagedTag: result.package.stagedTag,
-        baseline,
-        risk,
-        releaseRisk: riskSummary.releaseRisk,
-        artifactRisk: risk,
-        contextRisk: riskSummary.contextRisk,
-        durationMs: durationMsSince(args.pipelineStartedAtMs),
-      },
-    });
-  }
 
   emitOperationalEvent("info", "scan.pipeline.completed", {
     scanId: identity.scanId,

--- a/server/lib/staged-publishes-discovery.ts
+++ b/server/lib/staged-publishes-discovery.ts
@@ -191,16 +191,8 @@ export async function discoverAndQueueStagedPublishes(
   input: DiscoverStagedPublishesInput,
   connection: TokenForDiscovery,
 ): Promise<DiscoverStagedPublishesResult> {
-  const {
-    db,
-    env,
-    executionCtx,
-    organizationId,
-    actorUserId,
-    source,
-    eventSource,
-    allowInsecureLocalhost,
-  } = input;
+  const { db, env, executionCtx, organizationId, actorUserId, source, allowInsecureLocalhost } =
+    input;
 
   const stagedItems = await listAllStagedPublishes(connection, {
     perPage: 50,
@@ -260,42 +252,11 @@ export async function discoverAndQueueStagedPublishes(
         await deletePendingScanJob(db, scanId, organizationId);
         throw err;
       }
-      await recordScanEvent(db, {
-        organizationId,
-        actorUserId,
-        scanId,
-        type: "scan.queued",
-        metadata: { stageId, source: eventSource },
-      });
     } else {
-      await recordScanEvent(db, {
-        organizationId,
-        actorUserId,
-        scanId,
-        type: "scan.backgrounded",
-        metadata: { stageId, source: eventSource },
-      });
       executionCtx.waitUntil(
         executeScanJob(env, executionCtx, message, db, { finalAttempt: true }),
       );
     }
-  }
-
-  // Only audit sweeps that start scans: the */15min cron emits one event per
-  // connected org per run, and no-op sweeps were ~97% of all scan_events rows.
-  // Sweep observability itself lives in Workers Logs (staged_publishes.cron.*).
-  if (startedScans.length > 0) {
-    await recordScanEvent(db, {
-      organizationId,
-      actorUserId,
-      type: "staged_publishes.scans_started",
-      metadata: {
-        found: stageIds.length,
-        created: startedScans.length,
-        skipped: stageIds.length - startedScans.length,
-        source: eventSource,
-      },
-    });
   }
 
   return {

--- a/server/routes/audit.ts
+++ b/server/routes/audit.ts
@@ -1,0 +1,68 @@
+import { Hono } from "hono";
+import { createDb } from "../db/client";
+import {
+  AUDIT_LOG_DEFAULT_LIMIT,
+  AUDIT_LOG_MAX_LIMIT,
+  type AuditLogCursor,
+  listOrganizationAuditEvents,
+} from "../db/audit-log";
+import { requireActiveOrganizationContext } from "../lib/active-organization";
+import { describeAuditEvent } from "../lib/audit-events";
+import { roleCanManageMembers } from "../lib/roles";
+import type { Bindings, Variables } from "../types";
+
+export const auditRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+function parseCursor(raw: string | undefined): AuditLogCursor | null {
+  if (!raw) return null;
+  const sep = raw.indexOf(":");
+  if (sep <= 0) return null;
+  const createdAtMs = Number(raw.slice(0, sep));
+  const id = raw.slice(sep + 1);
+  if (!Number.isFinite(createdAtMs) || !id) return null;
+  return { createdAtMs, id };
+}
+
+function encodeCursor(cursor: AuditLogCursor | null): string | null {
+  return cursor ? `${cursor.createdAtMs}:${cursor.id}` : null;
+}
+
+// Organization audit log. Owner/admin only — the log records member changes,
+// credential rewiring, and release decisions, so it sits at the same trust tier
+// as member management. Metadata never leaves the Worker: each row is reduced to
+// a registry-derived label + short detail before serialization.
+auditRoutes.get("/", async (c) => {
+  const db = createDb(c.env.DB);
+  const { organizationId, role } = await requireActiveOrganizationContext(c, db);
+  if (!roleCanManageMembers(role)) return c.json({ error: "forbidden" }, 403);
+
+  const rawLimit = Number(c.req.query("limit"));
+  const limit = Number.isFinite(rawLimit)
+    ? Math.min(AUDIT_LOG_MAX_LIMIT, Math.max(1, Math.floor(rawLimit)))
+    : AUDIT_LOG_DEFAULT_LIMIT;
+  const cursor = parseCursor(c.req.query("cursor"));
+
+  const { events, nextCursor } = await listOrganizationAuditEvents(db, organizationId, {
+    cursor,
+    limit,
+  });
+
+  const shaped = events.map((row) => {
+    const descriptor = describeAuditEvent(row.type, row.metadataJson);
+    return {
+      id: row.id,
+      type: row.type,
+      category: descriptor?.category ?? "organization",
+      label: descriptor?.label ?? row.type,
+      severity: descriptor?.severity ?? "info",
+      detail: descriptor?.detail ?? null,
+      createdAt: new Date(row.createdAt).getTime(),
+      scanId: row.scanId,
+      actor: row.actorUserId
+        ? { type: "user" as const, name: row.actorName, email: row.actorEmail }
+        : { type: "system" as const },
+    };
+  });
+
+  return c.json({ events: shaped, nextCursor: encodeCursor(nextCursor), limit });
+});

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -1,6 +1,5 @@
 import { Hono, type Context } from "hono";
 import { createDb } from "../db/client";
-import { recordScanEvent } from "../db/events";
 import { getOrganizationRole } from "../db/invitations";
 import { getNpmConnection } from "../db/npm-connections";
 import { RateLimitError, enforceRateLimit } from "../db/rate-limit";
@@ -124,14 +123,6 @@ scansRoutes.post("/", async (c) => {
       organizationId,
       actorUserId: session.userId,
     };
-
-    await recordScanEvent(db, {
-      organizationId,
-      actorUserId: session.userId,
-      scanId,
-      type: c.env.SCAN_QUEUE ? "scan.queued" : "scan.backgrounded",
-      metadata: { stageId: input.stageId },
-    });
 
     if (c.env.SCAN_QUEUE) {
       await c.env.SCAN_QUEUE.send(message);
@@ -276,21 +267,11 @@ scansRoutes.post("/:id/decision", async (c) => {
 
 scansRoutes.get("/:id", async (c) => {
   const db = createDb(c.env.DB);
-  const session = c.get("authSession");
   const organizationId = await requireActiveOrganization(c, db);
   const scan = await getScan(db, c.req.param("id"), organizationId, scanArtifactReadBucket(c.env), {
     includeFileSamples: false,
   });
   if (!scan) return c.json({ error: "not found" }, 404);
-  if (c.req.query("poll") !== "1") {
-    await recordScanEvent(db, {
-      organizationId,
-      actorUserId: session.userId,
-      scanId: scan.scan.id,
-      type: "scan.viewed",
-      metadata: { stageId: scan.scan.stageId },
-    });
-  }
   return c.json(scan);
 });
 

--- a/src/models/audit-log.ts
+++ b/src/models/audit-log.ts
@@ -1,0 +1,110 @@
+import { computed, createModel, signal } from "@preact/signals";
+import { apiFetch, errorMessage } from "./api";
+
+export type AuditCategory =
+  | "release_decision"
+  | "member"
+  | "security"
+  | "integration"
+  | "organization";
+
+export type AuditSeverity = "info" | "notice" | "security";
+
+export type AuditActor =
+  | { type: "user"; name: string | null; email: string | null }
+  | { type: "system" };
+
+export interface AuditEvent {
+  id: string;
+  type: string;
+  category: AuditCategory;
+  label: string;
+  severity: AuditSeverity;
+  detail: string | null;
+  createdAt: number;
+  scanId: string | null;
+  actor: AuditActor;
+}
+
+interface ListResponse {
+  events: AuditEvent[];
+  nextCursor: string | null;
+  limit: number;
+}
+
+export type AuditLogStatus = "idle" | "loading" | "loadingMore";
+
+const AUDIT_EVENTS_PATH = "/api/v1/audit-events";
+
+export const AuditLogModel = createModel(() => {
+  const events = signal<AuditEvent[]>([]);
+  const loaded = signal(false);
+  const status = signal<AuditLogStatus>("idle");
+  const error = signal<string | null>(null);
+  const nextCursor = signal<string | null>(null);
+  let loadRequestId = 0;
+
+  const busy = computed(() => status.value !== "idle");
+  const hasMore = computed(() => nextCursor.value !== null);
+
+  return {
+    events,
+    loaded,
+    status,
+    error,
+    nextCursor,
+    busy,
+    hasMore,
+
+    // `enabled` gates the fetch on owner/admin access so members never hit the
+    // 403 endpoint. The request itself is org-scoped via the active-org header.
+    async load(enabled: boolean): Promise<void> {
+      const requestId = ++loadRequestId;
+      this.events.value = [];
+      this.nextCursor.value = null;
+      this.error.value = null;
+      this.loaded.value = false;
+      if (!enabled) {
+        this.loaded.value = true;
+        this.status.value = "idle";
+        return;
+      }
+      this.status.value = "loading";
+      try {
+        const data = await apiFetch<ListResponse>(AUDIT_EVENTS_PATH);
+        if (requestId === loadRequestId) {
+          this.events.value = data.events;
+          this.nextCursor.value = data.nextCursor;
+        }
+      } catch (err) {
+        if (requestId === loadRequestId) this.error.value = errorMessage(err);
+      } finally {
+        if (requestId === loadRequestId) {
+          this.loaded.value = true;
+          this.status.value = "idle";
+        }
+      }
+    },
+
+    async loadMore(): Promise<void> {
+      const cursor = this.nextCursor.peek();
+      if (!cursor || this.status.peek() !== "idle") return;
+      const requestId = loadRequestId;
+      this.status.value = "loadingMore";
+      this.error.value = null;
+      try {
+        const data = await apiFetch<ListResponse>(
+          `${AUDIT_EVENTS_PATH}?cursor=${encodeURIComponent(cursor)}`,
+        );
+        if (requestId === loadRequestId) {
+          this.events.value = [...this.events.value, ...data.events];
+          this.nextCursor.value = data.nextCursor;
+        }
+      } catch (err) {
+        if (requestId === loadRequestId) this.error.value = errorMessage(err);
+      } finally {
+        if (requestId === loadRequestId) this.status.value = "idle";
+      }
+    },
+  };
+});

--- a/src/pages/Dashboard/Settings/AuditLogSection.tsx
+++ b/src/pages/Dashboard/Settings/AuditLogSection.tsx
@@ -1,0 +1,128 @@
+import { useModel } from "@preact/signals";
+import { formatTimestamp } from "../../../lib/format";
+import {
+  AuditLogModel,
+  type AuditActor,
+  type AuditCategory,
+  type AuditEvent,
+  type AuditSeverity,
+} from "../../../models/audit-log";
+import { Alert } from "../../../components/Alert";
+import { Badge, type BadgeTone } from "../../../components/Badge";
+import { Button } from "../../../components/Button";
+import { CollapsibleCard, SettingsCardBody, SettingsCardListItem } from "../../../components/Card";
+import { Muted } from "../../../components/Typography";
+
+const CATEGORY_LABELS: Record<AuditCategory, string> = {
+  release_decision: "Release",
+  member: "Member",
+  security: "Security",
+  integration: "Integration",
+  organization: "Org",
+};
+
+function severityTone(severity: AuditSeverity): BadgeTone {
+  if (severity === "security") return "high";
+  if (severity === "notice") return "medium";
+  return "info";
+}
+
+function actorLabel(actor: AuditActor): string {
+  if (actor.type === "system") return "System";
+  return actor.name || actor.email || "Unknown user";
+}
+
+export function AuditLogSection({
+  audit,
+}: {
+  audit: ReturnType<typeof useModel<typeof AuditLogModel.prototype>>;
+}) {
+  const events = audit.events.value;
+  const loaded = audit.loaded.value;
+  const status = audit.status.value;
+  const error = audit.error.value;
+  const hasMore = audit.hasMore.value;
+
+  return (
+    <CollapsibleCard
+      title="Audit log"
+      defaultOpen
+      aside={
+        <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
+          {events.length}
+          {hasMore ? "+" : ""} {events.length === 1 ? "event" : "events"}
+        </span>
+      }
+    >
+      <SettingsCardBody>
+        <Muted class="text-[13px] m-0 max-w-[760px]">
+          Release decisions, member changes, security policy, and integration changes for this
+          organization. Events are retained for 90 days and visible to owners and admins.
+        </Muted>
+        {error ? <Alert tone="critical">{error}</Alert> : null}
+      </SettingsCardBody>
+
+      {loaded && !error && events.length === 0 ? (
+        <SettingsCardBody inset="belowHeader" gap="none">
+          <Muted class="text-[13px] m-0">No audit events yet.</Muted>
+        </SettingsCardBody>
+      ) : null}
+
+      {!loaded && status === "loading" ? (
+        <SettingsCardBody inset="belowHeader" gap="none">
+          <Muted class="text-[13px] m-0">Loading audit log…</Muted>
+        </SettingsCardBody>
+      ) : null}
+
+      {events.length ? (
+        <ul class="list-none m-0 p-0">
+          {events.map((event: AuditEvent) => (
+            <SettingsCardListItem key={event.id}>
+              <div class="flex flex-col gap-1 min-w-0">
+                <div class="flex items-center gap-2 flex-wrap">
+                  <Badge tone={severityTone(event.severity)} dot>
+                    {CATEGORY_LABELS[event.category]}
+                  </Badge>
+                  <span class="text-[13px] font-medium text-ink">{event.label}</span>
+                </div>
+                {event.detail ? (
+                  <span class="text-[12px] text-ink-muted break-words">{event.detail}</span>
+                ) : null}
+                <span class="text-[11px] text-ink-subtle">
+                  {actorLabel(event.actor)}
+                  {event.scanId ? (
+                    <>
+                      {" · "}
+                      <a
+                        class="text-accent hover:underline"
+                        href={`/dashboard/scans/${event.scanId}`}
+                      >
+                        view scan
+                      </a>
+                    </>
+                  ) : null}
+                </span>
+              </div>
+              <span class="font-mono text-[11px] text-ink-subtle shrink-0">
+                {formatTimestamp(event.createdAt)}
+              </span>
+            </SettingsCardListItem>
+          ))}
+        </ul>
+      ) : null}
+
+      {hasMore ? (
+        <SettingsCardBody inset="belowHeader" gap="none">
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={audit.busy.value}
+            onClick={() => void audit.loadMore()}
+          >
+            {status === "loadingMore" ? "Loading…" : "Load more"}
+          </Button>
+        </SettingsCardBody>
+      ) : null}
+    </CollapsibleCard>
+  );
+}

--- a/src/pages/Dashboard/Settings/SettingsNav.tsx
+++ b/src/pages/Dashboard/Settings/SettingsNav.tsx
@@ -1,12 +1,13 @@
 import { cn } from "../../../components/cn";
 
-export type SettingsTab = "general" | "members" | "notifications" | "integrations";
+export type SettingsTab = "general" | "members" | "notifications" | "integrations" | "audit";
 
 export const SETTINGS_TABS: ReadonlyArray<{ id: SettingsTab; label: string }> = [
   { id: "general", label: "General" },
   { id: "members", label: "Members" },
   { id: "notifications", label: "Notifications" },
   { id: "integrations", label: "Integrations" },
+  { id: "audit", label: "Audit log" },
 ];
 
 export function isSettingsTab(value: unknown): value is SettingsTab {
@@ -16,16 +17,18 @@ export function isSettingsTab(value: unknown): value is SettingsTab {
 export function SettingsNav({
   active,
   onSelect,
+  tabs = SETTINGS_TABS,
 }: {
   active: SettingsTab;
   onSelect: (tab: SettingsTab) => void;
+  tabs?: ReadonlyArray<{ id: SettingsTab; label: string }>;
 }) {
   return (
     <nav
       aria-label="Settings sections"
       class="flex md:flex-col gap-1 overflow-x-auto md:overflow-visible -mx-1 px-1 md:mx-0 md:px-0"
     >
-      {SETTINGS_TABS.map((tab) => {
+      {tabs.map((tab) => {
         const isActive = tab.id === active;
         return (
           <button

--- a/src/pages/Dashboard/Settings/index.tsx
+++ b/src/pages/Dashboard/Settings/index.tsx
@@ -7,6 +7,7 @@ import {
   useQuerySignal,
 } from "../../../lib/query-state";
 import { sessionModel } from "../../../models/auth";
+import { AuditLogModel } from "../../../models/audit-log";
 import { NpmConnectionModel } from "../../../models/npm-connection";
 import { NotificationRecipientsModel } from "../../../models/notification-recipients";
 import { SlackConnectionModel } from "../../../models/slack-connection";
@@ -31,7 +32,8 @@ import { NotificationRecipientsSection } from "./NotificationRecipientsSection";
 import { SlackConnectionSection } from "./SlackConnectionSection";
 import { NpmConnectionSection } from "./NpmConnectionSection";
 import { OrganizationMembersSection } from "./OrganizationMembersSection";
-import { SettingsNav, isSettingsTab, type SettingsTab } from "./SettingsNav";
+import { AuditLogSection } from "./AuditLogSection";
+import { SETTINGS_TABS, SettingsNav, isSettingsTab, type SettingsTab } from "./SettingsNav";
 
 export default function SettingsPage() {
   const location = useLocation();
@@ -41,6 +43,7 @@ export default function SettingsPage() {
   const members = useModel(MembersModel);
   const recipients = useModel(NotificationRecipientsModel);
   const slack = useModel(SlackConnectionModel);
+  const audit = useModel(AuditLogModel);
   const sessionChecked = useSignal(false);
   const activeTab = useSignal<SettingsTab>("general");
 
@@ -82,6 +85,7 @@ export default function SettingsPage() {
         members.load(canManageMembers(organizations)),
         recipients.load(organizations.active.peek()?.id ?? null),
         slack.load(organizations.active.peek()?.id ?? null),
+        audit.load(canManageMembers(organizations)),
       ]);
     })();
     return () => {
@@ -96,6 +100,7 @@ export default function SettingsPage() {
     loaders.push(githubApp.loadInstallations(), githubApp.loadReleaseTargets());
     loaders.push(recipients.load(organizations.active.peek()?.id ?? null));
     loaders.push(slack.load(organizations.active.peek()?.id ?? null));
+    loaders.push(audit.load(canManageMembers(organizations)));
     await Promise.all(loaders);
   };
 
@@ -130,7 +135,12 @@ export default function SettingsPage() {
   const githubAppLoaded = githubApp.loaded.value;
   const npmLoaded = npm.loaded.value;
   const workspaceLoaded = githubAppLoaded && npmLoaded;
-  const tab = activeTab.value;
+  // The audit log is owner/admin-only: hide the tab from members and fall back
+  // to General if a member deep-links to ?tab=audit (the endpoint 403s anyway).
+  const canViewAudit = canManageMembers(organizations);
+  const requestedTab = activeTab.value;
+  const tab = requestedTab === "audit" && !canViewAudit ? "general" : requestedTab;
+  const visibleTabs = SETTINGS_TABS.filter((entry) => entry.id !== "audit" || canViewAudit);
 
   return (
     <PageShell
@@ -152,7 +162,11 @@ export default function SettingsPage() {
 
       {workspaceLoaded ? (
         <div class="grid grid-cols-1 md:grid-cols-[200px_minmax(0,1fr)] gap-6 md:gap-8">
-          <SettingsNav active={tab} onSelect={(next) => (activeTab.value = next)} />
+          <SettingsNav
+            active={tab}
+            tabs={visibleTabs}
+            onSelect={(next) => (activeTab.value = next)}
+          />
 
           <div class="min-w-0 flex flex-col gap-6">
             {tab === "general" ? (
@@ -197,6 +211,7 @@ export default function SettingsPage() {
                 <GithubAppSection githubApp={githubApp} defaultOpen />
               </>
             ) : null}
+            {tab === "audit" && canViewAudit ? <AuditLogSection audit={audit} /> : null}
           </div>
         </div>
       ) : (

--- a/test/e2e/local-registry.spec.ts
+++ b/test/e2e/local-registry.spec.ts
@@ -240,10 +240,10 @@ async function createScan(page: Page, stageId: string): Promise<{ status: number
   );
 }
 
-// Poll the persisted detail route the way the dashboard does (?poll=1 skips
-// the scan.viewed audit event) until the background job reaches a terminal
-// status. The deadline stays inside the 90s Playwright test timeout so a stuck
-// scan fails with the last observed status instead of an opaque test timeout.
+// Poll the persisted detail route the way the dashboard does (with ?poll=1)
+// until the background job reaches a terminal status. The deadline stays inside
+// the 90s Playwright test timeout so a stuck scan fails with the last observed
+// status instead of an opaque test timeout.
 async function pollScanUntilTerminal(
   page: Page,
   scanId: string,

--- a/test/scan-job.test.mjs
+++ b/test/scan-job.test.mjs
@@ -195,16 +195,13 @@ describe("executeScanJob idempotency", () => {
     expect(dbMock.markScanFailed).not.toHaveBeenCalled();
   });
 
-  test("emits scan.started exactly once after a successful claim", async () => {
+  test("runs the pipeline exactly once after a successful claim", async () => {
     dbMock.claimScanForRun.mockResolvedValue(true);
 
     await executeScanJob(env, ctx, message, {}, { attempt: 1 });
 
-    const started = dbMock.recordScanEvent.mock.calls.filter(
-      ([, payload]) => payload?.type === "scan.started",
-    );
-    expect(started).toHaveLength(1);
     expect(pipelineMock.runScanPipeline).toHaveBeenCalledTimes(1);
+    expect(dbMock.markNpmConnectionUsed).toHaveBeenCalledWith({}, message.organizationId);
   });
 
   test("emits a structured completion log without token material", async () => {
@@ -251,7 +248,7 @@ describe("executeScanJob idempotency", () => {
     );
   });
 
-  test("records scan.failed and marks the scan failed on a terminal error in the final attempt", async () => {
+  test("marks the scan failed on a terminal error in the final attempt", async () => {
     dbMock.claimScanForRun.mockResolvedValue(true);
     pipelineMock.runScanPipeline.mockRejectedValue(
       new SandboxError(JSON.stringify({ error: "denied", status: 403 })),
@@ -262,10 +259,6 @@ describe("executeScanJob idempotency", () => {
     ).rejects.toBeInstanceOf(SandboxError);
 
     expect(dbMock.markScanFailed).toHaveBeenCalledTimes(1);
-    const failed = dbMock.recordScanEvent.mock.calls.filter(
-      ([, payload]) => payload?.type === "scan.failed",
-    );
-    expect(failed).toHaveLength(1);
     expect(notifyMock.notifyScanCompletion).toHaveBeenCalledWith(
       expect.objectContaining({
         scanId: message.scanId,
@@ -325,19 +318,6 @@ describe("executeScanJob idempotency", () => {
       message.scanId,
       message.organizationId,
     );
-    const failed = dbMock.recordScanEvent.mock.calls.filter(
-      ([, payload]) => payload?.type === "scan.failed",
-    );
-    expect(failed).toHaveLength(0);
-    const skipped = dbMock.recordScanEvent.mock.calls.filter(
-      ([, payload]) => payload?.type === "scan.skipped",
-    );
-    expect(skipped).toHaveLength(1);
-    expect(skipped[0]?.[1]?.scanId).toBeUndefined();
-    expect(skipped[0]?.[1]?.metadata).toMatchObject({
-      scanId: message.scanId,
-      stageId: message.stageId,
-    });
     expect(notifyMock.notifyScanCompletion).not.toHaveBeenCalled();
   });
 
@@ -364,7 +344,7 @@ describe("executeScanJob idempotency", () => {
     );
   });
 
-  test("records scan.retryable_failed without marking failed when a retryable error fires before exhaustion", async () => {
+  test("does not mark failed when a retryable error fires before exhaustion", async () => {
     dbMock.claimScanForRun.mockResolvedValue(true);
     pipelineMock.runScanPipeline.mockRejectedValue(
       new SandboxError(JSON.stringify({ error: "blip", status: 503 })),
@@ -375,9 +355,6 @@ describe("executeScanJob idempotency", () => {
     ).rejects.toBeInstanceOf(SandboxError);
 
     expect(dbMock.markScanFailed).not.toHaveBeenCalled();
-    const retryable = dbMock.recordScanEvent.mock.calls.filter(
-      ([, payload]) => payload?.type === "scan.retryable_failed",
-    );
-    expect(retryable).toHaveLength(1);
+    expect(dbMock.discardScanAttempt).not.toHaveBeenCalled();
   });
 });

--- a/test/scan-pipeline-phases.test.mjs
+++ b/test/scan-pipeline-phases.test.mjs
@@ -325,7 +325,7 @@ describe("recordCompletion", () => {
   };
   const identity = { scanId: "scan-1", stageId: "stage-1", organizationId: "org-1" };
 
-  test("records the completion audit event when the scan was persisted", async () => {
+  test("completes without writing a scan audit event", async () => {
     await recordCompletion({
       db: {},
       session: { userId: "user-1" },
@@ -334,27 +334,6 @@ describe("recordCompletion", () => {
       result: completedResult,
       baseline: baselineInfo,
       persisted: true,
-      pipelineStartedAtMs: Date.now(),
-    });
-
-    expect(dbMock.recordScanEvent).toHaveBeenCalledTimes(1);
-    expect(dbMock.recordScanEvent.mock.calls[0][1]).toMatchObject({
-      type: "scan.completed",
-      scanId: "scan-1",
-      organizationId: "org-1",
-      metadata: { packageName: "pkg", artifactRisk: "high", contextRisk: "high" },
-    });
-  });
-
-  test("skips the audit event when the scan was not persisted", async () => {
-    await recordCompletion({
-      db: {},
-      session: { userId: "user-1" },
-      identity,
-      adapterId: "fake",
-      result: completedResult,
-      baseline: baselineInfo,
-      persisted: false,
       pipelineStartedAtMs: Date.now(),
     });
 

--- a/test/scans-route-background.test.mjs
+++ b/test/scans-route-background.test.mjs
@@ -132,10 +132,5 @@ describe("scans route background fallback", () => {
       {},
       { finalAttempt: true },
     );
-
-    const backgroundedEvents = dbMock.recordScanEvent.mock.calls.filter(
-      ([, payload]) => payload?.type === "scan.backgrounded",
-    );
-    expect(backgroundedEvents).toHaveLength(1);
   });
 });

--- a/test/staged-publishes-discovery.test.mjs
+++ b/test/staged-publishes-discovery.test.mjs
@@ -416,12 +416,9 @@ describe("discoverAndQueueStagedPublishes", () => {
 
     const createdScanId = dbMock.createScanJob.mock.calls[0]?.[1]?.id;
     expect(dbMock.deletePendingScanJob).toHaveBeenCalledWith(db, createdScanId, "org_a");
-    expect(
-      dbMock.recordScanEvent.mock.calls.some(([, payload]) => payload?.type === "scan.queued"),
-    ).toBe(false);
   });
 
-  test("does not record scans_started when the sweep starts nothing", async () => {
+  test("starts nothing when every discovered stage is already known", async () => {
     stagedPublishesMock.listStagedPublishes.mockResolvedValue({
       items: [{ id: "stage-known", packageName: "pkg-a", version: "1.0.0" }],
     });
@@ -441,21 +438,18 @@ describe("discoverAndQueueStagedPublishes", () => {
     );
 
     expect(result).toEqual(expect.objectContaining({ found: 1, created: 0, skipped: 1 }));
-    expect(
-      dbMock.recordScanEvent.mock.calls.some(
-        ([, payload]) => payload?.type === "staged_publishes.scans_started",
-      ),
-    ).toBe(false);
+    expect(dbMock.createScanJob).not.toHaveBeenCalled();
+    expect(env.SCAN_QUEUE.send).not.toHaveBeenCalled();
   });
 
-  test("records scans_started when the sweep starts scans", async () => {
+  test("starts a scan for each newly discovered stage", async () => {
     stagedPublishesMock.listStagedPublishes.mockResolvedValue({
       items: [{ id: "stage-new", packageName: "pkg-a", version: "1.0.0" }],
     });
     dbMock.listExistingScanStageIds.mockResolvedValue(new Set());
     dbMock.createScanJob.mockResolvedValue({ id: "scan-new" });
 
-    await discoverAndQueueStagedPublishes(
+    const result = await discoverAndQueueStagedPublishes(
       {
         db,
         env,
@@ -468,12 +462,18 @@ describe("discoverAndQueueStagedPublishes", () => {
       { token: "npm_secret_token", registryUrl: "https://registry.npmjs.org" },
     );
 
-    const startedEvents = dbMock.recordScanEvent.mock.calls.filter(
-      ([, payload]) => payload?.type === "staged_publishes.scans_started",
+    expect(result).toEqual(
+      expect.objectContaining({ found: 1, created: 1, skipped: 0, queued: true }),
     );
-    expect(startedEvents).toHaveLength(1);
-    expect(startedEvents[0]?.[1]?.metadata).toEqual(
-      expect.objectContaining({ found: 1, created: 1, skipped: 0 }),
+    expect(result.scans).toHaveLength(1);
+    expect(dbMock.createScanJob).toHaveBeenCalledTimes(1);
+    expect(dbMock.createScanJob).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ stageId: "stage-new" }),
+    );
+    expect(env.SCAN_QUEUE.send).toHaveBeenCalledTimes(1);
+    expect(env.SCAN_QUEUE.send).toHaveBeenCalledWith(
+      expect.objectContaining({ stageId: "stage-new" }),
     );
   });
 });

--- a/test/workers/audit-events-route.test.ts
+++ b/test/workers/audit-events-route.test.ts
@@ -1,0 +1,255 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { describe, expect, test } from "vitest";
+import { createDb } from "../../server/db/client";
+import { ensurePersonalOrganization } from "../../server/db/organizations";
+import * as schema from "../../server/db/schema";
+import { auditRoutes } from "../../server/routes/audit";
+import { ACTIVE_ORG_HEADER } from "../../server/lib/active-organization";
+import type { Bindings, Variables } from "../../server/types";
+
+interface SeededUser {
+  userId: string;
+  organizationId: string;
+}
+
+async function seedUser(name = "Tester"): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name,
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+async function addMember(
+  organizationId: string,
+  userId: string,
+  role: "owner" | "admin" | "member",
+) {
+  const db = createDb(env.DB);
+  const now = new Date();
+  await db.insert(schema.organizationMembers).values({
+    id: `member_${crypto.randomUUID()}`,
+    organizationId,
+    userId,
+    role,
+    createdAt: now,
+    updatedAt: now,
+  });
+}
+
+async function insertEvent(input: {
+  organizationId: string;
+  type: string;
+  actorUserId?: string | null;
+  scanId?: string | null;
+  metadata?: unknown;
+  createdAt: Date;
+}) {
+  const db = createDb(env.DB);
+  await db.insert(schema.scanEvents).values({
+    id: `evt_${crypto.randomUUID()}`,
+    organizationId: input.organizationId,
+    actorUserId: input.actorUserId ?? null,
+    scanId: input.scanId ?? null,
+    type: input.type,
+    metadataJson: input.metadata ?? null,
+    createdAt: input.createdAt,
+  });
+}
+
+function buildTestApp(session: { userId: string }) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.use("*", async (c, next) => {
+    c.set("authSession", { userId: session.userId });
+    await next();
+  });
+  app.route("/api/v1/audit-events", auditRoutes);
+  return app;
+}
+
+async function fetchAudit(
+  app: Hono<{ Bindings: Bindings; Variables: Variables }>,
+  path: string,
+  orgHeader?: string,
+) {
+  const ctx = createExecutionContext();
+  const headers: Record<string, string> = {};
+  if (orgHeader) headers[ACTIVE_ORG_HEADER] = orgHeader;
+  const res = await app.fetch(
+    new Request(`http://test.local${path}`, { method: "GET", headers }),
+    env,
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+interface AuditEventBody {
+  id: string;
+  type: string;
+  category: string;
+  label: string;
+  severity: string;
+  detail: string | null;
+  createdAt: number;
+  scanId: string | null;
+  actor: { type: string; name?: string | null; email?: string | null };
+}
+
+describe("audit-events route", () => {
+  test("returns only audit-visible events, shaped with registry metadata", async () => {
+    const owner = await seedUser("Ada");
+    const base = Date.now();
+    await insertEvent({
+      organizationId: owner.organizationId,
+      type: "organization.member_invited",
+      actorUserId: owner.userId,
+      metadata: { invitedEmail: "invitee@example.com" },
+      createdAt: new Date(base),
+    });
+    // Not on the visible allowlist — must be filtered out.
+    await insertEvent({
+      organizationId: owner.organizationId,
+      type: "scan.started",
+      createdAt: new Date(base + 1),
+    });
+
+    const res = await fetchAudit(buildTestApp(owner), "/api/v1/audit-events");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { events: AuditEventBody[]; nextCursor: string | null };
+
+    expect(body.events.map((e) => e.type)).toEqual(["organization.member_invited"]);
+    const [event] = body.events;
+    expect(event.category).toBe("member");
+    expect(event.label).toBe("Member invited");
+    expect(event.detail).toBe("invitee@example.com");
+    expect(event.actor).toEqual({
+      type: "user",
+      name: "Ada",
+      email: `${owner.userId}@example.com`,
+    });
+  });
+
+  test("never leaks raw or sensitive event metadata", async () => {
+    const owner = await seedUser();
+    await insertEvent({
+      organizationId: owner.organizationId,
+      type: "npm_connection.upserted",
+      actorUserId: owner.userId,
+      metadata: {
+        label: "prod",
+        registryUrl: "https://registry.example.com",
+        tokenLast4: "9999",
+        tokenCiphertext: "SECRET_CIPHERTEXT",
+      },
+      createdAt: new Date(),
+    });
+
+    const res = await fetchAudit(buildTestApp(owner), "/api/v1/audit-events");
+    const raw = await res.text();
+    expect(raw).not.toContain("SECRET_CIPHERTEXT");
+    expect(raw).not.toContain("9999");
+    const body = JSON.parse(raw) as { events: Array<Record<string, unknown>> };
+    expect(body.events[0]).not.toHaveProperty("metadataJson");
+    expect(body.events[0].detail).toBe("prod");
+  });
+
+  test("scopes events to the caller's organization", async () => {
+    const owner = await seedUser();
+    const other = await seedUser();
+    await insertEvent({
+      organizationId: other.organizationId,
+      type: "organization.renamed",
+      actorUserId: other.userId,
+      metadata: { name: "Their Org" },
+      createdAt: new Date(),
+    });
+
+    const res = await fetchAudit(buildTestApp(owner), "/api/v1/audit-events");
+    const body = (await res.json()) as { events: AuditEventBody[] };
+    expect(body.events).toHaveLength(0);
+  });
+
+  test("paginates newest-first with a stable cursor", async () => {
+    const owner = await seedUser();
+    const base = Date.now();
+    for (let i = 0; i < 3; i++) {
+      await insertEvent({
+        organizationId: owner.organizationId,
+        type: "organization.renamed",
+        actorUserId: owner.userId,
+        metadata: { name: `rename-${i}` },
+        createdAt: new Date(base + i * 1000),
+      });
+    }
+
+    const app = buildTestApp(owner);
+    const firstRes = await fetchAudit(app, "/api/v1/audit-events?limit=2");
+    const first = (await firstRes.json()) as {
+      events: AuditEventBody[];
+      nextCursor: string | null;
+    };
+    expect(first.events).toHaveLength(2);
+    expect(first.nextCursor).toBeTruthy();
+    // Newest first: rename-2 then rename-1.
+    expect(first.events.map((e) => e.detail)).toEqual(["rename-2", "rename-1"]);
+
+    const secondRes = await fetchAudit(
+      app,
+      `/api/v1/audit-events?limit=2&cursor=${encodeURIComponent(first.nextCursor!)}`,
+    );
+    const second = (await secondRes.json()) as {
+      events: AuditEventBody[];
+      nextCursor: string | null;
+    };
+    expect(second.events.map((e) => e.detail)).toEqual(["rename-0"]);
+    expect(second.nextCursor).toBeNull();
+  });
+
+  test("forbids members from reading the audit log", async () => {
+    const owner = await seedUser();
+    const member = await seedUser();
+    await addMember(owner.organizationId, member.userId, "member");
+    await insertEvent({
+      organizationId: owner.organizationId,
+      type: "organization.renamed",
+      actorUserId: owner.userId,
+      metadata: { name: "Owned" },
+      createdAt: new Date(),
+    });
+
+    const res = await fetchAudit(
+      buildTestApp(member),
+      "/api/v1/audit-events",
+      owner.organizationId,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("allows admins to read the audit log", async () => {
+    const owner = await seedUser();
+    const admin = await seedUser();
+    await addMember(owner.organizationId, admin.userId, "admin");
+    await insertEvent({
+      organizationId: owner.organizationId,
+      type: "organization.renamed",
+      actorUserId: owner.userId,
+      metadata: { name: "Owned" },
+      createdAt: new Date(),
+    });
+
+    const res = await fetchAudit(buildTestApp(admin), "/api/v1/audit-events", owner.organizationId);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { events: AuditEventBody[] };
+    expect(body.events).toHaveLength(1);
+  });
+});

--- a/test/workers/cross-org-routes.test.ts
+++ b/test/workers/cross-org-routes.test.ts
@@ -502,7 +502,7 @@ describe("scans routes enforce organization boundaries", () => {
     expect(intruderRes.status).toBe(404);
   });
 
-  test("GET /scans/:id includes scan lifecycle events for the owning organization", async () => {
+  test("GET /scans/:id includes scan-scoped events for the owning organization", async () => {
     const owner = await seedUser();
     const scanId = await seedCompletedScan(owner, "@org/timeline-package");
     const db = createDb(env.DB);
@@ -513,8 +513,12 @@ describe("scans routes enforce organization boundaries", () => {
         organizationId: owner.organizationId,
         actorUserId: owner.userId,
         scanId,
-        type: "scan.started",
-        metadataJson: { stageId: "stage-timeline", attempt: 1 },
+        type: "scan.decided",
+        metadataJson: {
+          stageId: "stage-timeline",
+          decision: "publish",
+          tokenFingerprint: "secret-fingerprint",
+        },
         createdAt: new Date(1),
       },
       {
@@ -522,22 +526,9 @@ describe("scans routes enforce organization boundaries", () => {
         organizationId: owner.organizationId,
         actorUserId: owner.userId,
         scanId,
-        type: "npm_connection.used",
-        metadataJson: {
-          stageId: "stage-timeline",
-          registryUrl: "https://registry.npmjs.org/",
-          tokenFingerprint: "secret-fingerprint",
-        },
+        type: "scan.decided",
+        metadataJson: { stageId: "stage-timeline", decision: "no_publish" },
         createdAt: new Date(2),
-      },
-      {
-        id: crypto.randomUUID(),
-        organizationId: owner.organizationId,
-        actorUserId: owner.userId,
-        scanId,
-        type: "scan.completed",
-        metadataJson: { stageId: "stage-timeline", risk: "low" },
-        createdAt: new Date(3),
       },
     ]);
 
@@ -546,17 +537,14 @@ describe("scans routes enforce organization boundaries", () => {
     const body = (await res.json()) as {
       events: Array<{ type: string; metadataJson: Record<string, unknown> }>;
     };
-    expect(body.events.map((event) => event.type)).toEqual([
-      "scan.started",
-      "npm_connection.used",
-      "scan.completed",
-    ]);
-    expect(body.events[0].metadataJson).toMatchObject({ stageId: "stage-timeline", attempt: 1 });
-    expect(body.events[1].metadataJson).toMatchObject({
+    expect(body.events.map((event) => event.type)).toEqual(["scan.decided", "scan.decided"]);
+    expect(body.events[0].metadataJson).toMatchObject({
       stageId: "stage-timeline",
-      registryUrl: "https://registry.npmjs.org/",
+      decision: "publish",
     });
-    expect(body.events[1].metadataJson).not.toHaveProperty("tokenFingerprint");
+    // Sensitive metadata keys are redacted before the client sees them.
+    expect(body.events[0].metadataJson).not.toHaveProperty("tokenFingerprint");
+    expect(body.events[1].metadataJson).toMatchObject({ decision: "no_publish" });
   });
 
   test("GET /scans/:id/versions returns 404 for foreign scan ids", async () => {

--- a/test/workers/organizations-routes.test.ts
+++ b/test/workers/organizations-routes.test.ts
@@ -625,7 +625,7 @@ describe("organization deletion", () => {
       id: `event_${crypto.randomUUID()}`,
       organizationId: orgId,
       scanId,
-      type: "scan.completed",
+      type: "scan.decided",
       createdAt: now,
     });
 

--- a/test/workers/scans-route-queue.test.ts
+++ b/test/workers/scans-route-queue.test.ts
@@ -66,7 +66,7 @@ describe("scans route queue behavior", () => {
     vi.unstubAllGlobals();
   });
 
-  test("POST /scans enqueues a token-free scan message and records the queue event", async () => {
+  test("POST /scans enqueues a token-free scan message and persists the scan", async () => {
     const owner = await seedUser();
     const token = "npm_route_queue_secret_0123456789";
     await connectValidNpmToken(owner, token);
@@ -129,11 +129,9 @@ describe("scans route queue behavior", () => {
     expect(JSON.stringify(message)).not.toContain("authorization");
 
     const db = createDb(env.DB);
-    const events = await db
-      .select()
-      .from(schema.scanEvents)
-      .where(eq(schema.scanEvents.scanId, body.scan.id));
-    expect(events.map((event) => event.type)).toContain("scan.queued");
+    const scans = await db.select().from(schema.scans).where(eq(schema.scans.id, body.scan.id));
+    expect(scans).toHaveLength(1);
+    expect(scans[0]?.organizationId).toBe(owner.organizationId);
   });
 
   test("POST /scans rejects stage ids the organization token cannot access before persisting", async () => {


### PR DESCRIPTION
Surface `scan_events` as an owner/admin-only organization audit log, exposed as a new Settings "Audit log" tab (hidden from members) and a cursor-paginated, org-scoped `GET /api/v1/audit-events` endpoint that reduces each row to a registry-derived label/detail and never ships raw event metadata. A central registry (`server/lib/audit-events.ts`) maps the visible event types to category, label, severity, and a redaction-safe detail line, and a flat 90-day retention sweep runs from the scheduled handler. This change also stops recording high-volume scan-lifecycle and discovery events that carried no audit value — those remain observable in Workers Logs via `emitOperationalEvent` — and updates the coupled tests to assert the underlying behavior instead. Adds `docs/audit-log.md` plus worker-test coverage for visible-only filtering, metadata non-leakage, org scoping, cursor pagination, and the member-403/admin-200 role gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)