### PR TITLE
Add product analytics to measure funnel and release gates

### DIFF
--- a/docs/product-analytics.md
+++ b/docs/product-analytics.md
@@ -100,6 +100,12 @@ low-volume one out of the dataset.
 | `ai_review.finished`       | `maybeRunAiReview`            | reviewer health — the silent-failure rate  |
 | `npm_connection.validated` | npm connection validation     | onboarding funnel                          |
 | `public_diff.viewed`       | `loadRequestedDiff`           | growth-loop traffic, cache hit rate        |
+| `user.signed_up`           | Better Auth user-create hook  | acquisition — the funnel's numerator       |
+| `organization.created`     | `POST /api/v1/organizations`  | teams, excluding lazy personal workspaces  |
+| `integration.connected`    | npm / GitHub / Slack connect  | activation, by integration kind            |
+| `workflow_gate.opened`     | `deployment_protection_rule`  | gate volume                                |
+| `workflow_gate.reviewed`   | gate runner                   | recommendation mix; review latency         |
+| `workflow_gate.decided`    | human route + auto-block path | approval rate, human vs automatic          |
 
 `scan.failed` fires only on a terminal failure, so a scan that succeeds on retry
 is not filed as a failure. Both the npm queue path and the workflow-gate runner

--- a/server/lib/auth/index.ts
+++ b/server/lib/auth/index.ts
@@ -6,6 +6,7 @@ import { twoFactor } from "better-auth/plugins";
 import { eq } from "drizzle-orm";
 import { type AppDb, createDb } from "../../db/client";
 import { deleteUserAccount, findCoOwnedOrganizations } from "../../db/organizations";
+import { recordProductEvent } from "../platform/analytics";
 import * as schema from "../../db/schema";
 import { sendAccountVerificationEmail } from "../notify/account-email";
 
@@ -122,6 +123,25 @@ export function createAuth(env: Cloudflare.Env) {
       minPasswordLength: 12,
       maxPasswordLength: 256,
       ...(nativeScryptAvailable ? { password: nativeScryptPassword } : {}),
+    },
+    databaseHooks: {
+      user: {
+        create: {
+          // Top of the funnel. Fires once per account row, so it counts real
+          // signups rather than sign-in attempts. Nothing identifying is
+          // recorded — not the email, not the user id (see the privacy posture
+          // in lib/platform/analytics.ts). `emailVerificationEnabled` rides
+          // along as the outcome because an unverified account cannot reach a
+          // scan, and that is the first place the funnel leaks.
+          after: async () => {
+            recordProductEvent(env, {
+              name: "user.signed_up",
+              method: "email_password",
+              outcome: emailVerificationEnabled ? "verification_pending" : "active",
+            });
+          },
+        },
+      },
     },
     user: {
       deleteUser: {

--- a/server/lib/platform/analytics.ts
+++ b/server/lib/platform/analytics.ts
@@ -116,6 +116,74 @@ export type AnalyticsEvent =
       outcome: string;
     }
   | {
+      /**
+       * A new account. Carries no organization (the personal workspace is
+       * created lazily on first use) and, deliberately, no user id — see the
+       * privacy posture above. This is the funnel's numerator and nothing more.
+       */
+      name: "user.signed_up";
+      /** `email_password` — the sign-up method, for when others exist. */
+      method: string;
+      /** `verification_pending` | `active` */
+      outcome: string;
+    }
+  | {
+      /**
+       * An explicitly created organization. Personal workspaces are excluded:
+       * `ensurePersonalOrganization` creates one for every account on first
+       * request, so counting them would just restate `user.signed_up`.
+       */
+      name: "organization.created";
+      organizationId: string;
+    }
+  | {
+      /**
+       * An integration reaching a connected state for the first time — the
+       * activation step between signing up and reviewing anything.
+       *
+       * Distinct from `npm_connection.validated`, which fires on every
+       * revalidation and measures ongoing credential *health*. This one fires
+       * once per connection and measures *activation*.
+       */
+      name: "integration.connected";
+      organizationId: string;
+      /** `npm` | `github` | `slack` */
+      kind: string;
+      /** Integration-specific state slug (e.g. a GitHub installation status). */
+      outcome: string;
+    }
+  | {
+      /** A `deployment_protection_rule` delivery that opened a pending gate. */
+      name: "workflow_gate.opened";
+      organizationId: string;
+    }
+  | {
+      /** The reviewer's recommendation for a gate, before any human acts on it. */
+      name: "workflow_gate.reviewed";
+      organizationId: string;
+      /** `approve` | `reject` | … — the recommendation, not the outcome. */
+      recommendation: string;
+      /** `on_time` | `timed_out` — whether the review beat the gate's deadline. */
+      timeoutState: string;
+      durationMs: number;
+      /** Packages in the release bundle; a monorepo gate reviews several. */
+      packageCount: number;
+    }
+  | {
+      /**
+       * A gate decision reaching GitHub. `surface` separates a maintainer's
+       * click from the automatic block, so approval rate stays measurable
+       * against reviews rather than being diluted by auto-rejections.
+       */
+      name: "workflow_gate.decided";
+      organizationId: string;
+      /** `human` | `automatic` */
+      surface: string;
+      /** `approved` | `rejected` */
+      decision: string;
+      packageCount: number;
+    }
+  | {
       name: "public_diff.viewed";
       ecosystem: string;
       /** Public package/project name — already public in the URL and cache key. */
@@ -125,6 +193,43 @@ export type AnalyticsEvent =
       risk: string;
       durationMs: number;
     };
+
+/**
+ * Every event name, for the privacy test's exhaustiveness check.
+ *
+ * The two assertions below make this list and the union above check each other
+ * at compile time, in both directions. Without that the check degrades into two
+ * hand-maintained lists agreeing with each other while the union quietly grows
+ * a third arm nobody asserted a privacy shape for — which is exactly what
+ * happened to `scan.discarded`.
+ */
+export const ANALYTICS_EVENT_NAMES = [
+  "scan.queued",
+  "scan.completed",
+  "scan.failed",
+  "scan.discarded",
+  "scan.decided",
+  "ai_review.finished",
+  "npm_connection.validated",
+  "public_diff.viewed",
+  "user.signed_up",
+  "organization.created",
+  "integration.connected",
+  "workflow_gate.opened",
+  "workflow_gate.reviewed",
+  "workflow_gate.decided",
+] as const;
+
+// A name in the union but missing from the list, or vice versa, fails here.
+type AssertExtends<A extends B, B> = A;
+type _EveryEventIsListed = AssertExtends<
+  AnalyticsEvent["name"],
+  (typeof ANALYTICS_EVENT_NAMES)[number]
+>;
+type _EveryListedNameExists = AssertExtends<
+  (typeof ANALYTICS_EVENT_NAMES)[number],
+  AnalyticsEvent["name"]
+>;
 
 /**
  * Write one product event. Never throws and never blocks the caller's result:
@@ -215,6 +320,28 @@ function toDataPoint(event: AnalyticsEvent): AnalyticsEngineDataPoint {
       );
     case "npm_connection.validated":
       return base(event.organizationId, "npm", [event.outcome], [0]);
+    case "user.signed_up":
+      return base("", "", [event.method, event.outcome], [0]);
+    case "organization.created":
+      return base(event.organizationId, "", [], [0]);
+    case "integration.connected":
+      return base(event.organizationId, event.kind, [event.outcome], [0]);
+    case "workflow_gate.opened":
+      return base(event.organizationId, "", [], [0]);
+    case "workflow_gate.reviewed":
+      return base(
+        event.organizationId,
+        "",
+        [event.recommendation, event.timeoutState],
+        [event.durationMs, event.packageCount],
+      );
+    case "workflow_gate.decided":
+      return base(
+        event.organizationId,
+        "",
+        [event.surface, event.decision],
+        [0, event.packageCount],
+      );
     case "public_diff.viewed":
       return base(
         "",

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -410,6 +410,18 @@ export async function executeWorkflowGateJob(
     timeoutState,
     durationMs: jobDurationMs,
   });
+
+  // The denominator for gate approval rate, and the only place the reviewer's
+  // own recommendation is counted — a decision below records what a human (or
+  // the timeout) actually did with it.
+  recordProductEvent(env, {
+    name: "workflow_gate.reviewed",
+    organizationId,
+    recommendation,
+    timeoutState,
+    durationMs: jobDurationMs,
+    packageCount: reviewed.length,
+  });
 }
 
 interface ReviewedPackage {
@@ -536,6 +548,13 @@ async function rejectGateForArtifactError(
     reportUrl: null,
   });
   if (!decided) return;
+  recordProductEvent(env, {
+    name: "workflow_gate.decided",
+    organizationId: gate.organizationId,
+    surface: "automatic",
+    decision: "rejected",
+    packageCount: 0,
+  });
   try {
     await deliverGateDecision(config, db, decided);
   } catch (err) {

--- a/server/routes/github-app.ts
+++ b/server/routes/github-app.ts
@@ -11,6 +11,7 @@ import {
 import { userHasTwoFactor, verifyTotpStepUp } from "../lib/auth";
 import { roleCanManageIntegrations } from "../lib/auth/roles";
 import { rateLimitResponse } from "../lib/platform/http";
+import { recordProductEvent } from "../lib/platform/analytics";
 import { describeOperationalError, emitOperationalEvent } from "../lib/platform/observability";
 import { scanArtifactReadBucket } from "../lib/scan/artifacts";
 import {
@@ -184,6 +185,12 @@ githubAppRoutes.post("/install/callback", async (c) => {
         accountType: record.accountType,
         status: record.status,
       },
+    });
+    recordProductEvent(c.env, {
+      name: "integration.connected",
+      organizationId,
+      kind: "github",
+      outcome: record.status,
     });
     return c.json({ installation: publicInstallation(record) }, 201);
   } catch (err) {
@@ -638,6 +645,16 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
   // GitHub instead of getting stuck behind a future 409.
   const message = { kind: "workflow_gate" as const, organizationId, gateId };
   c.executionCtx.waitUntil(deliverGateDecisionJob(c, db, message));
+
+  // Counted separately from the automatic block below, so approval rate stays
+  // measurable against reviews instead of being diluted by auto-rejections.
+  recordProductEvent(c.env, {
+    name: "workflow_gate.decided",
+    organizationId,
+    surface: "human",
+    decision: gateDecision,
+    packageCount: packages.length,
+  });
 
   try {
     await recordScanEvent(db, {

--- a/server/routes/github-webhooks.ts
+++ b/server/routes/github-webhooks.ts
@@ -13,6 +13,7 @@ import {
   parseGithubWebhookEvent,
   verifyGithubWebhookSignature,
 } from "../lib/github-app/webhook";
+import { recordProductEvent } from "../lib/platform/analytics";
 import { emitOperationalEvent } from "../lib/platform/observability";
 import type { Bindings, Variables } from "../types";
 
@@ -144,6 +145,12 @@ githubWebhookRoutes.post("/github", async (c) => {
     // posts the deployment decision. Guarded because the binding is optional in
     // tests/local; GitHub retries a non-2xx delivery and the consumer is
     // idempotent (it re-checks the gate status), so a re-enqueue is safe.
+    if (outcome.kind === "gate_pending") {
+      recordProductEvent(c.env, {
+        name: "workflow_gate.opened",
+        organizationId: outcome.gate.organizationId,
+      });
+    }
     if (outcome.kind === "gate_pending" && c.env.SCAN_QUEUE) {
       await c.env.SCAN_QUEUE.send({
         kind: "workflow_gate",

--- a/server/routes/npm-connection.ts
+++ b/server/routes/npm-connection.ts
@@ -156,6 +156,17 @@ npmConnectionRoutes.post("/validate", async (c) => {
       organizationId,
       outcome: validation.ok ? "ok" : "failed",
     });
+    // Activation is a separate question from credential health: this one fires
+    // once, when the token first validates, so the signup -> connected step of
+    // the funnel is not diluted by every later revalidation.
+    if (validation.ok && !connection.validatedAt) {
+      recordProductEvent(c.env, {
+        name: "integration.connected",
+        organizationId,
+        kind: "npm",
+        outcome: "ok",
+      });
+    }
 
     return c.json({ validation, connection: publicNpmConnection(updated) });
   } catch (err) {

--- a/server/routes/organizations.ts
+++ b/server/routes/organizations.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { createDb } from "../db/client";
 import { recordScanEvent } from "../db/events";
+import { recordProductEvent } from "../lib/platform/analytics";
 import { getOrganizationRole } from "../db/invitations";
 import {
   type NotificationRecipient,
@@ -60,6 +61,11 @@ organizationsRoutes.post("/", async (c) => {
       type: "organization.created",
       metadata: { name },
     });
+    // Activation, not acquisition: an explicitly created organization means
+    // someone intends to work with other people. Personal workspaces are
+    // excluded — `ensurePersonalOrganization` makes one for every account on
+    // first request, so counting them would restate `user.signed_up`.
+    recordProductEvent(c.env, { name: "organization.created", organizationId: id });
     return c.json({ organization: { id, name } }, 201);
   } catch (err) {
     if (err instanceof RateLimitError) {

--- a/server/routes/slack.ts
+++ b/server/routes/slack.ts
@@ -17,6 +17,7 @@ import {
   requireActiveOrganizationContext,
 } from "../lib/auth/active-organization";
 import { rateLimitResponse } from "../lib/platform/http";
+import { recordProductEvent } from "../lib/platform/analytics";
 import { roleCanManageIntegrations } from "../lib/auth/roles";
 import { decryptSlackBotToken, encryptSlackBotToken } from "../lib/platform/secret-box";
 import {
@@ -137,6 +138,12 @@ slackRoutes.get("/callback", async (c) => {
     actorUserId: session.userId,
     type: "organization.slack_connected",
     metadata: { teamId: connection.teamId, teamName: connection.teamName },
+  });
+  recordProductEvent(c.env, {
+    name: "integration.connected",
+    organizationId: claims.organizationId,
+    kind: "slack",
+    outcome: "ok",
   });
 
   return c.redirect(settingsRedirect(c.env, "connected"));

--- a/src/pages/Privacy/index.tsx
+++ b/src/pages/Privacy/index.tsx
@@ -4,7 +4,7 @@ import { PageShell } from "../../components/PageShell";
 import { Eyebrow, SectionLabel } from "../../components/Typography";
 import { privacyPageSeo, PageSeo } from "../../lib/seo";
 
-const EFFECTIVE_DATE = "2026-06-16";
+const EFFECTIVE_DATE = "2026-07-28";
 
 const PRIVACY_MAILTO =
   "mailto:privacy@drydock.org?subject=Drydock%20privacy%20request&body=Tell%20us%20what%20you%27d%20like%20us%20to%20do%20with%20your%20data%3A%0A%0A";
@@ -56,6 +56,17 @@ export default function PrivacyPage() {
                 kept for reliability, abuse prevention, and debugging. We redact secrets and never
                 log raw credentials, headers, or package contents.
               </>,
+              <>
+                <Strong>Product usage.</Strong> Aggregate counts of a few milestones — an account
+                created, an integration connected, a review completed, a release decision recorded —
+                so we can tell whether the product works. These are recorded on our own servers and
+                carry no personal data at all: no email address, no user identifier, no organization
+                name, no package names or repositories. An internal organization ID is the only
+                identifier attached, so we can see how many organizations are active without
+                identifying a person. The one exception is our public diff tool, which is anonymous
+                and records the public registry package being compared, with no account attached.
+                There is no third-party analytics service and no tracking script in the app.
+              </>,
             ]}
           />
         </Section>
@@ -70,6 +81,7 @@ export default function PrivacyPage() {
                 connect to the registries and code hosts you authorize, and report decisions back;
               </>,
               <>keep the service secure, prevent abuse, and diagnose problems;</>,
+              <>measure, in aggregate, how the product is used so we can improve it;</>,
               <>send you transactional messages such as verification and review notifications.</>,
             ]}
           />

--- a/test/analytics.test.mjs
+++ b/test/analytics.test.mjs
@@ -1,5 +1,9 @@
 import { describe, expect, test, vi } from "vitest";
-import { ANALYTICS_SCHEMA_VERSION, recordProductEvent } from "../server/lib/platform/analytics.ts";
+import {
+  ANALYTICS_EVENT_NAMES,
+  ANALYTICS_SCHEMA_VERSION,
+  recordProductEvent,
+} from "../server/lib/platform/analytics.ts";
 
 function fakeDataset() {
   const points = [];
@@ -152,22 +156,44 @@ describe("recordProductEvent", () => {
         durationMs: 50,
         findingCount: 0,
       },
+      {
+        name: "scan.discarded",
+        organizationId: "org_1",
+        ecosystem: "npm",
+        source: "auto_discovery",
+        reason: "staged_tarball_unavailable",
+        durationMs: 12,
+      },
+      { name: "user.signed_up", method: "email_password", outcome: "verification_pending" },
+      { name: "organization.created", organizationId: "org_1" },
+      { name: "integration.connected", organizationId: "org_1", kind: "github", outcome: "active" },
+      { name: "workflow_gate.opened", organizationId: "org_1" },
+      {
+        name: "workflow_gate.reviewed",
+        organizationId: "org_1",
+        recommendation: "approve",
+        timeoutState: "on_time",
+        durationMs: 900,
+        packageCount: 3,
+      },
+      {
+        name: "workflow_gate.decided",
+        organizationId: "org_1",
+        surface: "human",
+        decision: "approved",
+        packageCount: 3,
+      },
     ];
     for (const event of events) recordProductEvent(env, event);
 
     // Exhaustiveness: every arm of the AnalyticsEvent union must be exercised,
     // so adding an event without a privacy assertion fails here rather than
-    // shipping unreviewed. Keep in sync with the union in analytics.ts.
-    const EVENT_NAMES = [
-      "scan.queued",
-      "scan.completed",
-      "scan.failed",
-      "scan.decided",
-      "ai_review.finished",
-      "npm_connection.validated",
-      "public_diff.viewed",
-    ];
-    expect([...new Set(events.map((event) => event.name))].sort()).toEqual([...EVENT_NAMES].sort());
+    // shipping unreviewed. ANALYTICS_EVENT_NAMES is tied to the union by a
+    // compile-time assertion in analytics.ts, so this compares against the real
+    // union rather than a second hand-maintained copy of it.
+    expect([...new Set(events.map((event) => event.name))].sort()).toEqual(
+      [...ANALYTICS_EVENT_NAMES].sort(),
+    );
 
     // Blobs are a fixed positional schema; nothing here may look like an email,
     // an IP address, a bearer token, or a file path from a package.

--- a/test/workers/analytics-events.test.ts
+++ b/test/workers/analytics-events.test.ts
@@ -1,0 +1,237 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import worker from "../../server";
+import { createDb } from "../../server/db/client";
+import { ensurePersonalOrganization } from "../../server/db/organizations";
+import * as schema from "../../server/db/schema";
+import { ACTIVE_ORG_HEADER } from "../../server/lib/auth/active-organization";
+import { npmConnectionRoutes } from "../../server/routes/npm-connection";
+import { organizationsRoutes } from "../../server/routes/organizations";
+import type { Bindings, Variables } from "../../server/types";
+
+// End-to-end check that the funnel is actually wired: the encoder is unit-tested
+// in test/analytics.test.mjs, but an event nobody emits measures nothing. These
+// drive real routes with a stub dataset bound and assert both that the event
+// lands and — for the surfaces that handle customer text — that the text does
+// not.
+
+const ORIGIN = "http://example.com";
+const PASSWORD = "correct horse battery staple";
+const WORKER_AUTH_TIMEOUT_MS = 15_000;
+
+// Positional blob layout from lib/platform/analytics.ts. blob5 onwards are
+// event-specific dimensions in declaration order.
+const BLOB = { schema: 0, name: 1, organizationId: 2, ecosystem: 3, dim1: 4, dim2: 5 } as const;
+
+interface CapturedPoint {
+  indexes: string[];
+  blobs: string[];
+  doubles: number[];
+}
+
+function withAnalytics(): CapturedPoint[] {
+  const written: CapturedPoint[] = [];
+  (env as { PRODUCT_ANALYTICS?: unknown }).PRODUCT_ANALYTICS = {
+    writeDataPoint: (point: CapturedPoint) => written.push(point),
+  };
+  return written;
+}
+
+function eventsNamed(written: CapturedPoint[], name: string): CapturedPoint[] {
+  return written.filter((point) => point.blobs[BLOB.name] === name);
+}
+
+afterEach(() => {
+  delete (env as { PRODUCT_ANALYTICS?: unknown }).PRODUCT_ANALYTICS;
+  vi.restoreAllMocks();
+});
+
+async function seedUser(): Promise<{ userId: string; personalOrganizationId: string }> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const personalOrganizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, personalOrganizationId };
+}
+
+function buildTestApp(session: { userId: string }) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.use("*", async (c, next) => {
+    c.set("authSession", { userId: session.userId });
+    await next();
+  });
+  app.route("/api/v1/organizations", organizationsRoutes);
+  app.route("/api/v1/npm-connection", npmConnectionRoutes);
+  return app;
+}
+
+async function call(
+  app: Hono<{ Bindings: Bindings; Variables: Variables }>,
+  method: string,
+  path: string,
+  options: { body?: unknown; activeOrganizationId?: string } = {},
+) {
+  const ctx = createExecutionContext();
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (options.activeOrganizationId) headers[ACTIVE_ORG_HEADER] = options.activeOrganizationId;
+  const res = await app.fetch(
+    new Request(`http://test.local${path}`, {
+      method,
+      headers,
+      body: options.body === undefined ? undefined : JSON.stringify(options.body),
+    }),
+    env,
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return res;
+}
+
+describe("product analytics wiring", () => {
+  test(
+    "sign-up emits user.signed_up carrying neither the email nor the user id",
+    async () => {
+      const written = withAnalytics();
+      const email = `analytics-${crypto.randomUUID()}@example.test`;
+
+      const ctx = createExecutionContext();
+      const res = await worker.fetch(
+        new Request(`${ORIGIN}/api/auth/sign-up/email`, {
+          method: "POST",
+          headers: { "content-type": "application/json", origin: ORIGIN },
+          body: JSON.stringify({ name: "Analytics Tester", email, password: PASSWORD }),
+        }),
+        env,
+        ctx,
+      );
+      await waitOnExecutionContext(ctx);
+      expect(res.status).toBe(200);
+
+      const signups = eventsNamed(written, "user.signed_up");
+      expect(signups).toHaveLength(1);
+      expect(signups[0].blobs[BLOB.dim1]).toBe("email_password");
+      // No organization exists yet (the personal workspace is created lazily),
+      // and the account holder is never identified — the whole point of this
+      // event is a count.
+      expect(signups[0].blobs[BLOB.organizationId]).toBe("");
+      expect(JSON.stringify(signups[0])).not.toContain(email);
+      expect(JSON.stringify(signups[0])).not.toContain("Analytics Tester");
+    },
+    WORKER_AUTH_TIMEOUT_MS,
+  );
+
+  test("organization create emits the event and keeps the name out of it", async () => {
+    const written = withAnalytics();
+    const { userId } = await seedUser();
+    const app = buildTestApp({ userId });
+
+    const res = await call(app, "POST", "/api/v1/organizations", {
+      body: { name: "Acme Confidential" },
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { organization: { id: string } };
+
+    const created = eventsNamed(written, "organization.created");
+    expect(created).toHaveLength(1);
+    expect(created[0].blobs[BLOB.organizationId]).toBe(body.organization.id);
+    expect(JSON.stringify(created[0])).not.toContain("Acme Confidential");
+    expect(JSON.stringify(created[0])).not.toContain(userId);
+  });
+
+  test("npm activation emits once, on the validation that first succeeds", async () => {
+    const written = withAnalytics();
+    const { userId } = await seedUser();
+    const app = buildTestApp({ userId });
+
+    const saved = await call(app, "POST", "/api/v1/npm-connection", {
+      body: { token: "npm_analytics_token_AAAAAAAA" },
+    });
+    expect(saved.status).toBe(200);
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const request = input instanceof Request ? input : new Request(input);
+      if (request.url.endsWith("/-/whoami")) {
+        return Response.json({ username: "analytics-tester" });
+      }
+      return Response.json({ objects: [] });
+    });
+
+    const validated = await call(app, "POST", "/api/v1/npm-connection/validate", { body: {} });
+    expect(validated.status).toBe(200);
+    const revalidated = await call(app, "POST", "/api/v1/npm-connection/validate", { body: {} });
+    expect(revalidated.status).toBe(200);
+
+    // Activation fires once; health keeps firing. Conflating them would make
+    // the signup -> connected step of the funnel grow every time a token is
+    // rechecked.
+    const connected = eventsNamed(written, "integration.connected");
+    expect(connected).toHaveLength(1);
+    expect(connected[0].blobs[BLOB.ecosystem]).toBe("npm");
+    expect(connected[0].blobs[BLOB.dim1]).toBe("ok");
+    expect(eventsNamed(written, "npm_connection.validated")).toHaveLength(2);
+  });
+
+  test("invalid npm credentials do not emit integration.connected", async () => {
+    const written = withAnalytics();
+    const { userId } = await seedUser();
+    const app = buildTestApp({ userId });
+
+    const saved = await call(app, "POST", "/api/v1/npm-connection", {
+      body: { token: "npm_invalid_token_BBBBBBBB" },
+    });
+    expect(saved.status).toBe(200);
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      Response.json({ error: "invalid token" }, { status: 401 }),
+    );
+
+    const validated = await call(app, "POST", "/api/v1/npm-connection/validate", { body: {} });
+    expect(validated.status).toBe(200);
+    expect(eventsNamed(written, "integration.connected")).toHaveLength(0);
+    expect(eventsNamed(written, "npm_connection.validated")).toHaveLength(1);
+  });
+
+  test("a rejected request emits nothing", async () => {
+    const written = withAnalytics();
+    const { userId } = await seedUser();
+    const app = buildTestApp({ userId });
+
+    const res = await call(app, "POST", "/api/v1/organizations", { body: { name: "" } });
+    expect(res.status).toBe(400);
+    expect(written).toHaveLength(0);
+  });
+
+  test("a failing dataset does not fail the request", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    (env as { PRODUCT_ANALYTICS?: unknown }).PRODUCT_ANALYTICS = {
+      writeDataPoint: () => {
+        throw new Error("dataset unavailable");
+      },
+    };
+    const { userId } = await seedUser();
+    const app = buildTestApp({ userId });
+
+    const res = await call(app, "POST", "/api/v1/organizations", { body: { name: "Still Works" } });
+    expect(res.status).toBe(201);
+  });
+
+  test("an unbound dataset leaves every route working", async () => {
+    delete (env as { PRODUCT_ANALYTICS?: unknown }).PRODUCT_ANALYTICS;
+    const { userId } = await seedUser();
+    const app = buildTestApp({ userId });
+
+    const res = await call(app, "POST", "/api/v1/organizations", {
+      body: { name: "No Telemetry" },
+    });
+    expect(res.status).toBe(201);
+  });
+});


### PR DESCRIPTION
Implements server-side product analytics to track the core funnel: account signups, organization creation, integration connections, scan completion, and release gate decisions. Events are written to a Cloudflare Workers Analytics Engine dataset and never leave the platform.

## Key changes

- **New analytics module** (`server/lib/platform/analytics.ts`): Defines the event schema, encoder, and writer. The encoder enforces privacy invariants: organization-scoped events cannot carry customer-supplied text, and all blobs are redacted and truncated. The binding is optional, so self-hosted deployments are uninstrumented by default.

- **Comprehensive documentation** (`docs/analytics.md`): Explains what gets recorded, the column layout (append-only for dataset stability), privacy guarantees, and example SQL queries for common analyses.

- **Event emissions across the product**:
  - `user.signed_up` — from Better Auth user creation hook
  - `organization.created` — from org creation route
  - `integration.connected` — from npm, GitHub, and Slack connection flows
  - `scan.completed` — from pipeline completion (covers manual, auto-discovery, and workflow-gate paths uniformly)
  - `scan.failed` — from queue job and gate reviewer error handling
  - `scan.decided` — from maintainer publish/no-publish decision
  - `workflow_gate.opened` — from GitHub webhook delivery
  - `workflow_gate.reviewed` — from gate review job with latency metrics
  - `workflow_gate.decided` — from gate approval/rejection
  - `public_diff.viewed` — from anonymous `/diff` endpoint

- **Privacy enforcement**: The encoder drops the free-form `label` column for any event carrying an `organizationId`, making it structurally impossible for a caller to leak customer text. All blobs are redacted of credential material and control characters.

- **Binding configuration**: Added optional `analytics_engine_datasets` to `wrangler.jsonc` and `wrangler.template.jsonc`. Deployments that omit it emit nothing.

- **Test coverage**: Unit tests in `test/analytics.test.mjs` verify the encoder's privacy invariants and column layout stability. End-to-end tests in `test/workers/analytics-events.test.ts` confirm events are actually emitted from real routes and that failures don't break the request path.

- **Privacy policy update**: Updated effective date to reflect the new analytics disclosure.

## Implementation notes

- Events are best-effort: a missing binding is a no-op, and write failures are logged but never thrown, so analytics cannot fail a request or webhook ack.
- The `source` field on scans ("manual", "auto_discovery", "workflow_gate") is carried through the pipeline for analytics only and doesn't affect scan logic.
- Gate scans emit `scan.failed` from the gate reviewer (not the queue job) because that's where error classification happens; this ensures full path coverage without duplication.
- The dataset uses a fixed, append-only column layout so queries in the docs remain stable as the dataset accumulates data.

https://claude.ai/code/session_019NhgMGUZ6dTZjtMtxnTb2g