### PR TITLE
Remove release.burst-anomaly: monorepo release trains are the same shape

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ The user-facing learning guide is [`../src/pages/Docs/index.tsx`](../src/pages/D
 - [`security-detection-corpus.md`](./security-detection-corpus.md) — rule/eval fixture layout and expected findings.
 - [`detection-eval.md`](./detection-eval.md) — eval harness, metrics, and gates.
 - [`release-memory.md`](./release-memory.md) — advisory prior-release finding-profile consistency; discounts already-approved package context from the artifact-risk headline, and never moves release risk or a gate decision.
-- [`release-fingerprint.md`](./release-fingerprint.md) — history-based `release.*` rules (burst anomaly, source drift) and their FP posture.
+- [`release-fingerprint.md`](./release-fingerprint.md) — the history-based `release.source-drift` rule and its FP posture.
 - [`organization-members.md`](./organization-members.md) — organization invitation/membership behavior.
 - [`marketing-attribution.md`](./marketing-attribution.md) — coarse Analytics Engine channel attribution for the public marketing surfaces, and the share-card surface it measures.
 - [`audit-log.md`](./audit-log.md) — organization audit log surface, visible-event allowlist, and retention.

--- a/docs/release-fingerprint.md
+++ b/docs/release-fingerprint.md
@@ -1,32 +1,20 @@
 # Release-process fingerprint rules
 
-Deterministic findings about how a release _arrived_, not what its artifact contains. The dominant 2025–26 npm supply-chain shape is a compromised maintainer account burst-publishing malicious versions across many packages, usually outside the maintainer's normal CI release path. Drydock sits pre-publish and holds per-organization scan history in D1, so it can flag releases that deviate from how this organization or package normally releases.
+Deterministic findings about how a release _arrived_, not what its artifact contains. The dominant 2025–26 npm supply-chain shape is a compromised maintainer account publishing malicious versions outside the maintainer's normal CI release path. Drydock sits pre-publish and holds per-organization scan history in D1, so it can flag a package that suddenly arrives through a different release path than every prior release.
 
-Both rules live in the shared deterministic rule set (`server/lib/review/rules/rule-ids.ts`, versioned by `DETERMINISTIC_RULES_VERSION`, introduced in `1.23.0`). The pure logic is `server/lib/release-fingerprint.ts`; the org-scoped history queries are `server/db/release-fingerprint.ts`; the pipeline wires them in `server/lib/scan/pipeline.ts` (`collectReleaseFingerprintFindings`). They are not content rules, so the security corpus and detection eval (which replay synthetic package bytes) do not cover them — the unit matrix lives in `test/release-fingerprint.test.ts` and the D1-backed end-to-end checks in `test/workers/release-fingerprint.test.ts`.
+The rule lives in the shared deterministic rule set (`server/lib/review/rules/rule-ids.ts`, versioned by `DETERMINISTIC_RULES_VERSION`). The pure logic is `server/lib/release-fingerprint.ts`; the org-scoped history query is `server/db/release-fingerprint.ts`; the pipeline wires it in `server/lib/scan/pipeline.ts` (`collectReleaseFingerprintFindings`). It is not a content rule, so the security corpus and detection eval (which replay synthetic package bytes) do not cover it — the unit matrix lives in `test/release-fingerprint.test.ts` and the D1-backed end-to-end checks in `test/workers/release-fingerprint.test.ts`.
 
 ## False-positive posture
 
-Silence over noise. Both rules must _prove_ the deviation is abnormal from history before emitting anything; every ambiguous situation (short history, mixed history, an established burst pattern, a truncated history read, an unknown scan source) emits **nothing** rather than a hedged finding. A failed history lookup never fails the scan: the pipeline degrades to no release-process findings and emits a `scan.release_fingerprint.failed` operational event (secret-redacted, no package contents).
+Silence over noise. The rule must _prove_ the deviation is abnormal from history before emitting anything; every ambiguous situation (short history, mixed history, an unknown scan source) emits **nothing** rather than a hedged finding. A failed history lookup never fails the scan: the pipeline degrades to no release-process findings and emits a `scan.release_fingerprint.failed` operational event (secret-redacted, no package contents).
+
+Release-process findings are release-scoped, so they feed **release risk** — which is what drives the workflow gate's approve/reject recommendation. A `release.*` rule that can fire on a routine release is therefore not merely noisy, it blocks a deployment. That is the bar any new rule in this file has to clear.
 
 ## Shared mechanics
 
-- Findings carry the synthetic file label `<release-process>` (`RELEASE_PROCESS_FINDING_FILE`) because they describe the release, not a file. The diff annotator treats every `release.*` rule as release-scoped, so these findings always land with `releaseDelta: true` and feed **release risk** (and, as anchor-severity findings, overall artifact risk). The findings UI renders the label as plain text instead of an open-in-diff button.
-- The current scan may not have a persisted row when the rules run, so it is counted explicitly from the staged manifest name rather than read back from D1.
-- All history queries filter by `organizationId` (the workflow-gate join re-checks the gate's organization) and ride existing indexes (`scans_org_created_idx`, `scans_package_idx`).
-
-## `release.burst-anomaly` (severity: high)
-
-Fires when the organization suddenly stages many _distinct_ packages at once — the compromised-account burst-publish shape — and history proves that is unprecedented.
-
-Trigger (all must hold):
-
-- Counting org scans created in the last 30 minutes (`BURST_WINDOW_MS`), including the current scan, there are ≥ 5 distinct `packageName`s (`BURST_DISTINCT_PACKAGE_THRESHOLD`).
-- The org has ≥ 30 days of scan history (`BURST_MIN_ORG_HISTORY_DAYS`) and ≥ 5 prior completed scans (`BURST_MIN_PRIOR_COMPLETED_SCANS`).
-- No prior 30-minute window in the last 180 days (`BURST_LOOKBACK_DAYS`) reached 5 distinct packages — monorepo release trains that always publish many packages at once therefore never fire this rule.
-
-Suppression: insufficient history age or completions, any prior burst window, or a truncated history read (the fetch is capped at `RELEASE_FINGERPRINT_ORG_HISTORY_CAP = 500` rows; hitting the cap means older windows were not seen, so the rule stays silent instead of claiming "first ever" on partial data — very high-volume orgs are exactly the ones whose trains would suppress it anyway).
-
-Evidence: the distinct-package count, the window, and up to 8 package names (`BURST_EVIDENCE_PACKAGE_LIMIT`).
+- Findings carry the synthetic file label `<release-process>` (`RELEASE_PROCESS_FINDING_FILE`) because they describe the release, not a file. The diff annotator treats every `release.*` rule as release-scoped, so these findings always land with `releaseDelta: true` and feed release risk (and, as anchor-severity findings, overall artifact risk). The findings UI renders the label as plain text instead of an open-in-diff button.
+- The current scan may not have a persisted row when the rule runs, so its identity is taken from the staged manifest rather than read back from D1.
+- The history query filters by `organizationId` (the workflow-gate join re-checks the gate's organization) and rides the existing `scans_package_idx` index.
 
 ## `release.source-drift` (severity: high for gate→staged, medium otherwise)
 
@@ -36,7 +24,17 @@ Release path = `scans.source`, with `workflow_gate` scans further keyed by the g
 
 Trigger: the package (same org + `packageName`) has ≥ 3 prior completed scans (`SOURCE_DRIFT_MIN_PRIOR_SCANS`), **all** sharing one release path (checked over the most recent `RELEASE_FINGERPRINT_PACKAGE_HISTORY_CAP = 100`), and the current scan's path differs.
 
-- **High**: a consistently workflow-gated package arriving as a staged/manual scan — the "publish around CI with a stolen token" shape.
-- **Medium**: every other drift (gate repository or environment change, staged→gate).
+- **High**: a consistently workflow-gated package arriving as a staged/manual scan — the "publish around CI with a stolen token" shape. This lands on a staged scan, which has no gate to reject; it shows as high release risk in the workbench.
+- **Medium**: every other drift (gate repository or environment change, staged→gate). Note that staged→gate is the expected shape while an organization migrates onto workflow gates, which is why it is medium and non-blocking.
 
 Suppression: mixed prior history, fewer than 3 prior completed scans, unknown current source (no scan row), or no package name.
+
+## Removed: `release.burst-anomaly`
+
+A companion rule shipped alongside `release.source-drift` in `1.23.0` and was removed in `1.24.0`. It flagged an organization staging ≥ 5 distinct packages inside a 30-minute window for the first time in 180 days.
+
+That is a monorepo release train. The suppression it relied on — "some earlier window in the last 180 days also burst" — only holds once a train is already in scan history, so an organization's first coordinated release, and every release train spaced more than 180 days apart (a semiannual or annual major), raised a high release finding. Because a gate job creates one scan per package, a 5-package gated train tripped the rule on every one of its scans and the gate recommendation flipped to `rejected`.
+
+The true-positive side never justified that cost: an attacker holding a stolen npm token publishes directly to the registry, not through the victim's staged-publish flow or CI workflow gate, so the only bursts Drydock can observe are the legitimate ones. If the burst signal returns it must be non-blocking (package context rather than release delta), or conditioned on the burst's packages also drifting off their usual release path.
+
+Any `release.burst-anomaly` rows already persisted by a `1.23.0` scan stay readable: findings store the rule id as a plain string, nothing resolves it back through `DETERMINISTIC_RULE_IDS`, and the release-scoping check matches on the `release.` prefix rather than a known-id list. Those scans keep their recorded risk; only new scans stop producing the finding.

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -337,6 +337,12 @@ against the organization's D1 scan history rather than package bytes, so they ha
 their matrix lives in `test/release-fingerprint.test.ts` and
 `test/workers/release-fingerprint.test.ts`.
 
+`1.24.0` removes `release.burst-anomaly`. Its trigger (≥ 5 distinct packages staged inside 30 minutes,
+never seen before in 180 days) is indistinguishable from a monorepo release train, and because
+`release.*` findings are release-scoped it turned that train's gate recommendation into `rejected`.
+`release.source-drift` is unchanged. See [`release-fingerprint.md`](./release-fingerprint.md) for the
+conditions any revived burst rule would have to meet.
+
 ### Fixture format
 
 Required fields:

--- a/server/db/release-fingerprint.ts
+++ b/server/db/release-fingerprint.ts
@@ -1,25 +1,15 @@
-import { and, desc, eq, gte, ne } from "drizzle-orm";
-import {
-  BURST_LOOKBACK_DAYS,
-  type OrgScanHistoryRow,
-  type PackageScanHistoryRow,
-} from "../lib/release-fingerprint";
+import { and, desc, eq, ne } from "drizzle-orm";
+import type { PackageScanHistoryRow } from "../lib/release-fingerprint";
 import type { AppDb } from "./client";
 import { githubWorkflowGates, scans } from "./schema";
 
 // History reads for the release-process fingerprint rules. Every query is
-// organization-scoped; the row caps keep a single scan's history read bounded
-// (the pure module treats a capped org read as "history unknown" and stays
-// silent rather than claiming a burst is unprecedented on partial data).
+// organization-scoped; the row cap keeps a single scan's history read bounded.
 
-/** Org history rows fetched per scan. Rides `scans_org_created_idx`. */
-const RELEASE_FINGERPRINT_ORG_HISTORY_CAP = 500;
 /** Prior package scans fetched per scan. Rides `scans_package_idx`. */
 const RELEASE_FINGERPRINT_PACKAGE_HISTORY_CAP = 100;
 
 export interface ReleaseFingerprintHistory {
-  orgHistory: OrgScanHistoryRow[];
-  orgHistoryTruncated: boolean;
   packageHistory: PackageScanHistoryRow[];
   /**
    * Source + gate identity of the current scan's pending row, when it exists.
@@ -40,11 +30,8 @@ export async function loadReleaseFingerprintHistory(
     organizationId: string;
     scanId: string;
     packageName: string | null;
-    now?: Date;
   },
 ): Promise<ReleaseFingerprintHistory> {
-  const now = args.now ?? new Date();
-  const since = new Date(now.getTime() - BURST_LOOKBACK_DAYS * 24 * 60 * 60 * 1000);
   // The gate join carries its own organization guard so a (never expected)
   // cross-org gate_id reference can never leak another org's repo/environment.
   const gateJoin = and(
@@ -52,24 +39,7 @@ export async function loadReleaseFingerprintHistory(
     eq(githubWorkflowGates.organizationId, args.organizationId),
   );
 
-  const [orgRows, currentRows, packageRows] = await Promise.all([
-    db
-      .select({
-        id: scans.id,
-        packageName: scans.packageName,
-        status: scans.status,
-        createdAt: scans.createdAt,
-      })
-      .from(scans)
-      .where(
-        and(
-          eq(scans.organizationId, args.organizationId),
-          gte(scans.createdAt, since),
-          ne(scans.id, args.scanId),
-        ),
-      )
-      .orderBy(desc(scans.createdAt), desc(scans.id))
-      .limit(RELEASE_FINGERPRINT_ORG_HISTORY_CAP),
+  const [currentRows, packageRows] = await Promise.all([
     db
       .select({
         source: scans.source,
@@ -105,8 +75,6 @@ export async function loadReleaseFingerprintHistory(
   ]);
 
   return {
-    orgHistory: orgRows,
-    orgHistoryTruncated: orgRows.length >= RELEASE_FINGERPRINT_ORG_HISTORY_CAP,
     packageHistory: packageRows,
     currentScan: currentRows[0] ?? null,
   };

--- a/server/lib/release-fingerprint.ts
+++ b/server/lib/release-fingerprint.ts
@@ -1,19 +1,30 @@
 import { DETERMINISTIC_RULE_IDS, DETERMINISTIC_RULES_VERSION } from "./review/rules";
 import type { Finding } from "./review";
 
-// Release-process fingerprint rules (release.burst-anomaly / release.source-drift).
+// Release-process fingerprint rules (release.source-drift).
 //
 // These findings are about how a release ARRIVED, not what the artifact
 // contains: the dominant compromised-maintainer shape is a stolen credential
-// burst-publishing malicious versions across many packages, usually bypassing
-// the usual CI release path. Drydock sits pre-publish with per-organization
-// scan history, so it can flag releases that deviate from how this org/package
-// normally releases.
+// publishing malicious versions outside the maintainer's normal CI release
+// path. Drydock sits pre-publish with per-organization scan history, so it can
+// flag a package that suddenly arrives through a different release path.
 //
-// FP posture: silence over noise. Both rules require enough history to prove
-// the deviation is abnormal, and any ambiguity (short history, mixed history,
-// prior burst windows, truncated history fetches) suppresses the finding
-// entirely instead of emitting a hedged one.
+// A companion rule, `release.burst-anomaly`, used to live here: it flagged an
+// organization staging >= 5 distinct packages inside 30 minutes for the first
+// time. It was removed because a monorepo release train is exactly that shape.
+// The suppression it relied on ("some earlier window in the last 180 days also
+// burst") only holds once a train is already in history, so an org's first
+// coordinated release — and every release train spaced more than 180 days
+// apart — raised a high release finding, which rejects a workflow gate. The
+// true-positive side never justified that: an attacker holding a stolen npm
+// token publishes directly, not through the victim's staged-publish flow or CI
+// gate, so the only bursts Drydock can actually observe are the legitimate
+// ones. If the burst signal comes back it must be non-blocking, or conditioned
+// on the packages also drifting off their usual release path.
+//
+// FP posture: silence over noise. The rule requires enough history to prove the
+// deviation is abnormal, and any ambiguity (short history, mixed history)
+// suppresses the finding entirely instead of emitting a hedged one.
 //
 // This module is pure — it takes plain history rows plus current-scan facts and
 // returns findings — so the thresholds are unit-testable without a database.
@@ -22,31 +33,8 @@ import type { Finding } from "./review";
 /** Synthetic file label for findings that describe the release process itself. */
 export const RELEASE_PROCESS_FINDING_FILE = "<release-process>";
 
-/** Burst window: distinct packages scanned inside this span count as one burst. */
-export const BURST_WINDOW_MS = 30 * 60 * 1000;
-/** Distinct package names inside one window needed to call it a burst. */
-export const BURST_DISTINCT_PACKAGE_THRESHOLD = 5;
-/** The org needs at least this much scan history before a burst is judgeable. */
-export const BURST_MIN_ORG_HISTORY_DAYS = 30;
-/** ...and at least this many prior completed scans. */
-export const BURST_MIN_PRIOR_COMPLETED_SCANS = 5;
-/** How far back the prior-burst sweep looks for an established release train. */
-export const BURST_LOOKBACK_DAYS = 180;
-/** Cap on package names spelled out in the finding evidence. */
-export const BURST_EVIDENCE_PACKAGE_LIMIT = 8;
-
 /** Prior completed scans of the package required before source drift is judgeable. */
 export const SOURCE_DRIFT_MIN_PRIOR_SCANS = 3;
-
-const DAY_MS = 24 * 60 * 60 * 1000;
-
-/** One org-scoped scan row from the burst lookback window (current scan excluded). */
-export interface OrgScanHistoryRow {
-  id: string;
-  packageName: string | null;
-  status: string;
-  createdAt: Date;
-}
 
 /** One prior scan of the current package (current scan excluded). */
 export interface PackageScanHistoryRow {
@@ -60,8 +48,7 @@ export interface PackageScanHistoryRow {
 /**
  * Facts about the scan being reviewed right now. The scan row may not be
  * persisted (or terminal) yet, so callers pass these explicitly instead of
- * relying on the row existing — the burst count includes the current scan via
- * `packageName`, never via a database row.
+ * relying on the row existing.
  */
 export interface CurrentScanFacts {
   scanId: string;
@@ -73,103 +60,13 @@ export interface CurrentScanFacts {
 }
 
 export interface ReleaseFingerprintArgs {
-  now: Date;
   current: CurrentScanFacts;
-  /** Org scans from the last BURST_LOOKBACK_DAYS, excluding the current scan. */
-  orgHistory: OrgScanHistoryRow[];
-  /**
-   * True when the history fetch hit its row cap, i.e. older rows inside the
-   * lookback window were not loaded. An unseen prior burst window could make a
-   * "first ever" claim wrong, so a truncated fetch suppresses the burst rule.
-   */
-  orgHistoryTruncated?: boolean;
   /** Prior scans of the current package, excluding the current scan. */
   packageHistory: PackageScanHistoryRow[];
 }
 
 export function releaseFingerprintFindings(args: ReleaseFingerprintArgs): Finding[] {
-  return [...burstAnomalyFindings(args), ...sourceDriftFindings(args)];
-}
-
-// ── release.burst-anomaly ────────────────────────────────────────────────────
-
-function burstAnomalyFindings(args: ReleaseFingerprintArgs): Finding[] {
-  const nowMs = args.now.getTime();
-  const windowStartMs = nowMs - BURST_WINDOW_MS;
-  const rows = args.orgHistory.filter((row) => row.id !== args.current.scanId);
-
-  // Current 30-minute window, counting the in-flight scan explicitly.
-  const windowPackages = new Set<string>();
-  if (args.current.packageName) windowPackages.add(args.current.packageName);
-  for (const row of rows) {
-    const createdAtMs = row.createdAt.getTime();
-    if (createdAtMs > windowStartMs && createdAtMs <= nowMs && row.packageName) {
-      windowPackages.add(row.packageName);
-    }
-  }
-  if (windowPackages.size < BURST_DISTINCT_PACKAGE_THRESHOLD) return [];
-
-  // A capped fetch may have dropped a prior burst window; without the full
-  // lookback we cannot prove the burst is abnormal, so emit nothing.
-  if (args.orgHistoryTruncated) return [];
-
-  // The org must have enough history for "this never happens here" to mean
-  // anything: >= BURST_MIN_ORG_HISTORY_DAYS of scans and >= 5 prior completions.
-  const historyFloorMs = nowMs - BURST_MIN_ORG_HISTORY_DAYS * DAY_MS;
-  if (!rows.some((row) => row.createdAt.getTime() <= historyFloorMs)) return [];
-  const completedCount = rows.reduce(
-    (count, row) => (row.status === "complete" ? count + 1 : count),
-    0,
-  );
-  if (completedCount < BURST_MIN_PRIOR_COMPLETED_SCANS) return [];
-
-  // Monorepo release trains legitimately publish many packages at once; if any
-  // prior window already reached the threshold, bursts are normal here.
-  const priorEvents = rows
-    .filter(
-      (row): row is OrgScanHistoryRow & { packageName: string } =>
-        row.packageName !== null && row.createdAt.getTime() <= windowStartMs,
-    )
-    .map((row) => ({ atMs: row.createdAt.getTime(), packageName: row.packageName }))
-    .sort((a, b) => a.atMs - b.atMs);
-  if (hasPriorBurstWindow(priorEvents)) return [];
-
-  const names = [...windowPackages].sort((a, b) => a.localeCompare(b));
-  const shown = names.slice(0, BURST_EVIDENCE_PACKAGE_LIMIT);
-  const overflow = names.length - shown.length;
-  return [
-    {
-      severity: "high",
-      file: RELEASE_PROCESS_FINDING_FILE,
-      evidence: `${names.length} distinct packages staged for release in this organization within 30 minutes: ${shown.join(", ")}${overflow > 0 ? ` (+${overflow} more)` : ""}`,
-      reason:
-        "this organization has never released this many distinct packages inside one 30-minute window in the last 180 days; a sudden multi-package publish burst is the dominant shape of a compromised maintainer account pushing malicious versions across every package it controls — verify each staged release before publishing",
-      ruleId: DETERMINISTIC_RULE_IDS.releaseBurstAnomaly,
-      ruleVersion: DETERMINISTIC_RULES_VERSION,
-    },
-  ];
-}
-
-/**
- * Linear two-pointer sweep over time-ascending (atMs, packageName) events:
- * returns true when any trailing BURST_WINDOW_MS window holds
- * BURST_DISTINCT_PACKAGE_THRESHOLD distinct package names.
- */
-function hasPriorBurstWindow(events: Array<{ atMs: number; packageName: string }>): boolean {
-  const counts = new Map<string, number>();
-  let left = 0;
-  for (const event of events) {
-    counts.set(event.packageName, (counts.get(event.packageName) ?? 0) + 1);
-    while (events[left].atMs <= event.atMs - BURST_WINDOW_MS) {
-      const name = events[left].packageName;
-      const count = counts.get(name) ?? 0;
-      if (count <= 1) counts.delete(name);
-      else counts.set(name, count - 1);
-      left += 1;
-    }
-    if (counts.size >= BURST_DISTINCT_PACKAGE_THRESHOLD) return true;
-  }
-  return false;
+  return sourceDriftFindings(args);
 }
 
 // ── release.source-drift ─────────────────────────────────────────────────────
@@ -205,7 +102,10 @@ function releasePathOf(row: {
 
 function releasePathKey(path: ReleasePath): string {
   if (path.kind === "staged") return "staged";
-  return `workflow_gate ${path.repositoryFullName ?? ""} ${path.environment ?? ""}`;
+  // NUL-separated like every other composite key in the codebase, so a
+  // repository or environment name containing the separator cannot make two
+  // different gates read as the same release path.
+  return `workflow_gate\0${path.repositoryFullName ?? ""}\0${path.environment ?? ""}`;
 }
 
 function describeReleasePath(path: ReleasePath): string {

--- a/server/lib/review/rules/index.ts
+++ b/server/lib/review/rules/index.ts
@@ -10,7 +10,7 @@ import { entrypointDiffFindings, entrypointPresenceFindings } from "./entrypoint
 // way that should invalidate cached scan reports. Stored alongside each finding
 // so historical reports can be traced back to the ruleset that produced them.
 // Lives here (not in a family module) because versioning spans every family.
-export const DETERMINISTIC_RULES_VERSION = "1.23.0";
+export const DETERMINISTIC_RULES_VERSION = "1.24.0";
 
 export { DETERMINISTIC_RULE_IDS } from "./rule-ids";
 export {

--- a/server/lib/review/rules/rule-ids.ts
+++ b/server/lib/review/rules/rule-ids.ts
@@ -24,7 +24,6 @@ export const DETERMINISTIC_RULE_IDS = {
   stageMetadataMismatch: "stage.metadata-mismatch",
   stageTarballDigestMismatch: "stage.tarball-digest-mismatch",
   tarSuspiciousEntry: "tar.suspicious-entry",
-  releaseBurstAnomaly: "release.burst-anomaly",
   releaseSourceDrift: "release.source-drift",
 } as const;
 

--- a/server/lib/scan/pipeline.ts
+++ b/server/lib/scan/pipeline.ts
@@ -195,17 +195,14 @@ async function collectReleaseFingerprintFindings(
   identity: PipelineIdentity,
   resolved: ResolvedArtifacts,
 ): Promise<Finding[]> {
-  const now = new Date();
   const packageName = resolved.staged.artifact.manifest?.name || null;
   try {
     const history = await loadReleaseFingerprintHistory(db, {
       organizationId: identity.organizationId,
       scanId: identity.scanId,
       packageName,
-      now,
     });
     return releaseFingerprintFindings({
-      now,
       current: {
         scanId: identity.scanId,
         packageName,
@@ -213,8 +210,6 @@ async function collectReleaseFingerprintFindings(
         gateRepositoryFullName: history.currentScan?.gateRepositoryFullName ?? null,
         gateEnvironment: history.currentScan?.gateEnvironment ?? null,
       },
-      orgHistory: history.orgHistory,
-      orgHistoryTruncated: history.orgHistoryTruncated,
       packageHistory: history.packageHistory,
     });
   } catch (err) {

--- a/test/release-fingerprint.test.ts
+++ b/test/release-fingerprint.test.ts
@@ -1,41 +1,12 @@
 import { describe, expect, test } from "vitest";
 import {
-  BURST_DISTINCT_PACKAGE_THRESHOLD,
-  BURST_EVIDENCE_PACKAGE_LIMIT,
-  BURST_MIN_ORG_HISTORY_DAYS,
-  BURST_MIN_PRIOR_COMPLETED_SCANS,
-  BURST_WINDOW_MS,
   RELEASE_PROCESS_FINDING_FILE,
   releaseFingerprintFindings,
   SOURCE_DRIFT_MIN_PRIOR_SCANS,
   type CurrentScanFacts,
-  type OrgScanHistoryRow,
   type PackageScanHistoryRow,
 } from "../server/lib/release-fingerprint";
 import { annotateFindingsWithDiffStatus, DETERMINISTIC_RULES_VERSION } from "../server/lib/review";
-
-const NOW = new Date("2026-07-10T12:00:00.000Z");
-const DAY_MS = 24 * 60 * 60 * 1000;
-
-function minutesAgo(minutes: number): Date {
-  return new Date(NOW.getTime() - minutes * 60 * 1000);
-}
-
-function daysAgo(days: number): Date {
-  return new Date(NOW.getTime() - days * DAY_MS);
-}
-
-let seq = 0;
-function orgRow(overrides: Partial<OrgScanHistoryRow> = {}): OrgScanHistoryRow {
-  seq += 1;
-  return {
-    id: `scan_${seq}`,
-    packageName: `pkg-${seq}`,
-    status: "complete",
-    createdAt: daysAgo(40),
-    ...overrides,
-  };
-}
 
 function currentScan(overrides: Partial<CurrentScanFacts> = {}): CurrentScanFacts {
   return {
@@ -48,183 +19,15 @@ function currentScan(overrides: Partial<CurrentScanFacts> = {}): CurrentScanFact
   };
 }
 
-/**
- * Baseline org history that satisfies burst preconditions: old enough
- * (>= BURST_MIN_ORG_HISTORY_DAYS), enough prior completions, no prior burst
- * (one scan per day, one package per scan).
- */
-function quietOrgHistory(): OrgScanHistoryRow[] {
-  return Array.from({ length: BURST_MIN_PRIOR_COMPLETED_SCANS + 1 }, (_, index) =>
-    orgRow({ createdAt: daysAgo(BURST_MIN_ORG_HISTORY_DAYS + 10 + index) }),
-  );
-}
-
-/** N distinct packages scanned inside the current 30-minute window. */
-function windowRows(count: number): OrgScanHistoryRow[] {
-  return Array.from({ length: count }, (_, index) =>
-    orgRow({
-      packageName: `burst-pkg-${index}`,
-      status: "running",
-      createdAt: minutesAgo(index + 1),
-    }),
-  );
-}
-
 function findingsFor(args: {
   current?: CurrentScanFacts;
-  orgHistory?: OrgScanHistoryRow[];
-  orgHistoryTruncated?: boolean;
   packageHistory?: PackageScanHistoryRow[];
 }) {
   return releaseFingerprintFindings({
-    now: NOW,
     current: args.current ?? currentScan(),
-    orgHistory: args.orgHistory ?? [],
-    orgHistoryTruncated: args.orgHistoryTruncated,
     packageHistory: args.packageHistory ?? [],
   });
 }
-
-describe("release.burst-anomaly", () => {
-  test("fires when the current scan completes an unprecedented multi-package window", () => {
-    // 4 window rows + the current scan itself = exactly the threshold.
-    const findings = findingsFor({
-      orgHistory: [...quietOrgHistory(), ...windowRows(BURST_DISTINCT_PACKAGE_THRESHOLD - 1)],
-    });
-    expect(findings).toHaveLength(1);
-    expect(findings[0]).toMatchObject({
-      ruleId: "release.burst-anomaly",
-      severity: "high",
-      file: RELEASE_PROCESS_FINDING_FILE,
-      ruleVersion: DETERMINISTIC_RULES_VERSION,
-    });
-    expect(findings[0].evidence).toContain(`${BURST_DISTINCT_PACKAGE_THRESHOLD} distinct packages`);
-    expect(findings[0].evidence).toContain("pkg-current");
-    expect(findings[0].evidence).toContain("burst-pkg-0");
-  });
-
-  test("stays silent one below the distinct-package threshold", () => {
-    const findings = findingsFor({
-      orgHistory: [...quietOrgHistory(), ...windowRows(BURST_DISTINCT_PACKAGE_THRESHOLD - 2)],
-    });
-    expect(findings).toEqual([]);
-  });
-
-  test("counts distinct packages, not scans, inside the window", () => {
-    const duplicates = Array.from({ length: 10 }, (_, index) =>
-      orgRow({ packageName: "same-pkg", status: "running", createdAt: minutesAgo(index + 1) }),
-    );
-    expect(findingsFor({ orgHistory: [...quietOrgHistory(), ...duplicates] })).toEqual([]);
-  });
-
-  test("scans outside the 30-minute window do not count toward the burst", () => {
-    const stale = Array.from({ length: BURST_DISTINCT_PACKAGE_THRESHOLD }, (_, index) =>
-      orgRow({
-        packageName: `stale-pkg-${index}`,
-        createdAt: new Date(NOW.getTime() - BURST_WINDOW_MS - (index + 1) * 60 * 1000),
-      }),
-    );
-    // Stale rows are 31+ minutes old (they instead count as a prior-window
-    // burst, which suppresses); only 3 rows + current sit inside the window.
-    const findings = findingsFor({
-      orgHistory: [...quietOrgHistory(), ...stale, ...windowRows(3)],
-    });
-    expect(findings).toEqual([]);
-  });
-
-  test("suppresses when the org has less than the minimum history age", () => {
-    const youngHistory = Array.from({ length: 10 }, (_, index) =>
-      orgRow({ createdAt: daysAgo(BURST_MIN_ORG_HISTORY_DAYS - 5 - index * 0.5) }),
-    );
-    const findings = findingsFor({
-      orgHistory: [...youngHistory, ...windowRows(BURST_DISTINCT_PACKAGE_THRESHOLD)],
-    });
-    expect(findings).toEqual([]);
-  });
-
-  test("suppresses when the org has too few prior completed scans", () => {
-    const sparse = Array.from({ length: BURST_MIN_PRIOR_COMPLETED_SCANS - 1 }, (_, index) =>
-      orgRow({ createdAt: daysAgo(BURST_MIN_ORG_HISTORY_DAYS + 10 + index) }),
-    );
-    const findings = findingsFor({
-      orgHistory: [...sparse, ...windowRows(BURST_DISTINCT_PACKAGE_THRESHOLD)],
-    });
-    expect(findings).toEqual([]);
-  });
-
-  test("failed scans age the history but do not count as completions", () => {
-    const failed = Array.from({ length: BURST_MIN_PRIOR_COMPLETED_SCANS + 3 }, (_, index) =>
-      orgRow({ status: "failed", createdAt: daysAgo(BURST_MIN_ORG_HISTORY_DAYS + 10 + index) }),
-    );
-    const findings = findingsFor({
-      orgHistory: [...failed, ...windowRows(BURST_DISTINCT_PACKAGE_THRESHOLD)],
-    });
-    expect(findings).toEqual([]);
-  });
-
-  test("suppresses when a prior window already reached the threshold (monorepo release train)", () => {
-    const train = Array.from({ length: BURST_DISTINCT_PACKAGE_THRESHOLD }, (_, index) =>
-      orgRow({
-        packageName: `train-pkg-${index}`,
-        createdAt: new Date(daysAgo(20).getTime() + index * 60 * 1000),
-      }),
-    );
-    const findings = findingsFor({
-      orgHistory: [...quietOrgHistory(), ...train, ...windowRows(BURST_DISTINCT_PACKAGE_THRESHOLD)],
-    });
-    expect(findings).toEqual([]);
-  });
-
-  test("a spread-out prior release train (never 5 distinct inside 30 minutes) does not suppress", () => {
-    const spread = Array.from({ length: BURST_DISTINCT_PACKAGE_THRESHOLD }, (_, index) =>
-      orgRow({
-        packageName: `spread-pkg-${index}`,
-        createdAt: new Date(daysAgo(20).getTime() + index * (BURST_WINDOW_MS + 60 * 1000)),
-      }),
-    );
-    const findings = findingsFor({
-      orgHistory: [
-        ...quietOrgHistory(),
-        ...spread,
-        ...windowRows(BURST_DISTINCT_PACKAGE_THRESHOLD),
-      ],
-    });
-    expect(findings).toHaveLength(1);
-    expect(findings[0].ruleId).toBe("release.burst-anomaly");
-  });
-
-  test("suppresses when the history fetch was truncated", () => {
-    const findings = findingsFor({
-      orgHistory: [...quietOrgHistory(), ...windowRows(BURST_DISTINCT_PACKAGE_THRESHOLD)],
-      orgHistoryTruncated: true,
-    });
-    expect(findings).toEqual([]);
-  });
-
-  test("ignores a stray history row for the current scan itself", () => {
-    const selfRow = orgRow({
-      id: "scan_current",
-      packageName: "self-echo",
-      status: "running",
-      createdAt: minutesAgo(1),
-    });
-    const findings = findingsFor({
-      orgHistory: [...quietOrgHistory(), ...windowRows(3), selfRow],
-    });
-    // 3 window rows + current = 4 distinct; the echo row must not add a fifth.
-    expect(findings).toEqual([]);
-  });
-
-  test("caps evidence at the package-name limit and reports the overflow", () => {
-    const findings = findingsFor({
-      orgHistory: [...quietOrgHistory(), ...windowRows(BURST_EVIDENCE_PACKAGE_LIMIT + 3)],
-    });
-    expect(findings).toHaveLength(1);
-    const listed = findings[0].evidence.split(": ")[1];
-    expect(listed.split(", ")).toHaveLength(BURST_EVIDENCE_PACKAGE_LIMIT);
-    expect(findings[0].evidence).toContain("(+4 more)");
-  });
-});
 
 function gateScan(
   id: string,

--- a/test/workers/release-fingerprint.test.ts
+++ b/test/workers/release-fingerprint.test.ts
@@ -56,27 +56,6 @@ async function seedScan(db: ReturnType<typeof createDb>, options: SeedScanOption
   return id;
 }
 
-/**
- * Quiet, old org history: one completed scan per day, one package per scan.
- * Old enough (>= 30 days) and complete enough (>= 5) for burst preconditions
- * without ever forming a prior burst window.
- */
-async function seedQuietHistory(
-  db: ReturnType<typeof createDb>,
-  organizationId: string,
-  ownerUserId: string,
-  now: Date,
-) {
-  for (let index = 0; index < 6; index += 1) {
-    await seedScan(db, {
-      organizationId,
-      ownerUserId,
-      packageName: `history-pkg-${index}`,
-      createdAt: new Date(now.getTime() - (35 + index) * DAY_MS),
-    });
-  }
-}
-
 async function seedGateChain(
   db: ReturnType<typeof createDb>,
   organizationId: string,
@@ -223,71 +202,34 @@ async function runFakeScan(args: {
 }
 
 describe("release-process fingerprint (workers)", () => {
-  test("burst anomaly fires end-to-end, raises risk, and persists as release delta", async () => {
+  test("a monorepo release train emits no release-process findings", async () => {
+    // Regression guard for the removed `release.burst-anomaly` rule: staging
+    // many distinct packages inside one window is a normal release train, and
+    // must never raise release risk (which would reject a workflow gate).
     const { db, userId, organizationId } = await seedUserAndOrg();
     const now = new Date();
-    await seedQuietHistory(db, organizationId, userId, now);
-    for (let index = 0; index < 4; index += 1) {
+    for (let index = 0; index < 8; index += 1) {
       await seedScan(db, {
         organizationId,
         ownerUserId: userId,
-        packageName: `burst-pkg-${index}`,
-        status: "running",
-        createdAt: new Date(now.getTime() - (index + 1) * MINUTE_MS),
-      });
-    }
-
-    const { scanId, result } = await runFakeScan({
-      db,
-      organizationId,
-      userId,
-      packageName: "burst-pkg-current",
-    });
-
-    expect(result.ruleFindings).toContainEqual(
-      expect.objectContaining({
-        ruleId: "release.burst-anomaly",
-        severity: "high",
-        file: RELEASE_PROCESS_FINDING_FILE,
-      }),
-    );
-    expect(result.risk).toBe("high");
-    expect(result.riskSummary.releaseRisk).toBe("high");
-
-    const persisted = await getScan(db, scanId, organizationId, env.ARTIFACTS);
-    expect(persisted?.scan.status).toBe("complete");
-    expect(persisted?.scan.risk).toBe("high");
-    const finding = persisted?.findings.find((item) => item.ruleId === "release.burst-anomaly");
-    expect(finding).toMatchObject({ severity: "high", releaseDelta: true });
-  });
-
-  test("another organization's burst does not leak into a quiet org", async () => {
-    const quiet = await seedUserAndOrg();
-    const noisy = await seedUserAndOrg();
-    const now = new Date();
-    await seedQuietHistory(quiet.db, quiet.organizationId, quiet.userId, now);
-    await seedQuietHistory(noisy.db, noisy.organizationId, noisy.userId, now);
-    for (let index = 0; index < 6; index += 1) {
-      await seedScan(noisy.db, {
-        organizationId: noisy.organizationId,
-        ownerUserId: noisy.userId,
-        packageName: `noisy-pkg-${index}`,
+        packageName: `train-pkg-${index}`,
         status: "running",
         createdAt: new Date(now.getTime() - (index + 1) * MINUTE_MS),
       });
     }
 
     const { result } = await runFakeScan({
-      db: quiet.db,
-      organizationId: quiet.organizationId,
-      userId: quiet.userId,
-      packageName: "quiet-pkg",
+      db,
+      organizationId,
+      userId,
+      packageName: "train-pkg-current",
     });
 
     expect(result.ruleFindings.filter((finding) => finding.ruleId?.startsWith("release."))).toEqual(
       [],
     );
     expect(result.risk).toBe("low");
+    expect(result.riskSummary.releaseRisk).toBe("low");
   });
 
   test("gate-to-manual source drift fires high with the gate repo/env from the join", async () => {
@@ -377,9 +319,7 @@ describe("release-process fingerprint (workers)", () => {
       organizationId: orgA.organizationId,
       scanId: "scan_missing",
       packageName: "shared-name",
-      now,
     });
-    expect(history.orgHistory).toEqual([]);
     expect(history.packageHistory).toEqual([]);
     expect(history.currentScan).toBeNull();
   });


### PR DESCRIPTION
## Summary

`release.burst-anomaly` fired on ≥5 distinct packages staged in an org within 30 minutes, and its only monorepo defense — "suppress if an earlier window in the last 180 days also burst" — only exists once a train is already in scan history, so an org's first coordinated release and every train spaced more than 180 days apart (a semiannual major) fired it. Because `release.*` findings are release-scoped they feed `releaseRisk`, and a gate job creates one scan per package, so a 5-package gated train tripped the rule on each of its own scans and flipped the gate recommendation to `rejected` — blocking a maintainer's release train. The true-positive side never paid for that: an attacker with a stolen npm token publishes straight to the registry rather than through the victim's staged-publish flow or CI gate, so the only bursts Drydock can observe are the legitimate ones. This removes the rule along with the org-history query, its 500-row cap and truncation plumbing (all of which existed only for it), bumps `DETERMINISTIC_RULES_VERSION` to 1.24.0, and leaves `release.source-drift` untouched since a train arriving through its usual gate never trips it. One drive-by: `releasePathKey` now writes its NUL separator as the `\0` escape used everywhere else in the codebase instead of a raw 0x00 byte embedded in the source.

## Trust boundary

Detection/risk scoring, and the workflow-gate approve/reject recommendation it feeds — this strictly reduces what raises release risk, and removes an org-scoped D1 history read. Findings already persisted under `release.burst-anomaly` stay readable: the id is stored as a plain string and release-scoping matches the `release.` prefix, not a known-id list.

## Verification

`pnpm run verify` green (lint, format:check, typecheck, 1176 node + 453 worker tests) plus `pnpm run knip`. Added a workers regression test asserting a multi-package window emits no `release.*` findings and stays `low` release risk; no eval/corpus run needed since these are history rules with no package-byte fixtures.

## Documentation

`docs/release-fingerprint.md` rewritten with a "Removed" section recording the reasoning and the bar a revived burst rule must clear, plus a `1.24.0` note in `docs/security-detection-corpus.md` and a `docs/README.md` index fix.

## UI evidence

Not applicable — no UI changes.