### PR TITLE
Consolidate dashboard scan-row actions into an overflow menu

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -221,16 +221,17 @@ The system is typography-first. It communicates through type, severity color, an
 
 ### Allowed glyphs
 
-| Glyph | Role                  | Used in                                     |
-| ----- | --------------------- | ------------------------------------------- |
-| `▸`   | Collapsed folder      | FileTree                                    |
-| `▾`   | Expanded folder       | FileTree (when needed)                      |
-| `→`   | Relation / flow       | `previous → staged` captions, VersionPicker |
-| `←`   | Back link             | Page header back-links                      |
-| `·`   | Metadata separator    | Mono detail line                            |
-| `✓`   | Passed / connected    | Inline status                               |
-| `✕`   | Failed / disconnected | Inline status                               |
-| `•`   | Badge dot             | `Badge dot` prop                            |
+| Glyph | Role                    | Used in                                     |
+| ----- | ----------------------- | ------------------------------------------- |
+| `▸`   | Collapsed folder        | FileTree                                    |
+| `▾`   | Expanded folder         | FileTree (when needed)                      |
+| `→`   | Relation / flow         | `previous → staged` captions, VersionPicker |
+| `←`   | Back link               | Page header back-links                      |
+| `·`   | Metadata separator      | Mono detail line                            |
+| `✓`   | Passed / connected      | Inline status                               |
+| `✕`   | Failed / disconnected   | Inline status                               |
+| `•`   | Badge dot               | `Badge dot` prop                            |
+| `⋯`   | More actions / overflow | Row action menus, DiffView "show more"      |
 
 ### Glyph treatment
 

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,8 +1,9 @@
 import type { ComponentChildren, JSX } from "preact";
 import { useId, useRef } from "preact/hooks";
 import { useComputed, useSignal, useSignalEffect } from "@preact/signals";
-import { Show, useLiveSignal } from "@preact/signals/utils";
+import { useLiveSignal } from "@preact/signals/utils";
 import { cn } from "./cn";
+import { menuPanelPosition } from "./menu-position";
 
 interface MenuProps {
   trigger: (open: boolean) => ComponentChildren;
@@ -27,6 +28,7 @@ export function Menu({
   const focusFirstOnOpen = useSignal(false);
   const rootRef = useRef<HTMLDivElement | null>(null);
   const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
   const panelId = useId();
 
   // `trigger` is a plain prop whose closure can change (e.g. its label derives
@@ -48,8 +50,35 @@ export function Menu({
     items[nextIndex]?.focus();
   };
 
+  const positionPanel = () => {
+    const triggerNode = triggerRef.current;
+    const panelNode = panelRef.current;
+    if (!triggerNode || !panelNode) return;
+    const position = menuPanelPosition(
+      triggerNode.getBoundingClientRect(),
+      panelNode.getBoundingClientRect(),
+      { width: window.innerWidth, height: window.innerHeight },
+      align,
+    );
+    panelNode.style.top = `${position.top}px`;
+    panelNode.style.left = `${position.left}px`;
+  };
+
   useSignalEffect(() => {
-    if (!open.value) return;
+    const isOpen = open.value;
+    const panelNode = panelRef.current;
+    if (!panelNode) return;
+    if (!isOpen) {
+      if (panelNode.matches(":popover-open")) panelNode.hidePopover();
+      return;
+    }
+
+    panelNode.style.visibility = "hidden";
+    if (!panelNode.matches(":popover-open")) panelNode.showPopover();
+    positionPanel();
+    panelNode.style.visibility = "";
+
+    const onPositionChange = () => positionPanel();
     const onPointer = (event: PointerEvent) => {
       const node = rootRef.current;
       if (!node) return;
@@ -63,9 +92,13 @@ export function Menu({
       focusFirstOnOpen.value = false;
       triggerRef.current?.focus();
     };
+    window.addEventListener("resize", onPositionChange);
+    window.addEventListener("scroll", onPositionChange, true);
     document.addEventListener("pointerdown", onPointer);
     document.addEventListener("keydown", onKey);
     return () => {
+      window.removeEventListener("resize", onPositionChange);
+      window.removeEventListener("scroll", onPositionChange, true);
       document.removeEventListener("pointerdown", onPointer);
       document.removeEventListener("keydown", onKey);
     };
@@ -179,32 +212,36 @@ export function Menu({
       >
         {triggerContent}
       </button>
-      <Show when={open}>
-        {() => (
-          <div
-            id={panelId}
-            role="menu"
-            onClick={onPanelClick}
-            class={cn(
-              "absolute z-20 mt-1 min-w-[200px] bg-surface border border-border rounded-md shadow-md py-1",
-              align === "end" ? "right-0" : "left-0",
-              panelClass,
-            )}
-          >
-            {children}
-          </div>
+      <div
+        ref={panelRef}
+        id={panelId}
+        role="menu"
+        popover="manual"
+        onClick={onPanelClick}
+        class={cn(
+          "fixed z-20 m-0 min-w-[200px] max-w-[calc(100vw-1rem)] max-h-[calc(100vh-1rem)] overflow-y-auto",
+          "bg-surface border border-border rounded-md shadow-md px-0 py-1",
+          panelClass,
         )}
-      </Show>
+      >
+        {children}
+      </div>
     </div>
   );
 }
 
 type MenuItemProps = Omit<JSX.ButtonHTMLAttributes<HTMLButtonElement>, "class" | "onClick"> & {
   onSelect?: () => void;
-  tone?: "default" | "accent";
+  tone?: "default" | "accent" | "danger";
   active?: boolean;
   class?: string;
   children: ComponentChildren;
+};
+
+const menuItemToneClass: Record<NonNullable<MenuItemProps["tone"]>, string> = {
+  default: "text-ink",
+  accent: "text-accent",
+  danger: "text-danger-text",
 };
 
 export function MenuItem({
@@ -227,7 +264,7 @@ export function MenuItem({
       class={cn(
         "w-full text-left text-[13px] px-3 py-1.5 cursor-pointer",
         "hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent",
-        tone === "accent" ? "text-accent" : "text-ink",
+        menuItemToneClass[tone],
         active ? "font-medium" : "",
         className,
       )}

--- a/src/components/menu-position.ts
+++ b/src/components/menu-position.ts
@@ -1,0 +1,39 @@
+export interface MenuRect {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+export interface MenuPanelPosition {
+  top: number;
+  left: number;
+}
+
+const VIEWPORT_PADDING = 8;
+const TRIGGER_GAP = 4;
+
+export function menuPanelPosition(
+  trigger: MenuRect,
+  panel: Pick<MenuRect, "width" | "height">,
+  viewport: { width: number; height: number },
+  align: "start" | "end",
+): MenuPanelPosition {
+  const preferredLeft = align === "end" ? trigger.right - panel.width : trigger.left;
+  const maxLeft = Math.max(VIEWPORT_PADDING, viewport.width - panel.width - VIEWPORT_PADDING);
+  const left = Math.min(Math.max(preferredLeft, VIEWPORT_PADDING), maxLeft);
+
+  const below = trigger.bottom + TRIGGER_GAP;
+  const above = trigger.top - panel.height - TRIGGER_GAP;
+  const maxTop = Math.max(VIEWPORT_PADDING, viewport.height - panel.height - VIEWPORT_PADDING);
+  const top =
+    below + panel.height <= viewport.height - VIEWPORT_PADDING
+      ? below
+      : above >= VIEWPORT_PADDING
+        ? above
+        : Math.min(Math.max(below, VIEWPORT_PADDING), maxTop);
+
+  return { top, left };
+}

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -491,7 +491,7 @@ function ScanTable({
                     triggerAriaLabel={`More actions for ${scan.packageName || scan.stageId}`}
                     triggerClass="inline-flex items-center justify-center h-7 w-7 rounded-md border border-transparent text-ink-muted hover:bg-surface-2 hover:text-ink transition-colors duration-150"
                     trigger={() => (
-                      <span aria-hidden="true" class="text-base leading-none">
+                      <span aria-hidden="true" class="text-[13px] leading-none">
                         ⋯
                       </span>
                     )}

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -21,6 +21,7 @@ import { Badge, severityTone } from "../../components/Badge";
 import { Button, LinkButton } from "../../components/Button";
 import { Card } from "../../components/Card";
 import { LoadingState } from "../../components/Loading";
+import { Menu, MenuItem, MenuLink } from "../../components/Menu";
 import { OrgSwitcher } from "../../components/OrgSwitcher";
 import { PageShell } from "../../components/PageShell";
 import { Select } from "../../components/Select";
@@ -466,8 +467,10 @@ function ScanTable({
                 <ScanStatusBadge status={scan.status} />
               </Td>
               <Td>
-                <div class="flex flex-wrap items-center gap-2">
-                  <DecisionBadge decision={scan.decision} />
+                <DecisionBadge decision={scan.decision} />
+              </Td>
+              <Td>
+                <div class="flex items-center gap-2">
                   {canQuickDecide(scan) ? (
                     <Button
                       variant={scan.decision ? "secondary" : "primary"}
@@ -483,21 +486,26 @@ function ScanTable({
                           : "Decide"}
                     </Button>
                   ) : null}
-                </div>
-              </Td>
-              <Td>
-                {scan.status === "failed" ? (
-                  <Button
-                    variant="danger"
-                    size="sm"
-                    onClick={() => onDelete(scan)}
-                    disabled={deleteBusy}
+                  <Menu
+                    align="end"
+                    triggerAriaLabel={`More actions for ${scan.packageName || scan.stageId}`}
+                    triggerClass="inline-flex items-center justify-center h-7 w-7 rounded-md border border-transparent text-ink-muted hover:bg-surface-2 hover:text-ink transition-colors duration-150"
+                    trigger={() => (
+                      <span aria-hidden="true" class="text-base leading-none">
+                        ⋯
+                      </span>
+                    )}
                   >
-                    Delete
-                  </Button>
-                ) : (
-                  <span class="font-mono text-xs text-ink-subtle">—</span>
-                )}
+                    <MenuLink href={`/dashboard/scans/${encodeURIComponent(scan.id)}`}>
+                      Open review
+                    </MenuLink>
+                    {scan.status === "failed" ? (
+                      <MenuItem tone="danger" onSelect={() => onDelete(scan)} disabled={deleteBusy}>
+                        Delete review
+                      </MenuItem>
+                    ) : null}
+                  </Menu>
+                </div>
               </Td>
             </tr>
           ))}

--- a/test/e2e/org-switcher.spec.ts
+++ b/test/e2e/org-switcher.spec.ts
@@ -48,7 +48,23 @@ test("OrgSwitcher trigger updates after organizations load", async ({ page }) =>
       status: 200,
       contentType: "application/json",
       body: JSON.stringify({
-        scans: [],
+        scans: [
+          {
+            id: "scan-failed-menu",
+            stageId: "stage-failed-menu",
+            source: "npm",
+            organizationId: "org-acme",
+            ownerUserId: "user-org-switcher",
+            packageName: "@acme/failed-release",
+            stagedVersion: "2.0.0",
+            previousVersion: "1.0.0",
+            risk: "unknown",
+            status: "failed",
+            decision: null,
+            createdAt: "2026-06-15T12:00:00.000Z",
+            updatedAt: "2026-06-15T12:00:00.000Z",
+          },
+        ],
         nextCursor: null,
         filter: "undecided",
         limit: 50,
@@ -94,4 +110,35 @@ test("OrgSwitcher trigger updates after organizations load", async ({ page }) =>
   releaseOrganizations?.();
 
   await expect(switcher).toContainText("Acme Widgets");
+  await switcher.click();
+
+  const menu = page.getByRole("menu");
+  await expect(menu).toBeVisible();
+  await expect(menu).toHaveAttribute("popover", "manual");
+  expect(await menu.evaluate((node) => node.matches(":popover-open"))).toBe(true);
+
+  const box = await menu.boundingBox();
+  const viewport = page.viewportSize();
+  expect(box).not.toBeNull();
+  expect(viewport).not.toBeNull();
+  expect(box!.x).toBeGreaterThanOrEqual(8);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width - 8);
+  expect(box!.y).toBeGreaterThanOrEqual(8);
+  expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height - 8);
+
+  await page.keyboard.press("Escape");
+  await page.setViewportSize({ width: 480, height: 360 });
+
+  const actions = page.getByRole("button", { name: "More actions for @acme/failed-release" });
+  await actions.evaluate((node) => node.scrollIntoView({ block: "end" }));
+  const triggerBox = await actions.boundingBox();
+  await actions.click();
+
+  const actionsMenu = page.getByRole("menu");
+  await expect(actionsMenu).toBeVisible();
+  await expect(actionsMenu.getByRole("menuitem", { name: "Delete review" })).toBeVisible();
+  const actionsBox = await actionsMenu.boundingBox();
+  expect(triggerBox).not.toBeNull();
+  expect(actionsBox).not.toBeNull();
+  expect(actionsBox!.y + actionsBox!.height).toBeLessThanOrEqual(triggerBox!.y);
 });

--- a/test/menu-position.test.ts
+++ b/test/menu-position.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "vitest";
+import { menuPanelPosition } from "../src/components/menu-position";
+
+describe("menuPanelPosition", () => {
+  test("places the panel below the trigger when it fits", () => {
+    expect(
+      menuPanelPosition(
+        { top: 40, right: 180, bottom: 68, left: 152, width: 28, height: 28 },
+        { width: 120, height: 80 },
+        { width: 320, height: 640 },
+        "end",
+      ),
+    ).toEqual({ top: 72, left: 60 });
+  });
+
+  test("flips the panel above a trigger near the viewport bottom", () => {
+    expect(
+      menuPanelPosition(
+        { top: 580, right: 300, bottom: 608, left: 272, width: 28, height: 28 },
+        { width: 200, height: 72 },
+        { width: 320, height: 640 },
+        "end",
+      ),
+    ).toEqual({ top: 504, left: 100 });
+  });
+
+  test("clamps start-aligned panels inside the viewport", () => {
+    expect(
+      menuPanelPosition(
+        { top: 40, right: 26, bottom: 68, left: -2, width: 28, height: 28 },
+        { width: 200, height: 80 },
+        { width: 320, height: 640 },
+        "start",
+      ),
+    ).toEqual({ top: 72, left: 8 });
+  });
+});


### PR DESCRIPTION
The dashboard reviews table now keeps the Decision column badge-only and moves the primary Decide/Update action into the Actions column, followed by a `⋯` overflow menu (Open review; Delete review for failed scans) — fixing the action button that previously floated in the Decision column's dead space and the near-empty Actions column.

The shared `Menu` primitive was reworked to render its panel via the native Popover API with viewport-aware fixed positioning (new `menu-position.ts`), so dropdowns escape the table's `overflow` clipping and flip above the trigger near the viewport bottom, and `MenuItem` gains a `danger` tone for the destructive Delete. This also adds a `menu-position` unit test, extends the org-switcher e2e to assert the popover stays in-viewport and the dashboard action menu opens unclipped, and documents `⋯` in DESIGN.md's allowed-glyph table.

Verified with typecheck, oxlint, oxfmt, the Vitest logic/worker suites, the org-switcher Playwright e2e, and the fake-registry agent tour (screenshot confirms the new layout).