### PR TITLE
Reduce PyPI deterministic review false positives

### DIFF
--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -196,10 +196,12 @@ regardless of the username, while bare weak words (`pass`, `secret`, `token`, `a
 as placeholders when the username is itself a placeholder word — `user:pass@proxy` (requests'
 CVE-2023-32681 changelog entry, the canonical benign hit) skips, but a `svc:secret@db` or
 `root:admin@host` connection string is a real weak credential and still flags. Redaction keeps the
-broad URL pattern; only the finding side (`FINDING_SECRET_PATTERNS`) narrows. On the PyPI side (`0.4.0`), explicit directory tar records (typeflag 5) are no longer
-surfaced as `tar.suspicious-entry`: setuptools always emits them, so unlike `npm pack` output they
-carry no provenance signal there (requests alone produced 16 release-delta info findings), and the
-remaining non-regular/suspicious-entry reasons use PyPI wording instead of npm's.
+broad URL pattern; only the finding side (`FINDING_SECRET_PATTERNS`) narrows. On the PyPI side
+(`0.4.0`), safely normalized explicit directory tar records (typeflag 5) are no longer surfaced as
+`tar.suspicious-entry`: setuptools always emits them, so unlike `npm pack` output they carry no
+provenance signal there (requests alone produced 16 release-delta info findings). Unsafe, absolute,
+or Unicode-confusable directory records remain findings, and the remaining
+non-regular/suspicious-entry reasons use PyPI wording instead of npm's.
 
 ### Fixture format
 

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -15,7 +15,7 @@ The fixture taxonomy is based on the current Drydock rule surface plus public np
 - [Aikido's AsyncAPI incident report](https://www.aikido.dev/blog/asyncapi-npm-packages-backdoored-via-github-actions) documents a compromised GitHub Actions publishing path that injected a rotating string-table wrapper around a detached `node -e` child process in shipped JavaScript. The safe `asyncapi-rotating-string-table-dropper` fixture preserves that detection shape without retaining its endpoint, identifier, or payload.
 - The same benchmark shows the central detection trade-off: benign and malicious packages often call the same APIs. Broad environment reads and secret-like environment names are capability evidence, while common runtime flags such as `process.env.NODE_ENV` or `import.meta.env.DEV` are not credential sources. Chains such as collect → serialize → exfiltrate are stronger intent evidence.
 - Network-only code follows that trade-off: unchanged network-only files are suppressed as package context, added network-only files remain medium-severity contextual evidence, and added network access escalates to high when it is tied to lifecycle scripts, process execution, dynamic evaluation, or credential access.
-- Documentation and prose files remain available as package evidence, but deterministic `code.*` rules do not treat them as executable capability evidence. Secret checks in documentation use only high-confidence token formats; generic key/value examples such as `token = localStorage.getItem("token")` are not `file.secret-content` findings.
+- Documentation and prose files remain available as package evidence, but deterministic `code.*` rules do not treat them as executable capability evidence. Secret checks in documentation use only high-confidence token formats; generic key/value examples such as `token = localStorage.getItem("token")` are not `file.secret-content` findings. Python packaging metadata (`PKG-INFO`, `*.dist-info/METADATA`) embeds the README long-description and gets the same treatment under the Python pattern set, and URL-with-credentials matches whose password is an obvious placeholder (`http://user:pass@proxy`) are excluded from findings everywhere (redaction still applies the broad pattern).
 - TypeScript declaration files (`.d.ts`/`.d.cts`/`.d.mts`) keep a diffable text sample but are excluded from `code.*` and `file.secret-content` content scanning (`isTypeDeclarationPath`). Declarations are never executed and carry only type signatures, so scanning large bundled declarations is pure perf/memory cost and a signature like `fetch(url: string)` would only produce false positives. Cheap path-based checks (credential filenames, the files-allowlist) still apply.
 
 ## Safety policy
@@ -99,9 +99,9 @@ versions (see the invariant below).
 
 A PyPI review runs two rule families over the staged artifacts:
 
-- `pypi.*` findings come from `pyPiReleaseFindings` and carry `PYPI_RULES_VERSION` (currently `0.2.0`).
+- `pypi.*` findings come from `pyPiReleaseFindings` and carry `PYPI_RULES_VERSION` (currently `0.4.0`).
 - shared `file.*` / `code.*` / `diff.*` findings come from `deterministicFindings` and carry
-  `DETERMINISTIC_RULES_VERSION` (currently `1.16.0`).
+  `DETERMINISTIC_RULES_VERSION` (currently `1.17.0`).
 
 The harness asserts this per family: every `pypi.*` finding must equal `PYPI_RULES_VERSION` and every
 other finding must equal `DETERMINISTIC_RULES_VERSION`. Bump the relevant constant **and** update the
@@ -178,7 +178,23 @@ describe only the npm invocation and the package's own manifest, so reading them
 positive (observed on dt-clean 1.2.1 and salita 2.0.0). `npm_config_*` is deliberately not
 allowlisted because it can carry live registry auth (`npm_config__authToken`). The strip also now
 preserves newlines when erasing a match, so a multiline access can no longer shift later findings'
-line numbers.
+line numbers. `1.17.0` fixes four false-positive classes observed on the benign
+requests 2.34.1→2.34.2 public PyPI diff (47 deterministic findings, nearly all noise):
+Python packaging metadata (`PKG-INFO`, `*.egg-info/PKG-INFO`, `*.dist-info/METADATA` —
+`isPythonMetadataPath`) embeds the README long-description, so under the Python pattern set it is
+excluded from `code.*` capability scanning and its secret scan drops to the documentation-strength
+high-confidence set (requests' README examples were flagging `code.network-access` and a high
+`code.credential-access` "collect-and-exfiltrate" three times over across sdist and wheel metadata);
+`file.secret-content` now gets the same unreachable-test-file demotion as the `code.*` rules
+(one severity step, `testScoped`, never dropped — requests ships six test-CA/server keys under
+`tests/certs/`); and URL-with-embedded-credentials matches whose password segment is an obvious
+placeholder (`user:pass@`, `<password>`, `${VAR}`, `changeme`, `xxx`…) are no longer
+`file.secret-content` findings — requests' CVE-2023-32681 changelog entry was the canonical benign
+hit. Redaction keeps the broad URL pattern; only the finding side (`FINDING_SECRET_PATTERNS`)
+narrows. On the PyPI side (`0.4.0`), explicit directory tar records (typeflag 5) are no longer
+surfaced as `tar.suspicious-entry`: setuptools always emits them, so unlike `npm pack` output they
+carry no provenance signal there (requests alone produced 16 release-delta info findings), and the
+remaining non-regular/suspicious-entry reasons use PyPI wording instead of npm's.
 
 ### Fixture format
 

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -15,7 +15,7 @@ The fixture taxonomy is based on the current Drydock rule surface plus public np
 - [Aikido's AsyncAPI incident report](https://www.aikido.dev/blog/asyncapi-npm-packages-backdoored-via-github-actions) documents a compromised GitHub Actions publishing path that injected a rotating string-table wrapper around a detached `node -e` child process in shipped JavaScript. The safe `asyncapi-rotating-string-table-dropper` fixture preserves that detection shape without retaining its endpoint, identifier, or payload.
 - The same benchmark shows the central detection trade-off: benign and malicious packages often call the same APIs. Broad environment reads and secret-like environment names are capability evidence, while common runtime flags such as `process.env.NODE_ENV` or `import.meta.env.DEV` are not credential sources. Chains such as collect → serialize → exfiltrate are stronger intent evidence.
 - Network-only code follows that trade-off: unchanged network-only files are suppressed as package context, added network-only files remain medium-severity contextual evidence, and added network access escalates to high when it is tied to lifecycle scripts, process execution, dynamic evaluation, or credential access.
-- Documentation and prose files remain available as package evidence, but deterministic `code.*` rules do not treat them as executable capability evidence. Secret checks in documentation use only high-confidence token formats; generic key/value examples such as `token = localStorage.getItem("token")` are not `file.secret-content` findings. Python packaging metadata (`PKG-INFO`, `*.dist-info/METADATA`) embeds the README long-description and gets the same treatment under the Python pattern set, and URL-with-credentials matches whose password is an obvious placeholder (`http://user:pass@proxy`) are excluded from findings everywhere (redaction still applies the broad pattern).
+- Documentation and prose files remain available as package evidence, but deterministic `code.*` rules do not treat them as executable capability evidence. Secret checks in documentation use only high-confidence token formats; generic key/value examples such as `token = localStorage.getItem("token")` are not `file.secret-content` findings. Python packaging metadata (`PKG-INFO`, `*.dist-info/METADATA`) embeds the README long-description and gets the same treatment under the Python pattern set, and URL-with-credentials matches that are doc-style placeholders (`http://user:pass@proxy`, template passwords like `<password>`/`${VAR}`) are excluded from findings everywhere — but weak-word passwords with a non-placeholder username (`svc:secret@db`) still flag, and redaction always applies the broad pattern.
 - TypeScript declaration files (`.d.ts`/`.d.cts`/`.d.mts`) keep a diffable text sample but are excluded from `code.*` and `file.secret-content` content scanning (`isTypeDeclarationPath`). Declarations are never executed and carry only type signatures, so scanning large bundled declarations is pure perf/memory cost and a signature like `fetch(url: string)` would only produce false positives. Cheap path-based checks (credential filenames, the files-allowlist) still apply.
 
 ## Safety policy
@@ -187,11 +187,16 @@ high-confidence set (requests' README examples were flagging `code.network-acces
 `code.credential-access` "collect-and-exfiltrate" three times over across sdist and wheel metadata);
 `file.secret-content` now gets the same unreachable-test-file demotion as the `code.*` rules
 (one severity step, `testScoped`, never dropped — requests ships six test-CA/server keys under
-`tests/certs/`); and URL-with-embedded-credentials matches whose password segment is an obvious
-placeholder (`user:pass@`, `<password>`, `${VAR}`, `changeme`, `xxx`…) are no longer
-`file.secret-content` findings — requests' CVE-2023-32681 changelog entry was the canonical benign
-hit. Redaction keeps the broad URL pattern; only the finding side (`FINDING_SECRET_PATTERNS`)
-narrows. On the PyPI side (`0.4.0`), explicit directory tar records (typeflag 5) are no longer
+`tests/certs/`), but only for material unchanged from the baseline: a secret newly entering a test
+tree is a fresh leak (or fresh payload staging) and keeps full severity; and
+URL-with-embedded-credentials matches are excluded from `file.secret-content` when they are
+doc-style placeholders, in two tiers: structural placeholder passwords (template syntax such as
+`<password>`/`${VAR}`/`%VAR%`, `xxx`/`***` masks, canonical fakes like `changeme`) never flag
+regardless of the username, while bare weak words (`pass`, `secret`, `token`, `admin`) only count
+as placeholders when the username is itself a placeholder word — `user:pass@proxy` (requests'
+CVE-2023-32681 changelog entry, the canonical benign hit) skips, but a `svc:secret@db` or
+`root:admin@host` connection string is a real weak credential and still flags. Redaction keeps the
+broad URL pattern; only the finding side (`FINDING_SECRET_PATTERNS`) narrows. On the PyPI side (`0.4.0`), explicit directory tar records (typeflag 5) are no longer
 surfaced as `tar.suspicious-entry`: setuptools always emits them, so unlike `npm pack` output they
 carry no provenance signal there (requests alone produced 16 release-delta info findings), and the
 remaining non-regular/suspicious-entry reasons use PyPI wording instead of npm's.

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -188,7 +188,9 @@ high-confidence set (requests' README examples were flagging `code.network-acces
 `file.secret-content` now gets the same unreachable-test-file demotion as the `code.*` rules
 (one severity step, `testScoped`, never dropped — requests ships six test-CA/server keys under
 `tests/certs/`), but only for material unchanged from the baseline: a secret newly entering a test
-tree is a fresh leak (or fresh payload staging) and keeps full severity; and
+tree is a fresh leak (or fresh payload staging) and keeps full severity. Python reachability starts
+from every non-test module and follows static imports, so an imported test module also keeps full
+severity; and
 URL-with-embedded-credentials matches are excluded from `file.secret-content` when they are
 doc-style placeholders, in two tiers: structural placeholder passwords (template syntax such as
 `<password>`/`${VAR}`/`%VAR%`, `xxx`/`***` masks, canonical fakes like `changeme`) never flag

--- a/server/lib/adapters/pypi/findings.ts
+++ b/server/lib/adapters/pypi/findings.ts
@@ -39,7 +39,14 @@ export function pyPiReleaseFindings(
     // entries, duplicates, confusable paths) the sandbox recorded for this
     // artifact. Without this the gate would drop them and pass an sdist whose
     // oversized file was never inspected — a fail-open gap the npm path avoids.
-    for (const finding of tarSuspiciousEntryFindings(artifact.suspiciousEntries)) {
+    // Explicit directory records are excluded: setuptools and every other
+    // Python build backend always emits them, so unlike an `npm pack` tarball a
+    // typeflag-5 entry is the archive norm here, not provenance evidence
+    // (requests alone carries 16, each one a noise finding on the public diff).
+    const suspiciousEntries = (artifact.suspiciousEntries ?? []).filter(
+      (entry) => !(entry.kind === "non-regular" && entry.detail.includes("(directory)")),
+    );
+    for (const finding of tarSuspiciousEntryFindings(suspiciousEntries, { dialect: "pypi" })) {
       findings.push({ ...finding, file: namespacedPath(artifact.path, finding.file) });
     }
     const metadataEvidencePath = namespacedPath(artifact.path, summary.metadataPath ?? "METADATA");

--- a/server/lib/adapters/pypi/findings.ts
+++ b/server/lib/adapters/pypi/findings.ts
@@ -4,6 +4,7 @@ import {
   PYTHON_EXECUTION_CAPABILITY_PATTERNS,
   tarSuspiciousEntryFindings,
 } from "../../review";
+import { canonicalizePath, normalizeTarPath, type TarSuspiciousEntry } from "../../tar-parser.js";
 import { firstMatchingLine } from "../../text-utils";
 import { normalizePyPiProjectName } from "./manifest";
 import { pyPiVersionsEquivalent } from "./version";
@@ -44,7 +45,7 @@ export function pyPiReleaseFindings(
     // typeflag-5 entry is the archive norm here, not provenance evidence
     // (requests alone carries 16, each one a noise finding on the public diff).
     const suspiciousEntries = (artifact.suspiciousEntries ?? []).filter(
-      (entry) => !(entry.kind === "non-regular" && entry.detail.includes("(directory)")),
+      (entry) => !isOrdinaryPyPiDirectoryEntry(entry),
     );
     for (const finding of tarSuspiciousEntryFindings(suspiciousEntries, { dialect: "pypi" })) {
       findings.push({ ...finding, file: namespacedPath(artifact.path, finding.file) });
@@ -199,6 +200,12 @@ export function pyPiReleaseFindings(
   }
 
   return findings;
+}
+
+function isOrdinaryPyPiDirectoryEntry(entry: TarSuspiciousEntry): boolean {
+  if (entry.kind !== "non-regular" || entry.detail !== "typeflag 5 (directory)") return false;
+  if (entry.path.startsWith("/") || canonicalizePath(entry.path) !== entry.path) return false;
+  return normalizeTarPath(entry.path) !== null;
 }
 
 export function summarizePyPiArtifact(

--- a/server/lib/adapters/pypi/types.ts
+++ b/server/lib/adapters/pypi/types.ts
@@ -2,7 +2,7 @@ import type { DiffEntry, FileRecord, Finding, RiskLevel } from "../../review";
 import type { TarSuspiciousEntry } from "../../tar-parser.js";
 
 export const PYPI_RELEASE_MANIFEST_SCHEMA = "drydock.release-artifacts.v1";
-export const PYPI_RULES_VERSION = "0.3.0";
+export const PYPI_RULES_VERSION = "0.4.0";
 
 export const PYPI_RULE_IDS = {
   metadataMissing: "pypi.metadata-missing",

--- a/server/lib/review-diff-annotation.ts
+++ b/server/lib/review-diff-annotation.ts
@@ -4,10 +4,10 @@ import {
   codePatternsFor,
   DETERMINISTIC_RULE_IDS,
   deterministicFindings,
+  FINDING_SECRET_PATTERNS,
   JS_PATTERN_SET,
   PYTHON_PATTERN_SET,
   safeJson,
-  SECRET_PATTERNS,
 } from "./review-rules";
 import type {
   CodePatternSet,
@@ -212,7 +212,9 @@ function patternsForFinding(
     case DETERMINISTIC_RULE_IDS.codeCredentialAccess:
       return patterns.credentialAccess;
     case DETERMINISTIC_RULE_IDS.fileSecretContent:
-      return SECRET_PATTERNS.map(([pattern]) => pattern);
+      // The finding-side set, so line matching agrees with what detection
+      // actually flagged (placeholder URL credentials are not secrets).
+      return FINDING_SECRET_PATTERNS.map(([pattern]) => pattern);
     default:
       return [];
   }

--- a/server/lib/review-rules/context.ts
+++ b/server/lib/review-rules/context.ts
@@ -60,6 +60,7 @@ export function buildRuleContext(
       files,
       packageJson,
       lifecycleScriptSeedPaths(files, scripts, implicitScripts),
+      options.codePatternSet,
     ),
     patterns: codePatternsFor(options.codePatternSet),
     codePatternSet: options.codePatternSet,

--- a/server/lib/review-rules/file-types.ts
+++ b/server/lib/review-rules/file-types.ts
@@ -24,6 +24,20 @@ export function isDocumentationPath(path: string): boolean {
   return DOCUMENTATION_BASENAMES.has(basename);
 }
 
+// Python packaging metadata files: an sdist's PKG-INFO (root or *.egg-info/),
+// and a wheel's *.dist-info/METADATA. Their payload is the project
+// long-description — README prose, not executable code — so running capability
+// regexes over them only re-flags documentation (`requests.get(...)` examples,
+// netrc mentions). The diff tree can collapse the versioned directory down to a
+// bare ".egg-info"/".dist-info" segment, so the parent match allows an empty
+// prefix. Secret scanning still applies at documentation (high-confidence)
+// strength: a real token pasted into metadata must keep surfacing.
+export function isPythonMetadataPath(path: string): boolean {
+  const normalized = path.replaceAll("\\", "/").toLowerCase();
+  if (/(^|\/)pkg-info$/.test(normalized)) return true;
+  return /(^|\/)[^/]*\.(?:dist-info|egg-info)\/metadata$/.test(normalized);
+}
+
 const TEST_DIRECTORY_SEGMENTS = new Set(["test", "tests", "__tests__", "spec", "specs"]);
 
 // Test-suite files shipped inside a package (a test runner's own test/ tree,

--- a/server/lib/review-rules/helpers.ts
+++ b/server/lib/review-rules/helpers.ts
@@ -1,6 +1,6 @@
 import type { Finding } from "../review";
 import { firstMatchingLine } from "../text-utils";
-import { HIGH_CONFIDENCE_SECRET_PATTERNS, SECRET_PATTERNS } from "./patterns";
+import { FINDING_SECRET_PATTERNS, HIGH_CONFIDENCE_SECRET_PATTERNS } from "./patterns";
 import { DETERMINISTIC_RULE_IDS, type DeterministicRuleKey } from "./rule-ids";
 
 // Family modules tag findings with a rule ID only; the deterministic ruleset
@@ -11,6 +11,27 @@ export function tag(
   finding: Omit<Finding, "ruleId" | "ruleVersion">,
 ): Finding {
   return { ...finding, ruleId: DETERMINISTIC_RULE_IDS[rule] };
+}
+
+const DEMOTED_SEVERITY: Partial<Record<Finding["severity"], Finding["severity"]>> = {
+  critical: "high",
+  high: "medium",
+  medium: "low",
+};
+
+// Demote a finding that lives in an unreachable test file by one severity step
+// and mark it test-scoped so the risk roll-up can keep it out of the capability
+// co-occurrence escalation. Findings are demoted, never dropped — malware does
+// hide in test directories. Obfuscated matches keep full severity: hiding an
+// identifier inside a test file is still a malice signal.
+export function testScope(testScoped: boolean, obfuscated: boolean, finding: Finding): Finding {
+  if (!testScoped || obfuscated) return finding;
+  return {
+    ...finding,
+    severity: DEMOTED_SEVERITY[finding.severity] ?? finding.severity,
+    evidence: `test-scoped ${finding.evidence}`,
+    testScoped: true,
+  };
 }
 
 interface SecretTextOptions {
@@ -36,7 +57,7 @@ export function firstSecretLine(
 }
 
 function secretPatternsFor(options: SecretTextOptions): Array<[RegExp, string]> {
-  return options.highConfidenceOnly ? HIGH_CONFIDENCE_SECRET_PATTERNS : SECRET_PATTERNS;
+  return options.highConfidenceOnly ? HIGH_CONFIDENCE_SECRET_PATTERNS : FINDING_SECRET_PATTERNS;
 }
 
 export function firstJsonPropertyLine(

--- a/server/lib/review-rules/index.ts
+++ b/server/lib/review-rules/index.ts
@@ -16,11 +16,12 @@ import { entrypointDiffFindings } from "./entrypoints";
 // way that should invalidate cached scan reports. Stored alongside each finding
 // so historical reports can be traced back to the ruleset that produced them.
 // Lives here (not in a family module) because versioning spans every family.
-export const DETERMINISTIC_RULES_VERSION = "1.16.0";
+export const DETERMINISTIC_RULES_VERSION = "1.17.0";
 
 export { DETERMINISTIC_RULE_IDS } from "./rule-ids";
 export {
   codePatternsFor,
+  FINDING_SECRET_PATTERNS,
   JS_PATTERN_SET,
   PYTHON_PATTERN_SET,
   PYTHON_EXECUTION_CAPABILITY_PATTERNS,

--- a/server/lib/review-rules/metadata.ts
+++ b/server/lib/review-rules/metadata.ts
@@ -1,8 +1,8 @@
 import { isOutsidePackageFilesAllowlist } from "../review-package-files";
 import type { Finding } from "../review";
-import { containsSecretLikeText, firstSecretLine, tag } from "./helpers";
-import { changedPrefix, type RuleContext } from "./context";
-import { isDocumentationPath, isTypeDeclarationPath } from "./file-types";
+import { containsSecretLikeText, firstSecretLine, tag, testScope } from "./helpers";
+import { changedPrefix, isUnreachableTestFile, type RuleContext } from "./context";
+import { isDocumentationPath, isPythonMetadataPath, isTypeDeclarationPath } from "./file-types";
 
 // Manifest integrity and secret-exposure rules: parse failures, secret-looking
 // files, files outside the declared allowlist, and credential files added to
@@ -29,7 +29,13 @@ export function metadataFindings(ctx: RuleContext): Finding[] {
     const sample = file.textSample || "";
     const prefix = changedPrefix(ctx, file.path);
     const changed = ctx.diffByPath.get(file.path)?.status;
-    const secretOptions = { highConfidenceOnly: isDocumentationPath(file.path) };
+    // Python packaging metadata embeds the README long-description, so it gets
+    // the same high-confidence-only treatment as documentation.
+    const secretOptions = {
+      highConfidenceOnly:
+        isDocumentationPath(file.path) ||
+        (ctx.codePatternSet === "python" && isPythonMetadataPath(file.path)),
+    };
     // Type declarations keep a diffable sample but are excluded from content
     // scanning (perf/memory); the cheap path-based checks below still apply.
     const scanContent = !isTypeDeclarationPath(file.path);
@@ -38,14 +44,22 @@ export function metadataFindings(ctx: RuleContext): Finding[] {
       /\.npmrc|\.env|id_rsa|id_ed25519/i.test(file.path) ||
       (scanContent && containsSecretLikeText(sample, secretOptions))
     ) {
+      // Test-suite fixture material (self-signed certs under tests/certs/,
+      // dummy tokens in test cases) is demoted one step like the code.*
+      // capability rules, never dropped: a shipped private key is still worth
+      // surfacing, but it is not the leak signal a package-code secret is.
       findings.push(
-        tag("fileSecretContent", {
-          severity: changed === "added" ? "critical" : "high",
-          file: file.path,
-          line: firstSecretLine(sample, secretOptions),
-          evidence: `${prefix}secret-looking file or content`,
-          reason: "published artifacts should not include credentials or private material",
-        }),
+        testScope(
+          isUnreachableTestFile(ctx, file.path),
+          false,
+          tag("fileSecretContent", {
+            severity: changed === "added" ? "critical" : "high",
+            file: file.path,
+            line: firstSecretLine(sample, secretOptions),
+            evidence: `${prefix}secret-looking file or content`,
+            reason: "published artifacts should not include credentials or private material",
+          }),
+        ),
       );
     }
     if (isOutsidePackageFilesAllowlist(file.path, ctx.packageJson) && changed !== "removed") {

--- a/server/lib/review-rules/metadata.ts
+++ b/server/lib/review-rules/metadata.ts
@@ -48,9 +48,12 @@ export function metadataFindings(ctx: RuleContext): Finding[] {
       // dummy tokens in test cases) is demoted one step like the code.*
       // capability rules, never dropped: a shipped private key is still worth
       // surfacing, but it is not the leak signal a package-code secret is.
+      // Only longstanding (unchanged-from-baseline) material demotes — a
+      // secret newly entering a test tree is a fresh leak or fresh payload
+      // staging and keeps full severity until a baseline knows about it.
       findings.push(
         testScope(
-          isUnreachableTestFile(ctx, file.path),
+          isUnreachableTestFile(ctx, file.path) && changed === "unchanged",
           false,
           tag("fileSecretContent", {
             severity: changed === "added" ? "critical" : "high",

--- a/server/lib/review-rules/patterns.ts
+++ b/server/lib/review-rules/patterns.ts
@@ -118,20 +118,39 @@ export const PYTHON_EXECUTION_CAPABILITY_PATTERNS = [
 // Doc-style placeholder passwords (`http://user:pass@proxy.example`,
 // `https://alice:<token>@host`) are ubiquitous in READMEs and changelogs —
 // requests' CVE-2023-32681 HISTORY entry is the canonical benign hit — and are
-// not leaked material. The finding-side pattern refuses a match when the
-// password segment is an obvious placeholder; redaction keeps the broad
+// not leaked material. The finding-side pattern refuses a match in two tiers:
+// structural placeholders (template syntax, masks, canonical fakes) are never
+// secrets regardless of the username, while bare weak words ("pass", "secret",
+// "token", "admin") only count as placeholders when the username is itself a
+// placeholder word — `svc:secret@db` or `root:admin@host` is a real (if weak)
+// connection-string credential and keeps flagging. Redaction keeps the broad
 // pattern, since over-redacting a placeholder is harmless while under-redacting
 // a real credential is not.
 const URL_CREDENTIALS_REDACTION_PATTERN = /\b(?:[A-Za-z]+:\/\/)[^\s/@:]+:[^\s/@]+@[^\s'"\\]+/g;
-const PLACEHOLDER_PASSWORD_SEGMENT = [
+const PLACEHOLDER_USERNAME_SEGMENT = [
+  "user(?:name)?",
+  "usr",
+  "foo",
+  "bar",
+  "alice",
+  "bob",
+  "me",
+  "test",
+  "demo",
+  "example",
+  "admin",
+].join("|");
+const WEAK_WORD_PASSWORD_SEGMENT = [
   "pass(?:word|wd)?",
   "pwd",
   "secret",
   "token",
   "example",
+  "admin",
+].join("|");
+const STRUCTURAL_PLACEHOLDER_SEGMENT = [
   "changeme",
   "hunter2",
-  "admin",
   "(?:your|my)[-_]?(?:password|token|secret|key)",
   "x{3,}",
   "\\*{3,}",
@@ -142,7 +161,7 @@ const PLACEHOLDER_PASSWORD_SEGMENT = [
   "%[^%@\\s]+%",
 ].join("|");
 const URL_CREDENTIALS_FINDING_PATTERN = new RegExp(
-  String.raw`\b(?:[A-Za-z]+:\/\/)[^\s/@:]+:(?!(?:${PLACEHOLDER_PASSWORD_SEGMENT})@)[^\s/@]+@[^\s'"\\]+`,
+  String.raw`\b(?:[A-Za-z]+:\/\/)(?!(?:${PLACEHOLDER_USERNAME_SEGMENT}):(?:${WEAK_WORD_PASSWORD_SEGMENT}|${STRUCTURAL_PLACEHOLDER_SEGMENT})@|[^\s/@:]+:(?:${STRUCTURAL_PLACEHOLDER_SEGMENT})@)[^\s/@:]+:[^\s/@]+@[^\s'"\\]+`,
   "gi",
 );
 

--- a/server/lib/review-rules/patterns.ts
+++ b/server/lib/review-rules/patterns.ts
@@ -115,6 +115,37 @@ export const PYTHON_EXECUTION_CAPABILITY_PATTERNS = [
   ...PYTHON_DYNAMIC_EVALUATION_PATTERNS,
 ];
 
+// Doc-style placeholder passwords (`http://user:pass@proxy.example`,
+// `https://alice:<token>@host`) are ubiquitous in READMEs and changelogs —
+// requests' CVE-2023-32681 HISTORY entry is the canonical benign hit — and are
+// not leaked material. The finding-side pattern refuses a match when the
+// password segment is an obvious placeholder; redaction keeps the broad
+// pattern, since over-redacting a placeholder is harmless while under-redacting
+// a real credential is not.
+const URL_CREDENTIALS_REDACTION_PATTERN = /\b(?:[A-Za-z]+:\/\/)[^\s/@:]+:[^\s/@]+@[^\s'"\\]+/g;
+const PLACEHOLDER_PASSWORD_SEGMENT = [
+  "pass(?:word|wd)?",
+  "pwd",
+  "secret",
+  "token",
+  "example",
+  "changeme",
+  "hunter2",
+  "admin",
+  "(?:your|my)[-_]?(?:password|token|secret|key)",
+  "x{3,}",
+  "\\*{3,}",
+  "<[^>@\\s]*>",
+  "\\{[^}@\\s]*\\}",
+  "\\$\\{[^}@\\s]*\\}",
+  "\\$[A-Za-z_][A-Za-z0-9_]*",
+  "%[^%@\\s]+%",
+].join("|");
+const URL_CREDENTIALS_FINDING_PATTERN = new RegExp(
+  String.raw`\b(?:[A-Za-z]+:\/\/)[^\s/@:]+:(?!(?:${PLACEHOLDER_PASSWORD_SEGMENT})@)[^\s/@]+@[^\s'"\\]+`,
+  "gi",
+);
+
 export const SECRET_PATTERNS: Array<[RegExp, string]> = [
   [/npm_[A-Za-z0-9]{20,}/g, "[REDACTED_NPM_TOKEN]"],
   [/gh[pousr]_[A-Za-z0-9_]{20,}/g, "[REDACTED_GITHUB_TOKEN]"],
@@ -128,7 +159,7 @@ export const SECRET_PATTERNS: Array<[RegExp, string]> = [
   [/xox[abprs]-[A-Za-z0-9-]{10,}/g, "[REDACTED_SLACK_TOKEN]"],
   [/https:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9/]+/g, "[REDACTED_SLACK_WEBHOOK]"],
   [/eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g, "[REDACTED_JWT]"],
-  [/\b(?:[A-Za-z]+:\/\/)[^\s/@:]+:[^\s/@]+@[^\s'"\\]+/g, "[REDACTED_URL_WITH_CREDENTIALS]"],
+  [URL_CREDENTIALS_REDACTION_PATTERN, "[REDACTED_URL_WITH_CREDENTIALS]"],
   [
     /-----BEGIN (?:RSA |OPENSSH |EC |DSA |PGP |ENCRYPTED )?PRIVATE KEY(?: BLOCK)?-----[\s\S]*?-----END (?:RSA |OPENSSH |EC |DSA |PGP |ENCRYPTED )?PRIVATE KEY(?: BLOCK)?-----/g,
     "[REDACTED_PRIVATE_KEY]",
@@ -137,10 +168,17 @@ export const SECRET_PATTERNS: Array<[RegExp, string]> = [
   ...genericSecretPatterns(),
 ];
 
-export const HIGH_CONFIDENCE_SECRET_PATTERNS: Array<[RegExp, string]> = SECRET_PATTERNS.slice(
-  0,
-  -1,
+// Detection-side view of SECRET_PATTERNS: identical except the URL-credentials
+// pattern requires a non-placeholder password. Redaction stays on the broad set.
+export const FINDING_SECRET_PATTERNS: Array<[RegExp, string]> = SECRET_PATTERNS.map(
+  ([pattern, label]) =>
+    pattern === URL_CREDENTIALS_REDACTION_PATTERN
+      ? [URL_CREDENTIALS_FINDING_PATTERN, label]
+      : [pattern, label],
 );
+
+export const HIGH_CONFIDENCE_SECRET_PATTERNS: Array<[RegExp, string]> =
+  FINDING_SECRET_PATTERNS.slice(0, -1);
 
 function genericSecretPatterns(): Array<[RegExp, string]> {
   return [

--- a/server/lib/review-rules/patterns.ts
+++ b/server/lib/review-rules/patterns.ts
@@ -138,7 +138,6 @@ const PLACEHOLDER_USERNAME_SEGMENT = [
   "test",
   "demo",
   "example",
-  "admin",
 ].join("|");
 const WEAK_WORD_PASSWORD_SEGMENT = [
   "pass(?:word|wd)?",

--- a/server/lib/review-rules/reachability.ts
+++ b/server/lib/review-rules/reachability.ts
@@ -1,4 +1,5 @@
-import type { FileRecord, PackageJsonSummary } from "../review";
+import type { CodePatternSet, FileRecord, PackageJsonSummary } from "../review";
+import { isTestPath } from "./file-types";
 import { CONSUMER_INSTALL_LIFECYCLE_SCRIPTS } from "./patterns";
 
 // Static require/import edges between files inside the package. The walk is a
@@ -24,6 +25,11 @@ const RESOLUTION_SUFFIXES = [
   "/index.cjs",
 ];
 
+const PYTHON_RESOLUTION_SUFFIXES = [".py", "/__init__.py"];
+const PYTHON_FROM_IMPORT_PATTERN =
+  /^\s*from\s+([A-Za-z_][\w.]*|\.+[A-Za-z_][\w.]*|\.+)\s+import\s+([^#;\n]+)/gm;
+const PYTHON_IMPORT_PATTERN = /^\s*import\s+([^#;\n]+)/gm;
+
 // Files a registry tarball consumer install can execute: declared entrypoints
 // (main/module/browser/exports), bin targets, lifecycle script targets, and everything
 // statically importable from them. Seeding from lifecycle scripts matters for
@@ -33,7 +39,10 @@ export function consumerReachablePaths(
   files: FileRecord[],
   packageJson: PackageJsonSummary | null,
   extraSeedPaths: string[] = [],
+  codePatternSet: CodePatternSet | undefined = "javascript",
 ): Set<string> {
+  if (codePatternSet === "python") return pythonConsumerReachablePaths(files);
+
   const byNormalizedPath = new Map<string, FileRecord>();
   for (const file of files) {
     byNormalizedPath.set(stripPackagePrefix(file.path), file);
@@ -58,6 +67,115 @@ export function consumerReachablePaths(
     }
   }
   return reachable;
+}
+
+// Python packages do not have a package.json-style entrypoint manifest. Treat
+// every non-test Python module as consumer-reachable, then follow its static
+// imports into test trees. This is deliberately conservative: an import edge
+// can only keep a finding loud, never hide one.
+function pythonConsumerReachablePaths(files: FileRecord[]): Set<string> {
+  const byNormalizedPath = new Map<string, FileRecord>();
+  const queue: string[] = [];
+  for (const file of files) {
+    const path = stripPackagePrefix(file.path);
+    byNormalizedPath.set(path, file);
+    if (/\.py$/i.test(path) && !isTestPath(path)) queue.push(path);
+  }
+
+  const reachable = new Set<string>();
+  while (queue.length) {
+    const path = queue.pop();
+    if (!path || reachable.has(path)) continue;
+    reachable.add(path);
+    const file = byNormalizedPath.get(path);
+    if (!file?.textSample) continue;
+    for (const candidate of pythonImportCandidates(path, file.textSample)) {
+      for (const resolved of resolvePythonModulePaths(candidate, byNormalizedPath)) {
+        if (!reachable.has(resolved)) queue.push(resolved);
+      }
+    }
+  }
+  return reachable;
+}
+
+function pythonImportCandidates(sourcePath: string, text: string): string[] {
+  const candidates: string[] = [];
+  PYTHON_FROM_IMPORT_PATTERN.lastIndex = 0;
+  for (const match of text.matchAll(PYTHON_FROM_IMPORT_PATTERN)) {
+    const base = pythonModuleCandidate(sourcePath, match[1]);
+    if (base) candidates.push(base);
+    for (const imported of pythonImportedNames(match[2])) {
+      const separator = match[1].endsWith(".") ? "" : ".";
+      const nested = pythonModuleCandidate(sourcePath, `${match[1]}${separator}${imported}`);
+      if (nested) candidates.push(nested);
+    }
+  }
+  PYTHON_IMPORT_PATTERN.lastIndex = 0;
+  for (const match of text.matchAll(PYTHON_IMPORT_PATTERN)) {
+    for (const imported of pythonImportedNames(match[1])) {
+      const candidate = pythonModuleCandidate(sourcePath, imported);
+      if (candidate) candidates.push(candidate);
+    }
+  }
+  return candidates;
+}
+
+function pythonImportedNames(value: string): string[] {
+  return value
+    .replace(/[()]/g, "")
+    .split(",")
+    .map((part) => part.trim().split(/\s+as\s+/i)[0])
+    .filter((part) => /^[A-Za-z_][\w.]*$/.test(part));
+}
+
+function pythonModuleCandidate(sourcePath: string, moduleName: string): string | null {
+  const root = pythonArtifactRoot(sourcePath);
+  const rootSegments = root ? root.split("/") : [];
+  const relative = /^(\.+)(.*)$/.exec(moduleName);
+  let segments: string[];
+  let remainder: string;
+  if (relative) {
+    segments = sourcePath.split("/").slice(0, -1);
+    for (let index = 1; index < relative[1].length; index += 1) {
+      if (segments.length <= rootSegments.length) return null;
+      segments.pop();
+    }
+    remainder = relative[2];
+  } else {
+    segments = [...rootSegments];
+    remainder = moduleName;
+  }
+  if (remainder) segments.push(...remainder.split(".").filter(Boolean));
+  return normalizePathSegments(segments.join("/"));
+}
+
+function pythonArtifactRoot(path: string): string {
+  const segments = path.split("/");
+  if (segments[0] === "sdist") return "sdist";
+  if (segments[0] === "wheel" && segments[1]) return `wheel/${segments[1]}`;
+  return "";
+}
+
+function resolvePythonModulePaths(
+  candidate: string,
+  byNormalizedPath: Map<string, FileRecord>,
+): string[] {
+  const resolved = new Set<string>();
+  for (const suffix of PYTHON_RESOLUTION_SUFFIXES) {
+    const exact = candidate + suffix;
+    if (byNormalizedPath.has(exact)) resolved.add(exact);
+
+    // Sdists commonly keep importable packages below src/. Absolute imports
+    // omit that source-root segment, so conservatively match the same module
+    // suffix anywhere inside this artifact namespace.
+    const root = pythonArtifactRoot(candidate);
+    const modulePath = root ? candidate.slice(root.length + 1) : candidate;
+    const ending = `/${modulePath}${suffix}`;
+    for (const path of byNormalizedPath.keys()) {
+      if (pythonArtifactRoot(path) === root && path.endsWith(ending)) resolved.add(path);
+    }
+  }
+  return [...resolved];
 }
 
 function entrypointCandidates(packageJson: PackageJsonSummary | null): string[] {

--- a/server/lib/review-rules/scripts.ts
+++ b/server/lib/review-rules/scripts.ts
@@ -2,9 +2,9 @@ import { hasImplicitNodeGypInstall, isRootGypPath } from "../tar-parser.js";
 import { firstMatchingLine, firstMatchingSourceLine } from "../text-utils";
 import type { Finding } from "../review";
 import { CONSUMER_INSTALL_LIFECYCLE_SCRIPTS } from "./patterns";
-import { firstJsonPropertyLine, tag } from "./helpers";
+import { firstJsonPropertyLine, tag, testScope } from "./helpers";
 import { changedPrefix, isUnreachableTestFile, type RuleContext } from "./context";
-import { isDocumentationPath, isTypeDeclarationPath } from "./file-types";
+import { isDocumentationPath, isPythonMetadataPath, isTypeDeclarationPath } from "./file-types";
 import { scriptCommandTokens, scriptPathCandidates } from "./reachability";
 import { normalizeCodeForScanning } from "./normalize";
 
@@ -130,6 +130,7 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
 
   for (const file of ctx.files) {
     if (isDocumentationPath(file.path) || isTypeDeclarationPath(file.path)) continue;
+    if (ctx.codePatternSet === "python" && isPythonMetadataPath(file.path)) continue;
 
     const sample = file.textSample || "";
     // Constant-fold runtime-assembled identifiers (`'chi'+'ld_process'`,
@@ -263,26 +264,6 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
   }
 
   return findings;
-}
-
-const DEMOTED_SEVERITY: Partial<Record<Finding["severity"], Finding["severity"]>> = {
-  critical: "high",
-  high: "medium",
-  medium: "low",
-};
-
-// Demote a capability finding that lives in an unreachable test file by one
-// severity step and mark it test-scoped so the risk roll-up can keep it out of
-// the capability co-occurrence escalation. Obfuscated matches keep full
-// severity: hiding an identifier inside a test file is still a malice signal.
-function testScope(testScoped: boolean, obfuscated: boolean, finding: Finding): Finding {
-  if (!testScoped || obfuscated) return finding;
-  return {
-    ...finding,
-    severity: DEMOTED_SEVERITY[finding.severity] ?? finding.severity,
-    evidence: `test-scoped ${finding.evidence}`,
-    testScoped: true,
-  };
 }
 
 // Match a capability category against the raw sample and, only if that misses,

--- a/server/lib/review.ts
+++ b/server/lib/review.ts
@@ -92,15 +92,19 @@ function severityToRisk(severity: string | null | undefined): RiskLevel {
   return "low";
 }
 
+// `dialect` only changes the human-facing reason text: what counts as a normal
+// archive shape differs per ecosystem (npm pack emits only regular file
+// records; Python build backends also emit directory records).
 export function tarSuspiciousEntryFindings(
   entries: TarSuspiciousEntry[] | undefined | null,
+  options: { dialect?: "npm" | "pypi" } = {},
 ): Finding[] {
   if (!entries || !entries.length) return [];
   return entries.map((entry) => ({
     severity: tarSuspiciousSeverity(entry),
     file: entry.path || "<unknown>",
     evidence: `${entry.kind}: ${entry.detail}`,
-    reason: tarSuspiciousReason(entry),
+    reason: tarSuspiciousReason(entry, options.dialect ?? "npm"),
     ruleId: DETERMINISTIC_RULE_IDS.tarSuspiciousEntry,
     ruleVersion: DETERMINISTIC_RULES_VERSION,
   }));
@@ -113,13 +117,17 @@ function tarSuspiciousSeverity(entry: TarSuspiciousEntry): Finding["severity"] {
   return "medium";
 }
 
-function tarSuspiciousReason(entry: TarSuspiciousEntry): string {
+function tarSuspiciousReason(entry: TarSuspiciousEntry, dialect: "npm" | "pypi"): string {
   switch (entry.kind) {
     case "non-regular":
       if (entry.detail.includes("(directory)")) {
-        return "archive contains an explicit directory entry; npm pack normally emits regular file records, so this is recorded for provenance but does not by itself indicate executable or link behavior";
+        return dialect === "pypi"
+          ? "archive contains an explicit directory entry; Python build backends normally emit these, so this is recorded for provenance but does not by itself indicate executable or link behavior"
+          : "archive contains an explicit directory entry; npm pack normally emits regular file records, so this is recorded for provenance but does not by itself indicate executable or link behavior";
       }
-      return "npm publish only emits regular files; symlinks, hardlinks, devices, FIFOs, directories, or reserved entries in a tarball indicate a hand-crafted archive that may target the consumer's filesystem on extract";
+      return dialect === "pypi"
+        ? "Python build backends only emit regular file and directory records; symlinks, hardlinks, devices, FIFOs, or reserved entries in an sdist indicate a hand-crafted archive that may target the consumer's filesystem on extract"
+        : "npm publish only emits regular files; symlinks, hardlinks, devices, FIFOs, directories, or reserved entries in a tarball indicate a hand-crafted archive that may target the consumer's filesystem on extract";
     case "duplicate":
       return "two entries share the same normalized path; last-write-wins extraction means a benign first entry can mask a malicious second";
     case "unicode-confusable":

--- a/test/fixtures/security-corpus/cases-pypi/14-benign-docs-metadata-and-test-fixtures.json
+++ b/test/fixtures/security-corpus/cases-pypi/14-benign-docs-metadata-and-test-fixtures.json
@@ -1,0 +1,135 @@
+{
+  "id": "pypi-benign-docs-metadata-and-test-fixtures",
+  "title": "README prose in PKG-INFO, placeholder doc credentials, sdist directory entries, and test-suite fixture material stay demoted",
+  "category": "control",
+  "intent": "modeled on the requests 2.34.1->2.34.2 public diff: packaging metadata embedding capability-looking README prose must not raise code.* findings, placeholder proxy credentials in docs are not secrets, setuptools' explicit directory tar records are the archive norm, and test-suite certs/env reads demote (never drop) to test-scoped severities",
+  "manifest": {
+    "schema": "drydock.release-artifacts.v1",
+    "ecosystem": "pypi",
+    "package": "demo-package",
+    "version": "1.3.0",
+    "artifacts": [
+      {
+        "path": "dist/demo_package-1.3.0.tar.gz",
+        "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+      }
+    ]
+  },
+  "artifacts": [
+    {
+      "path": "dist/demo_package-1.3.0.tar.gz",
+      "files": [
+        {
+          "path": "demo_package-1.3.0/PKG-INFO",
+          "size": 420,
+          "sha256": "1111111111111111111111111111111111111111111111111111111111111111",
+          "flags": [],
+          "textSample": "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.3.0\n\n# demo-package\n\nUsage example:\n\n    resp = requests.get(\"https://api.example.invalid/status\")\n\nProxy credentials can come from os.environ or a .netrc file, e.g.\n`http://user:pass@proxy.example.invalid`.\n"
+        },
+        {
+          "path": "demo_package-1.3.0/HISTORY.md",
+          "size": 180,
+          "sha256": "2222222222222222222222222222222222222222222222222222222222222222",
+          "flags": [],
+          "textSample": "# History\n\n## 1.3.0\n\n- Fixed forwarding of proxy auth when proxies are defined with user info\n  (`http://user:pass@proxy.example.invalid`).\n"
+        },
+        {
+          "path": "demo_package-1.3.0/demo_package/__init__.py",
+          "size": 24,
+          "sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+          "flags": [],
+          "textSample": "__version__ = \"1.3.0\"\n"
+        },
+        {
+          "path": "demo_package-1.3.0/tests/certs/server.key",
+          "size": 160,
+          "sha256": "4444444444444444444444444444444444444444444444444444444444444444",
+          "flags": [],
+          "textSample": "-----BEGIN PRIVATE KEY-----\nTESTFIXTUREONLYTESTFIXTUREONLYTESTFIXTUREONLY\n-----END PRIVATE KEY-----\n"
+        },
+        {
+          "path": "demo_package-1.3.0/tests/test_client.py",
+          "size": 120,
+          "sha256": "5555555555555555555555555555555555555555555555555555555555555555",
+          "flags": [],
+          "textSample": "import os\n\n\ndef test_env_default():\n    value = os.environ.get(\"DEMO_SETTING\", \"\")\n    assert value == \"\"\n"
+        }
+      ],
+      "suspiciousEntries": [
+        {
+          "kind": "non-regular",
+          "path": "demo_package-1.3.0",
+          "detail": "typeflag 5 (directory)"
+        },
+        {
+          "kind": "non-regular",
+          "path": "demo_package-1.3.0/tests",
+          "detail": "typeflag 5 (directory)"
+        },
+        {
+          "kind": "non-regular",
+          "path": "demo_package-1.3.0/tests/certs",
+          "detail": "typeflag 5 (directory)"
+        }
+      ]
+    }
+  ],
+  "previousArtifacts": [
+    {
+      "path": "dist/demo_package-1.2.9.tar.gz",
+      "files": [
+        {
+          "path": "demo_package-1.2.9/PKG-INFO",
+          "size": 300,
+          "sha256": "aaaa111111111111111111111111111111111111111111111111111111111111",
+          "flags": [],
+          "textSample": "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.9\n\n# demo-package\n\nUsage example:\n\n    resp = requests.get(\"https://api.example.invalid/status\")\n"
+        },
+        {
+          "path": "demo_package-1.2.9/HISTORY.md",
+          "size": 40,
+          "sha256": "aaaa222222222222222222222222222222222222222222222222222222222222",
+          "flags": [],
+          "textSample": "# History\n\n## 1.2.9\n\n- Initial release.\n"
+        },
+        {
+          "path": "demo_package-1.2.9/demo_package/__init__.py",
+          "size": 24,
+          "sha256": "aaaa333333333333333333333333333333333333333333333333333333333333",
+          "flags": [],
+          "textSample": "__version__ = \"1.2.9\"\n"
+        },
+        {
+          "path": "demo_package-1.2.9/tests/certs/server.key",
+          "size": 160,
+          "sha256": "4444444444444444444444444444444444444444444444444444444444444444",
+          "flags": [],
+          "textSample": "-----BEGIN PRIVATE KEY-----\nTESTFIXTUREONLYTESTFIXTUREONLYTESTFIXTUREONLY\n-----END PRIVATE KEY-----\n"
+        },
+        {
+          "path": "demo_package-1.2.9/tests/test_client.py",
+          "size": 120,
+          "sha256": "5555555555555555555555555555555555555555555555555555555555555555",
+          "flags": [],
+          "textSample": "import os\n\n\ndef test_env_default():\n    value = os.environ.get(\"DEMO_SETTING\", \"\")\n    assert value == \"\"\n"
+        }
+      ]
+    }
+  ],
+  "expectedRisk": "medium",
+  "expectedFindings": [
+    {
+      "ruleId": "file.secret-content",
+      "severity": "medium",
+      "file": "sdist/tests/certs/server.key"
+    },
+    {
+      "ruleId": "code.credential-access",
+      "severity": "low",
+      "file": "sdist/tests/test_client.py"
+    }
+  ],
+  "coverageGaps": [
+    "the shipped test private key still anchors overall risk at medium; there is no allowlist for well-known test-fixture certificate material"
+  ]
+}

--- a/test/pypi.test.mjs
+++ b/test/pypi.test.mjs
@@ -281,7 +281,7 @@ describe("PyPI artifact summaries and review", () => {
     );
   });
 
-  test("drops sdist directory tar entries and keeps other non-regular entries with PyPI wording", () => {
+  test("drops ordinary sdist directories and keeps unsafe non-regular entries", () => {
     const manifest = parsePyPiReleaseManifest({
       schema: "drydock.release-artifacts.v1",
       ecosystem: "pypi",
@@ -316,6 +316,16 @@ describe("PyPI artifact summaries and review", () => {
               path: "demo_package-1.2.0/evil",
               detail: "typeflag 2 (symlink)",
             },
+            {
+              kind: "non-regular",
+              path: "../../outside",
+              detail: "typeflag 5 (directory)",
+            },
+            {
+              kind: "non-regular",
+              path: "demo_package-1.2.0/tests\u200b/certs",
+              detail: "typeflag 5 (directory)",
+            },
           ],
         },
       ],
@@ -324,13 +334,16 @@ describe("PyPI artifact summaries and review", () => {
     const tarFindings = review.ruleFindings.filter(
       (finding) => finding.ruleId === "tar.suspicious-entry",
     );
-    expect(tarFindings).toHaveLength(1);
-    expect(tarFindings[0]).toMatchObject({
-      severity: "high",
-      file: "dist/demo_package-1.2.0.tar.gz/evil",
-    });
-    expect(tarFindings[0].reason).toContain("Python build backends");
-    expect(tarFindings[0].reason).not.toContain("npm");
+    expect(tarFindings).toHaveLength(3);
+    expect(tarFindings.map((finding) => finding.file)).toEqual([
+      "dist/demo_package-1.2.0.tar.gz/evil",
+      "dist/demo_package-1.2.0.tar.gz/../../outside",
+      "dist/demo_package-1.2.0.tar.gz/tests\u200b/certs",
+    ]);
+    for (const finding of tarFindings) {
+      expect(finding.reason).toContain("Python build backends");
+      expect(finding.reason).not.toContain("npm");
+    }
   });
 
   test("does not flag PEP 440-equivalent version spellings as metadata mismatches", () => {

--- a/test/pypi.test.mjs
+++ b/test/pypi.test.mjs
@@ -281,6 +281,58 @@ describe("PyPI artifact summaries and review", () => {
     );
   });
 
+  test("drops sdist directory tar entries and keeps other non-regular entries with PyPI wording", () => {
+    const manifest = parsePyPiReleaseManifest({
+      schema: "drydock.release-artifacts.v1",
+      ecosystem: "pypi",
+      package: "demo-package",
+      version: "1.2.0",
+      artifacts: [{ path: "dist/demo_package-1.2.0.tar.gz", sha256: "b".repeat(64) }],
+    });
+
+    const review = createPyPiReleaseCandidateReview({
+      manifest,
+      artifacts: [
+        {
+          path: "dist/demo_package-1.2.0.tar.gz",
+          files: [
+            file(
+              "demo_package-1.2.0/PKG-INFO",
+              "Metadata-Version: 2.3\nName: demo-package\nVersion: 1.2.0\n",
+            ),
+          ],
+          suspiciousEntries: [
+            // setuptools always emits explicit directory records, so these are
+            // the archive norm on PyPI — not the provenance signal they are for
+            // `npm pack` tarballs.
+            { kind: "non-regular", path: "demo_package-1.2.0", detail: "typeflag 5 (directory)" },
+            {
+              kind: "non-regular",
+              path: "demo_package-1.2.0/tests",
+              detail: "typeflag 5 (directory)",
+            },
+            {
+              kind: "non-regular",
+              path: "demo_package-1.2.0/evil",
+              detail: "typeflag 2 (symlink)",
+            },
+          ],
+        },
+      ],
+    });
+
+    const tarFindings = review.ruleFindings.filter(
+      (finding) => finding.ruleId === "tar.suspicious-entry",
+    );
+    expect(tarFindings).toHaveLength(1);
+    expect(tarFindings[0]).toMatchObject({
+      severity: "high",
+      file: "dist/demo_package-1.2.0.tar.gz/evil",
+    });
+    expect(tarFindings[0].reason).toContain("Python build backends");
+    expect(tarFindings[0].reason).not.toContain("npm");
+  });
+
   test("does not flag PEP 440-equivalent version spellings as metadata mismatches", () => {
     const manifest = parsePyPiReleaseManifest({
       schema: "drydock.release-artifacts.v1",

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -731,6 +731,49 @@ describe("review", () => {
     expect(secret.testScoped).toBeUndefined();
   });
 
+  test("keeps full severity for an unchanged Python test secret imported by package code", () => {
+    const absoluteSecret = {
+      path: "sdist/src/demo/tests/secrets.py",
+      size: 80,
+      sha256: "python-absolute-secret",
+      flags: [],
+      textSample: 'password = "production-secret-value"\n',
+    };
+    const relativeSecret = {
+      path: "sdist/src/demo/tests/relative_secrets.py",
+      size: 80,
+      sha256: "python-relative-secret",
+      flags: [],
+      textSample: 'password = "another-production-secret"\n',
+    };
+    const app = {
+      path: "sdist/src/demo/app.py",
+      size: 80,
+      sha256: "python-app",
+      flags: [],
+      textSample:
+        "from demo.tests.secrets import password\n" +
+        "from .tests.relative_secrets import password as relative_password\n",
+    };
+    const findings = deterministicFindings(
+      [absoluteSecret, relativeSecret, app],
+      createPackageDiff([absoluteSecret, relativeSecret], [absoluteSecret, relativeSecret, app]),
+      null,
+      { codePatternSet: "python" },
+    );
+    const secretFindings = findings.filter(
+      (candidate) => candidate.ruleId === "file.secret-content",
+    );
+
+    expect(secretFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ severity: "high", file: absoluteSecret.path }),
+        expect.objectContaining({ severity: "high", file: relativeSecret.path }),
+      ]),
+    );
+    expect(secretFindings.every((finding) => finding.testScoped === undefined)).toBe(true);
+  });
+
   test("does not flag secret-looking source map content", () => {
     // The tar parser strips text samples from .map files (shouldSkipTextSample),
     // so deterministic rules never see source-map contents.

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -572,6 +572,120 @@ describe("review", () => {
     });
   });
 
+  test("does not flag placeholder URL credentials as secret content", () => {
+    // requests' HISTORY.md CVE-2023-32681 entry (`http://user:pass@proxy`) is
+    // the canonical benign hit: doc-style placeholder passwords are not leaks.
+    const staged = [
+      {
+        path: "HISTORY.md",
+        size: 160,
+        sha256: "history",
+        flags: [],
+        textSample:
+          "When proxies are defined with user info (`http://user:pass@proxy.example`),\n" +
+          "a Proxy-Authorization header is constructed.\n",
+      },
+      {
+        path: "lib/config.js",
+        size: 120,
+        sha256: "config",
+        flags: [],
+        textSample: 'const proxyExample = "https://user:<password>@registry.example.com";\n',
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged));
+
+    expect(findings.some((finding) => finding.ruleId === "file.secret-content")).toBe(false);
+  });
+
+  test("still flags URL credentials with a real-looking password", () => {
+    const staged = [
+      {
+        path: "lib/config.js",
+        size: 120,
+        sha256: "config-real",
+        flags: [],
+        textSample: 'const upstream = "https://deploy:9f8a7b6c5d4e3f2a1b@registry.example.com";\n',
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged));
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({ ruleId: "file.secret-content", file: "lib/config.js" }),
+    );
+  });
+
+  test("does not scan Python packaging metadata prose as capability evidence", () => {
+    // PKG-INFO / .dist-info/METADATA embed the README long-description, so
+    // capability regexes over them only re-flag documentation examples.
+    const prose =
+      "Metadata-Version: 2.3\nName: demo\nVersion: 1.0.0\n\nUsage:\n\n" +
+      '    requests.get("https://api.example.invalid/status")\n\n' +
+      "Reads proxy auth from os.environ or a .netrc file.\n";
+    const staged = [
+      { path: "sdist/PKG-INFO", size: 200, sha256: "pkginfo", flags: [], textSample: prose },
+      {
+        path: "sdist/src/.egg-info/PKG-INFO",
+        size: 200,
+        sha256: "egg",
+        flags: [],
+        textSample: prose,
+      },
+      {
+        path: "wheel/py3-none-any/.dist-info/METADATA",
+        size: 200,
+        sha256: "meta",
+        flags: [],
+        textSample: prose,
+      },
+      {
+        path: "wheel/py3-none-any/demo/client.py",
+        size: 160,
+        sha256: "client",
+        flags: [],
+        textSample:
+          "import os\nimport requests\n\n\ndef send():\n" +
+          '    return requests.get("https://api.example.invalid", params={"k": os.environ.get("D")})\n',
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged), null, {
+      codePatternSet: "python",
+    });
+    const codeFindingFiles = new Set(
+      findings.filter((finding) => finding.ruleId?.startsWith("code.")).map((f) => f.file),
+    );
+
+    expect(codeFindingFiles.has("sdist/PKG-INFO")).toBe(false);
+    expect(codeFindingFiles.has("sdist/src/.egg-info/PKG-INFO")).toBe(false);
+    expect(codeFindingFiles.has("wheel/py3-none-any/.dist-info/METADATA")).toBe(false);
+    // Real package code with the same capabilities still flags.
+    expect(codeFindingFiles.has("wheel/py3-none-any/demo/client.py")).toBe(true);
+  });
+
+  test("demotes secret-looking content in unreachable test files", () => {
+    const staged = [
+      {
+        path: "test/fixtures/server.key",
+        size: 160,
+        sha256: "test-key",
+        flags: [],
+        textSample: "-----BEGIN PRIVATE KEY-----\nTESTFIXTUREONLY\n-----END PRIVATE KEY-----\n",
+      },
+    ];
+    const findings = deterministicFindings(staged, createPackageDiff([], staged));
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        ruleId: "file.secret-content",
+        file: "test/fixtures/server.key",
+        // Added files flag critical; the test-scope demotion steps it to high.
+        severity: "high",
+        testScoped: true,
+        evidence: expect.stringContaining("test-scoped"),
+      }),
+    );
+  });
+
   test("does not flag secret-looking source map content", () => {
     // The tar parser strips text samples from .map files (shouldSkipTextSample),
     // so deterministic rules never see source-map contents.

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -599,6 +599,9 @@ describe("review", () => {
   });
 
   test("still flags URL credentials with a real-looking password", () => {
+    // Weak-word passwords stay findings when the username is not itself a
+    // placeholder: `svc:secret@db` is a real (if weak) connection-string
+    // credential, unlike doc-style `user:pass@proxy`.
     const staged = [
       {
         path: "lib/config.js",
@@ -607,12 +610,29 @@ describe("review", () => {
         flags: [],
         textSample: 'const upstream = "https://deploy:9f8a7b6c5d4e3f2a1b@registry.example.com";\n',
       },
+      {
+        path: "lib/db.js",
+        size: 120,
+        sha256: "config-weak",
+        flags: [],
+        textSample: 'const dsn = "postgres://svc:secret@10.0.0.5:5432/prod";\n',
+      },
+      {
+        path: "lib/admin.js",
+        size: 120,
+        sha256: "config-admin",
+        flags: [],
+        textSample: 'const admin = "mysql://root:admin@db.internal:3306/app";\n',
+      },
     ];
     const findings = deterministicFindings(staged, createPackageDiff([], staged));
-
-    expect(findings).toContainEqual(
-      expect.objectContaining({ ruleId: "file.secret-content", file: "lib/config.js" }),
+    const secretFiles = new Set(
+      findings.filter((finding) => finding.ruleId === "file.secret-content").map((f) => f.file),
     );
+
+    expect(secretFiles.has("lib/config.js")).toBe(true);
+    expect(secretFiles.has("lib/db.js")).toBe(true);
+    expect(secretFiles.has("lib/admin.js")).toBe(true);
   });
 
   test("does not scan Python packaging metadata prose as capability evidence", () => {
@@ -662,7 +682,31 @@ describe("review", () => {
     expect(codeFindingFiles.has("wheel/py3-none-any/demo/client.py")).toBe(true);
   });
 
-  test("demotes secret-looking content in unreachable test files", () => {
+  test("demotes longstanding secret-looking content in unreachable test files", () => {
+    const key = {
+      path: "test/fixtures/server.key",
+      size: 160,
+      sha256: "test-key",
+      flags: [],
+      textSample: "-----BEGIN PRIVATE KEY-----\nTESTFIXTUREONLY\n-----END PRIVATE KEY-----\n",
+    };
+    const findings = deterministicFindings([key], createPackageDiff([key], [key]));
+
+    expect(findings).toContainEqual(
+      expect.objectContaining({
+        ruleId: "file.secret-content",
+        file: "test/fixtures/server.key",
+        // Unchanged files flag high; the test-scope demotion steps it to medium.
+        severity: "medium",
+        testScoped: true,
+        evidence: expect.stringContaining("test-scoped"),
+      }),
+    );
+  });
+
+  test("keeps full severity for a secret newly added to a test tree", () => {
+    // A secret entering a test tree is a fresh leak (or fresh payload staging),
+    // not longstanding fixture material — the test-scope demotion must not apply.
     const staged = [
       {
         path: "test/fixtures/server.key",
@@ -673,17 +717,10 @@ describe("review", () => {
       },
     ];
     const findings = deterministicFindings(staged, createPackageDiff([], staged));
+    const secret = findings.find((finding) => finding.ruleId === "file.secret-content");
 
-    expect(findings).toContainEqual(
-      expect.objectContaining({
-        ruleId: "file.secret-content",
-        file: "test/fixtures/server.key",
-        // Added files flag critical; the test-scope demotion steps it to high.
-        severity: "high",
-        testScoped: true,
-        evidence: expect.stringContaining("test-scoped"),
-      }),
-    );
+    expect(secret).toMatchObject({ severity: "critical", file: "test/fixtures/server.key" });
+    expect(secret.testScoped).toBeUndefined();
   });
 
   test("does not flag secret-looking source map content", () => {

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -624,6 +624,13 @@ describe("review", () => {
         flags: [],
         textSample: 'const admin = "mysql://root:admin@db.internal:3306/app";\n',
       },
+      {
+        path: "lib/default-admin.js",
+        size: 120,
+        sha256: "config-default-admin",
+        flags: [],
+        textSample: 'const admin = "mysql://admin:admin@db.internal:3306/app";\n',
+      },
     ];
     const findings = deterministicFindings(staged, createPackageDiff([], staged));
     const secretFiles = new Set(
@@ -633,6 +640,7 @@ describe("review", () => {
     expect(secretFiles.has("lib/config.js")).toBe(true);
     expect(secretFiles.has("lib/db.js")).toBe(true);
     expect(secretFiles.has("lib/admin.js")).toBe(true);
+    expect(secretFiles.has("lib/default-admin.js")).toBe(true);
   });
 
   test("does not scan Python packaging metadata prose as capability evidence", () => {


### PR DESCRIPTION
Reduces PyPI deterministic false positives by treating packaging metadata as documentation, suppressing placeholder URL credentials while retaining real credentials, and demoting only unchanged isolated test secrets. Adds Python-aware reachability so imported test modules retain full severity, and ignores only safely normalized PyPI directory records while surfacing unsafe archive entries. Updates rule versions, corpus documentation, and regression coverage. Testing: `pnpm run verify`; `pnpm run eval`.