### PR TITLE
Chunk staged-publish dedup lookup under D1's bound-parameter cap

### DIFF
--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -149,16 +149,24 @@ export async function listExistingScanStageIds(
   stageIds: string[],
 ) {
   if (!stageIds.length) return new Set<string>();
-  const rows = await db
-    .select({ stageId: scans.stageId })
-    .from(scans)
-    .where(
-      and(
-        inArray(scans.stageId, stageIds),
-        or(eq(scans.organizationId, organizationId), eq(scans.status, "complete")),
-      ),
-    );
-  return new Set(rows.map((row) => row.stageId));
+  // Discovery passes every staged publish it saw, which is unbounded; each id
+  // is one bound parameter, so chunk below D1's cap (reserving slots for the
+  // organizationId and status parameters) or the sweep throws
+  // "too many SQL variables" once an org stages ~100 items.
+  const known = new Set<string>();
+  for (const chunk of chunkForD1([...new Set(stageIds)], 1, 2)) {
+    const rows = await db
+      .select({ stageId: scans.stageId })
+      .from(scans)
+      .where(
+        and(
+          inArray(scans.stageId, chunk),
+          or(eq(scans.organizationId, organizationId), eq(scans.status, "complete")),
+        ),
+      );
+    for (const row of rows) known.add(row.stageId);
+  }
+  return known;
 }
 
 const NON_TERMINAL_STATUSES = ["pending", "running"] as const;
@@ -493,9 +501,12 @@ function withFindingAnnotations(
 
 const D1_MAX_BOUND_PARAMETERS = 100;
 
-export function chunkForD1<T>(rows: T[], columnsPerRow: number): T[][] {
+export function chunkForD1<T>(rows: T[], columnsPerRow: number, reservedParameters = 0): T[][] {
   if (!rows.length) return [];
-  const chunkSize = Math.max(1, Math.floor(D1_MAX_BOUND_PARAMETERS / columnsPerRow));
+  const chunkSize = Math.max(
+    1,
+    Math.floor((D1_MAX_BOUND_PARAMETERS - reservedParameters) / columnsPerRow),
+  );
   const chunks: T[][] = [];
   for (let i = 0; i < rows.length; i += chunkSize) {
     chunks.push(rows.slice(i, i + chunkSize));

--- a/server/index.ts
+++ b/server/index.ts
@@ -438,7 +438,17 @@ async function pruneStaleAuditEvents(env: Cloudflare.Env) {
 export default {
   fetch: app.fetch,
   async scheduled(_event: ScheduledController, env: Cloudflare.Env, ctx: ExecutionContext) {
-    await runStagedPublishesDiscoveryCron(env, ctx);
+    // The discovery sweep's first D1 read runs before the per-organization
+    // try/catch, so a transient D1 failure here used to surface as an uncaught
+    // exception and skip audit pruning. The sweep is idempotent and the next
+    // tick is 15 minutes away — log and move on instead of throwing.
+    try {
+      await runStagedPublishesDiscoveryCron(env, ctx);
+    } catch (err) {
+      emitOperationalEvent("error", "staged_publishes.cron.failed", {
+        error: describeOperationalError(err),
+      });
+    }
     await pruneStaleAuditEvents(env);
   },
   async queue(batch: MessageBatch<QueueMessage>, env: Cloudflare.Env, ctx: ExecutionContext) {

--- a/server/lib/observability.ts
+++ b/server/lib/observability.ts
@@ -37,9 +37,12 @@ export interface OperationalErrorSummary {
 // Drizzle wraps D1 failures in "Failed query: <sql>\nparams: <bound values>".
 // The bound values can carry anything a query touches (tokens, emails), so
 // they never reach the logs; the SQL text itself is static application code.
+// Keyed on the "\nparams:" delimiter rather than the "Failed query" prose
+// prefix so a drizzle wording change (or a wrapper that prefixes the message)
+// cannot silently disable the redaction. Over-matching an unrelated multiline
+// message is acceptable; leaking bound values is not.
 function redactFailedQueryParams(message: string): string {
-  if (!message.startsWith("Failed query")) return message;
-  return message.replace(/\bparams:[\s\S]*$/, "params: [redacted]");
+  return message.replace(/\nparams:[\s\S]*$/, "\nparams: [redacted]");
 }
 
 const ERROR_CAUSE_MAX_DEPTH = 3;

--- a/server/lib/observability.ts
+++ b/server/lib/observability.ts
@@ -28,15 +28,43 @@ export function emitOperationalEvent(
   }
 }
 
-export function describeOperationalError(err: unknown) {
+export interface OperationalErrorSummary {
+  name: string;
+  message?: string;
+  cause?: OperationalErrorSummary;
+}
+
+// Drizzle wraps D1 failures in "Failed query: <sql>\nparams: <bound values>".
+// The bound values can carry anything a query touches (tokens, emails), so
+// they never reach the logs; the SQL text itself is static application code.
+function redactFailedQueryParams(message: string): string {
+  if (!message.startsWith("Failed query")) return message;
+  return message.replace(/\bparams:[\s\S]*$/, "params: [redacted]");
+}
+
+const ERROR_CAUSE_MAX_DEPTH = 3;
+
+export function describeOperationalError(err: unknown, depth = 0): OperationalErrorSummary {
   if (err instanceof Error) {
-    return { name: err.name, message: err.message };
+    const summary: OperationalErrorSummary = {
+      name: err.name,
+      message: redactFailedQueryParams(err.message),
+    };
+    // Drizzle (and undici) surface the real failure — e.g. the underlying
+    // D1_ERROR — only on `cause`; without it the log says "Failed query" and
+    // nothing else, which is undiagnosable after the fact.
+    const cause = (err as { cause?: unknown }).cause;
+    if (cause !== undefined && cause !== null && depth < ERROR_CAUSE_MAX_DEPTH) {
+      summary.cause = describeOperationalError(cause, depth + 1);
+    }
+    return summary;
   }
   if (err && typeof err === "object") {
     const value = err as Record<string, unknown>;
     return {
       name: typeof value.name === "string" ? value.name : "UnknownError",
-      message: typeof value.message === "string" ? value.message : undefined,
+      message:
+        typeof value.message === "string" ? redactFailedQueryParams(value.message) : undefined,
     };
   }
   return { name: typeof err };
@@ -55,7 +83,11 @@ function sanitizeValue(
   if (key && SENSITIVE_KEY_RE.test(key)) return "[redacted]";
   if (typeof value === "string") return value.replace(BEARER_RE, "Bearer [redacted]");
   if (value === null || typeof value !== "object") return value;
-  if (value instanceof Error) return describeOperationalError(value);
+  // Re-sanitize the described error so its message strings (and cause chain)
+  // still get the Bearer-token redaction applied to every other string.
+  if (value instanceof Error) {
+    return sanitizeValue(describeOperationalError(value), seen, depth + 1, null);
+  }
   if (depth > 5) return "[truncated]";
   if (seen.has(value)) return "[circular]";
   seen.add(value);

--- a/test/observability.test.mjs
+++ b/test/observability.test.mjs
@@ -95,6 +95,13 @@ describe("operational observability helpers", () => {
     expect(describeOperationalError(new Error("invalid params: foo")).message).toBe(
       "invalid params: foo",
     );
+    // The redaction keys on the "\nparams:" delimiter, not drizzle's prose
+    // prefix, so reworded or re-wrapped query errors stay redacted.
+    expect(
+      describeOperationalError(
+        new Error("Failed to execute query: select 1\nparams: npm_secret,jovi@example.com"),
+      ).message,
+    ).toBe("Failed to execute query: select 1\nparams: [redacted]");
   });
 
   test("sanitizes error messages and causes inside logged fields", () => {

--- a/test/observability.test.mjs
+++ b/test/observability.test.mjs
@@ -56,4 +56,59 @@ describe("operational observability helpers", () => {
       message: "D1_ERROR: column not found",
     });
   });
+
+  test("surfaces the cause chain so wrapped D1 errors stay diagnosable", () => {
+    // Drizzle wraps the real D1 failure: without the cause, the log only says
+    // "Failed query" and the outage on the other end is invisible.
+    const wrapped = new Error('Failed query: select "id" from "npm_connections"', {
+      cause: new Error("D1_ERROR: Network connection lost."),
+    });
+    expect(describeOperationalError(wrapped)).toEqual({
+      name: "Error",
+      message: 'Failed query: select "id" from "npm_connections"',
+      cause: { name: "Error", message: "D1_ERROR: Network connection lost." },
+    });
+  });
+
+  test("bounds the described cause chain depth", () => {
+    let err = new Error("level-5");
+    for (let level = 4; level >= 0; level -= 1) {
+      err = new Error(`level-${level}`, { cause: err });
+    }
+    let described = describeOperationalError(err);
+    let depth = 0;
+    while (described.cause) {
+      described = described.cause;
+      depth += 1;
+    }
+    expect(depth).toBe(3);
+  });
+
+  test("redacts bound parameters from failed-query messages", () => {
+    const wrapped = new Error(
+      'Failed query: update "npm_connections" set "last_used_at" = ? where "organization_id" = ?\nparams: 1784219455018,personal:abc123',
+    );
+    expect(describeOperationalError(wrapped).message).toBe(
+      'Failed query: update "npm_connections" set "last_used_at" = ? where "organization_id" = ?\nparams: [redacted]',
+    );
+    // Non-query messages that merely mention params are left alone.
+    expect(describeOperationalError(new Error("invalid params: foo")).message).toBe(
+      "invalid params: foo",
+    );
+  });
+
+  test("sanitizes error messages and causes inside logged fields", () => {
+    const sanitized = sanitizeOperationalFields({
+      error: new Error("upstream said Bearer abc123secret", {
+        cause: new Error("also Bearer abc123secret"),
+      }),
+    });
+    expect(sanitized).toEqual({
+      error: {
+        name: "Error",
+        message: "upstream said Bearer [redacted]",
+        cause: { name: "Error", message: "also Bearer [redacted]" },
+      },
+    });
+  });
 });

--- a/test/workers/discovery-cron.test.ts
+++ b/test/workers/discovery-cron.test.ts
@@ -322,4 +322,32 @@ describe("staged publishes discovery cron", () => {
     });
     expect(orgA.email).toContain("@example.com");
   });
+
+  // Regression: on 2026-07-16 a transient D1 outage made the sweep's first
+  // read (listAutoDiscoveryNpmConnections) throw before the per-organization
+  // try/catch, which surfaced as an uncaught exception on the scheduled
+  // invocation and skipped audit pruning. The tick must log and complete.
+  test("a D1 failure during the sweep does not crash the scheduled invocation", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const brokenDb = {
+      prepare(): never {
+        throw new Error("D1_ERROR: simulated outage");
+      },
+    } as unknown as D1Database;
+
+    const ctx = createExecutionContext();
+    await worker.scheduled(
+      scheduledController(),
+      { ...env, DB: brokenDb } as unknown as Cloudflare.Env,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    const events = errorSpy.mock.calls.map((call) => call[0]);
+    expect(events).toContain("staged_publishes.cron.failed");
+    // Pruning still ran (and failed against the same broken binding) instead
+    // of being skipped by an uncaught sweep exception.
+    expect(events).toContain("audit_events.prune_failed");
+  });
 });

--- a/test/workers/scan-idempotency.test.ts
+++ b/test/workers/scan-idempotency.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "vitest";
 import { createDb } from "../../server/db/client";
 import { ensurePersonalOrganization } from "../../server/db/organizations";
 import {
+  chunkForD1,
   claimScanForRun,
   createScanJob,
   getScan,
@@ -265,6 +266,37 @@ describe("scan persistence idempotency", () => {
     expect(known.has(orgBOnlyStageId)).toBe(true);
     expect(known.has(inProgressStageId)).toBe(false);
     expect(known.has(untouchedStageId)).toBe(false);
+  });
+
+  // Regression: discovery passes every staged publish the registry lists, and
+  // D1 caps bound parameters at 100 per query. Before chunking, a sweep of
+  // ~100 staged items threw "too many SQL variables" on every cron tick.
+  test("listExistingScanStageIds handles more stage ids than D1's parameter cap", async () => {
+    const owner = await seedUserAndOrg();
+    const knownStageId = `stage-${crypto.randomUUID()}`;
+    await createScanJob(owner.db, {
+      id: `scan_${crypto.randomUUID()}`,
+      stageId: knownStageId,
+      organizationId: owner.organizationId,
+      ownerUserId: owner.userId,
+    });
+
+    const stageIds = Array.from({ length: 250 }, (_, i) => `stage-bulk-${i}`);
+    // Place the known id past the first chunk so the union across chunks is
+    // exercised, not just the first query.
+    stageIds.splice(180, 0, knownStageId);
+
+    const known = await listExistingScanStageIds(owner.db, owner.organizationId, stageIds);
+    expect(known.has(knownStageId)).toBe(true);
+    expect(known.size).toBe(1);
+  });
+
+  test("chunkForD1 reserves fixed parameters when sizing chunks", () => {
+    const rows = Array.from({ length: 250 }, (_, i) => i);
+    const chunks = chunkForD1(rows, 1, 2);
+    expect(chunks.every((chunk) => chunk.length <= 98)).toBe(true);
+    expect(chunks.flat()).toEqual(rows);
+    expect(chunkForD1([], 1, 2)).toEqual([]);
   });
 
   test("cross-organization claims and mutations are rejected", async () => {


### PR DESCRIPTION
Discovery passes every staged publish the registry lists into
listExistingScanStageIds, which bound one SQL variable per stage id.
D1 caps queries at 100 bound parameters, so once an organization's
staged list reached ~99 items the sweep threw "too many SQL variables
at offset ...: SQLITE_ERROR" on every cron tick and manual discovery,
surfacing as staged_publishes.cron.org_failed for that organization.

Reuse chunkForD1 (extended with a reserved-parameter count for the
organization and status bindings) to split the lookup and union the
results, mirroring how persistScan already chunks its inserts.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W8jXqNcK6Hb3a1R62xejwt