### PR TITLE
Add the incident-response content playbook and post templates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,7 @@ The user-facing learning guide is [`../src/pages/Docs/index.tsx`](../src/pages/D
 - [`tooling.md`](./tooling.md) — oxlint/oxfmt/typecheck, signals lint rules, route/client helpers.
 - [`ui.md`](./ui.md) — compact implementation map for the Preact UI: primitives, copy density, and large-diff performance rules. `DESIGN.md` remains the visual source of truth.
 - [`agent-tour.md`](./agent-tour.md) — portable product walkthrough artifacts.
+- [`incident-content-playbook.md`](./incident-content-playbook.md) — what to publish when a public supply-chain compromise breaks, the hard rules, and the post templates.
 - [`test-package.md`](./test-package.md) — package fixture used for manual staged-publish checks.
 
 ## Domain docs

--- a/docs/incident-content-playbook.md
+++ b/docs/incident-content-playbook.md
@@ -1,0 +1,75 @@
+# Incident content playbook
+
+What to publish when a public supply-chain compromise breaks, and — more importantly — what not to.
+
+The reach window for this content is roughly 24–48 hours. That is not enough time to decide policy under pressure, so the decisions are made here in advance: the hard rules below, the templates in [`../scripts/incident-post.mjs`](../scripts/incident-post.mjs), and a link check that runs before anything goes out.
+
+## Hard rules
+
+These are not style preferences. Breaking one of them costs more trust than any single post can earn.
+
+1. **Confirmed public incidents only.** A named package, a disclosed compromise, a public advisory or maintainer statement. Never a live maintainer's release on suspicion, and never "this looks sketchy" about someone's package. The first viral moment must not be a maintainer being publicly accused by a tool that reviews maintainers' work.
+2. **Describe the diff, not the intent.** The diff proves that bytes changed. It does not prove who changed them or why. Write "the release added X"; do not write "the attacker deliberately Y". Attribution belongs to the people running the actual investigation.
+3. **Name the package, never a person.** A compromised maintainer is the victim of the incident, not its cause. No usernames, no "they should have used 2FA".
+4. **Verify the link resolves first.** npm unpublishes malicious versions, often within hours. `scripts/incident-post.mjs` refuses to print a post when either version is gone. A post whose link 404s reads as opportunistic and cannot be quietly fixed after sharing.
+5. **Never claim we found it first** unless we did, with a scan timestamp to back it. "Here is the diff" is the claim. "We caught this" is a different claim and usually a false one.
+6. **No payload amplification.** Link the diff; do not paste the deobfuscated payload, the exfil endpoint, or anything that shortens the path to reuse. The diff view is enough to make the point.
+7. **No AI output in incident content.** The public diff runs deterministic rules only, on purpose — determinism _is_ the message. Quoting a model's opinion about a live incident undercuts that and invites an argument about the model instead of the bytes.
+8. **Correct in public, do not delete.** The correction template exists because the moment you need it is the moment you are least able to write it well.
+
+## The loop
+
+| When     | Do                                                                                                                         |
+| -------- | -------------------------------------------------------------------------------------------------------------------------- |
+| T+0      | Confirm it is real: advisory, maintainer statement, or registry action. Nothing goes out on a rumor.                       |
+| T+10     | Open the diff on drydock.org. Read it yourself. If the change is not legible in the diff, this is not our story — skip it. |
+| T+15     | Run `pnpm incident:post` to verify both versions resolve and fill the copy.                                                |
+| T+20     | Screenshot the diff hunk that shows the change. The image is the ad; the link is the proof.                                |
+| T+30     | Post to Bluesky and X — `breaking` then `whatToDo` in one thread.                                                          |
+| T+24–48h | LinkedIn `analysis` post: what changed, why it was reviewable, what provenance does and does not answer.                   |
+| T+1 week | Check the channel counters. Which channel actually sent people to the diff?                                                |
+
+The order matters. Bluesky and X are where the incident thread is alive on day one; LinkedIn rewards the considered write-up two days later, when the news cycle has moved and the analysis is the only thing left worth reading.
+
+## Using the script
+
+```bash
+pnpm incident:post \
+  --package chalk --from 5.6.0 --to 5.6.1 \
+  --vector "a postinstall script that posts environment variables to a remote host" \
+  --consequence "Anything the build host could reach should be treated as exposed."
+```
+
+It checks the registry, prints the diff URL, and emits per-channel copy with a character count against each channel's limit. Add `--ecosystem pypi` for PyPI, `--template provenance` when the compromised release passed provenance or 2FA, and `--template correction --claim … --correction …` when we get something wrong.
+
+If a version has been pulled, the script exits without printing and lists the surviving versions, so the post can be rebuilt around a pair that still resolves — usually the last clean version against the maintainer's remediation release.
+
+## Templates and when they apply
+
+| Template      | Channel    | Use when                                                                                                                                                 |
+| ------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `breaking`    | Bluesky, X | First post. States what the release added and links the diff.                                                                                            |
+| `whatToDo`    | Bluesky, X | Second post in the thread. What a reader with this package in a lockfile should do now.                                                                  |
+| `provenance`  | any        | The compromised release had valid provenance, a signed pipeline, or 2FA. The strongest argument we have: provenance attests the pipeline, not the bytes. |
+| `analysis`    | LinkedIn   | T+24–48h long form. Analysis first, product mentioned once at the end.                                                                                   |
+| `unpublished` | any        | The registry already pulled the malicious version. Talk about the gap, link a pair that still resolves.                                                  |
+| `correction`  | any        | We got something wrong.                                                                                                                                  |
+
+## What makes a good incident post
+
+The differentiator is the artifact, not the take. Every other account posting about a compromise is summarizing an advisory; the diff is a thing only we can show, so the post should be mostly diff and barely commentary.
+
+Concretely:
+
+- Lead with the change, not with the product. "`chalk` 5.6.1 added a postinstall script that is not in 5.6.0" is the story. "Drydock detected…" is not.
+- One screenshot of the actual hunk. Not a dashboard, not a findings list — the lines that changed.
+- Say what a reader should do. A post that only alarms is noise; a post that ends in "pin back to X and rotate Y" is useful.
+- Mention "free, no account" once. That is the friction the reader is silently pricing, and it is the reason the link is worth clicking.
+
+## Frequency
+
+The incident engine is reactive and cannot be scheduled — real compromises are the only input, and manufacturing urgency between them is exactly how this becomes noise. Two or three genuine incidents a quarter is a healthy rate for this channel. If a month passes with nothing, that is the correct output.
+
+## Measuring it
+
+Once the channel counters land (`marketing_referrals`, added separately), they answer whether a post worked: views on the `diff` surface, grouped by `source`, on the day of the post and the day after. Filter `source != 'bot'` — crawler fetches scale with how many platforms a link was posted to, not with interest. The `bot` count is still worth a glance as confirmation the unfurl actually happened on each platform.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate:local": "wrangler d1 migrations apply staged-publish-review --local",
     "db:migrate:remote": "wrangler d1 migrations apply staged-publish-review --remote",
+    "incident:post": "node scripts/incident-post.mjs",
     "scan-artifacts:backfill": "node scripts/backfill-scan-artifacts.mjs",
     "db:backfill:scan-list-summaries:local": "wrangler d1 execute staged-publish-review --local --file scripts/backfill-scan-list-summaries.sql",
     "db:backfill:scan-list-summaries:remote": "wrangler d1 execute staged-publish-review --remote --file scripts/backfill-scan-list-summaries.sql",

--- a/scripts/incident-post.mjs
+++ b/scripts/incident-post.mjs
@@ -1,0 +1,332 @@
+// Fills the incident-response post templates for a confirmed public
+// supply-chain compromise, and — more importantly — checks the diff link
+// actually resolves before anyone posts it.
+//
+// That check is the whole reason this is a script and not a snippet in a doc.
+// npm unpublishes malicious versions, often within hours of disclosure, which is
+// exactly the window this content targets. A post whose link 404s is worse than
+// no post: it reads as opportunistic and it cannot be quietly fixed once it has
+// been shared.
+//
+// Templates live here rather than in the playbook so there is one copy of the
+// wording. docs/incident-content-playbook.md explains when and why to send them.
+
+import { parseArgs } from "node:util";
+
+export const CHANNELS = ["bluesky", "x", "linkedin"];
+
+// Bluesky counts graphemes, X counts a weighted length that is close enough to
+// code points for copy this short. Both are advisory: the script reports an
+// overflow, it does not silently truncate someone's post.
+const CHANNEL_LIMITS = { bluesky: 300, x: 280, linkedin: 3000 };
+
+const REGISTRY = {
+  npm: {
+    metadataUrl: (pkg) =>
+      `https://registry.npmjs.org/${encodeURIComponent(pkg).replace(/^%40/, "@")}`,
+    listVersions: (body) => Object.keys(body?.versions ?? {}),
+  },
+  pypi: {
+    metadataUrl: (pkg) => `https://pypi.org/pypi/${encodeURIComponent(pkg)}/json`,
+    listVersions: (body) => Object.keys(body?.releases ?? {}),
+  },
+};
+
+// Mirrors packageDiffPath() in src/lib/package-diff-path.ts. This file is plain
+// ESM so it can run with bare `node`, and test/incident-post.test.mjs asserts
+// the two stay in agreement rather than trusting the duplication.
+export function diffUrl({
+  ecosystem = "npm",
+  packageName,
+  fromVersion,
+  toVersion,
+  origin = "https://drydock.org",
+}) {
+  const encodedName = packageName
+    .split("/")
+    .map((segment) => encodeURIComponent(segment).replace(/^%40/, "@"))
+    .join("/");
+  const prefix = ecosystem === "pypi" ? "/diff/pypi" : "/diff";
+  const path = `${prefix}/${encodedName}/${encodeURIComponent(fromVersion)}/${encodeURIComponent(toVersion)}`;
+  return `${origin}${path}`;
+}
+
+export async function fetchPublishedVersions({
+  ecosystem = "npm",
+  packageName,
+  fetchImpl = fetch,
+}) {
+  const registry = REGISTRY[ecosystem];
+  if (!registry) throw new Error(`unknown ecosystem: ${ecosystem}`);
+  const response = await fetchImpl(registry.metadataUrl(packageName), {
+    headers: { accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(`registry metadata for ${packageName} returned ${response.status}`);
+  }
+  return registry.listVersions(await response.json());
+}
+
+// The compromised version is the one most likely to be gone. Suggest the
+// surviving neighbours so the post can still show a real diff — usually the last
+// clean version against whatever the maintainer shipped as the remediation.
+export function checkVersionsSurvive({ published, fromVersion, toVersion }) {
+  const available = new Set(published);
+  const missing = [fromVersion, toVersion].filter((version) => !available.has(version));
+  return {
+    ok: missing.length === 0,
+    missing,
+    // Registry order is publish order for npm; keep it rather than sorting by
+    // semver, so "the versions either side of the gap" stays meaningful for
+    // prereleases and PEP 440 alike.
+    nearest: published.slice(-6),
+  };
+}
+
+function truthy(value) {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function req(fields) {
+  for (const [name, value] of Object.entries(fields)) {
+    if (!truthy(value)) throw new Error(`missing required field: ${name}`);
+  }
+}
+
+// Every template states only what the diff shows. Intent, attribution, and blast
+// radius are claims the diff cannot support, so they are not in the wording —
+// see the hard rules in docs/incident-content-playbook.md.
+export const TEMPLATES = {
+  // T+30min. The one that has to go out while the thread is still alive.
+  breaking: ({ packageName, fromVersion, toVersion, vector, url }) => {
+    req({ packageName, fromVersion, toVersion, vector, url });
+    return [
+      `${packageName} ${toVersion} added ${vector}. It is not in ${fromVersion}.`,
+      ``,
+      `Here is the diff. No login, no token, nothing installed:`,
+      url,
+    ].join("\n");
+  },
+
+  // T+30min, second post in the same thread. What a reader should do now.
+  whatToDo: ({ packageName, safeVersion, url }) => {
+    req({ packageName, safeVersion, url });
+    return [
+      `If you have ${packageName} in a lockfile, pin back to ${safeVersion} and rotate anything the build host could reach.`,
+      ``,
+      `The diff shows exactly which files changed, so you can check whether the version you shipped is affected: ${url}`,
+    ].join("\n");
+  },
+
+  // For compromises that passed provenance, 2FA, or a signed pipeline. The
+  // strongest argument we have, and the least intuitive one.
+  provenance: ({ packageName, toVersion, attestation, url }) => {
+    req({ packageName, toVersion, attestation, url });
+    return [
+      `${packageName} ${toVersion} had ${attestation}. The pipeline was authentic. The bytes were not.`,
+      ``,
+      `Provenance answers "did this come from the right pipeline". It does not answer "what is in it". Different questions.`,
+      ``,
+      url,
+    ].join("\n");
+  },
+
+  // T+24-48h, long form. Analysis, not product pitch.
+  analysis: ({ packageName, fromVersion, toVersion, vector, consequence, url }) => {
+    req({ packageName, fromVersion, toVersion, vector, consequence, url });
+    return [
+      `${packageName} ${fromVersion} → ${toVersion}: what actually changed`,
+      ``,
+      `The compromised release added ${vector}. ${consequence}`,
+      ``,
+      `The part worth sitting with: this was reviewable. The change is visible in a file-by-file diff of the two published tarballs, and it took seconds to find once someone looked. Almost nobody looks, because until recently there was nowhere to look — package managers show you a version number and a changelog, not the bytes.`,
+      ``,
+      `Diff, if you want to read it yourself: ${url}`,
+      ``,
+      `Free, no account. It is the same review Drydock runs before a publish goes out, pointed at two versions that are already public.`,
+    ].join("\n");
+  },
+
+  // When npm has already pulled the malicious version. Very common, and the
+  // reason to check before posting rather than after.
+  unpublished: ({ packageName, badVersion, fromVersion, toVersion, url }) => {
+    req({ packageName, badVersion, fromVersion, toVersion, url });
+    return [
+      `${packageName} ${badVersion} has been unpublished, so the malicious bytes are no longer fetchable — which also means nobody can independently check what shipped.`,
+      ``,
+      `What is still readable is ${fromVersion} → ${toVersion}: ${url}`,
+    ].join("\n");
+  },
+
+  // If we get something wrong. Pre-written on purpose: the moment you need this
+  // is the moment you are least able to write it well.
+  correction: ({ claim, correction, url }) => {
+    req({ claim, correction, url });
+    return [
+      `Correction to my earlier post: I said ${claim}. That is wrong — ${correction}.`,
+      ``,
+      `The diff is public either way, so you do not have to take my word for it: ${url}`,
+      ``,
+      `Leaving the original up rather than deleting it.`,
+    ].join("\n");
+  },
+};
+
+export const CHANNEL_TEMPLATES = {
+  bluesky: ["breaking", "whatToDo"],
+  x: ["breaking", "whatToDo"],
+  linkedin: ["analysis"],
+};
+
+export function renderPost(templateName, fields) {
+  const template = TEMPLATES[templateName];
+  if (!template) throw new Error(`unknown template: ${templateName}`);
+  return template(fields);
+}
+
+export function measure(text, channel) {
+  const length = [...text].length;
+  const limit = CHANNEL_LIMITS[channel];
+  return { length, limit, overflow: limit ? Math.max(0, length - limit) : 0 };
+}
+
+function usage() {
+  return `Usage: node scripts/incident-post.mjs --package <name> --from <version> --to <version> [options]
+
+Required:
+  --package <name>        Package or project name
+  --from <version>        Last known-clean version (the diff's left side)
+  --to <version>          Compromised or remediation version (right side)
+
+Content:
+  --vector <text>         What the release added, in the diff's own terms
+                          (e.g. "a postinstall script that posts env to a remote host")
+  --consequence <text>    One sentence of impact, for the long-form post
+  --attestation <text>    If it passed provenance/2FA, name it (e.g. "valid SLSA provenance")
+  --safe-version <ver>    Version to pin back to (defaults to --from)
+  --claim / --correction  Fill the correction template instead
+
+Options:
+  --ecosystem npm|pypi    Default npm
+  --template <name>       ${Object.keys(TEMPLATES).join(", ")}
+  --channel <name>        ${CHANNELS.join(", ")}, or all (default all)
+  --origin <url>          Default https://drydock.org
+  --no-verify             Skip the registry check (offline; not for real posts)
+`;
+}
+
+export async function main(
+  argv,
+  { fetchImpl = fetch, log = console.log, warn = console.warn } = {},
+) {
+  const { values } = parseArgs({
+    args: argv,
+    options: {
+      package: { type: "string" },
+      from: { type: "string" },
+      to: { type: "string" },
+      vector: { type: "string" },
+      consequence: { type: "string" },
+      attestation: { type: "string" },
+      "safe-version": { type: "string" },
+      claim: { type: "string" },
+      correction: { type: "string" },
+      ecosystem: { type: "string", default: "npm" },
+      template: { type: "string" },
+      channel: { type: "string", default: "all" },
+      origin: { type: "string", default: "https://drydock.org" },
+      verify: { type: "boolean", default: true },
+      help: { type: "boolean", default: false },
+    },
+    allowNegative: true,
+  });
+
+  if (values.help || !values.package || !values.from || !values.to) {
+    log(usage());
+    return values.help ? 0 : 1;
+  }
+
+  const spec = {
+    ecosystem: values.ecosystem,
+    packageName: values.package,
+    fromVersion: values.from,
+    toVersion: values.to,
+    origin: values.origin,
+  };
+  const url = diffUrl(spec);
+
+  let verified = false;
+  if (values.verify) {
+    try {
+      const published = await fetchPublishedVersions({ ...spec, fetchImpl });
+      const check = checkVersionsSurvive({
+        published,
+        fromVersion: values.from,
+        toVersion: values.to,
+      });
+      if (check.ok) {
+        verified = true;
+      } else {
+        warn(`
+!! ${check.missing.join(" and ")} ${check.missing.length > 1 ? "are" : "is"} not published.
+
+   The registry has probably pulled the compromised release. Do not post this
+   link — it will 404 for everyone who clicks it.
+
+   Most recent surviving versions: ${check.nearest.join(", ")}
+
+   Pick a pair from those, or use --template unpublished to post about the gap.
+`);
+        return 2;
+      }
+    } catch (err) {
+      warn(`!! could not verify versions against the registry: ${err.message}`);
+      warn("   Check the link by hand before posting.\n");
+    }
+  }
+
+  const fields = {
+    ...spec,
+    vector: values.vector,
+    consequence: values.consequence,
+    attestation: values.attestation,
+    safeVersion: values["safe-version"] ?? values.from,
+    badVersion: values.to,
+    claim: values.claim,
+    correction: values.correction,
+    url,
+  };
+
+  log(`diff: ${url}${verified ? "  (both versions resolve)" : "  (UNVERIFIED)"}\n`);
+
+  const channels = values.channel === "all" ? CHANNELS : [values.channel];
+  for (const channel of channels) {
+    if (!CHANNELS.includes(channel)) {
+      warn(`unknown channel: ${channel}`);
+      return 1;
+    }
+    const templateNames = values.template ? [values.template] : CHANNEL_TEMPLATES[channel];
+    log(`── ${channel} ${"─".repeat(Math.max(0, 60 - channel.length))}`);
+    for (const name of templateNames) {
+      let text;
+      try {
+        text = renderPost(name, fields);
+      } catch (err) {
+        log(`  [${name}] skipped: ${err.message}`);
+        continue;
+      }
+      const { length, limit, overflow } = measure(text, channel);
+      log(`\n[${name}]  ${length}/${limit}${overflow ? `  OVER BY ${overflow}` : ""}\n`);
+      log(text);
+      log("");
+    }
+  }
+
+  log(`Screenshot the diff before posting — the image is the ad, the link is the proof.`);
+  return 0;
+}
+
+// Only run when invoked directly, so the pure helpers above stay importable.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = await main(process.argv.slice(2));
+}

--- a/test/incident-post.test.mjs
+++ b/test/incident-post.test.mjs
@@ -1,0 +1,276 @@
+import { describe, expect, test } from "vitest";
+import {
+  CHANNEL_TEMPLATES,
+  CHANNELS,
+  checkVersionsSurvive,
+  diffUrl,
+  fetchPublishedVersions,
+  main,
+  measure,
+  renderPost,
+  TEMPLATES,
+} from "../scripts/incident-post.mjs";
+import { packageDiffPath } from "../src/lib/package-diff-path";
+
+// The script duplicates the diff-path encoding so it can run under bare `node`.
+// These tests are what make that duplication safe.
+describe("diffUrl", () => {
+  test("agrees with the app's own path builder", () => {
+    const cases = [
+      ["npm", "tape", "5.7.0", "5.7.1"],
+      ["npm", "@apollo/client", "3.11.8", "3.11.9"],
+      ["npm", "pkg", "1.0.0+build.1", "1.0.1"],
+      ["pypi", "requests", "2.31.0", "2.32.0"],
+    ];
+    for (const [ecosystem, name, from, to] of cases) {
+      expect(diffUrl({ ecosystem, packageName: name, fromVersion: from, toVersion: to })).toBe(
+        `https://drydock.org${packageDiffPath(ecosystem, name, from, to)}`,
+      );
+    }
+  });
+
+  test("honors a custom origin for staging checks", () => {
+    expect(
+      diffUrl({
+        packageName: "tape",
+        fromVersion: "1.0.0",
+        toVersion: "1.0.1",
+        origin: "http://localhost:5173",
+      }),
+    ).toBe("http://localhost:5173/diff/tape/1.0.0/1.0.1");
+  });
+});
+
+describe("checkVersionsSurvive", () => {
+  test("passes when both sides are still published", () => {
+    const check = checkVersionsSurvive({
+      published: ["1.0.0", "1.0.1", "1.0.2"],
+      fromVersion: "1.0.0",
+      toVersion: "1.0.1",
+    });
+    expect(check.ok).toBe(true);
+    expect(check.missing).toEqual([]);
+  });
+
+  test("names the unpublished side", () => {
+    // The compromised version is the one the registry pulls, and it is the one
+    // the post is about — so this is the common case, not the edge case.
+    const check = checkVersionsSurvive({
+      published: ["1.0.0", "1.0.2"],
+      fromVersion: "1.0.0",
+      toVersion: "1.0.1",
+    });
+    expect(check.ok).toBe(false);
+    expect(check.missing).toEqual(["1.0.1"]);
+    expect(check.nearest).toContain("1.0.2");
+  });
+
+  test("reports both sides when the package was fully pulled", () => {
+    const check = checkVersionsSurvive({
+      published: [],
+      fromVersion: "1.0.0",
+      toVersion: "1.0.1",
+    });
+    expect(check.missing).toEqual(["1.0.0", "1.0.1"]);
+  });
+});
+
+describe("fetchPublishedVersions", () => {
+  test("reads the npm versions map", async () => {
+    const fetchImpl = async (url) => {
+      expect(url).toBe("https://registry.npmjs.org/tape");
+      return new Response(JSON.stringify({ versions: { "5.7.0": {}, "5.7.1": {} } }));
+    };
+    expect(await fetchPublishedVersions({ packageName: "tape", fetchImpl })).toEqual([
+      "5.7.0",
+      "5.7.1",
+    ]);
+  });
+
+  test("keeps the scope readable in the npm metadata URL", async () => {
+    let seen;
+    const fetchImpl = async (url) => {
+      seen = url;
+      return new Response(JSON.stringify({ versions: {} }));
+    };
+    await fetchPublishedVersions({ packageName: "@apollo/client", fetchImpl });
+    expect(seen).toBe("https://registry.npmjs.org/@apollo%2Fclient");
+  });
+
+  test("reads the PyPI releases map", async () => {
+    const fetchImpl = async (url) => {
+      expect(url).toBe("https://pypi.org/pypi/requests/json");
+      return new Response(JSON.stringify({ releases: { "2.31.0": [], "2.32.0": [] } }));
+    };
+    expect(
+      await fetchPublishedVersions({ ecosystem: "pypi", packageName: "requests", fetchImpl }),
+    ).toEqual(["2.31.0", "2.32.0"]);
+  });
+
+  test("surfaces a registry error rather than returning an empty list", async () => {
+    const fetchImpl = async () => new Response("nope", { status: 404 });
+    await expect(fetchPublishedVersions({ packageName: "ghost", fetchImpl })).rejects.toThrow(
+      "returned 404",
+    );
+  });
+});
+
+describe("templates", () => {
+  const fields = {
+    packageName: "chalk",
+    fromVersion: "5.6.0",
+    toVersion: "5.6.1",
+    safeVersion: "5.6.0",
+    badVersion: "5.6.1",
+    vector: "a postinstall script that posts environment variables to a remote host",
+    consequence: "Anything the build host could reach should be treated as exposed.",
+    attestation: "valid npm provenance",
+    claim: "the payload ran on install",
+    correction: "it only ran during packaging",
+    url: "https://drydock.org/diff/chalk/5.6.0/5.6.1",
+  };
+
+  test("every channel maps to templates that exist", () => {
+    for (const channel of CHANNELS) {
+      expect(CHANNEL_TEMPLATES[channel], channel).toBeDefined();
+      for (const name of CHANNEL_TEMPLATES[channel]) {
+        expect(TEMPLATES[name], `${channel} -> ${name}`).toBeTypeOf("function");
+      }
+    }
+  });
+
+  test("every template renders and carries the diff link", () => {
+    for (const name of Object.keys(TEMPLATES)) {
+      const text = renderPost(name, fields);
+      expect(text, name).toContain(fields.url);
+      expect(text.length, name).toBeGreaterThan(40);
+    }
+  });
+
+  test("refuses to render with a missing field instead of emitting 'undefined'", () => {
+    // A post that reads "shipped undefined" is worse than no post.
+    expect(() => renderPost("breaking", { ...fields, vector: undefined })).toThrow(
+      "missing required field: vector",
+    );
+    expect(() => renderPost("breaking", { ...fields, vector: "  " })).toThrow("vector");
+  });
+
+  test("the short-form posts fit their channel limits", () => {
+    for (const channel of ["bluesky", "x"]) {
+      for (const name of CHANNEL_TEMPLATES[channel]) {
+        const { overflow, length, limit } = measure(renderPost(name, fields), channel);
+        expect(overflow, `${channel}/${name} is ${length}/${limit}`).toBe(0);
+      }
+    }
+  });
+
+  test("states what the diff shows, not what it implies about intent", () => {
+    // The diff proves bytes changed. It does not prove who, or why, and the
+    // playbook's hard rules say we never claim otherwise.
+    const forbidden = /\b(hacker|attacker|malicious actor|deliberately|on purpose|stole)\b/i;
+    for (const name of Object.keys(TEMPLATES)) {
+      expect(renderPost(name, fields), name).not.toMatch(forbidden);
+    }
+  });
+
+  test("names the package, never a person", () => {
+    for (const name of Object.keys(TEMPLATES)) {
+      expect(renderPost(name, fields), name).not.toMatch(/\bmaintainer('s)? (fault|error)\b/i);
+    }
+  });
+
+  test("the unpublished template explains the gap without linking a dead version", () => {
+    const text = renderPost("unpublished", { ...fields, badVersion: "5.6.1" });
+    expect(text).toContain("unpublished");
+    expect(text).toContain(fields.url);
+  });
+
+  test("the correction template does not delete history", () => {
+    expect(renderPost("correction", fields)).toContain("Leaving the original up");
+  });
+});
+
+describe("main", () => {
+  const baseArgs = [
+    "--package",
+    "chalk",
+    "--from",
+    "5.6.0",
+    "--to",
+    "5.6.1",
+    "--vector",
+    "a postinstall script that posts environment variables to a remote host",
+  ];
+
+  function capture() {
+    const lines = [];
+    return {
+      lines,
+      log: (line = "") => lines.push(String(line)),
+      warn: (line = "") => lines.push(String(line)),
+    };
+  }
+
+  test("prints per-channel copy when both versions resolve", async () => {
+    const out = capture();
+    const fetchImpl = async () =>
+      new Response(JSON.stringify({ versions: { "5.6.0": {}, "5.6.1": {} } }));
+    const code = await main(baseArgs, { fetchImpl, ...out });
+
+    expect(code).toBe(0);
+    const text = out.lines.join("\n");
+    expect(text).toContain("both versions resolve");
+    expect(text).toContain("── bluesky");
+    expect(text).toContain("── linkedin");
+    expect(text).toContain("https://drydock.org/diff/chalk/5.6.0/5.6.1");
+  });
+
+  test("refuses to print a post when the registry has pulled a version", async () => {
+    // The failure this whole script exists to prevent.
+    const out = capture();
+    const fetchImpl = async () => new Response(JSON.stringify({ versions: { "5.6.0": {} } }));
+    const code = await main(baseArgs, { fetchImpl, ...out });
+
+    expect(code).toBe(2);
+    const text = out.lines.join("\n");
+    expect(text).toContain("Do not post this");
+    expect(text).not.toContain("── bluesky");
+  });
+
+  test("still prints, marked unverified, when the registry is unreachable", async () => {
+    const out = capture();
+    const fetchImpl = async () => {
+      throw new Error("network down");
+    };
+    const code = await main(baseArgs, { fetchImpl, ...out });
+
+    expect(code).toBe(0);
+    const text = out.lines.join("\n");
+    expect(text).toContain("UNVERIFIED");
+    expect(text).toContain("Check the link by hand");
+  });
+
+  test("--no-verify skips the registry entirely", async () => {
+    const out = capture();
+    let called = false;
+    const fetchImpl = async () => {
+      called = true;
+      return new Response("{}");
+    };
+    const code = await main([...baseArgs, "--no-verify"], { fetchImpl, ...out });
+
+    expect(code).toBe(0);
+    expect(called).toBe(false);
+    expect(out.lines.join("\n")).toContain("UNVERIFIED");
+  });
+
+  test("prints usage and fails when required arguments are missing", async () => {
+    const out = capture();
+    const code = await main(["--package", "chalk"], {
+      fetchImpl: async () => new Response("{}"),
+      ...out,
+    });
+    expect(code).toBe(1);
+    expect(out.lines.join("\n")).toContain("Usage:");
+  });
+});


### PR DESCRIPTION
The reach window for incident content is roughly 24–48 hours. That is not enough time to decide what we are willing to say under pressure, so this makes those decisions in advance.

Companion to #529 (share cards + attribution), but independent — this branch is off `main` and touches no runtime code.

## The hard rules

`docs/incident-content-playbook.md` carries eight. The ones that actually constrain:

- **Confirmed public incidents only.** Never a live maintainer's release on suspicion. The first viral moment must not be a maintainer being publicly accused by a tool that reviews maintainers' work.
- **Describe the diff, not the intent.** The diff proves bytes changed. It does not prove who or why. Attribution belongs to the people running the actual investigation.
- **Name the package, never a person.** A compromised maintainer is the victim of the incident, not its cause.
- **No payload amplification.** Link the diff; don't paste the deobfuscated payload or the exfil endpoint.
- **No AI output in incident content.** The public diff runs deterministic rules on purpose, and determinism *is* the message. Quoting a model about a live incident invites an argument about the model instead of the bytes.
- **Correct in public, don't delete.**

## The script

`scripts/incident-post.mjs` holds the templates and — the reason it's a script rather than a snippet in a doc — the check that runs before any of them print.

npm unpublishes malicious versions, often within hours of disclosure, which is exactly the window this content targets. The script verifies both versions still resolve against the registry and **refuses to emit a post when one is gone**, listing the surviving versions so the post can be rebuilt around a pair that still works:

```
$ pnpm incident:post --package chalk --from 5.6.0 --to 5.6.1 --vector "…"

!! 5.6.1 is not published.

   The registry has probably pulled the compromised release. Do not post this
   link — it will 404 for everyone who clicks it.

   Most recent surviving versions: 5.5.0, 5.6.0, 5.6.2
```

A post whose link 404s reads as opportunistic and cannot be quietly fixed once shared.

On the happy path it prints the diff URL and per-channel copy with a character count against each channel's limit:

```
$ pnpm incident:post --package tape --from 5.7.0 --to 5.7.1 --vector "a postinstall hook"

diff: https://drydock.org/diff/tape/5.7.0/5.7.1  (both versions resolve)

── bluesky ───────────────────────────────────────────────────

[breaking]  156/300

tape 5.7.1 added a postinstall hook. It is not in 5.7.0.

Here is the diff. No login, no token, nothing installed:
https://drydock.org/diff/tape/5.7.0/5.7.1
```

## Templates

| Template | Channel | Use when |
| --- | --- | --- |
| `breaking` | Bluesky, X | First post — what the release added, plus the diff link |
| `whatToDo` | Bluesky, X | Second post in the thread — what a reader with this in a lockfile does now |
| `provenance` | any | The release passed provenance/2FA. The pipeline was authentic; the bytes were not |
| `analysis` | LinkedIn | T+24–48h long form, analysis first |
| `unpublished` | any | The registry got there first |
| `correction` | any | We got something wrong. Pre-written because the moment you need it is the moment you're least able to write it well |

Templates live in the script rather than the doc so there is exactly one copy of the wording; the doc explains when and why to send each one.

## Testing

`pnpm run verify` passes. 22 tests in `test/incident-post.test.mjs`:

- The script duplicates `packageDiffPath` so it can run under bare `node` — a test asserts the two agree across scoped names, build metadata, and PyPI, which is what makes the duplication safe.
- The unpublished-version refusal (exit 2, no copy printed) and registry-unreachable degradation (prints, marked `UNVERIFIED`).
- Short-form templates fit Bluesky's 300 and X's 280.
- No template renders `undefined` into a post — a missing field throws rather than emitting "shipped undefined".
- No template asserts intent the diff cannot support, enforced by a regex over the rendered output.

No runtime code, no migrations, no dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)