### PR TITLE
Name the exact npm token permissions during onboarding

### DIFF
--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -31,6 +31,8 @@ Drydock handles hostile package artifacts, private review evidence, and npm cred
 
 Organizations store their own encrypted npm connection. Operators should recommend read-only, granular, minimally scoped, expiring tokens without publish/write/org-management permission unless npm proves a staged-review endpoint requires more.
 
+In npm's granular-token form that is `Packages and scopes: Read-only` over the staged packages (or their scope) and `Organizations: No access` — an org-scoped package such as `@nanostores/i18n` is reached by selecting the `@nanostores` scope, not by granting the Organizations permission, which covers member and settings management Drydock never reads. The npm connection card in `Organization settings → npm access` states this permission set verbatim; keep the two in sync.
+
 Implementation requirements:
 
 - configure `NPM_CONNECTIONS_ENCRYPTION_KEY` for deployed instances;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
         "**/two-factor.spec.ts",
         "**/org-switcher.spec.ts",
         "**/slack-selector.spec.ts",
+        "**/npm-scope-guide.spec.ts",
       ],
       use: { ...devices["Desktop Chrome"] },
     },

--- a/src/pages/Dashboard/GettingStarted.tsx
+++ b/src/pages/Dashboard/GettingStarted.tsx
@@ -29,7 +29,9 @@ export function GettingStarted({ npmConnected }: { npmConnected: boolean }) {
             <>A read-only token is stored for this organization.</>
           ) : (
             <>
-              Store a read-only npm token so Drydock can fetch staged tarballs.{" "}
+              Store an npm token so Drydock can fetch staged tarballs — a granular token with{" "}
+              <strong class="font-medium text-ink">Packages and scopes: Read-only</strong> and{" "}
+              <strong class="font-medium text-ink">Organizations: No access</strong>.{" "}
               <a href="/dashboard/settings?tab=integrations" class="underline">
                 Open settings
               </a>

--- a/src/pages/Dashboard/Settings/NpmConnectionSection.tsx
+++ b/src/pages/Dashboard/Settings/NpmConnectionSection.tsx
@@ -7,7 +7,7 @@ import { Button } from "../../../components/Button";
 import { CollapsibleCard, SettingsCardBody } from "../../../components/Card";
 import { Field } from "../../../components/Field";
 import { Input } from "../../../components/Input";
-import { Muted } from "../../../components/Typography";
+import { MonoLabel, Muted } from "../../../components/Typography";
 
 export function NpmConnectionSection({
   npm,
@@ -50,7 +50,7 @@ export function NpmConnectionSection({
     >
       <SettingsCardBody>
         <Muted class="text-[13px] m-0 max-w-[760px]">
-          Add a read-only organization npm token so reviews can fetch staged packages securely. We
+          Add an npm token so reviews can fetch this organization's staged packages securely. We
           encrypt it, hide it after save, and use it only to retrieve release evidence.
         </Muted>
 
@@ -76,6 +76,8 @@ export function NpmConnectionSection({
             />
           </dl>
         ) : null}
+
+        <NpmTokenScopeGuide />
 
         <form
           class="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1.5fr)_auto] gap-3 items-end"
@@ -140,6 +142,64 @@ export function NpmConnectionSection({
         ) : null}
       </SettingsCardBody>
     </CollapsibleCard>
+  );
+}
+
+// The terms mirror the field names on npm's granular-token form, so a maintainer
+// can read this top to bottom while filling that form in. Getting this wrong is
+// the slowest part of onboarding: an over-scoped token is a needless credential
+// risk, and an under-scoped one fails validation with a 403 they have to guess at.
+function NpmTokenScopeGuide() {
+  return (
+    <div class="border border-border rounded-lg bg-surface-2 px-4 py-3 flex flex-col gap-3">
+      <MonoLabel>token permissions to select</MonoLabel>
+      <dl class="grid grid-cols-1 sm:grid-cols-2 gap-x-6 gap-y-2 m-0">
+        <ScopeRow term="token type" detail="Granular access token" />
+        <ScopeRow term="packages and scopes" detail="Read-only" />
+        <ScopeRow
+          term="select packages"
+          detail="The packages you stage — or their scope, e.g. @nanostores"
+        />
+        <ScopeRow term="organizations" detail="No access" />
+        <ScopeRow term="expiration" detail="Short, with planned rotation" />
+      </dl>
+      {/* Maintainers keep asking whether org-scoped packages need the Organizations
+          permission. They do not — a scope is selectable under Packages and scopes. */}
+      <Muted class="text-[12px] leading-[1.55] m-0">
+        A scoped package such as{" "}
+        <span class="font-mono text-[11px] text-ink-muted">@nanostores/i18n</span> is covered by
+        picking the <span class="text-ink">@nanostores</span> scope under{" "}
+        <span class="text-ink">Packages and scopes</span>; npm's separate{" "}
+        <span class="text-ink">Organizations</span> permission grants member and settings
+        management, which Drydock never reads. Read-only is all it uses — it lists staged releases
+        and downloads the staged tarball, never publishes, and the token never reaches the sandbox
+        that opens package bytes.
+      </Muted>
+      <p class="font-mono text-[11px] text-ink-subtle m-0">
+        npmjs.com → Access Tokens → Generate New Token → Granular ·{" "}
+        <a
+          class="underline"
+          href="https://docs.npmjs.com/creating-and-viewing-access-tokens/"
+          target="_blank"
+          rel="noreferrer"
+        >
+          npm docs
+        </a>
+      </p>
+    </div>
+  );
+}
+
+function ScopeRow({ term, detail }: { term: string; detail: string }) {
+  // 160px holds the longest term ("packages and scopes") on one line at 11px mono
+  // with 0.1em tracking; anything narrower wraps the label. On phones the term
+  // stacks above the value instead — a fixed label column leaves the value too
+  // narrow to read there.
+  return (
+    <div class="grid grid-cols-1 sm:grid-cols-[160px_minmax(0,1fr)] gap-x-3 gap-y-0.5 items-baseline text-[13px] min-w-0">
+      <MonoLabel as="dt">{term}</MonoLabel>
+      <dd class="m-0 text-ink-muted break-words">{detail}</dd>
+    </div>
   );
 }
 

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -364,9 +364,15 @@ export default function DocsPage() {
                 items={[
                   <>Create a Drydock organization for the team that publishes the package.</>,
                   <>
-                    Open <Code>Organization settings → npm access</Code> and paste an automation or
-                    granular npm token that can read the org's packages and list packages in npm
-                    stage publish.
+                    On npmjs.com, generate a granular access token with{" "}
+                    <Code>Packages and scopes: Read-only</Code> on the packages you stage and{" "}
+                    <Code>Organizations: No access</Code>. A scoped package like{" "}
+                    <Code>@nanostores/i18n</Code> is covered by selecting the{" "}
+                    <Code>@nanostores</Code> scope there; the Organizations permission is for member
+                    and settings management, which Drydock never reads.
+                  </>,
+                  <>
+                    Open <Code>Organization settings → npm access</Code> and paste the token.
                   </>,
                   <>
                     Save. Drydock encrypts the token and checks it against the registry right away.

--- a/test/e2e/npm-scope-guide.spec.ts
+++ b/test/e2e/npm-scope-guide.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+// The npm connection card states the exact granular-token permissions to pick.
+// It has been dropped once already by an unrelated settings refactor, and its
+// absence is invisible until a maintainer provisions the wrong token — so assert
+// the permission rows, not just the card.
+test("npm connection card names the exact token permissions", async ({ page }) => {
+  await installSettingsMocks(page);
+  await page.goto("/dashboard/settings?tab=integrations");
+
+  const guide = page.getByText("token permissions to select").locator("xpath=..");
+  await expect(guide).toBeVisible();
+
+  await expect(guide.getByText("Granular access token")).toBeVisible();
+  await expect(guide.locator("dt", { hasText: "packages and scopes" })).toBeVisible();
+  await expect(guide.getByText("Read-only", { exact: true })).toBeVisible();
+  await expect(guide.locator("dt", { hasText: "organizations" })).toBeVisible();
+  await expect(guide.getByText("No access", { exact: true })).toBeVisible();
+});
+
+async function installSettingsMocks(page: Page) {
+  await page.route("**/api/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+
+    if (path === "/api/auth/get-session") {
+      await fulfillJson(route, {
+        user: {
+          id: "user-guide",
+          name: "Guide Tester",
+          email: "guide@example.test",
+          twoFactorEnabled: false,
+        },
+      });
+      return;
+    }
+
+    if (path === "/api/v1/organizations") {
+      await fulfillJson(route, {
+        organizations: [
+          {
+            id: "org-guide",
+            name: "Drydock",
+            ownerUserId: "user-guide",
+            role: "owner",
+            isPersonal: false,
+            npmConnectionConfigured: false,
+            requireTwoFactorForReleaseDecisions: false,
+            createdAt: "2026-07-12T00:00:00.000Z",
+            updatedAt: "2026-07-12T00:00:00.000Z",
+          },
+        ],
+      });
+      return;
+    }
+
+    if (path === "/api/v1/npm-connection") {
+      await fulfillJson(route, { connection: null });
+      return;
+    }
+
+    if (path === "/api/v1/github-app/config") {
+      await fulfillJson(route, { configured: false });
+      return;
+    }
+
+    if (path === "/api/v1/github-app/installations") {
+      await fulfillJson(route, { installations: [] });
+      return;
+    }
+
+    if (path === "/api/v1/github-app/release-targets") {
+      await fulfillJson(route, { releaseTargets: [] });
+      return;
+    }
+
+    if (path === "/api/v1/slack") {
+      await fulfillJson(route, { configured: false, connection: null });
+      return;
+    }
+
+    if (path.endsWith("/notification-recipients")) {
+      await fulfillJson(route, { recipients: [] });
+      return;
+    }
+
+    if (path === "/api/v1/organizations/members") {
+      await fulfillJson(route, { members: [] });
+      return;
+    }
+
+    if (path === "/api/v1/organizations/invitations") {
+      await fulfillJson(route, { invitations: [] });
+      return;
+    }
+
+    if (path === "/api/v1/audit-events") {
+      await fulfillJson(route, { events: [], nextCursor: null });
+      return;
+    }
+
+    await fulfillJson(route, { error: `unexpected request: ${path}` }, 404);
+  });
+}
+
+async function fulfillJson(route: Route, json: unknown, status = 200) {
+  await route.fulfill({
+    status,
+    contentType: "application/json",
+    body: JSON.stringify(json),
+  });
+}


### PR DESCRIPTION
Provisioning the npm token was the slowest onboarding step: the connection card asked for "a read-only npm token" without saying which of npm's granular-token fields that maps to, so maintainers guessed — over-scoped tokens are a needless credential risk, and under-scoped ones fail validation with a 403. The card now states the permission set verbatim using npm's own field names (granular access token · Packages and scopes: Read-only · Organizations: No access · expiration), and answers the question that keeps coming back: an org-scoped package like `@nanostores/i18n` is reached by selecting the `@nanostores` scope, not by granting the Organizations permission, which covers member and settings management Drydock never reads.

The same permissions are echoed in the dashboard getting-started step, the /docs staged setup (now split into generate-token and paste-token steps), and the credential-posture section of `docs/security-model.md`.

**Testing:** `pnpm run verify` passes. An earlier copy of this guidance was silently dropped by a settings refactor, so `test/e2e/npm-scope-guide.spec.ts` now asserts the permission rows render; verified against the local e2e dev server in light desktop and dark 390px, where the term stacks above the value instead of using the fixed label column. Docs updated as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)