### PR TITLE
Fix npm entrypoint resolution gaps

### DIFF
--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -103,7 +103,7 @@ A PyPI review runs two rule families over the staged artifacts:
 
 - `pypi.*` findings come from `pyPiReleaseFindings` and carry `PYPI_RULES_VERSION` (currently `0.4.0`).
 - shared `file.*` / `code.*` / `diff.*` findings come from `deterministicFindings` and carry
-  `DETERMINISTIC_RULES_VERSION` (currently `1.20.0`).
+  `DETERMINISTIC_RULES_VERSION` (currently `1.21.0`).
 
 The harness asserts this per family: every `pypi.*` finding must equal `PYPI_RULES_VERSION` and every
 other finding must equal `DETERMINISTIC_RULES_VERSION`. Bump the relevant constant **and** update the
@@ -308,6 +308,14 @@ array) alongside every shape that cannot be reduced to a file. Four existing fix
 `wasm-instantiate-loader`) declared `main: index.js` without shipping it — an artifact of minimal
 synthetic fixtures rather than an intended signal — and now carry an unchanged `index.js` on both
 sides so they model a package that could actually load.
+
+`1.21.0` completes npm's CommonJS `main` resolution with Node's final package-root
+`index.js`/`index.json`/`index.node` fallback. A release that removes its declared `main` but still
+ships one of those root indexes remains loadable (with Node's invalid-main deprecation warning), so
+`package-json.entrypoint-missing` no longer raises a high release finding for that shape. The
+`legit-main-root-index-fallback` benign hard-negative locks down the regression. This release also
+preserves the string-form `browser` field through staged npm metadata parsing and manifest merging,
+so browser-only entrypoint changes reach package-json diffing and AI reviewer selection.
 
 ### Fixture format
 

--- a/server/lib/ecosystems/npm/findings.ts
+++ b/server/lib/ecosystems/npm/findings.ts
@@ -116,6 +116,7 @@ export function mergeStagedPackageJson(
     main: stagedMetadataPackageJson?.main ?? tarballPackageJson?.main,
     module: stagedMetadataPackageJson?.module ?? tarballPackageJson?.module,
     types: stagedMetadataPackageJson?.types ?? tarballPackageJson?.types,
+    browser: stagedMetadataPackageJson?.browser ?? tarballPackageJson?.browser,
     exports: stagedMetadataPackageJson?.exports ?? tarballPackageJson?.exports,
   };
 }

--- a/server/lib/ecosystems/npm/staged-publishes.ts
+++ b/server/lib/ecosystems/npm/staged-publishes.ts
@@ -295,6 +295,7 @@ function readPackageJsonSummary(
     ...(readString(value.main) ? { main: readString(value.main)! } : {}),
     ...(readString(value.module) ? { module: readString(value.module)! } : {}),
     ...(readString(value.types) ? { types: readString(value.types)! } : {}),
+    ...(readString(value.browser) ? { browser: readString(value.browser)! } : {}),
     ...("exports" in value ? { exports: value.exports } : {}),
   };
   const hasPackageData = Boolean(
@@ -309,6 +310,7 @@ function readPackageJsonSummary(
     summary.main ||
     summary.module ||
     summary.types ||
+    summary.browser ||
     "exports" in summary ||
     typeof summary.gypfile === "boolean",
   );

--- a/server/lib/review/rules/entrypoints.ts
+++ b/server/lib/review/rules/entrypoints.ts
@@ -30,6 +30,7 @@ export function entrypointDiffFindings(
 }
 
 const NPM_MAIN_EXTENSIONS = [".js", ".json", ".node"];
+const NPM_MAIN_ROOT_FALLBACKS = ["index.js", "index.json", "index.node"];
 const VSCODE_ENTRYPOINT_EXTENSIONS = [".js", ".mjs", ".cjs", ".json"];
 const TOOLING_EXPORT_CONDITIONS = new Set(["types", "typings"]);
 
@@ -254,5 +255,12 @@ function entrypointCandidates(
     resolution === "vscode"
       ? [".js", ".mjs", ".cjs"].map((extension) => `${path}/index${extension}`)
       : extensions.map((extension) => `${path}/index${extension}`);
-  return [path, ...extensions.map((extension) => `${path}${extension}`), ...directoryIndexes];
+  // CommonJS LOAD_AS_DIRECTORY makes one final LOAD_INDEX attempt at the
+  // package root when a declared main cannot resolve.
+  return [
+    path,
+    ...extensions.map((extension) => `${path}${extension}`),
+    ...directoryIndexes,
+    ...(resolution === "npm" && declared.kind === "main" ? NPM_MAIN_ROOT_FALLBACKS : []),
+  ];
 }

--- a/server/lib/review/rules/index.ts
+++ b/server/lib/review/rules/index.ts
@@ -10,7 +10,7 @@ import { entrypointDiffFindings, entrypointPresenceFindings } from "./entrypoint
 // way that should invalidate cached scan reports. Stored alongside each finding
 // so historical reports can be traced back to the ruleset that produced them.
 // Lives here (not in a family module) because versioning spans every family.
-export const DETERMINISTIC_RULES_VERSION = "1.20.0";
+export const DETERMINISTIC_RULES_VERSION = "1.21.0";
 
 export { DETERMINISTIC_RULE_IDS } from "./rule-ids";
 export {

--- a/test/fixtures/security-corpus/cases-benign/legit-main-root-index-fallback.json
+++ b/test/fixtures/security-corpus/cases-benign/legit-main-root-index-fallback.json
@@ -1,0 +1,60 @@
+{
+  "id": "legit-main-root-index-fallback",
+  "title": "Package remains loadable through Node's root index fallback after dropping its declared main",
+  "ecosystem": "npm",
+  "verdict": "benign",
+  "threatClass": "legit-entrypoint-declaration",
+  "source": "synthetic",
+  "intent": "Regression guard for Node's final CommonJS package-directory fallback. The staged release removes the file named by main but retains root index.js, so require(package) still resolves and package-json.entrypoint-missing must not turn the removal into a high release-scoped finding.",
+  "expectMinRisk": "low",
+  "expectAnyRule": [],
+  "previousPackageJson": {
+    "name": "root-index-fallback",
+    "version": "1.0.0",
+    "main": "dist/index.js"
+  },
+  "stagedPackageJson": {
+    "name": "root-index-fallback",
+    "version": "1.1.0",
+    "main": "dist/index.js"
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 78,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"root-index-fallback\",\"version\":\"1.0.0\",\"main\":\"dist/index.js\"}"
+    },
+    {
+      "path": "dist/index.js",
+      "size": 24,
+      "sha256": "prev-dist-index",
+      "flags": [],
+      "textSample": "module.exports = 42;\n"
+    },
+    {
+      "path": "index.js",
+      "size": 24,
+      "sha256": "root-index",
+      "flags": [],
+      "textSample": "module.exports = 42;\n"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 78,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"root-index-fallback\",\"version\":\"1.1.0\",\"main\":\"dist/index.js\"}"
+    },
+    {
+      "path": "index.js",
+      "size": 24,
+      "sha256": "root-index",
+      "flags": [],
+      "textSample": "module.exports = 42;\n"
+    }
+  ]
+}

--- a/test/npm-acquire.test.mjs
+++ b/test/npm-acquire.test.mjs
@@ -4,7 +4,8 @@ vi.mock("cloudflare:workers", () => ({
   WorkerEntrypoint: class {},
 }));
 
-const { acquireBaselineNpm } = await import("../server/lib/ecosystems/npm/acquire");
+const { acquireBaselineNpm, acquireStagedNpm } =
+  await import("../server/lib/ecosystems/npm/acquire");
 const { SandboxError } = await import("../server/lib/sandbox");
 
 function stagedArtifact() {
@@ -107,5 +108,27 @@ describe("acquireBaselineNpm", () => {
     };
 
     await expect(acquireBaselineNpm({}, {}, broker, stagedArtifact())).rejects.toThrow();
+  });
+});
+
+describe("acquireStagedNpm", () => {
+  test("preserves the browser entrypoint when staged metadata is merged", async () => {
+    const browser = "dist/browser.js";
+    const broker = {
+      dispose() {},
+      downloadStaged: vi.fn(async () => ({
+        files: [],
+        packageJson: { name: "pkg", version: "2.0.0", browser },
+      })),
+      fetchStagedDetails: vi.fn(async () => ({
+        packageName: "pkg",
+        version: "2.0.0",
+        packageJson: { name: "pkg", version: "2.0.0" },
+      })),
+    };
+
+    const result = await acquireStagedNpm({}, { stageId: "stage-1" }, broker);
+
+    expect(result.artifact.manifest).toMatchObject({ browser });
   });
 });

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -2877,6 +2877,20 @@ describe("package-json.entrypoint-missing", () => {
     ).toHaveLength(1);
   });
 
+  test.each(["js", "json", "node"])(
+    "uses npm's package-root index.%s fallback after an unresolved main",
+    (extension) => {
+      const manifest = { name: "pkg", version: "1.0.0", main: "dist/index.js" };
+      const previous = [
+        manifestFile({ ...manifest, version: "0.9.0" }),
+        file("dist/index.js"),
+        file(`index.${extension}`),
+      ];
+
+      expect(findingsFor(manifest, [`index.${extension}`], previous)).toEqual([]);
+    },
+  );
+
   test.each([
     ["a later array fallback", { exports: ["./index.js", "./missing.js"] }, ["index.js"]],
     [

--- a/test/staged-publishes.test.mjs
+++ b/test/staged-publishes.test.mjs
@@ -114,6 +114,7 @@ describe("staged publish metadata", () => {
           scripts: { install: "node-gyp rebuild" },
           gypfile: true,
           dependencies: { leftpad: "1.3.0" },
+          browser: "dist/browser.js",
         },
       },
     });
@@ -124,6 +125,7 @@ describe("staged publish metadata", () => {
       scripts: { install: "node-gyp rebuild" },
       gypfile: true,
       dependencies: { leftpad: "1.3.0" },
+      browser: "dist/browser.js",
     });
   });
 


### PR DESCRIPTION
## What changed

- honor Node's final package-root `index.js`/`index.json`/`index.node` fallback when an npm `main` target cannot resolve
- preserve string-form `browser` entrypoints through staged npm metadata parsing and manifest merging
- bump the deterministic ruleset to 1.21.0 and document the corrected semantics
- add focused unit/integration coverage and a benign detection-corpus regression

## Why

The entrypoint-missing rule modeled `main` extension and directory resolution but omitted Node's final root-index fallback. A release could therefore receive a high release-scoped finding even though CommonJS still loaded it. Separately, staged npm acquisition reconstructed package summaries without `browser`, so browser-only entrypoint changes could be mislabeled as unchanged and routed through low-signal AI review.

## Impact

Valid root-index fallback packages no longer receive the false high finding. Staged npm scans now retain browser entrypoint changes for package-json diffing, reviewer selection, and report evidence.

## Validation

- `pnpm exec vitest run --project node test/review.test.mjs test/npm-acquire.test.mjs test/staged-publishes.test.mjs test/security-corpus.test.mjs test/security-corpus-parity.test.mjs` (196 tests)
- `pnpm run verify`
- `pnpm run eval`

Docs updated in `docs/security-detection-corpus.md`.