### PR TITLE
Detect packed AsyncAPI downloader shape

### DIFF
--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -12,6 +12,7 @@ The fixture taxonomy is based on the current Drydock rule surface plus public np
 - [OpenSSF Package Analysis](https://github.com/ossf/package-analysis) tracks package behavior by asking what files packages access, what addresses they connect to, and what commands they run. Its public case studies are useful for behavior taxonomy, but Drydock should not execute packages.
 - [Datadog's malicious-software-packages-dataset](https://github.com/DataDog/malicious-software-packages-dataset/) is human-triaged and useful for taxonomy validation, but its samples are actively malicious and distributed as encrypted `infected` archives. Do not copy those samples into this repository.
 - Recent npm detection benchmark research reports a curated dataset of 6,420 malicious and 7,288 benign npm packages, with 11 behavior categories and 8 evasion categories. The most common behaviors were command execution, data collection, and data exfiltration; install scripts were used by about 72% of malicious packages in that study, and preinstall hooks were the dominant install-time entry point.
+- [Aikido's AsyncAPI incident report](https://www.aikido.dev/blog/asyncapi-npm-packages-backdoored-via-github-actions) documents a compromised GitHub Actions publishing path that injected a rotating string-table wrapper around a detached `node -e` child process in shipped JavaScript. The safe `asyncapi-rotating-string-table-dropper` fixture preserves that detection shape without retaining its endpoint, identifier, or payload.
 - The same benchmark shows the central detection trade-off: benign and malicious packages often call the same APIs. Broad environment reads and secret-like environment names are capability evidence, while common runtime flags such as `process.env.NODE_ENV` or `import.meta.env.DEV` are not credential sources. Chains such as collect → serialize → exfiltrate are stronger intent evidence.
 - Network-only code follows that trade-off: unchanged network-only files are suppressed as package context, added network-only files remain medium-severity contextual evidence, and added network access escalates to high when it is tied to lifecycle scripts, process execution, dynamic evaluation, or credential access.
 - Documentation and prose files remain available as package evidence, but deterministic `code.*` rules do not treat them as executable capability evidence. Secret checks in documentation use only high-confidence token formats; generic key/value examples such as `token = localStorage.getItem("token")` are not `file.secret-content` findings.
@@ -61,7 +62,8 @@ The first corpus slice covers:
 - credential file-path reads (`.aws/credentials`, `.ssh/id_`, `.netrc`) in addition to broad environment reads and known token names, matching the Python rule coverage while excluding common non-secret JS runtime flags;
 - the collect-and-exfiltrate sink: a single file that reads credentials and has a network egress path escalates `code.credential-access` to high even on a modified (not newly added) module;
 - implicit `node-gyp rebuild` from root `binding.gyp`, GYP command substitution that executes package JavaScript, and native artifact review — by extension and by magic-byte flags, so extensionless Linux/macOS platform binaries are held to the same bar as a Windows `.exe`;
-- base64/dynamic evaluation plus network-capable code, including the `WebAssembly.instantiateStreaming(fetch(...))` loader idiom (the whole `compile`/`compileStreaming`/`instantiate`/`instantiateStreaming` family counts as dynamic evaluation);
+- base64/dynamic evaluation plus network-capable code, including the `WebAssembly.instantiateStreaming(fetch(...))` loader idiom (the whole `compile`/`compileStreaming`/`instantiate`/`instantiateStreaming` family counts as dynamic evaluation) and literal `node -e`/`node --eval` child-process launches;
+- javascript-obfuscator-style rotating string tables around code capabilities, recognized from the combined hexadecimal lookup, `while (!![])`, `parseInt`, and `push(shift())` wrapper shape rather than any one minifier-like token;
 - secret-looking file addition;
 - large opaque binary addition;
 - files that appear in the tarball outside a declared `package.json.files` allowlist;
@@ -99,7 +101,7 @@ A PyPI review runs two rule families over the staged artifacts:
 
 - `pypi.*` findings come from `pyPiReleaseFindings` and carry `PYPI_RULES_VERSION` (currently `0.2.0`).
 - shared `file.*` / `code.*` / `diff.*` findings come from `deterministicFindings` and carry
-  `DETERMINISTIC_RULES_VERSION` (currently `1.14.0`).
+  `DETERMINISTIC_RULES_VERSION` (currently `1.15.0`).
 
 The harness asserts this per family: every `pypi.*` finding must equal `PYPI_RULES_VERSION` and every
 other finding must equal `DETERMINISTIC_RULES_VERSION`. Bump the relevant constant **and** update the
@@ -160,7 +162,14 @@ and MZ requires the NUL-padded DOS header so prose starting with "MZ" does not m
 fires on extension or flag, and the binary-shaped findings (`file.native-artifact`,
 `file.large-binary`, `diff.large-new-file`) now carry the file's sha256 in evidence so a reviewer
 can verify the artifact against the registry out of band (the `prebuilt-platform-binaries` golden
-case).
+case). `1.15.0` models the downloader shape from the AsyncAPI npm compromise without broadening
+plain process-execution noise: literal `spawn`/`spawnSync` calls that launch `node -e` or
+`node --eval` also emit `code.dynamic-evaluation`, while a code capability inside a recognized
+javascript-obfuscator-style rotating string-table wrapper is marked `obfuscated`. The latter reuses
+the existing risk rule that keeps a lone hidden process capability at high instead of applying the
+benign build-helper de-escalation. The wrapper requires five independent structural signals
+(hexadecimal lookup identifiers and function, `while (!![])`, lookup-fed `parseInt`, and bracketed
+`push`/`shift`) to avoid treating ordinary minified names or queue rotation as malice.
 
 ### Fixture format
 

--- a/server/lib/review-rules/index.ts
+++ b/server/lib/review-rules/index.ts
@@ -16,7 +16,7 @@ import { entrypointDiffFindings } from "./entrypoints";
 // way that should invalidate cached scan reports. Stored alongside each finding
 // so historical reports can be traced back to the ruleset that produced them.
 // Lives here (not in a family module) because versioning spans every family.
-export const DETERMINISTIC_RULES_VERSION = "1.14.0";
+export const DETERMINISTIC_RULES_VERSION = "1.15.0";
 
 export { DETERMINISTIC_RULE_IDS } from "./rule-ids";
 export {

--- a/server/lib/review-rules/patterns.ts
+++ b/server/lib/review-rules/patterns.ts
@@ -43,6 +43,9 @@ const PYTHON_NETWORK_ACCESS_PATTERNS = [
 const JS_DYNAMIC_EVALUATION_PATTERNS = [
   /\beval\s*\(/,
   /\bnew\s+Function\s*\(/,
+  // `node -e` is an interpreter-backed eval even when launched through the
+  // child-process API instead of JavaScript's in-process eval primitives.
+  /\bspawn(?:Sync)?\s*\(\s*["'`]node(?:js)?["'`]\s*,\s*\[\s*["'`](?:-e|--eval)["'`]/,
   // The whole compile/instantiate family: instantiate(Streaming) — not bare
   // compile — is the loader idiom packed wasm payloads actually use (typically
   // `WebAssembly.instantiateStreaming(fetch(...))`).

--- a/server/lib/review-rules/scripts.ts
+++ b/server/lib/review-rules/scripts.ts
@@ -44,6 +44,20 @@ const COMMON_IMPORT_META_ENV_BRACKET_ACCESS = new RegExp(
   `\\bimport\\s*\\.\\s*meta\\s*\\.\\s*env\\s*\\[\\s*(['"\`])(?:${COMMON_JS_ENV_NAME_PATTERN})\\1\\s*\\]`,
   "g",
 );
+// javascript-obfuscator-style output commonly wraps a hexadecimal identifier
+// lookup in a self-rotating string table. Individual names can remain opaque to
+// the bounded constant folder, but the wrapper itself is a strong evasion
+// signal. Require the whole shape so ordinary minified identifiers, loops, or
+// queue rotation do not mark otherwise plain code as obfuscated.
+const ROTATING_STRING_TABLE_SIGNALS = [
+  /\b_0x[\da-f]{4,}\b/i,
+  /\bfunction\s+_0x[\da-f]{3,}\s*\(/i,
+  /\bwhile\s*\(\s*!!\[\]\s*\)/,
+  /\bparseInt\s*\(\s*_0x[\da-f]+\s*\(/i,
+  /\[['"]push['"]\]\s*\(/,
+  /\[['"]shift['"]\]\s*\(\s*\)/,
+];
+const ROTATING_STRING_TABLE_SIGNAL_THRESHOLD = 5;
 
 // Install lifecycle hooks and in-file code-execution capability: the scripts and
 // code paths that run on, or are pulled in by, a registry tarball install.
@@ -108,6 +122,8 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
     // drop one a literal scan already finds. JavaScript only for now; the
     // normalizer is JS-flavored and Python evasion is out of scope.
     const normalized = ctx.codePatternSet === "python" ? sample : normalizeCodeForScanning(sample);
+    const packedObfuscation =
+      ctx.codePatternSet !== "python" && hasRotatingStringTableObfuscation(sample);
     const prefix = changedPrefix(ctx, file.path);
     const changed = ctx.diffByPath.get(file.path)?.status;
     const lifecycleScriptFile = isLifecycleScriptFile(ctx, file.path);
@@ -115,9 +131,24 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
     // test/ — an install hook pointing into the test tree is itself suspicious.
     const testScoped = !lifecycleScriptFile && isUnreachableTestFile(ctx, file.path);
 
-    const processExecution = matchCategory(ctx.patterns.processExecution, sample, normalized);
-    const networkAccess = matchCategory(ctx.patterns.networkAccess, sample, normalized);
-    const dynamicEvaluation = matchCategory(ctx.patterns.dynamicEvaluation, sample, normalized);
+    const processExecution = matchCategory(
+      ctx.patterns.processExecution,
+      sample,
+      normalized,
+      packedObfuscation,
+    );
+    const networkAccess = matchCategory(
+      ctx.patterns.networkAccess,
+      sample,
+      normalized,
+      packedObfuscation,
+    );
+    const dynamicEvaluation = matchCategory(
+      ctx.patterns.dynamicEvaluation,
+      sample,
+      normalized,
+      packedObfuscation,
+    );
     const credentialSample =
       ctx.codePatternSet === "python" ? sample : omitCommonEnvironmentAccesses(sample);
     const credentialNormalized =
@@ -126,6 +157,7 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
       ctx.patterns.credentialAccess,
       credentialSample,
       credentialNormalized,
+      packedObfuscation,
     );
     const adjacentExecutionRisk =
       processExecution.matched || dynamicEvaluation.matched || credentialAccess.matched;
@@ -240,22 +272,31 @@ function testScope(testScoped: boolean, obfuscated: boolean, finding: Finding): 
 // the constant-folded text. Prefers the raw line so evidence keeps pointing at
 // the literal match when one exists; folding preserves line numbers, so the
 // normalized line still maps to the real source line. `obfuscated` is set when
-// the match came only from the folded text — i.e. the identifier was assembled
-// (`['chi','ld_pro','cess'].join('')`) — which the risk roll-up treats as a
-// co-occurring malice signal.
+// the match came only from folded text or its containing file has a recognized
+// packed string-table wrapper. Either evasion technique is a co-occurring
+// malice signal in the risk roll-up.
 function matchCategory(
   patterns: RegExp[],
   sample: string,
   normalized: string,
+  sourceObfuscated = false,
 ): { matched: boolean; line: number | undefined; obfuscated: boolean } {
   const line = firstMatchingLine(sample, patterns);
-  if (line !== undefined) return { matched: true, line, obfuscated: false };
+  if (line !== undefined) return { matched: true, line, obfuscated: sourceObfuscated };
   if (normalized !== sample) {
     const normalizedLine = firstMatchingLine(normalized, patterns);
     if (normalizedLine !== undefined)
       return { matched: true, line: normalizedLine, obfuscated: true };
   }
   return { matched: false, line: undefined, obfuscated: false };
+}
+
+function hasRotatingStringTableObfuscation(source: string): boolean {
+  let matches = 0;
+  for (const signal of ROTATING_STRING_TABLE_SIGNALS) {
+    if (signal.test(source)) matches += 1;
+  }
+  return matches >= ROTATING_STRING_TABLE_SIGNAL_THRESHOLD;
 }
 
 function omitCommonEnvironmentAccesses(source: string): string {

--- a/server/lib/review-rules/scripts.ts
+++ b/server/lib/review-rules/scripts.ts
@@ -1,5 +1,5 @@
 import { hasImplicitNodeGypInstall, isRootGypPath } from "../tar-parser.js";
-import { firstMatchingLine } from "../text-utils";
+import { firstMatchingLine, firstMatchingSourceLine } from "../text-utils";
 import type { Finding } from "../review";
 import { CONSUMER_INSTALL_LIFECYCLE_SCRIPTS } from "./patterns";
 import { firstJsonPropertyLine, tag } from "./helpers";
@@ -148,6 +148,7 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
       sample,
       normalized,
       packedObfuscation,
+      true,
     );
     const credentialSample =
       ctx.codePatternSet === "python" ? sample : omitCommonEnvironmentAccesses(sample);
@@ -280,11 +281,13 @@ function matchCategory(
   sample: string,
   normalized: string,
   sourceObfuscated = false,
+  matchAcrossLines = false,
 ): { matched: boolean; line: number | undefined; obfuscated: boolean } {
-  const line = firstMatchingLine(sample, patterns);
+  const findLine = matchAcrossLines ? firstMatchingSourceLine : firstMatchingLine;
+  const line = findLine(sample, patterns);
   if (line !== undefined) return { matched: true, line, obfuscated: sourceObfuscated };
   if (normalized !== sample) {
-    const normalizedLine = firstMatchingLine(normalized, patterns);
+    const normalizedLine = findLine(normalized, patterns);
     if (normalizedLine !== undefined)
       return { matched: true, line: normalizedLine, obfuscated: true };
   }

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -21,9 +21,10 @@ export interface Finding {
   ruleId?: string;
   ruleVersion?: string;
   // True when a code.* capability matched only after constant-folding (the
-  // identifier was assembled/obfuscated, e.g. `['chi','ld_pro','cess'].join('')`).
-  // Obfuscating a capability is itself a malice signal, so the risk roll-up does
-  // not de-escalate a lone obfuscated capability the way it does a plain one.
+  // identifier was assembled, e.g. `['chi','ld_pro','cess'].join('')`) or its
+  // file uses a recognized packed string-table wrapper. Obfuscating a capability
+  // is itself a malice signal, so the risk roll-up does not de-escalate a lone
+  // obfuscated capability the way it does a plain one.
   obfuscated?: boolean;
   // True when a code.* capability matched inside a test-suite file that no
   // consumer-facing entrypoint can statically reach. The finding is emitted at

--- a/server/lib/text-utils.ts
+++ b/server/lib/text-utils.ts
@@ -12,3 +12,20 @@ export function firstMatchingLine(
   }
   return undefined;
 }
+
+export function firstMatchingSourceLine(
+  text: string | undefined | null,
+  patterns: RegExp[],
+): number | undefined {
+  if (!text) return undefined;
+  let firstIndex: number | undefined;
+  for (const pattern of patterns) {
+    pattern.lastIndex = 0;
+    const match = pattern.exec(text);
+    if (match && (firstIndex === undefined || match.index < firstIndex)) {
+      firstIndex = match.index;
+    }
+  }
+  if (firstIndex === undefined) return undefined;
+  return text.slice(0, firstIndex).split("\n").length;
+}

--- a/test/fixtures/security-corpus/cases/asyncapi-rotating-string-table-dropper.json
+++ b/test/fixtures/security-corpus/cases/asyncapi-rotating-string-table-dropper.json
@@ -1,0 +1,57 @@
+{
+  "id": "asyncapi-rotating-string-table-dropper",
+  "title": "Packed string-table child-process dropper keeps high risk",
+  "category": "obfuscation-assembly",
+  "intent": "A defanged reproduction of the AsyncAPI npm compromise shape: a modified consumer module contains a javascript-obfuscator-style rotating string table around a child-process launch. The lookup table keeps interpreter and payload strings opaque, but the packed wrapper makes the process capability an obfuscated high-risk finding. No live endpoint, credential, or executable payload is present.",
+  "provenance": "https://www.aikido.dev/blog/asyncapi-npm-packages-backdoored-via-github-actions",
+  "previousPackageJson": {
+    "name": "synthetic-schema-validator",
+    "version": "1.0.0",
+    "main": "lib/validator.js"
+  },
+  "stagedPackageJson": {
+    "name": "synthetic-schema-validator",
+    "version": "1.0.1",
+    "main": "lib/validator.js"
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 85,
+      "sha256": "previous-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"synthetic-schema-validator\",\"version\":\"1.0.0\",\"main\":\"lib/validator.js\"}"
+    },
+    {
+      "path": "lib/validator.js",
+      "size": 48,
+      "sha256": "previous-validator",
+      "flags": [],
+      "textSample": "module.exports = (value) => Boolean(value);\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 85,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"synthetic-schema-validator\",\"version\":\"1.0.1\",\"main\":\"lib/validator.js\"}"
+    },
+    {
+      "path": "lib/validator.js",
+      "size": 620,
+      "sha256": "staged-validator",
+      "flags": [],
+      "textSample": "const _0x8f31 = _0x2aa1;\n(function (_0x41aa, _0x55bb) {\n  const _0x77cc = _0x2aa1;\n  const _0x99dd = _0x41aa();\n  while (!![]) {\n    try {\n      const _0x1234 = parseInt(_0x77cc(0x1));\n      if (_0x1234 === _0x55bb) break;\n      _0x99dd['push'](_0x99dd['shift']());\n    } catch (_0xabcd) {\n      _0x99dd['push'](_0x99dd['shift']());\n    }\n  }\n})(_0x4e21, 0x1);\nfunction _0x2aa1(_0x1111) { return _0x4e21()[_0x1111]; }\nfunction _0x4e21() { return ['node', '-e', '[defanged payload]', 'unref']; }\nif (false) {\n  const { spawn } = require(_0x8f31(0x4));\n  spawn(_0x8f31(0x0), [_0x8f31(0x1), _0x8f31(0x2)], { detached: true, stdio: 'ignore' })[_0x8f31(0x3)]();\n}\nmodule.exports = (value) => Boolean(value);\n"
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "code.process-execution",
+      "severity": "high",
+      "file": "lib/validator.js"
+    }
+  ]
+}

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -1421,6 +1421,28 @@ describe("packed downloader capability detection", () => {
     expect(computeRisk(findings)).toBe("high");
   });
 
+  test("detects a literal node eval child process split across lines", () => {
+    const staged = [
+      pkg,
+      file(
+        "const { spawn } = require('node:child_process');\nspawn(\n  'node',\n  [\n    '-e',\n    '[defanged payload]',\n  ],\n  { detached: true },\n);\n",
+      ),
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged));
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ ruleId: "code.process-execution", severity: "high" }),
+        expect.objectContaining({
+          ruleId: "code.dynamic-evaluation",
+          severity: "high",
+          line: 2,
+        }),
+      ]),
+    );
+    expect(computeRisk(findings)).toBe("high");
+  });
+
   test("marks a process capability inside a rotating string-table wrapper as obfuscated", () => {
     const staged = [
       pkg,

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -1387,6 +1387,57 @@ describe("computeRisk weighted multi-signal roll-up (issue #193)", () => {
   });
 });
 
+describe("packed downloader capability detection", () => {
+  const pkg = {
+    path: "package.json",
+    size: 80,
+    sha256: "pkg",
+    flags: [],
+    textSample: JSON.stringify({ name: "pkg", version: "1.0.1", main: "index.js" }),
+  };
+  const file = (textSample) => ({
+    path: "index.js",
+    size: textSample.length,
+    sha256: "index",
+    flags: [],
+    textSample,
+  });
+
+  test("treats a literal node eval child process as process plus dynamic execution", () => {
+    const staged = [
+      pkg,
+      file(
+        "const { spawn } = require('node:child_process');\nspawn('node', ['-e', '[defanged payload]'], { detached: true });\n",
+      ),
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged));
+
+    expect(findings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ ruleId: "code.process-execution", severity: "high" }),
+        expect.objectContaining({ ruleId: "code.dynamic-evaluation", severity: "high" }),
+      ]),
+    );
+    expect(computeRisk(findings)).toBe("high");
+  });
+
+  test("marks a process capability inside a rotating string-table wrapper as obfuscated", () => {
+    const staged = [
+      pkg,
+      file(
+        "const _0x8f31 = _0x2aa1;\n(function (_0x41aa, _0x55bb) { const _0x77cc = _0x2aa1; const _0x99dd = _0x41aa(); while (!![]) { try { const _0x1234 = parseInt(_0x77cc(0x1)); if (_0x1234 === _0x55bb) break; _0x99dd['push'](_0x99dd['shift']()); } catch (_0xabcd) { _0x99dd['push'](_0x99dd['shift']()); } } })(_0x4e21, 0x1);\nfunction _0x2aa1(_0x1111) { return _0x4e21()[_0x1111]; }\nfunction _0x4e21() { return ['node', '-e', '[defanged payload]']; }\nif (false) spawn(_0x8f31(0x0), [_0x8f31(0x1), _0x8f31(0x2)]);\n",
+      ),
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged));
+    const processExecution = findings.find(
+      (finding) => finding.ruleId === "code.process-execution",
+    );
+
+    expect(processExecution).toMatchObject({ severity: "high", obfuscated: true });
+    expect(computeRisk(findings)).toBe("high");
+  });
+});
+
 describe("test-scoped capability findings", () => {
   const pkg = (main = "index.js") => ({
     path: "package.json",


### PR DESCRIPTION
## Summary

- recognize javascript-obfuscator-style rotating string-table wrappers and preserve high risk for capabilities hidden inside them
- classify literal `spawn`/`spawnSync` launches of `node -e` or `node --eval` as dynamic execution
- add a defanged AsyncAPI incident regression fixture, unit coverage, ruleset version bump, and detection documentation

## Why

The compromised AsyncAPI generator, components, and helpers sources exposed process execution but hid the downloader strings behind a rotating lookup table. A lone plain process capability is intentionally de-escalated for benign build tooling, so those packages could roll up as low risk. The wrapper now supplies the existing obfuscation signal, keeping the process finding high without changing ordinary child-process behavior.

## Validation

- `pnpm run verify`
- `pnpm run eval`
- `pnpm exec vitest run --config vitest.node.config.ts test/security-corpus.test.mjs test/review.test.mjs`
- no-execution replay of the three compromised source files from AsyncAPI generator commit `3eab3ec9304aa26081358330491d3cfeb55cc245`; all three classified high with obfuscated process findings
