### PR TITLE
Make the ai-review flag a killswitch that is on by default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
   - `routes/github-webhooks.ts` — public signed GitHub App webhook endpoint. Persists `deployment_protection_rule` deliveries into `github_workflow_gates`; see `docs/workflow-gates.md`, `docs/npm-workflow-gate.md`, `docs/pypi-workflow-gate.md`, and `docs/vscode-workflow-gate.md`.
   - `lib/sandbox.ts` — Dynamic Worker that downloads/parses package artifacts. `NpmStageGateway` is the only npm-token egress.
   - `lib/review.ts` — deterministic findings, package/package.json diffing, risk computation, and shared UI types.
-  - `lib/ai-review.ts` — Workers AI reviewer, wired via `scan-pipeline.ts` and default-off behind the `ai-review` Flagship flag.
+  - `lib/ai-review.ts` — Workers AI reviewer, wired via `scan-pipeline.ts` and on by default behind the `ai-review` Flagship killswitch.
   - `lib/adapters/` — ecosystem-specific registry/artifact behavior for npm, PyPI, VS Code, and workflow gates.
   - `db/` — Drizzle schema and persistence helpers for scans, findings, artifacts, workflow gates, and Better Auth.
 - `src/` — Preact UI. `index.tsx` mounts `preact-iso`; `models/` re-use `server/` types.
@@ -19,7 +19,7 @@
 
 - Package bytes are hostile evidence. Never execute package code, install dependencies, run lifecycle scripts, import modules, run builds, invoke shells, or render package-provided active content.
 - npm credentials stay outside the sandbox. Only `NpmStageGateway` may attach npm auth, only for allowed staged/metadata/tarball registry endpoints.
-- The AI reviewer is advisory and default-off behind the per-organization `ai-review` flag. It cannot downgrade deterministic findings.
+- The AI reviewer is advisory and on by default; the per-organization `ai-review` flag is a killswitch that disables it. It cannot downgrade deterministic findings.
 - D1/Better Auth are required for every non-auth `/api/*` endpoint; resource ownership must be organization-scoped.
 - Operational logs/events must be structured and secret-redacted. Never log raw tokens, headers, package contents, or unredacted errors.
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Consult route definitions under `server/routes/` for exact request/response shap
 - Package artifacts are untrusted evidence and are never executed.
 - npm credentials are encrypted at rest, decrypted only for registry access, and never passed into the Dynamic Worker sandbox.
 - The sandbox can fetch only through constrained brokers/gateways and returns bounded metadata/text evidence.
-- AI review is default-off, advisory, and cannot downgrade deterministic findings.
+- AI review is advisory and on by default behind the `ai-review` killswitch, and cannot downgrade deterministic findings.
 - Raw tarballs are not retained by default; persisted reports use redacted summaries and canonical report JSON.
 
 See [`docs/security-model.md`](docs/security-model.md) for the full contract.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,7 +67,7 @@ Cron-triggered npm discovery finds staged publishes for organizations with valid
 - **D1** — Better Auth tables, organizations, npm connections, scans, scan files/findings, workflow gates, release targets, summaries, and audit/event metadata. D1 remains the operational source of truth.
 - **R2** — canonical report JSON and redacted file/diff artifacts. D1 keeps compact metadata and historical fallback samples so list/detail pages remain cheap.
 - **KV** — session-related state where configured.
-- **Workers AI / AI Gateway** — optional advisory review path. The per-organization `ai-review` Flagship flag is off by default; deterministic findings remain authoritative.
+- **Workers AI / AI Gateway** — optional advisory review path. The per-organization `ai-review` Flagship flag is a killswitch that is on by default; deterministic findings remain authoritative.
 
 ## Organization and auth model
 

--- a/docs/diff-baseline.md
+++ b/docs/diff-baseline.md
@@ -44,7 +44,7 @@ The pipeline cross-checks staged detail package name/version against the staged 
 
 ## AI evidence budget impact
 
-AI review is Flagship-gated and off by default, but when enabled for an organization it should remain diff-first:
+AI review is Flagship-gated and on by default (the `ai-review` flag is a killswitch), and while it runs for an organization it should remain diff-first:
 
 - deterministic findings stay authoritative and are computed before AI;
 - AI sees the ecosystem id, normalized manifest diff, release-delta deterministic findings, changed-file diff, and bounded samples for changed files only;

--- a/docs/release-safety.md
+++ b/docs/release-safety.md
@@ -36,7 +36,7 @@ for the lifecycle behavior behind it.
 - Archive parsing fails closed on traversal, symlinks/hardlinks, malformed
   archives, excessive files, and excessive expanded size.
 - Deterministic findings are authoritative while AI review is unavailable, and AI
-  cannot downgrade deterministic findings when the Flagship gate enables it.
+  cannot downgrade deterministic findings when it runs.
 - AI review fails safe: an enabled review that was attempted but could not complete
   escalates the scan to manual-review risk rather than reading as clean, and a
   near-miss submission is clamped to bounds instead of discarded. See

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -1,6 +1,6 @@
 # Security detection corpus
 
-Drydock's deterministic findings are the authoritative review signal while AI review is unavailable behind the default-off feature gate. The detection corpus exists to make those findings measurable: every rule change should be checked against small, reviewable package scenarios with explicit expected rule IDs, severities, and risk.
+Drydock's deterministic findings are the authoritative review signal; AI review stays advisory behind the `ai-review` killswitch and cannot downgrade them. The detection corpus exists to make those findings measurable: every rule change should be checked against small, reviewable package scenarios with explicit expected rule IDs, severities, and risk.
 
 This is a **safe synthetic corpus**, not a malware zoo. It captures techniques observed in npm supply-chain research without vendoring live malicious packages, encrypted malware archives, real credentials, or private artifacts.
 

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -24,7 +24,7 @@ Drydock handles hostile package artifacts, private review evidence, and npm cred
 - **No approval automation.** Drydock must not run `npm stage approve`, collect npm 2FA codes, publish packages, or represent AI output as release approval.
 - **No package execution.** Do not execute package code, install dependencies, run lifecycle scripts, import modules, run builds, invoke shells, or render package-provided active content.
 - **No npm token in the sandbox.** The Dynamic Worker must never receive npm token material. Only `NpmStageGateway` may attach npm authorization, and only for allowlisted npm registry endpoints.
-- **AI is advisory and default-off.** Workers AI is gated by the per-organization Flagship `ai-review` flag. Deterministic findings remain authoritative and cannot be downgraded by AI output.
+- **AI is advisory and on by default.** Workers AI runs behind the per-organization Flagship `ai-review` killswitch; set the flag to false to disable it for an organization or globally. Deterministic findings remain authoritative and cannot be downgraded by AI output.
 - **Fail closed.** Artifact acquisition, validation, parsing, report generation, workflow-gate callback, and credential checks must block/reject on uncertainty rather than silently approving.
 
 ## Credential posture

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -74,8 +74,9 @@ edits in pull requests you send back upstream.
 - `d1_databases[].database_id` and `kv_namespaces[].id`;
 - custom `routes` with your own custom domain, or remove `routes` and use the
   generated `workers_dev` subdomain instead;
-- the `flagship` app id if you use Cloudflare Flagship for AI review, or remove
-  the `flagship` block to keep AI review disabled;
+- the `flagship` app id to wire the `ai-review` killswitch (with Flagship wired,
+  the AI reviewer is on by default per organization and can be switched off per
+  org or globally), or remove the `flagship` block to keep AI review disabled;
 - public integration vars such as `BETTER_AUTH_URL`, `EMAIL_FROM_ADDRESS`,
   `GITHUB_APP_ID`, `GITHUB_APP_SLUG`, `GITHUB_APP_CLIENT_ID`, and
   `SLACK_CLIENT_ID`.

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -132,8 +132,9 @@ interface AiReviewArgs {
 
 async function maybeRunAiReview(args: AiReviewArgs): Promise<AiReview> {
   // AI review is gated by the Cloudflare Flagship `ai-review` flag in the
-  // `drydock` app, evaluated per-organization. Default-off until Flagship
-  // returns true for the organization placing the scan.
+  // `drydock` app, evaluated per-organization. The flag is a killswitch: the
+  // reviewer is on by default, and Flagship returning false for an organization
+  // (or globally) disables it. Without a Flagship binding the reviewer stays off.
   const disabled: AiReview = {
     status: "unavailable",
     risk: "low",
@@ -144,7 +145,7 @@ async function maybeRunAiReview(args: AiReviewArgs): Promise<AiReview> {
     model: null,
   };
   const aiReviewEnabled = args.env.FLAGS
-    ? await args.env.FLAGS.getBooleanValue("ai-review", false, {
+    ? await args.env.FLAGS.getBooleanValue("ai-review", true, {
         targetingKey: args.identity.organizationId,
         organizationId: args.identity.organizationId,
       })
@@ -152,10 +153,11 @@ async function maybeRunAiReview(args: AiReviewArgs): Promise<AiReview> {
   if (!aiReviewEnabled) return disabled;
 
   // Loaded lazily so the Vercel AI SDK + workers-ai-provider stay out of the
-  // Worker's boot graph: AI review is off by default, so pulling these heavy
-  // modules eagerly would tax every cold start (and every per-file test isolate)
-  // for a path most scans never take. AI_MODEL rides along — it lives in the same
-  // module, so importing it statically would defeat the point.
+  // Worker's boot graph: this path is skipped whenever the killswitch is off or
+  // no Flagship binding is wired, so pulling these heavy modules eagerly would tax
+  // every cold start (and every per-file test isolate) for a path many scans skip.
+  // AI_MODEL rides along — it lives in the same module, so importing it statically
+  // would defeat the point.
   const { runSelectiveAiReview, AI_MODEL } = await import("./ai-review");
 
   const startedAtMs = Date.now();

--- a/test/scan-pipeline.test.mjs
+++ b/test/scan-pipeline.test.mjs
@@ -292,6 +292,70 @@ describe("scan pipeline baseline selection", () => {
     expect(dbMock.persistScan).toHaveBeenCalled();
   });
 
+  test("runs AI review by default when the killswitch is not disabled", async () => {
+    // Flagship with no explicit rule returns the default we pass. The `ai-review`
+    // flag is a killswitch, so that default is `true` and the reviewer runs.
+    const getBooleanValue = vi.fn(async (_flag, defaultValue) => defaultValue);
+    aiReviewMock.runSelectiveAiReview.mockResolvedValue({
+      review: {
+        status: "complete",
+        risk: "low",
+        releaseAssessment: "nothing_unusual",
+        summary: "Nothing unusual in the staged release.",
+        findings: [],
+        requiresManualReview: false,
+        model: "@cf/moonshotai/kimi-k2.7-code",
+      },
+      usage: null,
+    });
+    const context = {
+      ...baseContext,
+      env: { ...baseContext.env, FLAGS: { getBooleanValue } },
+    };
+
+    const result = await runScanPipeline(context, npmAdapter, {
+      scanId: "scan_ai_default_on",
+      stageId: "stage-beta-123",
+      organizationId: "org_1",
+    });
+
+    expect(getBooleanValue).toHaveBeenCalledWith(
+      "ai-review",
+      true,
+      expect.objectContaining({ organizationId: "org_1" }),
+    );
+    expect(aiReviewMock.runSelectiveAiReview).toHaveBeenCalled();
+    expect(result.aiFindings).toMatchObject({
+      status: "complete",
+      summary: "Nothing unusual in the staged release.",
+    });
+  });
+
+  test("skips AI review when the killswitch disables it", async () => {
+    const getBooleanValue = vi.fn(async () => false);
+    const context = {
+      ...baseContext,
+      env: { ...baseContext.env, FLAGS: { getBooleanValue } },
+    };
+
+    const result = await runScanPipeline(context, npmAdapter, {
+      scanId: "scan_ai_killswitch_off",
+      stageId: "stage-beta-123",
+      organizationId: "org_1",
+    });
+
+    expect(getBooleanValue).toHaveBeenCalledWith(
+      "ai-review",
+      true,
+      expect.objectContaining({ organizationId: "org_1" }),
+    );
+    expect(aiReviewMock.runSelectiveAiReview).not.toHaveBeenCalled();
+    expect(result.aiFindings).toMatchObject({
+      status: "unavailable",
+      summary: "AI review is disabled.",
+    });
+  });
+
   test("preserves diff-scoped deterministic findings from the npm adapter", async () => {
     stagedMock.fetchStagedPublishDetails.mockResolvedValue({
       id: "stage-diff123",

--- a/wrangler.template.jsonc
+++ b/wrangler.template.jsonc
@@ -31,9 +31,10 @@
 	"ai": {
 		"binding": "AI"
 	},
-	// Optional: only needed if you use Cloudflare Flagship to gate the AI
-	// reviewer. Remove this block to keep AI review disabled, or set your own
-	// Flagship app id.
+	// Optional: wires the Cloudflare Flagship `ai-review` killswitch. With it
+	// present the AI reviewer is on by default per organization and can be
+	// switched off per org (or globally) via Flagship. Remove this block to
+	// keep AI review disabled, or set your own Flagship app id.
 	"flagship": [
 		{
 			"binding": "FLAGS",


### PR DESCRIPTION
The `ai-review` Flagship flag now defaults to on (`getBooleanValue("ai-review", true, …)` in `server/lib/scan-pipeline.ts`), so the advisory AI reviewer runs on the staged-publish path by default and the flag disables it — per organization or globally — rather than opting in. Without a Flagship binding wired the reviewer still stays off, and it remains advisory: it cannot downgrade deterministic findings. Docs, project instructions (`AGENTS.md`), `README.md`, and the `wrangler.template.jsonc` comment are reworded from "default-off/opt-in" to killswitch semantics. Added two `scan-pipeline` tests covering the default-on path (Flagship's default is honored as `true`) and the killswitch-off path (flag `false` skips the reviewer). Verified with typecheck, oxfmt, oxlint, and the scan-pipeline suite (13 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)