### PR TITLE
Recover workflow gate reviews abandoned mid-batch

### DIFF
--- a/docs/workflow-gates.md
+++ b/docs/workflow-gates.md
@@ -162,6 +162,19 @@ The publish job must publish the reviewed VSIX bytes. Repacking after approval b
 - If artifact resolution, baseline acquisition, validation, scan, or callback fails, the gate remains blocked or is rejected; do not fail open.
 - Drydock never publishes. It only posts the GitHub deployment-protection decision.
 
+## Abandoned review recovery
+
+A delivery claims a gate's review batch by CAS-setting `review_started_at`, so a concurrent re-delivery cannot double-run the per-package scans. The claim is a **lease** (`GATE_REVIEW_CLAIM_LEASE_MS`, 30 minutes), not a permanent flag: a delivery that fails mid-batch hands the claim back, but a hard crash — worker eviction, a CPU limit, an exhausted queue retry ladder — cannot. Without a lease such a gate sits pending forever with an unreleasable claim, no scan, and no recorded failure, and every later delivery loses the CAS and skips.
+
+`claimGateReviewStart` therefore takes over a claim older than the lease **only while no representative scan is attached**. That guard is what keeps the takeover safe: a gate that finished its review and is waiting on a maintainer carries a scan, so it can never be reclaimed and re-run mid-decision.
+
+The 15-minute cron sweeps the leftovers (`recoverAbandonedGateReviews`, bounded to 20 gates per tick):
+
+- Still inside GitHub's deployment-protection callback window → the gate is re-enqueued and the expired lease is taken over on the next attempt.
+- Past the callback window → GitHub already auto-rejected the held deployment without telling us, so re-reviewing would produce a decision with nowhere to post it. The gate is annotated with the `callback_window_elapsed` failure reason and a single `github_workflow_gate.timeout_missed` audit event; the stored reason is the idempotency guard that stops the sweep re-notifying every tick.
+
+The sweep is enqueue-or-annotate only — it never approves or rejects a gate.
+
 ## Maintainer workbench
 
 The gate review workbench shows the release target, package identity/version, artifact set, scan status, findings, changed files, and accept/reject controls. Accept/reject actions require an authenticated maintainer in the owning organization. Step-up auth requirements should match other sensitive release decisions; see [`two-factor-auth.md`](./two-factor-auth.md).

--- a/server/index.ts
+++ b/server/index.ts
@@ -27,7 +27,7 @@ import {
   retryDelaySeconds,
   type QueueMessage,
 } from "./lib/scan/job";
-import { executeWorkflowGateJob } from "./lib/workflow-gate-job";
+import { executeWorkflowGateJob, recoverAbandonedGateReviews } from "./lib/workflow-gate-job";
 import {
   createStageStartCoordinator,
   discoverAndQueueStagedPublishes,
@@ -446,6 +446,19 @@ async function pruneStaleAuditEvents(env: Cloudflare.Env) {
   }
 }
 
+// Pick up gate reviews whose delivery died mid-batch. Without this nothing ever
+// revisits them: the abandoned claim makes every retry a no-op and the queue
+// message is gone. Never let a recovery failure abort the tick.
+async function sweepAbandonedGateReviews(env: Cloudflare.Env) {
+  try {
+    await recoverAbandonedGateReviews(env);
+  } catch (err) {
+    emitOperationalEvent("error", "github_workflow_gate.recovery_failed", {
+      error: describeOperationalError(err),
+    });
+  }
+}
+
 export default {
   fetch: app.fetch,
   async scheduled(_event: ScheduledController, env: Cloudflare.Env, ctx: ExecutionContext) {
@@ -460,6 +473,7 @@ export default {
         error: describeOperationalError(err),
       });
     }
+    await sweepAbandonedGateReviews(env);
     await pruneStaleAuditEvents(env);
   },
   async queue(batch: MessageBatch<QueueMessage>, env: Cloudflare.Env, ctx: ExecutionContext) {

--- a/server/lib/github-app/webhook-gates.ts
+++ b/server/lib/github-app/webhook-gates.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, sql } from "drizzle-orm";
+import { and, eq, isNull, lte, sql, type SQL } from "drizzle-orm";
 import { type AppDb } from "../../db/client";
 import { githubWorkflowGates, scans } from "../../db/schema";
 import type { InstallationRecord, ReleaseTargetRecord } from "./persistence";
@@ -27,8 +27,9 @@ export interface WorkflowGateRecord {
   // several per-package scans (`scans.gate_id = this.id`); this points at the
   // one surfaced as the gate's headline.
   scanId: string | null;
-  // CAS claim flipped once when a delivery starts the review batch, so a
-  // concurrent re-delivery does not double-run the per-package scans.
+  // CAS claim taken when a delivery starts the review batch, so a concurrent
+  // re-delivery does not double-run the per-package scans. It is a lease: see
+  // `GATE_REVIEW_CLAIM_LEASE_MS` for how an abandoned claim is taken over.
   reviewStartedAt: Date | null;
   failureReason: string | null;
   requestedAt: Date;
@@ -201,16 +202,65 @@ function readReleaseRisk(riskSummaryJson: unknown): string | null {
   return typeof value === "string" ? value : null;
 }
 
+// A review claim is a lease, not a permanent flag. A delivery that fails
+// mid-batch hands the claim back via `releaseGateReviewClaim`, but a hard crash
+// (worker eviction, CPU limit, an exhausted queue retry ladder) cannot: it
+// leaves `review_started_at` set with no scan attached, and every later
+// delivery loses the CAS and skips. The gate then sits pending forever with no
+// review, no failure reason, and nothing to tell the maintainer. Expiring the
+// claim keeps the fail-closed guarantee (an expired claim never approves
+// anything) while making an abandoned batch retryable.
+//
+// The lease has to outlast a healthy batch — a monorepo gate scans every
+// package — so it is set well above the queue's own retry ladder rather than
+// tuned tight. `recoverAbandonedGateReviews` sweeps on the same 15-minute cron.
+export const GATE_REVIEW_CLAIM_LEASE_MS = 30 * 60 * 1000;
+
+export type GateReviewClaim = "claimed" | "reclaimed" | "lost";
+
 /**
- * CAS-claim the review batch for a gate. Returns true for exactly the first
- * delivery that flips `review_started_at` from null while the gate is still
- * pending; a concurrent re-delivery loses the claim and skips. A claim that is
- * never finalized (a delivery that fails mid-batch releases it via
- * `releaseGateReviewClaim`; a hard crash leaves the gate pending — safe, never
- * auto-approved).
+ * CAS-claim the review batch for a gate. Returns `claimed` for exactly the
+ * first delivery that flips `review_started_at` from null while the gate is
+ * still pending; a concurrent re-delivery loses the claim and skips.
+ *
+ * A claim older than `GATE_REVIEW_CLAIM_LEASE_MS` with no representative scan
+ * attached belongs to a delivery that died mid-batch, and is taken over
+ * (`reclaimed`). The `scan_id is null` guard is what keeps that safe: a gate
+ * that finished its review and is waiting on a human carries a scan, so it can
+ * never be reclaimed and re-run out from under the maintainer.
  */
-export async function claimGateReviewStart(db: AppDb, gateId: string): Promise<boolean> {
-  const now = new Date();
+export async function claimGateReviewStart(
+  db: AppDb,
+  gateId: string,
+  now: Date = new Date(),
+): Promise<GateReviewClaim> {
+  // Two narrow CAS updates rather than one `or(...)`: SQLite `returning` on an
+  // UPDATE reports the new row, so a combined statement could not tell a fresh
+  // claim from a takeover, and the two cases are logged differently — a
+  // takeover means a previous delivery died mid-batch.
+  const fresh = await casClaimGateReview(
+    db,
+    gateId,
+    now,
+    isNull(githubWorkflowGates.reviewStartedAt),
+  );
+  if (fresh) return "claimed";
+  const staleBefore = new Date(now.getTime() - GATE_REVIEW_CLAIM_LEASE_MS);
+  const takeover = await casClaimGateReview(
+    db,
+    gateId,
+    now,
+    lte(githubWorkflowGates.reviewStartedAt, staleBefore),
+  );
+  return takeover ? "reclaimed" : "lost";
+}
+
+async function casClaimGateReview(
+  db: AppDb,
+  gateId: string,
+  now: Date,
+  claimCondition: SQL | undefined,
+): Promise<boolean> {
   const updated = await db
     .update(githubWorkflowGates)
     .set({ reviewStartedAt: now, updatedAt: now })
@@ -218,11 +268,56 @@ export async function claimGateReviewStart(db: AppDb, gateId: string): Promise<b
       and(
         eq(githubWorkflowGates.id, gateId),
         eq(githubWorkflowGates.status, "pending"),
-        isNull(githubWorkflowGates.reviewStartedAt),
+        isNull(githubWorkflowGates.scanId),
+        claimCondition,
       ),
     )
     .returning({ id: githubWorkflowGates.id });
   return updated.length > 0;
+}
+
+export interface AbandonedGateReview {
+  id: string;
+  organizationId: string;
+  repositoryFullName: string;
+  environment: string;
+  requestedAt: Date;
+  reviewStartedAt: Date;
+  failureReason: string | null;
+}
+
+/**
+ * Pending gates holding a review claim that has outlived its lease without
+ * attaching a scan — the abandoned-batch state described above. Ordered oldest
+ * first and bounded so a cron sweep stays cheap.
+ */
+export async function listAbandonedGateReviews(
+  db: AppDb,
+  input: { staleBefore: Date; limit: number },
+): Promise<AbandonedGateReview[]> {
+  const rows = await db
+    .select({
+      id: githubWorkflowGates.id,
+      organizationId: githubWorkflowGates.organizationId,
+      repositoryFullName: githubWorkflowGates.repositoryFullName,
+      environment: githubWorkflowGates.environment,
+      requestedAt: githubWorkflowGates.requestedAt,
+      reviewStartedAt: githubWorkflowGates.reviewStartedAt,
+      failureReason: githubWorkflowGates.failureReason,
+    })
+    .from(githubWorkflowGates)
+    .where(
+      and(
+        eq(githubWorkflowGates.status, "pending"),
+        isNull(githubWorkflowGates.scanId),
+        lte(githubWorkflowGates.reviewStartedAt, input.staleBefore),
+      ),
+    )
+    .orderBy(githubWorkflowGates.reviewStartedAt)
+    .limit(input.limit);
+  return rows.flatMap((row) =>
+    row.reviewStartedAt ? [{ ...row, reviewStartedAt: row.reviewStartedAt }] : [],
+  );
 }
 
 /**

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -15,8 +15,11 @@ import {
   type WorkflowGateRecord,
   attachScanToGate,
   claimGateReviewStart,
+  GATE_REVIEW_CLAIM_LEASE_MS,
   getGateForOrganization,
+  listAbandonedGateReviews,
   markGateDecided,
+  markGateErrored,
   releaseGateReviewClaim,
 } from "./github-app/webhook-gates";
 import { notifyWorkflowGateReview, notifyWorkflowGateTimeout } from "./notify";
@@ -239,8 +242,18 @@ export async function executeWorkflowGateJob(
   // runs the per-package scans; a concurrent re-delivery loses the CAS and skips
   // here rather than double-running. Early returns above leave the claim unset,
   // so a transient prepare/owner failure stays retryable.
-  const claimed = await claimGateReviewStart(db, gate.id);
-  if (!claimed) {
+  const claim = await claimGateReviewStart(db, gate.id);
+  if (claim === "reclaimed") {
+    // The lease expired with no scan attached, so a previous delivery died
+    // mid-batch without releasing its claim. Worth an operator signal: the
+    // abandoned attempt produced no review and nothing else reports it.
+    emitOperationalEvent("warn", "github_workflow_gate.review_claim_reclaimed", {
+      organizationId,
+      gateId,
+      abandonedAt: gate.reviewStartedAt?.toISOString() ?? null,
+    });
+  }
+  if (claim === "lost") {
     emitOperationalEvent("info", "github_workflow_gate.job_skipped", {
       organizationId,
       gateId,
@@ -409,6 +422,99 @@ export async function executeWorkflowGateJob(
     timeoutState,
     durationMs: jobDurationMs,
   });
+}
+
+// How many abandoned gates one cron tick will act on. Gate reviews are rare and
+// the backlog only ever grows by the number of deliveries that crashed
+// mid-batch, so a small cap keeps the tick cheap; anything beyond it is picked
+// up 15 minutes later. `recovered`/`skipped` counts are logged either way so a
+// truncated sweep is never mistaken for a drained one.
+const GATE_RECOVERY_SWEEP_LIMIT = 20;
+
+export const GATE_TIMEOUT_FAILURE_REASON = "callback_window_elapsed";
+
+export interface GateRecoverySweepResult {
+  abandoned: number;
+  requeued: number;
+  lapsed: number;
+}
+
+/**
+ * Cron sweep for gate reviews whose delivery died mid-batch: the gate is still
+ * pending, holds an expired review claim, and has no scan attached, so nothing
+ * in the delivery path will ever look at it again (a lost CAS makes every retry
+ * a no-op, and the queue message is long gone).
+ *
+ * A gate still inside GitHub's deployment-protection callback window is
+ * re-enqueued — `claimGateReviewStart` takes the expired lease over and re-runs
+ * the batch. A gate past the window is already lost: GitHub auto-rejected the
+ * held deployment without telling us, so re-reviewing it would only produce a
+ * decision with nowhere to go. Those are recorded as `timeout_missed` once
+ * (the stored failure reason is the idempotency guard) so the maintainer sees
+ * why the gate went nowhere instead of it sitting pending forever.
+ *
+ * Never approves or rejects anything: recovery is enqueue-or-annotate only.
+ */
+export async function recoverAbandonedGateReviews(
+  env: Cloudflare.Env,
+  db: AppDb = createDb(env.DB),
+  now: Date = new Date(),
+): Promise<GateRecoverySweepResult> {
+  const staleBefore = new Date(now.getTime() - GATE_REVIEW_CLAIM_LEASE_MS);
+  const abandoned = await listAbandonedGateReviews(db, {
+    staleBefore,
+    limit: GATE_RECOVERY_SWEEP_LIMIT,
+  });
+  const windowMs = workflowGateCallbackWindowMs(env);
+  const result: GateRecoverySweepResult = { abandoned: abandoned.length, requeued: 0, lapsed: 0 };
+
+  for (const gate of abandoned) {
+    const elapsedMs = now.getTime() - gate.requestedAt.getTime();
+    if (classifyGateTimeout(elapsedMs, windowMs) === "missed") {
+      result.lapsed += 1;
+      // Already annotated by an earlier tick — don't re-emit the audit event.
+      if (gate.failureReason === GATE_TIMEOUT_FAILURE_REASON) continue;
+      await markGateErrored(db, gate.id, GATE_TIMEOUT_FAILURE_REASON);
+      await recordScanEvent(db, {
+        organizationId: gate.organizationId,
+        type: "github_workflow_gate.timeout_missed",
+        metadata: { gateId: gate.id, elapsedMs, windowMs, reason: "review_abandoned" },
+      });
+      emitOperationalEvent("error", "github_workflow_gate.timeout_missed", {
+        organizationId: gate.organizationId,
+        gateId: gate.id,
+        repositoryFullName: gate.repositoryFullName,
+        environment: gate.environment,
+        elapsedMs,
+        windowMs,
+        reason: "review_abandoned",
+      });
+      continue;
+    }
+
+    if (!env.SCAN_QUEUE) continue;
+    await env.SCAN_QUEUE.send({
+      kind: "workflow_gate",
+      organizationId: gate.organizationId,
+      gateId: gate.id,
+    } satisfies WorkflowGateQueueMessage);
+    result.requeued += 1;
+    emitOperationalEvent("warn", "github_workflow_gate.review_requeued", {
+      organizationId: gate.organizationId,
+      gateId: gate.id,
+      repositoryFullName: gate.repositoryFullName,
+      environment: gate.environment,
+      abandonedAt: gate.reviewStartedAt.toISOString(),
+      elapsedMs,
+    });
+  }
+
+  emitOperationalEvent("info", "github_workflow_gate.recovery_swept", {
+    ...result,
+    limit: GATE_RECOVERY_SWEEP_LIMIT,
+    truncated: abandoned.length === GATE_RECOVERY_SWEEP_LIMIT,
+  });
+  return result;
 }
 
 interface ReviewedPackage {

--- a/test/workers/workflow-gate-job.test.ts
+++ b/test/workers/workflow-gate-job.test.ts
@@ -9,6 +9,8 @@ import { eq } from "drizzle-orm";
 import { createReleaseTarget, upsertInstallation } from "../../server/lib/github-app/persistence";
 import {
   attachScanToGate,
+  claimGateReviewStart,
+  GATE_REVIEW_CLAIM_LEASE_MS,
   getGateForOrganization,
   listGatePackageScans,
   markGateDecided,
@@ -16,6 +18,8 @@ import {
 import {
   classifyGateTimeout,
   executeWorkflowGateJob,
+  GATE_TIMEOUT_FAILURE_REASON,
+  recoverAbandonedGateReviews,
   recommendationForReleaseRisk,
   workflowGateCallbackWindowMs,
 } from "../../server/lib/workflow-gate-job";
@@ -482,6 +486,167 @@ describe("workflow gate scan attachment", () => {
       seeded.gateId,
     );
     expect(gateAfterRetryClaim?.scanId).toBe(secondScanId);
+  });
+});
+
+describe("workflow gate review claim lease", () => {
+  test("takes over a claim whose lease expired without attaching a scan", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9230",
+      repositoryId: 72031,
+      runId: 31001,
+    });
+    const db = createDb(env.DB);
+
+    // First delivery claims the batch; a concurrent re-delivery must lose.
+    await expect(claimGateReviewStart(db, seeded.gateId)).resolves.toBe("claimed");
+    await expect(claimGateReviewStart(db, seeded.gateId)).resolves.toBe("lost");
+
+    // That delivery then dies without releasing the claim (a hard crash cannot
+    // run the release path), so the claim ages out of its lease.
+    const afterLease = new Date(Date.now() + GATE_REVIEW_CLAIM_LEASE_MS + 1_000);
+    await expect(claimGateReviewStart(db, seeded.gateId, afterLease)).resolves.toBe("reclaimed");
+
+    const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(gate?.reviewStartedAt?.getTime()).toBe(afterLease.getTime());
+  });
+
+  test("never reclaims a reviewed gate that is waiting on a human decision", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9231",
+      repositoryId: 72032,
+      runId: 31002,
+    });
+    const db = createDb(env.DB);
+    const scanId = crypto.randomUUID();
+    await createScanJob(db, {
+      id: scanId,
+      stageId: `workflow-gate:${seeded.gateId}`,
+      organizationId: seeded.organizationId,
+      ownerUserId: seeded.userId,
+      source: "workflow_gate",
+    });
+
+    await expect(claimGateReviewStart(db, seeded.gateId)).resolves.toBe("claimed");
+    await expect(attachScanToGate(db, seeded.gateId, scanId, null)).resolves.toBe(true);
+
+    // A finished review parks the gate with a scan attached for as long as the
+    // maintainer takes to decide — far longer than the lease. Reclaiming it
+    // would re-run the batch under the maintainer's feet.
+    const longAfterLease = new Date(Date.now() + GATE_REVIEW_CLAIM_LEASE_MS * 10);
+    await expect(claimGateReviewStart(db, seeded.gateId, longAfterLease)).resolves.toBe("lost");
+
+    const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(gate?.scanId).toBe(scanId);
+  });
+});
+
+describe("recoverAbandonedGateReviews", () => {
+  // The sweep is deliberately account-wide, and these suites share one D1, so
+  // every assertion filters to the gate under test rather than reading the
+  // sweep's aggregate counters.
+  function recoveryEnv(overrides: Record<string, unknown> = {}) {
+    const sent: { gateId: string }[] = [];
+    const recovery = {
+      ...env,
+      SCAN_QUEUE: { send: async (message: { gateId: string }) => void sent.push(message) },
+      ...overrides,
+    } as unknown as Cloudflare.Env;
+    const requeuedIds = () => sent.map((message) => message.gateId);
+    return { recovery, sent, requeuedIds };
+  }
+
+  test("re-enqueues an abandoned review that is still inside the callback window", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9232",
+      repositoryId: 72033,
+      runId: 31003,
+    });
+    const db = createDb(env.DB);
+    await claimGateReviewStart(db, seeded.gateId);
+    const { recovery, sent } = recoveryEnv();
+
+    const now = new Date(Date.now() + GATE_REVIEW_CLAIM_LEASE_MS + 1_000);
+    await recoverAbandonedGateReviews(recovery, db, now);
+
+    expect(sent).toContainEqual({
+      kind: "workflow_gate",
+      organizationId: seeded.organizationId,
+      gateId: seeded.gateId,
+    });
+    // Enqueue-or-annotate only: the sweep itself never decides a gate.
+    const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(gate?.status).toBe("pending");
+    expect(gate?.failureReason).toBeNull();
+  });
+
+  test("leaves a live claim and a reviewed gate alone", async () => {
+    const live = await seedGateForTest({
+      installationExternalId: "9233",
+      repositoryId: 72034,
+      runId: 31004,
+    });
+    const reviewed = await seedGateForTest({
+      installationExternalId: "9234",
+      repositoryId: 72035,
+      runId: 31005,
+    });
+    const db = createDb(env.DB);
+    await claimGateReviewStart(db, live.gateId);
+    await claimGateReviewStart(db, reviewed.gateId);
+    const scanId = crypto.randomUUID();
+    await createScanJob(db, {
+      id: scanId,
+      stageId: `workflow-gate:${reviewed.gateId}`,
+      organizationId: reviewed.organizationId,
+      ownerUserId: reviewed.userId,
+      source: "workflow_gate",
+    });
+    await attachScanToGate(db, reviewed.gateId, scanId, null);
+
+    const { recovery, requeuedIds } = recoveryEnv();
+    // Only just claimed, so neither gate has aged past its lease yet.
+    await recoverAbandonedGateReviews(recovery, db, new Date());
+    expect(requeuedIds()).not.toContain(live.gateId);
+    expect(requeuedIds()).not.toContain(reviewed.gateId);
+
+    // Past the lease, the reviewed gate still must not be swept — it is waiting
+    // on a human, not abandoned.
+    const afterLease = new Date(Date.now() + GATE_REVIEW_CLAIM_LEASE_MS + 1_000);
+    await recoverAbandonedGateReviews(recovery, db, afterLease);
+    expect(requeuedIds()).toContain(live.gateId);
+    expect(requeuedIds()).not.toContain(reviewed.gateId);
+  });
+
+  test("records a single timeout_missed for an abandoned review past the callback window", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9235",
+      repositoryId: 72036,
+      runId: 31006,
+      requestedAt: new Date(Date.now() - 61_000),
+    });
+    const db = createDb(env.DB);
+    await claimGateReviewStart(db, seeded.gateId);
+    const { recovery, sent } = recoveryEnv({ WORKFLOW_GATE_CALLBACK_WINDOW_MS: "60000" });
+
+    const now = new Date(Date.now() + GATE_REVIEW_CLAIM_LEASE_MS + 1_000);
+    await recoverAbandonedGateReviews(recovery, db, now);
+
+    // GitHub already auto-rejected the held deployment, so re-reviewing would
+    // produce a decision with nowhere to post it.
+    expect(sent.map((message) => message.gateId)).not.toContain(seeded.gateId);
+    const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    expect(gate?.failureReason).toBe(GATE_TIMEOUT_FAILURE_REASON);
+    expect(gate?.status).toBe("pending");
+
+    const types = await scanEventTypes(seeded.organizationId, seeded.gateId);
+    expect(types).toEqual(["github_workflow_gate.timeout_missed"]);
+
+    // The sweep runs every 15 minutes; the stored reason keeps it from
+    // re-notifying the same dead gate forever.
+    await recoverAbandonedGateReviews(recovery, db, now);
+    const typesAfter = await scanEventTypes(seeded.organizationId, seeded.gateId);
+    expect(typesAfter).toEqual(["github_workflow_gate.timeout_missed"]);
   });
 });
 


### PR DESCRIPTION
## What surfaced in D1

A sweep of the production D1 (`staged-publish-review`) turned up three workflow gates permanently stuck in an unrecoverable state:

| gate | repo / env | claimed | scan | failure reason | events |
|---|---|---|---|---|---|
| `2aacf0d5…` | `JoviDeCroock/drydock-ci-example` / `pypi` | 2026-06-10 | none | none | `requested`, `received` |
| `71093fb8…` | same | 2026-06-10 | none | none | `requested`, `received` |
| `abcc3d5d…` | same | 2026-06-15 | none | none | `requested`, `received` |

All three are `status = 'pending'` with `review_started_at` set, `scan_id` null, and `failure_reason` null — and no `github_workflow_gate.reviewed` or `.review_failed` event ever followed the `received` one. They have been sitting untouched for 40+ days.

## Why they can never recover

A delivery claims a gate's review batch by CAS-setting `review_started_at`, so a concurrent re-delivery cannot double-run the per-package scans. A delivery that *fails* mid-batch hands the claim back via `releaseGateReviewClaim` — but a hard crash (worker eviction, a CPU limit, an exhausted queue retry ladder) cannot run that path. The claim is then unreleasable:

- every later delivery loses the CAS, logs `review_claim_lost`, and **returns successfully**, so the queue message acks and the gate is abandoned silently;
- `classifyGateTimeout` only runs *inside* the job, after a successful review, so nothing ever re-evaluates the gate afterwards — `github_workflow_gate.timeout_missed` has never once been recorded in production despite three gates being well past GitHub's 30-day callback window.

The existing comment called this "safe, never auto-approved", which is true — but it is also invisible, and the maintainer is never told the release review went nowhere.

## Changes

**The claim becomes a lease** (`GATE_REVIEW_CLAIM_LEASE_MS`, 30 minutes). `claimGateReviewStart` now returns `"claimed" | "reclaimed" | "lost"` and takes over an expired claim, logging `github_workflow_gate.review_claim_reclaimed` so a takeover surfaces as the crash signal it is.

The takeover is gated on `scan_id is null`. That guard is what keeps it safe: a gate that finished its review carries a representative scan for as long as the maintainer takes to decide — far longer than the lease — so it can never be reclaimed and re-run mid-decision. Covered by a test that parks a reviewed gate 10× past the lease and asserts the claim is still refused.

**A cron sweep for the leftovers** — `recoverAbandonedGateReviews`, wired into the existing 15-minute tick alongside audit pruning, bounded to 20 gates and logging `truncated` so a capped sweep is never mistaken for a drained one:

- still inside GitHub's callback window → re-enqueue the gate; the next attempt takes the expired lease over and re-runs the batch (`discardGateScans` already clears any half-finished scans);
- past the window → GitHub has already auto-rejected the held deployment without telling us, so re-reviewing would produce a decision with nowhere to post it. The gate is annotated `callback_window_elapsed` and gets one `github_workflow_gate.timeout_missed` audit event — a type already in the audit registry as "Release gate expired without a decision" but never previously emitted. The stored failure reason is the idempotency guard, so a dead gate is not re-notified every 15 minutes.

The sweep is enqueue-or-annotate only; it never approves or rejects a gate, and a recovery failure never aborts the tick.

## Testing

- `pnpm run verify` — lint, format, typecheck, and the full Vitest suite pass.
- New coverage in `test/workers/workflow-gate-job.test.ts`: lease takeover after expiry, refusal to reclaim a reviewed gate awaiting a human, re-enqueue inside the window, live claims left alone, and a single non-repeating `timeout_missed` past the window. Assertions filter to the gate under test because the sweep is deliberately account-wide over a shared D1.
- Docs: `docs/workflow-gates.md` gains an "Abandoned review recovery" section under trust and failure behavior.

## Note on the three existing gates

This change does not retroactively fix them — all three are past the 30-day callback window, so the first cron tick after deploy will annotate them `callback_window_elapsed` and record one `timeout_missed` each, which is the correct outcome. Their GitHub deployments are long gone.

---
_Generated by [Claude Code](https://claude.ai/code/session_019VkCUq9dCRH3Mjo55C7pbj)_