### PR TITLE
Fix saved Slack channel selection

### DIFF
--- a/src/models/slack-connection.ts
+++ b/src/models/slack-connection.ts
@@ -16,6 +16,15 @@ export interface SlackChannelOption {
   name: string;
 }
 
+export function getMissingSlackChannelOption(
+  connection: SlackConnection | null,
+  channels: SlackChannelOption[],
+): SlackChannelOption | null {
+  if (!connection?.channelId || !connection.channelName) return null;
+  if (channels.some((channel) => channel.id === connection.channelId)) return null;
+  return { id: connection.channelId, name: connection.channelName };
+}
+
 interface StatusResponse {
   configured: boolean;
   connection: SlackConnection | null;

--- a/src/pages/Dashboard/Settings/SlackConnectionSection.tsx
+++ b/src/pages/Dashboard/Settings/SlackConnectionSection.tsx
@@ -1,6 +1,7 @@
 import { useComputed, useModel, useSignal, useSignalEffect, type Signal } from "@preact/signals";
 import { For, Show, useLiveSignal } from "@preact/signals/utils";
 import {
+  getMissingSlackChannelOption,
   SlackConnectionModel,
   type SlackChannelOption,
   type SlackConnection,
@@ -152,6 +153,12 @@ function ConnectedSlackState({
     if (loading) return "Loading channels…";
     return channels.length === 0 ? "No public channels found" : "Choose a channel…";
   });
+  // A native select discards a value that has no matching option. Keep the
+  // persisted destination mounted while the asynchronous channel list loads,
+  // then let the matching Slack option replace it.
+  const savedChannelOption = useComputed(() =>
+    getMissingSlackChannelOption(slack.connection.value, slack.channels.value),
+  );
   const selectedChannelLabel = useComputed(() => {
     const current = slack.connection.value;
     if (!current?.channelId) return null;
@@ -303,6 +310,9 @@ function ConnectedSlackState({
                   <option value="" disabled>
                     {channelPickerPlaceholder}
                   </option>
+                  <Show<SlackChannelOption | null> when={savedChannelOption}>
+                    {(channel) => <option value={channel.id}>#{channel.name}</option>}
+                  </Show>
                   <For each={slack.channels}>
                     {(channel: SlackChannelOption) => (
                       <option key={channel.id} value={channel.id}>

--- a/test/slack-connection-model.test.ts
+++ b/test/slack-connection-model.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { getMissingSlackChannelOption } from "../src/models/slack-connection";
+
+const connection = {
+  teamId: "T123",
+  teamName: "Drydock",
+  channelId: "C_RELEASES",
+  channelName: "package-releases",
+  canListChannels: true,
+  enabled: true,
+  createdAt: "2026-07-12T00:00:00.000Z",
+};
+
+describe("getMissingSlackChannelOption", () => {
+  test("keeps the saved channel available while the channel list loads", () => {
+    expect(getMissingSlackChannelOption(connection, [])).toEqual({
+      id: "C_RELEASES",
+      name: "package-releases",
+    });
+  });
+
+  test("does not duplicate the saved channel once Slack returns it", () => {
+    expect(
+      getMissingSlackChannelOption(connection, [
+        { id: "C_ANNOUNCEMENTS", name: "announcements" },
+        { id: "C_RELEASES", name: "package-releases" },
+      ]),
+    ).toBeNull();
+  });
+
+  test("does not invent an option for a manually entered channel ID", () => {
+    expect(getMissingSlackChannelOption({ ...connection, channelName: null }, [])).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Fix the Slack notification selector so the persisted channel remains selected while the public channel list loads asynchronously.
The native select previously had no matching option at mount time, causing the browser to display the first returned channel even though the saved channel was unchanged.
Add regression coverage for loading, deduplication, and manually entered channel IDs.

## Testing

- `pnpm run verify`

Docs checked; no update needed.
