### PR TITLE
Remember the reviewer's npm staged-packages preference

### DIFF
--- a/docs/two-factor-auth.md
+++ b/docs/two-factor-auth.md
@@ -78,7 +78,10 @@ This is scoped to the approval gate. The **staged-publish** decision (`POST
 /api/v1/scans/:id/decision`) is an audit record only — it never publishes or cancels a
 release on npm — and intentionally does **not** require a step-up. The decision dialog can open npm's staged-packages page in a new tab with
 `filterPackage` set to the reviewed package; the maintainer still approves or declines
-in npm with npm's own 2FA.
+in npm with npm's own 2FA. That checkbox is sticky per browser
+(`drydock:open-npm-after-decision` in localStorage, `src/models/publish-preferences.ts`)
+so reviewers who always finish in npm opt in once — it is a UI convenience with no
+server state and no bearing on the step-up rules.
 Maintainers without 2FA enabled decide gates without a code, as before.
 
 ### Org-enforced step-up (organization policy)

--- a/src/models/publish-preferences.ts
+++ b/src/models/publish-preferences.ts
@@ -1,0 +1,29 @@
+import { signal } from "@preact/signals";
+
+// Reviewers who publish from npm's web UI open the staged-packages page after
+// every decision. Remembering the choice per browser turns a repeated click into
+// a one-time one; it is a UI convenience only, so localStorage is the right home
+// (no server state, nothing org-scoped, nothing worth syncing across devices).
+const STORAGE_KEY = "drydock:open-npm-after-decision";
+
+function readStored(): boolean {
+  if (typeof localStorage === "undefined") return false;
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export const openNpmAfterDecision = signal<boolean>(readStored());
+
+export function setOpenNpmAfterDecision(next: boolean) {
+  openNpmAfterDecision.value = next;
+  if (typeof localStorage === "undefined") return;
+  try {
+    if (next) localStorage.setItem(STORAGE_KEY, "true");
+    else localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // localStorage may be blocked; the in-memory signal still holds for this session.
+  }
+}

--- a/src/pages/Dashboard/ScanDetail/DecisionDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/DecisionDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "preact/hooks";
 import { useSignal } from "@preact/signals";
 import { formatDateTime } from "../../../lib/format";
 import type { DecisionStatus, ScanDecision } from "../../../models/scan";
+import { openNpmAfterDecision, setOpenNpmAfterDecision } from "../../../models/publish-preferences";
 import { Alert } from "../../../components/Alert";
 import { Badge } from "../../../components/Badge";
 import { Button } from "../../../components/Button";
@@ -31,19 +32,17 @@ export function DecisionDialog({
   onSubmit: (decision: ScanDecision, reason: string | null) => boolean | Promise<boolean>;
 }) {
   const reasonDraft = useSignal("");
-  const openNpmAfterSave = useSignal(false);
   const saving = status === "saving";
 
   useEffect(() => {
     if (open) {
       reasonDraft.value = decisionReason ?? "";
-      openNpmAfterSave.value = false;
     }
   }, [open, decisionReason]);
 
   const submit = async (next: ScanDecision) => {
     if (saving) return;
-    const shouldOpenNpm = Boolean(npmStagedPackagesUrl && openNpmAfterSave.peek());
+    const shouldOpenNpm = Boolean(npmStagedPackagesUrl && openNpmAfterDecision.peek());
     const npmWindow = shouldOpenNpm ? window.open("about:blank", "_blank") : null;
     if (npmWindow) npmWindow.opener = null;
     const trimmed = reasonDraft.value.trim();
@@ -98,14 +97,20 @@ export function DecisionDialog({
       </Field>
 
       {npmStagedPackagesUrl ? (
-        <label class="flex items-center gap-2 text-[13px] text-ink-muted">
+        <label class="flex items-start gap-2 text-[13px] text-ink-muted">
           <input
             type="checkbox"
-            checked={openNpmAfterSave.value}
-            onChange={(e) => (openNpmAfterSave.value = (e.target as HTMLInputElement).checked)}
+            class="mt-1"
+            checked={openNpmAfterDecision.value}
+            onChange={(e) => setOpenNpmAfterDecision((e.target as HTMLInputElement).checked)}
             disabled={saving}
           />
-          Open npm staged packages in a new tab after saving
+          <span class="flex flex-col gap-0.5">
+            Open npm staged packages in a new tab after saving
+            {/* Inside the label so the stickiness is part of the checkbox's
+                accessible name — no id/aria-describedby plumbing needed. */}
+            <span class="text-[12px] text-ink-subtle">Remembered on this browser.</span>
+          </span>
         </label>
       ) : null}
 

--- a/test/publish-preferences.test.ts
+++ b/test/publish-preferences.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const STORAGE_KEY = "drydock:open-npm-after-decision";
+
+function stubLocalStorage(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial));
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => void store.set(key, value),
+    removeItem: (key: string) => void store.delete(key),
+  };
+  return store;
+}
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  delete (globalThis as { localStorage?: unknown }).localStorage;
+});
+
+describe("openNpmAfterDecision", () => {
+  test("defaults to off when nothing is stored", async () => {
+    stubLocalStorage();
+
+    const { openNpmAfterDecision } = await import("../src/models/publish-preferences");
+
+    expect(openNpmAfterDecision.value).toBe(false);
+  });
+
+  test("starts on when the browser remembered the preference", async () => {
+    stubLocalStorage({ [STORAGE_KEY]: "true" });
+
+    const { openNpmAfterDecision } = await import("../src/models/publish-preferences");
+
+    expect(openNpmAfterDecision.value).toBe(true);
+  });
+
+  test("persists opting in and clears the key on opting back out", async () => {
+    const store = stubLocalStorage();
+
+    const { openNpmAfterDecision, setOpenNpmAfterDecision } =
+      await import("../src/models/publish-preferences");
+
+    setOpenNpmAfterDecision(true);
+    expect(openNpmAfterDecision.value).toBe(true);
+    expect(store.get(STORAGE_KEY)).toBe("true");
+
+    setOpenNpmAfterDecision(false);
+    expect(openNpmAfterDecision.value).toBe(false);
+    expect(store.has(STORAGE_KEY)).toBe(false);
+  });
+
+  test("falls back to an in-memory preference when localStorage is blocked", async () => {
+    (globalThis as { localStorage?: unknown }).localStorage = {
+      getItem: () => {
+        throw new Error("blocked");
+      },
+      setItem: () => {
+        throw new Error("blocked");
+      },
+      removeItem: () => {
+        throw new Error("blocked");
+      },
+    };
+
+    const { openNpmAfterDecision, setOpenNpmAfterDecision } =
+      await import("../src/models/publish-preferences");
+
+    expect(openNpmAfterDecision.value).toBe(false);
+    expect(() => setOpenNpmAfterDecision(true)).not.toThrow();
+    expect(openNpmAfterDecision.value).toBe(true);
+  });
+
+  test("works without localStorage at all", async () => {
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+
+    const { openNpmAfterDecision, setOpenNpmAfterDecision } =
+      await import("../src/models/publish-preferences");
+
+    expect(openNpmAfterDecision.value).toBe(false);
+    expect(() => setOpenNpmAfterDecision(true)).not.toThrow();
+    expect(openNpmAfterDecision.value).toBe(true);
+  });
+});


### PR DESCRIPTION
The decision dialog's "open npm staged packages in a new tab after saving" checkbox reset to off on every open, so a reviewer who always finishes the publish on npm re-checked it for every decision. It is now persisted per browser in localStorage (`drydock:open-npm-after-decision`, new `src/models/publish-preferences.ts`) following the `active-organization` pattern — guarded reads, try/catch writes, key removed rather than stored as `"false"`, in-memory fallback when storage is blocked — and both dialog hosts (dashboard list and scan detail) share the one signal. A hint inside the label says the choice is remembered, and it sits inside the `<label>` so it lands in the checkbox's accessible name without id plumbing. Kept browser-local on purpose: this is a workflow habit, not policy, so there is no server state and nothing to org-scope; the decision itself is still audit-only and npm still owns the 2FA confirmation.

Testing: `pnpm run verify` (lint, format, typecheck, 5 new cases in `test/publish-preferences.test.ts` covering default-off, restored-on, persist/clear, blocked localStorage, and no localStorage). No component-render test — this repo's node Vitest project has no DOM renderer, and adding one was out of scope. Docs updated (`docs/two-factor-auth.md`, the paragraph that already described this checkbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)