### PR TITLE
Rebuild attestation: opt-in checkout + rebuild + byte comparison for staged npm scans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
   - `routes/scans.ts` — `POST /api/v1/scans { stageId }`, `GET /api/v1/scans`, `GET /api/v1/scans/:id`.
   - `routes/github-webhooks.ts` — public signed GitHub App webhook endpoint. Persists `deployment_protection_rule` deliveries into `github_workflow_gates`; see `docs/workflow-gates.md`, `docs/npm-workflow-gate.md`, `docs/pypi-workflow-gate.md`, and `docs/vscode-workflow-gate.md`.
   - `lib/sandbox.ts` — Dynamic Worker that downloads/parses package artifacts. `NpmStageGateway` is the only npm-token egress.
+  - `lib/rebuild-sandbox.ts` / `lib/rebuild-steps.ts` / `lib/rebuild-job.ts` — opt-in rebuild attestation: disposable container rebuild + byte comparison; see `docs/rebuild-attestation.md`.
   - `lib/review.ts` — deterministic findings, package/package.json diffing, risk computation, and shared UI types.
   - `lib/ai-review.ts` — Workers AI reviewer, wired via `scan-pipeline.ts` and on by default behind the `ai-review` Flagship killswitch.
   - `lib/adapters/` — ecosystem-specific registry/artifact behavior for npm, PyPI, VS Code, and workflow gates.
@@ -17,7 +18,7 @@
 
 ## Non-negotiable boundaries
 
-- Package bytes are hostile evidence. Never execute package code, install dependencies, run lifecycle scripts, import modules, run builds, invoke shells, or render package-provided active content.
+- Package bytes are hostile evidence. Never execute package code, install dependencies, run lifecycle scripts, import modules, run builds, invoke shells, or render package-provided active content. Sole exception: the opt-in rebuild attestation executes repository build code inside the disposable, credential-free `RebuildSandbox` container only (see `docs/rebuild-attestation.md`); never in the Worker or the parse sandbox.
 - npm credentials stay outside the sandbox. Only `NpmStageGateway` may attach npm auth, only for allowed staged/metadata/tarball registry endpoints.
 - The AI reviewer is advisory and on by default; the per-organization `ai-review` flag is a killswitch that disables it. It cannot downgrade deterministic findings.
 - D1/Better Auth are required for every non-auth `/api/*` endpoint; resource ownership must be organization-scoped. Sole exception: the anonymous `/api/public/v1/package-diff` endpoints, which serve only public-registry and pkg.pr.new preview data, attach no credentials, and are IP rate-limited (see `docs/security-model.md`).

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,14 @@
+# Rebuild-attestation container image. The Sandbox SDK base image version must
+# match the @cloudflare/sandbox dependency in package.json — bump them together.
+#
+# The rebuild deliberately executes hostile repository code, so this image gets
+# no credentials and its egress is filtered by the RebuildSandbox allowlist
+# (server/lib/rebuild-sandbox.ts). Keep the toolchain here minimal and pinned:
+# the base image ships node + git + coreutils; package managers are activated
+# per-rebuild through corepack against the repository's `packageManager` pin.
+FROM docker.io/cloudflare/sandbox:0.12.3
+
+# Fail fast if a rebuild somehow reaches for interactive git auth instead of
+# surfacing a prompt that would hang the container until its exec timeout.
+ENV GIT_TERMINAL_PROMPT=0
+ENV CI=true

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ The user-facing learning guide is [`../src/pages/Docs/index.tsx`](../src/pages/D
 - [`workflow-gates.md`](./workflow-gates.md) — GitHub Environment gate flow for PyPI, npm, and VS Code workflow-gated releases.
 - [`diff-baseline.md`](./diff-baseline.md) — default previous-version comparison strategy.
 - [`intent-envelope.md`](./intent-envelope.md) — advisory source-binding tiers (attested / declared / absent) persisted with every scan.
+- [`rebuild-attestation.md`](./rebuild-attestation.md) — opt-in checkout + rebuild + byte comparison of staged npm artifacts in a disposable container.
 - [`artifact-storage.md`](./artifact-storage.md) — D1/R2 report and artifact persistence.
 
 ## Operations and setup

--- a/docs/rebuild-attestation.md
+++ b/docs/rebuild-attestation.md
@@ -35,7 +35,11 @@ staged shasum); PyPI and VS Code have no rebuild strategy yet.
    never the frozen `report.json` artifact, because the record is mutable).
 2. **Deferred job** (`rebuild-job.ts`): scan completion enqueues a
    `rebuild_attestation` message on `SCAN_QUEUE` (waitUntil fallback in local
-   dev). Container rebuilds take minutes and never hold up scan completion.
+   dev). If that handoff fails after scan persistence, redelivery of the
+   original scan message recovers the pending handoff. Rebuild-job D1/R2
+   failures retry through the queue and reach its DLQ after exhaustion instead
+   of being acknowledged while still pending. Container rebuilds take minutes
+   and never hold up scan completion.
 3. **Rebuild** (`rebuild-sandbox.ts` + `rebuild-steps.ts`): a disposable
    Cloudflare container clones the repo at the first resolvable ref, detects
    the strategy from the repository root (`packageManager` field via corepack,
@@ -65,7 +69,9 @@ pack`/`pnpm pack` apply the same `files`-field/`.npmignore` rules the
    The staged bytes are never re-fetched and never enter the container.
 5. The outcome replaces the pending record in `summary.rebuildAttestation`,
    surfaces under "Source binding" on the scan detail page, and exports as the
-   additive optional `rebuildAttestation` field of `drydock.report.v1`.
+   additive optional `rebuildAttestation` field of `drydock.report.v1`. A
+   completed scan page keeps polling while this record is pending, then stops
+   when the deferred outcome arrives.
 
 ## Outcome ladder
 

--- a/docs/rebuild-attestation.md
+++ b/docs/rebuild-attestation.md
@@ -1,0 +1,109 @@
+# Rebuild attestation
+
+Opt-in verification that a staged npm artifact can be reproduced from its
+declared source repository: check out the repo, install dependencies, run the
+build, pack, and compare the result against the staged bytes. It is the
+empirical upgrade of the [intent envelope](./intent-envelope.md)'s `declared`
+tier — the envelope records what the package _claims_, the rebuild tests it.
+
+Like the envelope, the result is **advisory metadata only**. It never changes
+risk levels or findings. A match proves _binding_ ("these bytes are exactly
+what this commit builds"), never benignness — if malicious code is committed to
+the repository, the rebuild truthfully matches, and source review covers it.
+
+## Opt-in
+
+The per-organization Cloudflare Flagship flag `rebuild-attestation` gates the
+feature and **defaults to off** (the inverse of the `ai-review` killswitch).
+Without a Flagship binding, or without an explicit organization rule turning it
+on, no rebuild plan is ever computed.
+
+v1 covers staged npm scans only. Workflow-gate scans are excluded (their
+artifact is already bound to a workflow run and their acquisition path has no
+staged shasum); PyPI and VS Code have no rebuild strategy yet.
+
+## Flow
+
+1. **Scan time** (`scan-pipeline.ts`): when the flag is on and the scan is
+   rebuildable, `computeRebuildPlan` (`server/lib/rebuild-attestation.ts`)
+   derives a plan — the envelope's normalized repository URL, checkout
+   candidates (`gitHead` from the staged version manifest first, then
+   `v{version}`/`{version}` tags), the manifest's `repository.directory` for
+   monorepos, and the staged tarball's SHA-1 `shasum`. The plan is persisted as
+   `summary.rebuildAttestation` with `status: "pending"` (summary blob only —
+   never the frozen `report.json` artifact, because the record is mutable).
+2. **Deferred job** (`rebuild-job.ts`): scan completion enqueues a
+   `rebuild_attestation` message on `SCAN_QUEUE` (waitUntil fallback in local
+   dev). Container rebuilds take minutes and never hold up scan completion.
+3. **Rebuild** (`rebuild-sandbox.ts` + `rebuild-steps.ts`): a disposable
+   Cloudflare container clones the repo at the first resolvable ref, detects
+   the strategy (`packageManager` field via corepack, else lockfile heuristics;
+   npm and pnpm supported, yarn reports unsupported), installs with
+   `--ignore-scripts`, runs the `build` script if declared, packs, and emits a
+   hash manifest: the tarball SHA-1 plus per-file sha256 of the unpacked
+   contents.
+4. **Comparison** (`compareRebuildOutput`): runs in the Worker against the
+   scan's persisted artifact hashes (R2 `files.json`) and the staged `shasum`.
+   The staged bytes are never re-fetched and never enter the container.
+5. The outcome replaces the pending record in `summary.rebuildAttestation`,
+   surfaces under "Source binding" on the scan detail page, and exports as the
+   additive optional `rebuildAttestation` field of `drydock.report.v1`.
+
+## Outcome ladder
+
+| Status           | Meaning                                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------------------ |
+| `byte-identical` | Rebuilt tarball SHA-1 equals the staged `shasum` (and the file sets agree). The strongest claim.       |
+| `file-identical` | Every packed file's sha256 matches the staged artifact; only tarball/pack metadata differs.            |
+| `diverged`       | The build succeeded but file sets differ. Informational evidence (divergent/missing/extra path lists). |
+| `inconclusive`   | No ref resolved, clone/install/build/pack failed, unsupported strategy, or no sandbox configured.      |
+| `pending`        | Plan persisted, deferred job not finished yet.                                                         |
+
+Ecosystem reality check: vlt's `reproduce` project found only ~6% of
+high-impact npm packages rebuild byte-for-byte, so `inconclusive` and
+`diverged` are expected, neutral outcomes — the UI renders them with
+informational tones, never severity colors. `file-identical` is the practical
+"reproduced" bar; `npm pack` itself is deterministic (fixed mtimes, sorted
+entries), so divergence almost always means the build output differs, not the
+packaging.
+
+## Security model
+
+The rebuild deliberately executes hostile code — repository contents, build
+scripts, and the dependency tree are all attacker-controlled. This is a second
+isolation ring, separate from the parse-only Dynamic Worker sandbox; the
+boundary is containment (see `docs/security-model.md`):
+
+- **Zero credentials in the container.** Public repos clone anonymously. The
+  npm staged token stays in the Worker. Because the staged tarball is
+  unpublished and requires that token, a hostile build _cannot_ fetch the
+  expected bytes and replay them — the classic self-fetch bypass of
+  post-publish rebuilders does not exist pre-publish.
+- **Deny-by-default egress.** `RebuildSandbox.allowedHosts` covers the source
+  forges (github.com, gitlab.com, bitbucket.org) and registry.npmjs.org for
+  dependency install; `interceptHttps` keeps the filter authoritative for TLS.
+- **Container output is hostile input.** Only a bounded hash manifest leaves
+  the container; the Worker re-validates it and performs the comparison itself.
+  A forged manifest can only produce a false `diverged`/`inconclusive`
+  (self-harm), because forging a _match_ requires the staged hashes.
+- **Dependency lifecycle scripts stay disabled** during install; the package's
+  own build/prepack scripts are the thing being attested and run inside the
+  container.
+- **Single-shot containers.** Sandbox ids are scan-scoped and destroyed after
+  one attestation; nothing is shared across scans or organizations.
+
+## Persistence and compatibility
+
+Everything lives in the scan's `summaryJson` blob — no schema migration. Every
+reader re-validates through `normalizeRebuildAttestation` (the
+`normalizeIntentEnvelope` pattern): scans that predate the feature, malformed
+blobs, and verdicts missing their evidence all read as `null`, and the UI hides
+the row. The report export carries `"rebuildAttestation": null` for those scans.
+
+## Deployment
+
+`wrangler.jsonc` defines the `RebuildSandbox` container (Durable Object binding
+`REBUILD_SANDBOX`, image `container/Dockerfile` pinned to the same version as
+the `@cloudflare/sandbox` dependency). Environments without the binding degrade
+gracefully: the job records `inconclusive` with a "sandbox not configured"
+signal instead of failing.

--- a/docs/rebuild-attestation.md
+++ b/docs/rebuild-attestation.md
@@ -120,17 +120,37 @@ the row. The report export carries `"rebuildAttestation": null` for those scans.
 
 ## Deployment
 
-`wrangler.jsonc` defines the `RebuildSandbox` container (Durable Object binding
-`REBUILD_SANDBOX`, image `container/Dockerfile` pinned to the same version as
-the `@cloudflare/sandbox` dependency). Environments without the binding degrade
-gracefully: the job records `inconclusive` with a "sandbox not configured"
-signal instead of failing.
+The feature ships in two stages because a container needs a Durable Object
+class as its control plane, and DO migrations cannot ride the versioned
+uploads Workers Builds performs (`wrangler versions upload` fails with error
+10211 for any version that carries an unapplied migration):
 
-**First deploy**: this feature introduces the Worker's first Durable Object
-migration (`new_sqlite_classes: ["RebuildSandbox"]`). DO migrations cannot ride
-a versioned upload — `wrangler versions upload` (which Workers Builds uses for
-preview branches) fails with error 10211 until the migration has been applied
-once by a full, non-versioned `wrangler deploy`. Expect preview builds of the
-introducing branch to fail; the production deploy applies the migration and
-subsequent version uploads (which then carry no _new_ migration) succeed.
-Building the container image also requires Docker in the deploy environment.
+1. **Feature code** (this layer): everything including the `RebuildSandbox`
+   class export, with **no** container/DO config in `wrangler.jsonc`.
+   Versioned uploads stay green. `env.REBUILD_SANDBOX` is absent, so if the
+   flag is turned on early the job records `inconclusive` with a "sandbox not
+   configured" signal instead of failing.
+2. **Container infra** (config-only follow-up): the exact block to add to
+   `wrangler.jsonc` (same convention as the detonation prototype, PR #472):
+
+   ```jsonc
+   "containers": [
+     {
+       "class_name": "RebuildSandbox",
+       "image": "./container/Dockerfile",
+       "max_instances": 5
+     }
+   ],
+   "durable_objects": {
+     "bindings": [{ "name": "REBUILD_SANDBOX", "class_name": "RebuildSandbox" }]
+   },
+   "migrations": [{ "tag": "v1", "new_sqlite_classes": ["RebuildSandbox"] }],
+   ```
+
+   This change must be applied by a one-time non-versioned `wrangler deploy`
+   run with Docker available — the image (`container/Dockerfile`, pinned to
+   the same version as the `@cloudflare/sandbox` dependency) is built at
+   deploy time, which the Workers Builds pipeline does not support. Once the
+   migration is applied, subsequent versioned uploads carry no _new_ migration
+   and succeed again. If the detonation prototype's container lands too, one
+   deploy can provision both under the same migration tag.

--- a/docs/rebuild-attestation.md
+++ b/docs/rebuild-attestation.md
@@ -28,8 +28,9 @@ staged shasum); PyPI and VS Code have no rebuild strategy yet.
    rebuildable, `computeRebuildPlan` (`server/lib/rebuild-attestation.ts`)
    derives a plan — the envelope's normalized repository URL, checkout
    candidates (`gitHead` from the staged version manifest first, then
-   `v{version}`/`{version}` tags), the manifest's `repository.directory` for
-   monorepos, and the staged tarball's SHA-1 `shasum`. The plan is persisted as
+   `v{version}`, changesets-style `{name}@{version}`, and `{version}` tags),
+   the manifest's `repository.directory` for monorepos, and the staged
+   tarball's SHA-1 `shasum`. The plan is persisted as
    `summary.rebuildAttestation` with `status: "pending"` (summary blob only —
    never the frozen `report.json` artifact, because the record is mutable).
 2. **Deferred job** (`rebuild-job.ts`): scan completion enqueues a
@@ -37,11 +38,28 @@ staged shasum); PyPI and VS Code have no rebuild strategy yet.
    dev). Container rebuilds take minutes and never hold up scan completion.
 3. **Rebuild** (`rebuild-sandbox.ts` + `rebuild-steps.ts`): a disposable
    Cloudflare container clones the repo at the first resolvable ref, detects
-   the strategy (`packageManager` field via corepack, else lockfile heuristics;
-   npm and pnpm supported, yarn reports unsupported), installs with
-   `--ignore-scripts`, runs the `build` script if declared, packs, and emits a
-   hash manifest: the tarball SHA-1 plus per-file sha256 of the unpacked
-   contents.
+   the strategy from the repository root (`packageManager` field via corepack,
+   else lockfile heuristics; npm and pnpm supported, yarn reports
+   unsupported), installs with `--ignore-scripts`, runs the `build` script if
+   declared, packs, and emits a hash manifest: the tarball SHA-1 plus per-file
+   sha256 of the unpacked contents.
+
+   **Monorepos**: install runs at the repository root (so the workspace graph
+   resolves); build and pack run in the package directory. That directory is
+   `repository.directory` when the manifest declares it; otherwise, when the
+   staged package name differs from the root manifest's name, the container
+   greps the workspace (depth ≤ 5, `node_modules` excluded) for the
+   package.json declaring that name, and the Worker validates both the located
+   path shape and that the located manifest's `name` matches before using it.
+   No unambiguous location → `inconclusive` with a `package-not-located`
+   signal, never a guess.
+
+   **What gets compared** is decided by `pack` itself, not by Drydock: `npm
+pack`/`pnpm pack` apply the same `files`-field/`.npmignore` rules the
+   publisher's client did, so the rebuilt file set is exactly "what this
+   commit would publish" — dist/ output included, sources excluded when the
+   manifest excludes them.
+
 4. **Comparison** (`compareRebuildOutput`): runs in the Worker against the
    scan's persisted artifact hashes (R2 `files.json`) and the staged `shasum`.
    The staged bytes are never re-fetched and never enter the container.
@@ -107,3 +125,12 @@ the row. The report export carries `"rebuildAttestation": null` for those scans.
 the `@cloudflare/sandbox` dependency). Environments without the binding degrade
 gracefully: the job records `inconclusive` with a "sandbox not configured"
 signal instead of failing.
+
+**First deploy**: this feature introduces the Worker's first Durable Object
+migration (`new_sqlite_classes: ["RebuildSandbox"]`). DO migrations cannot ride
+a versioned upload — `wrangler versions upload` (which Workers Builds uses for
+preview branches) fails with error 10211 until the migration has been applied
+once by a full, non-versioned `wrangler deploy`. Expect preview builds of the
+introducing branch to fail; the production deploy applies the migration and
+subsequent version uploads (which then carry no _new_ migration) succeed.
+Building the container image also requires Docker in the deploy environment.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -22,7 +22,7 @@ Drydock handles hostile package artifacts, private review evidence, and npm cred
 ## Non-negotiable boundaries
 
 - **No approval automation.** Drydock must not run `npm stage approve`, collect npm 2FA codes, publish packages, or represent AI output as release approval.
-- **No package execution.** Do not execute package code, install dependencies, run lifecycle scripts, import modules, run builds, invoke shells, or render package-provided active content.
+- **No package execution.** Do not execute package code, install dependencies, run lifecycle scripts, import modules, run builds, invoke shells, or render package-provided active content. Sole exception: the opt-in rebuild attestation ([`rebuild-attestation.md`](./rebuild-attestation.md)) executes _repository_ build code — never the staged package bytes — exclusively inside a disposable, credential-free container with deny-by-default egress; its output is a hash manifest treated as hostile input, and its verdict is advisory only.
 - **No npm token in the sandbox.** The Dynamic Worker must never receive npm token material. Only `NpmStageGateway` may attach npm authorization, and only for allowlisted npm registry endpoints.
 - **AI is advisory and on by default.** Workers AI runs behind the per-organization Flagship `ai-review` killswitch; set the flag to false to disable it for an organization or globally. Deterministic findings remain authoritative and cannot be downgraded by AI output.
 - **Fail closed.** Artifact acquisition, validation, parsing, report generation, workflow-gate callback, and credential checks must block/reject on uncertainty rather than silently approving.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "verify": "node scripts/verify.mjs"
   },
   "dependencies": {
+    "@cloudflare/sandbox": "^0.12.3",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@preact/signals": "^2.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
 
   .:
     dependencies:
+      '@cloudflare/sandbox':
+        specifier: ^0.12.3
+        version: 0.12.3
       '@fontsource-variable/geist':
         specifier: ^5.2.9
         version: 5.2.9
@@ -307,9 +310,26 @@ packages:
   '@better-fetch/fetch@1.3.1':
     resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
 
+  '@cloudflare/containers@0.3.7':
+    resolution: {integrity: sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw==}
+
   '@cloudflare/kv-asset-handler@0.5.0':
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
     engines: {node: '>=22.0.0'}
+
+  '@cloudflare/sandbox@0.12.3':
+    resolution: {integrity: sha512-4yx+PtBCZBrS3eZteefwBfGOm+8MTZahLH8/fG/qsvqoNflzno9780FsM6HZf02gGuoDy+s9jQrXbg/h5gEvgw==}
+    peerDependencies:
+      '@openai/agents': ^0.3.3
+      '@opencode-ai/sdk': ^1.1.40
+      '@xterm/xterm': '>=5.0.0'
+    peerDependenciesMeta:
+      '@openai/agents':
+        optional: true
+      '@opencode-ai/sdk':
+        optional: true
+      '@xterm/xterm':
+        optional: true
 
   '@cloudflare/unenv-preset@2.16.1':
     resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
@@ -1648,6 +1668,9 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  aws4fetch@1.0.20:
+    resolution: {integrity: sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g==}
+
   babel-plugin-transform-hook-names@1.0.2:
     resolution: {integrity: sha512-5gafyjyyBTTdX/tQQ0hRgu4AhNHG/hqWi0ZZmg2xvs2FgRkJXzDNKBZCyoYqgFkovfDrgM8OoKg8karoUvWeCw==}
     peerDependencies:
@@ -1748,6 +1771,9 @@ packages:
 
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+
+  capnweb@0.8.0:
+    resolution: {integrity: sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -2891,7 +2917,16 @@ snapshots:
 
   '@better-fetch/fetch@1.3.1': {}
 
+  '@cloudflare/containers@0.3.7': {}
+
   '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/sandbox@0.12.3':
+    dependencies:
+      '@cloudflare/containers': 0.3.7
+      aws4fetch: 1.0.20
+      capnweb: 0.8.0
+      hono: 4.12.27
 
   '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260617.1)':
     dependencies:
@@ -3785,6 +3820,8 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  aws4fetch@1.0.20: {}
+
   babel-plugin-transform-hook-names@1.0.2(@babel/core@7.29.7):
     dependencies:
       '@babel/core': 7.29.7
@@ -3845,6 +3882,8 @@ snapshots:
   camelcase@5.3.1: {}
 
   caniuse-lite@1.0.30001799: {}
+
+  capnweb@0.8.0: {}
 
   ccount@2.0.1: {}
 

--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -223,6 +223,41 @@ export async function discardScanAttempt(db: AppDb, scanId: string, organization
 }
 
 /**
+ * Replace `summary.rebuildAttestation` on a completed scan. The rebuild job is
+ * the only writer after scan completion, so a read-merge-write on the summary
+ * blob is safe; every other summary key is preserved as persisted.
+ */
+export async function updateScanRebuildAttestation(
+  db: AppDb,
+  scanId: string,
+  organizationId: string,
+  rebuildAttestation: unknown,
+) {
+  const rows = await db
+    .select({ summaryJson: scans.summaryJson })
+    .from(scans)
+    .where(
+      and(
+        eq(scans.id, scanId),
+        eq(scans.organizationId, organizationId),
+        eq(scans.status, "complete"),
+      ),
+    )
+    .limit(1);
+  if (!rows.length) return false;
+  const summary = rows[0].summaryJson;
+  const merged =
+    summary && typeof summary === "object" && !Array.isArray(summary)
+      ? { ...(summary as Record<string, unknown>), rebuildAttestation }
+      : { rebuildAttestation };
+  await db
+    .update(scans)
+    .set({ summaryJson: merged, updatedAt: new Date() })
+    .where(and(eq(scans.id, scanId), eq(scans.organizationId, organizationId)));
+  return true;
+}
+
+/**
  * Remove every scan attached to a gate. Used to discard a partially-completed
  * review batch before it is re-run, so a retry does not leave orphaned
  * per-package scans behind (cascades to scan_files / scan_findings). Safe only

--- a/server/env.d.ts
+++ b/server/env.d.ts
@@ -10,6 +10,12 @@ declare global {
       SCAN_ARTIFACT_READS_DISABLED?: string;
       COMPARE_CACHE?: KVNamespace;
       SCAN_QUEUE?: Queue<import("./lib/scan-job").QueueMessage>;
+      // Rebuild-attestation container namespace. Absent in tests and in
+      // environments without containers; the rebuild job then resolves to an
+      // inconclusive attestation instead of failing the scan.
+      REBUILD_SANDBOX?: DurableObjectNamespace<
+        import("./lib/rebuild-sandbox").RebuildSandbox
+      >;
       NPM_REGISTRY: string;
       ALLOW_INSECURE_LOCAL_REGISTRY?: string;
       // `.dev.vars`-only escape hatch (see securityHeadersDisabled). Never set in

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,9 +19,11 @@ import {
   durationMsSince,
   emitOperationalEvent,
 } from "./lib/observability";
+import { executeRebuildAttestationJob } from "./lib/rebuild-job";
 import {
   classifyScanError,
   executeScanJob,
+  isRebuildAttestationMessage,
   isWorkflowGateMessage,
   MAX_SCAN_JOB_ATTEMPTS,
   retryDelaySeconds,
@@ -436,6 +438,13 @@ async function pruneStaleAuditEvents(env: Cloudflare.Env) {
   }
 }
 
+// Rebuild-attestation container plumbing. The Durable Object class backing the
+// `REBUILD_SANDBOX` binding must be exported from the deploy entrypoint, and
+// the Sandbox SDK requires its ContainerProxy WorkerEntrypoint alongside it
+// (it powers the egress interception that enforces `allowedHosts`).
+export { RebuildSandbox } from "./lib/rebuild-sandbox";
+export { ContainerProxy } from "@cloudflare/sandbox";
+
 export default {
   fetch: app.fetch,
   async scheduled(_event: ScheduledController, env: Cloudflare.Env, ctx: ExecutionContext) {
@@ -455,6 +464,23 @@ export default {
   async queue(batch: MessageBatch<QueueMessage>, env: Cloudflare.Env, ctx: ExecutionContext) {
     for (const message of batch.messages) {
       const messageStartedAtMs = Date.now();
+      if (isRebuildAttestationMessage(message.body)) {
+        // Single-shot: the job persists every outcome (including failures) as
+        // an inconclusive attestation, so there is nothing useful to retry.
+        const rebuildMessage = message.body;
+        try {
+          await executeRebuildAttestationJob(env, rebuildMessage);
+        } catch (err) {
+          emitOperationalEvent("error", "rebuild.queue.message_failed", {
+            scanId: rebuildMessage.scanId,
+            organizationId: rebuildMessage.organizationId,
+            attempt: message.attempts,
+            durationMs: durationMsSince(messageStartedAtMs),
+            error: describeOperationalError(err),
+          });
+        }
+        continue;
+      }
       if (isWorkflowGateMessage(message.body)) {
         const gateMessage = message.body;
         try {

--- a/server/index.ts
+++ b/server/index.ts
@@ -465,19 +465,30 @@ export default {
     for (const message of batch.messages) {
       const messageStartedAtMs = Date.now();
       if (isRebuildAttestationMessage(message.body)) {
-        // Single-shot: the job persists every outcome (including failures) as
-        // an inconclusive attestation, so there is nothing useful to retry.
         const rebuildMessage = message.body;
         try {
           await executeRebuildAttestationJob(env, rebuildMessage);
         } catch (err) {
-          emitOperationalEvent("error", "rebuild.queue.message_failed", {
-            scanId: rebuildMessage.scanId,
-            organizationId: rebuildMessage.organizationId,
-            attempt: message.attempts,
-            durationMs: durationMsSince(messageStartedAtMs),
-            error: describeOperationalError(err),
-          });
+          if (message.attempts < MAX_SCAN_JOB_ATTEMPTS) {
+            message.retry({ delaySeconds: retryDelaySeconds(message.attempts) });
+            emitOperationalEvent("warn", "rebuild.queue.retry_scheduled", {
+              scanId: rebuildMessage.scanId,
+              organizationId: rebuildMessage.organizationId,
+              attempt: message.attempts,
+              nextDelaySeconds: retryDelaySeconds(message.attempts),
+              durationMs: durationMsSince(messageStartedAtMs),
+              error: describeOperationalError(err),
+            });
+          } else {
+            emitOperationalEvent("error", "rebuild.queue.message_failed", {
+              scanId: rebuildMessage.scanId,
+              organizationId: rebuildMessage.organizationId,
+              attempt: message.attempts,
+              durationMs: durationMsSince(messageStartedAtMs),
+              error: describeOperationalError(err),
+            });
+            throw err;
+          }
         }
         continue;
       }

--- a/server/lib/adapters/npm/index.ts
+++ b/server/lib/adapters/npm/index.ts
@@ -67,6 +67,7 @@ export const npmAdapter: PackageAdapter<NpmAdapterInput, NpmBroker> = {
       actorType: d.actorType,
       createdAt: d.createdAt,
       shasum: d.shasum,
+      gitHead: d.gitHead,
     };
   },
 };

--- a/server/lib/rebuild-attestation.ts
+++ b/server/lib/rebuild-attestation.ts
@@ -1,0 +1,390 @@
+// Rebuild attestation: opt-in verification that a staged npm artifact can be
+// reproduced from its declared source repository ("checkout + install + build
+// + pack" matches the staged bytes). This is the empirical upgrade of the
+// intent envelope's `declared` tier — see `intent-envelope.ts` and
+// `docs/rebuild-attestation.md`.
+//
+// Everything the rebuild consumes is attacker-controlled (repository URL,
+// gitHead, repository contents, build scripts, dependency tree), so:
+//
+//  - The rebuild runs in a disposable Cloudflare container with a
+//    deny-by-default egress allowlist and zero credentials (`rebuild-sandbox.ts`).
+//  - The container's output (a hash manifest) is treated as hostile input and
+//    re-validated here; the comparison itself runs in the Worker against the
+//    scan's persisted artifact hashes, never inside the container.
+//  - The result is advisory metadata only. A match proves *binding* ("these
+//    bytes are what this commit builds"), never benignness; a mismatch or
+//    failure is informational and must never change risk levels or findings.
+//
+// This module is pure (no bindings, no fetch) and shared with the UI.
+
+export type RebuildAttestationStatus =
+  | "pending"
+  | "byte-identical"
+  | "file-identical"
+  | "diverged"
+  | "inconclusive";
+
+export interface RebuildRef {
+  kind: "git-head" | "version-tag";
+  /** A full git object id for `git-head`, a tag name for `version-tag`. */
+  value: string;
+}
+
+export interface RebuildPlan {
+  /** Normalized https repository URL from the intent envelope. */
+  repository: string;
+  /** Checkout candidates in preference order (gitHead first). */
+  refs: RebuildRef[];
+  /** `repository.directory` for monorepo packages, validated. */
+  directory: string | null;
+  packageName: string | null;
+  version: string | null;
+  /** SHA-1 of the staged tarball, for the byte-identical comparison. */
+  expectedShasum: string | null;
+}
+
+export interface RebuildToolchain {
+  packageManager: string | null;
+  node: string | null;
+}
+
+export interface RebuildComparison {
+  /** Null when either side lacks a tarball digest. */
+  tarballShasumMatch: boolean | null;
+  stagedFileCount: number;
+  rebuiltFileCount: number;
+  matchedFileCount: number;
+  divergentPaths: string[];
+  missingFromRebuild: string[];
+  extraInRebuild: string[];
+}
+
+export interface RebuildSignal {
+  kind: string;
+  detail: string;
+}
+
+export interface RebuildAttestation {
+  status: RebuildAttestationStatus;
+  /** What the rebuild attempted (or will attempt while `pending`). */
+  plan: RebuildPlan | null;
+  /** The ref that was actually checked out, once the rebuild ran. */
+  ref: RebuildRef | null;
+  toolchain: RebuildToolchain | null;
+  comparison: RebuildComparison | null;
+  signals: RebuildSignal[];
+  completedAt: string | null;
+}
+
+/** Hash manifest produced inside the rebuild container. Hostile input. */
+export interface RebuildOutputManifest {
+  tarballSha1: string | null;
+  files: Array<{ path: string; sha256: string }>;
+}
+
+const STATUSES: ReadonlySet<string> = new Set([
+  "pending",
+  "byte-identical",
+  "file-identical",
+  "diverged",
+  "inconclusive",
+]);
+const REF_KINDS: ReadonlySet<string> = new Set(["git-head", "version-tag"]);
+
+const GIT_OBJECT_ID_RE = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
+// Conservative tag/directory charset: these values are interpolated into
+// container commands (always shell-quoted, but defense in depth is free).
+const TAG_RE = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$/;
+const DIRECTORY_SEGMENT_RE = /^[A-Za-z0-9_.@-]+$/;
+const MAX_REFS = 4;
+const MAX_PATH_LIST = 50;
+const MAX_FILES_IN_MANIFEST = 20_000;
+const MAX_SIGNALS = 20;
+const MAX_TEXT = 512;
+
+export interface RebuildPlanInput {
+  ecosystem: string;
+  /** Normalized repository URL from the intent envelope (null when absent). */
+  repository: string | null;
+  /** `gitHead` from the staged version manifest, when present. */
+  gitHead: string | null | undefined;
+  packageName: string | null;
+  version: string | null;
+  /** SHA-1 shasum of the staged tarball from the staged publish details. */
+  shasum: string | null | undefined;
+  /** Staged package.json text, for `repository.directory`. */
+  manifestText: string | null;
+}
+
+/**
+ * Decide whether a scan is rebuildable and pin down what to attempt. Returns
+ * null when there is nothing actionable (wrong ecosystem, no repository
+ * binding, or no checkout candidate) — callers then skip the attestation
+ * entirely rather than persisting a doomed plan.
+ */
+export function computeRebuildPlan(input: RebuildPlanInput): RebuildPlan | null {
+  if (input.ecosystem !== "npm") return null;
+  if (!input.repository || !/^https:\/\/[^/]+\/.+/.test(input.repository)) return null;
+
+  const refs: RebuildRef[] = [];
+  const gitHead = typeof input.gitHead === "string" ? input.gitHead.trim().toLowerCase() : "";
+  if (GIT_OBJECT_ID_RE.test(gitHead)) refs.push({ kind: "git-head", value: gitHead });
+  const version = typeof input.version === "string" ? input.version.trim() : "";
+  if (version && TAG_RE.test(version)) {
+    refs.push({ kind: "version-tag", value: `v${version}` });
+    refs.push({ kind: "version-tag", value: version });
+  }
+  if (!refs.length) return null;
+
+  return {
+    repository: input.repository,
+    refs: refs.slice(0, MAX_REFS),
+    directory: extractRepositoryDirectory(input.manifestText),
+    packageName: input.packageName,
+    version: version || null,
+    expectedShasum: normalizeSha1(input.shasum),
+  };
+}
+
+/**
+ * `repository.directory` from the staged manifest, accepted only when it is a
+ * plain relative path (no traversal, no absolute paths, bounded depth).
+ */
+export function extractRepositoryDirectory(manifestText: string | null): string | null {
+  if (!manifestText) return null;
+  let manifest: unknown;
+  try {
+    manifest = JSON.parse(manifestText);
+  } catch {
+    return null;
+  }
+  if (!manifest || typeof manifest !== "object" || Array.isArray(manifest)) return null;
+  const repository = (manifest as { repository?: unknown }).repository;
+  if (!repository || typeof repository !== "object" || Array.isArray(repository)) return null;
+  const raw = (repository as { directory?: unknown }).directory;
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim().replace(/^\.\//, "").replace(/\/+$/, "");
+  if (!trimmed || trimmed.length > 200) return null;
+  const segments = trimmed.split("/");
+  if (segments.length > 8) return null;
+  if (!segments.every((segment) => DIRECTORY_SEGMENT_RE.test(segment) && segment !== "..")) {
+    return null;
+  }
+  return segments.join("/");
+}
+
+export interface RebuildComparisonInput {
+  expectedShasum: string | null;
+  /** Staged artifact file hashes from the scan's persisted artifacts. */
+  stagedFiles: Array<{ path: string; sha256: string | null }>;
+  /** Hash manifest the rebuild container produced. Hostile input. */
+  output: RebuildOutputManifest;
+}
+
+export interface RebuildComparisonOutcome {
+  status: Extract<RebuildAttestationStatus, "byte-identical" | "file-identical" | "diverged">;
+  comparison: RebuildComparison;
+}
+
+/**
+ * Compare the rebuilt package against the staged artifact. Ladder:
+ * byte-identical (tarball SHA-1 matches the staged shasum) > file-identical
+ * (every packed file's sha256 matches) > diverged. Returns null when the
+ * staged side is missing hashes — the caller reports `inconclusive` instead of
+ * guessing.
+ */
+export function compareRebuildOutput(
+  input: RebuildComparisonInput,
+): RebuildComparisonOutcome | null {
+  const staged = new Map<string, string>();
+  for (const file of input.stagedFiles) {
+    if (typeof file.sha256 !== "string" || !file.sha256) return null;
+    staged.set(normalizePath(file.path), file.sha256.toLowerCase());
+  }
+  if (!staged.size) return null;
+
+  const rebuilt = new Map<string, string>();
+  for (const file of input.output.files.slice(0, MAX_FILES_IN_MANIFEST)) {
+    rebuilt.set(normalizePath(file.path), file.sha256.toLowerCase());
+  }
+
+  const divergentPaths: string[] = [];
+  const missingFromRebuild: string[] = [];
+  let matchedFileCount = 0;
+  for (const [path, sha256] of staged) {
+    const other = rebuilt.get(path);
+    if (other === undefined) missingFromRebuild.push(path);
+    else if (other === sha256) matchedFileCount += 1;
+    else divergentPaths.push(path);
+  }
+  const extraInRebuild = [...rebuilt.keys()].filter((path) => !staged.has(path));
+  divergentPaths.sort();
+  missingFromRebuild.sort();
+  extraInRebuild.sort();
+
+  const expected = normalizeSha1(input.expectedShasum);
+  const actual = normalizeSha1(input.output.tarballSha1);
+  const tarballShasumMatch = expected && actual ? expected === actual : null;
+  const filesIdentical =
+    !divergentPaths.length && !missingFromRebuild.length && !extraInRebuild.length;
+
+  const comparison: RebuildComparison = {
+    tarballShasumMatch,
+    stagedFileCount: staged.size,
+    rebuiltFileCount: rebuilt.size,
+    matchedFileCount,
+    divergentPaths: divergentPaths.slice(0, MAX_PATH_LIST),
+    missingFromRebuild: missingFromRebuild.slice(0, MAX_PATH_LIST),
+    extraInRebuild: extraInRebuild.slice(0, MAX_PATH_LIST),
+  };
+
+  if (tarballShasumMatch === true && filesIdentical) {
+    return { status: "byte-identical", comparison };
+  }
+  if (filesIdentical) return { status: "file-identical", comparison };
+  return { status: "diverged", comparison };
+}
+
+function normalizePath(path: string): string {
+  let value = path.trim().replace(/\\/g, "/");
+  while (value.startsWith("./")) value = value.slice(2);
+  if (value.startsWith("package/")) value = value.slice("package/".length);
+  return value;
+}
+
+function normalizeSha1(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim().toLowerCase();
+  return /^[0-9a-f]{40}$/.test(trimmed) ? trimmed : null;
+}
+
+/**
+ * Re-validate a persisted attestation from an untyped summary blob. Malformed
+ * or internally inconsistent data reads as null rather than a partial result —
+ * a verdict must not outlive the evidence that justified it. Follows the
+ * `normalizeIntentEnvelope` pattern.
+ */
+export function normalizeRebuildAttestation(value: unknown): RebuildAttestation | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const item = value as Partial<Record<keyof RebuildAttestation, unknown>>;
+  if (typeof item.status !== "string" || !STATUSES.has(item.status)) return null;
+  const status = item.status as RebuildAttestationStatus;
+
+  const plan = normalizePlan(item.plan);
+  const ref = normalizeRef(item.ref);
+  const toolchain = normalizeToolchain(item.toolchain);
+  const comparison = normalizeComparison(item.comparison);
+  const signals = normalizeSignals(item.signals);
+  const completedAt =
+    typeof item.completedAt === "string" && item.completedAt.trim()
+      ? item.completedAt.slice(0, 64)
+      : null;
+
+  // Verdicts require the evidence backing them; a pending record requires an
+  // actionable plan.
+  if (status === "pending" && !plan) return null;
+  if (
+    (status === "byte-identical" || status === "file-identical" || status === "diverged") &&
+    (!comparison || !plan)
+  ) {
+    return null;
+  }
+  if (status === "byte-identical" && comparison?.tarballShasumMatch !== true) return null;
+
+  return { status, plan, ref, toolchain, comparison, signals, completedAt };
+}
+
+function normalizePlan(value: unknown): RebuildPlan | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const item = value as Partial<Record<keyof RebuildPlan, unknown>>;
+  if (typeof item.repository !== "string" || !/^https:\/\/[^/]+\/.+/.test(item.repository)) {
+    return null;
+  }
+  const refs: RebuildRef[] = [];
+  if (Array.isArray(item.refs)) {
+    for (const raw of item.refs.slice(0, MAX_REFS)) {
+      const ref = normalizeRef(raw);
+      if (ref) refs.push(ref);
+    }
+  }
+  if (!refs.length) return null;
+  const directory =
+    typeof item.directory === "string" && item.directory ? item.directory.slice(0, 200) : null;
+  return {
+    repository: item.repository.slice(0, MAX_TEXT),
+    refs,
+    directory,
+    packageName: readBoundedString(item.packageName),
+    version: readBoundedString(item.version),
+    expectedShasum: normalizeSha1(item.expectedShasum as string | null | undefined),
+  };
+}
+
+function normalizeRef(value: unknown): RebuildRef | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const { kind, value: refValue } = value as { kind?: unknown; value?: unknown };
+  if (typeof kind !== "string" || !REF_KINDS.has(kind)) return null;
+  if (typeof refValue !== "string" || !refValue.trim()) return null;
+  if (kind === "git-head" && !GIT_OBJECT_ID_RE.test(refValue.trim().toLowerCase())) return null;
+  if (kind === "version-tag" && !TAG_RE.test(refValue.trim())) return null;
+  return { kind: kind as RebuildRef["kind"], value: refValue.trim().slice(0, 128) };
+}
+
+function normalizeToolchain(value: unknown): RebuildToolchain | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const item = value as { packageManager?: unknown; node?: unknown };
+  const packageManager = readBoundedString(item.packageManager);
+  const node = readBoundedString(item.node);
+  if (!packageManager && !node) return null;
+  return { packageManager, node };
+}
+
+function normalizeComparison(value: unknown): RebuildComparison | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const item = value as Partial<Record<keyof RebuildComparison, unknown>>;
+  const stagedFileCount = readCount(item.stagedFileCount);
+  const rebuiltFileCount = readCount(item.rebuiltFileCount);
+  const matchedFileCount = readCount(item.matchedFileCount);
+  if (stagedFileCount === null || rebuiltFileCount === null || matchedFileCount === null) {
+    return null;
+  }
+  return {
+    tarballShasumMatch:
+      typeof item.tarballShasumMatch === "boolean" ? item.tarballShasumMatch : null,
+    stagedFileCount,
+    rebuiltFileCount,
+    matchedFileCount,
+    divergentPaths: readPathList(item.divergentPaths),
+    missingFromRebuild: readPathList(item.missingFromRebuild),
+    extraInRebuild: readPathList(item.extraInRebuild),
+  };
+}
+
+function normalizeSignals(value: unknown): RebuildSignal[] {
+  const signals: RebuildSignal[] = [];
+  if (!Array.isArray(value)) return signals;
+  for (const signal of value.slice(0, MAX_SIGNALS)) {
+    if (!signal || typeof signal !== "object" || Array.isArray(signal)) continue;
+    const { kind, detail } = signal as { kind?: unknown; detail?: unknown };
+    if (typeof kind !== "string" || typeof detail !== "string") continue;
+    signals.push({ kind: kind.slice(0, MAX_TEXT), detail: detail.slice(0, MAX_TEXT) });
+  }
+  return signals;
+}
+
+function readPathList(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .slice(0, MAX_PATH_LIST)
+    .filter((entry): entry is string => typeof entry === "string")
+    .map((entry) => entry.slice(0, MAX_TEXT));
+}
+
+function readCount(value: unknown): number | null {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : null;
+}
+
+function readBoundedString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim().slice(0, MAX_TEXT) : null;
+}

--- a/server/lib/rebuild-attestation.ts
+++ b/server/lib/rebuild-attestation.ts
@@ -95,7 +95,9 @@ const REF_KINDS: ReadonlySet<string> = new Set(["git-head", "version-tag"]);
 const GIT_OBJECT_ID_RE = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
 // Conservative tag/directory charset: these values are interpolated into
 // container commands (always shell-quoted, but defense in depth is free).
-const TAG_RE = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$/;
+// `@` is allowed (not leading `@{`, which git refnames forbid) so
+// changesets-style monorepo tags like `@scope/pkg@2.0.0` validate.
+const TAG_RE = /^[A-Za-z0-9@][A-Za-z0-9._/@-]{0,127}$/;
 const DIRECTORY_SEGMENT_RE = /^[A-Za-z0-9_.@-]+$/;
 const MAX_REFS = 4;
 const MAX_PATH_LIST = 50;
@@ -133,6 +135,11 @@ export function computeRebuildPlan(input: RebuildPlanInput): RebuildPlan | null 
   const version = typeof input.version === "string" ? input.version.trim() : "";
   if (version && TAG_RE.test(version)) {
     refs.push({ kind: "version-tag", value: `v${version}` });
+    // Changesets-style monorepo release tags (`@scope/pkg@2.0.0`).
+    const packageTag = input.packageName ? `${input.packageName}@${version}` : null;
+    if (packageTag && TAG_RE.test(packageTag)) {
+      refs.push({ kind: "version-tag", value: packageTag });
+    }
     refs.push({ kind: "version-tag", value: version });
   }
   if (!refs.length) return null;

--- a/server/lib/rebuild-job.ts
+++ b/server/lib/rebuild-job.ts
@@ -1,0 +1,203 @@
+// Deferred rebuild-attestation job. Runs after a scan completes (queued by
+// `scan-job.ts`), resolves the pending plan persisted in the scan summary:
+// rebuilds the package from its declared repository in the disposable
+// container (`rebuild-sandbox.ts`) and compares the result against the scan's
+// persisted artifact hashes. The comparison happens entirely in the Worker —
+// the container only ever returns a hash manifest, which is treated as hostile
+// input. The outcome is advisory and never changes risk levels or findings.
+
+import { createDb, type AppDb } from "../db/client";
+import { updateScanRebuildAttestation } from "../db/scans";
+import { errorMessage } from "./errors";
+import { describeOperationalError, durationMsSince, emitOperationalEvent } from "./observability";
+import {
+  compareRebuildOutput,
+  normalizeRebuildAttestation,
+  type RebuildAttestation,
+  type RebuildPlan,
+  type RebuildSignal,
+} from "./rebuild-attestation";
+import type { RebuildExecution } from "./rebuild-steps";
+import { loadScanArtifacts, scanArtifactReadBucket } from "./scan-artifacts";
+import { eq, and } from "drizzle-orm";
+import { scans } from "../db/schema";
+
+export interface RebuildAttestationQueueMessage {
+  kind: "rebuild_attestation";
+  organizationId: string;
+  scanId: string;
+}
+
+export type RebuildExecutor = (plan: RebuildPlan) => Promise<RebuildExecution>;
+
+export interface ExecuteRebuildJobOptions {
+  /** Test seam; defaults to the Cloudflare container executor. */
+  executor?: RebuildExecutor;
+}
+
+export async function executeRebuildAttestationJob(
+  env: Cloudflare.Env,
+  message: RebuildAttestationQueueMessage,
+  db: AppDb = createDb(env.DB),
+  options: ExecuteRebuildJobOptions = {},
+) {
+  const startedAtMs = Date.now();
+  const rows = await db
+    .select({
+      id: scans.id,
+      organizationId: scans.organizationId,
+      status: scans.status,
+      summaryJson: scans.summaryJson,
+      reportDigest: scans.reportDigest,
+      artifactStorageVersion: scans.artifactStorageVersion,
+      artifactManifestKey: scans.artifactManifestKey,
+      artifactManifestDigest: scans.artifactManifestDigest,
+      artifactManifestSize: scans.artifactManifestSize,
+      reportArtifactKey: scans.reportArtifactKey,
+      fileSamplesArtifactKey: scans.fileSamplesArtifactKey,
+      diffArtifactKey: scans.diffArtifactKey,
+    })
+    .from(scans)
+    .where(and(eq(scans.id, message.scanId), eq(scans.organizationId, message.organizationId)))
+    .limit(1);
+  const scan = rows[0];
+  const summary =
+    scan?.summaryJson && typeof scan.summaryJson === "object" && !Array.isArray(scan.summaryJson)
+      ? (scan.summaryJson as Record<string, unknown>)
+      : null;
+  const pending = normalizeRebuildAttestation(summary?.rebuildAttestation);
+  if (!scan || scan.status !== "complete" || !pending || pending.status !== "pending") {
+    emitOperationalEvent("warn", "rebuild.job.skipped", {
+      scanId: message.scanId,
+      organizationId: message.organizationId,
+      reason: !scan ? "scan_missing" : pending ? "not_pending" : "no_pending_plan",
+      durationMs: durationMsSince(startedAtMs),
+    });
+    return null;
+  }
+  const plan = pending.plan!;
+
+  const finalize = async (attestation: RebuildAttestation) => {
+    await updateScanRebuildAttestation(db, message.scanId, message.organizationId, attestation);
+    emitOperationalEvent(
+      attestation.status === "inconclusive" ? "warn" : "info",
+      "rebuild.job.completed",
+      {
+        scanId: message.scanId,
+        organizationId: message.organizationId,
+        status: attestation.status,
+        repository: plan.repository,
+        ref: attestation.ref ? `${attestation.ref.kind}:${attestation.ref.value}` : null,
+        matchedFiles: attestation.comparison?.matchedFileCount ?? null,
+        divergentFiles: attestation.comparison?.divergentPaths.length ?? null,
+        durationMs: durationMsSince(startedAtMs),
+      },
+    );
+    return attestation;
+  };
+  const inconclusive = (signals: RebuildSignal[]): RebuildAttestation => ({
+    status: "inconclusive",
+    plan,
+    ref: null,
+    toolchain: null,
+    comparison: null,
+    signals,
+    completedAt: new Date().toISOString(),
+  });
+
+  if (!env.REBUILD_SANDBOX && !options.executor) {
+    return finalize(
+      inconclusive([
+        { kind: "sandbox", detail: "rebuild sandbox is not configured in this environment" },
+      ]),
+    );
+  }
+
+  let execution: RebuildExecution;
+  try {
+    if (options.executor) {
+      execution = await options.executor(plan);
+    } else {
+      // Lazy import keeps @cloudflare/sandbox out of the Worker boot graph for
+      // the many requests that never touch a rebuild.
+      const { runRebuildInSandbox } = await import("./rebuild-sandbox");
+      execution = await runRebuildInSandbox(env.REBUILD_SANDBOX!, message.scanId, plan);
+    }
+  } catch (err) {
+    emitOperationalEvent("error", "rebuild.job.failed", {
+      scanId: message.scanId,
+      organizationId: message.organizationId,
+      repository: plan.repository,
+      durationMs: durationMsSince(startedAtMs),
+      error: describeOperationalError(err),
+    });
+    return finalize(
+      inconclusive([{ kind: "sandbox", detail: safeSignalDetail(errorMessage(err)) }]),
+    );
+  }
+
+  const stepSignals: RebuildSignal[] = execution.steps
+    .filter((step) => step.exitCode !== 0)
+    .map((step) => ({
+      kind: "step-failed",
+      detail: `${step.step} exited ${step.exitCode}${step.detail ? `: ${step.detail}` : ""}`,
+    }));
+
+  if (!execution.ok) {
+    return finalize(inconclusive([{ kind: "rebuild", detail: execution.failure }, ...stepSignals]));
+  }
+
+  // Compare against the scan's persisted staged-file hashes (R2 files.json).
+  // The staged bytes themselves are never re-fetched and never enter the
+  // container.
+  const artifacts = await loadScanArtifacts(scanArtifactReadBucket(env), scan);
+  if (!artifacts) {
+    return finalize(
+      inconclusive([
+        { kind: "artifacts", detail: "staged artifact hashes are unavailable for this scan" },
+        ...stepSignals,
+      ]),
+    );
+  }
+
+  const outcome = compareRebuildOutput({
+    expectedShasum: plan.expectedShasum,
+    stagedFiles: artifacts.files.map((file) => ({ path: file.path, sha256: file.sha256 })),
+    output: execution.output,
+  });
+  if (!outcome) {
+    return finalize(
+      inconclusive([
+        { kind: "artifacts", detail: "staged file hashes are incomplete; cannot compare" },
+        ...stepSignals,
+      ]),
+    );
+  }
+
+  return finalize({
+    status: outcome.status,
+    plan,
+    ref: execution.ref,
+    toolchain: execution.toolchain,
+    comparison: outcome.comparison,
+    signals: [
+      {
+        kind: "rebuild",
+        detail: `checked out ${execution.ref.kind} ${execution.ref.value} and rebuilt with ${
+          execution.toolchain.packageManager ?? "npm"
+        }`,
+      },
+      ...stepSignals,
+    ],
+    completedAt: new Date().toISOString(),
+  });
+}
+
+// Signals are rendered in the UI and exported in reports; error text can quote
+// hostile input, so bound it and strip control characters.
+function safeSignalDetail(text: string): string {
+  return [...text]
+    .map((ch) => (ch >= " " && ch !== "\u007f" ? ch : " "))
+    .join("")
+    .slice(0, 300);
+}

--- a/server/lib/rebuild-job.ts
+++ b/server/lib/rebuild-job.ts
@@ -35,6 +35,29 @@ export interface ExecuteRebuildJobOptions {
   executor?: RebuildExecutor;
 }
 
+/**
+ * Check whether a terminal scan still has a rebuild handoff to recover. The
+ * original scan queue message calls this on redelivery when its first attempt
+ * completed the scan but failed to enqueue the rebuild message.
+ */
+export async function hasPendingRebuildAttestation(
+  db: AppDb,
+  message: RebuildAttestationQueueMessage,
+): Promise<boolean> {
+  const rows = await db
+    .select({ status: scans.status, summaryJson: scans.summaryJson })
+    .from(scans)
+    .where(and(eq(scans.id, message.scanId), eq(scans.organizationId, message.organizationId)))
+    .limit(1);
+  const scan = rows[0];
+  if (scan?.status !== "complete") return false;
+  const summary =
+    scan.summaryJson && typeof scan.summaryJson === "object" && !Array.isArray(scan.summaryJson)
+      ? (scan.summaryJson as Record<string, unknown>)
+      : null;
+  return normalizeRebuildAttestation(summary?.rebuildAttestation)?.status === "pending";
+}
+
 export async function executeRebuildAttestationJob(
   env: Cloudflare.Env,
   message: RebuildAttestationQueueMessage,

--- a/server/lib/rebuild-sandbox.ts
+++ b/server/lib/rebuild-sandbox.ts
@@ -1,0 +1,66 @@
+// Rebuild sandbox: the disposable Cloudflare container that checks out a
+// declared source repository and rebuilds a staged npm package so the Worker
+// can compare the result against the staged artifact (`rebuild-attestation.ts`).
+//
+// This is a *second* isolation ring, separate from the Dynamic Worker parse
+// sandbox in `sandbox.ts`, because it deliberately executes hostile code: the
+// repository contents, build scripts, and dependency tree are all attacker-
+// controlled. Containment, not prevention, is the boundary:
+//
+//  - Zero credentials ever enter the container. Public repos clone
+//    anonymously; the npm staged token stays in the Worker (the staged tarball
+//    is unpublished, so the container *cannot* fetch the expected bytes and
+//    replay them — the classic self-fetch bypass of post-publish rebuilders).
+//  - Egress is deny-by-default: `allowedHosts` covers the supported source
+//    forges and the public npm registry (dependency install), nothing else.
+//    `interceptHttps` keeps the filter authoritative for TLS traffic too.
+//  - Every command is built Worker-side from validated plan fields and
+//    shell-quoted; container stdout/stderr is bounded and re-validated by the
+//    caller before anything is persisted.
+//  - The container is destroyed after a single attestation. Sandbox ids are
+//    scan-scoped, so nothing is shared across scans or organizations.
+
+import { Sandbox } from "@cloudflare/sandbox";
+import type { RebuildPlan } from "./rebuild-attestation";
+import { runRebuildSteps, type RebuildExecution } from "./rebuild-steps";
+
+export class RebuildSandbox extends Sandbox<Cloudflare.Env> {
+  // Deny-by-default egress: with `allowedHosts` set and internet disabled,
+  // only these hosts resolve from inside the container.
+  enableInternet = false;
+  interceptHttps = true;
+  allowedHosts = [
+    // Source forges the intent envelope can normalize to.
+    "github.com",
+    "codeload.github.com",
+    "gitlab.com",
+    "bitbucket.org",
+    // Dependency install + corepack package-manager downloads.
+    "registry.npmjs.org",
+  ];
+  // Attestations are single-shot; reclaim the container quickly if the Worker
+  // dies between exec calls instead of paying for an idle instance.
+  sleepAfter = "10m";
+}
+
+/**
+ * Run one rebuild attempt in a disposable container. Never throws for
+ * build-shaped failures — those come back as `{ ok: false }` with step
+ * records; only infrastructure faults (container never became reachable)
+ * propagate so the caller can classify them separately.
+ */
+export async function runRebuildInSandbox(
+  namespace: DurableObjectNamespace<RebuildSandbox>,
+  scanId: string,
+  plan: RebuildPlan,
+): Promise<RebuildExecution> {
+  const { getSandbox } = await import("@cloudflare/sandbox");
+  const sandbox = getSandbox(namespace, `rebuild-${scanId}`);
+  try {
+    return await runRebuildSteps(sandbox, plan);
+  } finally {
+    // Best-effort teardown; the container is unusable for other scans anyway
+    // (id is scan-scoped) and `sleepAfter` reclaims it if this call is lost.
+    await sandbox.destroy().catch(() => {});
+  }
+}

--- a/server/lib/rebuild-steps.ts
+++ b/server/lib/rebuild-steps.ts
@@ -156,9 +156,10 @@ export async function runRebuildSteps(
     );
     if (!prepared.success) return { ok: false, failure: "toolchain-unavailable", steps };
   }
+  const packageManagerCommand = commandForPackageManager(strategy);
   const versions = await run(
     "versions",
-    `node --version && ${strategy.packageManager} --version`,
+    `node --version && ${packageManagerCommand} --version`,
     30_000,
   );
   const [nodeVersion, pmVersion] = versions.success
@@ -171,13 +172,17 @@ export async function runRebuildSteps(
   // free, egress-restricted container.
   // Install always runs at the repository root so monorepo workspace graphs
   // resolve; the build/pack steps then run in the package directory.
-  const install = await run("install", installCommand(strategy, repoDir), INSTALL_TIMEOUT_MS);
+  const install = await run(
+    "install",
+    installCommand(strategy, packageManagerCommand, repoDir),
+    INSTALL_TIMEOUT_MS,
+  );
   if (!install.success) return { ok: false, failure: "install-failed", steps };
 
   if (hasBuildScript) {
     const build = await run(
       "build",
-      `cd ${shq(pkgDir)} && ${strategy.packageManager} run build`,
+      `cd ${shq(pkgDir)} && ${packageManagerCommand} run build`,
       BUILD_TIMEOUT_MS,
     );
     if (!build.success) return { ok: false, failure: "build-failed", steps };
@@ -186,7 +191,7 @@ export async function runRebuildSteps(
   const outDir = `${WORKDIR}/out`;
   const pack = await run(
     "pack",
-    `mkdir -p ${shq(outDir)} && cd ${shq(pkgDir)} && ${strategy.packageManager} pack --pack-destination ${shq(outDir)}`,
+    `mkdir -p ${shq(outDir)} && cd ${shq(pkgDir)} && ${packageManagerCommand} pack --pack-destination ${shq(outDir)}`,
     PACK_TIMEOUT_MS,
   );
   if (!pack.success) return { ok: false, failure: "pack-failed", steps };
@@ -295,29 +300,43 @@ function locatePackageCommand(repoDir: string, packageName: string): string {
   ].join(" && ");
 }
 
-// The locate output is container stdout (hostile): accept only the first line
-// shaped exactly like `./<safe segments>/package.json`.
+// The locate output is container stdout (hostile): accept exactly one line
+// shaped like `./<safe segments>/package.json`. Multiple valid matches are
+// ambiguous and must never be resolved by filesystem order.
 function parseLocatedPackageDir(stdout: string): string | null {
+  const matches: string[] = [];
   for (const line of stdout.split("\n").slice(0, 5)) {
     const match = /^\.\/(.+)\/package\.json$/.exec(line.trim());
     if (!match) continue;
     const segments = match[1].split("/");
     if (segments.length > 8) continue;
     if (segments.every((segment) => /^[A-Za-z0-9_.@-]+$/.test(segment) && segment !== "..")) {
-      return segments.join("/");
+      matches.push(segments.join("/"));
     }
   }
-  return null;
+  return matches.length === 1 ? matches[0] : null;
 }
 
-function installCommand(strategy: RebuildStrategy, rootDir: string): string {
+function commandForPackageManager(strategy: RebuildStrategy): string {
+  // Corepack does not install an npm shim from a bare `corepack enable`, so a
+  // repository-level npm pin must be invoked through Corepack explicitly.
+  return strategy.packageManager === "npm" && strategy.corepackSpec
+    ? "corepack npm"
+    : strategy.packageManager;
+}
+
+function installCommand(
+  strategy: RebuildStrategy,
+  packageManagerCommand: string,
+  rootDir: string,
+): string {
   if (strategy.packageManager === "pnpm") {
     // Workspace installs happen at the repo root; --ignore-scripts covers
     // dependency lifecycle hooks. Frozen lockfile keeps the tree at what the
     // repository pinned; fall back to a plain install when out of sync.
-    return `cd ${shq(rootDir)} && (pnpm install --ignore-scripts --frozen-lockfile || pnpm install --ignore-scripts)`;
+    return `cd ${shq(rootDir)} && (${packageManagerCommand} install --ignore-scripts --frozen-lockfile || ${packageManagerCommand} install --ignore-scripts)`;
   }
-  return `cd ${shq(rootDir)} && (npm ci --ignore-scripts --no-audit --no-fund || npm install --ignore-scripts --no-audit --no-fund)`;
+  return `cd ${shq(rootDir)} && (${packageManagerCommand} ci --ignore-scripts --no-audit --no-fund || ${packageManagerCommand} install --ignore-scripts --no-audit --no-fund)`;
 }
 
 function parseHashOutput(stdout: string): {

--- a/server/lib/rebuild-steps.ts
+++ b/server/lib/rebuild-steps.ts
@@ -1,0 +1,281 @@
+// Rebuild step logic: the command sequence a rebuild attestation runs inside
+// the disposable container, plus the defensive parsers for everything the
+// container reports back. Pure (no Cloudflare imports) so the node test suite
+// can exercise it against a scripted exec runner; `rebuild-sandbox.ts` binds it
+// to the real Sandbox container. See that module for the isolation contract.
+
+import type { RebuildPlan, RebuildRef } from "./rebuild-attestation";
+
+export interface RebuildStepRecord {
+  step: string;
+  exitCode: number;
+  durationMs: number;
+  /** Bounded stderr tail; repository-controlled text, render-safe only. */
+  detail: string | null;
+}
+
+export type RebuildExecution =
+  | {
+      ok: true;
+      ref: RebuildRef;
+      toolchain: { packageManager: string | null; node: string | null };
+      output: { tarballSha1: string | null; files: Array<{ path: string; sha256: string }> };
+      steps: RebuildStepRecord[];
+    }
+  | { ok: false; failure: string; steps: RebuildStepRecord[] };
+
+const WORKDIR = "/workspace/rebuild";
+const CLONE_TIMEOUT_MS = 120_000;
+const INSTALL_TIMEOUT_MS = 420_000;
+const BUILD_TIMEOUT_MS = 600_000;
+const PACK_TIMEOUT_MS = 300_000;
+const HASH_TIMEOUT_MS = 120_000;
+const MAX_DETAIL = 200;
+const MAX_MANIFEST_BYTES = 4_000_000;
+const MAX_MANIFEST_FILES = 20_000;
+const SUPPORTED_PACKAGE_MANAGERS = new Set(["npm", "pnpm"]);
+
+interface SandboxExecutor {
+  exec(
+    command: string,
+    options?: { timeout?: number; cwd?: string },
+  ): Promise<{
+    success: boolean;
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+    duration: number;
+  }>;
+}
+
+/** Exported for tests: the step logic against any exec-shaped runner. */
+export async function runRebuildSteps(
+  sandbox: SandboxExecutor,
+  plan: RebuildPlan,
+): Promise<RebuildExecution> {
+  const steps: RebuildStepRecord[] = [];
+  const run = async (step: string, command: string, timeout: number) => {
+    const result = await sandbox.exec(command, { timeout });
+    steps.push({
+      step,
+      exitCode: result.exitCode,
+      durationMs: Math.max(0, Math.round(result.duration)),
+      detail: result.success ? null : boundedDetail(result.stderr || result.stdout),
+    });
+    return result;
+  };
+
+  const repoDir = `${WORKDIR}/repo`;
+  const pkgDir = plan.directory ? `${repoDir}/${plan.directory}` : repoDir;
+
+  await run("prepare", `rm -rf ${shq(WORKDIR)} && mkdir -p ${shq(WORKDIR)}`, 30_000);
+
+  // Checkout: try each candidate ref until one resolves. gitHead needs a
+  // fetch-by-sha (GitHub/GitLab allow any-sha fetches); tags use a shallow
+  // branch clone.
+  let ref: RebuildRef | null = null;
+  for (const candidate of plan.refs) {
+    const command =
+      candidate.kind === "git-head"
+        ? [
+            `rm -rf ${shq(repoDir)}`,
+            `git init -q ${shq(repoDir)}`,
+            `git -C ${shq(repoDir)} remote add origin ${shq(plan.repository)}`,
+            `git -C ${shq(repoDir)} fetch -q --depth 1 origin ${shq(candidate.value)}`,
+            `git -C ${shq(repoDir)} checkout -q FETCH_HEAD`,
+          ].join(" && ")
+        : [
+            `rm -rf ${shq(repoDir)}`,
+            `git clone -q --depth 1 --branch ${shq(candidate.value)} ${shq(plan.repository)} ${shq(repoDir)}`,
+          ].join(" && ");
+    const result = await run(
+      `checkout ${candidate.kind} ${candidate.value}`,
+      command,
+      CLONE_TIMEOUT_MS,
+    );
+    if (result.success) {
+      ref = candidate;
+      break;
+    }
+  }
+  if (!ref) return { ok: false, failure: "checkout-failed", steps };
+
+  // Read the repository manifest Worker-side and decide the strategy here;
+  // the container never interprets its own contents beyond running commands.
+  const manifestRead = await run(
+    "read manifest",
+    `cat ${shq(`${pkgDir}/package.json`)} && echo && ls -1 ${shq(pkgDir)}`,
+    30_000,
+  );
+  if (!manifestRead.success) return { ok: false, failure: "manifest-missing", steps };
+  const strategy = detectStrategy(manifestRead.stdout);
+  if (!strategy) return { ok: false, failure: "unsupported-package-manager", steps };
+
+  if (strategy.corepackSpec) {
+    const prepared = await run(
+      "toolchain",
+      `corepack enable && corepack prepare ${shq(strategy.corepackSpec)} --activate`,
+      120_000,
+    );
+    if (!prepared.success) return { ok: false, failure: "toolchain-unavailable", steps };
+  }
+  const versions = await run(
+    "versions",
+    `node --version && ${strategy.packageManager} --version`,
+    30_000,
+  );
+  const [nodeVersion, pmVersion] = versions.success
+    ? versions.stdout.split("\n").map((line) => line.trim().slice(0, 64))
+    : [null, null];
+
+  // Dependency lifecycle scripts are the widest arbitrary-code surface, so the
+  // install always runs with scripts disabled. The package's own build/prepack
+  // scripts run afterwards — that *is* the rebuild — inside this credential-
+  // free, egress-restricted container.
+  // Install always runs at the repository root so monorepo workspace graphs
+  // resolve; the build/pack steps then run in the package directory.
+  const install = await run("install", installCommand(strategy, repoDir), INSTALL_TIMEOUT_MS);
+  if (!install.success) return { ok: false, failure: "install-failed", steps };
+
+  if (strategy.hasBuildScript) {
+    const build = await run(
+      "build",
+      `cd ${shq(pkgDir)} && ${strategy.packageManager} run build`,
+      BUILD_TIMEOUT_MS,
+    );
+    if (!build.success) return { ok: false, failure: "build-failed", steps };
+  }
+
+  const outDir = `${WORKDIR}/out`;
+  const pack = await run(
+    "pack",
+    `mkdir -p ${shq(outDir)} && cd ${shq(pkgDir)} && ${strategy.packageManager} pack --pack-destination ${shq(outDir)}`,
+    PACK_TIMEOUT_MS,
+  );
+  if (!pack.success) return { ok: false, failure: "pack-failed", steps };
+
+  // Hash manifest: first line is the tarball SHA-1, the rest are
+  // `<sha256>  <path>` lines for the unpacked contents. Bounded with head -c
+  // so a hostile build cannot flood the Worker.
+  const hash = await run(
+    "hash",
+    [
+      `cd ${shq(outDir)}`,
+      `T=$(ls -1 *.tgz | head -n 1)`,
+      `sha1sum "$T" | cut -d" " -f1`,
+      `rm -rf x && mkdir x && tar -xzf "$T" -C x`,
+      `cd x/*/ && find . -type f -print0 | sort -z | xargs -0 sha256sum | head -c ${MAX_MANIFEST_BYTES}`,
+    ].join(" && "),
+    HASH_TIMEOUT_MS,
+  );
+  if (!hash.success) return { ok: false, failure: "hash-failed", steps };
+
+  const output = parseHashOutput(hash.stdout);
+  if (!output) return { ok: false, failure: "hash-unparseable", steps };
+
+  return {
+    ok: true,
+    ref,
+    toolchain: {
+      packageManager: pmVersion
+        ? `${strategy.packageManager}@${pmVersion}`
+        : strategy.packageManager,
+      node: nodeVersion,
+    },
+    output,
+    steps,
+  };
+}
+
+interface RebuildStrategy {
+  packageManager: "npm" | "pnpm";
+  corepackSpec: string | null;
+  hasBuildScript: boolean;
+}
+
+// `stdout` is `cat package.json`, a blank line, then `ls -1` of the package
+// directory. Hostile input: parsed defensively, unknown managers rejected.
+function detectStrategy(stdout: string): RebuildStrategy | null {
+  const separator = stdout.lastIndexOf("\n\n");
+  const manifestText = separator === -1 ? stdout : stdout.slice(0, separator);
+  const listing = separator === -1 ? "" : stdout.slice(separator + 2);
+
+  let manifest: Record<string, unknown> = {};
+  try {
+    const parsed = JSON.parse(manifestText) as unknown;
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      manifest = parsed as Record<string, unknown>;
+    }
+  } catch {
+    return null;
+  }
+
+  let packageManager: "npm" | "pnpm" | null = null;
+  let corepackSpec: string | null = null;
+  const declared =
+    typeof manifest.packageManager === "string" ? manifest.packageManager.trim() : "";
+  const declaredMatch = /^(npm|pnpm|yarn)@\d+[\w.+-]*$/.exec(declared);
+  if (declaredMatch) {
+    if (!SUPPORTED_PACKAGE_MANAGERS.has(declaredMatch[1])) return null;
+    packageManager = declaredMatch[1] as "npm" | "pnpm";
+    corepackSpec = declared;
+  } else {
+    const files = new Set(listing.split("\n").map((line) => line.trim()));
+    if (files.has("pnpm-lock.yaml")) {
+      packageManager = "pnpm";
+      corepackSpec = "pnpm@latest";
+    } else if (files.has("yarn.lock")) {
+      return null;
+    } else {
+      packageManager = "npm";
+    }
+  }
+
+  const scripts = manifest.scripts;
+  const hasBuildScript =
+    !!scripts &&
+    typeof scripts === "object" &&
+    !Array.isArray(scripts) &&
+    typeof (scripts as Record<string, unknown>).build === "string";
+
+  return { packageManager, corepackSpec, hasBuildScript };
+}
+
+function installCommand(strategy: RebuildStrategy, rootDir: string): string {
+  if (strategy.packageManager === "pnpm") {
+    // Workspace installs happen at the repo root; --ignore-scripts covers
+    // dependency lifecycle hooks. Frozen lockfile keeps the tree at what the
+    // repository pinned; fall back to a plain install when out of sync.
+    return `cd ${shq(rootDir)} && (pnpm install --ignore-scripts --frozen-lockfile || pnpm install --ignore-scripts)`;
+  }
+  return `cd ${shq(rootDir)} && (npm ci --ignore-scripts --no-audit --no-fund || npm install --ignore-scripts --no-audit --no-fund)`;
+}
+
+function parseHashOutput(stdout: string): {
+  tarballSha1: string | null;
+  files: Array<{ path: string; sha256: string }>;
+} | null {
+  const lines = stdout.split("\n");
+  const tarballSha1 = /^[0-9a-f]{40}$/.test(lines[0]?.trim() ?? "") ? lines[0].trim() : null;
+  const files: Array<{ path: string; sha256: string }> = [];
+  for (const line of lines.slice(1)) {
+    const match = /^([0-9a-f]{64})\s+(.+)$/.exec(line.trim());
+    if (!match) continue;
+    if (files.length >= MAX_MANIFEST_FILES) return null;
+    files.push({ path: match[2], sha256: match[1] });
+  }
+  if (!files.length) return null;
+  return { tarballSha1, files };
+}
+
+function boundedDetail(text: string): string | null {
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(-MAX_DETAIL);
+}
+
+// POSIX single-quote escaping; every interpolated value goes through this even
+// though plan fields are already charset-validated upstream.
+function shq(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}

--- a/server/lib/rebuild-steps.ts
+++ b/server/lib/rebuild-steps.ts
@@ -66,7 +66,6 @@ export async function runRebuildSteps(
   };
 
   const repoDir = `${WORKDIR}/repo`;
-  const pkgDir = plan.directory ? `${repoDir}/${plan.directory}` : repoDir;
 
   await run("prepare", `rm -rf ${shq(WORKDIR)} && mkdir -p ${shq(WORKDIR)}`, 30_000);
 
@@ -100,16 +99,54 @@ export async function runRebuildSteps(
   }
   if (!ref) return { ok: false, failure: "checkout-failed", steps };
 
-  // Read the repository manifest Worker-side and decide the strategy here;
-  // the container never interprets its own contents beyond running commands.
-  const manifestRead = await run(
+  // Read the repository root manifest Worker-side and decide the strategy
+  // here; the container never interprets its own contents beyond running
+  // commands. Package-manager evidence (packageManager field, lockfiles)
+  // lives at the repository root — in a monorepo the package directory has
+  // neither.
+  const rootRead = await run(
     "read manifest",
-    `cat ${shq(`${pkgDir}/package.json`)} && echo && ls -1 ${shq(pkgDir)}`,
+    `cat ${shq(`${repoDir}/package.json`)} && echo && ls -1 ${shq(repoDir)}`,
     30_000,
   );
-  if (!manifestRead.success) return { ok: false, failure: "manifest-missing", steps };
-  const strategy = detectStrategy(manifestRead.stdout);
+  if (!rootRead.success) return { ok: false, failure: "manifest-missing", steps };
+  const root = splitManifestListing(rootRead.stdout);
+  const rootManifest = root ? parseManifest(root.manifestText) : null;
+  if (!rootManifest) return { ok: false, failure: "manifest-missing", steps };
+  const strategy = detectPackageManager(rootManifest, root!.listing);
   if (!strategy) return { ok: false, failure: "unsupported-package-manager", steps };
+
+  // Resolve the package directory: an explicit `repository.directory` wins;
+  // otherwise, when the staged package name is not the root package, locate
+  // it in the workspace by manifest name.
+  let pkgDir = repoDir;
+  let pkgManifest = rootManifest;
+  if (plan.directory) {
+    pkgDir = `${repoDir}/${plan.directory}`;
+  } else if (plan.packageName && manifestName(rootManifest) !== plan.packageName) {
+    const located = await run(
+      "locate package",
+      locatePackageCommand(repoDir, plan.packageName),
+      60_000,
+    );
+    const relative = located.success ? parseLocatedPackageDir(located.stdout) : null;
+    if (!relative) return { ok: false, failure: "package-not-located", steps };
+    pkgDir = `${repoDir}/${relative}`;
+  }
+  if (pkgDir !== repoDir) {
+    const pkgRead = await run(
+      "read package manifest",
+      `cat ${shq(`${pkgDir}/package.json`)}`,
+      30_000,
+    );
+    const parsed = pkgRead.success ? parseManifest(pkgRead.stdout) : null;
+    if (!parsed) return { ok: false, failure: "manifest-missing", steps };
+    if (plan.packageName && manifestName(parsed) !== plan.packageName) {
+      return { ok: false, failure: "package-not-located", steps };
+    }
+    pkgManifest = parsed;
+  }
+  const hasBuildScript = manifestHasBuildScript(pkgManifest);
 
   if (strategy.corepackSpec) {
     const prepared = await run(
@@ -137,7 +174,7 @@ export async function runRebuildSteps(
   const install = await run("install", installCommand(strategy, repoDir), INSTALL_TIMEOUT_MS);
   if (!install.success) return { ok: false, failure: "install-failed", steps };
 
-  if (strategy.hasBuildScript) {
+  if (hasBuildScript) {
     const build = await run(
       "build",
       `cd ${shq(pkgDir)} && ${strategy.packageManager} run build`,
@@ -190,55 +227,87 @@ export async function runRebuildSteps(
 interface RebuildStrategy {
   packageManager: "npm" | "pnpm";
   corepackSpec: string | null;
-  hasBuildScript: boolean;
 }
 
-// `stdout` is `cat package.json`, a blank line, then `ls -1` of the package
-// directory. Hostile input: parsed defensively, unknown managers rejected.
-function detectStrategy(stdout: string): RebuildStrategy | null {
+// `stdout` is `cat package.json`, a blank line, then `ls -1`. The manifest
+// itself never contains a blank line when pretty-printed, so the last blank
+// line separates the two. Hostile input either way.
+function splitManifestListing(stdout: string): { manifestText: string; listing: string } | null {
   const separator = stdout.lastIndexOf("\n\n");
-  const manifestText = separator === -1 ? stdout : stdout.slice(0, separator);
-  const listing = separator === -1 ? "" : stdout.slice(separator + 2);
+  if (separator === -1) return { manifestText: stdout, listing: "" };
+  return { manifestText: stdout.slice(0, separator), listing: stdout.slice(separator + 2) };
+}
 
-  let manifest: Record<string, unknown> = {};
+function parseManifest(text: string): Record<string, unknown> | null {
   try {
-    const parsed = JSON.parse(manifestText) as unknown;
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      manifest = parsed as Record<string, unknown>;
-    }
+    const parsed = JSON.parse(text) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
   } catch {
     return null;
   }
+}
 
-  let packageManager: "npm" | "pnpm" | null = null;
-  let corepackSpec: string | null = null;
+function manifestName(manifest: Record<string, unknown>): string | null {
+  return typeof manifest.name === "string" ? manifest.name : null;
+}
+
+function manifestHasBuildScript(manifest: Record<string, unknown>): boolean {
+  const scripts = manifest.scripts;
+  return (
+    !!scripts &&
+    typeof scripts === "object" &&
+    !Array.isArray(scripts) &&
+    typeof (scripts as Record<string, unknown>).build === "string"
+  );
+}
+
+// Package-manager detection from the repository root: the `packageManager`
+// pin wins, then lockfile heuristics. Unknown managers are rejected rather
+// than guessed.
+function detectPackageManager(
+  manifest: Record<string, unknown>,
+  listing: string,
+): RebuildStrategy | null {
   const declared =
     typeof manifest.packageManager === "string" ? manifest.packageManager.trim() : "";
   const declaredMatch = /^(npm|pnpm|yarn)@\d+[\w.+-]*$/.exec(declared);
   if (declaredMatch) {
     if (!SUPPORTED_PACKAGE_MANAGERS.has(declaredMatch[1])) return null;
-    packageManager = declaredMatch[1] as "npm" | "pnpm";
-    corepackSpec = declared;
-  } else {
-    const files = new Set(listing.split("\n").map((line) => line.trim()));
-    if (files.has("pnpm-lock.yaml")) {
-      packageManager = "pnpm";
-      corepackSpec = "pnpm@latest";
-    } else if (files.has("yarn.lock")) {
-      return null;
-    } else {
-      packageManager = "npm";
+    return { packageManager: declaredMatch[1] as "npm" | "pnpm", corepackSpec: declared };
+  }
+  const files = new Set(listing.split("\n").map((line) => line.trim()));
+  if (files.has("pnpm-lock.yaml")) return { packageManager: "pnpm", corepackSpec: "pnpm@latest" };
+  if (files.has("yarn.lock")) return null;
+  return { packageManager: "npm", corepackSpec: null };
+}
+
+// Find the workspace directory whose package.json declares the staged package
+// name. grep uses a fixed, Worker-built ERE (the name is regex-escaped), and
+// a no-match exits non-zero, which the caller reports as package-not-located.
+function locatePackageCommand(repoDir: string, packageName: string): string {
+  const escaped = packageName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = `"name"[[:space:]]*:[[:space:]]*"${escaped}"`;
+  return [
+    `cd ${shq(repoDir)}`,
+    `find . -maxdepth 5 -name package.json -not -path '*/node_modules/*' -print0 | xargs -0 grep -lE ${shq(pattern)} | head -n 5`,
+  ].join(" && ");
+}
+
+// The locate output is container stdout (hostile): accept only the first line
+// shaped exactly like `./<safe segments>/package.json`.
+function parseLocatedPackageDir(stdout: string): string | null {
+  for (const line of stdout.split("\n").slice(0, 5)) {
+    const match = /^\.\/(.+)\/package\.json$/.exec(line.trim());
+    if (!match) continue;
+    const segments = match[1].split("/");
+    if (segments.length > 8) continue;
+    if (segments.every((segment) => /^[A-Za-z0-9_.@-]+$/.test(segment) && segment !== "..")) {
+      return segments.join("/");
     }
   }
-
-  const scripts = manifest.scripts;
-  const hasBuildScript =
-    !!scripts &&
-    typeof scripts === "object" &&
-    !Array.isArray(scripts) &&
-    typeof (scripts as Record<string, unknown>).build === "string";
-
-  return { packageManager, corepackSpec, hasBuildScript };
+  return null;
 }
 
 function installCommand(strategy: RebuildStrategy, rootDir: string): string {

--- a/server/lib/report-export.ts
+++ b/server/lib/report-export.ts
@@ -2,6 +2,7 @@ import type { getScan } from "../db/scans";
 import { parsePersistedAiReview } from "./ai-review-contract";
 import { displayedAiResult } from "./ai-review-types";
 import { normalizeIntentEnvelope } from "./intent-envelope";
+import { normalizeRebuildAttestation } from "./rebuild-attestation";
 import { normalizeReleaseConsistency } from "./release-memory";
 import type { ReleaseProvenance, ReleaseProvenanceArtifact } from "./adapters/types";
 
@@ -56,6 +57,10 @@ export function buildReportExport(detail: ScanDetail) {
     // Advisory source-binding tier (attested / declared / absent). Additive and
     // optional: scans persisted before the envelope existed export `null`.
     intentEnvelope: normalizeIntentEnvelope(summary.intentEnvelope),
+    // Opt-in rebuild-attestation outcome. Additive + optional: scans without
+    // the feature (or with a pending/malformed record) export what the summary
+    // holds at export time — `null` when never attempted.
+    rebuildAttestation: normalizeRebuildAttestation(summary.rebuildAttestation),
     aiReview: extractAiReview(scan.aiJson),
     riskSummary: detail.riskSummary ?? null,
     // Advisory release-memory signal. Additive + optional: scans that predate

--- a/server/lib/scan-job.ts
+++ b/server/lib/scan-job.ts
@@ -5,7 +5,11 @@ import { npmAdapter } from "./adapters/npm";
 import { errorMessage } from "./errors";
 import { notifyScanCompletion } from "./notify";
 import { describeOperationalError, durationMsSince, emitOperationalEvent } from "./observability";
-import { executeRebuildAttestationJob, type RebuildAttestationQueueMessage } from "./rebuild-job";
+import {
+  executeRebuildAttestationJob,
+  hasPendingRebuildAttestation,
+  type RebuildAttestationQueueMessage,
+} from "./rebuild-job";
 import { runScanPipeline } from "./scan-pipeline";
 import { sandboxErrorDetail } from "./sandbox";
 import type { ScanInput } from "../types";
@@ -69,6 +73,18 @@ export async function executeScanJob(
   const session: WorkspaceSession = { userId: message.actorUserId };
   const claimed = await claimScanForRun(db, message.scanId, message.organizationId);
   if (!claimed) {
+    // A queue-send failure can happen after the pipeline has already persisted
+    // the scan as complete. On redelivery that terminal scan cannot be claimed,
+    // so recover its pending rebuild handoff before treating the message as an
+    // ordinary duplicate.
+    const rebuildMessage: RebuildAttestationQueueMessage = {
+      kind: "rebuild_attestation",
+      organizationId: message.organizationId,
+      scanId: message.scanId,
+    };
+    if (attempt > 1 && (await hasPendingRebuildAttestation(db, rebuildMessage))) {
+      await dispatchRebuildAttestation(env, executionCtx, db, rebuildMessage);
+    }
     emitOperationalEvent("warn", "scan.job.skipped", {
       scanId: message.scanId,
       organizationId: message.organizationId,
@@ -130,13 +146,7 @@ export async function executeScanJob(
         organizationId: message.organizationId,
         scanId: message.scanId,
       };
-      if (env.SCAN_QUEUE) {
-        await env.SCAN_QUEUE.send(rebuildMessage);
-      } else {
-        executionCtx.waitUntil(
-          executeRebuildAttestationJob(env, rebuildMessage, db).then(() => {}),
-        );
-      }
+      await dispatchRebuildAttestation(env, executionCtx, db, rebuildMessage);
     }
     return result;
   } catch (err) {
@@ -195,6 +205,19 @@ export async function executeScanJob(
     }
     throw err;
   }
+}
+
+async function dispatchRebuildAttestation(
+  env: Cloudflare.Env,
+  executionCtx: ExecutionContext,
+  db: AppDb,
+  message: RebuildAttestationQueueMessage,
+) {
+  if (env.SCAN_QUEUE) {
+    await env.SCAN_QUEUE.send(message);
+    return;
+  }
+  executionCtx.waitUntil(executeRebuildAttestationJob(env, message, db).then(() => {}));
 }
 
 export function classifyScanError(err: unknown): SafeScanError {

--- a/server/lib/scan-job.ts
+++ b/server/lib/scan-job.ts
@@ -5,6 +5,7 @@ import { npmAdapter } from "./adapters/npm";
 import { errorMessage } from "./errors";
 import { notifyScanCompletion } from "./notify";
 import { describeOperationalError, durationMsSince, emitOperationalEvent } from "./observability";
+import { executeRebuildAttestationJob, type RebuildAttestationQueueMessage } from "./rebuild-job";
 import { runScanPipeline } from "./scan-pipeline";
 import { sandboxErrorDetail } from "./sandbox";
 import type { ScanInput } from "../types";
@@ -28,10 +29,19 @@ export interface WorkflowGateQueueMessage {
   gateId: string;
 }
 
-export type QueueMessage = ScanQueueMessage | WorkflowGateQueueMessage;
+export type QueueMessage =
+  | ScanQueueMessage
+  | WorkflowGateQueueMessage
+  | RebuildAttestationQueueMessage;
 
 export function isWorkflowGateMessage(message: QueueMessage): message is WorkflowGateQueueMessage {
   return "kind" in message && message.kind === "workflow_gate";
+}
+
+export function isRebuildAttestationMessage(
+  message: QueueMessage,
+): message is RebuildAttestationQueueMessage {
+  return "kind" in message && message.kind === "rebuild_attestation";
 }
 
 export const MAX_SCAN_JOB_ATTEMPTS = 3;
@@ -110,6 +120,23 @@ export async function executeScanJob(
           outcome: "complete",
         }),
       );
+    }
+    // Opt-in rebuild attestation runs as its own deferred job: container
+    // rebuilds take minutes and must never hold up scan completion. The queue
+    // path gets retries + DLQ; the waitUntil fallback covers local dev.
+    if (result.rebuildAttestation?.status === "pending") {
+      const rebuildMessage: RebuildAttestationQueueMessage = {
+        kind: "rebuild_attestation",
+        organizationId: message.organizationId,
+        scanId: message.scanId,
+      };
+      if (env.SCAN_QUEUE) {
+        await env.SCAN_QUEUE.send(rebuildMessage);
+      } else {
+        executionCtx.waitUntil(
+          executeRebuildAttestationJob(env, rebuildMessage, db).then(() => {}),
+        );
+      }
     }
     return result;
   } catch (err) {

--- a/server/lib/scan-pipeline-phases.ts
+++ b/server/lib/scan-pipeline-phases.ts
@@ -11,6 +11,7 @@ import type {
   StagedDetails,
 } from "./adapters/types";
 import type { IntentEnvelope } from "./intent-envelope";
+import type { RebuildAttestation } from "./rebuild-attestation";
 import { describeOperationalError, durationMsSince, emitOperationalEvent } from "./observability";
 import {
   computeReleaseConsistency,
@@ -248,6 +249,10 @@ export interface PersistResultsArgs<TInput, TBroker extends AdapterBroker> {
   // Advisory source-binding classification computed by the pipeline; persisted
   // with the scan but never allowed to influence risk or findings.
   intentEnvelope: IntentEnvelope;
+  // Opt-in rebuild attestation, persisted as a pending plan the deferred
+  // rebuild job later resolves. Null when the flag is off or the scan is not
+  // rebuildable. Advisory only, like the envelope.
+  rebuildAttestation: RebuildAttestation | null;
 }
 
 export interface PersistedScanOutcome {
@@ -290,6 +295,7 @@ export async function persistResults<TInput, TBroker extends AdapterBroker>(
     riskSummary: args.riskSummary,
     releaseConsistency: args.releaseConsistency,
     intentEnvelope: args.intentEnvelope,
+    rebuildAttestation: args.rebuildAttestation,
     safety,
   };
 
@@ -363,6 +369,10 @@ export async function persistResults<TInput, TBroker extends AdapterBroker>(
       baseline: baseline.baseline,
       releaseConsistency: args.releaseConsistency,
       intentEnvelope: args.intentEnvelope,
+      // Unlike the envelope this is mutable state: the deferred rebuild job
+      // replaces the pending record with its outcome. It therefore lives only
+      // in the summary blob, not in the frozen report.json artifact.
+      rebuildAttestation: args.rebuildAttestation,
       safety: result.safety,
     },
     ai: args.aiFindings,

--- a/server/lib/scan-pipeline.ts
+++ b/server/lib/scan-pipeline.ts
@@ -12,6 +12,7 @@ import {
   type WorkflowGateIntent,
 } from "./intent-envelope";
 import { describeOperationalError, durationMsSince, emitOperationalEvent } from "./observability";
+import { computeRebuildPlan, type RebuildAttestation } from "./rebuild-attestation";
 import {
   computeDiff,
   mergeAiFindings,
@@ -111,6 +112,19 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
       }),
     });
 
+    // Opt-in rebuild attestation: persist a pending plan when the organization
+    // enabled the flag and the scan is rebuildable. The actual rebuild runs as
+    // a deferred queue job (`rebuild-job.ts`) after the scan completes.
+    const rebuildAttestation = await maybeComputeRebuildAttestation({
+      env,
+      identity,
+      ecosystem: adapter.id,
+      gateScan: Boolean(input.gateContext),
+      repository: intentEnvelope.repository,
+      details: resolved.staged.details,
+      manifestText: diff.stagedManifestText,
+    });
+
     const { result, persisted } = await persistResults({
       env,
       db,
@@ -126,6 +140,7 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
       riskSummary,
       releaseConsistency,
       intentEnvelope,
+      rebuildAttestation,
     });
 
     await recordCompletion({
@@ -153,6 +168,61 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
   } finally {
     await broker.dispose();
   }
+}
+
+interface RebuildAttestationArgs {
+  env: Cloudflare.Env;
+  identity: PipelineIdentity;
+  ecosystem: string;
+  gateScan: boolean;
+  repository: string | null;
+  details: unknown;
+  manifestText: string | null;
+}
+
+// Rebuild attestation is opt-in per organization via the Cloudflare Flagship
+// `rebuild-attestation` flag (default off — the inverse of the `ai-review`
+// killswitch). v1 covers staged npm scans only: gate scans already bind the
+// artifact to a workflow run, and their acquisition path has no staged shasum.
+async function maybeComputeRebuildAttestation(
+  args: RebuildAttestationArgs,
+): Promise<RebuildAttestation | null> {
+  if (args.gateScan || args.ecosystem !== "npm") return null;
+  const enabled = args.env.FLAGS
+    ? await args.env.FLAGS.getBooleanValue("rebuild-attestation", false, {
+        targetingKey: args.identity.organizationId,
+        organizationId: args.identity.organizationId,
+      })
+    : false;
+  if (!enabled) return null;
+
+  // `details` is the adapter's staged metadata; for npm this is
+  // StagedPublishDetails. Read defensively — the plan validates every field.
+  const details = (args.details ?? null) as {
+    gitHead?: unknown;
+    shasum?: unknown;
+    packageName?: unknown;
+    version?: unknown;
+  } | null;
+  const plan = computeRebuildPlan({
+    ecosystem: args.ecosystem,
+    repository: args.repository,
+    gitHead: typeof details?.gitHead === "string" ? details.gitHead : null,
+    packageName: typeof details?.packageName === "string" ? details.packageName : null,
+    version: typeof details?.version === "string" ? details.version : null,
+    shasum: typeof details?.shasum === "string" ? details.shasum : null,
+    manifestText: args.manifestText,
+  });
+  if (!plan) return null;
+  return {
+    status: "pending",
+    plan,
+    ref: null,
+    toolchain: null,
+    comparison: null,
+    signals: [],
+    completedAt: null,
+  };
 }
 
 interface AiReviewArgs {

--- a/server/lib/staged-publishes.ts
+++ b/server/lib/staged-publishes.ts
@@ -19,6 +19,12 @@ export interface StagedPublishItem {
 
 export interface StagedPublishDetails extends StagedPublishItem {
   packageJson: PackageJsonSummary | null;
+  /**
+   * Commit SHA the npm CLI recorded at publish time (`gitHead` on the staged
+   * version manifest), when the publisher ran from a git checkout. This is the
+   * rebuild-attestation anchor; it is package-claimed metadata, not verified.
+   */
+  gitHead: string | null;
 }
 
 export interface StagedPublishesPage {
@@ -182,6 +188,7 @@ export function parseStagedPublishDetails(
   return {
     ...item,
     packageJson: extractPackageJsonSummary(root, item),
+    gitHead: extractGitHead(root, item),
   };
 }
 
@@ -257,6 +264,30 @@ function extractPackageJsonSummary(
 function readVersionManifest(root: Record<string, unknown>, version: string | null) {
   if (!version || !isRecord(root.versions)) return null;
   return root.versions[version];
+}
+
+// A git object id: 40-hex (SHA-1) or 64-hex (SHA-256 repositories). Anything
+// else — branch names, refs, hostile strings — is dropped rather than carried.
+const GIT_HEAD_RE = /^[0-9a-f]{40}(?:[0-9a-f]{24})?$/;
+
+function extractGitHead(root: Record<string, unknown>, item: StagedPublishItem): string | null {
+  const byVersion = readVersionManifest(root, item.version);
+  const candidates = [
+    root.manifest,
+    root.packageJson,
+    root.package_json,
+    root.versionManifest,
+    byVersion,
+    isRecord(root.metadata) ? readVersionManifest(root.metadata, item.version) : null,
+    isRecord(root.packument) ? readVersionManifest(root.packument, item.version) : null,
+    root,
+  ];
+  for (const candidate of candidates) {
+    if (!isRecord(candidate)) continue;
+    const gitHead = readString(candidate.gitHead)?.trim().toLowerCase();
+    if (gitHead && GIT_HEAD_RE.test(gitHead)) return gitHead;
+  }
+  return null;
 }
 
 function readPackageJsonSummary(

--- a/server/types.ts
+++ b/server/types.ts
@@ -9,6 +9,7 @@ export type {
 import type { AiReview } from "./lib/ai-review";
 import type { ReleaseConsistency } from "./lib/release-memory";
 import type { IntentEnvelope } from "./lib/intent-envelope";
+import type { RebuildAttestation } from "./lib/rebuild-attestation";
 import type { ScanRiskBreakdown } from "./lib/risk";
 import type {
   DiffEntry,
@@ -24,6 +25,13 @@ export type {
   IntentEnvelopeSignal,
   IntentEnvelopeTier,
 } from "./lib/intent-envelope";
+export type {
+  RebuildAttestation,
+  RebuildAttestationStatus,
+  RebuildComparison,
+  RebuildPlan,
+  RebuildRef,
+} from "./lib/rebuild-attestation";
 
 export type Bindings = Cloudflare.Env;
 
@@ -61,6 +69,9 @@ export interface ScanResult {
   releaseConsistency: ReleaseConsistency;
   // Advisory source-binding classification; never feeds risk or findings.
   intentEnvelope: IntentEnvelope;
+  // Opt-in rebuild attestation; pending at scan completion, resolved by the
+  // deferred rebuild job. Null when disabled or not rebuildable. Advisory only.
+  rebuildAttestation: RebuildAttestation | null;
   safety: {
     tokenExposedToSandbox: boolean;
     directSandboxNetwork: boolean;

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -5,6 +5,7 @@ import type {
   FindingDiffStatus,
   PackageJsonSummary,
 } from "../../server/lib/review";
+import { normalizeRebuildAttestation } from "../../server/lib/rebuild-attestation";
 import { apiFetch, apiJson, errorMessage } from "./api";
 import {
   decideWorkflowGate,
@@ -355,7 +356,17 @@ export const ScanDetailModel = createModel((id: string) => {
 
   const isWorkflowGate = computed(() => detail.value?.scan.source === "workflow_gate");
   const status = computed(() => detail.value?.scan.status ?? null);
-  const isPolling = computed(() => status.value === "pending" || status.value === "running");
+  const rebuildPending = computed(() => {
+    const summary = detail.value?.scan.summaryJson;
+    if (!summary || typeof summary !== "object" || Array.isArray(summary)) return false;
+    return (
+      normalizeRebuildAttestation((summary as Record<string, unknown>).rebuildAttestation)
+        ?.status === "pending"
+    );
+  });
+  const isPolling = computed(
+    () => status.value === "pending" || status.value === "running" || rebuildPending.value,
+  );
   const isDefaultComparison = computed(() => {
     const selected = selectedVersion.value;
     const v = versions.value;
@@ -371,11 +382,12 @@ export const ScanDetailModel = createModel((id: string) => {
     return v ? (cache[v] ?? null) : null;
   });
 
-  // Background polling while the scan is still running. A self-scheduling
-  // timeout chain (not setInterval) lets the cadence adapt: consecutive
-  // failures back off exponentially, and a scan stuck non-terminal past the
-  // stall window latches `pollingStalled` instead of polling forever. Both
-  // signals are read unconditionally so the effect tracks them on every run.
+  // Background polling while the scan or its deferred rebuild is still
+  // running. A self-scheduling timeout chain (not setInterval) lets the cadence
+  // adapt: consecutive failures back off exponentially, and a scan stuck
+  // non-terminal past the stall window latches `pollingStalled` instead of
+  // polling forever. Both signals are read unconditionally so the effect
+  // tracks them on every run.
   effect(() => {
     const polling = isPolling.value;
     const stalled = pollingStalled.value;

--- a/src/pages/Dashboard/ScanDetail/IntentEnvelopeSection.tsx
+++ b/src/pages/Dashboard/ScanDetail/IntentEnvelopeSection.tsx
@@ -1,12 +1,24 @@
-import type { IntentEnvelope, IntentEnvelopeTier } from "../../../../server/types";
+import type {
+  IntentEnvelope,
+  IntentEnvelopeTier,
+  RebuildAttestation,
+} from "../../../../server/types";
 import { Badge, type BadgeTone } from "../../../components/Badge";
 import { SectionLabel } from "../../../components/Typography";
 
 // Advisory source-binding row rendered under the recommendation. The envelope
 // never changes risk, so tier tones stay informational (ok / info / neutral)
 // rather than borrowing severity colors. Scans persisted before the envelope
-// existed render nothing (the parent passes null).
-export function IntentEnvelopeSection({ envelope }: { envelope: IntentEnvelope }) {
+// existed render nothing (the parent passes null). When the organization opted
+// into rebuild attestation, its outcome renders as a second row in the same
+// section — it is the empirical check of the binding the tier describes.
+export function IntentEnvelopeSection({
+  envelope,
+  rebuild,
+}: {
+  envelope: IntentEnvelope;
+  rebuild?: RebuildAttestation | null;
+}) {
   return (
     <section class="flex flex-col gap-3 min-w-0">
       <SectionLabel>Source binding</SectionLabel>
@@ -31,8 +43,82 @@ export function IntentEnvelopeSection({ envelope }: { envelope: IntentEnvelope }
           ))}
         </ul>
       ) : null}
+      {rebuild ? <RebuildAttestationRow rebuild={rebuild} /> : null}
     </section>
   );
+}
+
+const MAX_DIVERGENT_PATHS_SHOWN = 5;
+
+function RebuildAttestationRow({ rebuild }: { rebuild: RebuildAttestation }) {
+  const divergent = rebuild.comparison?.divergentPaths ?? [];
+  const missing = rebuild.comparison?.missingFromRebuild ?? [];
+  const shown = [...missing, ...divergent].slice(0, MAX_DIVERGENT_PATHS_SHOWN);
+  const totalDiffering =
+    (rebuild.comparison?.divergentPaths.length ?? 0) +
+    (rebuild.comparison?.missingFromRebuild.length ?? 0) +
+    (rebuild.comparison?.extraInRebuild.length ?? 0);
+  return (
+    <div class="flex flex-col gap-2 min-w-0">
+      <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <Badge tone={rebuildTone(rebuild.status)}>{rebuildBadgeLabel(rebuild.status)}</Badge>
+        <span class="text-[13px] leading-[1.55] text-ink-muted min-w-0">
+          {rebuildDescription(rebuild, totalDiffering)}
+        </span>
+      </div>
+      {shown.length ? (
+        <ul class="list-none p-0 m-0 flex flex-col gap-1">
+          {shown.map((path) => (
+            <li key={path} class="font-mono text-[12px] text-ink-muted break-all">
+              {path}
+            </li>
+          ))}
+          {totalDiffering > shown.length ? (
+            <li class="text-[12px] text-ink-subtle">
+              and {totalDiffering - shown.length} more differing files
+            </li>
+          ) : null}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+function rebuildTone(status: RebuildAttestation["status"]): BadgeTone {
+  if (status === "byte-identical" || status === "file-identical") return "ok";
+  if (status === "diverged") return "info";
+  return "neutral";
+}
+
+function rebuildBadgeLabel(status: RebuildAttestation["status"]): string {
+  if (status === "byte-identical" || status === "file-identical") return "reproduced";
+  if (status === "diverged") return "diverged";
+  if (status === "pending") return "rebuild queued";
+  return "not reproduced";
+}
+
+function rebuildDescription(rebuild: RebuildAttestation, totalDiffering: number): string {
+  const source = rebuild.ref
+    ? `${repositoryDisplayName(rebuild.plan?.repository ?? null) ?? "the declared repository"} at ${rebuild.ref.kind === "git-head" ? rebuild.ref.value.slice(0, 12) : rebuild.ref.value}`
+    : (repositoryDisplayName(rebuild.plan?.repository ?? null) ?? "the declared repository");
+  if (rebuild.status === "byte-identical") {
+    return `Rebuilt from ${source} — the staged tarball matches byte for byte.`;
+  }
+  if (rebuild.status === "file-identical") {
+    return `Rebuilt from ${source} — every packed file matches; only tarball metadata differs.`;
+  }
+  if (rebuild.status === "diverged") {
+    return `Rebuild from ${source} differs from the staged artifact in ${totalDiffering} ${
+      totalDiffering === 1 ? "file" : "files"
+    } — informational, not a risk signal.`;
+  }
+  if (rebuild.status === "pending") {
+    return "A rebuild from the declared repository is queued to verify this artifact.";
+  }
+  const reason = rebuild.signals[0]?.detail;
+  return reason
+    ? `The rebuild could not verify this artifact (${reason}).`
+    : "The rebuild could not verify this artifact.";
 }
 
 function tierTone(tier: IntentEnvelopeTier): BadgeTone {

--- a/src/pages/Dashboard/ScanDetail/IntentEnvelopeSection.tsx
+++ b/src/pages/Dashboard/ScanDetail/IntentEnvelopeSection.tsx
@@ -53,7 +53,8 @@ const MAX_DIVERGENT_PATHS_SHOWN = 5;
 function RebuildAttestationRow({ rebuild }: { rebuild: RebuildAttestation }) {
   const divergent = rebuild.comparison?.divergentPaths ?? [];
   const missing = rebuild.comparison?.missingFromRebuild ?? [];
-  const shown = [...missing, ...divergent].slice(0, MAX_DIVERGENT_PATHS_SHOWN);
+  const extra = rebuild.comparison?.extraInRebuild ?? [];
+  const shown = [...missing, ...divergent, ...extra].slice(0, MAX_DIVERGENT_PATHS_SHOWN);
   const totalDiffering =
     (rebuild.comparison?.divergentPaths.length ?? 0) +
     (rebuild.comparison?.missingFromRebuild.length ?? 0) +

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -21,6 +21,7 @@ import {
 import type { WorkflowGateDecision } from "../../../models/github-app";
 import { displayedAiResult, type AiReview } from "../../../../server/lib/ai-review-types";
 import { normalizeIntentEnvelope } from "../../../../server/lib/intent-envelope";
+import { normalizeRebuildAttestation } from "../../../../server/lib/rebuild-attestation";
 import { createPackageDiff, type DiffEntry } from "../../../../server/lib/review";
 import { Alert } from "../../../components/Alert";
 import { Button } from "../../../components/Button";
@@ -125,6 +126,9 @@ export default function ScanDetailPage() {
   // Older scans have no envelope; the normalizer returns null and the section
   // is simply not rendered.
   const intentEnvelope = useComputed(() => normalizeIntentEnvelope(summary.value.intentEnvelope));
+  const rebuildAttestation = useComputed(() =>
+    normalizeRebuildAttestation(summary.value.rebuildAttestation),
+  );
 
   const diffEntries = useComputed<DiffEntry[]>(() => {
     const detail = model.detail.value;
@@ -316,7 +320,9 @@ export default function ScanDetailPage() {
 
             <ReleaseConsistencyNotice value={summary.value.releaseConsistency} />
 
-            {envelope ? <IntentEnvelopeSection envelope={envelope} /> : null}
+            {envelope ? (
+              <IntentEnvelopeSection envelope={envelope} rebuild={rebuildAttestation.value} />
+            ) : null}
 
             {detail.scan.packageName ? (
               <div class="flex flex-col gap-2 border-t border-border pt-3">

--- a/src/pages/Dashboard/ScanDetail/types.ts
+++ b/src/pages/Dashboard/ScanDetail/types.ts
@@ -24,6 +24,9 @@ export interface PersistedSummary {
   // predate the feature or may be malformed; readers re-validate through
   // `normalizeIntentEnvelope`.
   intentEnvelope?: unknown;
+  // Opt-in rebuild-attestation record; same untyped-then-normalize contract
+  // via `normalizeRebuildAttestation`.
+  rebuildAttestation?: unknown;
 }
 
 export type PersistedFinding = PersistedScanDetail["findings"][number];

--- a/test/rebuild-attestation.test.mjs
+++ b/test/rebuild-attestation.test.mjs
@@ -1,0 +1,458 @@
+import { describe, expect, test } from "vitest";
+import {
+  compareRebuildOutput,
+  computeRebuildPlan,
+  extractRepositoryDirectory,
+  normalizeRebuildAttestation,
+} from "../server/lib/rebuild-attestation.ts";
+import { runRebuildSteps } from "../server/lib/rebuild-steps.ts";
+import { parseStagedPublishDetails } from "../server/lib/staged-publishes.ts";
+
+const GIT_HEAD = "a".repeat(40);
+
+function basePlanInput(overrides = {}) {
+  return {
+    ecosystem: "npm",
+    repository: "https://github.com/owner/repo",
+    gitHead: GIT_HEAD,
+    packageName: "@scope/pkg",
+    version: "2.0.0",
+    shasum: "4f7f5f1d5bcf2f72f6e4d6c4f3b2812d8a2f6c19",
+    manifestText: JSON.stringify({ name: "@scope/pkg" }),
+    ...overrides,
+  };
+}
+
+describe("computeRebuildPlan", () => {
+  test("builds a plan with gitHead first, then version-tag candidates", () => {
+    const plan = computeRebuildPlan(basePlanInput());
+    expect(plan).toEqual({
+      repository: "https://github.com/owner/repo",
+      refs: [
+        { kind: "git-head", value: GIT_HEAD },
+        { kind: "version-tag", value: "v2.0.0" },
+        { kind: "version-tag", value: "2.0.0" },
+      ],
+      directory: null,
+      packageName: "@scope/pkg",
+      version: "2.0.0",
+      expectedShasum: "4f7f5f1d5bcf2f72f6e4d6c4f3b2812d8a2f6c19",
+    });
+  });
+
+  test("requires the npm ecosystem and a normalized https repository", () => {
+    expect(computeRebuildPlan(basePlanInput({ ecosystem: "pypi" }))).toBeNull();
+    expect(computeRebuildPlan(basePlanInput({ repository: null }))).toBeNull();
+    expect(computeRebuildPlan(basePlanInput({ repository: "git@github.com:o/r.git" }))).toBeNull();
+  });
+
+  test("drops malformed gitHead values but keeps version tags", () => {
+    const plan = computeRebuildPlan(basePlanInput({ gitHead: "main; rm -rf /" }));
+    expect(plan?.refs).toEqual([
+      { kind: "version-tag", value: "v2.0.0" },
+      { kind: "version-tag", value: "2.0.0" },
+    ]);
+  });
+
+  test("returns null when no checkout candidate exists", () => {
+    expect(computeRebuildPlan(basePlanInput({ gitHead: null, version: null }))).toBeNull();
+    expect(computeRebuildPlan(basePlanInput({ gitHead: null, version: "$(evil)" }))).toBeNull();
+  });
+
+  test("rejects a non-sha1 staged shasum instead of carrying it", () => {
+    expect(computeRebuildPlan(basePlanInput({ shasum: "not-a-sha" }))?.expectedShasum).toBeNull();
+  });
+
+  test("carries a validated repository.directory for monorepos", () => {
+    const manifestText = JSON.stringify({
+      repository: { url: "https://github.com/owner/repo", directory: "packages/core" },
+    });
+    expect(computeRebuildPlan(basePlanInput({ manifestText }))?.directory).toBe("packages/core");
+  });
+});
+
+describe("extractRepositoryDirectory", () => {
+  test("accepts plain relative paths and trims ./ and trailing slashes", () => {
+    const text = (directory) => JSON.stringify({ repository: { url: "x", directory } });
+    expect(extractRepositoryDirectory(text("./packages/core/"))).toBe("packages/core");
+  });
+
+  test("rejects traversal, absolute paths, and hostile segments", () => {
+    const text = (directory) => JSON.stringify({ repository: { url: "x", directory } });
+    expect(extractRepositoryDirectory(text("../secrets"))).toBeNull();
+    expect(extractRepositoryDirectory(text("a/../../b"))).toBeNull();
+    expect(extractRepositoryDirectory(text("/etc"))).toBeNull();
+    expect(extractRepositoryDirectory(text("a/$(evil)"))).toBeNull();
+    expect(extractRepositoryDirectory(text("a/b c"))).toBeNull();
+  });
+
+  test("string repository declarations have no directory", () => {
+    expect(
+      extractRepositoryDirectory(JSON.stringify({ repository: "github:owner/repo" })),
+    ).toBeNull();
+  });
+});
+
+describe("compareRebuildOutput", () => {
+  const stagedFiles = [
+    { path: "package.json", sha256: "AA11" },
+    { path: "dist/index.js", sha256: "bb22" },
+  ];
+
+  test("byte-identical when the tarball shasum matches and files agree", () => {
+    const outcome = compareRebuildOutput({
+      expectedShasum: "f".repeat(40),
+      stagedFiles,
+      output: {
+        tarballSha1: "F".repeat(40),
+        files: [
+          { path: "./package/package.json", sha256: "aa11" },
+          { path: "package/dist/index.js", sha256: "BB22" },
+        ],
+      },
+    });
+    expect(outcome?.status).toBe("byte-identical");
+    expect(outcome?.comparison).toMatchObject({
+      tarballShasumMatch: true,
+      stagedFileCount: 2,
+      rebuiltFileCount: 2,
+      matchedFileCount: 2,
+      divergentPaths: [],
+      missingFromRebuild: [],
+      extraInRebuild: [],
+    });
+  });
+
+  test("file-identical when contents match but the tarball digest differs", () => {
+    const outcome = compareRebuildOutput({
+      expectedShasum: "f".repeat(40),
+      stagedFiles,
+      output: {
+        tarballSha1: "e".repeat(40),
+        files: [
+          { path: "package.json", sha256: "aa11" },
+          { path: "dist/index.js", sha256: "bb22" },
+        ],
+      },
+    });
+    expect(outcome?.status).toBe("file-identical");
+    expect(outcome?.comparison.tarballShasumMatch).toBe(false);
+  });
+
+  test("a matching shasum with a differing file set stays diverged", () => {
+    // Belt-and-braces: the tarball digest is compared against hostile output,
+    // so byte-identical additionally requires the file sets to agree.
+    const outcome = compareRebuildOutput({
+      expectedShasum: "f".repeat(40),
+      stagedFiles,
+      output: {
+        tarballSha1: "f".repeat(40),
+        files: [{ path: "package.json", sha256: "aa11" }],
+      },
+    });
+    expect(outcome?.status).toBe("diverged");
+  });
+
+  test("diverged reports sorted divergent/missing/extra path lists", () => {
+    const outcome = compareRebuildOutput({
+      expectedShasum: null,
+      stagedFiles: [
+        { path: "package.json", sha256: "aa11" },
+        { path: "dist/index.js", sha256: "bb22" },
+        { path: "dist/only-staged.js", sha256: "cc33" },
+      ],
+      output: {
+        tarballSha1: null,
+        files: [
+          { path: "package.json", sha256: "aa11" },
+          { path: "dist/index.js", sha256: "ff99" },
+          { path: "dist/only-rebuilt.js", sha256: "dd44" },
+        ],
+      },
+    });
+    expect(outcome?.status).toBe("diverged");
+    expect(outcome?.comparison).toMatchObject({
+      tarballShasumMatch: null,
+      matchedFileCount: 1,
+      divergentPaths: ["dist/index.js"],
+      missingFromRebuild: ["dist/only-staged.js"],
+      extraInRebuild: ["dist/only-rebuilt.js"],
+    });
+  });
+
+  test("returns null when staged hashes are incomplete", () => {
+    expect(
+      compareRebuildOutput({
+        expectedShasum: null,
+        stagedFiles: [{ path: "package.json", sha256: null }],
+        output: { tarballSha1: null, files: [{ path: "package.json", sha256: "aa" }] },
+      }),
+    ).toBeNull();
+    expect(
+      compareRebuildOutput({
+        expectedShasum: null,
+        stagedFiles: [],
+        output: { tarballSha1: null, files: [{ path: "package.json", sha256: "aa" }] },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("normalizeRebuildAttestation", () => {
+  const plan = {
+    repository: "https://github.com/owner/repo",
+    refs: [{ kind: "git-head", value: GIT_HEAD }],
+    directory: null,
+    packageName: "@scope/pkg",
+    version: "2.0.0",
+    expectedShasum: null,
+  };
+
+  test("round-trips a valid completed attestation", () => {
+    const value = {
+      status: "file-identical",
+      plan,
+      ref: { kind: "git-head", value: GIT_HEAD },
+      toolchain: { packageManager: "pnpm@11.1.1", node: "v22.11.0" },
+      comparison: {
+        tarballShasumMatch: false,
+        stagedFileCount: 3,
+        rebuiltFileCount: 3,
+        matchedFileCount: 3,
+        divergentPaths: [],
+        missingFromRebuild: [],
+        extraInRebuild: [],
+      },
+      signals: [{ kind: "rebuild", detail: "ok" }],
+      completedAt: "2026-07-17T00:00:00.000Z",
+    };
+    expect(normalizeRebuildAttestation(value)).toEqual(value);
+  });
+
+  test("verdicts must carry their evidence", () => {
+    expect(normalizeRebuildAttestation({ status: "file-identical", plan })).toBeNull();
+    expect(normalizeRebuildAttestation({ status: "pending" })).toBeNull();
+    expect(normalizeRebuildAttestation({ status: "made-up" })).toBeNull();
+    expect(normalizeRebuildAttestation(null)).toBeNull();
+    expect(normalizeRebuildAttestation("file-identical")).toBeNull();
+  });
+
+  test("byte-identical requires a persisted tarball shasum match", () => {
+    const value = {
+      status: "byte-identical",
+      plan,
+      ref: null,
+      toolchain: null,
+      comparison: {
+        tarballShasumMatch: false,
+        stagedFileCount: 1,
+        rebuiltFileCount: 1,
+        matchedFileCount: 1,
+        divergentPaths: [],
+        missingFromRebuild: [],
+        extraInRebuild: [],
+      },
+      signals: [],
+      completedAt: null,
+    };
+    expect(normalizeRebuildAttestation(value)).toBeNull();
+  });
+
+  test("pending records require an actionable plan with valid refs", () => {
+    expect(
+      normalizeRebuildAttestation({
+        status: "pending",
+        plan: { ...plan, refs: [{ kind: "git-head", value: "not-a-sha" }] },
+      }),
+    ).toBeNull();
+    const pending = normalizeRebuildAttestation({ status: "pending", plan });
+    expect(pending?.status).toBe("pending");
+    expect(pending?.plan?.refs).toEqual([{ kind: "git-head", value: GIT_HEAD }]);
+  });
+});
+
+describe("staged publish details gitHead extraction", () => {
+  test("reads a valid gitHead from the staged version manifest", () => {
+    const details = parseStagedPublishDetails(
+      {
+        id: "stage-abc-123",
+        packageName: "@scope/pkg",
+        version: "2.0.0",
+        versions: { "2.0.0": { name: "@scope/pkg", version: "2.0.0", gitHead: GIT_HEAD } },
+      },
+      "stage-abc-123",
+    );
+    expect(details?.gitHead).toBe(GIT_HEAD);
+  });
+
+  test("drops non-sha gitHead values", () => {
+    const details = parseStagedPublishDetails(
+      {
+        id: "stage-abc-123",
+        packageName: "@scope/pkg",
+        version: "2.0.0",
+        manifest: { gitHead: "refs/heads/main" },
+      },
+      "stage-abc-123",
+    );
+    expect(details?.gitHead).toBeNull();
+  });
+});
+
+describe("runRebuildSteps", () => {
+  const plan = {
+    repository: "https://github.com/owner/repo",
+    refs: [
+      { kind: "git-head", value: GIT_HEAD },
+      { kind: "version-tag", value: "v2.0.0" },
+    ],
+    directory: null,
+    packageName: "@scope/pkg",
+    version: "2.0.0",
+    expectedShasum: null,
+  };
+
+  const ok = (stdout = "") => ({
+    success: true,
+    exitCode: 0,
+    stdout,
+    stderr: "",
+    duration: 10,
+  });
+  const fail = (stderr = "boom") => ({
+    success: false,
+    exitCode: 1,
+    stdout: "",
+    stderr,
+    duration: 10,
+  });
+
+  function scriptedSandbox(script) {
+    const commands = [];
+    return {
+      commands,
+      exec: async (command) => {
+        commands.push(command);
+        for (const [pattern, result] of script) {
+          if (command.includes(pattern)) return result;
+        }
+        return ok();
+      },
+    };
+  }
+
+  const manifestStdout = (manifest, listing) => `${JSON.stringify(manifest)}\n\n${listing}`;
+  const hashStdout = [
+    "f".repeat(40),
+    `${"1".repeat(64)}  ./package.json`,
+    `${"2".repeat(64)}  ./dist/index.js`,
+  ].join("\n");
+
+  test("happy path: npm strategy produces a hash manifest", async () => {
+    const sandbox = scriptedSandbox([
+      [
+        "cat ",
+        ok(
+          manifestStdout(
+            { name: "@scope/pkg", scripts: { build: "tsc" } },
+            "package.json\npackage-lock.json",
+          ),
+        ),
+      ],
+      ["--version", ok("v22.11.0\n10.9.0")],
+      ["sha1sum", ok(hashStdout)],
+    ]);
+    const execution = await runRebuildSteps(sandbox, plan);
+    expect(execution.ok).toBe(true);
+    expect(execution.ref).toEqual({ kind: "git-head", value: GIT_HEAD });
+    expect(execution.toolchain).toEqual({ packageManager: "npm@10.9.0", node: "v22.11.0" });
+    expect(execution.output).toEqual({
+      tarballSha1: "f".repeat(40),
+      files: [
+        { path: "./package.json", sha256: "1".repeat(64) },
+        { path: "./dist/index.js", sha256: "2".repeat(64) },
+      ],
+    });
+    const joined = sandbox.commands.join("\n");
+    expect(joined).toContain("npm ci --ignore-scripts");
+    expect(joined).toContain("npm run build");
+    expect(joined).toContain("npm pack --pack-destination");
+  });
+
+  test("falls back to the version tag when the sha fetch fails", async () => {
+    const sandbox = scriptedSandbox([
+      [`fetch -q --depth 1 origin '${GIT_HEAD}'`, fail("not found")],
+      ["cat ", ok(manifestStdout({ name: "@scope/pkg" }, "package.json"))],
+      ["--version", ok("v22.11.0\n10.9.0")],
+      ["sha1sum", ok(hashStdout)],
+    ]);
+    const execution = await runRebuildSteps(sandbox, plan);
+    expect(execution.ok).toBe(true);
+    expect(execution.ref).toEqual({ kind: "version-tag", value: "v2.0.0" });
+  });
+
+  test("pnpm packageManager pins the toolchain through corepack", async () => {
+    const sandbox = scriptedSandbox([
+      [
+        "cat ",
+        ok(manifestStdout({ name: "@scope/pkg", packageManager: "pnpm@11.1.1" }, "pnpm-lock.yaml")),
+      ],
+      ["--version", ok("v22.11.0\n11.1.1")],
+      ["sha1sum", ok(hashStdout)],
+    ]);
+    const execution = await runRebuildSteps(sandbox, plan);
+    expect(execution.ok).toBe(true);
+    expect(execution.toolchain?.packageManager).toBe("pnpm@11.1.1");
+    const joined = sandbox.commands.join("\n");
+    expect(joined).toContain("corepack prepare 'pnpm@11.1.1' --activate");
+    expect(joined).toContain("pnpm install --ignore-scripts --frozen-lockfile");
+    expect(joined).toContain("pnpm pack --pack-destination");
+  });
+
+  test("yarn repositories are reported as unsupported", async () => {
+    const sandbox = scriptedSandbox([
+      ["cat ", ok(manifestStdout({ name: "@scope/pkg" }, "yarn.lock"))],
+    ]);
+    const execution = await runRebuildSteps(sandbox, plan);
+    expect(execution).toMatchObject({ ok: false, failure: "unsupported-package-manager" });
+  });
+
+  test("checkout failure across all refs surfaces step details", async () => {
+    const sandbox = scriptedSandbox([["git ", fail("fatal: repository not found")]]);
+    const execution = await runRebuildSteps(sandbox, plan);
+    expect(execution).toMatchObject({ ok: false, failure: "checkout-failed" });
+    const checkoutSteps = execution.steps.filter((step) => step.step.startsWith("checkout"));
+    expect(checkoutSteps).toHaveLength(2);
+    expect(checkoutSteps[0].detail).toContain("repository not found");
+  });
+
+  test("build failures stop before pack", async () => {
+    const sandbox = scriptedSandbox([
+      [
+        "cat ",
+        ok(manifestStdout({ name: "@scope/pkg", scripts: { build: "tsc" } }, "package.json")),
+      ],
+      ["--version", ok("v22.11.0\n10.9.0")],
+      ["run build", fail("TS2304: Cannot find name")],
+    ]);
+    const execution = await runRebuildSteps(sandbox, plan);
+    expect(execution).toMatchObject({ ok: false, failure: "build-failed" });
+    expect(sandbox.commands.join("\n")).not.toContain("npm pack");
+  });
+
+  test("monorepo directory scopes build and pack, not install", async () => {
+    const sandbox = scriptedSandbox([
+      [
+        "cat ",
+        ok(manifestStdout({ name: "@scope/pkg", scripts: { build: "tsc" } }, "package.json")),
+      ],
+      ["--version", ok("v22.11.0\n10.9.0")],
+      ["sha1sum", ok(hashStdout)],
+    ]);
+    await runRebuildSteps(sandbox, { ...plan, directory: "packages/core" });
+    const joined = sandbox.commands.join("\n");
+    expect(joined).toContain("cat '/workspace/rebuild/repo/packages/core/package.json'");
+    expect(joined).toContain("cd '/workspace/rebuild/repo' && (npm ci --ignore-scripts");
+    expect(joined).toContain("cd '/workspace/rebuild/repo/packages/core' && npm run build");
+  });
+});

--- a/test/rebuild-attestation.test.mjs
+++ b/test/rebuild-attestation.test.mjs
@@ -411,6 +411,25 @@ describe("runRebuildSteps", () => {
     expect(joined).toContain("pnpm pack --pack-destination");
   });
 
+  test("npm packageManager pins invoke npm through corepack", async () => {
+    const sandbox = scriptedSandbox([
+      [
+        "cat ",
+        ok(
+          manifestStdout({ name: "@scope/pkg", packageManager: "npm@10.9.0" }, "package-lock.json"),
+        ),
+      ],
+      ["--version", ok("v22.11.0\n10.9.0")],
+      ["sha1sum", ok(hashStdout)],
+    ]);
+    const execution = await runRebuildSteps(sandbox, plan);
+    expect(execution.ok).toBe(true);
+    const joined = sandbox.commands.join("\n");
+    expect(joined).toContain("corepack prepare 'npm@10.9.0' --activate");
+    expect(joined).toContain("corepack npm ci --ignore-scripts");
+    expect(joined).toContain("corepack npm pack --pack-destination");
+  });
+
   test("yarn repositories are reported as unsupported", async () => {
     const sandbox = scriptedSandbox([
       ["cat ", ok(manifestStdout({ name: "@scope/pkg" }, "yarn.lock"))],
@@ -478,6 +497,21 @@ describe("runRebuildSteps", () => {
     ]);
     const execution = await runRebuildSteps(sandbox, plan);
     expect(execution).toMatchObject({ ok: false, failure: "package-not-located" });
+  });
+
+  test("rejects multiple workspace packages with the same manifest name", async () => {
+    const sandbox = scriptedSandbox([
+      [
+        "cat '/workspace/rebuild/repo/package.json'",
+        ok(manifestStdout({ name: "monorepo-root" }, "package.json")),
+      ],
+      ["grep -lE", ok("./packages/core/package.json\n./fixtures/core/package.json\n")],
+    ]);
+    const execution = await runRebuildSteps(sandbox, plan);
+    expect(execution).toMatchObject({ ok: false, failure: "package-not-located" });
+    expect(sandbox.commands.join("\n")).not.toContain(
+      "cat '/workspace/rebuild/repo/packages/core/package.json'",
+    );
   });
 
   test("hostile locate output is rejected instead of trusted as a path", async () => {

--- a/test/rebuild-attestation.test.mjs
+++ b/test/rebuild-attestation.test.mjs
@@ -31,6 +31,7 @@ describe("computeRebuildPlan", () => {
       refs: [
         { kind: "git-head", value: GIT_HEAD },
         { kind: "version-tag", value: "v2.0.0" },
+        { kind: "version-tag", value: "@scope/pkg@2.0.0" },
         { kind: "version-tag", value: "2.0.0" },
       ],
       directory: null,
@@ -50,6 +51,7 @@ describe("computeRebuildPlan", () => {
     const plan = computeRebuildPlan(basePlanInput({ gitHead: "main; rm -rf /" }));
     expect(plan?.refs).toEqual([
       { kind: "version-tag", value: "v2.0.0" },
+      { kind: "version-tag", value: "@scope/pkg@2.0.0" },
       { kind: "version-tag", value: "2.0.0" },
     ]);
   });
@@ -440,11 +442,65 @@ describe("runRebuildSteps", () => {
     expect(sandbox.commands.join("\n")).not.toContain("npm pack");
   });
 
+  test("locates a workspace package by name when no directory is declared", async () => {
+    const sandbox = scriptedSandbox([
+      // Root manifest belongs to the workspace root, not the staged package.
+      [
+        "cat '/workspace/rebuild/repo/package.json'",
+        ok(
+          manifestStdout({ name: "monorepo-root", private: true }, "package.json\npnpm-lock.yaml"),
+        ),
+      ],
+      ["grep -lE", ok("./packages/core/package.json\n")],
+      [
+        "cat '/workspace/rebuild/repo/packages/core/package.json'",
+        ok(JSON.stringify({ name: "@scope/pkg", scripts: { build: "tsc" } })),
+      ],
+      ["--version", ok("v22.11.0\n11.1.1")],
+      ["sha1sum", ok(hashStdout)],
+    ]);
+    const execution = await runRebuildSteps(sandbox, plan);
+    expect(execution.ok).toBe(true);
+    const joined = sandbox.commands.join("\n");
+    // pnpm detected from the ROOT lockfile even though the package dir has none.
+    expect(joined).toContain("pnpm install --ignore-scripts");
+    expect(joined).toContain("cd '/workspace/rebuild/repo/packages/core' && pnpm run build");
+    expect(joined).toContain('"name"[[:space:]]*:[[:space:]]*"@scope/pkg"');
+  });
+
+  test("fails as package-not-located when the workspace has no matching manifest", async () => {
+    const sandbox = scriptedSandbox([
+      [
+        "cat '/workspace/rebuild/repo/package.json'",
+        ok(manifestStdout({ name: "monorepo-root" }, "package.json")),
+      ],
+      ["grep -lE", fail("")],
+    ]);
+    const execution = await runRebuildSteps(sandbox, plan);
+    expect(execution).toMatchObject({ ok: false, failure: "package-not-located" });
+  });
+
+  test("hostile locate output is rejected instead of trusted as a path", async () => {
+    const sandbox = scriptedSandbox([
+      [
+        "cat '/workspace/rebuild/repo/package.json'",
+        ok(manifestStdout({ name: "monorepo-root" }, "package.json")),
+      ],
+      ["grep -lE", ok("./../../../etc/package.json\n./a/$(evil)/package.json\n")],
+    ]);
+    const execution = await runRebuildSteps(sandbox, plan);
+    expect(execution).toMatchObject({ ok: false, failure: "package-not-located" });
+  });
+
   test("monorepo directory scopes build and pack, not install", async () => {
     const sandbox = scriptedSandbox([
       [
-        "cat ",
-        ok(manifestStdout({ name: "@scope/pkg", scripts: { build: "tsc" } }, "package.json")),
+        "cat '/workspace/rebuild/repo/packages/core/package.json'",
+        ok(JSON.stringify({ name: "@scope/pkg", scripts: { build: "tsc" } })),
+      ],
+      [
+        "cat '/workspace/rebuild/repo/package.json'",
+        ok(manifestStdout({ name: "monorepo-root", private: true }, "package.json")),
       ],
       ["--version", ok("v22.11.0\n10.9.0")],
       ["sha1sum", ok(hashStdout)],

--- a/test/scan-detail-polling-model.test.ts
+++ b/test/scan-detail-polling-model.test.ts
@@ -26,6 +26,35 @@ function runningDetail(): PersistedScanDetail {
   };
 }
 
+function completedDetail(rebuildStatus: "pending" | "inconclusive"): PersistedScanDetail {
+  const detail = runningDetail();
+  return {
+    ...detail,
+    scan: {
+      ...detail.scan,
+      status: "complete",
+      summaryJson: {
+        rebuildAttestation: {
+          status: rebuildStatus,
+          plan: {
+            repository: "https://github.com/owner/repo",
+            refs: [{ kind: "git-head", value: "a".repeat(40) }],
+            directory: null,
+            packageName: "left-pad",
+            version: "1.0.1",
+            expectedShasum: "b".repeat(40),
+          },
+          ref: null,
+          toolchain: null,
+          comparison: null,
+          signals: [],
+          completedAt: rebuildStatus === "inconclusive" ? "2026-07-23T00:00:00.000Z" : null,
+        },
+      },
+    },
+  };
+}
+
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
     status: 200,
@@ -123,6 +152,32 @@ describe("ScanDetailModel polling", () => {
     // Success resets the cadence: the next poll fires at the base delay again.
     await vi.advanceTimersByTimeAsync(SCAN_POLL_BASE_DELAY_MS);
     expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  test("keeps polling a completed scan until its deferred rebuild resolves", async () => {
+    const resolved = completedDetail("inconclusive");
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      return Promise.resolve(
+        url.endsWith("/status") ? jsonResponse({ scan: resolved.scan }) : jsonResponse(resolved),
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    model = new ScanDetailModel("scan-1");
+    model.detail.value = completedDetail("pending");
+
+    await vi.advanceTimersByTimeAsync(SCAN_POLL_BASE_DELAY_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const updated = model.detail.value;
+    expect(updated).not.toBeNull();
+    expect(
+      (updated!.scan.summaryJson as { rebuildAttestation?: { status?: string } }).rebuildAttestation
+        ?.status,
+    ).toBe("inconclusive");
+
+    await vi.advanceTimersByTimeAsync(2 * SCAN_POLL_BASE_DELAY_MS);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   test("stops polling and raises pollingStalled after the stall window", async () => {

--- a/test/scan-job.test.mjs
+++ b/test/scan-job.test.mjs
@@ -18,6 +18,10 @@ const npmConnectionMock = vi.hoisted(() => ({ decryptNpmToken: vi.fn() }));
 const notifyMock = vi.hoisted(() => ({
   notifyScanCompletion: vi.fn().mockResolvedValue(undefined),
 }));
+const rebuildJobMock = vi.hoisted(() => ({
+  executeRebuildAttestationJob: vi.fn().mockResolvedValue(null),
+  hasPendingRebuildAttestation: vi.fn().mockResolvedValue(false),
+}));
 
 vi.mock("../server/db/client.ts", () => dbMock);
 vi.mock("../server/db/events.ts", () => dbMock);
@@ -26,6 +30,7 @@ vi.mock("../server/db/scans.ts", () => dbMock);
 vi.mock("../server/lib/scan-pipeline.ts", () => pipelineMock);
 vi.mock("../server/lib/npm-connection.ts", () => npmConnectionMock);
 vi.mock("../server/lib/notify.ts", () => notifyMock);
+vi.mock("../server/lib/rebuild-job.ts", () => rebuildJobMock);
 
 const { classifyScanError, executeScanJob, retryDelaySeconds } =
   await import("../server/lib/scan-job.ts");
@@ -174,6 +179,7 @@ describe("executeScanJob idempotency", () => {
       riskSummary: { releaseRisk: "low" },
       package: { name: null },
     });
+    rebuildJobMock.hasPendingRebuildAttestation.mockResolvedValue(false);
   });
 
   afterEach(() => {
@@ -181,6 +187,8 @@ describe("executeScanJob idempotency", () => {
     pipelineMock.runScanPipeline.mockReset();
     npmConnectionMock.decryptNpmToken.mockReset();
     notifyMock.notifyScanCompletion.mockClear();
+    rebuildJobMock.executeRebuildAttestationJob.mockReset();
+    rebuildJobMock.hasPendingRebuildAttestation.mockReset();
     vi.restoreAllMocks();
   });
 
@@ -202,6 +210,39 @@ describe("executeScanJob idempotency", () => {
 
     expect(pipelineMock.runScanPipeline).toHaveBeenCalledTimes(1);
     expect(dbMock.markNpmConnectionUsed).toHaveBeenCalledWith({}, message.organizationId);
+  });
+
+  test("recovers a pending rebuild handoff when queue dispatch fails after completion", async () => {
+    const send = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("queue unavailable"))
+      .mockResolvedValueOnce(undefined);
+    const queueEnv = { DB: {}, SCAN_QUEUE: { send } };
+    dbMock.claimScanForRun.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    pipelineMock.runScanPipeline.mockResolvedValue({
+      id: message.scanId,
+      risk: "low",
+      riskSummary: { releaseRisk: "low" },
+      package: { name: "@scope/pkg" },
+      rebuildAttestation: { status: "pending" },
+    });
+
+    await expect(
+      executeScanJob(queueEnv, ctx, message, {}, { attempt: 1, finalAttempt: false }),
+    ).rejects.toThrow("queue unavailable");
+
+    rebuildJobMock.hasPendingRebuildAttestation.mockResolvedValueOnce(true);
+    await expect(
+      executeScanJob(queueEnv, ctx, message, {}, { attempt: 2, finalAttempt: false }),
+    ).resolves.toBeNull();
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send).toHaveBeenLastCalledWith({
+      kind: "rebuild_attestation",
+      organizationId: message.organizationId,
+      scanId: message.scanId,
+    });
+    expect(pipelineMock.runScanPipeline).toHaveBeenCalledTimes(1);
   });
 
   test("emits a structured completion log without token material", async () => {

--- a/test/scan-pipeline.test.mjs
+++ b/test/scan-pipeline.test.mjs
@@ -384,6 +384,7 @@ describe("scan pipeline baseline selection", () => {
         refs: [
           { kind: "git-head", value: gitHead },
           { kind: "version-tag", value: "v2.0.0-beta.3" },
+          { kind: "version-tag", value: "@scope/pkg@2.0.0-beta.3" },
           { kind: "version-tag", value: "2.0.0-beta.3" },
         ],
         expectedShasum: "4f7f5f1d5bcf2f72f6e4d6c4f3b2812d8a2f6c19",

--- a/test/scan-pipeline.test.mjs
+++ b/test/scan-pipeline.test.mjs
@@ -328,6 +328,116 @@ describe("scan pipeline baseline selection", () => {
     expect(result.intentEnvelope).toEqual({ tier: "absent", repository: null, signals: [] });
   });
 
+  test("persists a pending rebuild plan when the opt-in flag is enabled", async () => {
+    const gitHead = "b".repeat(40);
+    stagedMock.fetchStagedPublishDetails.mockResolvedValue({
+      id: "stage-beta-123",
+      packageName: "@scope/pkg",
+      version: "2.0.0-beta.3",
+      tag: "beta",
+      access: "public",
+      actor: "octocat",
+      actorType: "user",
+      createdAt: "2026-03-16T09:00:00.000Z",
+      shasum: "4f7f5f1d5bcf2f72f6e4d6c4f3b2812d8a2f6c19",
+      packageJson: null,
+      gitHead,
+    });
+    sandboxMock.downloadInSandbox.mockResolvedValue({
+      files: [
+        {
+          path: "package.json",
+          size: 96,
+          sha256: "staged-pkg",
+          flags: [],
+          textSample: JSON.stringify({
+            name: "@scope/pkg",
+            version: "2.0.0-beta.3",
+            repository: { type: "git", url: "git+https://github.com/scope/pkg.git" },
+          }),
+        },
+      ],
+      packageJson: { name: "@scope/pkg", version: "2.0.0-beta.3" },
+    });
+    // Opt-in: the default is false, so only an explicit organization rule
+    // (Flagship returning true) enables the rebuild.
+    const getBooleanValue = vi.fn(async (flag, defaultValue) =>
+      flag === "rebuild-attestation" ? true : defaultValue,
+    );
+    const context = { ...baseContext, env: { ...baseContext.env, FLAGS: { getBooleanValue } } };
+
+    const result = await runScanPipeline(context, npmAdapter, {
+      scanId: "scan_rebuild_pending",
+      stageId: "stage-beta-123",
+      organizationId: "org_1",
+    });
+
+    expect(getBooleanValue).toHaveBeenCalledWith(
+      "rebuild-attestation",
+      false,
+      expect.objectContaining({ organizationId: "org_1" }),
+    );
+    expect(result.rebuildAttestation).toMatchObject({
+      status: "pending",
+      plan: {
+        repository: "https://github.com/scope/pkg",
+        refs: [
+          { kind: "git-head", value: gitHead },
+          { kind: "version-tag", value: "v2.0.0-beta.3" },
+          { kind: "version-tag", value: "2.0.0-beta.3" },
+        ],
+        expectedShasum: "4f7f5f1d5bcf2f72f6e4d6c4f3b2812d8a2f6c19",
+      },
+    });
+    expect(dbMock.persistScan.mock.calls[0]?.[1].summary.rebuildAttestation).toEqual(
+      result.rebuildAttestation,
+    );
+  });
+
+  test("rebuild attestation stays off without the opt-in flag", async () => {
+    sandboxMock.downloadInSandbox.mockResolvedValue({
+      files: [
+        {
+          path: "package.json",
+          size: 96,
+          sha256: "staged-pkg",
+          flags: [],
+          textSample: JSON.stringify({
+            name: "@scope/pkg",
+            version: "2.0.0-beta.3",
+            repository: "github:scope/pkg",
+          }),
+        },
+      ],
+      packageJson: { name: "@scope/pkg", version: "2.0.0-beta.3" },
+    });
+    // Flagship present but returning the default (false) — and the AI killswitch
+    // stays on its own default.
+    const getBooleanValue = vi.fn(async (_flag, defaultValue) => defaultValue);
+    aiReviewMock.runSelectiveAiReview.mockResolvedValue({
+      review: {
+        status: "complete",
+        risk: "low",
+        releaseAssessment: "nothing_unusual",
+        summary: "Nothing unusual in the staged release.",
+        findings: [],
+        requiresManualReview: false,
+        model: "@cf/moonshotai/kimi-k2.7-code",
+      },
+      usage: null,
+    });
+    const context = { ...baseContext, env: { ...baseContext.env, FLAGS: { getBooleanValue } } };
+
+    const result = await runScanPipeline(context, npmAdapter, {
+      scanId: "scan_rebuild_default_off",
+      stageId: "stage-beta-123",
+      organizationId: "org_1",
+    });
+
+    expect(result.rebuildAttestation).toBeNull();
+    expect(dbMock.persistScan.mock.calls[0]?.[1].summary.rebuildAttestation).toBeNull();
+  });
+
   test("persists deterministic results when enabled AI review fails", async () => {
     aiReviewMock.runSelectiveAiReview.mockRejectedValue(new Error("workers ai unavailable"));
     const context = {

--- a/test/workers/scan-rebuild-attestation.test.ts
+++ b/test/workers/scan-rebuild-attestation.test.ts
@@ -1,0 +1,294 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { describe, expect, test } from "vitest";
+import { createDb } from "../../server/db/client";
+import { ensurePersonalOrganization } from "../../server/db/organizations";
+import { createScanJob, persistScan } from "../../server/db/scans";
+import * as schema from "../../server/db/schema";
+import { executeRebuildAttestationJob } from "../../server/lib/rebuild-job";
+import type { RebuildAttestation, RebuildPlan } from "../../server/lib/rebuild-attestation";
+import type { RebuildExecution } from "../../server/lib/rebuild-steps";
+import { maybeWriteScanArtifacts } from "../../server/lib/scan-artifacts";
+import { sha256Hex, stableJson } from "../../server/lib/stable-json";
+import { scansRoutes } from "../../server/routes/scans";
+import type { Bindings, Variables } from "../../server/types";
+
+const GIT_HEAD = "c".repeat(40);
+const STAGED_SHA1 = "d".repeat(40);
+const PKG_SHA256 = "1".repeat(64);
+const DIST_SHA256 = "2".repeat(64);
+
+interface SeededUser {
+  userId: string;
+  organizationId: string;
+}
+
+async function seedUser(): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+function buildTestApp(session: { userId: string }) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.use("*", async (c, next) => {
+    c.set("authSession", { userId: session.userId });
+    await next();
+  });
+  app.route("/api/v1/scans", scansRoutes);
+  return app;
+}
+
+async function fetchJson(
+  app: Hono<{ Bindings: Bindings; Variables: Variables }>,
+  path: string,
+): Promise<Response> {
+  const ctx = createExecutionContext();
+  const res = await app.fetch(new Request(`http://test.local${path}`, { method: "GET" }), env, ctx);
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+function pendingPlan(): RebuildPlan {
+  return {
+    repository: "https://github.com/scope/pkg",
+    refs: [{ kind: "git-head", value: GIT_HEAD }],
+    directory: null,
+    packageName: "@scope/pkg",
+    version: "2.0.0",
+    expectedShasum: STAGED_SHA1,
+  };
+}
+
+function pendingAttestation(): RebuildAttestation {
+  return {
+    status: "pending",
+    plan: pendingPlan(),
+    ref: null,
+    toolchain: null,
+    comparison: null,
+    signals: [],
+    completedAt: null,
+  };
+}
+
+// Seed a completed scan with real R2 artifacts so the rebuild job can load the
+// staged file hashes the way production does.
+async function seedCompletedScan(
+  owner: SeededUser,
+  rebuildAttestation: RebuildAttestation | null,
+): Promise<string> {
+  const db = createDb(env.DB);
+  const scanId = `scan_${crypto.randomUUID()}`;
+  const stageId = `stage-${scanId.slice(-12)}`;
+  const files = [
+    { path: "package.json", size: 10, sha256: PKG_SHA256, flags: [], textSample: "{}" },
+    { path: "dist/index.js", size: 20, sha256: DIST_SHA256, flags: [], textSample: "x" },
+  ];
+  const diff = [{ path: "dist/index.js", status: "modified", flags: [] }];
+  const reportJson = stableJson({ version: 1, scanId, ruleFindings: [] });
+  const reportDigest = await sha256Hex(reportJson);
+  const artifacts = await maybeWriteScanArtifacts(env.ARTIFACTS, {
+    organizationId: owner.organizationId,
+    scanId,
+    reportJson,
+    reportDigest,
+    files,
+    diff,
+    generatedAt: "2026-07-17T00:00:00.000Z",
+  });
+  expect(artifacts).not.toBeNull();
+
+  await createScanJob(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+  });
+  await persistScan(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+    packageJson: { name: "@scope/pkg", version: "2.0.0" },
+    risk: "low",
+    status: "complete",
+    summary: {
+      report: {
+        version: 1,
+        digest: reportDigest,
+        digestAlgorithm: "sha256",
+        generatedAt: "2026-07-17T00:00:00.000Z",
+        rulesVersion: "1.8.0",
+      },
+      diff,
+      ...(rebuildAttestation ? { rebuildAttestation } : {}),
+    },
+    ai: null,
+    files,
+    diff,
+    findings: [],
+    report: { version: 1, digest: reportDigest },
+    artifacts,
+  });
+  return scanId;
+}
+
+function successfulExecution(): RebuildExecution {
+  return {
+    ok: true,
+    ref: { kind: "git-head", value: GIT_HEAD },
+    toolchain: { packageManager: "npm@10.9.0", node: "v22.11.0" },
+    output: {
+      tarballSha1: STAGED_SHA1,
+      files: [
+        { path: "./package.json", sha256: PKG_SHA256 },
+        { path: "./dist/index.js", sha256: DIST_SHA256 },
+      ],
+    },
+    steps: [{ step: "pack", exitCode: 0, durationMs: 10, detail: null }],
+  };
+}
+
+describe("rebuild attestation job", () => {
+  test("resolves a pending plan to byte-identical and persists it for readers", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner, pendingAttestation());
+
+    const result = await executeRebuildAttestationJob(
+      env,
+      { kind: "rebuild_attestation", organizationId: owner.organizationId, scanId },
+      undefined,
+      { executor: async () => successfulExecution() },
+    );
+    expect(result?.status).toBe("byte-identical");
+    expect(result?.comparison).toMatchObject({
+      tarballShasumMatch: true,
+      stagedFileCount: 2,
+      matchedFileCount: 2,
+    });
+
+    const res = await fetchJson(buildTestApp(owner), `/api/v1/scans/${scanId}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      scan: { summaryJson: { rebuildAttestation?: { status?: string }; report?: unknown } };
+    };
+    expect(body.scan.summaryJson.rebuildAttestation?.status).toBe("byte-identical");
+    // The merge preserved the rest of the summary blob.
+    expect(body.scan.summaryJson.report).toBeTruthy();
+
+    const report = await fetchJson(buildTestApp(owner), `/api/v1/scans/${scanId}/report.json`);
+    expect(report.status).toBe(200);
+    const reportBody = (await report.json()) as { rebuildAttestation: { status: string } | null };
+    expect(reportBody.rebuildAttestation?.status).toBe("byte-identical");
+  });
+
+  test("a diverged rebuild stays advisory: risk is untouched", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner, pendingAttestation());
+
+    const execution = successfulExecution();
+    if (execution.ok) {
+      execution.output = {
+        tarballSha1: "e".repeat(40),
+        files: [
+          { path: "package.json", sha256: PKG_SHA256 },
+          { path: "dist/index.js", sha256: "9".repeat(64) },
+        ],
+      };
+    }
+    const result = await executeRebuildAttestationJob(
+      env,
+      { kind: "rebuild_attestation", organizationId: owner.organizationId, scanId },
+      undefined,
+      { executor: async () => execution },
+    );
+    expect(result?.status).toBe("diverged");
+    expect(result?.comparison?.divergentPaths).toEqual(["dist/index.js"]);
+
+    const res = await fetchJson(buildTestApp(owner), `/api/v1/scans/${scanId}`);
+    const body = (await res.json()) as { scan: { risk: string } };
+    expect(body.scan.risk).toBe("low");
+  });
+
+  test("reports inconclusive when no rebuild sandbox is configured", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner, pendingAttestation());
+
+    // The test environment has no REBUILD_SANDBOX binding and no executor
+    // override, which is exactly the deployment-without-containers shape.
+    const result = await executeRebuildAttestationJob(env, {
+      kind: "rebuild_attestation",
+      organizationId: owner.organizationId,
+      scanId,
+    });
+    expect(result?.status).toBe("inconclusive");
+    expect(result?.signals[0]).toMatchObject({ kind: "sandbox" });
+  });
+
+  test("a failed rebuild persists inconclusive with step evidence", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner, pendingAttestation());
+
+    const result = await executeRebuildAttestationJob(
+      env,
+      { kind: "rebuild_attestation", organizationId: owner.organizationId, scanId },
+      undefined,
+      {
+        executor: async () => ({
+          ok: false,
+          failure: "build-failed",
+          steps: [{ step: "build", exitCode: 1, durationMs: 10, detail: "TS2304" }],
+        }),
+      },
+    );
+    expect(result?.status).toBe("inconclusive");
+    expect(result?.signals).toEqual([
+      { kind: "rebuild", detail: "build-failed" },
+      { kind: "step-failed", detail: "build exited 1: TS2304" },
+    ]);
+  });
+
+  test("skips scans without a pending plan and other organizations' scans", async () => {
+    const owner = await seedUser();
+    const scanId = await seedCompletedScan(owner, null);
+    const noPlan = await executeRebuildAttestationJob(
+      env,
+      { kind: "rebuild_attestation", organizationId: owner.organizationId, scanId },
+      undefined,
+      { executor: async () => successfulExecution() },
+    );
+    expect(noPlan).toBeNull();
+
+    const withPlanScanId = await seedCompletedScan(owner, pendingAttestation());
+    const stranger = await seedUser();
+    const crossOrg = await executeRebuildAttestationJob(
+      env,
+      {
+        kind: "rebuild_attestation",
+        organizationId: stranger.organizationId,
+        scanId: withPlanScanId,
+      },
+      undefined,
+      { executor: async () => successfulExecution() },
+    );
+    expect(crossOrg).toBeNull();
+
+    // The cross-org attempt must not have touched the pending record.
+    const res = await fetchJson(buildTestApp(owner), `/api/v1/scans/${withPlanScanId}`);
+    const body = (await res.json()) as {
+      scan: { summaryJson: { rebuildAttestation?: { status?: string } } };
+    };
+    expect(body.scan.summaryJson.rebuildAttestation?.status).toBe("pending");
+  });
+});

--- a/test/workers/scan-rebuild-attestation.test.ts
+++ b/test/workers/scan-rebuild-attestation.test.ts
@@ -1,6 +1,7 @@
 import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
 import { Hono } from "hono";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
+import worker from "../../server/index";
 import { createDb } from "../../server/db/client";
 import { ensurePersonalOrganization } from "../../server/db/organizations";
 import { createScanJob, persistScan } from "../../server/db/scans";
@@ -161,6 +162,42 @@ function successfulExecution(): RebuildExecution {
 }
 
 describe("rebuild attestation job", () => {
+  test("retries queue messages when persistence infrastructure fails", async () => {
+    const retry = vi.fn();
+    const body = {
+      kind: "rebuild_attestation" as const,
+      organizationId: "org-retry",
+      scanId: "scan-retry",
+    };
+    const batch = {
+      messages: [{ body, attempts: 1, retry }],
+    } as unknown as MessageBatch<import("../../server/lib/scan-job").QueueMessage>;
+    const brokenEnv = {
+      ...env,
+      DB: {
+        prepare() {
+          throw new Error("transient D1 failure");
+        },
+      },
+    } as unknown as Cloudflare.Env;
+    const ctx = createExecutionContext();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await worker.queue(batch, brokenEnv, ctx);
+
+    expect(retry).toHaveBeenCalledWith({ delaySeconds: 5 });
+    expect(warn).toHaveBeenCalledWith(
+      "rebuild.queue.retry_scheduled",
+      expect.objectContaining({
+        event: "rebuild.queue.retry_scheduled",
+        scanId: body.scanId,
+        organizationId: body.organizationId,
+        attempt: 1,
+      }),
+    );
+    warn.mockRestore();
+  });
+
   test("resolves a pending plan to byte-identical and persists it for readers", async () => {
     const owner = await seedUser();
     const scanId = await seedCompletedScan(owner, pendingAttestation());

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -32,6 +32,30 @@
 			"binding": "LOADER"
 		}
 	],
+	// Rebuild-attestation container (opt-in via the `rebuild-attestation`
+	// Flagship flag). Disposable, credential-free, deny-by-default egress; see
+	// server/lib/rebuild-sandbox.ts and docs/rebuild-attestation.md.
+	"containers": [
+		{
+			"class_name": "RebuildSandbox",
+			"image": "./container/Dockerfile",
+			"max_instances": 5
+		}
+	],
+	"durable_objects": {
+		"bindings": [
+			{
+				"name": "REBUILD_SANDBOX",
+				"class_name": "RebuildSandbox"
+			}
+		]
+	},
+	"migrations": [
+		{
+			"tag": "v1",
+			"new_sqlite_classes": ["RebuildSandbox"]
+		}
+	],
 	"d1_databases": [
 		{
 			"binding": "DB",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -32,30 +32,13 @@
 			"binding": "LOADER"
 		}
 	],
-	// Rebuild-attestation container (opt-in via the `rebuild-attestation`
-	// Flagship flag). Disposable, credential-free, deny-by-default egress; see
-	// server/lib/rebuild-sandbox.ts and docs/rebuild-attestation.md.
-	"containers": [
-		{
-			"class_name": "RebuildSandbox",
-			"image": "./container/Dockerfile",
-			"max_instances": 5
-		}
-	],
-	"durable_objects": {
-		"bindings": [
-			{
-				"name": "REBUILD_SANDBOX",
-				"class_name": "RebuildSandbox"
-			}
-		]
-	},
-	"migrations": [
-		{
-			"tag": "v1",
-			"new_sqlite_classes": ["RebuildSandbox"]
-		}
-	],
+	// The rebuild-attestation container config (containers + REBUILD_SANDBOX
+	// Durable Object binding + its migration) is intentionally NOT here yet:
+	// a Durable Object migration cannot ride the versioned uploads Workers
+	// Builds performs, so it lands in a separate infra change applied by a
+	// one-time non-versioned `wrangler deploy` (with Docker available for the
+	// image build). Until then the binding is absent and rebuild jobs resolve
+	// to `inconclusive`. See docs/rebuild-attestation.md.
 	"d1_databases": [
 		{
 			"binding": "DB",


### PR DESCRIPTION
Closes #499. Stacked on #478 (intent envelope) — this PR targets that branch; once #478 merges it retargets to main and only the rebuild-attestation diff remains.

## What

Opt-in per organization (Flagship flag `rebuild-attestation`, **default off**): for a staged npm publish with a declared repository, Drydock checks out the repo in a disposable Cloudflare container, runs install + build + pack, and attests how strongly the result matches the staged artifact. It is the empirical upgrade of the envelope's `declared` tier — advisory only, never changes risk or findings.

```
byte-identical   rebuilt tarball SHA-1 == staged shasum (and file sets agree)
file-identical   every packed file's sha256 matches; only tar/pack metadata differs
diverged         build succeeded, file sets differ (divergent/missing/extra path lists)
inconclusive     ref unresolvable / build failed / unsupported strategy / no sandbox
```

For most straightforward repos (install + build → dist/), `file-identical` or `byte-identical` is the expected outcome; ecosystem-wide, vlt's `reproduce` measured only ~6% byte-for-byte, so failures render as neutral information, never as a risk signal.

## How

- **Scan time**: `computeRebuildPlan` derives repository (from the envelope), checkout refs (`gitHead` from the staged version manifest — newly captured on `StagedPublishDetails` — then `v{version}`/`{version}` tags), `repository.directory`, and the staged `shasum`; persisted as a `pending` record in `summary.rebuildAttestation` (summary blob only, no migration).
- **Deferred job** on SCAN_QUEUE (`rebuild_attestation` kind): rebuild runs minutes-long in a container and never blocks scan completion.
- **Container** (`RebuildSandbox`, Sandbox SDK 0.12.3 + `container/Dockerfile`): deny-by-default `allowedHosts` (forges + registry.npmjs.org), `interceptHttps`, zero credentials, single-shot per scan, destroyed after. Strategy: `packageManager` via corepack, else lockfile heuristics (npm + pnpm; yarn → unsupported). Install always `--ignore-scripts`; the package's own build/prepack scripts are the thing being attested.
- **Comparison happens in the Worker** against the scan's persisted R2 `files.json` hashes + staged shasum. Staged bytes are never re-fetched and never enter the container — pre-publish, a hostile build cannot fetch-and-replay the expected bytes because the staged tarball sits behind npm auth the container doesn't have.
- Container output (hash manifest) is hostile input: bounded, re-validated (`normalizeRebuildAttestation`, same pattern as the envelope), and a forged manifest can only self-harm into `diverged`/`inconclusive`.
- Readers: "Source binding" row on scan detail, additive optional `rebuildAttestation` in `drydock.report.v1`, pre-feature scans normalize to null.
- Environments without the `REBUILD_SANDBOX` binding degrade to `inconclusive` with a "sandbox not configured" signal.

v1 scope: staged npm scans only (gate scans are already run-bound; PyPI/VSIX have no strategy yet).

## Tests

- `test/rebuild-attestation.test.mjs` — plan computation (ref ladder, hostile gitHead/directory rejection), comparison ladder (path normalization, sorted divergence lists, incomplete-hash bailout, forged-shasum belt-and-braces), normalize guard, and the container step logic against a scripted exec runner (npm/pnpm strategies, tag fallback, monorepo scoping, failure stops).
- `test/scan-pipeline.test.mjs` — pending plan persisted only with the opt-in flag; default stays off.
- `test/workers/scan-rebuild-attestation.test.ts` — job resolves pending → byte-identical against real R2 artifacts; diverged leaves risk untouched; sandbox-unavailable and failed-build inconclusive paths; org scoping + no-plan skips.
- `pnpm run verify` green.

Docs: new `docs/rebuild-attestation.md`, index entry, security-model "No package execution" exception, AGENTS.md boundary note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)