### PR TITLE
Left-align the diff gap expander label

### DIFF
--- a/src/components/DiffView.tsx
+++ b/src/components/DiffView.tsx
@@ -922,7 +922,7 @@ function GapRow({
           type="button"
           onClick={onExpand}
           aria-label={`Show more of ${hiddenCount} hidden ${noun}`}
-          class="w-full cursor-pointer border-y border-border bg-surface-2 px-3 py-1 text-center font-mono text-[11px] text-ink-subtle transition-colors hover:bg-accent-soft hover:text-ink"
+          class="w-full cursor-pointer border-y border-border bg-surface-2 px-3 py-1 text-left font-mono text-[11px] text-ink-subtle transition-colors hover:bg-accent-soft hover:text-ink"
         >
           ⋯ {hiddenCount.toLocaleString()} {noun} · show more
         </button>


### PR DESCRIPTION
On wide viewports the diff's full-width "⋯ N unchanged lines · show more" button centered its label, pushing it to the middle of the row and far away from the line-number gutters and code on the left.

The button now uses `text-left`, so the label sits at the start of the row while the whole row stays clickable. `GapRow` is shared, so this fixes both the split diff ("unchanged lines") and the single-sided view ("more lines"). Docs checked, no update needed.