### PR TITLE
Give the empty release-memory profile its own banner wording

### DIFF
--- a/docs/release-memory.md
+++ b/docs/release-memory.md
@@ -40,6 +40,13 @@ renders it as a positive banner (`match`/`subset`) or a quiet "N findings are
 new since the last approved release" line (`diverged`) next to the
 recommendation; `none` renders nothing.
 
+A `match`/`subset` with **zero current findings** is a vacuous comparison
+(empty profile vs. empty-or-any prior profile), so the banner switches to
+dedicated "No deterministic findings" wording that says only deterministic
+checks are compared. The banner is not suppressed — the prior-approval context
+is still useful — but it must not read as reassurance about the diff or the AI
+review, which remain specific to the new release.
+
 ## Failure and compatibility behavior
 
 - The lookup is wrapped: a database or artifact-read error degrades to `none`

--- a/src/pages/Dashboard/ScanDetail/ReleaseConsistencyNotice.tsx
+++ b/src/pages/Dashboard/ScanDetail/ReleaseConsistencyNotice.tsx
@@ -11,11 +11,28 @@ import { Alert } from "../../../components/Alert";
 // capability findings are not news. diverged: a quiet one-liner pointing at the
 // count of genuinely new findings. It never changes risk and renders nothing
 // when there is no approved prior scan (or the scan predates the field).
+//
+// An empty profile (zero deterministic findings) gets its own wording instead
+// of "finding profile matches": a vacuous match must not read as reassurance
+// about anything beyond deterministic checks — the diff and AI review still
+// carry release-specific signal.
+export type ReleaseConsistencyVariant = "match" | "subset" | "empty" | "diverged";
+
+export function releaseConsistencyVariant(
+  consistency: ReleaseConsistency,
+): ReleaseConsistencyVariant | null {
+  if (consistency.status === "none") return null;
+  if (consistency.status === "diverged") return "diverged";
+  return consistency.currentFindingCount === 0 ? "empty" : consistency.status;
+}
+
 export function ReleaseConsistencyNotice({ value }: { value: unknown }) {
   const consistency = normalizeReleaseConsistency(value);
-  if (!consistency || consistency.status === "none") return null;
+  if (!consistency) return null;
+  const variant = releaseConsistencyVariant(consistency);
+  if (!variant) return null;
 
-  if (consistency.status === "diverged") {
+  if (variant === "diverged") {
     const count = consistency.newFindingCount;
     return (
       <p class="m-0 text-[13px] text-ink-muted">
@@ -32,9 +49,28 @@ export function ReleaseConsistencyNotice({ value }: { value: unknown }) {
   const approvedOn = consistency.decidedAt
     ? `, approved on ${formatDateTime(consistency.decidedAt)}`
     : "";
+  if (variant === "empty") {
+    return (
+      <Alert tone="ok">
+        No deterministic findings —{" "}
+        {consistency.priorFindingCount === 0 ? (
+          <>
+            none in {priorScanLink(consistency)} either{approvedOn}
+          </>
+        ) : (
+          <>
+            down from {consistency.priorFindingCount} in {priorScanLink(consistency)}
+            {approvedOn}
+          </>
+        )}
+        . Only deterministic checks are compared; the diff and AI review are specific to this
+        release.
+      </Alert>
+    );
+  }
   return (
     <Alert tone="ok">
-      {consistency.status === "match" ? (
+      {variant === "match" ? (
         <>
           Finding profile matches {priorScanLink(consistency)}
           {approvedOn}. The same deterministic findings were already reviewed and published.

--- a/test/release-consistency-notice.test.ts
+++ b/test/release-consistency-notice.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+import { releaseConsistencyVariant } from "../src/pages/Dashboard/ScanDetail/ReleaseConsistencyNotice.tsx";
+import type { ReleaseConsistency } from "../server/lib/release-memory";
+
+function consistency(overrides: Partial<ReleaseConsistency>): ReleaseConsistency {
+  return {
+    status: "match",
+    priorScanId: "prior-scan",
+    priorVersion: "10.29.6",
+    decidedAt: "2026-07-15T15:44:43.168Z",
+    currentFindingCount: 2,
+    priorFindingCount: 2,
+    newFindingCount: 0,
+    newFindings: [],
+    ...overrides,
+  };
+}
+
+describe("releaseConsistencyVariant", () => {
+  test("none renders nothing", () => {
+    expect(releaseConsistencyVariant(consistency({ status: "none" }))).toBeNull();
+  });
+
+  test("diverged stays diverged even with zero current findings", () => {
+    expect(releaseConsistencyVariant(consistency({ status: "diverged" }))).toBe("diverged");
+  });
+
+  test("match with findings keeps the profile-match wording", () => {
+    expect(releaseConsistencyVariant(consistency({ status: "match" }))).toBe("match");
+  });
+
+  test("subset with findings keeps the no-new-findings wording", () => {
+    expect(
+      releaseConsistencyVariant(
+        consistency({ status: "subset", currentFindingCount: 1, priorFindingCount: 2 }),
+      ),
+    ).toBe("subset");
+  });
+
+  test("vacuous match (zero findings on both sides) gets the empty wording", () => {
+    expect(
+      releaseConsistencyVariant(
+        consistency({ status: "match", currentFindingCount: 0, priorFindingCount: 0 }),
+      ),
+    ).toBe("empty");
+  });
+
+  test("subset that emptied out gets the empty wording", () => {
+    expect(
+      releaseConsistencyVariant(
+        consistency({ status: "subset", currentFindingCount: 0, priorFindingCount: 3 }),
+      ),
+    ).toBe("empty");
+  });
+});


### PR DESCRIPTION
## What

When release memory finds a `match`/`subset` against a prior approved release but the current scan has **zero deterministic findings**, the banner now uses dedicated wording instead of "Finding profile matches …":

- prior also had none: *"No deterministic findings — none in v10.29.6 either, approved on 15 Jul, 17:44. Only deterministic checks are compared; the diff and AI review are specific to this release."*
- prior had some (`subset` that emptied out): *"No deterministic findings — down from 3 in v10.29.6, approved on …"* with the same caveat sentence.

## Why

Spotted on the preact `11.0.0-beta.2` scan in prod: the green "Finding profile matches v10.29.6" banner was a vacuous 0-vs-0 comparison, rendered directly above "2 lifecycle or package script changes / 1 dependency change". Script and dependency changes are diff summary stats, not rule findings, so they never participate in the profile — the banner read as more reassurance than the comparison provides.

The banner is deliberately **not** suppressed: the prior-approval context is still useful, and the AI review still carries release-specific signal — the new copy just scopes the claim to deterministic checks.

## Notes

- Variant selection extracted as `releaseConsistencyVariant()` and unit-tested (vacuous match → empty, emptied-out subset → empty, `diverged` unaffected even at zero findings, `none` still renders nothing).
- Advisory-only invariant untouched: no change to risk, findings, or the persisted `releaseConsistency` blob — display copy only.
- Docs: `docs/release-memory.md` updated with the empty-profile behavior.

## Testing

- `pnpm run verify` green (lint, format:check, typecheck, tests).
- New `test/release-consistency-notice.test.ts` covers all variant branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)