### PR TITLE
Fix Slack channel selector load race

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,12 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      testMatch: ["**/local-registry.spec.ts", "**/two-factor.spec.ts", "**/org-switcher.spec.ts"],
+      testMatch: [
+        "**/local-registry.spec.ts",
+        "**/two-factor.spec.ts",
+        "**/org-switcher.spec.ts",
+        "**/slack-selector.spec.ts",
+      ],
       use: { ...devices["Desktop Chrome"] },
     },
     {

--- a/src/models/slack-connection.ts
+++ b/src/models/slack-connection.ts
@@ -16,12 +16,10 @@ export interface SlackChannelOption {
   name: string;
 }
 
-export function getMissingSlackChannelOption(
+export function getSavedSlackChannelOption(
   connection: SlackConnection | null,
-  channels: SlackChannelOption[],
 ): SlackChannelOption | null {
   if (!connection?.channelId || !connection.channelName) return null;
-  if (channels.some((channel) => channel.id === connection.channelId)) return null;
   return { id: connection.channelId, name: connection.channelName };
 }
 

--- a/src/pages/Dashboard/Settings/SlackConnectionSection.tsx
+++ b/src/pages/Dashboard/Settings/SlackConnectionSection.tsx
@@ -1,7 +1,7 @@
 import { useComputed, useModel, useSignal, useSignalEffect, type Signal } from "@preact/signals";
 import { For, Show, useLiveSignal } from "@preact/signals/utils";
 import {
-  getMissingSlackChannelOption,
+  getSavedSlackChannelOption,
   SlackConnectionModel,
   type SlackChannelOption,
   type SlackConnection,
@@ -153,12 +153,16 @@ function ConnectedSlackState({
     if (loading) return "Loading channels…";
     return channels.length === 0 ? "No public channels found" : "Choose a channel…";
   });
-  // A native select discards a value that has no matching option. Keep the
-  // persisted destination mounted while the asynchronous channel list loads,
-  // then let the matching Slack option replace it.
-  const savedChannelOption = useComputed(() =>
-    getMissingSlackChannelOption(slack.connection.value, slack.channels.value),
-  );
+  // Keep the persisted destination mounted even after the asynchronous list
+  // loads. Removing it before For inserts the matching option briefly leaves
+  // the select without its value and makes the browser choose the first item.
+  const savedChannelOption = useComputed(() => getSavedSlackChannelOption(slack.connection.value));
+  const selectableChannels = useComputed(() => {
+    const savedChannelId = savedChannelOption.value?.id;
+    return slack.channels.value.filter(
+      (channel: SlackChannelOption) => channel.id !== savedChannelId,
+    );
+  });
   const selectedChannelLabel = useComputed(() => {
     const current = slack.connection.value;
     if (!current?.channelId) return null;
@@ -313,7 +317,7 @@ function ConnectedSlackState({
                   <Show<SlackChannelOption | null> when={savedChannelOption}>
                     {(channel) => <option value={channel.id}>#{channel.name}</option>}
                   </Show>
-                  <For each={slack.channels}>
+                  <For each={selectableChannels}>
                     {(channel: SlackChannelOption) => (
                       <option key={channel.id} value={channel.id}>
                         #{channel.name}

--- a/test/e2e/slack-selector.spec.ts
+++ b/test/e2e/slack-selector.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+const selectedChannelId = "C_RELEASES";
+
+test("Slack selector reflects the saved channel after channels load", async ({ page }) => {
+  let releaseChannels!: () => void;
+  const channelsReady = new Promise<void>((resolve) => {
+    releaseChannels = resolve;
+  });
+
+  await installSettingsMocks(page, channelsReady);
+  await page.goto("/dashboard/settings?tab=notifications");
+
+  const selector = page.getByLabel("Channel", { exact: true });
+  await expect(selector).toHaveValue(selectedChannelId);
+
+  releaseChannels();
+
+  await expect(selector).toBeEnabled();
+  await expect(selector).toHaveValue(selectedChannelId);
+  await expect(selector.locator("option:checked")).toHaveText("#package-releases");
+  await expect(selector.locator(`option[value="${selectedChannelId}"]`)).toHaveCount(1);
+});
+
+async function installSettingsMocks(page: Page, channelsReady: Promise<void>) {
+  await page.route("**/api/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+
+    if (path === "/api/auth/get-session") {
+      await fulfillJson(route, {
+        user: {
+          id: "user-slack-selector",
+          name: "Slack Selector Tester",
+          email: "slack-selector@example.test",
+          twoFactorEnabled: false,
+        },
+      });
+      return;
+    }
+
+    if (path === "/api/v1/organizations") {
+      await fulfillJson(route, {
+        organizations: [
+          {
+            id: "org-slack-selector",
+            name: "Drydock",
+            ownerUserId: "user-slack-selector",
+            role: "owner",
+            isPersonal: false,
+            npmConnectionConfigured: false,
+            requireTwoFactorForReleaseDecisions: false,
+            createdAt: "2026-07-12T00:00:00.000Z",
+            updatedAt: "2026-07-12T00:00:00.000Z",
+          },
+        ],
+      });
+      return;
+    }
+
+    if (path === "/api/v1/slack/channels") {
+      await channelsReady;
+      await fulfillJson(route, {
+        channels: [
+          { id: "C_ANNOUNCEMENTS", name: "announcements" },
+          { id: selectedChannelId, name: "package-releases" },
+        ],
+      });
+      return;
+    }
+
+    if (path === "/api/v1/slack") {
+      await fulfillJson(route, {
+        configured: true,
+        connection: {
+          teamId: "T_DRYDOCK",
+          teamName: "Drydock",
+          channelId: selectedChannelId,
+          channelName: "package-releases",
+          canListChannels: true,
+          enabled: true,
+          createdAt: "2026-07-12T00:00:00.000Z",
+        },
+      });
+      return;
+    }
+
+    if (path === "/api/v1/npm-connection") {
+      await fulfillJson(route, { connection: null });
+      return;
+    }
+
+    if (path === "/api/v1/github-app/config") {
+      await fulfillJson(route, { configured: false });
+      return;
+    }
+
+    if (path === "/api/v1/github-app/installations") {
+      await fulfillJson(route, { installations: [] });
+      return;
+    }
+
+    if (path === "/api/v1/github-app/release-targets") {
+      await fulfillJson(route, { releaseTargets: [] });
+      return;
+    }
+
+    if (path.endsWith("/notification-recipients")) {
+      await fulfillJson(route, { recipients: [] });
+      return;
+    }
+
+    if (path === "/api/v1/organizations/members") {
+      await fulfillJson(route, { members: [] });
+      return;
+    }
+
+    if (path === "/api/v1/organizations/invitations") {
+      await fulfillJson(route, { invitations: [] });
+      return;
+    }
+
+    if (path === "/api/v1/audit-events") {
+      await fulfillJson(route, { events: [], nextCursor: null });
+      return;
+    }
+
+    await fulfillJson(route, { error: `unexpected request: ${path}` }, 404);
+  });
+}
+
+async function fulfillJson(route: Route, json: unknown, status = 200) {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(json),
+  });
+}

--- a/test/slack-connection-model.test.ts
+++ b/test/slack-connection-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { getMissingSlackChannelOption } from "../src/models/slack-connection";
+import { getSavedSlackChannelOption } from "../src/models/slack-connection";
 
 const connection = {
   teamId: "T123",
@@ -11,24 +11,15 @@ const connection = {
   createdAt: "2026-07-12T00:00:00.000Z",
 };
 
-describe("getMissingSlackChannelOption", () => {
+describe("getSavedSlackChannelOption", () => {
   test("keeps the saved channel available while the channel list loads", () => {
-    expect(getMissingSlackChannelOption(connection, [])).toEqual({
+    expect(getSavedSlackChannelOption(connection)).toEqual({
       id: "C_RELEASES",
       name: "package-releases",
     });
   });
 
-  test("does not duplicate the saved channel once Slack returns it", () => {
-    expect(
-      getMissingSlackChannelOption(connection, [
-        { id: "C_ANNOUNCEMENTS", name: "announcements" },
-        { id: "C_RELEASES", name: "package-releases" },
-      ]),
-    ).toBeNull();
-  });
-
   test("does not invent an option for a manually entered channel ID", () => {
-    expect(getMissingSlackChannelOption({ ...connection, channelName: null }, [])).toBeNull();
+    expect(getSavedSlackChannelOption({ ...connection, channelName: null })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Fix the Slack channel selector race that still allowed the saved channel to flip to the first listed channel after Slack's asynchronous channel response arrived.
The saved option is now kept mounted throughout the list update and deduplicated from the remaining channel options, so the native select never temporarily loses its controlled value.
Add a Playwright regression that reproduces the delayed response and asserts the saved channel remains selected without duplicate options.

## Testing

- `pnpm run verify`
- `E2E_APP_PORT=5220 E2E_REGISTRY_PORT=5221 pnpm exec playwright test test/e2e/slack-selector.spec.ts --project=chromium`

Docs checked; no update needed.
