### PR TITLE
Import recordScanEvent in scans route

### DIFF
--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -1,5 +1,6 @@
 import { Hono, type Context } from "hono";
 import { createDb } from "../db/client";
+import { recordScanEvent } from "../db/events";
 import { getOrganizationRole } from "../db/invitations";
 import { getNpmConnection } from "../db/npm-connections";
 import { RateLimitError, enforceRateLimit } from "../db/rate-limit";


### PR DESCRIPTION
## Problem

CI on `main` was failing ([run #29141891323](https://github.com/JoviDeCroock/drydock/actions/runs/29141891323)) across two jobs from a single root cause: the failed-scan deletion route calls `recordScanEvent(...)` but never imported it.

- **`lint · format · typecheck · test`** — caught it statically: `server/routes/scans.ts(283,5): error TS2304: Cannot find name 'recordScanEvent'.`
- **`e2e`** — at runtime the `DELETE /:id` handler threw `ReferenceError: recordScanEvent is not defined`, returning a 500. The `registry-failure` scenario (which deletes the failed scan) hung on the response and hit Playwright's 90s timeout.

## Why it wasn't caught pre-merge

`recordScanEvent` didn't exist as an export until the audit-log branch (#482). On the failed-scan-deletion branch (#481) alone the symbol was undefined, so the failure only materialized once both landed on `main`.

## Fix

One line — import `recordScanEvent` from `../db/events`, matching every other route file.

## Testing

- `pnpm run typecheck` ✓
- `pnpm exec oxlint` ✓ / `pnpm run format:check` ✓
- `test/workers/scan-delete.test.ts` ✓ (5 passed)

docs checked, no update needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)