### PR TITLE
Add configurable dialog size support

### DIFF
--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -3,6 +3,18 @@ import { useEffect, useId, useRef } from "preact/hooks";
 import { CloseButton } from "./CloseButton";
 import { cn } from "./cn";
 
+/**
+ * `sm` fits the prose-and-buttons default. `md` is for dialogs whose body
+ * carries a fixed-width payload — a shell command, a key — that reads as
+ * cramped when wrapped or scrolled at the default width.
+ */
+type DialogSize = "sm" | "md";
+
+const SIZE_CLASS: Record<DialogSize, string> = {
+  sm: "w-[min(92vw,440px)] max-w-[440px]",
+  md: "w-[min(92vw,560px)] max-w-[560px]",
+};
+
 interface DialogProps {
   open: boolean;
   onClose: () => void;
@@ -10,6 +22,7 @@ interface DialogProps {
   description?: string;
   children: ComponentChildren;
   footer?: ComponentChildren;
+  size?: DialogSize;
   class?: string;
 }
 
@@ -20,6 +33,7 @@ export function Dialog({
   description,
   children,
   footer,
+  size = "sm",
   class: className,
 }: DialogProps) {
   const ref = useRef<HTMLDialogElement | null>(null);
@@ -65,7 +79,7 @@ export function Dialog({
       onClick={onBackdropClick}
       class={cn(
         "p-0 m-auto bg-surface text-ink border border-border rounded-lg shadow-md",
-        "w-[min(92vw,440px)] max-w-[440px]",
+        SIZE_CLASS[size],
         "backdrop:bg-black/40",
         className,
       )}

--- a/src/pages/Dashboard/ScanDetail/StageCommandDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/StageCommandDialog.tsx
@@ -51,6 +51,10 @@ function StageCommandDialog({ prompt }: { prompt: StageCommandPrompt }) {
     <Dialog
       open={true}
       onClose={dismissStageCommandPrompt}
+      // Wider than the default: the body is a copyable one-line shell command
+      // whose stage id runs long, so the default width scrolls it almost
+      // immediately.
+      size="md"
       title={approving ? "Finish the publish on npm" : "Remove the staged publish on npm"}
       description={
         approving


### PR DESCRIPTION
## Summary
Add support for configurable dialog sizes to accommodate different content types, with `sm` (440px) as the default and `md` (560px) for fixed-width payloads like shell commands.

## Changes
- **Dialog component**: Introduced `DialogSize` type with `sm` and `md` options, and a `SIZE_CLASS` mapping for width styling
- **Dialog props**: Added optional `size` prop (defaults to `"sm"`) to allow consumers to specify dialog width
- **StageCommandDialog**: Updated to use `size="md"` since the shell command body needs extra width to avoid immediate scrolling

## Implementation Details
The size configuration uses CSS `min()` and `max-width` to ensure dialogs remain responsive on smaller viewports (92vw) while maintaining fixed widths on larger screens. The `md` size increases the dialog width from 440px to 560px, providing better readability for fixed-width content like shell commands with long stage IDs.

https://claude.ai/code/session_011uqhMdV2n8r9DNaG3Juq74