### PR TITLE
Surface release memory in scan notifications

### DIFF
--- a/docs/release-memory.md
+++ b/docs/release-memory.md
@@ -31,6 +31,12 @@ migration; it lives in `summaryJson`), returned on `ScanResult`, included in
 the digested report payload, and exported by `report.json` as an additive
 optional field (`null` for scans that predate it).
 
+Completion email and Slack notifications surface the same context. They lead
+with release-delta risk (rather than whole-package artifact risk) and say when
+the profile matches, is a subset of, or has diverged from the prior approved
+release. This keeps recurring package-context findings from arriving as an
+unexplained high-risk alert while preserving the recorded risk and findings.
+
 ## It never changes risk
 
 Release memory is **advisory display context only**. It does not modify

--- a/docs/slack-notifications.md
+++ b/docs/slack-notifications.md
@@ -99,7 +99,10 @@ renders one Block Kit message (`renderSlackMessage`), and POSTs it with
 `chat.postMessage`. It is isolated from email: a missing connection or a failing
 post only records a `notification_failed` event and **never throws**, so it
 cannot block scan completion or gate processing. Slack delivery is decoupled from
-email recipients — it still fires when no email recipients resolve.
+email recipients — it still fires when no email recipients resolve. Completed
+staged-publish notifications report release-delta risk and include release-memory
+context when a prior approved profile exists; the underlying artifact risk and
+deterministic findings remain unchanged.
 
 `postSlackMessage` (`server/lib/slack.ts`) is self-contained and best-effort:
 Slack returns HTTP 200 with `{ ok: false, error }` for app errors (keyed off

--- a/server/lib/notify.ts
+++ b/server/lib/notify.ts
@@ -8,6 +8,7 @@ import {
 import { getScan } from "../db/scans";
 import { getSlackConnectionSecret } from "../db/slack-connection";
 import { sendNotificationEmail } from "./email";
+import { normalizeReleaseConsistency, type ReleaseConsistency } from "./release-memory";
 import type { RiskLevel } from "./review";
 import type { OrganizationRole } from "./roles";
 import { decryptSlackBotToken } from "./secret-box";
@@ -41,6 +42,8 @@ export async function notifyScanCompletion(input: NotifyScanCompletionInput): Pr
   const scan = detail?.scan;
   const packageLabel = formatPackageLabel(scan?.packageName, scan?.stagedVersion);
   const dashboardUrl = scanUrl(env, scanId, organizationId);
+  const releaseRisk = detail?.riskSummary?.releaseRisk ?? scan?.risk ?? null;
+  const releaseMemory = formatReleaseMemory(scan?.summaryJson);
   const subject =
     outcome === "complete"
       ? `Staged release scan complete — ${packageLabel}`
@@ -53,7 +56,8 @@ export async function notifyScanCompletion(input: NotifyScanCompletionInput): Pr
           "",
           `We finished scanning the staged release ${packageLabel}.`,
           organizationName ? `Organization: ${organizationName}` : null,
-          scan?.risk ? `Overall risk: ${scan.risk}.` : null,
+          releaseRisk ? `Release risk: ${releaseRisk}.` : null,
+          releaseMemory ? `Release memory: ${releaseMemory}` : null,
           dashboardUrl ? `Review the report: ${dashboardUrl}` : null,
           "",
           "— Drydock",
@@ -74,8 +78,9 @@ export async function notifyScanCompletion(input: NotifyScanCompletionInput): Pr
     title: outcome === "complete" ? "Staged release scan complete" : "Staged release scan failed",
     packageLabel,
     source: "npm staged publish",
-    risk: scan?.risk ?? null,
+    risk: releaseRisk,
     findingsSummary: formatFindingsSummary(detail?.riskSummary),
+    releaseMemory,
     statusLine:
       outcome === "failed"
         ? error?.message
@@ -125,6 +130,31 @@ export async function notifyScanCompletion(input: NotifyScanCompletionInput): Pr
   );
 
   await Promise.all([emailDelivery, slackDelivery]);
+}
+
+function formatReleaseMemory(summaryJson: unknown): string | null {
+  if (!summaryJson || typeof summaryJson !== "object" || Array.isArray(summaryJson)) return null;
+  const consistency = normalizeReleaseConsistency(
+    (summaryJson as { releaseConsistency?: unknown }).releaseConsistency,
+  );
+  if (!consistency || consistency.status === "none") return null;
+
+  const prior = priorReleaseLabel(consistency);
+  if (consistency.status === "diverged") {
+    const count = consistency.newFindingCount;
+    return `${count} new deterministic ${count === 1 ? "finding" : "findings"} since ${prior}.`;
+  }
+  if (consistency.currentFindingCount === 0) {
+    return `No deterministic findings; compared with ${prior}, which was already reviewed and published.`;
+  }
+  if (consistency.status === "subset") {
+    return `No new deterministic findings since ${prior}; every current finding was already reviewed and published.`;
+  }
+  return `Finding profile matches ${prior}; the same deterministic findings were already reviewed and published.`;
+}
+
+function priorReleaseLabel(consistency: ReleaseConsistency): string {
+  return consistency.priorVersion ? `v${consistency.priorVersion}` : "the last approved release";
 }
 
 export interface NotifyNpmConnectionExpiredInput {

--- a/server/lib/slack.ts
+++ b/server/lib/slack.ts
@@ -253,6 +253,7 @@ export interface SlackNotificationPayload {
   risk?: string | null;
   recommendation?: string | null;
   findingsSummary?: string | null;
+  releaseMemory?: string | null;
   repository?: string | null;
   environment?: string | null;
   statusLine?: string | null;
@@ -285,6 +286,7 @@ export function renderSlackMessage(payload: SlackNotificationPayload): SlackMess
     field("Source", payload.source),
     field("Risk", payload.risk ?? undefined),
     field("Findings", payload.findingsSummary ?? undefined),
+    field("Release memory", payload.releaseMemory ?? undefined),
     field("Repository", payload.repository ?? undefined),
     field("Environment", payload.environment ?? undefined),
     field("Recommendation", payload.recommendation ?? undefined),

--- a/test/notify.test.mjs
+++ b/test/notify.test.mjs
@@ -275,7 +275,7 @@ describe("notifyScanCompletion", () => {
     expect(dbMock.resolveNotificationEmails).toHaveBeenCalledWith({}, "org_1", "user_1");
   });
 
-  test("emails the resolved recipients on success with package and risk", async () => {
+  test("emails the resolved recipients on success with package and release risk", async () => {
     dbMock.resolveNotificationEmails.mockResolvedValue([
       "security@example.com",
       "lead@example.com",
@@ -287,7 +287,7 @@ describe("notifyScanCompletion", () => {
     const [, message] = emailMock.sendNotificationEmail.mock.calls[0];
     expect(message.subject).toContain("demo-package@1.2.0");
     expect(message.text).toContain("Organization: Acme Corp");
-    expect(message.text).toContain("Overall risk: high");
+    expect(message.text).toContain("Release risk: high");
     expect(message.text).toContain("https://drydock.test/dashboard/scans/scan_1?org=org_1");
 
     expect(dbMock.recordScanEvent).toHaveBeenCalledTimes(2);
@@ -295,6 +295,54 @@ describe("notifyScanCompletion", () => {
       expect(event.type).toBe("scan.notification_sent");
       expect(event.metadata).toMatchObject({ outcome: "complete", channel: "email" });
     }
+  });
+
+  test("surfaces approved release memory and the release-delta risk", async () => {
+    dbMock.getSlackConnectionSecret.mockResolvedValue(slackConnection());
+    dbMock.getScan.mockResolvedValue({
+      scan: {
+        packageName: "tape",
+        stagedVersion: "5.9.0",
+        risk: "high",
+        summaryJson: {
+          releaseConsistency: {
+            status: "match",
+            priorScanId: "scan_prior",
+            priorVersion: "5.8.1",
+            decidedAt: "2026-07-15T10:00:00.000Z",
+            currentFindingCount: 2,
+            priorFindingCount: 2,
+            newFindingCount: 0,
+            newFindings: [],
+          },
+        },
+      },
+      riskSummary: {
+        artifactRisk: "high",
+        releaseRisk: "low",
+        contextRisk: "high",
+        releaseFindingCount: 0,
+        contextFindingCount: 2,
+        unknownFindingCount: 0,
+      },
+    });
+
+    await notifyScanCompletion(scanInput());
+
+    const [, message] = emailMock.sendNotificationEmail.mock.calls[0];
+    expect(message.text).toContain("Release risk: low");
+    expect(message.text).toContain(
+      "Release memory: Finding profile matches v5.8.1; the same deterministic findings were already reviewed and published.",
+    );
+    expect(message.text).not.toContain("Overall risk: high");
+
+    expect(slackMock.renderSlackMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        risk: "low",
+        releaseMemory:
+          "Finding profile matches v5.8.1; the same deterministic findings were already reviewed and published.",
+      }),
+    );
   });
 
   test("reports the failure reason on a failed scan", async () => {

--- a/test/slack.test.mjs
+++ b/test/slack.test.mjs
@@ -213,6 +213,8 @@ describe("renderSlackMessage", () => {
       source: "npm staged publish",
       risk: "high",
       findingsSummary: "3 findings (2 on the release diff)",
+      releaseMemory:
+        "Finding profile matches v1.1.0; the same deterministic findings were already reviewed and published.",
       dashboardUrl: "https://drydock.test/dashboard/scans/scan_1",
     });
 
@@ -224,6 +226,8 @@ describe("renderSlackMessage", () => {
     expect(serialized).toContain("npm staged publish");
     expect(serialized).toContain("high");
     expect(serialized).toContain("3 findings (2 on the release diff)");
+    expect(serialized).toContain("Release memory");
+    expect(serialized).toContain("Finding profile matches v1.1.0");
     expect(serialized).toContain("https://drydock.test/dashboard/scans/scan_1");
   });
 


### PR DESCRIPTION
## What changed

- report release-delta risk in staged-scan completion email and Slack instead of the whole-package artifact risk
- include prior-approved release-memory context for matching, subset, empty, and diverged finding profiles
- render release memory as a dedicated Slack field
- document the notification behavior and add focused email/Slack regressions

## Why

PR #477 added release memory to the saved report, but completion notifications still collapsed a scan to its artifact risk and omitted that context. A package such as `tape` could therefore keep delivering an unexplained high-risk notification for recurring process-execution findings even when the release contained no new deterministic signals.

This change keeps the recorded artifact risk and every deterministic finding unchanged. It only makes the proactive notification align with the report's release-delta recommendation and surfaces the prior human approval.

## Validation

- `pnpm run verify`
- focused notification, Slack, and release-memory tests

Docs updated: `docs/release-memory.md` and `docs/slack-notifications.md`.