### PR TITLE
Drop numpy from the PyPI project-name suggestion

### DIFF
--- a/src/pages/Diff/index.tsx
+++ b/src/pages/Diff/index.tsx
@@ -95,7 +95,7 @@ function DiffLanding() {
   const error = useSignal<string | null>(null);
   const namePlaceholder = useComputed(() =>
     ecosystem.value === "pypi"
-      ? "project name, e.g. requests or numpy"
+      ? "project name, e.g. requests"
       : "package name or pkg.pr.new URL, e.g. react",
   );
   const nameLabel = useComputed(() =>


### PR DESCRIPTION
Removes `numpy` from the example project names in the public diff landing page, leaving `requests` as the sole suggestion in the PyPI project-name input placeholder (`src/pages/Diff/index.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)