### PR TITLE
Show the npm stage CLI command after a staged-publish decision

### DIFF
--- a/docs/two-factor-auth.md
+++ b/docs/two-factor-auth.md
@@ -84,6 +84,14 @@ so reviewers who always finish in npm opt in once — it is a UI convenience wit
 server state and no bearing on the step-up rules.
 Maintainers without 2FA enabled decide gates without a code, as before.
 
+When that npm tab is _not_ opened (the checkbox is off, or the browser blocked the
+popup), a follow-up dialog (`StageCommandDialog`) shows the equivalent CLI command for
+the stage — `npm stage approve|reject <stage-id>`, built by
+`src/lib/npm-stage-command.ts` — as copyable text. It is display only: Drydock never
+runs npm, and npm still asks the maintainer for proof-of-presence. The stage id is
+validated against npm's stage-id shape before it is placed in that string, so
+registry-supplied text cannot smuggle shell metacharacters into a copy-paste.
+
 ### Org-enforced step-up (organization policy)
 
 By default the step-up is per-user: enrolled maintainers step up, others decide without a

--- a/src/lib/npm-stage-command.ts
+++ b/src/lib/npm-stage-command.ts
@@ -1,0 +1,27 @@
+import { isValidStageId } from "../../server/lib/ecosystems/npm/stage-id";
+import type { ScanDecision } from "../models/scan";
+
+export type NpmStagedCommandScan = {
+  source?: string | null;
+  stageId?: string | null;
+};
+
+/**
+ * The terminal half of "finish this staged publish": npm CLI 11.15+ completes or
+ * removes a stage with `npm stage approve|reject <stage-id>`, the same action the
+ * staged-packages web page performs. Drydock only prints it — running it (and the
+ * 2FA it prompts for) stays with the maintainer.
+ *
+ * The string is meant to be pasted into a shell, so the stage id is validated
+ * against npm's stage-id shape rather than interpolated raw: registry-supplied
+ * text must never reach a command line with shell metacharacters intact.
+ */
+export function npmStageCommandFor(
+  decision: ScanDecision,
+  scan: NpmStagedCommandScan,
+): string | null {
+  if (scan.source === "workflow_gate") return null;
+  const stageId = scan.stageId?.trim();
+  if (!isValidStageId(stageId)) return null;
+  return `npm stage ${decision === "publish" ? "approve" : "reject"} ${stageId}`;
+}

--- a/src/models/stage-command-prompt.ts
+++ b/src/models/stage-command-prompt.ts
@@ -1,0 +1,25 @@
+import { signal } from "@preact/signals";
+import type { ScanDecision } from "./scan";
+
+export interface StageCommandPrompt {
+  decision: ScanDecision;
+  /** Ready-to-paste `npm stage approve|reject <stage-id>`. */
+  command: string;
+  packageName: string | null;
+  stagedVersion: string | null;
+  npmStagedPackagesUrl: string | null;
+}
+
+// Module-level store, like the toaster's: the decision dialog raises the prompt
+// and then unmounts (the dashboard list drops it as soon as the decision saves),
+// so the follow-up cannot live inside that component. A single host per decision
+// surface renders whatever is in here.
+export const stageCommandPrompt = signal<StageCommandPrompt | null>(null);
+
+export function showStageCommandPrompt(prompt: StageCommandPrompt): void {
+  stageCommandPrompt.value = prompt;
+}
+
+export function dismissStageCommandPrompt(): void {
+  stageCommandPrompt.value = null;
+}

--- a/src/pages/Dashboard/ScanDetail/DecisionDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/DecisionDialog.tsx
@@ -1,8 +1,10 @@
 import { useEffect } from "preact/hooks";
 import { useSignal } from "@preact/signals";
 import { formatDateTime } from "../../../lib/format";
-import type { DecisionStatus, ScanDecision } from "../../../models/scan";
+import type { DecisionStatus, ScanDecision, ScanListItem } from "../../../models/scan";
 import { openNpmAfterDecision, setOpenNpmAfterDecision } from "../../../models/publish-preferences";
+import { showStageCommandPrompt } from "../../../models/stage-command-prompt";
+import { npmStageCommandFor } from "../../../lib/npm-stage-command";
 import { Alert } from "../../../components/Alert";
 import { Badge } from "../../../components/Badge";
 import { Button } from "../../../components/Button";
@@ -19,6 +21,7 @@ export function DecisionDialog({
   status,
   error,
   npmStagedPackagesUrl,
+  scan,
   onSubmit,
 }: {
   open: boolean;
@@ -29,6 +32,8 @@ export function DecisionDialog({
   status: DecisionStatus;
   error: string | null;
   npmStagedPackagesUrl?: string | null;
+  /** Identifies the stage for the follow-up CLI command. */
+  scan: Pick<ScanListItem, "stageId" | "packageName" | "stagedVersion" | "source">;
   onSubmit: (decision: ScanDecision, reason: string | null) => boolean | Promise<boolean>;
 }) {
   const reasonDraft = useSignal("");
@@ -47,10 +52,26 @@ export function DecisionDialog({
     if (npmWindow) npmWindow.opener = null;
     const trimmed = reasonDraft.value.trim();
     const saved = await onSubmit(next, trimmed.length ? trimmed : null);
-    if (saved && npmWindow && npmStagedPackagesUrl) {
-      npmWindow.location.href = npmStagedPackagesUrl;
-    } else if (!saved) {
+    if (!saved) {
       npmWindow?.close();
+      return;
+    }
+    if (npmWindow && npmStagedPackagesUrl) {
+      npmWindow.location.href = npmStagedPackagesUrl;
+      return;
+    }
+    // Nobody is going to npm's web UI for us: either the reviewer finishes in a
+    // terminal, or the tab we tried to open was blocked. Both cases end with the
+    // same open question — what exactly do I run — so answer it.
+    const command = npmStageCommandFor(next, scan);
+    if (command) {
+      showStageCommandPrompt({
+        decision: next,
+        command,
+        packageName: scan.packageName,
+        stagedVersion: scan.stagedVersion,
+        npmStagedPackagesUrl: npmStagedPackagesUrl ?? null,
+      });
     }
   };
 

--- a/src/pages/Dashboard/ScanDetail/StageCommandDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/StageCommandDialog.tsx
@@ -1,0 +1,104 @@
+import { useEffect } from "preact/hooks";
+import { useSignal } from "@preact/signals";
+import { Show } from "@preact/signals/utils";
+import {
+  dismissStageCommandPrompt,
+  stageCommandPrompt,
+  type StageCommandPrompt,
+} from "../../../models/stage-command-prompt";
+import { Button, LinkButton } from "../../../components/Button";
+import { Dialog } from "../../../components/Dialog";
+
+/**
+ * Shown after a decision is recorded for a reviewer who is not finishing the
+ * publish in npm's web UI. Drydock never runs the command — it only saves the
+ * reviewer a trip to the docs to look up the stage id and subcommand.
+ *
+ * Mounted by every surface that hosts the decision dialog; it renders nothing
+ * until `stageCommandPrompt` holds a prompt.
+ */
+export function StageCommandDialogHost() {
+  // The store outlives this route, so drop any pending prompt on the way out —
+  // otherwise a decision made on the dashboard would reopen the dialog on the
+  // next surface that hosts it.
+  useEffect(() => dismissStageCommandPrompt, []);
+  return (
+    <Show<StageCommandPrompt | null> when={stageCommandPrompt}>
+      {(prompt) => <StageCommandDialog prompt={prompt} />}
+    </Show>
+  );
+}
+
+function StageCommandDialog({ prompt }: { prompt: StageCommandPrompt }) {
+  // null while untouched so the <Show> boundary renders nothing until a copy is
+  // actually attempted.
+  const copyState = useSignal<"copied" | "failed" | null>(null);
+  const approving = prompt.decision === "publish";
+  const target = [prompt.packageName, prompt.stagedVersion].filter(Boolean).join("@");
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(prompt.command);
+      copyState.value = "copied";
+    } catch {
+      // Clipboard access is denied outside secure contexts and in some
+      // permission setups; the command stays selectable either way.
+      copyState.value = "failed";
+    }
+  };
+
+  return (
+    <Dialog
+      open={true}
+      onClose={dismissStageCommandPrompt}
+      title={approving ? "Finish the publish on npm" : "Remove the staged publish on npm"}
+      description={
+        approving
+          ? "Your approval is recorded in Drydock. npm still holds the staged tarball until you approve it there, with your normal 2FA."
+          : "Your decision is recorded in Drydock. The staged tarball stays on npm until you reject it there, with your normal 2FA."
+      }
+    >
+      {target ? (
+        <p class="m-0 text-[13px] leading-[1.6] text-ink-muted">
+          Release <span class="font-mono text-[12px] text-ink">{target}</span>
+        </p>
+      ) : null}
+
+      <div class="flex flex-col gap-2">
+        <code class="font-mono text-[12px] text-ink bg-surface-2 border border-border rounded px-2.5 py-2 overflow-x-auto whitespace-pre">
+          {prompt.command}
+        </code>
+        <div class="flex flex-wrap items-center gap-2">
+          <Button variant="secondary" size="sm" onClick={() => void copy()}>
+            Copy command
+          </Button>
+          {/* aria-live so the confirmation reaches screen readers; the button
+              label stays stable so its accessible name does not shift. */}
+          <span class="text-[12px] text-ink-subtle" aria-live="polite">
+            <Show<"copied" | "failed" | null> when={copyState}>
+              {(state) => (state === "copied" ? "Copied." : "Copy failed — select it manually.")}
+            </Show>
+          </span>
+        </div>
+      </div>
+
+      <p class="m-0 text-[12px] leading-[1.6] text-ink-subtle">
+        Needs npm CLI 11.15 or newer, signed in as a maintainer of the package.
+      </p>
+
+      <div class="flex flex-wrap gap-2">
+        <Button onClick={dismissStageCommandPrompt}>Done</Button>
+        {prompt.npmStagedPackagesUrl ? (
+          <LinkButton
+            variant="secondary"
+            href={prompt.npmStagedPackagesUrl}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            Open npm instead
+          </LinkButton>
+        ) : null}
+      </div>
+    </Dialog>
+  );
+}

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -33,6 +33,7 @@ import { VersionPicker } from "../../../components/VersionPicker";
 import { DeleteScanDialog } from "./DeleteScanDialog";
 import { DecisionDialog } from "./DecisionDialog";
 import { GateContextPanel, GateDecisionDialog, GatePackagesPanel } from "./GateDecisionDialog";
+import { StageCommandDialogHost } from "./StageCommandDialog";
 import { DiffWorkbench } from "./DiffWorkbench";
 import { RiskSignalsSection } from "../../../features/review/RiskSignalsSection";
 import { ReleaseConsistencyNotice } from "./ReleaseConsistencyNotice";
@@ -424,6 +425,7 @@ export default function ScanDetailPage() {
           statusSignal={model.decisionStatus}
           errorSignal={model.decisionError}
           npmStagedPackagesUrlSignal={npmStagedPackagesUrlSignal}
+          scan={detail.scan}
           onSubmit={handleDecisionSubmit}
         />
       ) : null}
@@ -449,6 +451,8 @@ export default function ScanDetailPage() {
           onSubmit={handleGateDecision}
         />
       ) : null}
+
+      <StageCommandDialogHost />
 
       {detail?.scan.status === "failed" ? (
         <DeleteDialogHost

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -30,6 +30,7 @@ import { UserMenu } from "../../components/UserMenu";
 import { GettingStarted } from "./GettingStarted";
 import { DeleteScanDialog } from "./ScanDetail/DeleteScanDialog";
 import { DecisionDialog } from "./ScanDetail/DecisionDialog";
+import { StageCommandDialogHost } from "./ScanDetail/StageCommandDialog";
 
 export default function DashboardPage() {
   const location = useLocation();
@@ -321,10 +322,12 @@ function RecentReviewsSection({
             status={scans.decisionStatus.value}
             error={scans.decisionError.value}
             npmStagedPackagesUrl={npmStagedPackagesUrlFor(scan)}
+            scan={scan}
             onSubmit={onQuickDecisionSubmit}
           />
         )}
       </Show>
+      <StageCommandDialogHost />
       <Show<ScanListItem | null> when={deleteScan}>
         {(scan) => (
           <DeleteScanDialog

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -407,8 +407,10 @@ export default function DocsPage() {
                     when possible, so beta and maintenance releases compare against the right line.
                   </>,
                   <>
-                    Record your decision and reason in Drydock. Then open npm's staged-packages page
-                    and complete or decline the publish with your normal npm 2FA.
+                    Record your decision and reason in Drydock. Then finish on npm with your normal
+                    2FA — either on npm's staged-packages page, or with the{" "}
+                    <Code>npm stage approve</Code> / <Code>npm stage reject</Code> command Drydock
+                    shows you after saving.
                   </>,
                 ]}
               />

--- a/test/e2e/local-registry.spec.ts
+++ b/test/e2e/local-registry.spec.ts
@@ -115,6 +115,23 @@ test("UI smoke: reviews the implicit node-gyp fixture", async ({ browser, baseUR
       fullPage: true,
     });
 
+    // Record a decision without the "open npm" hand-off. The reviewer still has
+    // to finish the publish on npm, so the follow-up hands them the exact CLI
+    // command for this stage instead of leaving them to look it up.
+    await page.getByRole("button", { name: "Decide" }).click();
+    const decisionDialog = page.getByRole("dialog").filter({ hasText: "Publish decision" });
+    await expect(decisionDialog).toBeVisible();
+    const openNpmToggle = decisionDialog.getByRole("checkbox");
+    if (await openNpmToggle.isChecked()) await openNpmToggle.uncheck();
+    await decisionDialog.getByRole("button", { name: "Approve publish" }).click();
+
+    const commandDialog = page.getByRole("dialog").filter({ hasText: "Finish the publish on npm" });
+    await expect(commandDialog).toBeVisible({ timeout: 30_000 });
+    await expect(commandDialog.getByText(`npm stage approve ${uiStageId}`)).toBeVisible();
+    await page.screenshot({ path: path.join(artifactsDir, "stage-command-dialog.png") });
+    await commandDialog.getByRole("button", { name: "Done" }).click();
+    await expect(commandDialog).toBeHidden();
+
     // Now exercise Check npm as the live entry point. The button kicks off
     // discovery and we wait only for the "Started N new reviews" message —
     // the resulting background scans are exercised by the scenarios below.

--- a/test/npm-stage-command.test.ts
+++ b/test/npm-stage-command.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+import { npmStageCommandFor } from "../src/lib/npm-stage-command";
+
+const stageId = "stage-1a2b3c4d5e";
+
+describe("npm stage commands", () => {
+  test("maps each decision to its npm subcommand", () => {
+    expect(npmStageCommandFor("publish", { stageId })).toBe(`npm stage approve ${stageId}`);
+    expect(npmStageCommandFor("no_publish", { stageId })).toBe(`npm stage reject ${stageId}`);
+  });
+
+  test("trims surrounding whitespace from the stage id", () => {
+    expect(npmStageCommandFor("publish", { stageId: `  ${stageId}  ` })).toBe(
+      `npm stage approve ${stageId}`,
+    );
+  });
+
+  test("has no command for workflow-gate scans", () => {
+    expect(npmStageCommandFor("publish", { source: "workflow_gate", stageId })).toBeNull();
+  });
+
+  test("has no command without a stage id", () => {
+    expect(npmStageCommandFor("publish", {})).toBeNull();
+    expect(npmStageCommandFor("publish", { stageId: null })).toBeNull();
+    expect(npmStageCommandFor("publish", { stageId: "   " })).toBeNull();
+  });
+
+  test("refuses stage ids that would carry shell metacharacters into a paste", () => {
+    expect(npmStageCommandFor("publish", { stageId: "stage-1; rm -rf /" })).toBeNull();
+    expect(npmStageCommandFor("publish", { stageId: "stage-1 && curl evil.example" })).toBeNull();
+    expect(npmStageCommandFor("publish", { stageId: "$(whoami)" })).toBeNull();
+    expect(npmStageCommandFor("publish", { stageId: "`id`" })).toBeNull();
+    // Too short to be a real stage id, and a bare word is still worth rejecting.
+    expect(npmStageCommandFor("publish", { stageId: "abc" })).toBeNull();
+  });
+});


### PR DESCRIPTION
A reviewer who does not finish the publish in npm's web UI was left without a next step, so after a decision saves without the npm hand-off tab (checkbox off, or a blocked popup — which previously failed silently) a follow-up dialog now shows the exact command for that stage: `npm stage approve <stage-id>` for an approval, `npm stage reject <stage-id>` for a block, as copyable text alongside the package@version, the npm CLI 11.15 requirement, and an "Open npm instead" link. The command is built in `src/lib/npm-stage-command.ts`, which validates the stage id against npm's stage-id shape before interpolating it — the string is pasted into a shell, so registry-supplied text must not carry shell metacharacters into it — and returns nothing for workflow-gate scans. The prompt lives in a module-level store like the toaster's because the decision dialog unmounts as soon as the decision saves; both decision surfaces mount the host and clear a pending prompt on unmount. Drydock still runs nothing: npm keeps the proof-of-presence prompt and the decision record stays audit-only.

Testing: `pnpm run verify` passes; new unit tests cover both subcommands, gate scans, missing ids, and metacharacter rejection; the fake-registry e2e smoke test now approves with the checkbox off and asserts the command dialog. Docs updated (`docs/two-factor-auth.md` and the staged-publish path in the product docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)