### PR TITLE
Log transient discovery-cron sweep failures at warn

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,6 +62,8 @@ Workflow gates reuse the scan pipeline when the registry cannot stage a release 
 
 Cron-triggered npm discovery finds staged publishes for organizations with validated npm connections and creates scans using the same pipeline. Token-expiry and validation issues should surface through settings/UI status and redacted observability events.
 
+A per-org sweep failure is logged as `staged_publishes.cron.org_failed` with a `transient` field. Registry transport failures (status `0` — timeout, DNS, TLS) and 408/429/5xx responses are classified transient by `isTransientSweepFailure` and logged at **warn**: `reliableFetch` has already retried, discovery is idempotent, and the next 15-minute tick re-sweeps the org, so the cost is at most one cycle of detection latency. Everything else — unexpected statuses, D1 failures, bugs in the sweep — stays at **error**. Expired tokens never reach this log; they take the `recordExpiredNpmConnection` path instead. Repeated transient failures for one org are deliberately not escalated here; that would need failure counting across ticks.
+
 Within a single org sweep, new staged publishes are started through a bounded-concurrency pool capped at `STAGED_PUBLISH_SCAN_START_CONCURRENCY` (`mapWithConcurrency` in `server/lib/staged-publishes-discovery.ts`) rather than sequentially. Because the same staged publish can be visible to more than one organization, a cron invocation shares a `StageStartCoordinator` across its concurrent org sweeps: matching stage IDs are started one at a time, while each org still gets its own scan row and queue message. Raise the concurrency constant only after measuring CPU time per tick.
 
 ## Data stores

--- a/server/index.ts
+++ b/server/index.ts
@@ -33,6 +33,7 @@ import {
   discoverAndQueueStagedPublishes,
   ensureUsableNpmConnection,
   isNpmConnectionAuthFailure,
+  isTransientSweepFailure,
   recordExpiredNpmConnection,
   StagedPublishesFetchError,
 } from "./lib/staged-publishes-discovery";
@@ -402,8 +403,14 @@ async function runStagedPublishesDiscoveryCron(env: Cloudflare.Env, ctx: Executi
           err instanceof StagedPublishesFetchError
             ? { status: err.status, detail: err.detail }
             : describeOperationalError(err);
-        emitOperationalEvent("error", "staged_publishes.cron.org_failed", {
+        // Registry timeouts and 5xx are upstream weather, not a broken sweep;
+        // logging them at error made every npm hiccup indistinguishable from a
+        // real failure. `transient` is emitted either way so a query can select
+        // on the field rather than on the level.
+        const transient = isTransientSweepFailure(err);
+        emitOperationalEvent(transient ? "warn" : "error", "staged_publishes.cron.org_failed", {
           organizationId: connection.organizationId,
+          transient,
           error: detail,
         });
       }

--- a/server/lib/staged-publishes-discovery.ts
+++ b/server/lib/staged-publishes-discovery.ts
@@ -79,6 +79,24 @@ export function isNpmConnectionAuthFailure(err: unknown): boolean {
   return false;
 }
 
+/**
+ * Whether a cron sweep error is upstream infrastructure trouble rather than
+ * something an operator can act on. `reliableFetch` has already retried GETs
+ * three times by the time these surface, so this is not "might still succeed" —
+ * it is "the registry, not us". Status 0 is a transport failure (timeout, DNS,
+ * TLS); 408/429/5xx are the registry saying it could not serve the request.
+ *
+ * These are logged at warn so the error channel stays actionable: discovery is
+ * idempotent and the next 15-minute tick re-sweeps the org, so a single one
+ * costs at most one cycle of detection latency. A registry that stays
+ * unreachable for an org is invisible here by design — that needs failure
+ * counting across ticks, not a louder single-tick log.
+ */
+export function isTransientSweepFailure(err: unknown): boolean {
+  if (!(err instanceof StagedPublishesFetchError)) return false;
+  return err.status === 0 || err.status === 408 || err.status === 429 || err.status >= 500;
+}
+
 function describeNpmAuthFailure(err: unknown): string {
   if (err instanceof StagedPublishesFetchError) return `staged_list_${err.status}`;
   if (err instanceof InvalidNpmConnectionError && err.validation) {

--- a/test/staged-publishes-discovery.test.mjs
+++ b/test/staged-publishes-discovery.test.mjs
@@ -36,6 +36,7 @@ const {
   discoverAndQueueStagedPublishes,
   InvalidNpmConnectionError,
   isNpmConnectionAuthFailure,
+  isTransientSweepFailure,
 } = await import("../server/lib/staged-publishes-discovery.ts");
 
 const env = { DB: {}, SCAN_QUEUE: { send: vi.fn() } };
@@ -608,6 +609,37 @@ describe("discoverAndQueueStagedPublishes", () => {
     expect(env.SCAN_QUEUE.send).toHaveBeenCalledWith(
       expect.objectContaining({ stageId: "stage-new" }),
     );
+  });
+});
+
+describe("isTransientSweepFailure", () => {
+  function fetchError(status) {
+    const err = new stagedPublishesMock.StagedPublishesFetchError();
+    err.status = status;
+    return err;
+  }
+
+  test("classifies transport and registry-side failures as transient", () => {
+    // 0 is the reliableFetch abort (timeout/DNS/TLS); the rest are the registry
+    // declining to serve after retries.
+    for (const status of [0, 408, 429, 500, 502, 503, 504]) {
+      expect(isTransientSweepFailure(fetchError(status))).toBe(true);
+    }
+  });
+
+  test("keeps auth and client-side statuses actionable", () => {
+    // 401/403 never reach the generic failure log (they take the expired-token
+    // path), but classification must not quietly downgrade them if they do.
+    for (const status of [400, 401, 403, 404, 410, 422]) {
+      expect(isTransientSweepFailure(fetchError(status))).toBe(false);
+    }
+  });
+
+  test("treats non-fetch failures as actionable", () => {
+    // A D1 error or a bug in the sweep is ours to fix, not upstream weather.
+    expect(isTransientSweepFailure(new Error("D1_ERROR"))).toBe(false);
+    expect(isTransientSweepFailure(new InvalidNpmConnectionError("org_a"))).toBe(false);
+    expect(isTransientSweepFailure(null)).toBe(false);
   });
 });
 

--- a/test/workers/discovery-cron.test.ts
+++ b/test/workers/discovery-cron.test.ts
@@ -245,6 +245,7 @@ describe("staged publishes discovery cron", () => {
     vi.stubGlobal("fetch", fetchMock);
     vi.spyOn(console, "log").mockImplementation(() => {});
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const send = vi.fn(async () => undefined);
     const ctx = createExecutionContext();
@@ -255,15 +256,21 @@ describe("staged publishes discovery cron", () => {
     );
     await waitOnExecutionContext(ctx);
 
-    const failureCall = errorSpy.mock.calls.find(
+    // Upstream weather is warn-level: the error channel is reserved for
+    // failures an operator can act on.
+    const failureCall = warnSpy.mock.calls.find(
       (call) => call[0] === "staged_publishes.cron.org_failed",
     );
     expect(failureCall).toBeDefined();
     expect(failureCall![1]).toMatchObject({
       event: "staged_publishes.cron.org_failed",
       organizationId: org.organizationId,
+      transient: true,
       error: { status: 500 },
     });
+    expect(
+      errorSpy.mock.calls.find((call) => call[0] === "staged_publishes.cron.org_failed"),
+    ).toBeUndefined();
 
     const connection = await getNpmConnection(createDb(env.DB), org.organizationId);
     expect(connection?.validationStatus).toBe("valid");
@@ -271,6 +278,81 @@ describe("staged publishes discovery cron", () => {
     expect(await eventTypesForOrg(org.organizationId)).not.toContain(
       "npm_connection.token_expired",
     );
+  });
+
+  test("logs a staged-list fetch timeout as a transient warning", async () => {
+    // The production case: registry.npmjs.org never answers `/-/stage`, so
+    // reliableFetch aborts every attempt and the sweep sees status 0. The next
+    // tick re-sweeps the org, so this must not page anyone.
+    const org = await seedOrg({
+      index: 0,
+      token: "npm_valid_aaaaaaaaaaaa",
+      validationStatus: "valid",
+    });
+
+    const fetchMock = vi.fn(async () => {
+      throw new Error("fetch timeout");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const ctx = createExecutionContext();
+    await worker.scheduled(scheduledController(), env as Cloudflare.Env, ctx);
+    await waitOnExecutionContext(ctx);
+
+    const failureCall = warnSpy.mock.calls.find(
+      (call) => call[0] === "staged_publishes.cron.org_failed",
+    );
+    expect(failureCall).toBeDefined();
+    expect(failureCall![1]).toMatchObject({
+      organizationId: org.organizationId,
+      transient: true,
+      error: { status: 0, detail: "fetch timeout" },
+    });
+    expect(
+      errorSpy.mock.calls.find((call) => call[0] === "staged_publishes.cron.org_failed"),
+    ).toBeUndefined();
+
+    // Still eligible for the next sweep.
+    const connection = await getNpmConnection(createDb(env.DB), org.organizationId);
+    expect(connection?.validationStatus).toBe("valid");
+  });
+
+  test("keeps a non-transient sweep failure at error level", async () => {
+    // A 404 on `/-/stage` is not upstream weather — the endpoint the sweep
+    // depends on is gone or the registry URL is wrong. That stays actionable.
+    const org = await seedOrg({
+      index: 0,
+      token: "npm_valid_aaaaaaaaaaaa",
+      validationStatus: "valid",
+    });
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("not found", { status: 404 })),
+    );
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const ctx = createExecutionContext();
+    await worker.scheduled(scheduledController(), env as Cloudflare.Env, ctx);
+    await waitOnExecutionContext(ctx);
+
+    const failureCall = errorSpy.mock.calls.find(
+      (call) => call[0] === "staged_publishes.cron.org_failed",
+    );
+    expect(failureCall).toBeDefined();
+    expect(failureCall![1]).toMatchObject({
+      organizationId: org.organizationId,
+      transient: false,
+      error: { status: 404 },
+    });
+    expect(
+      warnSpy.mock.calls.find((call) => call[0] === "staged_publishes.cron.org_failed"),
+    ).toBeUndefined();
   });
 
   test("dispatches an auto-discovery email for the valid org", async () => {


### PR DESCRIPTION
A registry timeout on `/-/stage` surfaced as an error-level `staged_publishes.cron.org_failed`, indistinguishable from a failure an operator can act on — but `reliableFetch` has already retried by then, discovery is idempotent, and the next 15-minute tick re-sweeps the org, so the cost is one cycle of detection latency. `isTransientSweepFailure` now classifies status 0 (transport: timeout, DNS, TLS) and 408/429/5xx as upstream weather and logs those at warn, while unexpected statuses, D1 failures, and sweep bugs stay at error; the new `transient` field is emitted at both levels so log queries can select on the field rather than the level. Expired tokens are unaffected — they take the `recordExpiredNpmConnection` path before this classification runs, and a unit test pins 401/403 as non-transient so a refactor can't silently downgrade them.

Coverage: three cron cases in `test/workers/discovery-cron.test.ts` (500 → warn, the production `fetch timeout` → warn with `{status: 0, detail: "fetch timeout"}`, 404 → error), each asserting the other level was not also called, plus `isTransientSweepFailure` unit coverage across transient statuses, client statuses, and non-fetch errors. `docs/architecture.md` documents the split and records that repeated transient failures for one org are deliberately not escalated, since that needs failure counting across ticks.

Testing: `pnpm run verify` (lint, format check, typecheck, tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)