### PR TITLE
Right-align Release security submit buttons

### DIFF
--- a/src/pages/Dashboard/Settings/ReleaseSecuritySection.tsx
+++ b/src/pages/Dashboard/Settings/ReleaseSecuritySection.tsx
@@ -104,7 +104,7 @@ export function ReleaseSecuritySection({
                 size="sm"
                 onClick={disable}
                 disabled={saving || blockedOnCode}
-                class="self-start"
+                class="self-end"
               >
                 {saving ? "Saving…" : "Stop requiring two-factor"}
               </Button>
@@ -116,7 +116,7 @@ export function ReleaseSecuritySection({
                 size="sm"
                 onClick={enable}
                 disabled={saving}
-                class="self-start"
+                class="self-end"
               >
                 {saving ? "Saving…" : "Require two-factor for releases"}
               </Button>


### PR DESCRIPTION
The two buttons in `ReleaseSecuritySection` ("Require two-factor for releases" and "Stop requiring two-factor") used `self-start`, left-aligning them and making the section the lone outlier among the app's submit actions. The Account `TwoFactorSection` — the same code-entry step-up flow — and the Settings save/submit buttons (NpmConnection, NotificationRecipients, delete-confirm dialogs) all right-align with `self-end`. This switches both buttons to `self-end` for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)