### PR TITLE
Implement Drydock observability foundation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,8 @@ The user-facing learning guide is [`../src/pages/Docs/index.tsx`](../src/pages/D
 - [`e2e-test-environment.md`](./e2e-test-environment.md) — fake registry and Playwright harness.
 - [`tooling.md`](./tooling.md) — oxlint/oxfmt/typecheck, signals lint rules, route/client helpers.
 - [`agent-tour.md`](./agent-tour.md) — portable product walkthrough artifacts.
-- [`observability-proposal.md`](./observability-proposal.md) — proposed runtime, customer, adoption, journey, support, and LLM observability model.
+- [`observability.md`](./observability.md) — implemented runtime event contract, tracing, analytics, milestones, data safety, and operator setup.
+- [`observability-proposal.md`](./observability-proposal.md) — design rationale and remaining customer-health, support, dashboard, and LLM-tool roadmap.
 - [`test-package.md`](./test-package.md) — package fixture used for manual staged-publish checks.
 
 ## Domain docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ The user-facing learning guide is [`../src/pages/Docs/index.tsx`](../src/pages/D
 - [`e2e-test-environment.md`](./e2e-test-environment.md) — fake registry and Playwright harness.
 - [`tooling.md`](./tooling.md) — oxlint/oxfmt/typecheck, signals lint rules, route/client helpers.
 - [`agent-tour.md`](./agent-tour.md) — portable product walkthrough artifacts.
+- [`observability-proposal.md`](./observability-proposal.md) — proposed runtime, customer, adoption, journey, support, and LLM observability model.
 - [`test-package.md`](./test-package.md) — package fixture used for manual staged-publish checks.
 
 ## Domain docs

--- a/docs/observability-proposal.md
+++ b/docs/observability-proposal.md
@@ -373,15 +373,15 @@ Use it for exact activation, support, and lifecycle queries. Use Analytics Engin
 
 Telemetry must not flood D1. Every store this proposal adds declares a retention window and a pruning path up front; no telemetry table is allowed to grow unbounded. The existing precedent is `pruneAuditEventsOlderThan` running on each scheduled tick ([`docs/audit-log.md`](./audit-log.md)); new stores follow the same pattern.
 
-| Store | Growth shape | Retention | Wipe mechanism |
-| --- | --- | --- | --- |
-| D1 domain state (scans, gates, decisions) | Product data | Product lifecycle | Existing org/scan cascade and account deletion |
-| D1 `scan_events` (audit) | Append-only | 90 days (existing) | Existing scheduled prune |
-| D1 `organization_milestones` | One row per (organization, milestone) — bounded by design | Lifetime of the organization | Org cascade delete; no age prune needed |
-| D1 daily cohort/health rollups | One row per org/cohort per day | 13 months (one year of trends plus comparison margin) | Age prune on scheduled tick |
-| D1 support references / incident bundles | Append-only | 90 days, matching the audit window | Age prune on scheduled tick |
-| Workers Logs / traces | Platform-managed | Platform retention | None needed |
-| Analytics Engine | Platform-managed | 3 months, platform-enforced | None needed |
+| Store                                     | Growth shape                                              | Retention                                             | Wipe mechanism                                 |
+| ----------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------- | ---------------------------------------------- |
+| D1 domain state (scans, gates, decisions) | Product data                                              | Product lifecycle                                     | Existing org/scan cascade and account deletion |
+| D1 `scan_events` (audit)                  | Append-only                                               | 90 days (existing)                                    | Existing scheduled prune                       |
+| D1 `organization_milestones`              | One row per (organization, milestone) — bounded by design | Lifetime of the organization                          | Org cascade delete; no age prune needed        |
+| D1 daily cohort/health rollups            | One row per org/cohort per day                            | 13 months (one year of trends plus comparison margin) | Age prune on scheduled tick                    |
+| D1 support references / incident bundles  | Append-only                                               | 90 days, matching the audit window                    | Age prune on scheduled tick                    |
+| Workers Logs / traces                     | Platform-managed                                          | Platform retention                                    | None needed                                    |
+| Analytics Engine                          | Platform-managed                                          | 3 months, platform-enforced                           | None needed                                    |
 
 Rules:
 

--- a/docs/observability-proposal.md
+++ b/docs/observability-proposal.md
@@ -1,0 +1,674 @@
+# Drydock observability proposal
+
+**Status:** proposal  
+**Date:** 2026-07-14  
+**Scope:** runtime reliability, customer pain, adoption, user journeys, support, and safe LLM access
+
+## Executive recommendation
+
+Drydock should treat observability as a versioned product data contract, not as a collection of log statements.
+
+The goal is that a person or an authorized LLM can answer these questions in minutes, with evidence:
+
+- Is Drydock working for customers right now?
+- Which customers are blocked, at what step, and by which stable error code?
+- What changed after a deployment?
+- Where do organizations abandon setup?
+- How long does it take an organization to reach its first protected release?
+- Which product paths create repeated value and retention?
+- What exactly happened for a support reference, scan, workflow gate, or organization?
+
+The recommended stack is:
+
+1. **D1 remains the exact domain truth.** Add a compact organization-milestone projection for exact first/last value timestamps and counts. Do not turn the organization audit log into product analytics.
+2. **Cloudflare Workers Logs and traces hold diagnostic evidence.** Emit one structured JSON object per event, enable source maps and sampled traces, and add custom spans around the scan and workflow-gate phases.
+3. **Workers Analytics Engine holds high-cardinality product and service aggregates.** It is appropriate for funnels, rates, durations, and per-organization health trends, but not audit, billing, or exact lifetime facts because it can sample and currently retains data for three months.
+4. **A hosted issue tracker is optional, not canonical.** If Cloudflare's error investigation is insufficient, export logs and traces over OTLP to Sentry or an equivalent provider for issue grouping, regressions, ownership, and alerting. Keep the event contract provider-neutral and require an approved data-processing agreement, region, retention policy, and deletion path.
+5. **LLMs receive tools, not a log dump.** Use Cloudflare's official Workers Observability MCP for runtime investigation and add a narrow, read-only Drydock tool service for customer health, timelines, funnels, release comparisons, and support-reference lookup.
+6. **Production session replay is deferred.** Drydock renders hostile package evidence, so replay creates disproportionate privacy and leakage risk. Start with semantic journey events and the existing local Playwright/agent-tour traces. If replay is added later, use an explicit page allowlist; never record scan/detail, diff, credential, account, 2FA, or organization-settings surfaces; and mask all text and inputs by default.
+
+This produces a useful first version without introducing a warehouse or a large analytics SDK into the critical Worker path.
+
+## What exists today
+
+Drydock already has strong pieces to build on:
+
+- [`server/lib/observability.ts`](../server/lib/observability.ts) emits structured operational events and recursively redacts sensitive-looking keys and bearer values.
+- The scan pipeline, queue, scheduled discovery, GitHub webhook, workflow-gate, artifact-storage, and AI-review paths already emit named events.
+- [`wrangler.jsonc`](../wrangler.jsonc) enables Workers Logs and invocation logs.
+- D1 stores scans, gates, release decisions, integrations, and a 90-day organization audit log in `scan_events`.
+- Scan records already contain timestamps, source, status, risk, findings, decisions, safe error JSON, and artifact metadata.
+- The UI already shows safe error codes in important paths and exposes a feedback mail link.
+
+The current gaps are structural:
+
+- Operational event payloads are not a typed or versioned contract.
+- `console.log(event, payload)` does not make the sanitized payload the sole top-level structured log object.
+- Events do not consistently include an event ID, deployment/release, request or journey ID, phase, outcome, customer visibility, or error fingerprint.
+- `describeOperationalError()` includes arbitrary error messages. Key-based token redaction is valuable but cannot prove that registry responses, package names, URLs, or package-derived text never enter telemetry.
+- Runtime events are rich around scan execution but sparse around setup, activation, collaboration, feedback, and customer recovery.
+- There is no exact organization-milestone projection, adoption funnel, health view, or support timeline.
+- Logs can correlate by `scanId`, `gateId`, and `organizationId` in some paths, but there is no single correlation model across browser requests, queue work, webhooks, scheduled discovery, and notifications.
+- Logs are enabled, but traces and source-map upload are not configured.
+- The audit log is intentionally curated for customer-visible administrative history. Reusing it for high-volume telemetry would weaken both purposes.
+
+## Principles
+
+### Observe customer value, not page views
+
+The primary adoption signals should be server-confirmed domain outcomes: an integration validated, a release target created, a scan completed, a gate review became ready, a release decision was delivered, or a teammate accepted an invitation.
+
+UI events are useful for finding friction between those outcomes, but should not define activation or retention.
+
+### Preserve four distinct records
+
+| Record                | Purpose                                      | Store                            | Exact?                        | Customer-visible?      |
+| --------------------- | -------------------------------------------- | -------------------------------- | ----------------------------- | ---------------------- |
+| Domain state          | What is true now                             | D1 core tables                   | Yes                           | Through product UI/API |
+| Audit event           | Who changed an important setting or decision | D1 `scan_events`                 | Yes, within retention         | Yes, curated           |
+| Operational telemetry | Why and where execution succeeded or failed  | Workers Logs/traces              | Subject to retention/sampling | No                     |
+| Product analytics     | How cohorts adopt and receive value          | Analytics Engine + D1 milestones | Aggregate; milestones exact   | No                     |
+
+One action may update more than one record, but each record has a different schema and retention policy.
+
+### Make every failure classifiable
+
+Every customer-visible failure should have:
+
+- a stable `error.code` from a registry;
+- `error.class`: `product_bug`, `customer_configuration`, `external_dependency`, `policy_block`, or `expected_control_flow`;
+- `error.phase`, such as `auth`, `integration_validation`, `artifact_acquisition`, `archive_parse`, `deterministic_review`, `ai_review`, `persistence`, `notification`, or `decision_callback`;
+- `error.retryable` and `error.customer_visible`;
+- a deterministic `error.fingerprint`;
+- an opaque support `reference_id` shown to the user;
+- an owner/runbook mapping.
+
+Raw exception messages are diagnostic input, not identifiers. Unknown exceptions should become `internal.unclassified` plus a source-mapped stack in the restricted error sink; they should not send arbitrary messages or local variables to product analytics.
+
+### Make telemetry safe by construction
+
+Use explicit event schemas and per-sink allowlists rather than attempting to redact arbitrary objects after the fact. Sanitization remains a final defense.
+
+Never emit:
+
+- authorization, cookies, tokens, secrets, ciphertext, nonces, or token fingerprints;
+- package file contents, diffs, manifests, AI prompts/responses, or finding evidence;
+- request/response bodies or headers;
+- package-derived error text or unbounded external-provider responses;
+- email addresses, names, IP addresses, or raw user-agent strings;
+- full registry or artifact URLs;
+- free-form release decision reasons or customer feedback text;
+- third-party trace baggage containing organization or user identity.
+
+Opaque internal `organizationId`, `scanId`, and `gateId` values may appear in restricted operational telemetry for correlation. Product analytics should use a separately keyed pseudonymous organization identifier. User identifiers should be one-way pseudonyms outside D1.
+
+## Canonical event contract
+
+Create a discriminated TypeScript union under `server/lib/telemetry/` and make all sinks accept only that union. The shape below is conceptual; the implementation should flatten fields where the destination queries more efficiently.
+
+```json
+{
+  "event": {
+    "id": "evt_01...",
+    "name": "scan.pipeline.failed",
+    "version": 1,
+    "occurred_at": "2026-07-14T09:42:11.120Z"
+  },
+  "severity": "error",
+  "service": {
+    "name": "drydock-worker",
+    "version": "git-sha-or-worker-version",
+    "environment": "production"
+  },
+  "correlation": {
+    "request_id": "req_01...",
+    "journey_id": "jny_01...",
+    "scan_id": "scan_01...",
+    "gate_id": null,
+    "delivery_id": null
+  },
+  "tenant": {
+    "organization_id": "org_01..."
+  },
+  "actor": {
+    "kind": "user",
+    "id_hash": "usrh_..."
+  },
+  "product": {
+    "surface": "manual_scan",
+    "ecosystem": "npm",
+    "phase": "artifact_acquisition"
+  },
+  "outcome": {
+    "status": "failure",
+    "error_code": "registry.auth.insufficient_scope",
+    "error_class": "customer_configuration",
+    "error_fingerprint": "v1:...",
+    "retryable": false,
+    "customer_visible": true
+  },
+  "measurements": {
+    "duration_ms": 412,
+    "attempt": 1
+  }
+}
+```
+
+Contract rules:
+
+- Event names use `domain.object.past_tense_outcome` and never embed values.
+- Every event declares its schema version; incompatible changes create a new version.
+- Dimensions are enumerated strings with bounded cardinality, except explicitly documented opaque correlation IDs.
+- Durations use milliseconds and counts are numeric.
+- The deployment identifier is present on every event so release regressions are queryable.
+- Error fingerprints are produced by code, never by an LLM.
+- The typed schema defines the fields allowed in each sink: logs, traces, Analytics Engine, audit, and support.
+- Contract tests serialize every event variant and assert that denied keys and representative secrets cannot escape.
+
+Suggested layout:
+
+```text
+server/lib/telemetry/
+  context.ts       request, organization, actor, release, and correlation context
+  events.ts        versioned event union and event-name registry
+  errors.ts        stable error catalog, classification, ownership, and fingerprints
+  emit.ts          sink projection and final sanitization
+  analytics.ts     Analytics Engine ordered-column mapping
+  milestones.ts    exact D1 milestone upserts
+test/telemetry-contract.test.mjs
+docs/observability.md
+docs/runbooks/
+```
+
+## Correlation and tracing
+
+Use two complementary correlation mechanisms.
+
+### Platform trace
+
+Enable Cloudflare tracing with a conservative production head sample, initially 10%, and 100% in staging. Cloudflare automatically traces handler invocations and supported binding/fetch operations. Add custom spans around meaningful phases:
+
+```text
+request
+  authenticate
+  resolve_active_organization
+  enqueue_scan
+
+queue scan job
+  claim_scan
+  acquire_staged_artifact
+  acquire_baseline
+  parse_archive
+  deterministic_review
+  release_memory_lookup
+  ai_review
+  persist_report
+  notify
+
+workflow gate job
+  load_gate
+  download_artifact_bundle
+  prepare_release_candidates
+  review_packages
+  await_human_decision
+  deliver_github_callback
+```
+
+Only attach bounded attributes such as adapter, ecosystem, source, phase, result, counts, safe error code, and opaque IDs. Do not attach package names, paths, evidence, URLs, or free text.
+
+### Application journey
+
+Platform traces cannot represent a multi-day setup journey, and Cloudflare's current custom-span API does not expose manual trace-ID wiring across arbitrary boundaries. Add an application-owned `journey_id` and carry it through authenticated UI requests, queued messages, webhook-created gates, notifications, and feedback references where meaningful.
+
+Use the most specific durable correlation key:
+
+- request: `request_id`;
+- scan lifecycle: `scan_id`;
+- workflow-gate lifecycle: `gate_id` and GitHub `delivery_id`;
+- organization setup: `journey_id` scoped to the setup path;
+- support: `reference_id` resolving to the safe event/timeline context.
+
+Do not put organization or user identity in generic OpenTelemetry baggage. Baggage can be propagated to third parties; use explicit application fields and destination allowlists instead.
+
+## Customer journey model
+
+The first journey model should be small enough that every event has a clear decision attached to it.
+
+### Acquisition and account creation
+
+- registration completed;
+- email verified;
+- first organization created;
+- invited member accepted.
+
+Anonymous marketing attribution should remain separate from authenticated product telemetry. Do not weaken the repository rule that non-auth `/api/*` endpoints require authentication. If anonymous attribution becomes important, add a separately threat-modeled, rate-limited, allowlisted collector or privacy-preserving web analytics product.
+
+### Setup
+
+- setup path selected: npm staged publish or GitHub workflow gate;
+- npm connection save attempted, validated, failed, or deleted;
+- GitHub App installation started and completed;
+- release target created and first webhook observed;
+- Slack connected and test notification delivered;
+- notification recipient added;
+- 2FA requirement enabled.
+
+Each failed setup event needs an actionable error code and a link to the exact remediation shown in the UI.
+
+### Activation
+
+Define activation as the first **protected release**, not sign-up or first page view.
+
+An organization is activated when it reaches either:
+
+1. a completed manual/auto-discovery scan that a maintainer views and records a release decision against; or
+2. a workflow-gate review that reaches `review_ready` and successfully delivers a decision callback to GitHub.
+
+Track:
+
+- time from account creation to valid integration;
+- time from valid integration to first artifact observed;
+- time from first artifact to first completed review;
+- time from completed review to decision;
+- total time to first protected release;
+- activation within 1 day and 7 days.
+
+### Repeated value and retention
+
+The value event is `protected_release.completed`. It should be emitted only from server-confirmed state and include path, ecosystem, source, outcome, risk band, finding-count band, and duration—not package identity or evidence.
+
+Measure:
+
+- weekly organizations with at least one protected release;
+- protected releases per active organization;
+- organizations with protected releases in 2, 4, and 8 distinct weeks;
+- week-1 and week-4 retained organizations by acquisition cohort and setup path;
+- median and p95 decision latency;
+- expansion into a second release target, ecosystem, or teammate;
+- automation share: scheduled discovery/workflow gate versus manual scans.
+
+### Friction and recovery
+
+Track these as first-class journey events:
+
+- repeated integration validation failures;
+- artifact observed but no review completed;
+- completed review never viewed or decided;
+- workflow gate timed out or callback delivery failed;
+- three consecutive customer-visible failures;
+- feedback opened/submitted;
+- support reference created;
+- the next successful value event after a failure (`customer.recovered`).
+
+Recovery is as important as failure count. It tells us whether remediation actually works.
+
+## Adoption and customer-health metrics
+
+### North star
+
+**Weekly protected-release organizations:** distinct organizations that completed at least one review-to-decision or gate-to-callback loop in the last seven days.
+
+This measures delivered customer value while avoiding vanity activity. Keep the raw protected-release count as a supporting throughput metric.
+
+### Funnel
+
+```text
+organization created
+  -> integration valid
+  -> first artifact observed
+  -> first review completed
+  -> first protected release
+  -> second active week
+  -> fourth active week
+```
+
+Break the funnel down by setup path, ecosystem, acquisition cohort, organization size band, and deployment version. Do not use package identity as an analytics dimension.
+
+### Transparent customer-health state
+
+Do not begin with an opaque ML or LLM health score. Materialize a small set of facts and a rule-based state that people and agents can explain:
+
+```text
+setup:
+  npm_connection_valid
+  github_installation_active
+  release_target_count
+  notifications_configured
+
+value:
+  first_protected_release_at
+  last_protected_release_at
+  protected_releases_7d / 28d
+  active_weeks_8w
+
+friction:
+  customer_visible_failures_7d
+  consecutive_failed_value_attempts
+  blocked_since
+  last_error_code
+
+collaboration:
+  member_count
+  accepted_invites_28d
+```
+
+Suggested states:
+
+- `onboarding`: created but not activated;
+- `activated`: first protected release within the last seven days;
+- `healthy`: repeated value and no unresolved blocking signal;
+- `blocked`: last three value attempts failed or a gate decision cannot be delivered;
+- `at_risk`: previously active but no value event for 14 days, or error rate materially increased;
+- `dormant`: no value event for 30 days.
+
+Expose the facts and the matched rule whenever a state is shown. An LLM may summarize the state; it must not invent the state.
+
+### Exact milestone projection
+
+Create an `organization_milestones` D1 table keyed by `(organization_id, milestone)` with `first_at`, `last_at`, and `count`. Update it idempotently in the same domain functions that create the underlying durable state, in the same D1 batch where possible. Treat it as a rebuildable projection rather than a second source of truth; add backfill and periodic reconciliation from the core tables.
+
+Use it for exact activation, support, and lifecycle queries. Use Analytics Engine for time-series breakdowns and rates. Generate daily cohort rollups into D1 if trends longer than Analytics Engine's three-month retention are needed.
+
+## Data retention and pruning
+
+Telemetry must not flood D1. Every store this proposal adds declares a retention window and a pruning path up front; no telemetry table is allowed to grow unbounded. The existing precedent is `pruneAuditEventsOlderThan` running on each scheduled tick ([`docs/audit-log.md`](./audit-log.md)); new stores follow the same pattern.
+
+| Store | Growth shape | Retention | Wipe mechanism |
+| --- | --- | --- | --- |
+| D1 domain state (scans, gates, decisions) | Product data | Product lifecycle | Existing org/scan cascade and account deletion |
+| D1 `scan_events` (audit) | Append-only | 90 days (existing) | Existing scheduled prune |
+| D1 `organization_milestones` | One row per (organization, milestone) — bounded by design | Lifetime of the organization | Org cascade delete; no age prune needed |
+| D1 daily cohort/health rollups | One row per org/cohort per day | 13 months (one year of trends plus comparison margin) | Age prune on scheduled tick |
+| D1 support references / incident bundles | Append-only | 90 days, matching the audit window | Age prune on scheduled tick |
+| Workers Logs / traces | Platform-managed | Platform retention | None needed |
+| Analytics Engine | Platform-managed | 3 months, platform-enforced | None needed |
+
+Rules:
+
+- Pruning piggybacks on the existing `scheduled` handler: age-based `DELETE` in bounded batches (`LIMIT`) so a large backlog can never stall a tick, emitting a `telemetry.pruned` event with row counts, and an error event if a prune fails.
+- Add a cheap row-count guard per telemetry table on a daily tick with an alert threshold. A runaway writer (the `file.outside-files-list`-style flood, but in telemetry) should page before it becomes a storage or query-latency problem, not after.
+- All org-keyed telemetry participates in organization cascade delete and the account-deletion path ([`docs/account-deletion.md`](./account-deletion.md)); pseudonymous product-analytics identifiers are unlinkable after key deletion.
+- The schema PR for any new telemetry table must state its retention window and include prune coverage in tests; add this to the [`docs/release-safety.md`](./release-safety.md) checklist alongside the existing "operational events exist and carry no sensitive material" item.
+
+## Reliability, SLOs, and alerts
+
+Define success from the maintainer's perspective. A fail-closed, actionable verdict on a malformed or unsafe artifact can be a successful product outcome even though the release is blocked.
+
+Initial service-level indicators:
+
+| Indicator              | Good event                                                                     | Initial objective                                  |
+| ---------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------- |
+| API availability       | authenticated request completes without a product-bug/5xx outcome              | 99.9% over 28 days                                 |
+| Review completion      | accepted scan reaches completed review or actionable fail-closed verdict       | 99.5% over 28 days                                 |
+| Review latency         | enqueue to terminal review                                                     | p95 under 2 minutes; validate with production data |
+| Gate callback delivery | recorded decision is accepted by GitHub                                        | 99.9% over 28 days                                 |
+| Discovery continuity   | eligible npm connection receives a completed sweep                             | within 30 minutes                                  |
+| Notification delivery  | requested notification reaches provider or returns an actionable provider code | 99% over 28 days                                   |
+
+Keep AI-review availability separate. It is advisory and its killswitch/fail-safe behavior must not make the deterministic scanner's SLO misleading.
+
+Alert on impact rather than individual exceptions:
+
+- fast and slow multi-window burn alerts for the first four SLIs;
+- any credential/sandbox security invariant violation immediately;
+- a new `product_bug` fingerprint after a deployment;
+- an error-code rate or p95 latency regression by deployment version;
+- a customer-visible error affecting multiple organizations in a short window;
+- one organization blocked on three consecutive value attempts;
+- a cron without its matching completion event;
+- queue retries exhausted or messages reaching the dead-letter queue;
+- telemetry sink health, schema rejections, or missing deployment identifiers.
+
+During the early customer phase, alert on every newly blocked organization. Revisit thresholds only after volume makes that noisy.
+
+## Error and support workflow
+
+### User experience
+
+Every error surface should show:
+
+- a plain-language explanation;
+- a stable error code;
+- the next action the customer can take;
+- a copyable support reference;
+- retry status when relevant.
+
+The support reference must not encode an organization, user, scan, or secret. It resolves server-side for authorized staff.
+
+Replace the context-free feedback mail link on authenticated pages with a small feedback flow that attaches only safe context: reference ID, route name, client release, organization ID, scan/gate ID, and recent stable event codes. Free-text feedback is stored or sent as support content, never copied into operational telemetry or LLM prompts by default.
+
+### Issue grouping
+
+Group deterministic fingerprints such as:
+
+```text
+error.code + error.phase + service.version + top_application_frame
+```
+
+For external dependencies, prefer:
+
+```text
+error.code + provider + status_class + operation
+```
+
+Track per issue:
+
+- first and last seen;
+- first and last affected deployment;
+- occurrence count;
+- distinct impacted organizations;
+- blocked value attempts;
+- owner and runbook;
+- triage status;
+- fixed deployment;
+- recovered organizations.
+
+This can live in Sentry or an equivalent issue product if adopted. Drydock's stable code, fingerprint, and impact fields remain the source contract so provider replacement is possible.
+
+### Customer timeline
+
+Support should have one chronological, sanitized view that combines:
+
+- milestone and integration state from D1;
+- curated audit actions;
+- scans, gates, decisions, and notifications;
+- customer-visible operational errors;
+- deployment changes;
+- feedback/support references;
+- subsequent recovery.
+
+Do not copy package contents or raw log lines into this timeline.
+
+## LLM-ready observability
+
+An LLM works best with bounded, typed, correlated evidence. It works poorly with screenshots, arbitrary log strings, unexplained fields, and unconstrained SQL.
+
+### Tool layer 1: Cloudflare Workers Observability MCP
+
+Connect authorized engineering agents to Cloudflare's official Workers Observability MCP. It can discover log fields and values, query events, calculate metrics, and locate invocations. This is the fastest path to questions such as:
+
+- What errors appeared after the latest deployment?
+- Which phase dominates p95 scan time?
+- Find the invocation for this support reference.
+- Compare error rates between two Worker versions.
+
+This becomes substantially more useful after events are emitted as a single structured object with stable fields.
+
+### Tool layer 2: Drydock observability tools
+
+Add a read-only internal service or MCP server with parameterized tools:
+
+- `get_service_health(window)`
+- `get_customer_health(organization_id)`
+- `get_customer_timeline(organization_id, start, end)`
+- `explain_support_reference(reference_id)`
+- `get_adoption_funnel(start, end, cohort, path)`
+- `get_retention(cohort, interval)`
+- `list_customer_pain(window, minimum_organizations)`
+- `compare_deployments(before_version, after_version, window)`
+- `get_scan_or_gate_timeline(id)`
+- `get_runbook(error_code)`
+
+Do not expose arbitrary SQL, raw D1, raw R2, package evidence, or unrestricted log search to the LLM. Tool authorization must be staff-only, organization-aware where appropriate, read-only, audited, rate-limited, and able to redact fields again at the response boundary.
+
+Every tool response should include:
+
+```json
+{
+  "generated_at": "...",
+  "window": { "start": "...", "end": "..." },
+  "freshness_seconds": 42,
+  "sampled": false,
+  "sources": ["d1", "workers_logs"],
+  "query_id": "qry_01...",
+  "facts": [],
+  "missing_evidence": [],
+  "links": []
+}
+```
+
+The LLM must cite `query_id`, event/reference IDs, and deployment versions in incident summaries. It should say when evidence is sampled, stale, missing, or conflicting.
+
+### Deterministic incident bundle before prose
+
+For a support reference or alert, produce a compact incident bundle in code:
+
+```text
+identity        support ref, organization, scan/gate, deployment
+impact          affected organizations and blocked value events
+timeline        ordered event IDs and stable codes
+first change    deployment/configuration boundary before the issue
+current state   active, recovered, or unknown
+runbook         owner and next deterministic checks
+evidence gaps   missing/sampled/unavailable sources
+```
+
+Let the model explain this bundle. Do not ask the model to discover facts by reading an unbounded log stream.
+
+### Golden-question eval
+
+Add fixtures and an automated eval for questions the system must answer correctly:
+
+- Why did this scan fail?
+- Did the customer recover?
+- Which organizations are blocked by the same issue?
+- Did deployment B regress against deployment A?
+- Where does the npm setup funnel lose organizations?
+- Was the gate reviewed but the callback not delivered?
+- Is a rise in failures a product bug, customer configuration problem, external outage, or expected fail-closed behavior?
+
+Fixtures should contain distractor events and forbidden data. The eval must check evidence selection, uncertainty, authorization, and redaction—not just prose quality.
+
+## Dashboards and operating cadence
+
+Start with five views:
+
+1. **Service health:** request/review/gate SLOs, error budget, queue depth/retries, p50/p95 duration by phase and deployment.
+2. **Customer pain:** blocked organizations, customer-visible error codes, consecutive failures, unresolved support references, and recovery rate.
+3. **Adoption:** funnel, time to first protected release, weekly protected-release organizations, cohort retention, automation share, and expansion.
+4. **Journey explorer:** one organization's sanitized chronological path across setup, artifact, review, decision, notification, and recovery.
+5. **Release comparison:** before/after deployment volume, failure rate, error fingerprints, latency, and affected organizations.
+
+Operating rhythm:
+
+- real-time: invariant, SLO-burn, blocked-customer, and new-regression alerts;
+- daily: LLM-drafted digest of new issues, affected customers, recoveries, and funnel anomalies, approved from linked evidence;
+- weekly: product/reliability review of north-star, activation, retention, top pain, and error-budget burn;
+- per deployment: automatic 30-minute and 24-hour comparison against the prior version;
+- monthly: telemetry-schema review, redaction tests, retention/deletion audit, and unused-event cleanup.
+
+## Delivery plan
+
+### Phase 0: make current telemetry queryable (2-3 days)
+
+- Change operational logging to emit one top-level JSON object.
+- Add `event.id`, schema version, deployment version, environment, outcome, phase, and stable error code fields.
+- Remove arbitrary error messages from normal telemetry; retain source-mapped exceptions only in the restricted diagnostic path.
+- Enable source-map upload.
+- Enable traces at 100% in staging and an initial 10% in production.
+- Add custom spans around the existing scan pipeline and workflow-gate phases.
+- Connect the Cloudflare Workers Observability MCP for authorized engineers.
+- Save the first service-health, release-regression, and customer-error queries.
+- Add telemetry contract/redaction tests.
+
+Exit criterion: an engineer or agent can locate a failed scan by support reference and produce a phase-by-phase evidence trail without changing instrumentation.
+
+### Phase 1: customer value and adoption (about 1 week)
+
+- Add the typed event and error registries.
+- Add the Analytics Engine binding and explicit ordered schema mapping.
+- Add `organization_milestones` with idempotent domain-level updates.
+- Instrument integration validation, first artifact, review, decision/callback, invitation, notification, and recovery events.
+- Add an authenticated, allowlisted UI-event endpoint only for the few interaction gaps the server cannot observe.
+- Build the adoption funnel, north-star, customer-pain, and journey views.
+- Add support references to customer-visible errors and feedback.
+
+Exit criterion: activation, time-to-value, retention, top customer pain, and one organization's journey are answerable from server-confirmed data.
+
+### Phase 2: proactive operations and LLM tools (about 1 week)
+
+- Define SLIs/SLOs and multi-window alerts.
+- Add blocked-customer and silent-cron/queue monitors.
+- Implement the narrow Drydock read-only tool service.
+- Add incident-bundle generation and golden-question evals.
+- Add release comparison and daily evidence-linked digest.
+- Decide whether Cloudflare investigation is sufficient or an OTLP issue backend is justified.
+
+Exit criterion: the system detects a regression, identifies affected organizations, links the deployment, and drafts an evidence-backed triage summary without raw data access.
+
+### Phase 3: learn and deepen
+
+- Tune sampling and retention from measured volume and cost.
+- Add longer-term D1 daily cohort rollups.
+- Add privacy-reviewed anonymous attribution only if it changes acquisition decisions.
+- Consider restricted session replay only for explicitly allowlisted, non-sensitive surfaces.
+- Add automated customer recovery follow-up and product experiments with explicit success metrics.
+
+## Success criteria
+
+Within one month of implementation:
+
+- at least 95% of customer-visible failures carry a stable code, phase, classification, support reference, and owner;
+- 100% of scans and workflow gates have a queryable end-to-end application timeline;
+- activation and retention are computed from server-confirmed value events;
+- support can answer “what happened?” from a reference in under two minutes;
+- deployment regressions are attributable by version within five minutes of alerting;
+- customer health always shows its underlying facts and matched rule;
+- no telemetry contract test can emit a representative secret, package content, external response body, or free-form decision reason;
+- LLM eval answers cite evidence and refuse or qualify conclusions when data is missing or sampled.
+
+## Explicit non-goals
+
+- Do not replace the organization audit log with analytics.
+- Do not store package evidence in analytics or error vendors.
+- Do not make the AI reviewer responsible for operational triage.
+- Do not let an LLM assign canonical error classes, fingerprints, customer-health states, or incident severity.
+- Do not give an LLM arbitrary production SQL, R2 access, or mutation tools.
+- Do not use page views as the north star.
+- Do not add production session replay to scan/diff surfaces.
+- Do not build a large data warehouse before the event contract and operating questions are stable.
+
+## References
+
+Current Drydock implementation:
+
+- [`server/lib/observability.ts`](../server/lib/observability.ts)
+- [`server/lib/scan-pipeline.ts`](../server/lib/scan-pipeline.ts)
+- [`server/lib/scan-job.ts`](../server/lib/scan-job.ts)
+- [`server/lib/workflow-gate-job.ts`](../server/lib/workflow-gate-job.ts)
+- [`server/db/schema.ts`](../server/db/schema.ts)
+- [`docs/release-safety.md`](./release-safety.md)
+- [`docs/audit-log.md`](./audit-log.md)
+
+Platform references:
+
+- [Cloudflare Workers observability](https://developers.cloudflare.com/workers/observability/)
+- [Cloudflare Workers structured logs](https://developers.cloudflare.com/workers/observability/logs/workers-logs/)
+- [Cloudflare Workers custom spans](https://developers.cloudflare.com/workers/observability/traces/custom-spans/)
+- [Cloudflare Workers source maps](https://developers.cloudflare.com/workers/observability/source-maps/)
+- [Cloudflare OpenTelemetry export](https://developers.cloudflare.com/workers/observability/exporting-opentelemetry-data/)
+- [Cloudflare Workers Analytics Engine](https://developers.cloudflare.com/analytics/analytics-engine/)
+- [Cloudflare Analytics Engine limits and retention](https://developers.cloudflare.com/analytics/analytics-engine/limits/)
+- [Cloudflare Workers Observability MCP](https://github.com/cloudflare/mcp-server-cloudflare/tree/main/apps/workers-observability)
+- [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/)
+- [OpenTelemetry baggage security considerations](https://opentelemetry.io/docs/concepts/signals/baggage/#baggage-security-considerations)

--- a/docs/observability-proposal.md
+++ b/docs/observability-proposal.md
@@ -1,6 +1,6 @@
 # Drydock observability proposal
 
-**Status:** proposal  
+**Status:** Phase 0 and core Phase 1 implemented; later phases remain a roadmap
 **Date:** 2026-07-14  
 **Scope:** runtime reliability, customer pain, adoption, user journeys, support, and safe LLM access
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,123 @@
+# Observability
+
+Drydock observability is a versioned product data contract. D1 remains the exact
+domain truth, the organization audit log remains a curated customer-visible
+record, Workers Logs and traces carry restricted diagnostic evidence, and
+Workers Analytics Engine receives bounded aggregate dimensions.
+
+The design and remaining roadmap are in
+[`observability-proposal.md`](./observability-proposal.md).
+
+## Runtime event contract
+
+All operational producers call `emitOperationalEvent` through
+[`server/lib/observability.ts`](../server/lib/observability.ts). Event names are
+registered in `server/lib/telemetry/events.ts`; an unregistered name fails
+typechecking.
+
+Each console call receives one JSON object containing:
+
+- an opaque event ID, registered name, schema version, and occurrence time;
+- severity plus service version and environment from the Worker version binding;
+- request, journey, scan, gate, delivery, and organization correlation where
+  available;
+- a bounded surface, ecosystem, and phase;
+- a success, failure, retry, or skipped outcome;
+- a stable error code, class, fingerprint, retryability, customer visibility,
+  owner, runbook, and opaque support reference for customer-visible failures;
+- allowlisted numeric measurements and bounded scalar dimensions.
+
+Unknown exceptions become `internal.unclassified`. Arbitrary exception messages
+are not copied to telemetry. Cloudflare's source-mapped runtime stack is the
+restricted diagnostic evidence for an uncaught exception.
+
+## Data safety
+
+The log and Analytics Engine projectors use explicit allowlists. They reject
+package names, stage IDs, paths, URLs, headers, bodies, external response detail,
+free-form reasons and messages, identities, credentials, token fingerprints,
+package contents, manifests, evidence, AI prompts, and AI responses. Recursive
+sanitization is retained as a final defense.
+
+Opaque organization IDs exist only in restricted operational logs. Analytics
+Engine uses a SHA-256 pseudonym keyed by `TELEMETRY_HASH_KEY`; no analytics write
+occurs when that secret is absent. Rotating or deleting the key breaks the link
+to an organization.
+
+Contract tests in `test/observability.test.mjs` include representative denied
+fields and secrets. Add a test whenever a producer needs a new field; do not
+weaken the denied-key policy to make a free-form value convenient.
+
+## Correlation and traces
+
+The Worker creates a request ID for HTTP, scheduled, and queue invocations.
+Authenticated browser journeys may send an opaque `x-drydock-journey-id` in the
+form `jny_<8-128 safe characters>`; invalid values are discarded. Queue and
+domain events continue to use durable scan and gate IDs across invocations.
+
+Automatic traces run at a 10% production head sample. Source-map upload is
+enabled. Custom spans wrap baseline resolution, diffing, deterministic review,
+AI review, release-memory lookup, report persistence, gate loading, candidate
+preparation, and package review. Span attributes contain only bounded ecosystem,
+count, and opaque internal IDs.
+
+Use a separate staging Wrangler configuration with
+`observability.traces.head_sampling_rate` set to `1` when full staging traces are
+required.
+
+## Analytics Engine schema
+
+`TELEMETRY_ANALYTICS` writes one point per operational event. Columns are ordered
+and append-only:
+
+- blobs: event name, deployment, environment, severity, surface, ecosystem,
+  phase, outcome, error code, error class, retryable, customer-visible;
+- doubles: duration milliseconds, attempt, count;
+- index: keyed organization pseudonym, or `anonymous` when no organization is
+  associated with the event.
+
+Do not reorder columns. Analytics Engine is for funnels, rates, durations, and
+deployment comparisons, not billing, audit, or exact lifetime facts.
+
+## Exact organization milestones
+
+`organization_milestones` is a bounded D1 projection with one row per
+organization and milestone. Each row records exact `first_at`, `last_at`, and
+`count` values and cascades with organization deletion. Current durable
+milestones are:
+
+- organization created;
+- integration validated;
+- artifact observed;
+- review completed;
+- protected release completed.
+
+A manual scan becomes a protected release when its decision is recorded. A
+workflow gate becomes one only after GitHub accepts the callback. The gate row's
+`callback_delivered_at` CAS prevents retries and redeliveries from double
+counting the milestone. Manual decisions use the equivalent
+`protected_release_recorded_at` CAS, so editing a recorded decision does not
+create another value event.
+
+The midnight UTC scheduled tick reconciles the projection from organizations,
+current valid npm connections, completed scans, decisions, and delivered
+workflow-gate callbacks. This populates existing tenants after migration and
+repairs missed writes. Validation history older than the current connection row
+cannot be reconstructed, so reconciliation never replaces a richer live
+validation count.
+
+## Operator setup
+
+Create the pseudonym key as a secret:
+
+```sh
+openssl rand -base64 32 | pnpm exec wrangler secret put TELEMETRY_HASH_KEY
+```
+
+The checked-in Wrangler configs enable logs, 10% traces, source maps, version
+metadata, and the `drydock_telemetry` Analytics Engine dataset. Deploy only after
+applying the checked-in D1 migrations.
+
+Start investigations from a support reference, scan ID, gate ID, request ID, or
+deployment version. Treat logs and analytics as sampled evidence; use D1 domain
+state and milestones for exact customer lifecycle facts.

--- a/docs/release-safety.md
+++ b/docs/release-safety.md
@@ -45,9 +45,10 @@ for the lifecycle behavior behind it.
 ## Operational observability
 
 Runtime paths should emit structured events through
-`server/lib/observability.ts`. The helper redacts sensitive key names and bearer
-tokens before calling `console`, which keeps Cloudflare logs useful without
-turning them into a credential sink.
+`server/lib/observability.ts`. The typed, versioned contract projects one
+allowlisted JSON object per console call and rejects free-form or package-derived
+fields before the final recursive sanitizer runs. See
+[`observability.md`](./observability.md).
 
 Current structured events cover:
 
@@ -77,4 +78,6 @@ Before merging server-risk changes:
    changed.
 5. Confirm operational events exist for new failure modes and do not include
    sensitive material.
-6. Update the relevant docs in the same change.
+6. For a new telemetry table, define bounded growth or a retention window,
+   organization deletion behavior, a pruning/reconciliation path, and tests.
+7. Update the relevant docs in the same change.

--- a/docs/runbooks/integrations.md
+++ b/docs/runbooks/integrations.md
@@ -1,0 +1,13 @@
+# Integration telemetry runbook
+
+Use this runbook for npm registry, GitHub App, workflow callback, Slack, email,
+and other external-provider failures.
+
+1. Group by stable error code, provider operation, status class, and deployment.
+2. Separate customer configuration from a provider outage or Drydock regression.
+3. Verify the durable gate/scan state before retrying. Never approve or publish as
+   a recovery action.
+4. For callback failures, keep the release held and use the existing idempotent
+   redelivery path. Confirm `callback_delivered_at` before declaring recovery.
+5. Never attach provider response bodies, callback URLs, tokens, headers, or
+   customer package identity to telemetry or support notes.

--- a/docs/runbooks/notifications.md
+++ b/docs/runbooks/notifications.md
@@ -1,0 +1,11 @@
+# Notification telemetry runbook
+
+Notification delivery is best effort and must not change deterministic review or
+release-gate state.
+
+1. Resolve the event to its organization and scan/gate correlation ID.
+2. Check provider operation, stable code, retryability, and recent organization
+   impact without exposing recipient addresses or message content.
+3. Confirm the underlying review or decision remains visible in Drydock.
+4. Retry only through the bounded notification path; never replay arbitrary
+   provider payloads.

--- a/docs/runbooks/platform.md
+++ b/docs/runbooks/platform.md
@@ -1,0 +1,16 @@
+# Platform telemetry runbook
+
+Use this runbook for `product_bug` events, request failures, queue exhaustion,
+cron failures, persistence failures, and telemetry-sink failures.
+
+1. Locate the event by support reference, event ID, request ID, scan/gate ID, or
+   deployment version.
+2. Compare the error fingerprint and rate with the previous deployment.
+3. Follow the correlated custom spans and find the first failing application
+   phase. Do not copy raw request, package, or provider content into an incident.
+4. Confirm whether durable D1 state is complete, retryable, or fail-closed.
+5. Roll back or disable the affected optional path when the new deployment is
+   causal; preserve deterministic scanning and release holds.
+
+Escalate any missing deployment ID, unclassified error spike, or telemetry event
+containing a denied field as an observability incident.

--- a/docs/runbooks/scanner.md
+++ b/docs/runbooks/scanner.md
@@ -1,0 +1,13 @@
+# Scanner telemetry runbook
+
+Use this runbook for artifact acquisition, archive parsing, deterministic review,
+report persistence, and release-memory failures.
+
+1. Resolve the event to the organization-scoped scan or workflow gate.
+2. Check the stable error code, phase, retryability, and fail-closed state.
+3. Confirm that no credential entered the sandbox and that no package-derived
+   text entered telemetry.
+4. Retry only errors classified as retryable. Archive limits, malformed evidence,
+   and policy blocks require customer remediation or out-of-band verification.
+5. Validate any parser fix with the narrow regression, security corpus, and fake
+   registry path before deployment.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -97,6 +97,7 @@ Set required secrets with Wrangler:
 ```sh
 pnpm exec wrangler secret put BETTER_AUTH_SECRET
 pnpm exec wrangler secret put NPM_CONNECTIONS_ENCRYPTION_KEY
+openssl rand -base64 32 | pnpm exec wrangler secret put TELEMETRY_HASH_KEY
 ```
 
 Required non-secret vars:
@@ -105,6 +106,7 @@ Required non-secret vars:
 - `NPM_REGISTRY` — defaults to `https://registry.npmjs.org`
 - `AI_CACHE_AFFINITY` — stable prefix-cache affinity string for Workers AI
 - `PNPM_VERSION` — used by the runtime where npm tooling parity matters
+- `ENVIRONMENT` — bounded deployment environment attached to telemetry
 
 Optional integrations:
 
@@ -132,6 +134,8 @@ After deploying:
 5. Run a test staged-publish review.
 6. Check Worker logs for structured events without raw package contents or
    secrets.
+7. Confirm traces carry the deployed Worker version and Analytics Engine receives
+   pseudonymous events. See [`observability.md`](observability.md).
 
 ## GitHub workflow gates
 

--- a/drizzle/0024_cloudy_ares.sql
+++ b/drizzle/0024_cloudy_ares.sql
@@ -1,0 +1,12 @@
+CREATE TABLE `organization_milestones` (
+	`organization_id` text NOT NULL,
+	`milestone` text NOT NULL,
+	`first_at` integer NOT NULL,
+	`last_at` integer NOT NULL,
+	`count` integer DEFAULT 1 NOT NULL,
+	FOREIGN KEY (`organization_id`) REFERENCES `organizations`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `organization_milestones_org_milestone_unique_idx` ON `organization_milestones` (`organization_id`,`milestone`);--> statement-breakpoint
+CREATE INDEX `organization_milestones_milestone_last_idx` ON `organization_milestones` (`milestone`,`last_at`);--> statement-breakpoint
+ALTER TABLE `github_workflow_gates` ADD `callback_delivered_at` integer;

--- a/drizzle/0025_talented_sway.sql
+++ b/drizzle/0025_talented_sway.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `scans` ADD `protected_release_recorded_at` integer;

--- a/drizzle/meta/0024_snapshot.json
+++ b/drizzle/meta/0024_snapshot.json
@@ -1,0 +1,2518 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "96420814-6e73-44ec-86fe-69d8c891c276",
+  "prevId": "af5319c5-52c1-4869-b227-071e492db6fd",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_user_idx": {
+          "name": "account_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_app_installations": {
+      "name": "github_app_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Organization'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uninstalled_at": {
+          "name": "uninstalled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_app_installations_installation_unique_idx": {
+          "name": "github_app_installations_installation_unique_idx",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        },
+        "github_app_installations_org_idx": {
+          "name": "github_app_installations_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installations_created_by_user_id_user_id_fk": {
+          "name": "github_app_installations_created_by_user_id_user_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_release_targets": {
+      "name": "github_release_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ecosystem": {
+          "name": "ecosystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_release_targets_org_repo_env_unique_idx": {
+          "name": "github_release_targets_org_repo_env_unique_idx",
+          "columns": [
+            "organization_id",
+            "repository_id",
+            "environment"
+          ],
+          "isUnique": true
+        },
+        "github_release_targets_installation_idx": {
+          "name": "github_release_targets_installation_idx",
+          "columns": [
+            "installation_row_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_release_targets_organization_id_organizations_id_fk": {
+          "name": "github_release_targets_organization_id_organizations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_release_targets_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_created_by_user_id_user_id_fk": {
+          "name": "github_release_targets_created_by_user_id_user_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_workflow_gates": {
+      "name": "github_workflow_gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_target_id": {
+          "name": "release_target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deployment_callback_url": {
+          "name": "deployment_callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_comment": {
+          "name": "decision_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_url": {
+          "name": "report_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_started_at": {
+          "name": "review_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_delivered_at": {
+          "name": "callback_delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_workflow_gates_delivery_unique_idx": {
+          "name": "github_workflow_gates_delivery_unique_idx",
+          "columns": [
+            "delivery_id"
+          ],
+          "isUnique": true
+        },
+        "github_workflow_gates_org_status_idx": {
+          "name": "github_workflow_gates_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_release_target_idx": {
+          "name": "github_workflow_gates_release_target_idx",
+          "columns": [
+            "release_target_id"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_scan_idx": {
+          "name": "github_workflow_gates_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_workflow_gates_organization_id_organizations_id_fk": {
+          "name": "github_workflow_gates_organization_id_organizations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_workflow_gates_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_release_target_id_github_release_targets_id_fk": {
+          "name": "github_workflow_gates_release_target_id_github_release_targets_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_release_targets",
+          "columnsFrom": [
+            "release_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_scan_id_scans_id_fk": {
+          "name": "github_workflow_gates_scan_id_scans_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_unique_idx": {
+          "name": "npm_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_invitations": {
+      "name": "organization_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_invitations_token_hash_unique_idx": {
+          "name": "organization_invitations_token_hash_unique_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "organization_invitations_org_status_idx": {
+          "name": "organization_invitations_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "organization_invitations_org_email_idx": {
+          "name": "organization_invitations_org_email_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_invitations_organization_id_organizations_id_fk": {
+          "name": "organization_invitations_organization_id_organizations_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_invited_by_user_id_user_id_fk": {
+          "name": "organization_invitations_invited_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_accepted_by_user_id_user_id_fk": {
+          "name": "organization_invitations_accepted_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_milestones": {
+      "name": "organization_milestones",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_at": {
+          "name": "last_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "organization_milestones_org_milestone_unique_idx": {
+          "name": "organization_milestones_org_milestone_unique_idx",
+          "columns": [
+            "organization_id",
+            "milestone"
+          ],
+          "isUnique": true
+        },
+        "organization_milestones_milestone_last_idx": {
+          "name": "organization_milestones_milestone_last_idx",
+          "columns": [
+            "milestone",
+            "last_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_milestones_organization_id_organizations_id_fk": {
+          "name": "organization_milestones_organization_id_organizations_id_fk",
+          "tableFrom": "organization_milestones",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_notification_recipients": {
+      "name": "organization_notification_recipients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_notification_recipients_org_email_unique_idx": {
+          "name": "organization_notification_recipients_org_email_unique_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_notification_recipients_organization_id_organizations_id_fk": {
+          "name": "organization_notification_recipients_organization_id_organizations_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_notification_recipients_created_by_user_id_user_id_fk": {
+          "name": "organization_notification_recipients_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_slack_connections": {
+      "name": "organization_slack_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_token_ciphertext": {
+          "name": "bot_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bot_token_nonce": {
+          "name": "bot_token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slack_connections_org_unique_idx": {
+          "name": "organization_slack_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_slack_connections_organization_id_organizations_id_fk": {
+          "name": "organization_slack_connections_organization_id_organizations_id_fk",
+          "tableFrom": "organization_slack_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_slack_connections_created_by_user_id_user_id_fk": {
+          "name": "organization_slack_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_slack_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "require_two_factor_for_release_decisions": {
+          "name": "require_two_factor_for_release_decisions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_findings_scan_severity_idx": {
+          "name": "scan_findings_scan_severity_idx",
+          "columns": [
+            "scan_id",
+            "severity"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changed_file_count": {
+          "name": "changed_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_summary_json": {
+          "name": "risk_summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_storage_version": {
+          "name": "artifact_storage_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_key": {
+          "name": "artifact_manifest_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_digest": {
+          "name": "artifact_manifest_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_size": {
+          "name": "artifact_manifest_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_artifact_key": {
+          "name": "report_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_samples_artifact_key": {
+          "name": "file_samples_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "diff_artifact_key": {
+          "name": "diff_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        },
+        "scans_gate_org_idx": {
+          "name": "scans_gate_org_idx",
+          "columns": [
+            "gate_id",
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_artifact_backfill_idx": {
+          "name": "scans_artifact_backfill_idx",
+          "columns": [
+            "organization_id",
+            "status",
+            "artifact_storage_version",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "scans_org_decision_created_idx": {
+          "name": "scans_org_decision_created_idx",
+          "columns": [
+            "organization_id",
+            "decision",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scans_org_created_idx": {
+          "name": "scans_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_gate_id_github_workflow_gates_id_fk": {
+          "name": "scans_gate_id_github_workflow_gates_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "github_workflow_gates",
+          "columnsFrom": [
+            "gate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_decided_by_user_id_user_id_fk": {
+          "name": "scans_decided_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "two_factor": {
+      "name": "two_factor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed_verification_count": {
+          "name": "failed_verification_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "two_factor_user_idx": {
+          "name": "two_factor_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0025_snapshot.json
+++ b/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,2525 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "6cf6dd50-b88e-4187-bc7d-e4c88d53e2ad",
+  "prevId": "96420814-6e73-44ec-86fe-69d8c891c276",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_user_idx": {
+          "name": "account_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_app_installations": {
+      "name": "github_app_installations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Organization'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uninstalled_at": {
+          "name": "uninstalled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_app_installations_installation_unique_idx": {
+          "name": "github_app_installations_installation_unique_idx",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": true
+        },
+        "github_app_installations_org_idx": {
+          "name": "github_app_installations_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_app_installations_organization_id_organizations_id_fk": {
+          "name": "github_app_installations_organization_id_organizations_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_app_installations_created_by_user_id_user_id_fk": {
+          "name": "github_app_installations_created_by_user_id_user_id_fk",
+          "tableFrom": "github_app_installations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_release_targets": {
+      "name": "github_release_targets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ecosystem": {
+          "name": "ecosystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_name": {
+          "name": "artifact_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_release_targets_org_repo_env_unique_idx": {
+          "name": "github_release_targets_org_repo_env_unique_idx",
+          "columns": [
+            "organization_id",
+            "repository_id",
+            "environment"
+          ],
+          "isUnique": true
+        },
+        "github_release_targets_installation_idx": {
+          "name": "github_release_targets_installation_idx",
+          "columns": [
+            "installation_row_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_release_targets_organization_id_organizations_id_fk": {
+          "name": "github_release_targets_organization_id_organizations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_release_targets_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_release_targets_created_by_user_id_user_id_fk": {
+          "name": "github_release_targets_created_by_user_id_user_id_fk",
+          "tableFrom": "github_release_targets",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_workflow_gates": {
+      "name": "github_workflow_gates",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_row_id": {
+          "name": "installation_row_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "release_target_id": {
+          "name": "release_target_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_full_name": {
+          "name": "repository_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deployment_callback_url": {
+          "name": "deployment_callback_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_action": {
+          "name": "event_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_comment": {
+          "name": "decision_comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_url": {
+          "name": "report_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_started_at": {
+          "name": "review_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "callback_delivered_at": {
+          "name": "callback_delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_workflow_gates_delivery_unique_idx": {
+          "name": "github_workflow_gates_delivery_unique_idx",
+          "columns": [
+            "delivery_id"
+          ],
+          "isUnique": true
+        },
+        "github_workflow_gates_org_status_idx": {
+          "name": "github_workflow_gates_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_release_target_idx": {
+          "name": "github_workflow_gates_release_target_idx",
+          "columns": [
+            "release_target_id"
+          ],
+          "isUnique": false
+        },
+        "github_workflow_gates_scan_idx": {
+          "name": "github_workflow_gates_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_workflow_gates_organization_id_organizations_id_fk": {
+          "name": "github_workflow_gates_organization_id_organizations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_installation_row_id_github_app_installations_id_fk": {
+          "name": "github_workflow_gates_installation_row_id_github_app_installations_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_app_installations",
+          "columnsFrom": [
+            "installation_row_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_release_target_id_github_release_targets_id_fk": {
+          "name": "github_workflow_gates_release_target_id_github_release_targets_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "github_release_targets",
+          "columnsFrom": [
+            "release_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_workflow_gates_scan_id_scans_id_fk": {
+          "name": "github_workflow_gates_scan_id_scans_id_fk",
+          "tableFrom": "github_workflow_gates",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "npm_connections": {
+      "name": "npm_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registry_url": {
+          "name": "registry_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_ciphertext": {
+          "name": "token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_nonce": {
+          "name": "token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_fingerprint": {
+          "name": "token_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_last4": {
+          "name": "token_last4",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validation_status": {
+          "name": "validation_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unvalidated'"
+        },
+        "capabilities_json": {
+          "name": "capabilities_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "validated_at": {
+          "name": "validated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "npm_connections_org_unique_idx": {
+          "name": "npm_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        },
+        "npm_connections_fingerprint_idx": {
+          "name": "npm_connections_fingerprint_idx",
+          "columns": [
+            "token_fingerprint"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "npm_connections_organization_id_organizations_id_fk": {
+          "name": "npm_connections_organization_id_organizations_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "npm_connections_created_by_user_id_user_id_fk": {
+          "name": "npm_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "npm_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_invitations": {
+      "name": "organization_invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "invited_by_user_id": {
+          "name": "invited_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_by_user_id": {
+          "name": "accepted_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_invitations_token_hash_unique_idx": {
+          "name": "organization_invitations_token_hash_unique_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        },
+        "organization_invitations_org_status_idx": {
+          "name": "organization_invitations_org_status_idx",
+          "columns": [
+            "organization_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "organization_invitations_org_email_idx": {
+          "name": "organization_invitations_org_email_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_invitations_organization_id_organizations_id_fk": {
+          "name": "organization_invitations_organization_id_organizations_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_invited_by_user_id_user_id_fk": {
+          "name": "organization_invitations_invited_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "organization_invitations_accepted_by_user_id_user_id_fk": {
+          "name": "organization_invitations_accepted_by_user_id_user_id_fk",
+          "tableFrom": "organization_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "accepted_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_members": {
+      "name": "organization_members",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'owner'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_members_user_idx": {
+          "name": "organization_members_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organization_members_org_user_unique_idx": {
+          "name": "organization_members_org_user_unique_idx",
+          "columns": [
+            "organization_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_members_organization_id_organizations_id_fk": {
+          "name": "organization_members_organization_id_organizations_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_members_user_id_user_id_fk": {
+          "name": "organization_members_user_id_user_id_fk",
+          "tableFrom": "organization_members",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_milestones": {
+      "name": "organization_milestones",
+      "columns": {
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "milestone": {
+          "name": "milestone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_at": {
+          "name": "first_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_at": {
+          "name": "last_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "organization_milestones_org_milestone_unique_idx": {
+          "name": "organization_milestones_org_milestone_unique_idx",
+          "columns": [
+            "organization_id",
+            "milestone"
+          ],
+          "isUnique": true
+        },
+        "organization_milestones_milestone_last_idx": {
+          "name": "organization_milestones_milestone_last_idx",
+          "columns": [
+            "milestone",
+            "last_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organization_milestones_organization_id_organizations_id_fk": {
+          "name": "organization_milestones_organization_id_organizations_id_fk",
+          "tableFrom": "organization_milestones",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_notification_recipients": {
+      "name": "organization_notification_recipients",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_notification_recipients_org_email_unique_idx": {
+          "name": "organization_notification_recipients_org_email_unique_idx",
+          "columns": [
+            "organization_id",
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_notification_recipients_organization_id_organizations_id_fk": {
+          "name": "organization_notification_recipients_organization_id_organizations_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_notification_recipients_created_by_user_id_user_id_fk": {
+          "name": "organization_notification_recipients_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_notification_recipients",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization_slack_connections": {
+      "name": "organization_slack_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_user_id": {
+          "name": "bot_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bot_token_ciphertext": {
+          "name": "bot_token_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bot_token_nonce": {
+          "name": "bot_token_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "channel_name": {
+          "name": "channel_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slack_connections_org_unique_idx": {
+          "name": "organization_slack_connections_org_unique_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "organization_slack_connections_organization_id_organizations_id_fk": {
+          "name": "organization_slack_connections_organization_id_organizations_id_fk",
+          "tableFrom": "organization_slack_connections",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "organization_slack_connections_created_by_user_id_user_id_fk": {
+          "name": "organization_slack_connections_created_by_user_id_user_id_fk",
+          "tableFrom": "organization_slack_connections",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organizations": {
+      "name": "organizations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "require_two_factor_for_release_decisions": {
+          "name": "require_two_factor_for_release_decisions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizations_owner_idx": {
+          "name": "organizations_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "organizations_owner_user_id_user_id_fk": {
+          "name": "organizations_owner_user_id_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "rate_limits": {
+      "name": "rate_limits",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "rate_limits_expires_idx": {
+          "name": "rate_limits_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_events": {
+      "name": "scan_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata_json": {
+          "name": "metadata_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_events_org_created_idx": {
+          "name": "scan_events_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scan_events_scan_idx": {
+          "name": "scan_events_scan_idx",
+          "columns": [
+            "scan_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_events_organization_id_organizations_id_fk": {
+          "name": "scan_events_organization_id_organizations_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scan_events_actor_user_id_user_id_fk": {
+          "name": "scan_events_actor_user_id_user_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scan_events_scan_id_scans_id_fk": {
+          "name": "scan_events_scan_id_scans_id_fk",
+          "tableFrom": "scan_events",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_files": {
+      "name": "scan_files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sha256": {
+          "name": "sha256",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "flags_json": {
+          "name": "flags_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_sample": {
+          "name": "text_sample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_files_scan_path_idx": {
+          "name": "scan_files_scan_path_idx",
+          "columns": [
+            "scan_id",
+            "path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_files_scan_id_scans_id_fk": {
+          "name": "scan_files_scan_id_scans_id_fk",
+          "tableFrom": "scan_files",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_findings": {
+      "name": "scan_findings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_id": {
+          "name": "scan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "severity": {
+          "name": "severity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file": {
+          "name": "file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "line": {
+          "name": "line",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'rule'"
+        },
+        "rule_id": {
+          "name": "rule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rule_version": {
+          "name": "rule_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scan_findings_scan_severity_idx": {
+          "name": "scan_findings_scan_severity_idx",
+          "columns": [
+            "scan_id",
+            "severity"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scan_findings_scan_id_scans_id_fk": {
+          "name": "scan_findings_scan_id_scans_id_fk",
+          "tableFrom": "scan_findings",
+          "tableTo": "scans",
+          "columnsFrom": [
+            "scan_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scans": {
+      "name": "scans",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stage_id": {
+          "name": "stage_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gate_id": {
+          "name": "gate_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "package_name": {
+          "name": "package_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "staged_version": {
+          "name": "staged_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk": {
+          "name": "risk",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "decision": {
+          "name": "decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decision_reason": {
+          "name": "decision_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_by_user_id": {
+          "name": "decided_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "protected_release_recorded_at": {
+          "name": "protected_release_recorded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_json": {
+          "name": "summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ai_json": {
+          "name": "ai_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_json": {
+          "name": "error_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changed_file_count": {
+          "name": "changed_file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finding_count": {
+          "name": "finding_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "risk_summary_json": {
+          "name": "risk_summary_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_version": {
+          "name": "report_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_digest": {
+          "name": "report_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_storage_version": {
+          "name": "artifact_storage_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_key": {
+          "name": "artifact_manifest_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_digest": {
+          "name": "artifact_manifest_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "artifact_manifest_size": {
+          "name": "artifact_manifest_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "report_artifact_key": {
+          "name": "report_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_samples_artifact_key": {
+          "name": "file_samples_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "diff_artifact_key": {
+          "name": "diff_artifact_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scans_org_idx": {
+          "name": "scans_org_idx",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_owner_idx": {
+          "name": "scans_owner_idx",
+          "columns": [
+            "owner_user_id"
+          ],
+          "isUnique": false
+        },
+        "scans_stage_id_idx": {
+          "name": "scans_stage_id_idx",
+          "columns": [
+            "stage_id"
+          ],
+          "isUnique": false
+        },
+        "scans_package_idx": {
+          "name": "scans_package_idx",
+          "columns": [
+            "package_name"
+          ],
+          "isUnique": false
+        },
+        "scans_gate_org_idx": {
+          "name": "scans_gate_org_idx",
+          "columns": [
+            "gate_id",
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "scans_artifact_backfill_idx": {
+          "name": "scans_artifact_backfill_idx",
+          "columns": [
+            "organization_id",
+            "status",
+            "artifact_storage_version",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "scans_org_decision_created_idx": {
+          "name": "scans_org_decision_created_idx",
+          "columns": [
+            "organization_id",
+            "decision",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "scans_org_created_idx": {
+          "name": "scans_org_created_idx",
+          "columns": [
+            "organization_id",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scans_organization_id_organizations_id_fk": {
+          "name": "scans_organization_id_organizations_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scans_owner_user_id_user_id_fk": {
+          "name": "scans_owner_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "owner_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_gate_id_github_workflow_gates_id_fk": {
+          "name": "scans_gate_id_github_workflow_gates_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "github_workflow_gates",
+          "columnsFrom": [
+            "gate_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "scans_decided_by_user_id_user_id_fk": {
+          "name": "scans_decided_by_user_id_user_id_fk",
+          "tableFrom": "scans",
+          "tableTo": "user",
+          "columnsFrom": [
+            "decided_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_user_idx": {
+          "name": "session_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "two_factor": {
+      "name": "two_factor",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failed_verification_count": {
+          "name": "failed_verification_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "locked_until": {
+          "name": "locked_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "two_factor_user_idx": {
+          "name": "two_factor_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,20 @@
       "when": 1783170819713,
       "tag": "0023_clammy_loki",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "6",
+      "when": 1784095544981,
+      "tag": "0024_cloudy_ares",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "6",
+      "when": 1784095871352,
+      "tag": "0025_talented_sway",
+      "breakpoints": true
     }
   ]
 }

--- a/server/db/organization-milestones.ts
+++ b/server/db/organization-milestones.ts
@@ -1,0 +1,175 @@
+import { and, asc, eq, sql } from "drizzle-orm";
+import type { AppDb } from "./client";
+import {
+  githubWorkflowGates,
+  npmConnections,
+  organizationMilestones,
+  organizations,
+  scans,
+} from "./schema";
+import { emitOperationalEvent } from "../lib/observability";
+import { currentTelemetryContext } from "../lib/telemetry/context";
+
+export const ORGANIZATION_MILESTONES = [
+  "organization_created",
+  "integration_validated",
+  "artifact_observed",
+  "review_completed",
+  "protected_release_completed",
+] as const;
+
+export type OrganizationMilestone = (typeof ORGANIZATION_MILESTONES)[number];
+
+export async function recordOrganizationMilestone(
+  db: AppDb,
+  organizationId: string,
+  milestone: OrganizationMilestone,
+  occurredAt = new Date(),
+) {
+  await db
+    .insert(organizationMilestones)
+    .values({
+      organizationId,
+      milestone,
+      firstAt: occurredAt,
+      lastAt: occurredAt,
+      count: 1,
+    })
+    .onConflictDoUpdate({
+      target: [organizationMilestones.organizationId, organizationMilestones.milestone],
+      set: {
+        firstAt: sql`min(${organizationMilestones.firstAt}, ${occurredAt.getTime()})`,
+        lastAt: sql`max(${organizationMilestones.lastAt}, ${occurredAt.getTime()})`,
+        count: sql`${organizationMilestones.count} + 1`,
+      },
+    });
+  if (currentTelemetryContext().requestId) {
+    emitOperationalEvent("info", "organization.milestone.recorded", {
+      organizationId,
+      milestone,
+    });
+  }
+}
+
+export async function listOrganizationMilestones(db: AppDb, organizationId: string) {
+  return db
+    .select({
+      milestone: organizationMilestones.milestone,
+      firstAt: organizationMilestones.firstAt,
+      lastAt: organizationMilestones.lastAt,
+      count: organizationMilestones.count,
+    })
+    .from(organizationMilestones)
+    .where(eq(organizationMilestones.organizationId, organizationId))
+    .orderBy(asc(organizationMilestones.firstAt));
+}
+
+export async function hasOrganizationMilestone(
+  db: AppDb,
+  organizationId: string,
+  milestone: OrganizationMilestone,
+) {
+  const [row] = await db
+    .select({ count: organizationMilestones.count })
+    .from(organizationMilestones)
+    .where(
+      and(
+        eq(organizationMilestones.organizationId, organizationId),
+        eq(organizationMilestones.milestone, milestone),
+      ),
+    )
+    .limit(1);
+  return Boolean(row);
+}
+
+// Daily reconciliation makes the projection deploy-safe for existing tenants
+// and repairs missed domain writes from exact durable state. Validation history
+// cannot be reconstructed from the one current connection row, so that query
+// inserts a missing milestone but never overwrites a richer live count.
+export async function reconcileOrganizationMilestones(db: AppDb) {
+  const results = await db.batch([
+    db.run(sql`
+      insert into ${organizationMilestones}
+        (organization_id, milestone, first_at, last_at, count)
+      select ${organizations.id}, 'organization_created', ${organizations.createdAt},
+        ${organizations.createdAt}, 1
+      from ${organizations}
+      where true
+      on conflict (organization_id, milestone) do update set
+        first_at = excluded.first_at,
+        last_at = excluded.last_at,
+        count = excluded.count
+    `),
+    db.run(sql`
+      insert into ${organizationMilestones}
+        (organization_id, milestone, first_at, last_at, count)
+      select ${npmConnections.organizationId}, 'integration_validated',
+        min(${npmConnections.validatedAt}), max(${npmConnections.validatedAt}), 1
+      from ${npmConnections}
+      where ${npmConnections.validationStatus} = 'valid'
+        and ${npmConnections.validatedAt} is not null
+      group by ${npmConnections.organizationId}
+      on conflict (organization_id, milestone) do nothing
+    `),
+    db.run(sql`
+      insert into ${organizationMilestones}
+        (organization_id, milestone, first_at, last_at, count)
+      select ${scans.organizationId}, 'artifact_observed', min(${scans.completedAt}),
+        max(${scans.completedAt}), count(*)
+      from ${scans}
+      where ${scans.status} = 'complete'
+        and ${scans.organizationId} is not null
+        and ${scans.completedAt} is not null
+      group by ${scans.organizationId}
+      on conflict (organization_id, milestone) do update set
+        first_at = excluded.first_at,
+        last_at = excluded.last_at,
+        count = excluded.count
+    `),
+    db.run(sql`
+      insert into ${organizationMilestones}
+        (organization_id, milestone, first_at, last_at, count)
+      select ${scans.organizationId}, 'review_completed', min(${scans.completedAt}),
+        max(${scans.completedAt}), count(*)
+      from ${scans}
+      where ${scans.status} = 'complete'
+        and ${scans.organizationId} is not null
+        and ${scans.completedAt} is not null
+      group by ${scans.organizationId}
+      on conflict (organization_id, milestone) do update set
+        first_at = excluded.first_at,
+        last_at = excluded.last_at,
+        count = excluded.count
+    `),
+    db.run(sql`
+      insert into ${organizationMilestones}
+        (organization_id, milestone, first_at, last_at, count)
+      select protected.organization_id, 'protected_release_completed',
+        min(protected.occurred_at), max(protected.occurred_at), count(*)
+      from (
+        select ${scans.organizationId} as organization_id,
+          coalesce(${scans.protectedReleaseRecordedAt}, ${scans.decidedAt}) as occurred_at
+        from ${scans}
+        where ${scans.source} <> 'workflow_gate'
+          and ${scans.decision} is not null
+          and ${scans.organizationId} is not null
+          and ${scans.decidedAt} is not null
+        union all
+        select ${githubWorkflowGates.organizationId} as organization_id,
+          ${githubWorkflowGates.callbackDeliveredAt} as occurred_at
+        from ${githubWorkflowGates}
+        where ${githubWorkflowGates.callbackDeliveredAt} is not null
+      ) protected
+      group by protected.organization_id
+      on conflict (organization_id, milestone) do update set
+        first_at = excluded.first_at,
+        last_at = excluded.last_at,
+        count = excluded.count
+    `),
+  ]);
+  const rows = results.reduce((total, result) => total + (result.meta.changes ?? 0), 0);
+  if (currentTelemetryContext().requestId) {
+    emitOperationalEvent("info", "organization.milestones.reconciled", { rows });
+  }
+  return rows;
+}

--- a/server/db/organizations.ts
+++ b/server/db/organizations.ts
@@ -2,6 +2,7 @@ import { and, asc, eq, inArray, ne, sql } from "drizzle-orm";
 import { personalOrganizationId } from "../lib/ownership";
 import { deleteOrganizationArtifacts } from "../lib/scan-artifacts";
 import type { AppDb, WorkspaceSession } from "./client";
+import { recordOrganizationMilestone } from "./organization-milestones";
 import {
   githubAppInstallations,
   githubReleaseTargets,
@@ -59,6 +60,8 @@ export async function ensurePersonalOrganization(db: AppDb, session: WorkspaceSe
       updatedAt: now,
     })
     .onConflictDoNothing();
+
+  await recordOrganizationMilestone(db, organizationId, "organization_created", now);
 
   return organizationId;
 }
@@ -169,6 +172,7 @@ export async function createOrganization(db: AppDb, input: CreateOrganizationInp
       updatedAt: now,
     }),
   ]);
+  await recordOrganizationMilestone(db, id, "organization_created", now);
   return id;
 }
 

--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -23,6 +23,7 @@ import {
   type ScanArtifactMetadata,
 } from "../lib/scan-artifacts";
 import type { AppDb } from "./client";
+import { recordOrganizationMilestone } from "./organization-milestones";
 import { recordScanEvent, redactScanEventForClient } from "./events";
 import { githubWorkflowGates, scanEvents, scanFiles, scanFindings, scans } from "./schema";
 
@@ -408,6 +409,12 @@ export async function persistScan(db: AppDb, input: PersistedScanInput) {
   if (Array.isArray(claimed) && claimed.length === 0) {
     return { persisted: false, reason: "already_terminal" as const };
   }
+  if (isComplete) {
+    await Promise.all([
+      recordOrganizationMilestone(db, input.organizationId, "artifact_observed", now),
+      recordOrganizationMilestone(db, input.organizationId, "review_completed", now),
+    ]);
+  }
   return { persisted: true as const };
 }
 
@@ -741,6 +748,11 @@ export async function recordScanDecision(
 ) {
   const now = new Date();
   const reason = input.reason?.trim() ? input.reason.trim() : null;
+  const [previous] = await db
+    .select({ decision: scans.decision })
+    .from(scans)
+    .where(and(eq(scans.id, input.scanId), eq(scans.organizationId, input.organizationId)))
+    .limit(1);
   const updated = await db
     .update(scans)
     .set({
@@ -757,7 +769,7 @@ export async function recordScanDecision(
         eq(scans.status, "complete"),
       ),
     )
-    .returning({ id: scans.id });
+    .returning({ id: scans.id, source: scans.source });
 
   if (updated.length === 0) return null;
 
@@ -768,6 +780,28 @@ export async function recordScanDecision(
     type: "scan.decided",
     metadata: { decision: input.decision, reason },
   });
+
+  if (updated[0]?.source !== "workflow_gate" && !previous?.decision) {
+    const recorded = await db
+      .update(scans)
+      .set({ protectedReleaseRecordedAt: now, updatedAt: now })
+      .where(
+        and(
+          eq(scans.id, input.scanId),
+          eq(scans.organizationId, input.organizationId),
+          isNull(scans.protectedReleaseRecordedAt),
+        ),
+      )
+      .returning({ id: scans.id });
+    if (recorded.length > 0) {
+      await recordOrganizationMilestone(
+        db,
+        input.organizationId,
+        "protected_release_completed",
+        now,
+      );
+    }
+  }
 
   return getScan(db, input.scanId, input.organizationId, artifactBucket);
 }

--- a/server/db/schema.ts
+++ b/server/db/schema.ts
@@ -43,6 +43,32 @@ export const organizations = sqliteTable(
   }),
 );
 
+// Rebuildable exact projection of the first/last occurrence and lifetime count
+// for a bounded set of organization value milestones. This is deliberately not
+// an audit or event table: one organization can own only one row per milestone.
+export const organizationMilestones = sqliteTable(
+  "organization_milestones",
+  {
+    organizationId: text("organization_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    milestone: text("milestone").notNull(),
+    firstAt: integer("first_at", { mode: "timestamp_ms" }).notNull(),
+    lastAt: integer("last_at", { mode: "timestamp_ms" }).notNull(),
+    count: integer("count").notNull().default(1),
+  },
+  (table) => ({
+    orgMilestoneUniqueIdx: uniqueIndex("organization_milestones_org_milestone_unique_idx").on(
+      table.organizationId,
+      table.milestone,
+    ),
+    milestoneLastIdx: index("organization_milestones_milestone_last_idx").on(
+      table.milestone,
+      table.lastAt,
+    ),
+  }),
+);
+
 export const organizationMembers = sqliteTable(
   "organization_members",
   {
@@ -149,6 +175,9 @@ export const scans = sqliteTable(
       onDelete: "set null",
     }),
     decidedAt: integer("decided_at", { mode: "timestamp_ms" }),
+    protectedReleaseRecordedAt: integer("protected_release_recorded_at", {
+      mode: "timestamp_ms",
+    }),
     summaryJson: text("summary_json", { mode: "json" }),
     aiJson: text("ai_json", { mode: "json" }),
     errorJson: text("error_json", { mode: "json" }),
@@ -421,6 +450,7 @@ export const githubWorkflowGates = sqliteTable(
     failureReason: text("failure_reason"),
     requestedAt: integer("requested_at", { mode: "timestamp_ms" }).notNull(),
     decidedAt: integer("decided_at", { mode: "timestamp_ms" }),
+    callbackDeliveredAt: integer("callback_delivered_at", { mode: "timestamp_ms" }),
     createdAt: integer("created_at", { mode: "timestamp_ms" }).notNull(),
     updatedAt: integer("updated_at", { mode: "timestamp_ms" }).notNull(),
   },

--- a/server/env.d.ts
+++ b/server/env.d.ts
@@ -10,6 +10,14 @@ declare global {
       SCAN_ARTIFACT_READS_DISABLED?: string;
       COMPARE_CACHE?: KVNamespace;
       SCAN_QUEUE?: Queue<import("./lib/scan-job").QueueMessage>;
+      TELEMETRY_ANALYTICS?: AnalyticsEngineDataset;
+      TELEMETRY_HASH_KEY?: string;
+      CF_VERSION_METADATA?: {
+        id: string;
+        tag?: string;
+        timestamp?: string;
+      };
+      ENVIRONMENT?: string;
       NPM_REGISTRY: string;
       ALLOW_INSECURE_LOCAL_REGISTRY?: string;
       // `.dev.vars`-only escape hatch (see securityHeadersDisabled). Never set in

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,7 @@ import { createDb } from "./db/client";
 import { AUDIT_LOG_RETENTION_DAYS, pruneAuditEventsOlderThan } from "./db/audit-log";
 import { listAutoDiscoveryNpmConnections } from "./db/npm-connections";
 import { getOrganizationOwnerUserId } from "./db/organizations";
+import { reconcileOrganizationMilestones } from "./db/organization-milestones";
 import { RateLimitError, enforceRateLimit } from "./db/rate-limit";
 import { createAuth, getAuthSession } from "./lib/auth";
 import { rateLimitResponse } from "./lib/http";
@@ -19,6 +20,7 @@ import {
   durationMsSince,
   emitOperationalEvent,
 } from "./lib/observability";
+import { newTelemetryId, readJourneyId, withTelemetryContext } from "./lib/telemetry/context";
 import {
   classifyScanError,
   executeScanJob,
@@ -293,12 +295,18 @@ app.notFound(async (c) => {
 });
 
 app.onError((err, c) => {
-  emitOperationalEvent("error", "request.unhandled_error", {
+  const telemetry = emitOperationalEvent("error", "request.unhandled_error", {
     method: c.req.method,
     path: c.req.path,
-    error: describeOperationalError(err),
+    error: { ...describeOperationalError(err), customerVisible: true },
   });
-  return c.json({ error: "internal error" }, 500);
+  const referenceId = telemetry.outcome.reference_id;
+  const response = c.json(
+    { error: "internal error", code: "internal.unclassified", referenceId },
+    500,
+  );
+  if (referenceId) response.headers.set("x-drydock-support-reference", referenceId);
+  return response;
 });
 
 // A scheduled invocation gets a bounded CPU budget. Sweeping organizations
@@ -396,7 +404,12 @@ async function runStagedPublishesDiscoveryCron(env: Cloudflare.Env, ctx: Executi
         }
         const detail =
           err instanceof StagedPublishesFetchError
-            ? { status: err.status, detail: err.detail }
+            ? {
+                code: "registry.metadata_fetch_failed",
+                status: err.status,
+                detail: err.detail,
+                retryable: err.status === 429 || err.status >= 500,
+              }
             : describeOperationalError(err);
         emitOperationalEvent("error", "staged_publishes.cron.org_failed", {
           organizationId: connection.organizationId,
@@ -436,89 +449,126 @@ async function pruneStaleAuditEvents(env: Cloudflare.Env) {
 }
 
 export default {
-  fetch: app.fetch,
-  async scheduled(_event: ScheduledController, env: Cloudflare.Env, ctx: ExecutionContext) {
-    await runStagedPublishesDiscoveryCron(env, ctx);
-    await pruneStaleAuditEvents(env);
+  fetch(request: Request, env: Cloudflare.Env, ctx: ExecutionContext) {
+    return withTelemetryContext(
+      telemetryInvocationContext(env, ctx, {
+        requestId: newTelemetryId("req"),
+        journeyId: readJourneyId(request.headers.get("x-drydock-journey-id")),
+      }),
+      () => app.fetch(request, env, ctx),
+    );
+  },
+  async scheduled(event: ScheduledController, env: Cloudflare.Env, ctx: ExecutionContext) {
+    await withTelemetryContext(
+      telemetryInvocationContext(env, ctx, { requestId: newTelemetryId("req") }),
+      async () => {
+        await runStagedPublishesDiscoveryCron(env, ctx);
+        await pruneStaleAuditEvents(env);
+        const scheduledAt = new Date(event.scheduledTime);
+        if (scheduledAt.getUTCHours() === 0 && scheduledAt.getUTCMinutes() === 0) {
+          await reconcileOrganizationMilestones(createDb(env.DB));
+        }
+      },
+    );
   },
   async queue(batch: MessageBatch<QueueMessage>, env: Cloudflare.Env, ctx: ExecutionContext) {
-    for (const message of batch.messages) {
-      const messageStartedAtMs = Date.now();
-      if (isWorkflowGateMessage(message.body)) {
-        const gateMessage = message.body;
-        try {
-          await executeWorkflowGateJob(env, ctx, gateMessage);
-          emitOperationalEvent("info", "workflow_gate.queue.message.completed", {
-            organizationId: gateMessage.organizationId,
-            gateId: gateMessage.gateId,
-            attempt: message.attempts,
-            durationMs: durationMsSince(messageStartedAtMs),
-          });
-        } catch (err) {
-          if (message.attempts < MAX_SCAN_JOB_ATTEMPTS) {
-            message.retry({ delaySeconds: retryDelaySeconds(message.attempts) });
-            emitOperationalEvent("warn", "workflow_gate.queue.retry_scheduled", {
-              organizationId: gateMessage.organizationId,
-              gateId: gateMessage.gateId,
+    await withTelemetryContext(
+      telemetryInvocationContext(env, ctx, { requestId: newTelemetryId("req") }),
+      async () => {
+        for (const message of batch.messages) {
+          const messageStartedAtMs = Date.now();
+          if (isWorkflowGateMessage(message.body)) {
+            const gateMessage = message.body;
+            try {
+              await executeWorkflowGateJob(env, ctx, gateMessage);
+              emitOperationalEvent("info", "workflow_gate.queue.message.completed", {
+                organizationId: gateMessage.organizationId,
+                gateId: gateMessage.gateId,
+                attempt: message.attempts,
+                durationMs: durationMsSince(messageStartedAtMs),
+              });
+            } catch (err) {
+              if (message.attempts < MAX_SCAN_JOB_ATTEMPTS) {
+                message.retry({ delaySeconds: retryDelaySeconds(message.attempts) });
+                emitOperationalEvent("warn", "workflow_gate.queue.retry_scheduled", {
+                  organizationId: gateMessage.organizationId,
+                  gateId: gateMessage.gateId,
+                  attempt: message.attempts,
+                  nextDelaySeconds: retryDelaySeconds(message.attempts),
+                  durationMs: durationMsSince(messageStartedAtMs),
+                  error: describeOperationalError(err),
+                });
+              } else {
+                emitOperationalEvent("error", "workflow_gate.queue.message_failed", {
+                  organizationId: gateMessage.organizationId,
+                  gateId: gateMessage.gateId,
+                  attempt: message.attempts,
+                  durationMs: durationMsSince(messageStartedAtMs),
+                  error: describeOperationalError(err),
+                });
+                throw err;
+              }
+            }
+            continue;
+          }
+          try {
+            await executeScanJob(env, ctx, message.body, undefined, {
               attempt: message.attempts,
-              nextDelaySeconds: retryDelaySeconds(message.attempts),
-              durationMs: durationMsSince(messageStartedAtMs),
-              error: describeOperationalError(err),
+              finalAttempt: message.attempts >= MAX_SCAN_JOB_ATTEMPTS,
             });
-          } else {
-            emitOperationalEvent("error", "workflow_gate.queue.message_failed", {
-              organizationId: gateMessage.organizationId,
-              gateId: gateMessage.gateId,
+            emitOperationalEvent("info", "scan.queue.message.completed", {
+              scanId: message.body.scanId,
+              organizationId: message.body.organizationId,
+              stageId: message.body.stageId,
+              source: message.body.source ?? "manual",
               attempt: message.attempts,
               durationMs: durationMsSince(messageStartedAtMs),
-              error: describeOperationalError(err),
             });
-            throw err;
+          } catch (err) {
+            const safe = classifyScanError(err);
+            if (safe.retryable && message.attempts < MAX_SCAN_JOB_ATTEMPTS) {
+              message.retry({ delaySeconds: retryDelaySeconds(message.attempts) });
+              emitOperationalEvent("warn", "scan.queue.retry_scheduled", {
+                scanId: message.body.scanId,
+                organizationId: message.body.organizationId,
+                stageId: message.body.stageId,
+                source: message.body.source ?? "manual",
+                attempt: message.attempts,
+                nextDelaySeconds: retryDelaySeconds(message.attempts),
+                durationMs: durationMsSince(messageStartedAtMs),
+                error: safe,
+              });
+            } else {
+              emitOperationalEvent("error", "scan.queue.message_failed", {
+                scanId: message.body.scanId,
+                organizationId: message.body.organizationId,
+                stageId: message.body.stageId,
+                source: message.body.source ?? "manual",
+                attempt: message.attempts,
+                exhausted: safe.retryable,
+                durationMs: durationMsSince(messageStartedAtMs),
+                error: safe,
+              });
+              if (safe.retryable) throw err;
+            }
           }
         }
-        continue;
-      }
-      try {
-        await executeScanJob(env, ctx, message.body, undefined, {
-          attempt: message.attempts,
-          finalAttempt: message.attempts >= MAX_SCAN_JOB_ATTEMPTS,
-        });
-        emitOperationalEvent("info", "scan.queue.message.completed", {
-          scanId: message.body.scanId,
-          organizationId: message.body.organizationId,
-          stageId: message.body.stageId,
-          source: message.body.source ?? "manual",
-          attempt: message.attempts,
-          durationMs: durationMsSince(messageStartedAtMs),
-        });
-      } catch (err) {
-        const safe = classifyScanError(err);
-        if (safe.retryable && message.attempts < MAX_SCAN_JOB_ATTEMPTS) {
-          message.retry({ delaySeconds: retryDelaySeconds(message.attempts) });
-          emitOperationalEvent("warn", "scan.queue.retry_scheduled", {
-            scanId: message.body.scanId,
-            organizationId: message.body.organizationId,
-            stageId: message.body.stageId,
-            source: message.body.source ?? "manual",
-            attempt: message.attempts,
-            nextDelaySeconds: retryDelaySeconds(message.attempts),
-            durationMs: durationMsSince(messageStartedAtMs),
-            error: safe,
-          });
-        } else {
-          emitOperationalEvent("error", "scan.queue.message_failed", {
-            scanId: message.body.scanId,
-            organizationId: message.body.organizationId,
-            stageId: message.body.stageId,
-            source: message.body.source ?? "manual",
-            attempt: message.attempts,
-            exhausted: safe.retryable,
-            durationMs: durationMsSince(messageStartedAtMs),
-            error: safe,
-          });
-          if (safe.retryable) throw err;
-        }
-      }
-    }
+      },
+    );
   },
 };
+
+function telemetryInvocationContext(
+  env: Cloudflare.Env,
+  executionCtx: ExecutionContext,
+  correlation: { requestId: string; journeyId?: string | null },
+) {
+  return {
+    ...correlation,
+    serviceVersion: env.CF_VERSION_METADATA?.tag || env.CF_VERSION_METADATA?.id || "local",
+    environment: env.ENVIRONMENT || (env.CF_VERSION_METADATA ? "production" : "development"),
+    analytics: env.TELEMETRY_ANALYTICS,
+    analyticsHashKey: env.TELEMETRY_HASH_KEY,
+    executionCtx,
+  };
+}

--- a/server/lib/observability.ts
+++ b/server/lib/observability.ts
@@ -1,72 +1,20 @@
-export type OperationalEventLevel = "info" | "warn" | "error";
-
-export type OperationalFields = Record<string, unknown>;
-
-const SENSITIVE_KEY_RE =
-  /(authorization|cookie|credential|password|secret|token|ciphertext|nonce)/i;
-const BEARER_RE = /\bBearer\s+[A-Za-z0-9._\-+/=]+/gi;
+export {
+  emitOperationalEvent,
+  projectOperationalEvent,
+  sanitizeOperationalFields,
+} from "./telemetry/emit";
+export type {
+  OperationalEventFields as OperationalFields,
+  OperationalEventLevel,
+} from "./telemetry/events";
 
 export function durationMsSince(startedAtMs: number, nowMs = Date.now()) {
   return Math.max(0, nowMs - startedAtMs);
 }
 
-export function emitOperationalEvent(
-  level: OperationalEventLevel,
-  event: string,
-  fields: OperationalFields = {},
-) {
-  const payload = sanitizeOperationalFields({ event, ...fields });
-  switch (level) {
-    case "error":
-      console.error(event, payload);
-      break;
-    case "warn":
-      console.warn(event, payload);
-      break;
-    default:
-      console.log(event, payload);
-  }
-}
-
 export function describeOperationalError(err: unknown) {
-  if (err instanceof Error) {
-    return { name: err.name, message: err.message };
-  }
-  if (err && typeof err === "object") {
-    const value = err as Record<string, unknown>;
-    return {
-      name: typeof value.name === "string" ? value.name : "UnknownError",
-      message: typeof value.message === "string" ? value.message : undefined,
-    };
-  }
-  return { name: typeof err };
-}
-
-export function sanitizeOperationalFields(value: unknown): unknown {
-  return sanitizeValue(value, new WeakSet(), 0, null);
-}
-
-function sanitizeValue(
-  value: unknown,
-  seen: WeakSet<object>,
-  depth: number,
-  key: string | null,
-): unknown {
-  if (key && SENSITIVE_KEY_RE.test(key)) return "[redacted]";
-  if (typeof value === "string") return value.replace(BEARER_RE, "Bearer [redacted]");
-  if (value === null || typeof value !== "object") return value;
-  if (value instanceof Error) return describeOperationalError(value);
-  if (depth > 5) return "[truncated]";
-  if (seen.has(value)) return "[circular]";
-  seen.add(value);
-
-  if (Array.isArray(value)) {
-    return value.map((item) => sanitizeValue(item, seen, depth + 1, null));
-  }
-
-  const output: Record<string, unknown> = {};
-  for (const [entryKey, entryValue] of Object.entries(value)) {
-    output[entryKey] = sanitizeValue(entryValue, seen, depth + 1, entryKey);
-  }
-  return output;
+  const value = err && typeof err === "object" ? (err as Record<string, unknown>) : null;
+  const code = typeof value?.code === "string" ? value.code : "internal.unclassified";
+  const retryable = typeof value?.retryable === "boolean" ? value.retryable : true;
+  return { code, retryable, customerVisible: false };
 }

--- a/server/lib/scan-job.ts
+++ b/server/lib/scan-job.ts
@@ -130,8 +130,7 @@ export async function executeScanJob(
           error: safe,
         });
       } else {
-        await markScanFailed(db, message.scanId, message.organizationId, safe);
-        emitOperationalEvent("error", "scan.job.failed", {
+        const telemetry = emitOperationalEvent("error", "scan.job.failed", {
           scanId: message.scanId,
           organizationId: message.organizationId,
           stageId: message.stageId,
@@ -139,8 +138,13 @@ export async function executeScanJob(
           attempt,
           finalAttempt: Boolean(options.finalAttempt),
           durationMs: durationMsSince(startedAtMs),
-          error: safe,
+          error: { ...safe, customerVisible: true },
         });
+        const persistedError = {
+          ...safe,
+          referenceId: telemetry.outcome.reference_id ?? undefined,
+        };
+        await markScanFailed(db, message.scanId, message.organizationId, persistedError);
         if (message.source !== "workflow_gate") {
           executionCtx.waitUntil(
             notifyScanCompletion({
@@ -150,7 +154,7 @@ export async function executeScanJob(
               organizationId: message.organizationId,
               ownerUserId: message.actorUserId,
               outcome: "failed",
-              error: safe,
+              error: persistedError,
             }),
           );
         }

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -7,6 +7,7 @@ import type {
   PackageAdapter,
 } from "./adapters/types";
 import { describeOperationalError, durationMsSince, emitOperationalEvent } from "./observability";
+import { enterTelemetrySpan } from "./telemetry/tracing";
 import {
   computeDiff,
   persistResults,
@@ -47,52 +48,87 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
   const connectionRef: AdapterConnectionRef = { organizationId: input.organizationId };
   const broker = adapter.createBroker(adapterCtx, connectionRef);
   const pipelineStartedAtMs = Date.now();
+  const spanAttributes = {
+    "drydock.scan.id": input.scanId,
+    "drydock.organization.id": input.organizationId,
+    "drydock.ecosystem": adapter.id,
+  };
 
   try {
-    const resolved = await resolveBaseline(adapter, adapterCtx, adapterInput, broker);
-    const diff = computeDiff(resolved);
-    const findings = runDeterministicFindings(adapter, resolved, diff);
+    const resolved = await enterTelemetrySpan(
+      executionCtx,
+      "scan.resolve_baseline",
+      spanAttributes,
+      () => resolveBaseline(adapter, adapterCtx, adapterInput, broker),
+    );
+    const diff = enterTelemetrySpan(executionCtx, "scan.compute_diff", spanAttributes, () =>
+      computeDiff(resolved),
+    );
+    const findings = enterTelemetrySpan(
+      executionCtx,
+      "scan.deterministic_review",
+      spanAttributes,
+      () => runDeterministicFindings(adapter, resolved, diff),
+    );
 
     const identity: PipelineIdentity = {
       scanId: input.scanId || crypto.randomUUID(),
       stageId: input.stageId,
       organizationId: input.organizationId,
     };
-    const aiFindings = await maybeRunAiReview({
-      env,
-      identity,
-      ecosystem: adapter.id,
-      previousVersionAvailable: resolved.baseline.artifact !== null,
-      findings,
-      diff,
-    });
+    const aiFindings = await enterTelemetrySpan(
+      executionCtx,
+      "scan.ai_review",
+      spanAttributes,
+      () =>
+        maybeRunAiReview({
+          env,
+          identity,
+          ecosystem: adapter.id,
+          previousVersionAvailable: resolved.baseline.artifact !== null,
+          findings,
+          diff,
+        }),
+    );
     const riskSummary = scoreRisk(findings.annotatedFindings, aiFindings);
 
     // Advisory release-memory lookup (db read) before persistence. It compares
     // finding profiles only; it never touches risk or findings, and a lookup
     // failure degrades to "none" inside the phase instead of failing the scan.
-    const releaseConsistency = await resolveReleaseConsistency({
-      db,
-      env,
-      identity,
-      packageName: findings.redactedStagedManifest?.name ?? null,
-      ruleFindings: findings.ruleFindings,
-    });
+    const releaseConsistency = await enterTelemetrySpan(
+      executionCtx,
+      "scan.release_memory_lookup",
+      spanAttributes,
+      () =>
+        resolveReleaseConsistency({
+          db,
+          env,
+          identity,
+          packageName: findings.redactedStagedManifest?.name ?? null,
+          ruleFindings: findings.ruleFindings,
+        }),
+    );
 
-    const { result, persisted } = await persistResults({
-      env,
-      db,
-      session,
-      adapter,
-      adapterInput,
-      identity,
-      resolved,
-      diff,
-      findings,
-      aiFindings,
-      riskSummary,
-      releaseConsistency,
-    });
+    const { result, persisted } = await enterTelemetrySpan(
+      executionCtx,
+      "scan.persist_report",
+      spanAttributes,
+      () =>
+        persistResults({
+          env,
+          db,
+          session,
+          adapter,
+          adapterInput,
+          identity,
+          resolved,
+          diff,
+          findings,
+          aiFindings,
+          riskSummary,
+          releaseConsistency,
+        }),
+    );
 
     await recordCompletion({
       db,

--- a/server/lib/telemetry/analytics.ts
+++ b/server/lib/telemetry/analytics.ts
@@ -1,0 +1,45 @@
+import type { OperationalTelemetryEvent } from "./events";
+
+export async function writeAnalyticsEvent(
+  dataset: AnalyticsEngineDataset,
+  hashKey: string,
+  telemetry: OperationalTelemetryEvent,
+): Promise<void> {
+  const organizationId = telemetry.tenant.organization_id;
+  const tenantIndex = organizationId
+    ? await sha256Base64Url(`${hashKey}:${organizationId}`)
+    : "anonymous";
+  const error = telemetry.outcome.error;
+
+  dataset.writeDataPoint({
+    // Ordered schema is a contract. Append columns; never reorder existing ones.
+    blobs: [
+      telemetry.event.name,
+      telemetry.service.version,
+      telemetry.service.environment,
+      telemetry.severity,
+      telemetry.product.surface,
+      telemetry.product.ecosystem ?? "",
+      telemetry.product.phase,
+      telemetry.outcome.status,
+      error?.code ?? "",
+      error?.class ?? "",
+      String(error?.retryable ?? false),
+      String(error?.customer_visible ?? false),
+    ],
+    doubles: [
+      telemetry.measurements.duration_ms ?? 0,
+      telemetry.measurements.attempt ?? 0,
+      telemetry.measurements.count ?? 1,
+    ],
+    indexes: [tenantIndex.slice(0, 96)],
+  });
+}
+
+async function sha256Base64Url(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  const bytes = new Uint8Array(digest);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}

--- a/server/lib/telemetry/context.ts
+++ b/server/lib/telemetry/context.ts
@@ -1,0 +1,32 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export interface TelemetryRuntimeContext {
+  requestId?: string | null;
+  journeyId?: string | null;
+  organizationId?: string | null;
+  serviceVersion?: string | null;
+  environment?: string | null;
+  analytics?: AnalyticsEngineDataset | null;
+  analyticsHashKey?: string | null;
+  executionCtx?: ExecutionContext | null;
+}
+
+const storage = new AsyncLocalStorage<TelemetryRuntimeContext>();
+const OPAQUE_ID_RE = /^(?:req|jny)_[A-Za-z0-9_-]{8,128}$/;
+
+export function newTelemetryId(prefix: "evt" | "req" | "ref" | "jny") {
+  return `${prefix}_${crypto.randomUUID().replaceAll("-", "")}`;
+}
+
+export function readJourneyId(value: string | null | undefined): string | null {
+  if (!value || !OPAQUE_ID_RE.test(value)) return null;
+  return value;
+}
+
+export function withTelemetryContext<T>(context: TelemetryRuntimeContext, callback: () => T): T {
+  return storage.run(context, callback);
+}
+
+export function currentTelemetryContext(): TelemetryRuntimeContext {
+  return storage.getStore() ?? {};
+}

--- a/server/lib/telemetry/emit.ts
+++ b/server/lib/telemetry/emit.ts
@@ -1,0 +1,228 @@
+import { writeAnalyticsEvent } from "./analytics";
+import { currentTelemetryContext, newTelemetryId } from "./context";
+import { telemetryError } from "./errors";
+import type {
+  OperationalEventFields,
+  OperationalEventLevel,
+  OperationalEventName,
+  OperationalTelemetryEvent,
+  TelemetryOutcomeStatus,
+} from "./events";
+
+const DENIED_KEY_RE =
+  /(authorization|cookie|credential|password|secret|token|ciphertext|nonce|message|detail|reason|packageName|stageId|path|url|header|body|content|evidence|manifest|prompt|response|email|name|userAgent)/i;
+const BEARER_RE = /\bBearer\s+[A-Za-z0-9._\-+/=]+/gi;
+const MEASUREMENT_KEYS = new Set([
+  "attempt",
+  "batchSize",
+  "bytes",
+  "changedFileCount",
+  "concurrencyLimit",
+  "contentLength",
+  "durationMs",
+  "diffCount",
+  "elapsedMs",
+  "fileCount",
+  "fileSampleCount",
+  "findingCount",
+  "limit",
+  "nextDelaySeconds",
+  "organizations",
+  "orgsProcessed",
+  "packageCount",
+  "previousFileCount",
+  "reportSize",
+  "retentionDays",
+  "rows",
+  "windowMs",
+]);
+const CORRELATION_KEYS = new Set(["scanId", "gateId", "deliveryId", "organizationId"]);
+
+export function emitOperationalEvent(
+  level: OperationalEventLevel,
+  eventName: OperationalEventName,
+  fields: OperationalEventFields = {},
+): OperationalTelemetryEvent {
+  const telemetry = projectOperationalEvent(level, eventName, fields);
+  if (level === "error") console.error(telemetry);
+  else if (level === "warn") console.warn(telemetry);
+  else console.log(telemetry);
+  scheduleAnalyticsWrite(telemetry);
+  return telemetry;
+}
+
+export function projectOperationalEvent(
+  level: OperationalEventLevel,
+  eventName: OperationalEventName,
+  fields: OperationalEventFields = {},
+): OperationalTelemetryEvent {
+  const context = currentTelemetryContext();
+  const phase = phaseFor(eventName, fields.error);
+  const status = outcomeFor(level, eventName);
+  const failed = status === "failure" || status === "retry";
+  const error = failed ? telemetryError(eventName, phase, fields.error ?? fields.reason) : null;
+  const eventId = newTelemetryId("evt");
+  const measurements: Record<string, number> = {};
+  const dimensions: Record<string, string | number | boolean | null> = {};
+
+  for (const [key, value] of Object.entries(fields)) {
+    if (CORRELATION_KEYS.has(key) || key === "error" || DENIED_KEY_RE.test(key)) continue;
+    if (MEASUREMENT_KEYS.has(key) && typeof value === "number" && Number.isFinite(value)) {
+      measurements[toSnakeCase(key)] = Math.max(0, value);
+      continue;
+    }
+    if (
+      value === null ||
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
+      dimensions[toSnakeCase(key)] = typeof value === "string" ? boundedString(value) : value;
+    }
+  }
+  measurements.count = 1;
+
+  return {
+    event: {
+      id: eventId,
+      name: eventName,
+      version: 1,
+      occurred_at: new Date().toISOString(),
+    },
+    severity: level,
+    service: {
+      name: "drydock-worker",
+      version: context.serviceVersion || "local",
+      environment: context.environment || "development",
+    },
+    correlation: {
+      request_id: context.requestId ?? null,
+      journey_id: context.journeyId ?? null,
+      scan_id: readString(fields.scanId),
+      gate_id: readString(fields.gateId),
+      delivery_id: readString(fields.deliveryId),
+    },
+    tenant: {
+      organization_id: readString(fields.organizationId) ?? context.organizationId ?? null,
+    },
+    product: {
+      surface: surfaceFor(eventName, fields.source),
+      ecosystem: readString(fields.ecosystem) ?? readString(fields.adapterId),
+      phase,
+    },
+    outcome: {
+      status,
+      error,
+      reference_id: error?.customer_visible ? eventId.replace("evt_", "ref_") : null,
+    },
+    measurements,
+    dimensions,
+  };
+}
+
+export function sanitizeOperationalFields(value: unknown): unknown {
+  return sanitizeValue(value, new WeakSet(), 0, null);
+}
+
+function scheduleAnalyticsWrite(telemetry: OperationalTelemetryEvent) {
+  const context = currentTelemetryContext();
+  if (!context.analytics || !context.analyticsHashKey) return;
+  const write = writeAnalyticsEvent(context.analytics, context.analyticsHashKey, telemetry).catch(
+    () => {
+      console.error(
+        projectOperationalEvent("error", "telemetry.analytics_write_failed", {
+          reason: "analytics_binding_write_failed",
+        }),
+      );
+    },
+  );
+  context.executionCtx?.waitUntil(write);
+}
+
+function outcomeFor(level: OperationalEventLevel, eventName: string): TelemetryOutcomeStatus {
+  if (eventName.includes("retry")) return "retry";
+  if (eventName.endsWith(".skipped") || eventName.endsWith(".ignored")) return "skipped";
+  if (
+    level === "error" ||
+    level === "warn" ||
+    eventName.endsWith(".failed") ||
+    eventName.endsWith(".error")
+  ) {
+    return "failure";
+  }
+  return "success";
+}
+
+function phaseFor(eventName: string, errorInput?: object | string | null): string {
+  const errorCode =
+    errorInput && typeof errorInput === "object" && "code" in errorInput
+      ? String(errorInput.code)
+      : "";
+  if (
+    errorCode.startsWith("sandbox_download") ||
+    errorCode.startsWith("staged_tarball") ||
+    errorCode.startsWith("registry.")
+  ) {
+    return "artifact_acquisition";
+  }
+  if (errorCode.startsWith("archive_")) return "archive_parse";
+  if (errorCode.startsWith("npm_connection_")) return "integration_validation";
+  if (eventName.includes("ai_review")) return "ai_review";
+  if (eventName.includes("release_memory")) return "release_memory_lookup";
+  if (eventName.includes("artifacts") || eventName.includes("bundle")) return "artifact_storage";
+  if (eventName.includes("callback") || eventName.includes("redeliver")) return "decision_callback";
+  if (eventName.includes("notification")) return "notification";
+  if (eventName.includes("webhook")) return "webhook";
+  if (eventName.includes("queue")) return "queue";
+  if (eventName.includes("pipeline") || eventName.includes("review")) return "deterministic_review";
+  if (eventName.includes("auth")) return "auth";
+  if (eventName.includes("connection") || eventName.includes("registry")) {
+    return "integration_validation";
+  }
+  if (eventName.includes("cron") || eventName.includes("prune")) return "scheduled_task";
+  return "request";
+}
+
+function surfaceFor(eventName: string, source: unknown): string {
+  if (eventName.startsWith("github_workflow_gate") || eventName.startsWith("workflow_gate")) {
+    return "workflow_gate";
+  }
+  if (eventName.startsWith("staged_publishes.cron")) return "scheduled_discovery";
+  if (typeof source === "string" && source) return boundedString(source);
+  if (eventName.startsWith("scan")) return "scan";
+  return "api";
+}
+
+function sanitizeValue(
+  value: unknown,
+  seen: WeakSet<object>,
+  depth: number,
+  key: string | null,
+): unknown {
+  if (key && DENIED_KEY_RE.test(key)) return "[redacted]";
+  if (typeof value === "string")
+    return boundedString(value.replace(BEARER_RE, "Bearer [redacted]"));
+  if (value === null || typeof value !== "object") return value;
+  if (value instanceof Error) return { code: "internal.unclassified" };
+  if (depth > 5) return "[truncated]";
+  if (seen.has(value)) return "[circular]";
+  seen.add(value);
+  if (Array.isArray(value)) return value.map((item) => sanitizeValue(item, seen, depth + 1, null));
+  const output: Record<string, unknown> = {};
+  for (const [entryKey, entryValue] of Object.entries(value)) {
+    output[entryKey] = sanitizeValue(entryValue, seen, depth + 1, entryKey);
+  }
+  return output;
+}
+
+function boundedString(value: string): string {
+  return value.slice(0, 120);
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value ? boundedString(value) : null;
+}
+
+function toSnakeCase(value: string): string {
+  return value.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
+}

--- a/server/lib/telemetry/errors.ts
+++ b/server/lib/telemetry/errors.ts
@@ -1,0 +1,77 @@
+import type { OperationalErrorInput, TelemetryError } from "./events";
+
+const ERROR_CODE_RE = /^[a-z][a-z0-9_.-]{2,79}$/;
+
+export function telemetryError(
+  eventName: string,
+  phase: string,
+  input: object | string | null | undefined,
+): TelemetryError {
+  const supplied = typeof input === "object" && input ? (input as OperationalErrorInput) : null;
+  const suppliedCode = typeof supplied?.code === "string" ? supplied.code : null;
+  const code =
+    suppliedCode && ERROR_CODE_RE.test(suppliedCode) ? suppliedCode : eventErrorCode(eventName);
+  const errorClass = classifyErrorCode(code, eventName);
+  const retryable =
+    typeof supplied?.retryable === "boolean" ? supplied.retryable : defaultRetryable(errorClass);
+  const customerVisibleValue = supplied?.customerVisible ?? supplied?.customer_visible;
+  const customerVisible =
+    typeof customerVisibleValue === "boolean"
+      ? customerVisibleValue
+      : errorClass === "customer_configuration" || errorClass === "policy_block";
+  const owner = ownerFor(errorClass, phase);
+
+  return {
+    code,
+    class: errorClass,
+    phase,
+    retryable,
+    customer_visible: customerVisible,
+    fingerprint: `v1:${fnv1a(`${code}|${phase}`)}`,
+    owner,
+    runbook: `/docs/runbooks/${owner}.md`,
+  };
+}
+
+function eventErrorCode(eventName: string): string {
+  if (eventName === "scan.error.unclassified" || eventName === "request.unhandled_error") {
+    return "internal.unclassified";
+  }
+  return eventName.replaceAll("_", ".");
+}
+
+function classifyErrorCode(code: string, eventName: string): TelemetryError["class"] {
+  if (/(archive|artifact|policy|unsupported|too.large|too.many)/.test(code)) {
+    return "policy_block";
+  }
+  if (/(invalid|missing|config|auth|credential|token|connection)/.test(code)) {
+    return "customer_configuration";
+  }
+  if (/(registry|github|slack|notification|timeout|transient|callback)/.test(code)) {
+    return "external_dependency";
+  }
+  if (/(ignored|skipped|already|unavailable)/.test(code) || eventName.endsWith(".skipped")) {
+    return "expected_control_flow";
+  }
+  return "product_bug";
+}
+
+function defaultRetryable(errorClass: TelemetryError["class"]): boolean {
+  return errorClass === "product_bug" || errorClass === "external_dependency";
+}
+
+function ownerFor(errorClass: TelemetryError["class"], phase: string): string {
+  if (errorClass === "external_dependency") return "integrations";
+  if (phase.includes("artifact") || phase.includes("archive")) return "scanner";
+  if (phase.includes("notification")) return "notifications";
+  return "platform";
+}
+
+function fnv1a(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}

--- a/server/lib/telemetry/events.ts
+++ b/server/lib/telemetry/events.ts
@@ -1,0 +1,202 @@
+export const OPERATIONAL_EVENT_NAMES = [
+  "audit_events.prune_failed",
+  "audit_events.pruned",
+  "auth.initialization_failed",
+  "github_app.route_error",
+  "github_webhook.apply_failed",
+  "github_webhook.body_too_large",
+  "github_webhook.config_error",
+  "github_webhook.config_missing",
+  "github_webhook.empty_body",
+  "github_webhook.ignored",
+  "github_webhook.invalid_content_length",
+  "github_webhook.invalid_payload",
+  "github_webhook.missing_headers",
+  "github_webhook.signature_invalid",
+  "github_workflow_gate.bundle_failed",
+  "github_workflow_gate.config_error",
+  "github_workflow_gate.decision_bookkeeping_failed",
+  "github_workflow_gate.decision_callback_failed",
+  "github_workflow_gate.decision_redelivered",
+  "github_workflow_gate.job_skipped",
+  "github_workflow_gate.mark_errored_failed",
+  "github_workflow_gate.notification_error",
+  "github_workflow_gate.redelivery_failed",
+  "github_workflow_gate.rejected_artifact_error",
+  "github_workflow_gate.review_failed",
+  "github_workflow_gate.review_ready",
+  "github_workflow_gate.timeout_imminent",
+  "github_workflow_gate.timeout_missed",
+  "github_workflow_gate.unsupported_ecosystem",
+  "npm_connection.token_expired_alert_failed",
+  "npm_connection.token_retrieval_failed",
+  "npm_connection.upsert_failed",
+  "npm_connection.validation_failed",
+  "organization.create_failed",
+  "organization.milestone.recorded",
+  "organization.milestones.reconciled",
+  "registry.metadata_fetch_failed",
+  "request.unhandled_error",
+  "scan.ai_review.completed",
+  "scan.ai_review.failed",
+  "scan.artifacts.backfill_digest_mismatch",
+  "scan.artifacts.backfill_failed",
+  "scan.artifacts.backfilled",
+  "scan.artifacts.binding_missing",
+  "scan.artifacts.delete_failed",
+  "scan.artifacts.deleted",
+  "scan.artifacts.fallback_read",
+  "scan.artifacts.write_failed",
+  "scan.artifacts.written",
+  "scan.error.unclassified",
+  "scan.job.completed",
+  "scan.job.failed",
+  "scan.job.retryable_failed",
+  "scan.job.skipped",
+  "scan.pipeline.completed",
+  "scan.pipeline.failed",
+  "scan.queue.message.completed",
+  "scan.queue.message_failed",
+  "scan.queue.retry_scheduled",
+  "scan.release_memory.lookup_failed",
+  "staged_publishes.cron.org_completed",
+  "staged_publishes.cron.org_failed",
+  "staged_publishes.cron.skipped",
+  "staged_publishes.cron.started",
+  "staged_publishes.cron.swept",
+  "telemetry.analytics_write_failed",
+  "workflow_gate.queue.message.completed",
+  "workflow_gate.queue.message_failed",
+  "workflow_gate.queue.retry_scheduled",
+] as const;
+
+export type OperationalEventName = (typeof OPERATIONAL_EVENT_NAMES)[number];
+export type OperationalEventLevel = "info" | "warn" | "error";
+export type TelemetryOutcomeStatus = "success" | "failure" | "skipped" | "retry";
+
+export interface OperationalErrorInput {
+  code?: string;
+  message?: string;
+  retryable?: boolean;
+  customerVisible?: boolean;
+  customer_visible?: boolean;
+}
+
+// Producers can supply only bounded scalar dimensions, measurements, and the
+// safe error envelope. Free-form values are removed again by the sink projector.
+export interface OperationalEventFields {
+  adapterId?: string | null;
+  artifactRisk?: string | null;
+  attempt?: number;
+  batchSize?: number;
+  bytes?: number;
+  changedFileCount?: number;
+  concurrencyLimit?: number;
+  contentLength?: number;
+  contextRisk?: string | null;
+  cutoff?: string;
+  decision?: string | null;
+  deliveryId?: string | null;
+  detail?: string | null;
+  diffCount?: number;
+  durationMs?: number;
+  ecosystem?: string | null;
+  elapsedMs?: number;
+  error?: object | string | null;
+  eventName?: string | null;
+  exhausted?: boolean;
+  fileCount?: number;
+  fileSampleCount?: number;
+  finalAttempt?: boolean;
+  findingCount?: number;
+  gateId?: string | null;
+  hasEvent?: boolean;
+  hasDelivery?: boolean;
+  hasSignature?: boolean;
+  installationId?: string | null;
+  limit?: number;
+  message?: unknown;
+  method?: string;
+  milestone?: string;
+  model?: string | null;
+  nextDelaySeconds?: number;
+  operation?: string;
+  organizationId?: string | null;
+  organizations?: number;
+  orgsProcessed?: number;
+  objectsDeleted?: number;
+  packageCount?: number;
+  packageName?: string | null;
+  path?: string;
+  persisted?: boolean;
+  previousFileCount?: number;
+  reason?: string | null;
+  recommendation?: string | null;
+  releaseRisk?: string | null;
+  reportSize?: number;
+  reportVersion?: number;
+  repositoryFullName?: string | null;
+  retentionDays?: number;
+  rows?: number;
+  runId?: number;
+  scanId?: string | null;
+  source?: string | null;
+  stageId?: string | null;
+  status?: number | string | null;
+  storageVersion?: number;
+  timeoutState?: string | null;
+  usage?: unknown;
+  windowMs?: number;
+  written?: boolean;
+}
+
+export interface TelemetryError {
+  code: string;
+  class:
+    | "product_bug"
+    | "customer_configuration"
+    | "external_dependency"
+    | "policy_block"
+    | "expected_control_flow";
+  phase: string;
+  retryable: boolean;
+  customer_visible: boolean;
+  fingerprint: string;
+  owner: string;
+  runbook: string;
+}
+
+export interface OperationalTelemetryEvent {
+  event: {
+    id: string;
+    name: OperationalEventName;
+    version: 1;
+    occurred_at: string;
+  };
+  severity: OperationalEventLevel;
+  service: {
+    name: "drydock-worker";
+    version: string;
+    environment: string;
+  };
+  correlation: {
+    request_id: string | null;
+    journey_id: string | null;
+    scan_id: string | null;
+    gate_id: string | null;
+    delivery_id: string | null;
+  };
+  tenant: { organization_id: string | null };
+  product: {
+    surface: string;
+    ecosystem: string | null;
+    phase: string;
+  };
+  outcome: {
+    status: TelemetryOutcomeStatus;
+    error: TelemetryError | null;
+    reference_id: string | null;
+  };
+  measurements: Record<string, number>;
+  dimensions: Record<string, string | number | boolean | null>;
+}

--- a/server/lib/telemetry/tracing.ts
+++ b/server/lib/telemetry/tracing.ts
@@ -1,0 +1,25 @@
+type SpanAttribute = string | number | boolean | undefined;
+
+interface RuntimeSpan {
+  setAttribute(key: string, value: SpanAttribute): void;
+}
+
+interface RuntimeTracing {
+  enterSpan<T>(name: string, callback: (span: RuntimeSpan) => T): T;
+}
+
+export function enterTelemetrySpan<T>(
+  executionCtx: ExecutionContext,
+  name: string,
+  attributes: Record<string, SpanAttribute>,
+  callback: () => T,
+): T {
+  const tracing = (executionCtx as ExecutionContext & { tracing?: RuntimeTracing }).tracing;
+  if (!tracing) return callback();
+  return tracing.enterSpan(name, (span) => {
+    for (const [key, value] of Object.entries(attributes)) {
+      span.setAttribute(key, value);
+    }
+    return callback();
+  });
+}

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -1,9 +1,10 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import { type AppDb, createDb } from "../db/client";
 import { recordScanEvent } from "../db/events";
+import { recordOrganizationMilestone } from "../db/organization-milestones";
 import { getOrganizationOwnerUserId } from "../db/organizations";
 import { createScanJob, discardGateScans, markScanFailed } from "../db/scans";
-import { githubAppInstallations } from "../db/schema";
+import { githubAppInstallations, githubWorkflowGates } from "../db/schema";
 import { WorkflowArtifactError } from "./github-app/artifacts";
 import {
   type GithubAppConfig,
@@ -21,6 +22,7 @@ import {
 } from "./github-app/webhook-gates";
 import { notifyWorkflowGateReview, notifyWorkflowGateTimeout } from "./notify";
 import { describeOperationalError, durationMsSince, emitOperationalEvent } from "./observability";
+import { enterTelemetrySpan } from "./telemetry/tracing";
 import {
   type PreparedGatePackage,
   type PreparedGateRelease,
@@ -119,7 +121,12 @@ export async function executeWorkflowGateJob(
     return;
   }
 
-  const gate = await getGateForOrganization(db, organizationId, gateId);
+  const gate = await enterTelemetrySpan(
+    executionCtx,
+    "workflow_gate.load_gate",
+    { "drydock.organization.id": organizationId, "drydock.gate.id": gateId },
+    () => getGateForOrganization(db, organizationId, gateId),
+  );
   if (!gate) {
     emitOperationalEvent("warn", "github_workflow_gate.job_skipped", {
       organizationId,
@@ -170,11 +177,17 @@ export async function executeWorkflowGateJob(
 
   let prepared: PreparedGateRelease;
   try {
-    prepared = await prepareReleaseCandidatesForGate(env, executionCtx, db, {
-      config,
-      organizationId,
-      gateId,
-    });
+    prepared = await enterTelemetrySpan(
+      executionCtx,
+      "workflow_gate.prepare_release_candidates",
+      { "drydock.organization.id": organizationId, "drydock.gate.id": gateId },
+      () =>
+        prepareReleaseCandidatesForGate(env, executionCtx, db, {
+          config,
+          organizationId,
+          gateId,
+        }),
+    );
   } catch (err) {
     if (err instanceof WorkflowArtifactError) {
       // The published artifacts could not be verified against the reviewed
@@ -242,9 +255,19 @@ export async function executeWorkflowGateJob(
     // the half-finished scans first so the gate's package set is exactly this
     // batch.
     await discardGateScans(db, gate.id, organizationId, env.ARTIFACTS);
-    reviewed = await reviewGatePackages(
-      { env, executionCtx, db },
-      { gate, ownerUserId, packages: prepared.packages },
+    reviewed = await enterTelemetrySpan(
+      executionCtx,
+      "workflow_gate.review_packages",
+      {
+        "drydock.organization.id": organizationId,
+        "drydock.gate.id": gateId,
+        "drydock.package.count": prepared.packages.length,
+      },
+      () =>
+        reviewGatePackages(
+          { env, executionCtx, db },
+          { gate, ownerUserId, packages: prepared.packages },
+        ),
     );
   } catch (err) {
     // A per-package scan failed. Release the claim so a retry re-runs the whole
@@ -563,6 +586,22 @@ async function deliverGateDecision(
     state: gate.decision,
     comment: gate.decisionComment ?? "",
   });
+  const deliveredAt = new Date();
+  const recorded = await db
+    .update(githubWorkflowGates)
+    .set({ callbackDeliveredAt: deliveredAt, updatedAt: deliveredAt })
+    .where(
+      and(eq(githubWorkflowGates.id, gate.id), isNull(githubWorkflowGates.callbackDeliveredAt)),
+    )
+    .returning({ id: githubWorkflowGates.id });
+  if (recorded.length > 0) {
+    await recordOrganizationMilestone(
+      db,
+      gate.organizationId,
+      "protected_release_completed",
+      deliveredAt,
+    );
+  }
 }
 
 async function getInstallationExternalId(

--- a/server/routes/npm-connection.ts
+++ b/server/routes/npm-connection.ts
@@ -8,6 +8,7 @@ import {
   upsertNpmConnection,
 } from "../db/npm-connections";
 import { RateLimitError, enforceRateLimit } from "../db/rate-limit";
+import { recordOrganizationMilestone } from "../db/organization-milestones";
 import {
   requireActiveOrganization,
   requireActiveOrganizationContext,
@@ -146,6 +147,9 @@ npmConnectionRoutes.post("/validate", async (c) => {
           capabilities: validation.capabilities,
         },
       }),
+      validation.ok
+        ? recordOrganizationMilestone(db, organizationId, "integration_validated")
+        : Promise.resolve(),
     ]);
 
     return c.json({ validation, connection: publicNpmConnection(updated) });

--- a/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
+++ b/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
@@ -120,7 +120,7 @@ const FAILURE_GUIDANCE: Record<string, { hint: string; action: string }> = {
 export function ScanFailureAlert({ errorJson }: { errorJson: unknown }) {
   const error =
     errorJson && typeof errorJson === "object"
-      ? (errorJson as { message?: unknown; code?: unknown })
+      ? (errorJson as { message?: unknown; code?: unknown; referenceId?: unknown })
       : null;
   const guidance = typeof error?.code === "string" ? FAILURE_GUIDANCE[error.code] : undefined;
   return (
@@ -134,6 +134,9 @@ export function ScanFailureAlert({ errorJson }: { errorJson: unknown }) {
         ) : null}
         {typeof error?.code === "string" ? (
           <span class="font-mono text-xs">code: {error.code}</span>
+        ) : null}
+        {typeof error?.referenceId === "string" ? (
+          <span class="font-mono text-xs">support: {error.referenceId}</span>
         ) : null}
       </div>
     </Alert>

--- a/test/observability.test.mjs
+++ b/test/observability.test.mjs
@@ -4,11 +4,13 @@ const {
   describeOperationalError,
   durationMsSince,
   emitOperationalEvent,
+  projectOperationalEvent,
   sanitizeOperationalFields,
 } = await import("../server/lib/observability.ts");
+const { withTelemetryContext } = await import("../server/lib/telemetry/context.ts");
 
-describe("operational observability helpers", () => {
-  test("redacts token-like fields before logging", () => {
+describe("operational telemetry contract", () => {
+  test("redacts denied keys, bearer values, and arbitrary error messages", () => {
     const sanitized = sanitizeOperationalFields({
       scanId: "scan_1",
       npmToken: "npm_secret_token",
@@ -17,6 +19,7 @@ describe("operational observability helpers", () => {
         tokenFingerprint: "fp_should_not_log",
       },
       message: "upstream said Bearer abc123secret",
+      error: new Error("D1_ERROR: column not found"),
     });
 
     expect(sanitized).toEqual({
@@ -26,34 +29,97 @@ describe("operational observability helpers", () => {
         authorization: "[redacted]",
         tokenFingerprint: "[redacted]",
       },
-      message: "upstream said Bearer [redacted]",
+      message: "[redacted]",
+      error: { code: "internal.unclassified" },
     });
   });
 
-  test("logs structured events with bounded duration fields", () => {
+  test("logs one versioned top-level object with correlation and a stable failure envelope", () => {
     const spy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     try {
-      emitOperationalEvent("warn", "scan.queue.retry_scheduled", {
-        scanId: "scan_1",
-        durationMs: durationMsSince(100, 175),
-        token: "npm_secret_token",
-      });
+      const telemetry = withTelemetryContext(
+        {
+          requestId: "req_12345678",
+          journeyId: "jny_12345678",
+          serviceVersion: "version_1",
+          environment: "test",
+        },
+        () =>
+          emitOperationalEvent("warn", "scan.queue.retry_scheduled", {
+            scanId: "scan_1",
+            organizationId: "org_1",
+            durationMs: durationMsSince(100, 175),
+            attempt: 2,
+            error: {
+              code: "sandbox_download_transient",
+              message: "Bearer upstream-secret",
+              retryable: true,
+            },
+          }),
+      );
 
-      expect(spy).toHaveBeenCalledWith("scan.queue.retry_scheduled", {
-        event: "scan.queue.retry_scheduled",
-        scanId: "scan_1",
-        durationMs: 75,
-        token: "[redacted]",
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(telemetry);
+      expect(telemetry).toMatchObject({
+        event: {
+          id: expect.stringMatching(/^evt_/),
+          name: "scan.queue.retry_scheduled",
+          version: 1,
+          occurred_at: expect.any(String),
+        },
+        service: { version: "version_1", environment: "test" },
+        correlation: {
+          request_id: "req_12345678",
+          journey_id: "jny_12345678",
+          scan_id: "scan_1",
+        },
+        tenant: { organization_id: "org_1" },
+        outcome: {
+          status: "retry",
+          error: {
+            code: "sandbox_download_transient",
+            class: "external_dependency",
+            phase: "artifact_acquisition",
+            retryable: true,
+            fingerprint: expect.stringMatching(/^v1:/),
+          },
+        },
+        measurements: { duration_ms: 75, attempt: 2, count: 1 },
       });
+      expect(JSON.stringify(telemetry)).not.toContain("upstream-secret");
     } finally {
       spy.mockRestore();
     }
   });
 
-  test("describes errors with sanitizable messages", () => {
+  test("uses explicit sink allowlists for package-derived and free-form fields", () => {
+    const telemetry = projectOperationalEvent("error", "scan.pipeline.failed", {
+      scanId: "scan_1",
+      organizationId: "org_1",
+      packageName: "private-package-name",
+      stageId: "private-stage-id",
+      path: "/private/package/path",
+      reason: "external response body",
+      error: { code: "archive_invalid", retryable: false },
+    });
+    const serialized = JSON.stringify(telemetry);
+    expect(serialized).not.toContain("private-package-name");
+    expect(serialized).not.toContain("private-stage-id");
+    expect(serialized).not.toContain("external response body");
+    expect(serialized).not.toContain("/private/package/path");
+    expect(telemetry.outcome.error).toMatchObject({
+      code: "archive_invalid",
+      class: "policy_block",
+      customer_visible: true,
+    });
+    expect(telemetry.outcome.reference_id).toMatch(/^ref_/);
+  });
+
+  test("describes unknown errors without copying their name or message", () => {
     expect(describeOperationalError(new Error("D1_ERROR: column not found"))).toEqual({
-      name: "Error",
-      message: "D1_ERROR: column not found",
+      code: "internal.unclassified",
+      retryable: true,
+      customerVisible: false,
     });
   });
 });

--- a/test/scan-job.test.mjs
+++ b/test/scan-job.test.mjs
@@ -82,10 +82,15 @@ describe("scan job retry classification", () => {
       retryable: true,
     });
     expect(JSON.stringify(safe)).not.toContain("D1_ERROR");
-    expect(errorSpy).toHaveBeenCalledWith("scan.error.unclassified", {
-      event: "scan.error.unclassified",
-      error: { name: "Error", message: "D1_ERROR: column not found" },
-    });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: expect.objectContaining({ name: "scan.error.unclassified", version: 1 }),
+        outcome: expect.objectContaining({
+          error: expect.objectContaining({ code: "internal.unclassified" }),
+        }),
+      }),
+    );
+    expect(JSON.stringify(errorSpy.mock.calls)).not.toContain("D1_ERROR");
     errorSpy.mockRestore();
   });
 
@@ -216,20 +221,17 @@ describe("executeScanJob idempotency", () => {
     await executeScanJob(env, ctx, message, {}, { attempt: 1 });
 
     expect(console.log).toHaveBeenCalledWith(
-      "scan.job.completed",
       expect.objectContaining({
-        event: "scan.job.completed",
-        scanId: message.scanId,
-        organizationId: message.organizationId,
-        stageId: message.stageId,
-        source: "manual",
-        attempt: 1,
-        packageName: "@scope/pkg",
-        releaseRisk: "low",
-        artifactRisk: "high",
-        durationMs: expect.any(Number),
+        event: expect.objectContaining({ name: "scan.job.completed", version: 1 }),
+        correlation: expect.objectContaining({ scan_id: message.scanId }),
+        tenant: { organization_id: message.organizationId },
+        product: expect.objectContaining({ surface: "manual" }),
+        outcome: expect.objectContaining({ status: "success" }),
+        measurements: expect.objectContaining({ attempt: 1, duration_ms: expect.any(Number) }),
+        dimensions: expect.objectContaining({ release_risk: "low", artifact_risk: "high" }),
       }),
     );
+    expect(JSON.stringify(console.log.mock.calls)).not.toContain("@scope/pkg");
     expect(JSON.stringify(console.log.mock.calls)).not.toContain("npm_token");
   });
 
@@ -265,11 +267,12 @@ describe("executeScanJob idempotency", () => {
         organizationId: message.organizationId,
         ownerUserId: message.actorUserId,
         outcome: "failed",
-        error: {
+        error: expect.objectContaining({
           code: "staged_tarball_unavailable",
           message: "The staged tarball could not be accessed with this organization's npm token.",
           retryable: false,
-        },
+          referenceId: expect.stringMatching(/^ref_/),
+        }),
       }),
     );
   });
@@ -289,11 +292,17 @@ describe("executeScanJob idempotency", () => {
     expect(npmConnectionMock.decryptNpmToken).not.toHaveBeenCalled();
     expect(dbMock.markNpmConnectionUsed).not.toHaveBeenCalled();
     expect(pipelineMock.runScanPipeline).not.toHaveBeenCalled();
-    expect(dbMock.markScanFailed).toHaveBeenCalledWith({}, message.scanId, message.organizationId, {
-      code: "npm_connection_unvalidated",
-      message: "Validate the organization npm token before scanning staged publishes.",
-      retryable: false,
-    });
+    expect(dbMock.markScanFailed).toHaveBeenCalledWith(
+      {},
+      message.scanId,
+      message.organizationId,
+      expect.objectContaining({
+        code: "npm_connection_unvalidated",
+        message: "Validate the organization npm token before scanning staged publishes.",
+        retryable: false,
+        referenceId: expect.stringMatching(/^ref_/),
+      }),
+    );
   });
 
   test("discards auto-discovered scans when the org's token cannot access the tarball", async () => {

--- a/test/workers/cross-org-routes.test.ts
+++ b/test/workers/cross-org-routes.test.ts
@@ -1,5 +1,5 @@
 import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { describe, expect, test } from "vitest";
 import { createDb } from "../../server/db/client";
@@ -445,6 +445,30 @@ describe("scans routes enforce organization boundaries", () => {
     };
     expect(body.scan.decision).toBe("publish");
     expect(body.scan.decisionReason).toBe("minor patch");
+
+    const updateCtx = createExecutionContext();
+    const updateRes = await buildTestApp(owner).fetch(
+      new Request(`http://test.local/api/v1/scans/${scanId}/decision`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ decision: "no_publish", reason: "reviewed again" }),
+      }),
+      env,
+      updateCtx,
+    );
+    await waitOnExecutionContext(updateCtx);
+    expect(updateRes.status).toBe(200);
+
+    const [milestone] = await createDb(env.DB)
+      .select({ count: schema.organizationMilestones.count })
+      .from(schema.organizationMilestones)
+      .where(
+        and(
+          eq(schema.organizationMilestones.organizationId, owner.organizationId),
+          eq(schema.organizationMilestones.milestone, "protected_release_completed"),
+        ),
+      );
+    expect(milestone?.count).toBe(1);
   });
 
   test("POST /scans/:id/decision rejects invalid decision values", async () => {

--- a/test/workers/discovery-cron-concurrency.test.ts
+++ b/test/workers/discovery-cron-concurrency.test.ts
@@ -62,11 +62,15 @@ describe("discovery cron concurrency", () => {
     await waitOnExecutionContext(ctx);
 
     expect(fetchMock).not.toHaveBeenCalled();
-    const sweptCall = logSpy.mock.calls.find((call) => call[0] === "staged_publishes.cron.swept");
+    const sweptCall = logSpy.mock.calls.find(
+      (call) => call[0]?.event?.name === "staged_publishes.cron.swept",
+    );
     expect(sweptCall).toBeDefined();
-    expect(sweptCall![1]).toMatchObject({
-      orgsProcessed: 0,
-      concurrencyLimit: CONCURRENCY_LIMIT,
+    expect(sweptCall![0]).toMatchObject({
+      measurements: {
+        orgs_processed: 0,
+        concurrency_limit: CONCURRENCY_LIMIT,
+      },
     });
   });
 
@@ -108,17 +112,19 @@ describe("discovery cron concurrency", () => {
     expect(maxInFlight).toBeLessThanOrEqual(CONCURRENCY_LIMIT);
     expect(maxInFlight).toBe(CONCURRENCY_LIMIT);
 
-    const sweptCall = logSpy.mock.calls.find((call) => call[0] === "staged_publishes.cron.swept");
+    const sweptCall = logSpy.mock.calls.find(
+      (call) => call[0]?.event?.name === "staged_publishes.cron.swept",
+    );
     expect(sweptCall).toBeDefined();
-    const sweptFields = sweptCall![1] as {
-      orgsProcessed: number;
-      durationMs: number;
-      concurrencyLimit: number;
+    const sweptFields = sweptCall![0]?.measurements as {
+      orgs_processed: number;
+      duration_ms: number;
+      concurrency_limit: number;
     };
     expect(sweptFields).toMatchObject({
-      orgsProcessed: orgCount,
-      concurrencyLimit: CONCURRENCY_LIMIT,
+      orgs_processed: orgCount,
+      concurrency_limit: CONCURRENCY_LIMIT,
     });
-    expect(sweptFields.durationMs).toBeGreaterThanOrEqual(0);
+    expect(sweptFields.duration_ms).toBeGreaterThanOrEqual(0);
   });
 });

--- a/test/workers/discovery-cron.test.ts
+++ b/test/workers/discovery-cron.test.ts
@@ -214,8 +214,8 @@ describe("staged publishes discovery cron", () => {
     expect(sentMeta).not.toMatchObject({ recipient: orgB.connectionCreatorEmail });
     const genericFailureForOrgB = errorSpy.mock.calls.find(
       (call) =>
-        call[0] === "staged_publishes.cron.org_failed" &&
-        (call[1] as { organizationId?: string })?.organizationId === orgB.organizationId,
+        call[0]?.event?.name === "staged_publishes.cron.org_failed" &&
+        call[0]?.tenant?.organization_id === orgB.organizationId,
     );
     expect(genericFailureForOrgB).toBeUndefined();
 
@@ -226,9 +226,11 @@ describe("staged publishes discovery cron", () => {
     expect(await eventTypesForOrg(orgC.organizationId)).toHaveLength(0);
 
     // Sweep finished cleanly over the two eligible orgs.
-    const sweptCall = logSpy.mock.calls.find((call) => call[0] === "staged_publishes.cron.swept");
+    const sweptCall = logSpy.mock.calls.find(
+      (call) => call[0]?.event?.name === "staged_publishes.cron.swept",
+    );
     expect(sweptCall).toBeDefined();
-    expect(sweptCall![1]).toMatchObject({ orgsProcessed: 2 });
+    expect(sweptCall![0]?.measurements).toMatchObject({ orgs_processed: 2 });
   });
 
   test("logs a generic per-org failure for a non-auth registry error without alerting", async () => {
@@ -256,13 +258,19 @@ describe("staged publishes discovery cron", () => {
     await waitOnExecutionContext(ctx);
 
     const failureCall = errorSpy.mock.calls.find(
-      (call) => call[0] === "staged_publishes.cron.org_failed",
+      (call) => call[0]?.event?.name === "staged_publishes.cron.org_failed",
     );
     expect(failureCall).toBeDefined();
-    expect(failureCall![1]).toMatchObject({
-      event: "staged_publishes.cron.org_failed",
-      organizationId: org.organizationId,
-      error: { status: 500 },
+    expect(failureCall![0]).toMatchObject({
+      event: { name: "staged_publishes.cron.org_failed", version: 1 },
+      tenant: { organization_id: org.organizationId },
+      outcome: {
+        error: {
+          code: "registry.metadata_fetch_failed",
+          class: "external_dependency",
+          retryable: true,
+        },
+      },
     });
 
     const connection = await getNpmConnection(createDb(env.DB), org.organizationId);

--- a/test/workers/organization-milestones.test.ts
+++ b/test/workers/organization-milestones.test.ts
@@ -1,0 +1,131 @@
+import { env } from "cloudflare:test";
+import { eq } from "drizzle-orm";
+import { afterEach, describe, expect, test } from "vitest";
+import { createDb } from "../../server/db/client";
+import {
+  listOrganizationMilestones,
+  reconcileOrganizationMilestones,
+  recordOrganizationMilestone,
+} from "../../server/db/organization-milestones";
+import { organizations, scans, user } from "../../server/db/schema";
+
+const db = createDb(env.DB);
+const userId = `milestone-user-${crypto.randomUUID()}`;
+const organizationId = `milestone-org-${crypto.randomUUID()}`;
+
+afterEach(async () => {
+  await db.delete(scans).where(eq(scans.organizationId, organizationId));
+  await db.delete(organizations).where(eq(organizations.id, organizationId));
+  await db.delete(user).where(eq(user.id, userId));
+});
+
+describe("organization milestone projection", () => {
+  test("keeps exact first/last timestamps and an idempotent bounded row", async () => {
+    const createdAt = new Date("2026-07-15T08:00:00.000Z");
+    await db.insert(user).values({
+      id: userId,
+      name: "Milestone Test",
+      email: `${userId}@example.test`,
+      emailVerified: true,
+      createdAt,
+      updatedAt: createdAt,
+    });
+    await db.insert(organizations).values({
+      id: organizationId,
+      name: "Milestones",
+      ownerUserId: userId,
+      createdAt,
+      updatedAt: createdAt,
+    });
+
+    await recordOrganizationMilestone(
+      db,
+      organizationId,
+      "protected_release_completed",
+      new Date("2026-07-15T10:00:00.000Z"),
+    );
+    await recordOrganizationMilestone(
+      db,
+      organizationId,
+      "protected_release_completed",
+      new Date("2026-07-15T12:00:00.000Z"),
+    );
+
+    const rows = await listOrganizationMilestones(db, organizationId);
+    expect(rows).toEqual([
+      {
+        milestone: "protected_release_completed",
+        firstAt: new Date("2026-07-15T10:00:00.000Z"),
+        lastAt: new Date("2026-07-15T12:00:00.000Z"),
+        count: 2,
+      },
+    ]);
+  });
+
+  test("reconciles existing durable organization, review, and decision state", async () => {
+    const createdAt = new Date("2026-07-14T08:00:00.000Z");
+    const completedAt = new Date("2026-07-15T10:00:00.000Z");
+    await db.insert(user).values({
+      id: userId,
+      name: "Milestone Test",
+      email: `${userId}@example.test`,
+      emailVerified: true,
+      createdAt,
+      updatedAt: createdAt,
+    });
+    await db.insert(organizations).values({
+      id: organizationId,
+      name: "Milestones",
+      ownerUserId: userId,
+      createdAt,
+      updatedAt: createdAt,
+    });
+    await db.insert(scans).values({
+      id: `scan-${crypto.randomUUID()}`,
+      stageId: "@scope/pkg@1.0.0",
+      organizationId,
+      ownerUserId: userId,
+      status: "complete",
+      source: "manual",
+      risk: "low",
+      decision: "publish",
+      decidedAt: completedAt,
+      completedAt,
+      createdAt,
+      updatedAt: completedAt,
+    });
+
+    await reconcileOrganizationMilestones(db);
+
+    const milestones = await listOrganizationMilestones(db, organizationId);
+    expect(milestones).toHaveLength(4);
+    expect(milestones).toEqual(
+      expect.arrayContaining([
+        {
+          milestone: "organization_created",
+          firstAt: createdAt,
+          lastAt: createdAt,
+          count: 1,
+        },
+        {
+          milestone: "artifact_observed",
+          firstAt: completedAt,
+          lastAt: completedAt,
+          count: 1,
+        },
+        {
+          milestone: "review_completed",
+          firstAt: completedAt,
+          lastAt: completedAt,
+          count: 1,
+        },
+        {
+          milestone: "protected_release_completed",
+          firstAt: completedAt,
+          lastAt: completedAt,
+          count: 1,
+        },
+      ]),
+    );
+  });
+});

--- a/test/workers/workflow-gate-job.test.ts
+++ b/test/workers/workflow-gate-job.test.ts
@@ -588,8 +588,14 @@ describe("executeWorkflowGateJob", () => {
         expect.arrayContaining([expect.objectContaining({ state: "rejected" })]),
       );
       expect(errorSpy).toHaveBeenCalledWith(
-        "github_workflow_gate.decision_callback_failed",
-        expect.objectContaining({ gateId: seeded.gateId, decision: "rejected" }),
+        expect.objectContaining({
+          event: expect.objectContaining({
+            name: "github_workflow_gate.decision_callback_failed",
+            version: 1,
+          }),
+          correlation: expect.objectContaining({ gate_id: seeded.gateId }),
+          dimensions: expect.objectContaining({ decision: "rejected" }),
+        }),
       );
     } finally {
       errorSpy.mockRestore();

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,17 +2,31 @@
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "staged-publish-review",
 	"main": "./server/index.ts",
-	"compatibility_date": "2026-05-20",
+	"compatibility_date": "2026-07-15",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],
 	"workers_dev": true,
+	"upload_source_maps": true,
 	"observability": {
 		"logs": {
 			"enabled": true,
 			"invocation_logs": true
+		},
+		"traces": {
+			"enabled": true,
+			"head_sampling_rate": 0.1
 		}
 	},
+	"version_metadata": {
+		"binding": "CF_VERSION_METADATA"
+	},
+	"analytics_engine_datasets": [
+		{
+			"binding": "TELEMETRY_ANALYTICS",
+			"dataset": "drydock_telemetry"
+		}
+	],
 	"assets": {
 		"not_found_handling": "single-page-application",
 		"binding": "ASSETS",
@@ -95,6 +109,7 @@
 		}
 	],
 	"vars": {
+		"ENVIRONMENT": "production",
 		"BETTER_AUTH_URL": "https://drydock.org",
 		"AI_CACHE_AFFINITY": "staged-publish-review-release-reviewer-v1",
 		"NPM_REGISTRY": "https://registry.npmjs.org",

--- a/wrangler.template.jsonc
+++ b/wrangler.template.jsonc
@@ -12,17 +12,31 @@
 	// work unchanged. Rename both together if you prefer a different name.
 	"name": "staged-publish-review",
 	"main": "./server/index.ts",
-	"compatibility_date": "2026-05-20",
+	"compatibility_date": "2026-07-15",
 	"compatibility_flags": [
 		"nodejs_compat"
 	],
 	"workers_dev": true,
+	"upload_source_maps": true,
 	"observability": {
 		"logs": {
 			"enabled": true,
 			"invocation_logs": true
+		},
+		"traces": {
+			"enabled": true,
+			"head_sampling_rate": 0.1
 		}
 	},
+	"version_metadata": {
+		"binding": "CF_VERSION_METADATA"
+	},
+	"analytics_engine_datasets": [
+		{
+			"binding": "TELEMETRY_ANALYTICS",
+			"dataset": "drydock_telemetry"
+		}
+	],
 	"assets": {
 		"not_found_handling": "single-page-application",
 		"binding": "ASSETS",
@@ -105,6 +119,7 @@
 		}
 	],
 	"vars": {
+		"ENVIRONMENT": "production",
 		// Must match your deployed origin (custom domain or *.workers.dev URL).
 		"BETTER_AUTH_URL": "https://REPLACE_WITH_YOUR_ORIGIN",
 		"AI_CACHE_AFFINITY": "drydock-release-reviewer-v1",


### PR DESCRIPTION
## Summary

- introduce a versioned, allowlisted telemetry contract with request correlation, stable operational error metadata, support references, and an Analytics Engine projection
- enable Cloudflare tracing, source maps, deployment version metadata, and custom spans across scan and workflow-gate processing
- add exact organization milestone persistence and reconciliation, surface support references for failed scans, and document operator workflows with focused runbooks

## Testing

- `pnpm run verify`
- `pnpm run build`
- `pnpm run test:e2e` (16 passed)
- `git diff --check`

## Deployment

- apply the generated D1 migrations
- configure `TELEMETRY_HASH_KEY` with `wrangler secret put`
