### PR TITLE
Prune expired Better Auth session and verification rows

### DIFF
--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -67,6 +67,17 @@ longer written, retention is a single age sweep across all rows rather than a
 type-restricted one. The sweep's bare `createdAt` predicate is backed by the
 `scan_events_created_idx` index, so it never scans the whole table.
 
+The same tick also prunes expired Better Auth rows (`pruneExpiredAuthRows`,
+`server/db/auth-retention.ts`), which the Drizzle adapter never removes on its
+own: `session` otherwise grows with every sign-in and keeps each dead session's
+`ip_address` and `user_agent` forever, and `verification` accumulates consumed or
+abandoned email-verification and password-reset values. A row is deleted only
+once its own `expires_at` is more than `AUTH_ROW_RETENTION_GRACE_MS` (one day)
+in the past, which keeps the sweep clear of Better Auth's session refresh. This
+cannot sign anyone out — an expired row already authenticates nothing. Both
+prunes are wrapped so a failure is logged (`audit_events.prune_failed`,
+`auth_rows.prune_failed`) and never aborts the cron.
+
 ## UI
 
 The **Audit log** tab in organization settings

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -58,6 +58,8 @@ Do not retain raw tarballs by default. Persist redacted, reviewable evidence:
 
 Avoid storing raw staged/baseline tarballs, unredacted full source, binary payload contents, or rendered package assets unless a future explicit short-TTL org setting is added.
 
+Session records carry an IP address and user agent, so they are not kept past their usefulness: the scheduled tick deletes Better Auth `session` and `verification` rows once they expired more than a day ago (`pruneExpiredAuthRows`, see [`audit-log.md`](./audit-log.md)). Better Auth's Drizzle adapter does not do this itself.
+
 ## Sandbox and broker posture
 
 The sandbox parses untrusted bytes under archive/file/expanded-size caps and returns evidence only. Direct Internet egress is intercepted. Registry/artifact fetches go through constrained brokers:

--- a/server/db/auth-retention.ts
+++ b/server/db/auth-retention.ts
@@ -1,0 +1,49 @@
+import { lt } from "drizzle-orm";
+import type { AppDb } from "./client";
+import { session, verification } from "./schema";
+
+/**
+ * Grace period applied on top of a row's own `expires_at` before the sweep will
+ * delete it. Better Auth refreshes a session by writing a new `expires_at` on
+ * the same row, so a row that is merely a few seconds past expiry may still be
+ * mid-refresh. A day of slack keeps the sweep well clear of that window while
+ * still bounding how long dead rows (and the `ip_address` / `user_agent` they
+ * carry) survive.
+ */
+export const AUTH_ROW_RETENTION_GRACE_MS = 24 * 60 * 60 * 1000;
+
+export interface PrunedAuthRowCounts {
+  sessions: number;
+  verifications: number;
+}
+
+/**
+ * Delete Better Auth rows whose own expiry passed more than the grace period
+ * ago. Better Auth's Drizzle adapter never removes them: an expired session is
+ * rejected at auth time but its row stays forever, so `session` grows with every
+ * sign-in and keeps each dead session's IP address and user agent indefinitely.
+ * `verification` has the same shape — short-lived email-verification and
+ * password-reset values that are consumed or abandoned but never cleaned up.
+ *
+ * Deleting an expired row cannot sign anyone out: Better Auth already treats
+ * `expires_at` in the past as no session at all, and a consumed verification
+ * value is single-use. This is purely removing rows that can no longer
+ * authenticate anything.
+ */
+export async function pruneExpiredAuthRows(
+  db: AppDb,
+  now: Date = new Date(),
+): Promise<PrunedAuthRowCounts> {
+  const cutoff = new Date(now.getTime() - AUTH_ROW_RETENTION_GRACE_MS);
+
+  const deletedSessions = await db
+    .delete(session)
+    .where(lt(session.expiresAt, cutoff))
+    .returning({ id: session.id });
+  const deletedVerifications = await db
+    .delete(verification)
+    .where(lt(verification.expiresAt, cutoff))
+    .returning({ id: verification.id });
+
+  return { sessions: deletedSessions.length, verifications: deletedVerifications.length };
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { createDb } from "./db/client";
 import { AUDIT_LOG_RETENTION_DAYS, pruneAuditEventsOlderThan } from "./db/audit-log";
+import { pruneExpiredAuthRows } from "./db/auth-retention";
 import { listAutoDiscoveryNpmConnections } from "./db/npm-connections";
 import { getOrganizationOwnerUserId } from "./db/organizations";
 import { RateLimitError, enforceRateLimit } from "./db/rate-limit";
@@ -446,6 +447,26 @@ async function pruneStaleAuditEvents(env: Cloudflare.Env) {
   }
 }
 
+// Better Auth never removes its own expired rows, so `session` grows with every
+// sign-in and holds each dead session's IP address and user agent forever. Sweep
+// them on the same tick as the audit log, and on the same terms: a prune failure
+// is logged, never thrown, so it can't take the cron down with it.
+async function pruneStaleAuthRows(env: Cloudflare.Env) {
+  try {
+    const pruned = await pruneExpiredAuthRows(createDb(env.DB));
+    if (pruned.sessions > 0 || pruned.verifications > 0) {
+      emitOperationalEvent("info", "auth_rows.pruned", {
+        sessions: pruned.sessions,
+        verifications: pruned.verifications,
+      });
+    }
+  } catch (err) {
+    emitOperationalEvent("error", "auth_rows.prune_failed", {
+      error: describeOperationalError(err),
+    });
+  }
+}
+
 export default {
   fetch: app.fetch,
   async scheduled(_event: ScheduledController, env: Cloudflare.Env, ctx: ExecutionContext) {
@@ -461,6 +482,7 @@ export default {
       });
     }
     await pruneStaleAuditEvents(env);
+    await pruneStaleAuthRows(env);
   },
   async queue(batch: MessageBatch<QueueMessage>, env: Cloudflare.Env, ctx: ExecutionContext) {
     for (const message of batch.messages) {

--- a/test/workers/auth-retention.test.ts
+++ b/test/workers/auth-retention.test.ts
@@ -1,0 +1,186 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { eq, inArray } from "drizzle-orm";
+import { createDb } from "../../server/db/client";
+import { AUTH_ROW_RETENTION_GRACE_MS, pruneExpiredAuthRows } from "../../server/db/auth-retention";
+import * as schema from "../../server/db/schema";
+import worker from "../../server";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+function scheduledController(): ScheduledController {
+  return {
+    scheduledTime: Date.now(),
+    cron: "*/15 * * * *",
+    noRetry() {},
+  } as unknown as ScheduledController;
+}
+
+async function seedUser(): Promise<string> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Retention Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  return userId;
+}
+
+async function seedSession(userId: string, expiresAt: Date): Promise<string> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const id = `session_${crypto.randomUUID()}`;
+  await db.insert(schema.session).values({
+    id,
+    token: `token_${crypto.randomUUID()}`,
+    userId,
+    expiresAt,
+    ipAddress: "203.0.113.7",
+    userAgent: "drydock-test/1.0",
+    createdAt: now,
+    updatedAt: now,
+  });
+  return id;
+}
+
+async function seedVerification(expiresAt: Date): Promise<string> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const id = `verification_${crypto.randomUUID()}`;
+  await db.insert(schema.verification).values({
+    id,
+    identifier: `identifier_${crypto.randomUUID()}`,
+    value: "verification-value",
+    expiresAt,
+    createdAt: now,
+    updatedAt: now,
+  });
+  return id;
+}
+
+async function sessionIds(ids: string[]): Promise<string[]> {
+  const rows = await createDb(env.DB)
+    .select({ id: schema.session.id })
+    .from(schema.session)
+    .where(inArray(schema.session.id, ids));
+  return rows.map((row) => row.id);
+}
+
+async function verificationIds(ids: string[]): Promise<string[]> {
+  const rows = await createDb(env.DB)
+    .select({ id: schema.verification.id })
+    .from(schema.verification)
+    .where(inArray(schema.verification.id, ids));
+  return rows.map((row) => row.id);
+}
+
+describe("expired auth row retention", () => {
+  beforeEach(async () => {
+    const db = createDb(env.DB);
+    await db.delete(schema.session);
+    await db.delete(schema.verification);
+    vi.restoreAllMocks();
+  });
+
+  test("deletes only rows past expiry plus the grace period", async () => {
+    const userId = await seedUser();
+    const now = new Date();
+
+    const live = await seedSession(userId, new Date(now.getTime() + 7 * 24 * HOUR_MS));
+    // Expired, but inside the grace window: Better Auth may still be refreshing
+    // it, so the sweep leaves it alone.
+    const justExpired = await seedSession(userId, new Date(now.getTime() - HOUR_MS));
+    const longExpired = await seedSession(
+      userId,
+      new Date(now.getTime() - AUTH_ROW_RETENTION_GRACE_MS - HOUR_MS),
+    );
+
+    const liveToken = await seedVerification(new Date(now.getTime() + HOUR_MS));
+    const staleToken = await seedVerification(
+      new Date(now.getTime() - AUTH_ROW_RETENTION_GRACE_MS - HOUR_MS),
+    );
+
+    const pruned = await pruneExpiredAuthRows(createDb(env.DB), now);
+
+    expect(pruned).toEqual({ sessions: 1, verifications: 1 });
+    expect((await sessionIds([live, justExpired, longExpired])).sort()).toEqual(
+      [live, justExpired].sort(),
+    );
+    expect(await verificationIds([liveToken, staleToken])).toEqual([liveToken]);
+  });
+
+  test("keeps the surviving session usable", async () => {
+    const userId = await seedUser();
+    const now = new Date();
+    const live = await seedSession(userId, new Date(now.getTime() + 7 * 24 * HOUR_MS));
+    await seedSession(userId, new Date(now.getTime() - AUTH_ROW_RETENTION_GRACE_MS - HOUR_MS));
+
+    await pruneExpiredAuthRows(createDb(env.DB), now);
+
+    const [row] = await createDb(env.DB)
+      .select()
+      .from(schema.session)
+      .where(eq(schema.session.id, live));
+    expect(row?.userId).toBe(userId);
+    expect(row?.ipAddress).toBe("203.0.113.7");
+  });
+
+  test("is a no-op when nothing has aged out", async () => {
+    const userId = await seedUser();
+    const now = new Date();
+    await seedSession(userId, new Date(now.getTime() + HOUR_MS));
+
+    expect(await pruneExpiredAuthRows(createDb(env.DB), now)).toEqual({
+      sessions: 0,
+      verifications: 0,
+    });
+  });
+
+  test("the scheduled tick sweeps expired rows", async () => {
+    const userId = await seedUser();
+    const now = Date.now();
+    const stale = await seedSession(
+      userId,
+      new Date(now - AUTH_ROW_RETENTION_GRACE_MS - 7 * 24 * HOUR_MS),
+    );
+    const live = await seedSession(userId, new Date(now + 7 * 24 * HOUR_MS));
+
+    // The discovery sweep runs first on the same tick; it has no connections to
+    // walk here and must not stop pruning from happening.
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const ctx = createExecutionContext();
+    await worker.scheduled(scheduledController(), env as Cloudflare.Env, ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(await sessionIds([stale, live])).toEqual([live]);
+  });
+
+  test("a prune failure is logged and never thrown", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    const brokenDb = {
+      delete() {
+        throw new Error("d1 unavailable");
+      },
+    } as unknown as ReturnType<typeof createDb>;
+
+    await expect(pruneExpiredAuthRows(brokenDb)).rejects.toThrow("d1 unavailable");
+
+    // The scheduled wrapper is what swallows it: a broken DB binding must not
+    // take the cron down.
+    const ctx = createExecutionContext();
+    await worker.scheduled(
+      scheduledController(),
+      { ...env, DB: undefined } as unknown as Cloudflare.Env,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(errorSpy.mock.calls.some((call) => call[0] === "auth_rows.prune_failed")).toBe(true);
+  });
+});


### PR DESCRIPTION
Found while sweeping production D1 for anomalies.

## The problem

Better Auth's Drizzle adapter never deletes its own expired rows. Nothing else does either — the scheduled tick prunes `scan_events` (90-day window) but stops there.

Production `staged-publish-review` D1 right now:

| table | rows | expired | oldest expiry |
| --- | --- | --- | --- |
| `session` | 60 | **53** | 2026-05-28 |
| `verification` | 0 | 0 | — |

So `session` grows monotonically with every sign-in, and each dead row keeps its `ip_address` and `user_agent` indefinitely. `verification` has the same shape — short-lived email-verification and password-reset values that are consumed or abandoned and then never cleaned up (empty today, but only because the flows are low-traffic).

The volume is small; the retention is the real issue. `docs/security-model.md` commits to not keeping evidence past its usefulness, and an expired session record is exactly that.

## The change

- **`server/db/auth-retention.ts`** (new) — `pruneExpiredAuthRows(db, now)` deletes `session` and `verification` rows whose own `expires_at` is more than `AUTH_ROW_RETENTION_GRACE_MS` (one day) in the past, returning per-table counts.
- **`server/index.ts`** — runs it on the scheduled tick immediately after `pruneStaleAuditEvents`, in the same never-throw wrapper: a failure emits `auth_rows.prune_failed` and the cron continues. A successful sweep emits `auth_rows.pruned` only when it actually deleted something, so the quiet case stays quiet.

The one-day grace exists because Better Auth refreshes a session by writing a new `expires_at` onto the same row; a row a few seconds past expiry may be mid-refresh. A day of slack keeps the sweep well clear of that window.

**This cannot sign anyone out.** Better Auth already treats a past `expires_at` as no session at all, and a consumed verification value is single-use — the sweep only removes rows that can no longer authenticate anything.

No schema change, so no migration.

## Testing

`pnpm run verify` passes (lint, format, typecheck, full test suite).

New `test/workers/auth-retention.test.ts` covers, against real D1:

- only rows past expiry **plus** grace are deleted — a live session, a session expired one hour ago, and a session expired past the grace window are seeded together, and only the last is removed;
- the surviving session row is left fully intact;
- a no-op tick reports `{ sessions: 0, verifications: 0 }`;
- driving `worker.scheduled()` end to end sweeps the stale session and keeps the live one — i.e. the discovery sweep running first on the same tick does not prevent pruning;
- a broken `DB` binding surfaces `auth_rows.prune_failed` through the wrapper instead of throwing out of the cron.

## Docs

`docs/audit-log.md` (retention section) and `docs/security-model.md` (artifact handling and retention) both updated.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RRMMofqiGaEW36fwPxqcJg)_