### PR TITLE
Allowlist npm's own lifecycle env vars in code.credential-access

### DIFF
--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -59,7 +59,7 @@ The first corpus slice covers:
 
 - benign version bump control;
 - preinstall credential/environment collection with command and network capability;
-- credential file-path reads (`.aws/credentials`, `.ssh/id_`, `.netrc`) in addition to broad environment reads and known token names, matching the Python rule coverage while excluding common non-secret JS runtime flags;
+- credential file-path reads (`.aws/credentials`, `.ssh/id_`, `.netrc`) in addition to broad environment reads and known token names, matching the Python rule coverage while excluding common non-secret JS runtime flags and npm's own lifecycle variables (`npm_command`, `npm_lifecycle_event`, `npm_package_name`, …) — but not `npm_config_*`, which can carry live registry auth such as `npm_config__authToken`;
 - the collect-and-exfiltrate sink: a single file that reads credentials and has a network egress path escalates `code.credential-access` to high even on a modified (not newly added) module;
 - implicit `node-gyp rebuild` from root `binding.gyp`, GYP command substitution that executes package JavaScript, and native artifact review — by extension and by magic-byte flags, so extensionless Linux/macOS platform binaries are held to the same bar as a Windows `.exe`;
 - base64/dynamic evaluation plus network-capable code, including the `WebAssembly.instantiateStreaming(fetch(...))` loader idiom (the whole `compile`/`compileStreaming`/`instantiate`/`instantiateStreaming` family counts as dynamic evaluation) and literal `node -e`/`node --eval` child-process launches;

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -101,7 +101,7 @@ A PyPI review runs two rule families over the staged artifacts:
 
 - `pypi.*` findings come from `pyPiReleaseFindings` and carry `PYPI_RULES_VERSION` (currently `0.2.0`).
 - shared `file.*` / `code.*` / `diff.*` findings come from `deterministicFindings` and carry
-  `DETERMINISTIC_RULES_VERSION` (currently `1.15.0`).
+  `DETERMINISTIC_RULES_VERSION` (currently `1.16.0`).
 
 The harness asserts this per family: every `pypi.*` finding must equal `PYPI_RULES_VERSION` and every
 other finding must equal `DETERMINISTIC_RULES_VERSION`. Bump the relevant constant **and** update the
@@ -169,7 +169,16 @@ javascript-obfuscator-style rotating string-table wrapper is marked `obfuscated`
 the existing risk rule that keeps a lone hidden process capability at high instead of applying the
 benign build-helper de-escalation. The wrapper requires five independent structural signals
 (hexadecimal lookup identifiers and function, `while (!![])`, lookup-fed `parseInt`, and bracketed
-`push`/`shift`) to avoid treating ordinary minified names or queue rotation as malice.
+`push`/`shift`) to avoid treating ordinary minified names or queue rotation as malice. `1.16.0`
+allowlists npm's own lifecycle variables (`npm_command`, `npm_execpath`, `npm_lifecycle_event`,
+`npm_lifecycle_script`, `npm_node_execpath`, `npm_package_json`, `npm_package_name`,
+`npm_package_version`) in the environment-access pre-strip that runs before JavaScript
+`code.credential-access` matching: npm exports them onto every lifecycle-script process and they
+describe only the npm invocation and the package's own manifest, so reading them was a pure false
+positive (observed on dt-clean 1.2.1 and salita 2.0.0). `npm_config_*` is deliberately not
+allowlisted because it can carry live registry auth (`npm_config__authToken`). The strip also now
+preserves newlines when erasing a match, so a multiline access can no longer shift later findings'
+line numbers.
 
 ### Fixture format
 

--- a/server/lib/review-rules/index.ts
+++ b/server/lib/review-rules/index.ts
@@ -16,7 +16,7 @@ import { entrypointDiffFindings } from "./entrypoints";
 // way that should invalidate cached scan reports. Stored alongside each finding
 // so historical reports can be traced back to the ruleset that produced them.
 // Lives here (not in a family module) because versioning spans every family.
-export const DETERMINISTIC_RULES_VERSION = "1.15.0";
+export const DETERMINISTIC_RULES_VERSION = "1.16.0";
 
 export { DETERMINISTIC_RULE_IDS } from "./rule-ids";
 export {

--- a/server/lib/review-rules/scripts.ts
+++ b/server/lib/review-rules/scripts.ts
@@ -27,7 +27,23 @@ const COMMON_JS_ENV_NAMES = [
   "SSR",
   "TZ",
 ];
-const COMMON_JS_ENV_NAME_PATTERN = COMMON_JS_ENV_NAMES.map(escapeRegex).join("|");
+// npm exports these onto every lifecycle-script process; they only describe the
+// running npm invocation and the package's own manifest, never secrets.
+// npm_config_* is deliberately excluded: it can carry live registry auth
+// (npm_config__authToken) and stays covered by the credential patterns.
+const NPM_LIFECYCLE_ENV_NAMES = [
+  "npm_command",
+  "npm_execpath",
+  "npm_lifecycle_event",
+  "npm_lifecycle_script",
+  "npm_node_execpath",
+  "npm_package_json",
+  "npm_package_name",
+  "npm_package_version",
+];
+const COMMON_JS_ENV_NAME_PATTERN = [...COMMON_JS_ENV_NAMES, ...NPM_LIFECYCLE_ENV_NAMES]
+  .map(escapeRegex)
+  .join("|");
 const COMMON_PROCESS_ENV_DOT_ACCESS = new RegExp(
   `\\bprocess\\.env\\s*\\.\\s*(?:${COMMON_JS_ENV_NAME_PATTERN})\\b`,
   "g",

--- a/server/lib/review-rules/scripts.ts
+++ b/server/lib/review-rules/scripts.ts
@@ -320,10 +320,18 @@ function hasRotatingStringTableObfuscation(source: string): boolean {
 
 function omitCommonEnvironmentAccesses(source: string): string {
   return source
-    .replace(COMMON_PROCESS_ENV_DOT_ACCESS, "")
-    .replace(COMMON_PROCESS_ENV_BRACKET_ACCESS, "")
-    .replace(COMMON_IMPORT_META_ENV_DOT_ACCESS, "")
-    .replace(COMMON_IMPORT_META_ENV_BRACKET_ACCESS, "");
+    .replace(COMMON_PROCESS_ENV_DOT_ACCESS, eraseKeepingNewlines)
+    .replace(COMMON_PROCESS_ENV_BRACKET_ACCESS, eraseKeepingNewlines)
+    .replace(COMMON_IMPORT_META_ENV_DOT_ACCESS, eraseKeepingNewlines)
+    .replace(COMMON_IMPORT_META_ENV_BRACKET_ACCESS, eraseKeepingNewlines);
+}
+
+// The access regexes' \s* can span newlines (`process.env\n  .npm_command`), so
+// erasing a match outright would shrink the line count and point every later
+// finding — and the release-delta changed-line check that consumes finding.line
+// — one line early. Keep the match's newlines so line numbers stay stable.
+function eraseKeepingNewlines(match: string): string {
+  return match.replace(/[^\n]+/g, "");
 }
 
 function escapeRegex(value: string): string {

--- a/test/fixtures/security-corpus/cases/npm-config-auth-token-read.json
+++ b/test/fixtures/security-corpus/cases/npm-config-auth-token-read.json
@@ -1,0 +1,49 @@
+{
+  "id": "npm-config-auth-token-read",
+  "title": "Added script reads npm registry auth from npm_config__authToken",
+  "category": "credential-access",
+  "intent": "npm_config_* variables can carry live registry auth (npm_config__authToken), so they stay outside the npm lifecycle-variable allowlist and must keep raising code.credential-access.",
+  "previousPackageJson": {
+    "name": "npm-config-auth-token-read",
+    "version": "1.0.0",
+    "main": "index.js"
+  },
+  "stagedPackageJson": {
+    "name": "npm-config-auth-token-read",
+    "version": "1.0.1",
+    "main": "index.js"
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 74,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"npm-config-auth-token-read\",\"version\":\"1.0.0\",\"main\":\"index.js\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 74,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"npm-config-auth-token-read\",\"version\":\"1.0.1\",\"main\":\"index.js\"}"
+    },
+    {
+      "path": "collect.js",
+      "size": 130,
+      "sha256": "collect-js",
+      "flags": [],
+      "textSample": "const event = process.env.npm_lifecycle_event;\nconst registryAuth = process.env.npm_config__authToken;\nmodule.exports = { event, registryAuth };\n"
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "code.credential-access",
+      "severity": "high",
+      "file": "collect.js"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases/npm-config-auth-token-read.json
+++ b/test/fixtures/security-corpus/cases/npm-config-auth-token-read.json
@@ -16,7 +16,7 @@
   "previousFiles": [
     {
       "path": "package.json",
-      "size": 74,
+      "size": 73,
       "sha256": "prev-package-json",
       "flags": [],
       "textSample": "{\"name\":\"npm-config-auth-token-read\",\"version\":\"1.0.0\",\"main\":\"index.js\"}"
@@ -25,14 +25,14 @@
   "stagedFiles": [
     {
       "path": "package.json",
-      "size": 74,
+      "size": 73,
       "sha256": "staged-package-json",
       "flags": [],
       "textSample": "{\"name\":\"npm-config-auth-token-read\",\"version\":\"1.0.1\",\"main\":\"index.js\"}"
     },
     {
       "path": "collect.js",
-      "size": 130,
+      "size": 145,
       "sha256": "collect-js",
       "flags": [],
       "textSample": "const event = process.env.npm_lifecycle_event;\nconst registryAuth = process.env.npm_config__authToken;\nmodule.exports = { event, registryAuth };\n"

--- a/test/fixtures/security-corpus/cases/npm-lifecycle-env-read.json
+++ b/test/fixtures/security-corpus/cases/npm-lifecycle-env-read.json
@@ -16,7 +16,7 @@
   "previousFiles": [
     {
       "path": "package.json",
-      "size": 71,
+      "size": 69,
       "sha256": "prev-package-json",
       "flags": [],
       "textSample": "{\"name\":\"npm-lifecycle-env-read\",\"version\":\"1.0.0\",\"main\":\"index.js\"}"
@@ -25,14 +25,14 @@
   "stagedFiles": [
     {
       "path": "package.json",
-      "size": 71,
+      "size": 69,
       "sha256": "staged-package-json",
       "flags": [],
       "textSample": "{\"name\":\"npm-lifecycle-env-read\",\"version\":\"1.0.1\",\"main\":\"index.js\"}"
     },
     {
       "path": "setup.mjs",
-      "size": 260,
+      "size": 352,
       "sha256": "setup-mjs",
       "flags": [],
       "textSample": "const command = process.env.npm_command;\nconst event = process.env.npm_lifecycle_event;\nconst script = process.env['npm_lifecycle_script'];\nconst name = process.env.npm_package_name;\nconst version = process.env['npm_package_version'];\nif (event !== 'prepare') process.exit(0);\nconsole.log(`${name}@${version} running ${command}:${event} (${script})`);\n"

--- a/test/fixtures/security-corpus/cases/npm-lifecycle-env-read.json
+++ b/test/fixtures/security-corpus/cases/npm-lifecycle-env-read.json
@@ -1,0 +1,43 @@
+{
+  "id": "npm-lifecycle-env-read",
+  "title": "Added script reads npm's own lifecycle environment variables",
+  "category": "benign-env-read",
+  "intent": "npm exports npm_command, npm_lifecycle_event, npm_package_name and friends onto every lifecycle-script process; they describe the running npm invocation, never secrets. Reading them must not raise code.credential-access (observed as false positives on dt-clean 1.2.1 and salita 2.0.0).",
+  "previousPackageJson": {
+    "name": "npm-lifecycle-env-read",
+    "version": "1.0.0",
+    "main": "index.js"
+  },
+  "stagedPackageJson": {
+    "name": "npm-lifecycle-env-read",
+    "version": "1.0.1",
+    "main": "index.js"
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 71,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"npm-lifecycle-env-read\",\"version\":\"1.0.0\",\"main\":\"index.js\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 71,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"npm-lifecycle-env-read\",\"version\":\"1.0.1\",\"main\":\"index.js\"}"
+    },
+    {
+      "path": "setup.mjs",
+      "size": 260,
+      "sha256": "setup-mjs",
+      "flags": [],
+      "textSample": "const command = process.env.npm_command;\nconst event = process.env.npm_lifecycle_event;\nconst script = process.env['npm_lifecycle_script'];\nconst name = process.env.npm_package_name;\nconst version = process.env['npm_package_version'];\nif (event !== 'prepare') process.exit(0);\nconsole.log(`${name}@${version} running ${command}:${event} (${script})`);\n"
+    }
+  ],
+  "expectedRisk": "low",
+  "expectedFindings": []
+}

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -530,6 +530,29 @@ describe("review", () => {
     );
   });
 
+  test("keeps credential finding lines stable when a multiline env access is stripped", () => {
+    // The allowlist strip erases `process.env\n  .npm_command` across the line
+    // break; if it also swallowed the newline, the authToken read below would be
+    // reported at line 2 instead of its real line 3.
+    const staged = [
+      {
+        path: "index.js",
+        size: 92,
+        sha256: "multiline-env",
+        flags: [],
+        textSample:
+          "const a = process.env\n  .npm_command;\nconst b = process.env.npm_config__authToken;\n",
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged));
+
+    expect(findings.find((finding) => finding.ruleId === "code.credential-access")).toMatchObject({
+      severity: "high",
+      file: "index.js",
+      line: 3,
+    });
+  });
+
   test("still flags token reads next to common env flags", () => {
     const staged = [
       {


### PR DESCRIPTION
npm exports npm_command, npm_lifecycle_event, npm_lifecycle_script,
npm_node_execpath, npm_execpath, npm_package_name, npm_package_version,
and npm_package_json onto every lifecycle-script process. They describe
the running npm invocation and the package's own manifest, never
secrets, but reading them tripped a medium code.credential-access
finding (observed on dt-clean 1.2.1 setup.mjs and salita 2.0.0).

Strip these names in omitCommonEnvironmentAccesses alongside the
existing common runtime flags. npm_config_* is deliberately NOT
allowlisted: it can carry live registry auth (npm_config__authToken)
and the /\bnpm_config_/ credential pattern still covers it.

Bump DETERMINISTIC_RULES_VERSION to 1.16.0 and add corpus fixtures for
the allowlisted read (no finding) and an npm_config__authToken read
(still high on an added file).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01263sMh7Ems5uDPAedXrpQA