### PR TITLE
Name the organization in notification emails and deep-link to it

### DIFF
--- a/server/lib/notify.ts
+++ b/server/lib/notify.ts
@@ -1,6 +1,10 @@
 import { type AppDb } from "../db/client";
 import { recordScanEvent } from "../db/events";
-import { getOrganizationOwnerUserId, resolveNotificationEmails } from "../db/organizations";
+import {
+  getOrganizationName,
+  getOrganizationOwnerUserId,
+  resolveNotificationEmails,
+} from "../db/organizations";
 import { getScan } from "../db/scans";
 import { getSlackConnectionSecret } from "../db/slack-connection";
 import { sendNotificationEmail } from "./email";
@@ -28,14 +32,15 @@ export async function notifyScanCompletion(input: NotifyScanCompletionInput): Pr
   const { env, db, scanId, organizationId, ownerUserId, outcome, error } = input;
   const notificationOwnerUserId =
     (await getOrganizationOwnerUserId(db, organizationId)) ?? ownerUserId;
-  const [recipients, detail] = await Promise.all([
+  const [recipients, detail, organizationName] = await Promise.all([
     resolveNotificationEmails(db, organizationId, notificationOwnerUserId),
     getScan(db, scanId, organizationId),
+    getOrganizationName(db, organizationId),
   ]);
 
   const scan = detail?.scan;
   const packageLabel = formatPackageLabel(scan?.packageName, scan?.stagedVersion);
-  const dashboardUrl = scanUrl(env, scanId);
+  const dashboardUrl = scanUrl(env, scanId, organizationId);
   const subject =
     outcome === "complete"
       ? `Staged release scan complete — ${packageLabel}`
@@ -47,6 +52,7 @@ export async function notifyScanCompletion(input: NotifyScanCompletionInput): Pr
           "Hi there,",
           "",
           `We finished scanning the staged release ${packageLabel}.`,
+          organizationName ? `Organization: ${organizationName}` : null,
           scan?.risk ? `Overall risk: ${scan.risk}.` : null,
           dashboardUrl ? `Review the report: ${dashboardUrl}` : null,
           "",
@@ -56,6 +62,7 @@ export async function notifyScanCompletion(input: NotifyScanCompletionInput): Pr
           "Hi there,",
           "",
           `We could not complete the staged release scan for ${packageLabel}.`,
+          organizationName ? `Organization: ${organizationName}` : null,
           error?.message ? `Reason: ${error.message}` : null,
           dashboardUrl ? `Review the scan: ${dashboardUrl}` : null,
           "",
@@ -146,7 +153,10 @@ export async function notifyNpmConnectionExpired(
   input: NotifyNpmConnectionExpiredInput,
 ): Promise<void> {
   const { env, db, organizationId, ownerUserId, registryUrl } = input;
-  const recipients = await resolveNotificationEmails(db, organizationId, ownerUserId);
+  const [recipients, organizationName] = await Promise.all([
+    resolveNotificationEmails(db, organizationId, ownerUserId),
+    getOrganizationName(db, organizationId),
+  ]);
   if (recipients.length === 0) {
     await recordScanEvent(db, {
       organizationId,
@@ -157,13 +167,19 @@ export async function notifyNpmConnectionExpired(
     return;
   }
 
-  const settingsLink = settingsUrl(env);
+  // A recipient can watch several organizations from one inbox, so name the org
+  // in both the body and the link — otherwise "your organization" leaves them
+  // guessing which token to replace and lands them on whatever org their browser
+  // last had active.
+  const orgLabel = organizationName ?? "your organization";
+  const settingsLink = settingsUrl(env, organizationId);
   const subject = "Your npm token can no longer reach the staging registry";
   const lines = [
     "Hi there,",
     "",
-    "Drydock can no longer reach the npm staging registry with your saved token, so staged-release reviews are paused for your organization.",
+    `Drydock can no longer reach the npm staging registry with the saved token for ${orgLabel}, so staged-release reviews are paused.`,
     "",
+    organizationName ? `Organization: ${organizationName}` : null,
     `Registry: ${registryUrl}`,
     "",
     settingsLink
@@ -238,10 +254,13 @@ export async function notifyWorkflowGateReview(
     packageCount,
   } = input;
 
-  const recipients = await resolveNotificationEmails(db, organizationId, ownerUserId);
+  const [recipients, organizationName] = await Promise.all([
+    resolveNotificationEmails(db, organizationId, ownerUserId),
+    getOrganizationName(db, organizationId),
+  ]);
 
   const packageLabel = formatPackageLabel(packageName, version);
-  const dashboardUrl = scanUrl(env, scanId);
+  const dashboardUrl = scanUrl(env, scanId, organizationId);
   const otherPackages = packageCount && packageCount > 1 ? packageCount - 1 : 0;
   // A monorepo release fans out into several per-package scans behind one gate;
   // the gate carries only its headline (highest-risk) package. Surface the bundle
@@ -257,6 +276,7 @@ export async function notifyWorkflowGateReview(
     "",
     `A staged release is held in ${repositoryFullName} and is waiting for a decision before it can publish.`,
     "",
+    organizationName ? `Organization: ${organizationName}` : null,
     packageLine,
     `Release risk: ${releaseRisk}`,
     `Repository: ${repositoryFullName}`,
@@ -366,7 +386,10 @@ export async function notifyWorkflowGateTimeout(
     version,
   } = input;
 
-  const recipients = await resolveNotificationEmails(db, organizationId, ownerUserId);
+  const [recipients, organizationName] = await Promise.all([
+    resolveNotificationEmails(db, organizationId, ownerUserId),
+    getOrganizationName(db, organizationId),
+  ]);
   if (recipients.length === 0) {
     await recordScanEvent(db, {
       organizationId,
@@ -379,7 +402,7 @@ export async function notifyWorkflowGateTimeout(
   }
 
   const packageLabel = formatPackageLabel(packageName, version);
-  const dashboardUrl = scanUrl(env, scanId);
+  const dashboardUrl = scanUrl(env, scanId, organizationId);
   const subject = `GitHub gate for ${packageLabel} timed out before scan completed`;
   const lines = [
     "Hi there,",
@@ -387,6 +410,7 @@ export async function notifyWorkflowGateTimeout(
     `The GitHub release gate for ${packageLabel} in ${repositoryFullName} timed out before Drydock finished scanning it.`,
     "GitHub may have already blocked the release because the review did not return inside its decision window.",
     "",
+    organizationName ? `Organization: ${organizationName}` : null,
     `Repository: ${repositoryFullName}`,
     `Environment: ${environment}`,
     "",
@@ -583,23 +607,25 @@ function formatPackageLabel(
   return packageName ?? "a staged release";
 }
 
-function scanUrl(env: Cloudflare.Env, scanId: string): string | null {
+function scanUrl(env: Cloudflare.Env, scanId: string, organizationId?: string): string | null {
   const base = env.BETTER_AUTH_URL;
   if (typeof base !== "string" || !base) return null;
   try {
     const url = new URL(`/dashboard/scans/${encodeURIComponent(scanId)}`, base);
+    if (organizationId) url.searchParams.set("org", organizationId);
     return url.toString();
   } catch {
     return null;
   }
 }
 
-function settingsUrl(env: Cloudflare.Env): string | null {
+function settingsUrl(env: Cloudflare.Env, organizationId?: string): string | null {
   const base = env.BETTER_AUTH_URL;
   if (typeof base !== "string" || !base) return null;
   try {
     const url = new URL("/dashboard/settings", base);
     url.searchParams.set("tab", "integrations");
+    if (organizationId) url.searchParams.set("org", organizationId);
     return url.toString();
   } catch {
     return null;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import { hydrate, render } from "preact";
 import { ErrorBoundary, LocationProvider, Route, Router, lazy, prerender as ssr } from "preact-iso";
 import { Toaster } from "./components/Toast";
+import { applyActiveOrganizationFromUrl } from "./models/active-organization";
 import { extractPrerenderHead, getPageSeoMetadata } from "./lib/seo";
 import {
   isDashboardShellRoute,
@@ -61,6 +62,13 @@ function emptyAppShell() {
 if (typeof window !== "undefined") {
   const appElement = document.getElementById("app");
   if (!appElement) throw new Error("App element not found");
+  // Adopt an emailed `?org=<id>` deep-link before the router mounts so the first
+  // org-scoped request (which reads the active org from localStorage) targets the
+  // organization the link is about. Scoped to the dashboard, the only surface the
+  // param means anything on.
+  if (location.pathname.startsWith("/dashboard")) {
+    applyActiveOrganizationFromUrl();
+  }
   if (isPrerenderedRoute(location.pathname) && appElement.firstChild) {
     hydrate(<App />, appElement);
   } else {

--- a/src/models/active-organization.ts
+++ b/src/models/active-organization.ts
@@ -2,6 +2,9 @@ import { signal } from "@preact/signals";
 
 export const ACTIVE_ORG_HEADER = "x-organization-id";
 const STORAGE_KEY = "drydock:active-organization-id";
+// Notification emails deep-link with `?org=<id>` so a link opens the organization
+// the alert is about — not whichever org this browser last had active.
+const ACTIVE_ORG_QUERY_PARAM = "org";
 
 function readStored(): string | null {
   if (typeof localStorage === "undefined") return null;
@@ -24,4 +27,27 @@ export function setActiveOrganizationId(id: string | null) {
   } catch {
     // localStorage may be blocked; in-memory signal still updates.
   }
+}
+
+/**
+ * Adopt an `?org=<id>` deep-link into the stored active organization, then strip
+ * the param from the URL. Notification emails append it so their links (Settings,
+ * a scan report, a release gate) land on the organization the email is about
+ * rather than whatever org this browser last used.
+ *
+ * The id is trusted only as an optimistic starting point: it sets the header the
+ * next request sends, and `OrganizationModel.load()` re-points to a real
+ * membership if it isn't one the user belongs to. We drop the param afterwards so
+ * a later list reload (rename, delete, gate refresh) can't snap the org back to
+ * the link's value after the user has switched away. No-op outside the browser
+ * and when the param is absent.
+ */
+export function applyActiveOrganizationFromUrl() {
+  if (typeof window === "undefined") return;
+  const url = new URL(window.location.href);
+  const requested = url.searchParams.get(ACTIVE_ORG_QUERY_PARAM);
+  if (!requested) return;
+  setActiveOrganizationId(requested);
+  url.searchParams.delete(ACTIVE_ORG_QUERY_PARAM);
+  window.history.replaceState(window.history.state, "", `${url.pathname}${url.search}${url.hash}`);
 }

--- a/test/active-organization-model.test.ts
+++ b/test/active-organization-model.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  activeOrganizationId,
+  applyActiveOrganizationFromUrl,
+  setActiveOrganizationId,
+} from "../src/models/active-organization";
+
+interface WindowStub {
+  replacedTo: string | null;
+}
+
+// The node test environment has no `window`; stand up the minimal surface the
+// helper touches (location.href to read, history.replaceState to strip the param).
+function stubWindow(href: string): WindowStub {
+  const stub: WindowStub = { replacedTo: null };
+  (globalThis as { window?: unknown }).window = {
+    location: { href },
+    history: {
+      state: { marker: "keep" },
+      replaceState: (_state: unknown, _title: string, next: string) => {
+        stub.replacedTo = next;
+      },
+    },
+  };
+  return stub;
+}
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window;
+  setActiveOrganizationId(null);
+});
+
+describe("applyActiveOrganizationFromUrl", () => {
+  test("adopts ?org= into the active organization and strips only that param", () => {
+    const win = stubWindow("https://drydock.test/dashboard/settings?tab=integrations&org=org_9");
+
+    applyActiveOrganizationFromUrl();
+
+    expect(activeOrganizationId.value).toBe("org_9");
+    // Keeps the tab param, drops org, leaves the path intact.
+    expect(win.replacedTo).toBe("/dashboard/settings?tab=integrations");
+  });
+
+  test("strips the org param from a scan deep-link", () => {
+    const win = stubWindow("https://drydock.test/dashboard/scans/scan_1?org=org_9");
+
+    applyActiveOrganizationFromUrl();
+
+    expect(activeOrganizationId.value).toBe("org_9");
+    expect(win.replacedTo).toBe("/dashboard/scans/scan_1");
+  });
+
+  test("is a no-op when no org param is present", () => {
+    setActiveOrganizationId("existing_org");
+    const win = stubWindow("https://drydock.test/dashboard/settings?tab=integrations");
+
+    applyActiveOrganizationFromUrl();
+
+    expect(activeOrganizationId.value).toBe("existing_org");
+    expect(win.replacedTo).toBeNull();
+  });
+
+  test("does nothing outside the browser", () => {
+    setActiveOrganizationId("existing_org");
+
+    expect(() => applyActiveOrganizationFromUrl()).not.toThrow();
+    expect(activeOrganizationId.value).toBe("existing_org");
+  });
+});

--- a/test/notify.test.mjs
+++ b/test/notify.test.mjs
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 const dbMock = vi.hoisted(() => ({
   getOrganizationOwnerUserId: vi.fn(),
+  getOrganizationName: vi.fn(),
   getScan: vi.fn(),
   resolveNotificationEmails: vi.fn(),
   getSlackConnectionSecret: vi.fn(),
@@ -94,6 +95,7 @@ function npmConnectionExpiredInput(overrides = {}) {
 
 beforeEach(() => {
   dbMock.getOrganizationOwnerUserId.mockResolvedValue("user_1");
+  dbMock.getOrganizationName.mockResolvedValue("Acme Corp");
   dbMock.resolveNotificationEmails.mockResolvedValue(["owner@example.com"]);
   dbMock.getSlackConnectionSecret.mockResolvedValue(null);
   dbMock.getScan.mockResolvedValue({
@@ -106,6 +108,7 @@ beforeEach(() => {
 
 afterEach(() => {
   dbMock.getOrganizationOwnerUserId.mockReset();
+  dbMock.getOrganizationName.mockReset();
   dbMock.resolveNotificationEmails.mockReset();
   dbMock.getSlackConnectionSecret.mockReset();
   dbMock.getScan.mockReset();
@@ -125,10 +128,11 @@ describe("notifyWorkflowGateReview", () => {
     expect(message.to).toBe("owner@example.com");
     expect(message.subject).toContain("demo-package@1.2.0");
     expect(message.text).toContain("demo-package@1.2.0");
+    expect(message.text).toContain("Organization: Acme Corp");
     expect(message.text).toContain("Release risk: high");
     expect(message.text).toContain("Repository: octo/example");
     expect(message.text).toContain("Environment: pypi");
-    expect(message.text).toContain("https://drydock.test/dashboard/scans/scan_1");
+    expect(message.text).toContain("https://drydock.test/dashboard/scans/scan_1?org=org_1");
 
     expect(dbMock.recordScanEvent).toHaveBeenCalledTimes(1);
     const [, event] = dbMock.recordScanEvent.mock.calls[0];
@@ -221,13 +225,17 @@ describe("notifyWorkflowGateReview", () => {
 });
 
 describe("notifyNpmConnectionExpired", () => {
-  test("emails the integrations tab link for replacing the npm token", async () => {
+  test("names the organization and deep-links the integrations tab to it", async () => {
     await notifyNpmConnectionExpired(npmConnectionExpiredInput());
 
     expect(emailMock.sendNotificationEmail).toHaveBeenCalledTimes(1);
     const [, message] = emailMock.sendNotificationEmail.mock.calls[0];
     expect(message.subject).toBe("Your npm token can no longer reach the staging registry");
-    expect(message.text).toContain("https://drydock.test/dashboard/settings?tab=integrations");
+    expect(message.text).toContain("with the saved token for Acme Corp");
+    expect(message.text).toContain("Organization: Acme Corp");
+    expect(message.text).toContain(
+      "https://drydock.test/dashboard/settings?tab=integrations&org=org_1",
+    );
     expect(message.text).toContain("Registry: https://registry.npmjs.org");
 
     expect(dbMock.recordScanEvent).toHaveBeenCalledTimes(1);
@@ -242,6 +250,20 @@ describe("notifyNpmConnectionExpired", () => {
         recipient: "owner@example.com",
       },
     });
+  });
+
+  test("falls back to a generic phrasing without an Organization line when the org name is gone", async () => {
+    dbMock.getOrganizationName.mockResolvedValue(null);
+
+    await notifyNpmConnectionExpired(npmConnectionExpiredInput());
+
+    const [, message] = emailMock.sendNotificationEmail.mock.calls[0];
+    expect(message.text).toContain("with the saved token for your organization");
+    expect(message.text).not.toContain("Organization:");
+    // The link stays org-scoped even when the display name is unavailable.
+    expect(message.text).toContain(
+      "https://drydock.test/dashboard/settings?tab=integrations&org=org_1",
+    );
   });
 });
 
@@ -264,8 +286,9 @@ describe("notifyScanCompletion", () => {
     expect(emailMock.sendNotificationEmail).toHaveBeenCalledTimes(2);
     const [, message] = emailMock.sendNotificationEmail.mock.calls[0];
     expect(message.subject).toContain("demo-package@1.2.0");
+    expect(message.text).toContain("Organization: Acme Corp");
     expect(message.text).toContain("Overall risk: high");
-    expect(message.text).toContain("https://drydock.test/dashboard/scans/scan_1");
+    expect(message.text).toContain("https://drydock.test/dashboard/scans/scan_1?org=org_1");
 
     expect(dbMock.recordScanEvent).toHaveBeenCalledTimes(2);
     for (const [, event] of dbMock.recordScanEvent.mock.calls) {


### PR DESCRIPTION
Alert emails go to an org's notification recipients, but one inbox can receive alerts for several organizations — the body said "your organization" without naming it, and every link opened whatever org the browser last had active (localStorage) rather than the org the email was about. This adds a `?org=<id>` deep-link that `applyActiveOrganizationFromUrl()` adopts into the active org before the router mounts (then strips), so a link targets the right org even on the scan-detail page, which never loads the org list; `OrganizationModel.load()` re-points if the id isn't a real membership. The npm-token-expired, scan complete/failed, and workflow-gate review/timeout emails now name the org (adding an `Organization:` line) and make their Settings/scan links `?org=`-scoped, with a graceful fallback to "your organization" when the name is unavailable. The invite email already names its org and the account-verification email is pre-org, so both are left as-is; Slack messages are untouched since a channel is already bound to one org. Adds a frontend test suite for the deep-link helper and extends the notify tests; `pnpm run verify` passes and docs were checked (delivery mechanism and audit events are documented, not email body text or link formats — no update needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)