### PR TITLE
Unexport release fingerprint history caps to fix knip

### DIFF
--- a/server/db/release-fingerprint.ts
+++ b/server/db/release-fingerprint.ts
@@ -13,9 +13,9 @@ import { githubWorkflowGates, scans } from "./schema";
 // silent rather than claiming a burst is unprecedented on partial data).
 
 /** Org history rows fetched per scan. Rides `scans_org_created_idx`. */
-export const RELEASE_FINGERPRINT_ORG_HISTORY_CAP = 500;
+const RELEASE_FINGERPRINT_ORG_HISTORY_CAP = 500;
 /** Prior package scans fetched per scan. Rides `scans_package_idx`. */
-export const RELEASE_FINGERPRINT_PACKAGE_HISTORY_CAP = 100;
+const RELEASE_FINGERPRINT_PACKAGE_HISTORY_CAP = 100;
 
 export interface ReleaseFingerprintHistory {
   orgHistory: OrgScanHistoryRow[];


### PR DESCRIPTION
## Summary

`pnpm run knip` was failing on `main` with two unused exports: `RELEASE_FINGERPRINT_ORG_HISTORY_CAP` and `RELEASE_FINGERPRINT_PACKAGE_HISTORY_CAP` in `server/db/release-fingerprint.ts`. Both are only read inside that same file (the two `.limit()` calls and the `orgHistoryTruncated` check), so this drops the `export` keyword rather than deleting them.

## Trust boundary

None — no behavior change; the cap values and their org-scoped queries are untouched.

## Verification

`pnpm run knip` (now clean) and `pnpm run verify` (lint, format:check, typecheck, test — all pass).

## Documentation

docs checked, no update needed.

## UI evidence

Not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)