### PR TITLE
Keep DiffView responsive on megabyte-scale package files

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -27,6 +27,15 @@ Prefer existing primitives in `src/components/` before adding one-off classes:
 - Use severity stacked bars for risk distribution; avoid decorative charts.
 - Icons are text glyphs only; no SVG icon libraries.
 
+## Large diffs
+
+`DiffView` must stay responsive on megabyte-scale bundled artifacts (e.g. vite's 1.3 MiB `dist/node/chunks/node.js`):
+
+- Syntax highlighting is skipped per side above `HIGHLIGHT_MAX_LINES` (3,000 lines, ~1.7s of main-thread tokenization for bundled JS) or `HIGHLIGHT_MAX_CHARS` (256 KiB, guards minified few-enormous-lines samples) in `src/components/highlight.ts`. The meta row notes "syntax highlighting off (large file)".
+- Two-sided diffs collapse long unchanged runs into expandable gap rows (`src/components/diff-hunks.ts`, 3 context lines); rows carrying pinned findings never collapse.
+- Single-sided views render 1,000 lines initially with a "show more" expander; findings pinned past the rendered window fall back to the banner above the diff.
+- Word-diff pairing bails out for changed blocks beyond 10,000 line-pair combinations to avoid quadratic scoring.
+
 ## Signals reminder
 
 Render signals directly or derive with `useComputed`; do not eagerly unwrap `.value` in component bodies for conditional JSX. See `docs/tooling.md` and `.claude/skills/preact-signals-*` for the detailed rules.

--- a/src/components/DiffView.tsx
+++ b/src/components/DiffView.tsx
@@ -10,12 +10,14 @@ import {
   type DiffFinding,
   type SeverityGroup,
 } from "./diff-annotations";
+import { buildDisplaySegments, GAP_EXPAND_STEP } from "./diff-hunks";
 import {
   diffOverviewMarkers,
   type DiffOverviewMarker,
   type DiffOverviewRow,
 } from "./diff-overview";
 import {
+  canHighlight,
   ensureHighlighter,
   highlighterReady,
   langForPath,
@@ -228,11 +230,18 @@ function stripWhitespace(value: string): string {
   return value.replace(/\s+/g, "");
 }
 
+// pairChangedRows scores every removed×added line pair with a word diff, so a
+// single huge changed block (common in bundled artifacts) turns quadratic.
+// Beyond this cell budget the word-diff decoration is skipped for that block;
+// line tones still render.
+const WORD_DIFF_MAX_PAIR_CELLS = 10_000;
+
 function applyWordDiff(chunks: RowChunk[]) {
   for (let index = 0; index < chunks.length - 1; index += 1) {
     const removed = chunks[index];
     const added = chunks[index + 1];
     if (removed.tone !== "removed" || added.tone !== "added") continue;
+    if (removed.rows.length * added.rows.length > WORD_DIFF_MAX_PAIR_CELLS) continue;
     for (const [beforeRow, afterRow] of pairChangedRows(removed.rows, added.rows)) {
       const parts = buildWordParts(beforeRow.text, afterRow.text);
       beforeRow.wordParts = parts.before;
@@ -369,10 +378,12 @@ function partTone(part: ChangeObject<string>): WordPart["tone"] {
 }
 
 // Tokenize an entire side once, memoized on the sample/language/ready signal.
+// Sides beyond the highlight cap stay plain text: tokenizing them would block
+// the main thread for seconds (see HIGHLIGHT_MAX_LINES).
 function useLineTokens(text: string, lang: string | undefined): TokenLine[] | null {
   const ready = highlighterReady.value;
   return useMemo(
-    () => (lang && ready && text ? tokenizeLines(text, lang) : null),
+    () => (lang && ready && text && canHighlight(text) ? tokenizeLines(text, lang) : null),
     [text, lang, ready],
   );
 }
@@ -540,6 +551,11 @@ export function DiffView({
   const native = nativeBadge(after) ?? nativeBadge(before);
   const showDiffOptions = !binary && !contentSkipped && Boolean(beforeSample && afterSample);
   const hashLines = diffHashLines(before, after, beforeLabel, afterLabel);
+  const highlightCapped =
+    !binary &&
+    !contentSkipped &&
+    Boolean(langForPath(path)) &&
+    (!canHighlight(beforeSample) || !canHighlight(afterSample));
 
   return (
     <div class="flex flex-col gap-3 min-h-0">
@@ -564,6 +580,7 @@ export function DiffView({
           <span>
             {afterLabel}: {formatSize(after?.size ?? null)}
           </span>
+          {highlightCapped ? <span>syntax highlighting off (large file)</span> : null}
         </div>
         {hashLines.map((line) => (
           <span key={line} class="break-all">
@@ -665,7 +682,10 @@ function DiffBody({
   ignoreWhitespace: boolean;
 }) {
   const lang = langForPath(path);
-  if (lang && !binary) ensureHighlighter();
+  const anyHighlightableSide =
+    Boolean(beforeSample && canHighlight(beforeSample)) ||
+    Boolean(afterSample && canHighlight(afterSample));
+  if (lang && !binary && anyHighlightableSide) ensureHighlighter();
   const beforeTokens = useLineTokens(beforeSample, lang);
   const afterTokens = useLineTokens(afterSample, lang);
 
@@ -761,13 +781,77 @@ function DiffBody({
     );
   }
 
-  const rows = buildRows(beforeSample, afterSample, beforeTokens, afterTokens, {
-    wordDiff,
-    ignoreWhitespace,
-  });
+  return (
+    <TwoSidedView
+      path={path}
+      status={status}
+      beforeSample={beforeSample}
+      afterSample={afterSample}
+      beforeTokens={beforeTokens}
+      afterTokens={afterTokens}
+      beforeLabel={beforeLabel}
+      afterLabel={afterLabel}
+      findings={findings}
+      wordDiff={wordDiff}
+      ignoreWhitespace={ignoreWhitespace}
+    />
+  );
+}
+
+function TwoSidedView({
+  path,
+  status,
+  beforeSample,
+  afterSample,
+  beforeTokens,
+  afterTokens,
+  beforeLabel,
+  afterLabel,
+  findings,
+  wordDiff,
+  ignoreWhitespace,
+}: {
+  path: string;
+  status: string;
+  beforeSample: string;
+  afterSample: string;
+  beforeTokens: TokenLine[] | null;
+  afterTokens: TokenLine[] | null;
+  beforeLabel: string;
+  afterLabel: string;
+  findings: DiffFinding[];
+  wordDiff: boolean;
+  ignoreWhitespace: boolean;
+}) {
+  // Line-diffing two large sides is too expensive to redo on every render.
+  const rows = useMemo(
+    () =>
+      buildRows(beforeSample, afterSample, beforeTokens, afterTokens, {
+        wordDiff,
+        ignoreWhitespace,
+      }),
+    [beforeSample, afterSample, beforeTokens, afterTokens, wordDiff, ignoreWhitespace],
+  );
   const presentLines = new Set<number>();
   for (const row of rows) if (row.afterLine !== null) presentLines.add(row.afterLine);
   const { pinned, unpinned } = partitionFindingsByLine(findings, presentLines);
+  // Gap keys embed the file identity and the whitespace mode (which reshapes
+  // row indexes), so expansion state from a previously viewed file can never
+  // apply to the wrong gap.
+  const gapKeyPrefix = [path, beforeSample.length, afterSample.length, ignoreWhitespace].join("\0");
+  const expansions = useSignal<Record<string, number>>({});
+  const segments = buildDisplaySegments(
+    rows,
+    new Set(pinned.keys()),
+    expansions.value,
+    gapKeyPrefix,
+  );
+  const expandGap = (key: string) => {
+    expansions.value = {
+      ...expansions.value,
+      [key]: (expansions.value[key] ?? 0) + GAP_EXPAND_STEP,
+    };
+  };
   return (
     <div class="border border-border rounded-md overflow-hidden">
       <div class="bg-surface-2 px-3 py-2 font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle flex justify-between">
@@ -781,10 +865,22 @@ function DiffBody({
         >
           <table class="w-full border-collapse font-mono text-[12px] leading-[1.55]">
             <tbody>
-              {rows.map((row, index) => {
+              {segments.map((segment) => {
+                if (segment.kind === "gap") {
+                  return (
+                    <GapRow
+                      key={segment.key}
+                      hiddenCount={segment.hiddenCount}
+                      noun="unchanged lines"
+                      colSpan={4}
+                      onExpand={() => expandGap(segment.key)}
+                    />
+                  );
+                }
+                const row = rows[segment.index];
                 const pins = row.afterLine !== null ? pinned.get(row.afterLine) : undefined;
                 return (
-                  <Fragment key={index}>
+                  <Fragment key={segment.index}>
                     <DiffRow row={row} status={status} />
                     {pins ? (
                       <AnnotationRows
@@ -802,6 +898,36 @@ function DiffBody({
         <DiffOverview markers={diffOverviewMarkers(toOverviewRows(rows), pinned)} />
       </div>
     </div>
+  );
+}
+
+// A collapsed run of rows, rendered as a full-width expander. Clicking reveals
+// GAP_EXPAND_STEP rows from each edge of the gap so context grows around the
+// changes above and below it.
+function GapRow({
+  hiddenCount,
+  noun,
+  colSpan,
+  onExpand,
+}: {
+  hiddenCount: number;
+  noun: string;
+  colSpan: number;
+  onExpand: () => void;
+}) {
+  return (
+    <tr>
+      <td colSpan={colSpan} class="p-0">
+        <button
+          type="button"
+          onClick={onExpand}
+          aria-label={`Show more of ${hiddenCount} hidden ${noun}`}
+          class="w-full cursor-pointer border-y border-border bg-surface-2 px-3 py-1 text-center font-mono text-[11px] text-ink-subtle transition-colors hover:bg-accent-soft hover:text-ink"
+        >
+          ⋯ {hiddenCount.toLocaleString()} {noun} · show more
+        </button>
+      </td>
+    </tr>
   );
 }
 
@@ -827,6 +953,12 @@ function DiffRow({ row, status }: { row: Row; status: string }) {
   );
 }
 
+// Every line of a single-sided view is "changed", so there is nothing to
+// collapse; instead the table renders incrementally so a 36k-line added bundle
+// doesn't build tens of thousands of rows in one pass.
+const SINGLE_SIDED_INITIAL_LINES = 1000;
+const SINGLE_SIDED_LINE_STEP = 1000;
+
 function SingleSidedView({
   label,
   tone,
@@ -847,9 +979,19 @@ function SingleSidedView({
   const headerBg =
     tone === "added" ? "bg-ok-soft" : tone === "removed" ? "bg-danger-soft" : "bg-surface-2";
   const rowBg = tone === "added" ? "bg-ok-soft" : tone === "removed" ? "bg-danger-soft" : "";
-  const lines = text.split("\n");
-  if (lines.length && lines[lines.length - 1] === "") lines.pop();
-  const presentLines = new Set<number>(lines.map((_, index) => index + 1));
+  const lines = useMemo(() => splitLines(text), [text]);
+  // The stored count only applies while its resetKey matches, so switching
+  // files snaps back to the initial window without an effect.
+  const visibleStore = useSignal({ key: resetKey, count: SINGLE_SIDED_INITIAL_LINES });
+  const stored = visibleStore.value;
+  const visibleCount = Math.min(
+    lines.length,
+    stored.key === resetKey ? stored.count : SINGLE_SIDED_INITIAL_LINES,
+  );
+  const visibleLines = visibleCount < lines.length ? lines.slice(0, visibleCount) : lines;
+  // Findings pinned past the rendered window fall back to the banner above the
+  // diff (same as truncated samples), so capping rendering never hides one.
+  const presentLines = new Set<number>(visibleLines.map((_, index) => index + 1));
   const { pinned, unpinned } = partitionFindingsByLine(findings, presentLines);
   return (
     <div class="border border-border rounded-md overflow-hidden">
@@ -866,7 +1008,7 @@ function SingleSidedView({
         <DiffScrollViewport resetKey={resetKey}>
           <table class="w-full border-collapse font-mono text-[12px] leading-[1.55]">
             <tbody>
-              {lines.map((line, index) => {
+              {visibleLines.map((line, index) => {
                 const pins = pinned.get(index + 1);
                 return (
                   <Fragment key={index}>
@@ -891,6 +1033,19 @@ function SingleSidedView({
                   </Fragment>
                 );
               })}
+              {visibleCount < lines.length ? (
+                <GapRow
+                  hiddenCount={lines.length - visibleCount}
+                  noun="more lines"
+                  colSpan={2}
+                  onExpand={() =>
+                    (visibleStore.value = {
+                      key: resetKey,
+                      count: visibleCount + SINGLE_SIDED_LINE_STEP,
+                    })
+                  }
+                />
+              ) : null}
             </tbody>
           </table>
         </DiffScrollViewport>

--- a/src/components/diff-hunks.ts
+++ b/src/components/diff-hunks.ts
@@ -1,0 +1,81 @@
+// Collapses runs of unchanged rows in a diff table into expandable gap rows,
+// so a 36k-line bundle diff renders hundreds of DOM rows instead of tens of
+// thousands. Pure so DiffView's table stays declarative and this stays
+// unit-testable.
+
+export const GAP_CONTEXT_LINES = 3;
+// A run only collapses when it hides at least this many rows; below that the
+// gap row costs as much space as the lines it would hide.
+export const GAP_MIN_HIDDEN = 10;
+// Rows revealed per edge per "show more" click, so one click grows context
+// from both ends of the gap by this amount.
+export const GAP_EXPAND_STEP = 100;
+
+export interface HunkRowLike {
+  tone: "added" | "removed" | "unchanged";
+  afterLine: number | null;
+}
+
+export interface RowSegment {
+  kind: "row";
+  index: number;
+}
+
+export interface GapSegment {
+  kind: "gap";
+  key: string;
+  hiddenCount: number;
+}
+
+export type DisplaySegment = RowSegment | GapSegment;
+
+// `keepLines` are afterLine numbers that must stay visible (rows carrying
+// pinned findings); a collapsed row can never hide a deterministic signal.
+// `expansions` maps a gap key to how many rows each edge has revealed; keys
+// embed `keyPrefix` so stale entries from a previously viewed file never
+// collide with the current table.
+export function buildDisplaySegments(
+  rows: readonly HunkRowLike[],
+  keepLines: ReadonlySet<number>,
+  expansions: Readonly<Record<string, number>>,
+  keyPrefix: string,
+): DisplaySegment[] {
+  const keep = Array.from({ length: rows.length }, () => false);
+  for (let index = 0; index < rows.length; index += 1) {
+    const row = rows[index];
+    const anchored =
+      row.tone !== "unchanged" || (row.afterLine !== null && keepLines.has(row.afterLine));
+    if (!anchored) continue;
+    const from = Math.max(0, index - GAP_CONTEXT_LINES);
+    const to = Math.min(rows.length - 1, index + GAP_CONTEXT_LINES);
+    for (let context = from; context <= to; context += 1) keep[context] = true;
+  }
+
+  const segments: DisplaySegment[] = [];
+  let index = 0;
+  while (index < rows.length) {
+    if (keep[index]) {
+      segments.push({ kind: "row", index });
+      index += 1;
+      continue;
+    }
+    let runEnd = index;
+    while (runEnd < rows.length && !keep[runEnd]) runEnd += 1;
+    const key = `${keyPrefix}:${index}`;
+    const runLength = runEnd - index;
+    const expanded = Math.min(expansions[key] ?? 0, Math.ceil(runLength / 2));
+    const hiddenStart = index + expanded;
+    const hiddenEnd = Math.max(hiddenStart, runEnd - expanded);
+    if (hiddenEnd - hiddenStart < GAP_MIN_HIDDEN) {
+      // Fully reveal residual gaps below the collapse floor: a gap row hiding
+      // three lines is worse than the three lines.
+      for (let row = index; row < runEnd; row += 1) segments.push({ kind: "row", index: row });
+    } else {
+      for (let row = index; row < hiddenStart; row += 1) segments.push({ kind: "row", index: row });
+      segments.push({ kind: "gap", key, hiddenCount: hiddenEnd - hiddenStart });
+      for (let row = hiddenEnd; row < runEnd; row += 1) segments.push({ kind: "row", index: row });
+    }
+    index = runEnd;
+  }
+  return segments;
+}

--- a/src/components/highlight.ts
+++ b/src/components/highlight.ts
@@ -43,6 +43,30 @@ const BASE_TO_LANG: Record<string, string> = {
   Dockerfile: "docker",
 };
 
+// Tokenization runs synchronously on the main thread and its cost tracks line
+// count (~1.7s for 3,000 lines of bundled JavaScript per side, measured on
+// vite's dist chunks), so samples beyond this cap render as plain text instead
+// of freezing the tab.
+export const HIGHLIGHT_MAX_LINES = 3000;
+// Line count alone misses the few-enormous-lines shape (minified one-liners):
+// a single 512 KiB line already costs ~0.9s, so total size stays bounded too.
+export const HIGHLIGHT_MAX_CHARS = 256 * 1024;
+
+export function canHighlight(text: string): boolean {
+  return text.length <= HIGHLIGHT_MAX_CHARS && !exceedsLineCount(text, HIGHLIGHT_MAX_LINES);
+}
+
+function exceedsLineCount(text: string, limit: number): boolean {
+  let count = 1;
+  let index = text.indexOf("\n");
+  while (index !== -1) {
+    count += 1;
+    if (count > limit) return true;
+    index = text.indexOf("\n", index + 1);
+  }
+  return false;
+}
+
 export function langForPath(path: string): string | undefined {
   const base = path.split("/").pop() ?? path;
   const basenameLang = BASE_TO_LANG[base];

--- a/test/diff-hunks.test.ts
+++ b/test/diff-hunks.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildDisplaySegments,
+  GAP_CONTEXT_LINES,
+  GAP_EXPAND_STEP,
+  GAP_MIN_HIDDEN,
+  type HunkRowLike,
+} from "../src/components/diff-hunks";
+
+function unchangedRows(count: number, startLine = 1): HunkRowLike[] {
+  return Array.from({ length: count }, (_, index) => ({
+    tone: "unchanged" as const,
+    afterLine: startLine + index,
+  }));
+}
+
+function rowIndexes(segments: ReturnType<typeof buildDisplaySegments>): number[] {
+  return segments.filter((segment) => segment.kind === "row").map((segment) => segment.index);
+}
+
+function gaps(segments: ReturnType<typeof buildDisplaySegments>) {
+  return segments.filter((segment) => segment.kind === "gap");
+}
+
+describe("buildDisplaySegments", () => {
+  test("keeps changed rows and context, collapses the long unchanged middle", () => {
+    const rows: HunkRowLike[] = [
+      ...unchangedRows(50),
+      { tone: "removed", afterLine: null },
+      { tone: "added", afterLine: 51 },
+      ...unchangedRows(50, 52),
+    ];
+    const segments = buildDisplaySegments(rows, new Set(), {}, "k");
+
+    const visible = rowIndexes(segments);
+    // Change block at indexes 50/51 plus GAP_CONTEXT_LINES on each side.
+    expect(visible).toEqual([47, 48, 49, 50, 51, 52, 53, 54]);
+    const collapsed = gaps(segments);
+    expect(collapsed).toHaveLength(2);
+    expect(collapsed[0].hiddenCount).toBe(47);
+    expect(collapsed[1].hiddenCount).toBe(47);
+    // Leading gap renders before its context rows, trailing gap after.
+    expect(segments[0].kind).toBe("gap");
+    expect(segments[segments.length - 1].kind).toBe("gap");
+  });
+
+  test("renders short unchanged runs in full", () => {
+    const rows: HunkRowLike[] = [
+      { tone: "added", afterLine: 1 },
+      ...unchangedRows(GAP_CONTEXT_LINES * 2 + GAP_MIN_HIDDEN - 1, 2),
+      { tone: "added", afterLine: 100 },
+    ];
+    const segments = buildDisplaySegments(rows, new Set(), {}, "k");
+    expect(gaps(segments)).toHaveLength(0);
+    expect(rowIndexes(segments)).toHaveLength(rows.length);
+  });
+
+  test("a fully unchanged table becomes a single gap", () => {
+    const segments = buildDisplaySegments(unchangedRows(100), new Set(), {}, "k");
+    expect(segments).toEqual([{ kind: "gap", key: "k:0", hiddenCount: 100 }]);
+  });
+
+  test("rows with pinned findings never collapse and keep their own context", () => {
+    const rows = unchangedRows(200);
+    const segments = buildDisplaySegments(rows, new Set([100]), {}, "k");
+
+    const visible = rowIndexes(segments);
+    // afterLine 100 is index 99; it and its context must be visible.
+    expect(visible).toEqual([96, 97, 98, 99, 100, 101, 102]);
+    expect(gaps(segments).map((gap) => gap.hiddenCount)).toEqual([96, 97]);
+  });
+
+  test("expansion reveals rows from both edges of the gap", () => {
+    const rows: HunkRowLike[] = [{ tone: "added", afterLine: 1 }, ...unchangedRows(500, 2)];
+    const collapsedFirst = buildDisplaySegments(rows, new Set(), {}, "k");
+    const gapKey = gaps(collapsedFirst)[0].key;
+
+    const segments = buildDisplaySegments(rows, new Set(), { [gapKey]: GAP_EXPAND_STEP }, "k");
+    const gap = gaps(segments)[0];
+    expect(gap.hiddenCount).toBe(gaps(collapsedFirst)[0].hiddenCount - 2 * GAP_EXPAND_STEP);
+    // Revealed rows appear on both sides of the remaining gap.
+    const gapPosition = segments.indexOf(gap);
+    expect(segments[gapPosition - 1].kind).toBe("row");
+    expect(segments[gapPosition + 1].kind).toBe("row");
+  });
+
+  test("expansion that leaves a tiny residual reveals the whole run", () => {
+    const rows = unchangedRows(2 * GAP_EXPAND_STEP + GAP_MIN_HIDDEN - 1);
+    const segments = buildDisplaySegments(rows, new Set(), { "k:0": GAP_EXPAND_STEP }, "k");
+    expect(gaps(segments)).toHaveLength(0);
+    expect(rowIndexes(segments)).toHaveLength(rows.length);
+  });
+
+  test("over-expansion clamps instead of producing negative gaps", () => {
+    const rows = unchangedRows(30);
+    const segments = buildDisplaySegments(rows, new Set(), { "k:0": 10_000 }, "k");
+    expect(gaps(segments)).toHaveLength(0);
+    expect(rowIndexes(segments)).toHaveLength(30);
+  });
+
+  test("gap keys embed the caller prefix so stale expansions cannot collide", () => {
+    const rows = unchangedRows(100);
+    const fromOtherFile = buildDisplaySegments(rows, new Set(), { "other:0": 50 }, "current");
+    expect(gaps(fromOtherFile)[0].hiddenCount).toBe(100);
+  });
+});

--- a/test/diff-view.test.ts
+++ b/test/diff-view.test.ts
@@ -85,6 +85,20 @@ describe("buildRows", () => {
     });
   });
 
+  test("skips word-diff decoration for huge changed blocks instead of going quadratic", () => {
+    // Pairing scores every removed×added line combination, so a 150×150 block
+    // (common in bundled artifacts) must bail out rather than run 22,500 word
+    // diffs; line tones still render.
+    const before = Array.from({ length: 150 }, (_, i) => `const before${i} = ${i};`).join("\n");
+    const after = Array.from({ length: 150 }, (_, i) => `const after${i} = ${i};`).join("\n");
+    const rows = buildRows(`${before}\n`, `${after}\n`, null, null, { wordDiff: true });
+
+    expect(rows).toHaveLength(300);
+    expect(rows.every((row) => row.wordParts === null)).toBe(true);
+    expect(rows[0].tone).toBe("removed");
+    expect(rows[150].tone).toBe("added");
+  });
+
   test("treats whitespace-only line edits as unchanged with -w", () => {
     const rows = buildRows("const value=1;\n", "const value = 1;\n", null, null, {
       ignoreWhitespace: true,

--- a/test/highlight.test.ts
+++ b/test/highlight.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "vitest";
 import {
+  canHighlight,
   ensureHighlighter,
+  HIGHLIGHT_MAX_CHARS,
+  HIGHLIGHT_MAX_LINES,
   highlighterReady,
   langForPath,
   tokenizeLines,
@@ -36,6 +39,25 @@ describe("langForPath", () => {
   test("returns undefined for unsupported, extension-less, and dotfile paths", () => {
     expect(langForPath("LICENSE")).toBeUndefined();
     expect(langForPath(".gitignore")).toBeUndefined();
+  });
+});
+
+describe("canHighlight", () => {
+  test("caps synchronous tokenization by line count", () => {
+    // Tokenizing costs ~0.6ms per line of bundled JS on the main thread; a
+    // 36k-line sample would freeze the tab for ~25s (issue observed on vite's
+    // dist/node/chunks/node.js).
+    expect(canHighlight("x\n".repeat(HIGHLIGHT_MAX_LINES - 1))).toBe(true);
+    // repeat(N) yields N newlines → N+1 lines, one over the cap.
+    expect(canHighlight("x\n".repeat(HIGHLIGHT_MAX_LINES))).toBe(false);
+    expect(canHighlight("")).toBe(true);
+  });
+
+  test("still rejects few-enormous-lines samples the line cap would miss", () => {
+    // A minified one-liner is "1 line" but tokenizes in ~0.9s per 512 KiB, so
+    // total size stays bounded independently of line count.
+    expect(canHighlight("x".repeat(HIGHLIGHT_MAX_CHARS))).toBe(true);
+    expect(canHighlight("x".repeat(HIGHLIGHT_MAX_CHARS + 1))).toBe(false);
   });
 });
 


### PR DESCRIPTION
Selecting vite's 1.3 MiB `dist/node/chunks/node.js` on the public diff page froze the tab for ~55s: shiki tokenized both full sides synchronously (~25s per side, measured) and the table rendered all ~36k rows with ~510k token spans. Syntax highlighting is now capped per side at `HIGHLIGHT_MAX_LINES` (3,000 lines ≈ 1.7s of main-thread work) with a 256 KiB guard for minified few-enormous-lines samples, falling back to plain text with a "syntax highlighting off (large file)" note. Two-sided diffs collapse long unchanged runs into expandable gap rows (3 context lines, findings-pinned rows never collapse — the vite file now renders 367 rows instead of 36k), and single-sided views render 1,000 lines incrementally with a "show more" expander that falls back to the annotation banner for findings past the window. `buildRows` is memoized and word-diff pairing bails out beyond 10k line-pair combinations to avoid quadratic scoring on huge changed blocks. Unit tests cover the collapse logic, highlight caps, and word-diff guard; docs updated (`docs/ui.md` "Large diffs" section); verified end-to-end on the local dev server against the real vite 8.1.4→8.1.5 pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)