### PR TITLE
Verify build provenance at workflow gates

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ The user-facing learning guide is [`../src/pages/Docs/index.tsx`](../src/pages/D
 - [`workflow-gates.md`](./workflow-gates.md) — GitHub Environment gate flow for PyPI, npm, and VS Code workflow-gated releases.
 - [`diff-baseline.md`](./diff-baseline.md) — default previous-version comparison strategy.
 - [`intent-envelope.md`](./intent-envelope.md) — advisory source-binding tiers (attested / declared / absent) persisted with every scan.
+- [`build-attestation.md`](./build-attestation.md) — advisory SLSA/Sigstore build-provenance verdict graded at workflow gates, and the trust ceiling on it.
 - [`artifact-storage.md`](./artifact-storage.md) — D1/R2 report and artifact persistence.
 - [`public-reports.md`](./public-reports.md) — public share links, signed report attestations, badges, and the threat feed.
 

--- a/docs/build-attestation.md
+++ b/docs/build-attestation.md
@@ -1,0 +1,205 @@
+# Build attestation
+
+Every workflow-gate review carries a **build-attestation verdict**: a
+deterministic, advisory grade on whether a SLSA/in-toto build attestation exists
+for the reviewed bytes, and whether what it claims agrees with what Drydock
+already knows. It **never changes risk levels or findings**.
+
+Computed in `server/lib/workflow-gate-job.ts` (`gradeCandidateAttestation`) from
+the pure module `server/lib/build-attestation/`, persisted inside the scan's
+`summaryJson` blob (`summary.buildAttestation`, no dedicated column), returned on
+`ScanResult`, exported in the report as the optional `buildAttestation` field,
+and rendered as the "Build provenance" section on the scan detail page.
+
+## Where this sits among the four questions
+
+Supply-chain trust conflates four separate questions. Keeping them apart is what
+makes each one useful:
+
+| Question                                                         | Answered by                        | Where it lives                                    |
+| ---------------------------------------------------------------- | ---------------------------------- | ------------------------------------------------- |
+| **Identity** — who published this?                               | Trusted Publishing / OIDC          | outside Drydock                                   |
+| **Provenance** — where did these bytes come from?                | Build attestations, SLSA, Sigstore | **this document**                                 |
+| **Artifact integrity** — are these the bytes that were reviewed? | Digest continuity                  | `provenance.artifacts[]`, `artifact-integrity.ts` |
+| **Maintainer intent** — is this the authority you agreed to?     | Release authority                  | `release-authority.md`                            |
+
+Note the naming collision: the persisted key `provenance` and the report's
+**Provenance** section are the _artifact integrity_ record — the artifacts
+Drydock reviewed and the SHA-256s it recomputed from them. This feature is a
+separate blob, `buildAttestation`, so neither has to be renamed.
+
+The build-attestation verdict is also the natural next step for the intent
+envelope's claim ceiling: `intent-envelope.md` says an `attested` tier "can
+later support **proven** claims", and this is the evidence such a claim would
+rest on.
+
+## Sources
+
+The wired source is the **GitHub artifact-attestation store**
+(`server/lib/github-app/attestations.ts`):
+`GET /repos/{owner}/{repo}/attestations/sha256:{digest}`, queried with the
+existing installation token for each digest the control plane recomputed from
+the immutable Actions artifact.
+
+That endpoint attests _files_, not packages, so it is ecosystem-neutral by
+construction: npm tarballs, wheels, sdists and VSIXes all resolve through one
+path with no per-ecosystem branching. Repositories opt in by running
+`actions/attest-build-provenance` in the build job.
+
+Staged npm publishes have no attestation source today (the staged registry
+metadata exposes identity, actor and shasum, but no provenance), so they carry
+no verdict. The npm registry's published-version attestations endpoint would be
+the natural second source; it is not wired.
+
+## Verdict lattice
+
+Every level except `mismatch` is an absence-of-evidence state, not an
+accusation.
+
+| Status        | Meaning                                                                                                                                                                                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `verified`    | An attestation covers a digest Drydock recomputed, its DSSE signature verified against the key in its own certificate, it agrees with at least one binding Drydock holds independently (repository or run), and it contradicts none.                          |
+| `partial`     | An attestation covers the reviewed bytes and contradicts nothing, but either no signature verified, or the predicate names no repository/run to compare (the npm publish attestation, for instance, attests the publish event and carries no source binding). |
+| `mismatch`    | An attestation exists and **contradicts** Drydock's own binding — different bytes, different repository, or different run. The only status that asserts something is wrong.                                                                                   |
+| `absent`      | The lookup succeeded and no attestation covers these bytes. The common case.                                                                                                                                                                                  |
+| `unavailable` | The lookup or parse failed. Evidence is missing, which is not evidence of wrongdoing.                                                                                                                                                                         |
+
+Two rules shape the grading:
+
+- **A contradiction dominates.** A release can carry several attestations; if
+  any of them disagrees, the verdict is `mismatch`. Reporting an agreeable
+  sibling instead would hide exactly the signal this exists to surface.
+- **`verified` requires positive agreement, not merely absent disagreement.** An
+  attestation that covers the right bytes but names no repository or run has
+  nothing to corroborate, so it caps at `partial` however well it is signed.
+
+A missing value on _either_ side of a comparison is `skipped`, never `fail` —
+the same rule `evaluateStagedArtifactIntegrity` follows for digests. Accusing a
+publisher of contradicting themselves requires two values that both exist.
+
+## Trust ceiling — what `verified` does not mean
+
+Drydock verifies the DSSE signature against the public key in the bundle's own
+certificate. It does **not**:
+
+- validate the certificate chain to a Fulcio root;
+- check signed certificate timestamps (SCTs);
+- verify Rekor transparency-log inclusion proofs;
+- read the Fulcio certificate's OID extensions (which carry the repository and
+  workflow identity Fulcio asserted from the OIDC token, rather than the
+  self-asserted values in the payload).
+
+So the signature check alone proves only that the bundle is _internally
+consistent_. That ceiling is recorded on the verdict as
+`trustCeiling: "self-consistent"` and stated in the UI, so no reader has to
+remember the caveat.
+
+**The load-bearing evidence is the cross-check, not the PKI.** At a workflow
+gate Drydock already holds a repository + run binding that arrived on a
+signature-verified GitHub webhook, and artifact digests it recomputed itself
+from immutable Actions bytes. None of that is claimed by the package. An
+attestation that agrees with all of it is corroborated by an independent
+channel; one that disagrees is a contradiction worth surfacing — and neither
+conclusion needs a certificate chain. Full Sigstore verification would raise the
+ceiling for a _third party_ re-checking the report later; it is deliberately out
+of scope here rather than quietly missing.
+
+## Cross-checks
+
+| Check            | Claimed by the attestation           | Compared against                                                     |
+| ---------------- | ------------------------------------ | -------------------------------------------------------------------- |
+| `subject-digest` | in-toto `subject[].digest.sha256`    | SHA-256 the control plane recomputed from the reviewed artifact      |
+| `repository`     | build-definition source repository   | `github_workflow_gates.repository_full_name` from the signed webhook |
+| `workflow-run`   | run id parsed from the invocation id | `github_workflow_gates.run_id` from the signed webhook               |
+| `source-commit`  | resolved git commit                  | `head_sha` from `GET /repos/…/actions/runs/{id}`                     |
+| `signature`      | DSSE signature                       | public key in the bundle's leaf certificate                          |
+
+The `subject-digest` detail states coverage as a fraction ("attests 1 of 3
+reviewed artifacts"). One attested wheel in a thirty-wheel release is a true
+`pass` — the bytes it names really were reviewed — but reading that as "this
+release is attested" would be wrong, so the fraction is always stated. Lookups
+are capped at 8 digests per candidate (`MAX_DIGEST_LOOKUPS`); a release with
+more artifacts than that has the remainder unchecked.
+
+Digests are per **candidate**, not per bundle: a monorepo release fans out into
+one scan per package, and each scan's lookup asks about its own artifacts only.
+Attributing a sibling package's attestation to this scan would be exactly the
+false corroboration the verdict exists to avoid.
+
+## Predicate shapes
+
+`server/lib/build-attestation/statement.ts` projects three shapes into one
+`BuildClaim`, so the verdict never branches on predicate version:
+
+- **SLSA provenance v1** (`buildDefinition` / `runDetails`) — what
+  `actions/attest-build-provenance` and current npm provenance emit. The source
+  commit is read from `resolvedDependencies`, not `externalParameters`: a build
+  resolves a mutable branch ref to a commit, and that resolution is the
+  interesting fact.
+- **SLSA provenance v0.2** (`invocation.configSource` / `metadata`) — what npm
+  provenance emitted before the v1 migration, still attached to versions from
+  that era.
+- **The npm publish attestation** — attests the publish event, carries no source
+  binding, and therefore caps at `partial`.
+
+Shapes are distinguished by structure rather than by the declared predicate type
+string, which has carried several spellings over its life while the shapes have
+not.
+
+## Failure posture
+
+Advisory and strictly non-blocking. Every failure path returns a verdict rather
+than throwing:
+
+- No attestation → `absent`. Most repositories publish none; this must stay
+  quiet.
+- Lookup, transport, or parse failure → `unavailable`, plus a
+  `github_workflow_gate.build_attestation_unavailable` operational event.
+- A `mismatch` is logged at `warn`
+  (`github_workflow_gate.build_attestation_mismatch`) and rendered with a
+  severity tone, but it does **not** move risk, change the gate recommendation,
+  or auto-reject. A human still decides.
+
+A GitHub outage in the attestation store must never be able to stall a release.
+
+## Persistence and re-validation
+
+`normalizeBuildAttestation` re-reads the persisted blob under one governing
+rule, the same one `normalizeIntentEnvelope` follows: **a persisted status must
+not outlive the evidence that justified it**. A blob claiming `verified` without
+a passing subject-digest check, a passing corroboration check, a passing
+signature check, and a `self-consistent` ceiling reads as `null` rather than
+rendering a build claim nobody established. Scans persisted before this feature
+have no verdict and render nothing.
+
+## Testing
+
+- `test/build-attestation.test.ts` — DSSE/PAE encoding, the X.509 walk to
+  SubjectPublicKeyInfo, DER→P1363 signature conversion, statement projection for
+  all three predicate shapes, the verdict lattice, and the normalizer's
+  downgrade rules.
+- `test/workers/workflow-gate-job.test.ts` — the gate path end to end: verified,
+  mismatch, and absent, against a mocked GitHub attestation store.
+- `test/helpers/sigstore-bundle.ts` — shared fixtures. The bundles are _really_
+  signed: a fresh P-256 key signs the actual PAE bytes and its public key is
+  carried in a DER certificate the parser must walk. A faked signature would
+  leave the PAE encoding, the certificate walk, and the signature conversion
+  untested, and each of those failing silently degrades every real attestation
+  to `partial` instead of breaking loudly.
+
+## Known gaps
+
+- Certificate-chain, SCT, and Rekor-inclusion verification (see the trust
+  ceiling above). Reading the Fulcio OID extensions is the highest-value next
+  step: those values are asserted by Fulcio from the OIDC token rather than
+  self-asserted in the payload.
+- No npm registry attestation source, so staged publishes carry no verdict.
+- `verified` means an attestation covers _some_ reviewed artifact, not that
+  every artifact in the release is attested. The coverage fraction is stated in
+  the check detail rather than encoded in the status; a per-artifact verdict
+  would be the fuller answer.
+- No finding for "the previous release had provenance and this one does not".
+  That is a real signal, but it is a detection change and needs corpus and
+  false-positive measurement first — see `security-detection-corpus.md`.
+- `fetchWorkflowRunHeadSha` overlaps with the release-authority run-context
+  fetch; whichever lands second should collapse them into one call.

--- a/docs/build-attestation.md
+++ b/docs/build-attestation.md
@@ -39,7 +39,15 @@ The wired source is the **GitHub artifact-attestation store**
 (`server/lib/github-app/attestations.ts`):
 `GET /repos/{owner}/{repo}/attestations/sha256:{digest}`, queried with the
 existing installation token for each digest the control plane recomputed from
-the immutable Actions artifact.
+the immutable Actions artifact. The query sets `predicate_type=provenance` and
+`per_page=8`, and the GitHub App must have the repository permission
+**Attestations: read**. Existing installations must approve that permission
+before private-repository lookups will succeed.
+
+GitHub may return either an embedded Sigstore bundle or a `bundle_url` for a
+Snappy-compressed bundle. URL-backed bundles are fetched without the
+installation token, with redirects disabled, and with the same byte and time
+limits as the API response.
 
 That endpoint attests _files_, not packages, so it is ecosystem-neutral by
 construction: npm tarballs, wheels, sdists and VSIXes all resolve through one
@@ -66,9 +74,10 @@ accusation.
 
 Two rules shape the grading:
 
-- **A contradiction dominates.** A release can carry several attestations; if
-  any of them disagrees, the verdict is `mismatch`. Reporting an agreeable
-  sibling instead would hide exactly the signal this exists to surface.
+- **Agreement is monotonic.** A repository can retain several attestations for
+  the same bytes after reruns. A `verified` or `partial` current-run candidate
+  outranks a historical candidate whose run binding differs. `mismatch`
+  remains the result when no agreeable candidate exists.
 - **`verified` requires positive agreement, not merely absent disagreement.** An
   attestation that covers the right bytes but names no repository or run has
   nothing to corroborate, so it caps at `partial` however well it is signed.
@@ -119,7 +128,9 @@ reviewed artifacts"). One attested wheel in a thirty-wheel release is a true
 `pass` — the bytes it names really were reviewed — but reading that as "this
 release is attested" would be wrong, so the fraction is always stated. Lookups
 are capped at 8 digests per candidate (`MAX_DIGEST_LOOKUPS`); a release with
-more artifacts than that has the remainder unchecked.
+more artifacts than that has the remainder unchecked. Each digest lookup asks
+for at most 8 provenance records, and each API or bundle response is capped at
+1 MiB while streaming.
 
 Digests are per **candidate**, not per bundle: a monorepo release fans out into
 one scan per package, and each scan's lookup asks about its own artifacts only.
@@ -155,6 +166,9 @@ than throwing:
   quiet.
 - Lookup, transport, or parse failure → `unavailable`, plus a
   `github_workflow_gate.build_attestation_unavailable` operational event.
+- Advisory GitHub calls use one attempt with a 5-second deadline. Digest
+  lookups run two at a time, so a slow or unavailable store does not serialize
+  the full eight-digest allowance.
 - A `mismatch` is logged at `warn`
   (`github_workflow_gate.build_attestation_mismatch`) and rendered with a
   severity tone, but it does **not** move risk, change the gate recommendation,
@@ -178,8 +192,9 @@ have no verdict and render nothing.
   SubjectPublicKeyInfo, DER→P1363 signature conversion, statement projection for
   all three predicate shapes, the verdict lattice, and the normalizer's
   downgrade rules.
-- `test/workers/workflow-gate-job.test.ts` — the gate path end to end: verified,
-  mismatch, and absent, against a mocked GitHub attestation store.
+- `test/workers/workflow-gate-job.test.ts` — the gate path end to end: embedded
+  and URL-backed Snappy bundles, verified, mismatch, absent, and streamed
+  oversized responses against a mocked GitHub attestation store.
 - `test/helpers/sigstore-bundle.ts` — shared fixtures. The bundles are _really_
   signed: a fresh P-256 key signs the actual PAE bytes and its public key is
   carried in a DER certificate the parser must walk. A faked signature would

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -176,6 +176,11 @@ publish the reviewed artifact bundle after approval. See
 [`workflow-gates.md`](workflow-gates.md) and
 [`npm-workflow-gate.md`](npm-workflow-gate.md).
 
+The App also needs the repository permission **Attestations: read** so Drydock
+can grade build provenance for private repositories. Existing installations
+must approve that added permission. Until they do, gate reviews remain usable,
+but their build-attestation verdict is `unavailable`.
+
 ## Slack notifications
 
 Slack notifications require a Slack OAuth app. Register the redirect URL:

--- a/docs/workflow-gates.md
+++ b/docs/workflow-gates.md
@@ -26,7 +26,7 @@ The GitHub webhook is public but signed with `GITHUB_APP_WEBHOOK_SECRET` and byp
 - `server/lib/workflow-gates/` resolves workflow runs, artifacts, release targets, callback URLs, and gate lifecycle state.
 - `server/lib/scan/pipeline.ts` runs the same deterministic/AI/report pipeline used by npm registry-staged scans.
 
-Required bindings/secrets include the GitHub App id/private key/client credentials, webhook secret, installation access, queues, D1, R2, and normal scan pipeline bindings. See [`self-hosting.md`](./self-hosting.md) for setup.
+Required bindings/secrets include the GitHub App id/private key/client credentials, webhook secret, installation access, queues, D1, R2, and normal scan pipeline bindings. The App's repository permissions must include **Attestations: read**; existing installations must approve that permission before private-repository provenance can be queried. See [`self-hosting.md`](./self-hosting.md) for setup.
 
 ## Release set derivation
 
@@ -161,6 +161,11 @@ repository's attestation store about the SHA-256s Drydock recomputed, then
 compares what the attestation claims (repository, workflow run, source commit)
 against what the signed `deployment_protection_rule` webhook already bound.
 Neither side of that comparison is claimed by the package.
+
+The lookup is bounded and advisory: Drydock requests only provenance records,
+caps the response count and bytes, and supports both embedded bundles and
+GitHub's URL-backed Snappy bundles. A missing App permission or lookup timeout
+produces `unavailable`; it does not block the deterministic review pipeline.
 
 The verdict is advisory — it never moves risk, changes the recommendation, or
 auto-rejects — and it is ecosystem-neutral, because GitHub's attestation store

--- a/docs/workflow-gates.md
+++ b/docs/workflow-gates.md
@@ -153,6 +153,24 @@ jobs:
 
 The publish job must publish the reviewed VSIX bytes. Repacking after approval breaks the review boundary.
 
+## Build attestation
+
+Alongside the byte-continuity record above, each gate review grades any
+SLSA/in-toto **build attestation** covering the reviewed digests: it asks the
+repository's attestation store about the SHA-256s Drydock recomputed, then
+compares what the attestation claims (repository, workflow run, source commit)
+against what the signed `deployment_protection_rule` webhook already bound.
+Neither side of that comparison is claimed by the package.
+
+The verdict is advisory — it never moves risk, changes the recommendation, or
+auto-rejects — and it is ecosystem-neutral, because GitHub's attestation store
+addresses files rather than packages. `absent` is the common, quiet case.
+
+See [`build-attestation.md`](./build-attestation.md) for the verdict lattice,
+the cross-checks, and the explicit ceiling on what a `verified` verdict proves
+(Drydock does not validate the Sigstore certificate chain or transparency-log
+inclusion).
+
 ## Trust and failure behavior
 
 - The GitHub webhook signature is mandatory.
@@ -190,4 +208,5 @@ byte-continuity loop without trusting any single step.
 ## Remaining work
 
 - Expand gate-specific e2e coverage as more ecosystems are added.
+- Raise the build-attestation trust ceiling (Fulcio certificate extensions, then chain/Rekor verification).
 - Keep GitHub/PyPI/npm/VS Code validation failures user-actionable without leaking credentials or private package bytes.

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "preact-iso": "^2.12.1",
     "qrcode": "^1.5.4",
     "shiki": "^4.4.1",
+    "snappyjs": "^0.7.0",
     "workers-ai-provider": "^4.0.0",
     "zod": "^4.4.3"
   },
@@ -61,6 +62,7 @@
     "@preact/preset-vite": "^2.10.6",
     "@tailwindcss/vite": "^4.3.3",
     "@types/qrcode": "^1.5.6",
+    "@types/snappyjs": "^0.7.1",
     "drizzle-kit": "^0.31.10",
     "fast-check": "^4.9.0",
     "knip": "^6.31.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       shiki:
         specifier: ^4.4.1
         version: 4.4.1
+      snappyjs:
+        specifier: ^0.7.0
+        version: 0.7.0
       workers-ai-provider:
         specifier: ^4.0.0
         version: 4.0.0(@ai-sdk/provider@4.0.4)(ai@7.0.48(zod@4.4.3))
@@ -88,6 +91,9 @@ importers:
       '@types/qrcode':
         specifier: ^1.5.6
         version: 1.5.6
+      '@types/snappyjs':
+        specifier: ^0.7.1
+        version: 0.7.1
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
@@ -1711,6 +1717,9 @@ packages:
   '@types/qrcode@1.5.6':
     resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
 
+  '@types/snappyjs@0.7.1':
+    resolution: {integrity: sha512-OxjzJ6cQZstysMh6PEwZWmK9qlKZyezHJKOkcUkZDooSFuog2votUEKkxMaTq51UQF3cJkXKQ+XGlj4FSl8JQQ==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
@@ -2735,6 +2744,9 @@ packages:
   smol-toml@1.7.1:
     resolution: {integrity: sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==}
     engines: {node: '>= 18'}
+
+  snappyjs@0.7.0:
+    resolution: {integrity: sha512-u5iEEXkMe2EInQio6Wv9LWHOQYRDbD2O9hzS27GpT/lwfIQhTCnHCTqedqHIHe9ZcvQo+9au6vngQayipz1NYw==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -4153,6 +4165,8 @@ snapshots:
     dependencies:
       '@types/node': 26.1.2
 
+  '@types/snappyjs@0.7.1': {}
+
   '@types/unist@3.0.3': {}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
@@ -5050,6 +5064,8 @@ snapshots:
       kolorist: 1.8.0
 
   smol-toml@1.7.1: {}
+
+  snappyjs@0.7.0: {}
 
   source-map-js@1.2.1: {}
 

--- a/server/lib/build-attestation/dsse.ts
+++ b/server/lib/build-attestation/dsse.ts
@@ -300,7 +300,7 @@ const OID_CURVES: Record<string, SubjectPublicKeyInfo["algorithm"]> = {
  * signature, issuer, validity, subject, subjectPublicKeyInfo, … — so the SPKI
  * is the seventh element once the optional version tag is accounted for.
  */
-export function extractSubjectPublicKeyInfo(certificate: Uint8Array): SubjectPublicKeyInfo | null {
+function extractSubjectPublicKeyInfo(certificate: Uint8Array): SubjectPublicKeyInfo | null {
   const root = readDerNode(certificate, 0);
   if (!root || root.tag !== DER_SEQUENCE) return null;
   const certChildren = readDerChildren(certificate, root, 0);

--- a/server/lib/build-attestation/dsse.ts
+++ b/server/lib/build-attestation/dsse.ts
@@ -1,0 +1,414 @@
+/**
+ * Bounded reader for Sigstore bundles and the DSSE envelopes inside them.
+ *
+ * Attestation bundles are hostile evidence in exactly the way package bytes
+ * are: they arrive from a registry or from a repository's own attestation
+ * store, and a malicious release controls their contents. Everything here
+ * parses and compares; nothing evaluates, and every structure is size-bounded
+ * before it is walked.
+ *
+ * Signature verification here is deliberately *narrow*: it checks the DSSE
+ * signature against the public key carried in the bundle's own certificate. It
+ * does not validate the certificate chain to a Fulcio root, check SCTs, or
+ * verify Rekor inclusion proofs — see `docs/build-attestation.md` for why that
+ * ceiling is where it is, and why the binding cross-checks rather than the PKI
+ * carry the weight of the verdict.
+ */
+
+// Bundles are small by construction: a DSSE payload is a JSON statement naming
+// a handful of digests, and a Fulcio leaf certificate is ~1-2 KB. These caps
+// are far above every legitimate value and exist so a hostile bundle cannot
+// make the parser do unbounded work.
+const MAX_PAYLOAD_BYTES = 256 * 1024;
+const MAX_CERTIFICATE_BYTES = 16 * 1024;
+const MAX_SIGNATURE_BYTES = 1024;
+const MAX_SIGNATURES = 8;
+const MAX_BASE64_INPUT = 512 * 1024;
+// A certificate nests a handful of levels; anything deeper is malformed or
+// hostile and is refused rather than walked.
+const MAX_DER_DEPTH = 16;
+
+export interface ParsedDsseEnvelope {
+  /** Decoded payload bytes — the in-toto statement JSON. */
+  payload: Uint8Array;
+  /** DSSE payload type, e.g. `application/vnd.in-toto+json`. */
+  payloadType: string;
+  signatures: Uint8Array[];
+  /** Leaf certificate DER, when the bundle carries verification material. */
+  certificate: Uint8Array | null;
+}
+
+export type SignatureOutcome =
+  | { verified: true; algorithm: string }
+  | { verified: false; reason: string };
+
+/**
+ * Pull the DSSE envelope and leaf certificate out of a Sigstore bundle.
+ *
+ * Accepts both bundle layouts in circulation: `verificationMaterial.certificate`
+ * (bundle v0.3+) and `verificationMaterial.x509CertificateChain.certificates[0]`
+ * (v0.1/v0.2). A bundle with a bare public key and no certificate parses fine
+ * and yields `certificate: null` — the envelope is still readable, it just
+ * cannot be signature-checked here.
+ */
+export function parseSigstoreBundle(value: unknown): ParsedDsseEnvelope | null {
+  if (!isRecord(value)) return null;
+  const envelope = value.dsseEnvelope;
+  if (!isRecord(envelope)) return null;
+
+  const payloadType = envelope.payloadType;
+  if (typeof payloadType !== "string" || !payloadType || payloadType.length > 256) return null;
+
+  const payload = decodeBase64(envelope.payload, MAX_PAYLOAD_BYTES);
+  if (!payload) return null;
+
+  const signatures: Uint8Array[] = [];
+  if (Array.isArray(envelope.signatures)) {
+    for (const entry of envelope.signatures.slice(0, MAX_SIGNATURES)) {
+      if (!isRecord(entry)) continue;
+      const sig = decodeBase64(entry.sig, MAX_SIGNATURE_BYTES);
+      if (sig && sig.length) signatures.push(sig);
+    }
+  }
+
+  return {
+    payload,
+    payloadType,
+    signatures,
+    certificate: extractCertificate(value.verificationMaterial),
+  };
+}
+
+function extractCertificate(material: unknown): Uint8Array | null {
+  if (!isRecord(material)) return null;
+  const direct = material.certificate;
+  if (isRecord(direct)) {
+    const bytes = decodeBase64(direct.rawBytes, MAX_CERTIFICATE_BYTES);
+    if (bytes) return bytes;
+  }
+  const chain = material.x509CertificateChain;
+  if (isRecord(chain) && Array.isArray(chain.certificates)) {
+    // The leaf is first by specification; intermediates and roots are ignored
+    // because no chain validation happens here.
+    const leaf = chain.certificates[0];
+    if (isRecord(leaf)) return decodeBase64(leaf.rawBytes, MAX_CERTIFICATE_BYTES);
+  }
+  return null;
+}
+
+/**
+ * DSSE Pre-Authentication Encoding (PAE), the exact byte string a DSSE
+ * signature covers:
+ *
+ *   "DSSEv1" SP len(payloadType) SP payloadType SP len(payload) SP payload
+ *
+ * Lengths are ASCII decimal byte counts, not character counts. Getting this
+ * wrong makes every signature fail to verify, so it is exercised directly in
+ * the tests against a known-good bundle.
+ */
+export function dssePae(payloadType: string, payload: Uint8Array): Uint8Array {
+  const encoder = new TextEncoder();
+  const typeBytes = encoder.encode(payloadType);
+  const prefix = encoder.encode(`DSSEv1 ${typeBytes.length} ${payloadType} ${payload.length} `);
+  const out = new Uint8Array(prefix.length + payload.length);
+  out.set(prefix, 0);
+  out.set(payload, prefix.length);
+  return out;
+}
+
+/**
+ * Verify the envelope's DSSE signature against the public key in its own
+ * certificate. Any signature in the envelope verifying is enough — DSSE allows
+ * multiple signers and the bundles in circulation carry one.
+ *
+ * Returns a structured non-verified outcome rather than throwing: an
+ * unsupported key type or a malformed signature must degrade the verdict to
+ * `partial`, never fail the scan.
+ */
+export async function verifyDsseSignature(envelope: ParsedDsseEnvelope): Promise<SignatureOutcome> {
+  if (!envelope.signatures.length) return { verified: false, reason: "no signature in envelope" };
+  if (!envelope.certificate) {
+    return { verified: false, reason: "no certificate in verification material" };
+  }
+
+  const publicKey = extractSubjectPublicKeyInfo(envelope.certificate);
+  if (!publicKey) return { verified: false, reason: "certificate public key not readable" };
+
+  const imported = await importVerificationKey(publicKey);
+  if (!imported) {
+    return { verified: false, reason: `unsupported key algorithm (${publicKey.algorithm})` };
+  }
+
+  const message = dssePae(envelope.payloadType, envelope.payload);
+  for (const signature of envelope.signatures) {
+    const raw =
+      imported.kind === "ecdsa"
+        ? derEcdsaSignatureToRaw(signature, imported.coordinateBytes)
+        : signature;
+    if (!raw) continue;
+    let ok = false;
+    try {
+      ok = await crypto.subtle.verify(
+        imported.verifyParams,
+        imported.key,
+        toArrayBuffer(raw),
+        toArrayBuffer(message),
+      );
+    } catch {
+      ok = false;
+    }
+    if (ok) return { verified: true, algorithm: publicKey.algorithm };
+  }
+  return { verified: false, reason: "signature did not verify against certificate key" };
+}
+
+interface SubjectPublicKeyInfo {
+  /** The complete SubjectPublicKeyInfo TLV, ready for WebCrypto `importKey`. */
+  der: Uint8Array;
+  algorithm: "ecdsa-p256" | "ecdsa-p384" | "ecdsa-p521" | "ed25519" | "unknown";
+}
+
+type ImportedKey =
+  | {
+      kind: "ecdsa";
+      key: CryptoKey;
+      verifyParams: EcdsaParams;
+      coordinateBytes: number;
+    }
+  | { kind: "eddsa"; key: CryptoKey; verifyParams: AlgorithmIdentifier };
+
+async function importVerificationKey(info: SubjectPublicKeyInfo): Promise<ImportedKey | null> {
+  const curves = {
+    "ecdsa-p256": { namedCurve: "P-256", hash: "SHA-256", coordinateBytes: 32 },
+    "ecdsa-p384": { namedCurve: "P-384", hash: "SHA-384", coordinateBytes: 48 },
+    "ecdsa-p521": { namedCurve: "P-521", hash: "SHA-512", coordinateBytes: 66 },
+  } as const;
+
+  try {
+    if (info.algorithm === "ed25519") {
+      const key = await crypto.subtle.importKey(
+        "spki",
+        toArrayBuffer(info.der),
+        { name: "Ed25519" },
+        false,
+        ["verify"],
+      );
+      return { kind: "eddsa", key, verifyParams: { name: "Ed25519" } };
+    }
+    const curve = curves[info.algorithm as keyof typeof curves];
+    if (!curve) return null;
+    const key = await crypto.subtle.importKey(
+      "spki",
+      toArrayBuffer(info.der),
+      { name: "ECDSA", namedCurve: curve.namedCurve },
+      false,
+      ["verify"],
+    );
+    return {
+      kind: "ecdsa",
+      key,
+      verifyParams: { name: "ECDSA", hash: curve.hash },
+      coordinateBytes: curve.coordinateBytes,
+    };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Minimal DER reader
+//
+// Only what is needed to walk an X.509 certificate to its SubjectPublicKeyInfo
+// and to unpack an ECDSA signature. It reads structure and never interprets
+// semantics beyond the OIDs it recognizes.
+// ---------------------------------------------------------------------------
+
+interface DerNode {
+  tag: number;
+  /** Offset of the first content byte. */
+  start: number;
+  /** Offset one past the last content byte. */
+  end: number;
+  /** Offset of the tag byte — the start of the complete TLV. */
+  tlvStart: number;
+}
+
+function readDerNode(bytes: Uint8Array, offset: number): DerNode | null {
+  if (offset + 2 > bytes.length) return null;
+  const tag = bytes[offset];
+  // High-tag-number form (tag byte's low 5 bits all set) never appears in the
+  // structures read here; refusing it keeps the reader simple and total.
+  if ((tag & 0x1f) === 0x1f) return null;
+
+  let cursor = offset + 1;
+  const first = bytes[cursor];
+  cursor += 1;
+  let length: number;
+  if (first < 0x80) {
+    length = first;
+  } else {
+    const lengthBytes = first & 0x7f;
+    // Indefinite length (0x80) is not valid DER, and a length needing more than
+    // 4 bytes exceeds every cap this module enforces anyway.
+    if (lengthBytes === 0 || lengthBytes > 4) return null;
+    if (cursor + lengthBytes > bytes.length) return null;
+    length = 0;
+    for (let i = 0; i < lengthBytes; i += 1) {
+      length = length * 256 + bytes[cursor + i];
+    }
+    cursor += lengthBytes;
+  }
+  const end = cursor + length;
+  if (end > bytes.length) return null;
+  return { tag, start: cursor, end, tlvStart: offset };
+}
+
+/** Read every immediate child TLV of a constructed node. */
+function readDerChildren(bytes: Uint8Array, node: DerNode, depth: number): DerNode[] | null {
+  if (depth > MAX_DER_DEPTH) return null;
+  const children: DerNode[] = [];
+  let cursor = node.start;
+  while (cursor < node.end) {
+    const child = readDerNode(bytes, cursor);
+    if (!child || child.end > node.end) return null;
+    children.push(child);
+    cursor = child.end;
+  }
+  return children;
+}
+
+const DER_SEQUENCE = 0x30;
+const DER_INTEGER = 0x02;
+const DER_OID = 0x06;
+// Context-specific constructed [0] — the EXPLICIT tag wrapping X.509 `version`.
+const DER_CONTEXT_0 = 0xa0;
+
+const OID_EC_PUBLIC_KEY = "2a8648ce3d0201";
+const OID_ED25519 = "2b6570";
+const OID_CURVES: Record<string, SubjectPublicKeyInfo["algorithm"]> = {
+  "2a8648ce3d030107": "ecdsa-p256",
+  "2b81040022": "ecdsa-p384",
+  "2b81040023": "ecdsa-p521",
+};
+
+/**
+ * Walk an X.509 certificate to its SubjectPublicKeyInfo and identify the key
+ * algorithm.
+ *
+ * Structure (RFC 5280): Certificate is a SEQUENCE whose first element is
+ * tbsCertificate, itself a SEQUENCE of `[0] version` (optional), serialNumber,
+ * signature, issuer, validity, subject, subjectPublicKeyInfo, … — so the SPKI
+ * is the seventh element once the optional version tag is accounted for.
+ */
+export function extractSubjectPublicKeyInfo(certificate: Uint8Array): SubjectPublicKeyInfo | null {
+  const root = readDerNode(certificate, 0);
+  if (!root || root.tag !== DER_SEQUENCE) return null;
+  const certChildren = readDerChildren(certificate, root, 0);
+  if (!certChildren?.length) return null;
+
+  const tbs = certChildren[0];
+  if (tbs.tag !== DER_SEQUENCE) return null;
+  const tbsChildren = readDerChildren(certificate, tbs, 1);
+  if (!tbsChildren) return null;
+
+  // `version` is EXPLICIT [0] and optional (absent means v1).
+  const fields = tbsChildren[0]?.tag === DER_CONTEXT_0 ? tbsChildren.slice(1) : tbsChildren;
+  const spki = fields[5];
+  if (!spki || spki.tag !== DER_SEQUENCE) return null;
+
+  const spkiChildren = readDerChildren(certificate, spki, 2);
+  const algorithmId = spkiChildren?.[0];
+  if (!algorithmId || algorithmId.tag !== DER_SEQUENCE) return null;
+  const algorithmParts = readDerChildren(certificate, algorithmId, 3);
+  const algorithmOid = algorithmParts?.[0];
+  if (!algorithmOid || algorithmOid.tag !== DER_OID) return null;
+
+  const der = certificate.slice(spki.tlvStart, spki.end);
+  const oid = toHex(certificate.subarray(algorithmOid.start, algorithmOid.end));
+  if (oid === OID_ED25519) return { der, algorithm: "ed25519" };
+  if (oid !== OID_EC_PUBLIC_KEY) return { der, algorithm: "unknown" };
+
+  const curveOid = algorithmParts?.[1];
+  if (!curveOid || curveOid.tag !== DER_OID) return { der, algorithm: "unknown" };
+  const curve = OID_CURVES[toHex(certificate.subarray(curveOid.start, curveOid.end))];
+  return { der, algorithm: curve ?? "unknown" };
+}
+
+/**
+ * Convert an ASN.1 DER ECDSA signature (`SEQUENCE { INTEGER r, INTEGER s }`) to
+ * the fixed-width `r || s` form WebCrypto expects.
+ *
+ * Sigstore signs with DER-encoded ECDSA; WebCrypto's ECDSA verify takes IEEE
+ * P1363. Without this conversion every signature check fails, which would
+ * silently downgrade every real attestation to `unsigned`.
+ */
+export function derEcdsaSignatureToRaw(
+  signature: Uint8Array,
+  coordinateBytes: number,
+): Uint8Array | null {
+  const root = readDerNode(signature, 0);
+  if (!root || root.tag !== DER_SEQUENCE || root.end !== signature.length) return null;
+  const parts = readDerChildren(signature, root, 0);
+  if (!parts || parts.length !== 2) return null;
+  const [r, s] = parts;
+  if (r.tag !== DER_INTEGER || s.tag !== DER_INTEGER) return null;
+
+  const out = new Uint8Array(coordinateBytes * 2);
+  if (!writeFixedWidth(signature.subarray(r.start, r.end), out, 0, coordinateBytes)) return null;
+  if (!writeFixedWidth(signature.subarray(s.start, s.end), out, coordinateBytes, coordinateBytes)) {
+    return null;
+  }
+  return out;
+}
+
+/**
+ * Right-align a DER INTEGER's magnitude into a fixed-width slot, dropping the
+ * leading zero byte DER adds to keep values positive. A value that still does
+ * not fit is not a coordinate for this curve.
+ */
+function writeFixedWidth(
+  value: Uint8Array,
+  out: Uint8Array,
+  offset: number,
+  width: number,
+): boolean {
+  let start = 0;
+  while (start < value.length - 1 && value[start] === 0x00) start += 1;
+  const magnitude = value.subarray(start);
+  if (magnitude.length > width) return false;
+  out.set(magnitude, offset + width - magnitude.length);
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+
+function decodeBase64(value: unknown, maxBytes: number): Uint8Array | null {
+  if (typeof value !== "string" || !value || value.length > MAX_BASE64_INPUT) return null;
+  // Bundles use standard base64. Reject anything outside the alphabet before
+  // handing it to `atob`, which is lenient about some malformed input.
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(value)) return null;
+  let binary: string;
+  try {
+    binary = atob(value);
+  } catch {
+    return null;
+  }
+  if (binary.length > maxBytes) return null;
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+function toHex(bytes: Uint8Array): string {
+  let out = "";
+  for (const byte of bytes) out += byte.toString(16).padStart(2, "0");
+  return out;
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/server/lib/build-attestation/index.ts
+++ b/server/lib/build-attestation/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Build attestation verification — public entry.
+ *
+ * Answers "where did these bytes come from?" from SLSA/in-toto attestations,
+ * and grades the answer against bindings Drydock holds independently of the
+ * package. Advisory only: like the intent envelope, it never feeds risk or
+ * findings.
+ *
+ * See `docs/build-attestation.md` for the trust model, including what a
+ * `verified` verdict does and does not establish.
+ */
+
+export { evaluateBuildAttestation, type AttestationLookup } from "./verdict";
+export { normalizeBuildAttestation } from "./normalize";
+export { parseInTotoStatement } from "./statement";
+export { parseSigstoreBundle, verifyDsseSignature, dssePae, derEcdsaSignatureToRaw } from "./dsse";
+export type {
+  AttestationBinding,
+  BuildAttestation,
+  BuildAttestationCheck,
+  BuildAttestationCheckKind,
+  BuildAttestationCheckResult,
+  BuildAttestationStatus,
+  BuildAttestationTrustCeiling,
+  BuildClaim,
+} from "./types";

--- a/server/lib/build-attestation/index.ts
+++ b/server/lib/build-attestation/index.ts
@@ -10,17 +10,8 @@
  * `verified` verdict does and does not establish.
  */
 
-export { evaluateBuildAttestation, type AttestationLookup } from "./verdict";
+export { evaluateBuildAttestation } from "./verdict";
 export { normalizeBuildAttestation } from "./normalize";
 export { parseInTotoStatement } from "./statement";
 export { parseSigstoreBundle, verifyDsseSignature, dssePae, derEcdsaSignatureToRaw } from "./dsse";
-export type {
-  AttestationBinding,
-  BuildAttestation,
-  BuildAttestationCheck,
-  BuildAttestationCheckKind,
-  BuildAttestationCheckResult,
-  BuildAttestationStatus,
-  BuildAttestationTrustCeiling,
-  BuildClaim,
-} from "./types";
+export type { BuildAttestation, BuildAttestationStatus } from "./types";

--- a/server/lib/build-attestation/normalize.ts
+++ b/server/lib/build-attestation/normalize.ts
@@ -1,0 +1,165 @@
+/**
+ * Tolerant re-reader for a persisted build-attestation verdict.
+ *
+ * Persisted JSON is untyped by the time it is read back, and the report export
+ * and UI both consume it. The governing rule, the same one
+ * `normalizeIntentEnvelope` follows: **a persisted status must not outlive the
+ * evidence that justified it**. A blob claiming `verified` without the checks
+ * that produce `verified` reads as null rather than rendering a
+ * machine-verified build claim nobody ever established.
+ */
+
+import { normalizeRepositoryUrl } from "../intent-envelope";
+import type {
+  BuildAttestation,
+  BuildAttestationCheck,
+  BuildAttestationCheckKind,
+  BuildAttestationCheckResult,
+  BuildAttestationStatus,
+  BuildClaim,
+} from "./types";
+
+const STATUSES: ReadonlySet<string> = new Set([
+  "verified",
+  "partial",
+  "mismatch",
+  "absent",
+  "unavailable",
+]);
+
+const CHECK_KINDS: ReadonlySet<string> = new Set([
+  "subject-digest",
+  "repository",
+  "workflow-run",
+  "source-commit",
+  "signature",
+]);
+
+const CHECK_RESULTS: ReadonlySet<string> = new Set(["pass", "fail", "skipped"]);
+
+const MAX_CHECKS = 16;
+const MAX_DETAIL_LENGTH = 512;
+const MAX_SUBJECT_DIGESTS = 64;
+const MAX_FIELD_LENGTH = 1024;
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+const COMMIT_SHA = /^[0-9a-f]{40}$/;
+const NUMERIC_ID = /^\d{1,20}$/;
+
+export function normalizeBuildAttestation(value: unknown): BuildAttestation | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.status !== "string" || !STATUSES.has(value.status)) return null;
+  const status = value.status as BuildAttestationStatus;
+
+  const checks = normalizeChecks(value.checks);
+  const claim = normalizeClaim(value.claim);
+  const trustCeiling = value.trustCeiling === "self-consistent" ? "self-consistent" : "none";
+
+  const passed = (kind: BuildAttestationCheckKind) =>
+    checks.some((check) => check.kind === kind && check.result === "pass");
+  const failed = (kind: BuildAttestationCheckKind) =>
+    checks.some((check) => check.kind === kind && check.result === "fail");
+
+  if (status === "absent" || status === "unavailable") {
+    // These states describe the lookup, not an attestation; carrying a claim
+    // would mean something was read after all.
+    if (claim) return null;
+    return { status, claim: null, checks, trustCeiling: "none" };
+  }
+
+  // Every remaining status asserts that an attestation was read.
+  if (!claim) return null;
+
+  if (status === "mismatch") {
+    const contradicted =
+      failed("subject-digest") ||
+      failed("repository") ||
+      failed("workflow-run") ||
+      failed("source-commit");
+    return contradicted ? { status, claim, checks, trustCeiling: "none" } : null;
+  }
+
+  // `partial` and `verified` both require the attestation to actually cover the
+  // reviewed bytes, and neither may contradict anything.
+  if (!passed("subject-digest")) return null;
+  if (
+    failed("subject-digest") ||
+    failed("repository") ||
+    failed("workflow-run") ||
+    failed("source-commit")
+  ) {
+    return null;
+  }
+
+  if (status === "verified") {
+    const corroborated = passed("repository") || passed("workflow-run");
+    if (!corroborated || !passed("signature") || trustCeiling !== "self-consistent") return null;
+    return { status, claim, checks, trustCeiling: "self-consistent" };
+  }
+
+  return {
+    status: "partial",
+    claim,
+    checks,
+    trustCeiling: passed("signature") ? trustCeiling : "none",
+  };
+}
+
+function normalizeChecks(value: unknown): BuildAttestationCheck[] {
+  if (!Array.isArray(value)) return [];
+  const checks: BuildAttestationCheck[] = [];
+  for (const entry of value.slice(0, MAX_CHECKS)) {
+    if (!isRecord(entry)) continue;
+    const { kind, result, detail } = entry;
+    if (typeof kind !== "string" || !CHECK_KINDS.has(kind)) continue;
+    if (typeof result !== "string" || !CHECK_RESULTS.has(result)) continue;
+    if (typeof detail !== "string") continue;
+    checks.push({
+      kind: kind as BuildAttestationCheckKind,
+      result: result as BuildAttestationCheckResult,
+      detail: detail.slice(0, MAX_DETAIL_LENGTH),
+    });
+  }
+  return checks;
+}
+
+function normalizeClaim(value: unknown): BuildClaim | null {
+  if (!isRecord(value)) return null;
+  const predicateType = str(value.predicateType);
+  if (!predicateType) return null;
+
+  const subjectDigests: string[] = [];
+  if (Array.isArray(value.subjectDigests)) {
+    for (const digest of value.subjectDigests.slice(0, MAX_SUBJECT_DIGESTS)) {
+      if (typeof digest !== "string") continue;
+      const normalized = digest.trim().toLowerCase();
+      if (SHA256_HEX.test(normalized)) subjectDigests.push(normalized);
+    }
+  }
+
+  const commit = str(value.commit)?.toLowerCase() ?? null;
+  const runId = str(value.runId);
+  const runAttempt = str(value.runAttempt);
+
+  return {
+    predicateType,
+    repository: normalizeRepositoryUrl(value.repository),
+    workflowPath: str(value.workflowPath),
+    ref: str(value.ref),
+    commit: commit && COMMIT_SHA.test(commit) ? commit : null,
+    runId: runId && NUMERIC_ID.test(runId) ? runId : null,
+    runAttempt: runAttempt && NUMERIC_ID.test(runAttempt) ? runAttempt : null,
+    builderId: str(value.builderId),
+    subjectDigests,
+  };
+}
+
+function str(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_FIELD_LENGTH) return null;
+  return trimmed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/server/lib/build-attestation/statement.ts
+++ b/server/lib/build-attestation/statement.ts
@@ -1,0 +1,237 @@
+/**
+ * Projection of an in-toto statement into the normalized `BuildClaim` the
+ * verdict compares against Drydock's own bindings.
+ *
+ * Three predicate shapes are in circulation and all three reach Drydock:
+ *
+ *  - SLSA provenance v1 (`buildDefinition` / `runDetails`) — what
+ *    `actions/attest-build-provenance` and current npm provenance emit;
+ *  - SLSA provenance v0.2 (`invocation.configSource` / `metadata`) — what npm
+ *    provenance emitted before the v1 migration, still attached to published
+ *    versions from that era;
+ *  - the npm publish attestation, which attests the publish event rather than a
+ *    build and therefore carries no source binding at all.
+ *
+ * Projecting them into one shape keeps the verdict free of predicate-version
+ * branching, and keeps "this predicate names no repository" a normal, quiet
+ * outcome instead of a parse failure.
+ */
+
+import { normalizeRepositoryUrl } from "../intent-envelope";
+import type { BuildClaim } from "./types";
+
+// The statement is a small JSON document naming a handful of digests. Anything
+// larger is padding, and decoding it before the size check would be the work
+// the cap exists to prevent.
+const MAX_STATEMENT_BYTES = 256 * 1024;
+const MAX_SUBJECTS = 256;
+const MAX_RESOLVED_DEPENDENCIES = 64;
+const MAX_FIELD_LENGTH = 1024;
+
+const IN_TOTO_STATEMENT_TYPES: ReadonlySet<string> = new Set([
+  "https://in-toto.io/Statement/v1",
+  "https://in-toto.io/Statement/v0.1",
+]);
+
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+const COMMIT_SHA = /^[0-9a-f]{40}$/;
+// `https://github.com/owner/repo/actions/runs/<run>/attempts/<attempt>`
+const INVOCATION_ID = /\/actions\/runs\/(\d{1,20})(?:\/attempts\/(\d{1,10}))?/;
+// `git+https://github.com/owner/repo@refs/heads/main` and the commit-pinned form.
+const GIT_URI_REF = /^(.*?)@(refs\/[^\s@]{1,512}|[0-9a-f]{40})$/;
+
+/**
+ * Decode and project a DSSE payload into a `BuildClaim`.
+ *
+ * Returns null when the payload is not a readable in-toto statement. A
+ * statement that parses but names nothing useful still returns a claim — an
+ * attestation that covers the right bytes while claiming no repository is a
+ * real and reportable state, distinct from an unreadable one.
+ */
+export function parseInTotoStatement(payload: Uint8Array): BuildClaim | null {
+  if (payload.length > MAX_STATEMENT_BYTES) return null;
+  let statement: unknown;
+  try {
+    statement = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(payload));
+  } catch {
+    return null;
+  }
+  if (!isRecord(statement)) return null;
+
+  const type = statement._type;
+  if (typeof type !== "string" || !IN_TOTO_STATEMENT_TYPES.has(type)) return null;
+
+  const predicateType = str(statement.predicateType);
+  if (!predicateType) return null;
+
+  const predicate = isRecord(statement.predicate) ? statement.predicate : {};
+  const source = projectSource(predicate);
+
+  return {
+    predicateType,
+    repository: source.repository,
+    workflowPath: source.workflowPath,
+    ref: source.ref,
+    commit: source.commit,
+    runId: source.runId,
+    runAttempt: source.runAttempt,
+    builderId: source.builderId,
+    subjectDigests: collectSubjectDigests(statement.subject),
+  };
+}
+
+/**
+ * Collect the lowercase-hex SHA-256 digests a statement's subjects cover.
+ *
+ * Only SHA-256 is collected: it is the algorithm Drydock recomputes from the
+ * reviewed bytes, so it is the only one a cross-check can compare against.
+ * Subjects carrying only other algorithms contribute nothing rather than a
+ * digest the verdict would have to trust without being able to check it.
+ */
+function collectSubjectDigests(subjects: unknown): string[] {
+  if (!Array.isArray(subjects)) return [];
+  const digests = new Set<string>();
+  for (const subject of subjects.slice(0, MAX_SUBJECTS)) {
+    if (!isRecord(subject) || !isRecord(subject.digest)) continue;
+    const sha256 = subject.digest.sha256;
+    if (typeof sha256 !== "string") continue;
+    const normalized = sha256.trim().toLowerCase();
+    if (SHA256_HEX.test(normalized)) digests.add(normalized);
+  }
+  return [...digests].sort();
+}
+
+interface ProjectedSource {
+  repository: string | null;
+  workflowPath: string | null;
+  ref: string | null;
+  commit: string | null;
+  runId: string | null;
+  runAttempt: string | null;
+  builderId: string | null;
+}
+
+const EMPTY_SOURCE: ProjectedSource = {
+  repository: null,
+  workflowPath: null,
+  ref: null,
+  commit: null,
+  runId: null,
+  runAttempt: null,
+  builderId: null,
+};
+
+function projectSource(predicate: Record<string, unknown>): ProjectedSource {
+  // v1 and v0.2 are distinguished by structure rather than by the statement's
+  // declared predicate type, because the type string has carried several
+  // spellings over its life while the shapes have not.
+  if (isRecord(predicate.buildDefinition) || isRecord(predicate.runDetails)) {
+    return projectSlsaV1(predicate);
+  }
+  if (isRecord(predicate.invocation) || isRecord(predicate.builder)) {
+    return projectSlsaV02(predicate);
+  }
+  return EMPTY_SOURCE;
+}
+
+function projectSlsaV1(predicate: Record<string, unknown>): ProjectedSource {
+  const buildDefinition = isRecord(predicate.buildDefinition) ? predicate.buildDefinition : {};
+  const runDetails = isRecord(predicate.runDetails) ? predicate.runDetails : {};
+  const external = isRecord(buildDefinition.externalParameters)
+    ? buildDefinition.externalParameters
+    : {};
+  const workflow = isRecord(external.workflow) ? external.workflow : {};
+
+  const invocation = parseInvocationId(
+    isRecord(runDetails.metadata) ? str(runDetails.metadata.invocationId) : null,
+  );
+
+  return {
+    repository: normalizeRepositoryUrl(str(workflow.repository)),
+    workflowPath: str(workflow.path),
+    ref: str(workflow.ref),
+    // The source commit lives in the resolved dependency describing the repo
+    // itself, not in externalParameters — a build can resolve a mutable branch
+    // ref to a commit, and that resolution is the interesting fact.
+    commit: resolvedSourceCommit(buildDefinition.resolvedDependencies),
+    runId: invocation.runId,
+    runAttempt: invocation.runAttempt,
+    builderId: isRecord(runDetails.builder) ? str(runDetails.builder.id) : null,
+  };
+}
+
+function projectSlsaV02(predicate: Record<string, unknown>): ProjectedSource {
+  const invocation = isRecord(predicate.invocation) ? predicate.invocation : {};
+  const configSource = isRecord(invocation.configSource) ? invocation.configSource : {};
+  const metadata = isRecord(predicate.metadata) ? predicate.metadata : {};
+  const parsedInvocation = parseInvocationId(str(metadata.buildInvocationId));
+
+  const { uri, ref } = splitGitUri(str(configSource.uri));
+  const digest = isRecord(configSource.digest) ? configSource.digest : {};
+  // v0.2 labels the commit `sha1`; it is a git object id, not a content hash.
+  const commit = normalizeCommit(str(digest.sha1) ?? str(digest.gitCommit));
+
+  return {
+    repository: normalizeRepositoryUrl(uri),
+    workflowPath: str(configSource.entryPoint),
+    ref,
+    commit,
+    runId: parsedInvocation.runId,
+    runAttempt: parsedInvocation.runAttempt,
+    builderId: isRecord(predicate.builder) ? str(predicate.builder.id) : null,
+  };
+}
+
+/**
+ * Find the source commit among a build's resolved dependencies: the entry whose
+ * URI is the repository itself. Falls back to the first entry carrying a git
+ * commit digest, which is the shape single-source builds emit.
+ */
+function resolvedSourceCommit(dependencies: unknown): string | null {
+  if (!Array.isArray(dependencies)) return null;
+  for (const dependency of dependencies.slice(0, MAX_RESOLVED_DEPENDENCIES)) {
+    if (!isRecord(dependency) || !isRecord(dependency.digest)) continue;
+    const commit = normalizeCommit(str(dependency.digest.gitCommit) ?? str(dependency.digest.sha1));
+    if (commit) return commit;
+  }
+  return null;
+}
+
+/**
+ * Split `git+https://host/owner/repo@refs/heads/main` into its repository URI
+ * and ref. The `git+` scheme prefix is left in place — `normalizeRepositoryUrl`
+ * already understands it.
+ */
+function splitGitUri(value: string | null): { uri: string | null; ref: string | null } {
+  if (!value) return { uri: null, ref: null };
+  const match = GIT_URI_REF.exec(value);
+  if (!match) return { uri: value, ref: null };
+  return { uri: match[1] || null, ref: match[2] || null };
+}
+
+function parseInvocationId(value: string | null): {
+  runId: string | null;
+  runAttempt: string | null;
+} {
+  if (!value) return { runId: null, runAttempt: null };
+  const match = INVOCATION_ID.exec(value);
+  if (!match) return { runId: null, runAttempt: null };
+  return { runId: match[1], runAttempt: match[2] ?? null };
+}
+
+function normalizeCommit(value: string | null): string | null {
+  if (!value) return null;
+  const normalized = value.trim().toLowerCase();
+  return COMMIT_SHA.test(normalized) ? normalized : null;
+}
+
+function str(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > MAX_FIELD_LENGTH) return null;
+  return trimmed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/server/lib/build-attestation/types.ts
+++ b/server/lib/build-attestation/types.ts
@@ -115,7 +115,7 @@ export interface BuildAttestation {
  * signature alone proves only that the bundle is internally consistent. The
  * load-bearing trust comes from the binding cross-checks, not the PKI.
  */
-export type BuildAttestationTrustCeiling = "self-consistent" | "none";
+type BuildAttestationTrustCeiling = "self-consistent" | "none";
 
 /**
  * Facts Drydock holds independently of the attestation, used as the comparison

--- a/server/lib/build-attestation/types.ts
+++ b/server/lib/build-attestation/types.ts
@@ -1,0 +1,136 @@
+/**
+ * Build attestation: the evidence that a reviewed artifact was produced by a
+ * specific build, and Drydock's verdict on whether that evidence agrees with
+ * what Drydock independently knows about the release.
+ *
+ * Naming note — `provenance` is already taken in this codebase. `ReleaseProvenance`
+ * (`server/lib/ecosystems/package-adapter.ts`, surfaced as `summary.stagedPublish.provenance`
+ * and the report's Provenance section) is the *byte-continuity* record: the
+ * artifacts Drydock reviewed and the SHA-256s it recomputed from them. That
+ * answers "are these the bytes that were reviewed?".
+ *
+ * This module answers a different question — "where did these bytes come from?"
+ * — from SLSA/in-toto build attestations. The two are complementary and are
+ * deliberately kept as separate persisted blobs.
+ */
+
+/**
+ * Verdict on the build attestation evidence for one reviewed release.
+ *
+ * The lattice is ordered by what it lets a reader conclude, and every level
+ * except `mismatch` is an absence-of-evidence state rather than an accusation:
+ *
+ *  - `verified` — an attestation exists whose subject digest is one of the
+ *    digests Drydock recomputed from the reviewed bytes, whose DSSE signature
+ *    verified against the key in its own certificate, and which agrees with at
+ *    least one binding Drydock independently holds (repository or workflow run)
+ *    while contradicting none.
+ *  - `partial` — an attestation covers the reviewed bytes and contradicts
+ *    nothing, but the evidence is weaker than `verified`: either no signature
+ *    could be verified, or the predicate names no repository/run for Drydock to
+ *    compare against (the npm publish attestation, for instance, attests the
+ *    publish event and carries no source binding).
+ *  - `mismatch` — an attestation exists and *contradicts* Drydock's own
+ *    binding: it attests different bytes, a different repository, or a
+ *    different workflow run. The only level that asserts something is wrong.
+ *  - `absent` — the lookup succeeded and no attestation covers these bytes.
+ *    Normal for releases that do not publish provenance.
+ *  - `unavailable` — the lookup or parse failed. Evidence is missing, which is
+ *    not evidence of wrongdoing.
+ */
+export type BuildAttestationStatus = "verified" | "partial" | "mismatch" | "absent" | "unavailable";
+
+/** Which independently-held fact a cross-check compared the claim against. */
+export type BuildAttestationCheckKind =
+  /** Subject digest vs the SHA-256 Drydock recomputed from the reviewed bytes. */
+  | "subject-digest"
+  /** Claimed source repository vs the repository the signed webhook bound. */
+  | "repository"
+  /** Claimed workflow run vs the run id the signed webhook bound. */
+  | "workflow-run"
+  /** Claimed source commit vs the head commit of that run. */
+  | "source-commit"
+  /** DSSE signature over the payload, using the key in the bundle's certificate. */
+  | "signature";
+
+export type BuildAttestationCheckResult = "pass" | "fail" | "skipped";
+
+export interface BuildAttestationCheck {
+  kind: BuildAttestationCheckKind;
+  result: BuildAttestationCheckResult;
+  /** Human-readable evidence. Never contains credential material. */
+  detail: string;
+}
+
+/**
+ * The build claims projected out of an in-toto statement, normalized across
+ * predicate versions. Every field is what the attestation *says*; whether to
+ * believe it is the verdict's job.
+ */
+export interface BuildClaim {
+  /** Predicate type URI, e.g. `https://slsa.dev/provenance/v1`. */
+  predicateType: string;
+  /** Normalized `https://github.com/owner/repo` when the claim names one. */
+  repository: string | null;
+  /** Workflow file path within the repository, when claimed. */
+  workflowPath: string | null;
+  /** Git ref the build ran against, e.g. `refs/heads/main`. */
+  ref: string | null;
+  /** 40-hex source commit the build resolved, when claimed. */
+  commit: string | null;
+  /** Workflow run id parsed out of the invocation id, when claimed. */
+  runId: string | null;
+  /** Run attempt parsed out of the invocation id, when claimed. */
+  runAttempt: string | null;
+  /** Builder identity URI, e.g. `https://github.com/actions/runner/github-hosted`. */
+  builderId: string | null;
+  /** Lowercase hex SHA-256 subject digests this statement covers. */
+  subjectDigests: string[];
+}
+
+/**
+ * The persisted, display-ready verdict. Advisory: like the intent envelope, it
+ * never feeds risk or findings.
+ */
+export interface BuildAttestation {
+  status: BuildAttestationStatus;
+  /** Null unless an attestation was found and parsed. */
+  claim: BuildClaim | null;
+  /** Every cross-check that ran, in stable order. */
+  checks: BuildAttestationCheck[];
+  /**
+   * What this verdict does *not* establish, carried with the verdict so no
+   * reader has to remember the caveat. See `docs/build-attestation.md`.
+   */
+  trustCeiling: BuildAttestationTrustCeiling;
+}
+
+/**
+ * The honest ceiling on what a `verified` verdict means here.
+ *
+ * `self-consistent` — the DSSE signature verified against the public key in the
+ * bundle's own certificate, and the claims agree with Drydock's independently
+ * authenticated binding. Drydock does **not** validate the certificate chain to
+ * a Fulcio root, check SCTs, or verify Rekor transparency-log inclusion, so the
+ * signature alone proves only that the bundle is internally consistent. The
+ * load-bearing trust comes from the binding cross-checks, not the PKI.
+ */
+export type BuildAttestationTrustCeiling = "self-consistent" | "none";
+
+/**
+ * Facts Drydock holds independently of the attestation, used as the comparison
+ * basis. For a workflow gate these come from the signed
+ * `deployment_protection_rule` webhook and the digests the control plane
+ * recomputed from the immutable Actions artifact — none of it is claimed by the
+ * package.
+ */
+export interface AttestationBinding {
+  /** `owner/repo` bound by the signed webhook. */
+  repositoryFullName: string;
+  /** Workflow run id bound by the signed webhook. */
+  runId: number | string;
+  /** Head commit of that run, when the control plane resolved it. */
+  headSha?: string | null;
+  /** Lowercase hex SHA-256 of every artifact in this review candidate. */
+  artifactDigests: string[];
+}

--- a/server/lib/build-attestation/verdict.ts
+++ b/server/lib/build-attestation/verdict.ts
@@ -1,0 +1,262 @@
+/**
+ * The verdict: compare what an attestation *claims* against what Drydock
+ * *independently knows*, and grade the agreement.
+ *
+ * The design decision worth stating plainly: the load-bearing evidence here is
+ * not the Sigstore PKI, it is the cross-check. At a workflow gate, Drydock
+ * already holds a repository + run binding that arrived on a signature-verified
+ * GitHub webhook, and artifact digests it recomputed itself from the immutable
+ * Actions bytes. None of that is claimed by the package. An attestation that
+ * agrees with all of it is corroborated by an independent channel; an
+ * attestation that disagrees is a contradiction worth surfacing loudly — and
+ * neither conclusion needs a certificate chain to reach.
+ *
+ * That is why full Sigstore verification (Fulcio chain, SCTs, Rekor inclusion)
+ * is deliberately out of scope for this layer rather than quietly missing. See
+ * `docs/build-attestation.md`.
+ */
+
+import { parseSigstoreBundle, verifyDsseSignature } from "./dsse";
+import { parseInTotoStatement } from "./statement";
+import type {
+  AttestationBinding,
+  BuildAttestation,
+  BuildAttestationCheck,
+  BuildClaim,
+} from "./types";
+
+// A release publishes a handful of attestations at most (build provenance plus
+// a publish attestation per artifact). This cap bounds the signature
+// verification work a hostile attestation store can ask for.
+const MAX_BUNDLES = 32;
+
+/**
+ * Bundles as returned by an attestation source.
+ *
+ * Contract: `bundles` must be what the source returned when asked about
+ * `binding.artifactDigests` specifically. Both wired sources query by digest,
+ * so a returned bundle that covers none of those digests is the store
+ * answering about the wrong bytes — which is why that case grades `mismatch`
+ * rather than being filtered out as irrelevant. A future source that lists a
+ * repository's attestations wholesale would need different handling.
+ */
+export type AttestationLookup =
+  | { status: "ok"; bundles: unknown[] }
+  | { status: "failed"; reason: string };
+
+const NO_ATTESTATION_CEILING = "none" as const;
+
+/**
+ * Grade the attestation evidence for one review candidate. Pure: every input is
+ * already-fetched data, and the result is advisory — it never feeds risk or
+ * findings.
+ */
+export async function evaluateBuildAttestation(
+  lookup: AttestationLookup,
+  binding: AttestationBinding,
+): Promise<BuildAttestation> {
+  if (lookup.status === "failed") {
+    return {
+      status: "unavailable",
+      claim: null,
+      checks: [
+        { kind: "subject-digest", result: "skipped", detail: `lookup failed: ${lookup.reason}` },
+      ],
+      trustCeiling: NO_ATTESTATION_CEILING,
+    };
+  }
+
+  if (!lookup.bundles.length) {
+    return {
+      status: "absent",
+      claim: null,
+      checks: [
+        {
+          kind: "subject-digest",
+          result: "skipped",
+          detail: "no build attestation published for the reviewed bytes",
+        },
+      ],
+      trustCeiling: NO_ATTESTATION_CEILING,
+    };
+  }
+
+  const digests = new Set(
+    binding.artifactDigests
+      .map((digest) => digest.trim().toLowerCase())
+      .filter((digest) => /^[0-9a-f]{64}$/.test(digest)),
+  );
+
+  const candidates: BuildAttestation[] = [];
+  let parsedAny = false;
+  for (const bundle of lookup.bundles.slice(0, MAX_BUNDLES)) {
+    const envelope = parseSigstoreBundle(bundle);
+    if (!envelope) continue;
+    const claim = parseInTotoStatement(envelope.payload);
+    if (!claim) continue;
+    parsedAny = true;
+    candidates.push(await gradeClaim(claim, envelope, digests, binding));
+  }
+
+  if (!parsedAny) {
+    return {
+      status: "unavailable",
+      claim: null,
+      checks: [
+        {
+          kind: "subject-digest",
+          result: "skipped",
+          detail: "attestation returned but no readable in-toto statement inside it",
+        },
+      ],
+      trustCeiling: NO_ATTESTATION_CEILING,
+    };
+  }
+
+  // A contradiction dominates: if any attestation covering this release
+  // disagrees with Drydock's own binding, reporting a different, agreeable one
+  // instead would hide exactly the signal this feature exists to surface.
+  const contradiction = candidates.find((candidate) => candidate.status === "mismatch");
+  if (contradiction) return contradiction;
+
+  const rank = { verified: 0, partial: 1 } as Record<string, number>;
+  return candidates.sort((a, b) => (rank[a.status] ?? 9) - (rank[b.status] ?? 9))[0];
+}
+
+async function gradeClaim(
+  claim: BuildClaim,
+  envelope: NonNullable<ReturnType<typeof parseSigstoreBundle>>,
+  digests: ReadonlySet<string>,
+  binding: AttestationBinding,
+): Promise<BuildAttestation> {
+  const checks: BuildAttestationCheck[] = [];
+
+  const covered = claim.subjectDigests.filter((digest) => digests.has(digest));
+  if (covered.length) {
+    // State the coverage fraction rather than just "it matched". One attestation
+    // covering one wheel of a thirty-wheel release is a true `pass` — the bytes
+    // it names really were reviewed — but reading it as "this release is
+    // attested" would be wrong, and a bare digest in the detail invites exactly
+    // that reading.
+    const total = digests.size;
+    const scope =
+      covered.length === total
+        ? `all ${total} reviewed artifact${total === 1 ? "" : "s"}`
+        : `${covered.length} of ${total} reviewed artifacts`;
+    checks.push({
+      kind: "subject-digest",
+      result: "pass",
+      detail: `attests ${scope} (sha256:${covered[0]}), digests Drydock recomputed from the reviewed bytes`,
+    });
+  } else {
+    checks.push({
+      kind: "subject-digest",
+      result: "fail",
+      detail: claim.subjectDigests.length
+        ? `attests sha256:${claim.subjectDigests[0]}, which is not among the reviewed artifacts`
+        : "attests no sha256 digest, so it cannot be tied to the reviewed bytes",
+    });
+  }
+
+  const expectedRepository = `https://github.com/${binding.repositoryFullName}`;
+  checks.push(
+    compare({
+      kind: "repository",
+      claimed: claim.repository,
+      expected: expectedRepository,
+      absentDetail: "attestation names no source repository",
+      passDetail: (value) => `built from ${value}, matching the repository the gate bound`,
+      failDetail: (value) => `claims ${value} but the signed webhook bound ${expectedRepository}`,
+    }),
+  );
+
+  checks.push(
+    compare({
+      kind: "workflow-run",
+      claimed: claim.runId,
+      expected: String(binding.runId),
+      absentDetail: "attestation names no workflow run",
+      passDetail: (value) => `built by run ${value}, matching the run the gate bound`,
+      failDetail: (value) =>
+        `claims run ${value} but the signed webhook bound run ${binding.runId}`,
+    }),
+  );
+
+  const headSha = binding.headSha?.trim().toLowerCase() || null;
+  checks.push(
+    compare({
+      kind: "source-commit",
+      claimed: claim.commit,
+      expected: headSha,
+      absentDetail: headSha
+        ? "attestation names no source commit"
+        : "run head commit was not resolved, so there is nothing to compare",
+      passDetail: (value) => `built from commit ${value}, matching the run's head commit`,
+      failDetail: (value) => `claims commit ${value} but the run's head commit is ${headSha}`,
+    }),
+  );
+
+  const signature = await verifyDsseSignature(envelope);
+  checks.push({
+    kind: "signature",
+    result: signature.verified ? "pass" : "fail",
+    detail: signature.verified
+      ? `DSSE signature verified against the bundle's certificate key (${signature.algorithm})`
+      : `signature not verified: ${signature.reason}`,
+  });
+
+  const failed = (kind: BuildAttestationCheck["kind"]) =>
+    checks.some((check) => check.kind === kind && check.result === "fail");
+  const passed = (kind: BuildAttestationCheck["kind"]) =>
+    checks.some((check) => check.kind === kind && check.result === "pass");
+
+  // A contradiction on any binding Drydock holds independently.
+  const contradicted =
+    failed("subject-digest") ||
+    failed("repository") ||
+    failed("workflow-run") ||
+    failed("source-commit");
+
+  if (contradicted) {
+    return { status: "mismatch", claim, checks, trustCeiling: NO_ATTESTATION_CEILING };
+  }
+
+  // `verified` requires a positive agreement with an independently-held fact,
+  // not merely the absence of disagreement. An attestation that covers the
+  // right bytes but names no repository or run has nothing to corroborate.
+  const corroborated = passed("repository") || passed("workflow-run");
+  if (corroborated && passed("signature")) {
+    return { status: "verified", claim, checks, trustCeiling: "self-consistent" };
+  }
+  return {
+    status: "partial",
+    claim,
+    checks,
+    trustCeiling: passed("signature") ? "self-consistent" : NO_ATTESTATION_CEILING,
+  };
+}
+
+interface CompareArgs {
+  kind: BuildAttestationCheck["kind"];
+  claimed: string | null;
+  expected: string | null;
+  absentDetail: string;
+  passDetail: (value: string) => string;
+  failDetail: (value: string) => string;
+}
+
+/**
+ * Compare one claimed value against one independently-held value. A missing
+ * value on either side is `skipped`, never `fail`: asserting that an
+ * attestation contradicts Drydock requires two values that both exist, the same
+ * rule `evaluateStagedArtifactIntegrity` follows for digests.
+ */
+function compare(args: CompareArgs): BuildAttestationCheck {
+  if (!args.claimed || !args.expected) {
+    return { kind: args.kind, result: "skipped", detail: args.absentDetail };
+  }
+  if (args.claimed === args.expected) {
+    return { kind: args.kind, result: "pass", detail: args.passDetail(args.claimed) };
+  }
+  return { kind: args.kind, result: "fail", detail: args.failDetail(args.claimed) };
+}

--- a/server/lib/build-attestation/verdict.ts
+++ b/server/lib/build-attestation/verdict.ts
@@ -113,13 +113,13 @@ export async function evaluateBuildAttestation(
     };
   }
 
-  // A contradiction dominates: if any attestation covering this release
-  // disagrees with Drydock's own binding, reporting a different, agreeable one
-  // instead would hide exactly the signal this feature exists to surface.
-  const contradiction = candidates.find((candidate) => candidate.status === "mismatch");
-  if (contradiction) return contradiction;
-
-  const rank = { verified: 0, partial: 1 } as Record<string, number>;
+  // Verification is monotonic across the repository's digest-indexed
+  // collection. Re-running a release can legitimately attach the same bytes to
+  // more than one workflow run; an older run is not allowed to turn a matching
+  // current-run attestation into a mismatch. A contradiction remains visible
+  // when it is the strongest evidence available, but never outranks an
+  // agreeable candidate.
+  const rank = { verified: 0, partial: 1, mismatch: 2 } as Record<string, number>;
   return candidates.sort((a, b) => (rank[a.status] ?? 9) - (rank[b.status] ?? 9))[0];
 }
 

--- a/server/lib/ecosystems/npm/workflow-gate.ts
+++ b/server/lib/ecosystems/npm/workflow-gate.ts
@@ -112,6 +112,7 @@ function deriveNpmReleaseCandidates(artifacts: ParsedGateArtifact[]): PreparedRe
         },
       },
       package: { name: manifest.package, version: manifest.version },
+      artifactDigests: group.artifacts.map((entry) => entry.sha256),
     };
   });
 }

--- a/server/lib/ecosystems/pypi/workflow-gate.ts
+++ b/server/lib/ecosystems/pypi/workflow-gate.ts
@@ -142,6 +142,7 @@ function deriveReleaseCandidates(entries: PreparedArtifactEntry[]): PreparedRele
       ecosystem: "pypi",
       pipelineInput: { manifest, artifacts: group.entries.map((entry) => entry.input) },
       package: { name: manifest.package, version: manifest.version },
+      artifactDigests: group.entries.map((entry) => entry.artifact.sha256),
     };
   });
 }

--- a/server/lib/ecosystems/vscode/workflow-gate.ts
+++ b/server/lib/ecosystems/vscode/workflow-gate.ts
@@ -87,6 +87,7 @@ function deriveVscodeReleaseCandidates(
         },
       },
       package: { name: manifest.package, version: manifest.version },
+      artifactDigests: [artifact.sha256],
     };
   });
 }

--- a/server/lib/github-app/api.ts
+++ b/server/lib/github-app/api.ts
@@ -230,3 +230,45 @@ export async function listRepositoryEnvironments(
 
   return environments;
 }
+
+/**
+ * Resolve the head commit of a workflow run.
+ *
+ * Used by the build-attestation cross-check: an attestation claims the commit
+ * it built from, and the run's own head commit is the independently-held value
+ * to compare it against. Reads through the existing `actions: read` grant that
+ * artifact discovery already requires.
+ *
+ * Returns null rather than throwing — a missing head commit degrades the
+ * `source-commit` check to `skipped`, and must never fail a gate review.
+ *
+ * NOTE: the release-authority work (`github-app/workflow-source.ts` on the
+ * port-vila branch) resolves the same field as part of a larger run-context
+ * fetch. Whichever lands second should collapse these into one call.
+ */
+export async function fetchWorkflowRunHeadSha(
+  config: GithubAppConfig,
+  installationId: string,
+  fullName: string,
+  runId: number | string,
+): Promise<string | null> {
+  const repository = parseRepositoryFullName(fullName);
+  if (!repository) return null;
+  if (!/^\d{1,20}$/.test(String(runId))) return null;
+
+  try {
+    const token = await getInstallationAccessToken(config, installationId);
+    const response = await reliableFetch(
+      `https://api.github.com/repos/${encodeURIComponent(repository.owner)}/` +
+        `${encodeURIComponent(repository.name)}/actions/runs/${String(runId)}`,
+      { headers: githubInstallationHeaders(token), redirect: "manual" },
+    );
+    if (!response.ok) return null;
+    const data = (await response.json()) as { head_sha?: unknown };
+    if (typeof data.head_sha !== "string") return null;
+    const headSha = data.head_sha.trim().toLowerCase();
+    return /^[0-9a-f]{40}$/.test(headSha) ? headSha : null;
+  } catch {
+    return null;
+  }
+}

--- a/server/lib/github-app/api.ts
+++ b/server/lib/github-app/api.ts
@@ -2,7 +2,7 @@ import { GithubAppValidationError, type GithubAppConfig } from "./config";
 import { githubAppHeaders, githubInstallationHeaders, nextLink } from "./http";
 import { generateGithubAppJwt } from "./jwt";
 import { parseRepositoryFullName } from "./validation";
-import { reliableFetch } from "../platform/reliable-fetch";
+import { reliableFetch, type ReliableFetchOptions } from "../platform/reliable-fetch";
 
 export interface GithubInstallationMetadata {
   installationId: string;
@@ -57,6 +57,7 @@ export async function fetchInstallationMetadata(
 export async function getInstallationAccessToken(
   config: GithubAppConfig,
   installationId: string,
+  fetchOptions: Pick<ReliableFetchOptions, "attempts" | "timeoutMs"> = {},
 ): Promise<string> {
   const jwt = await generateGithubAppJwt(config);
   const response = await reliableFetch(
@@ -65,6 +66,7 @@ export async function getInstallationAccessToken(
       method: "POST",
       headers: githubAppHeaders(jwt),
       retryMethods: ["POST"],
+      ...fetchOptions,
     },
   );
   if (!response.ok) {
@@ -257,11 +259,21 @@ export async function fetchWorkflowRunHeadSha(
   if (!/^\d{1,20}$/.test(String(runId))) return null;
 
   try {
-    const token = await getInstallationAccessToken(config, installationId);
+    // This lookup is advisory. Keep it on a short single-attempt budget so an
+    // unavailable GitHub API cannot delay the release review itself.
+    const token = await getInstallationAccessToken(config, installationId, {
+      attempts: 1,
+      timeoutMs: 5_000,
+    });
     const response = await reliableFetch(
       `https://api.github.com/repos/${encodeURIComponent(repository.owner)}/` +
         `${encodeURIComponent(repository.name)}/actions/runs/${String(runId)}`,
-      { headers: githubInstallationHeaders(token), redirect: "manual" },
+      {
+        headers: githubInstallationHeaders(token),
+        redirect: "manual",
+        attempts: 1,
+        timeoutMs: 5_000,
+      },
     );
     if (!response.ok) return null;
     const data = (await response.json()) as { head_sha?: unknown };

--- a/server/lib/github-app/attestations.ts
+++ b/server/lib/github-app/attestations.ts
@@ -1,0 +1,154 @@
+/**
+ * GitHub artifact-attestation lookup.
+ *
+ * `actions/attest-build-provenance` stores a Sigstore bundle per attested file,
+ * addressed by the file's SHA-256. Drydock already recomputes that digest from
+ * the immutable Actions artifact it reviewed, so it can ask the repository's
+ * attestation store the exact question that matters: *is there a build
+ * attestation for these bytes?*
+ *
+ * Ecosystem-neutral by construction — the endpoint attests files, not packages,
+ * so npm tarballs, wheels, sdists, and VSIXes all resolve through this one path
+ * with no per-ecosystem branching.
+ *
+ * The installation token stays in the control plane: this module is called from
+ * the workflow-gate job, and only the parsed bundles (no credentials, no
+ * headers) are handed onward to the pure verdict layer.
+ */
+
+import { reliableFetch } from "../platform/reliable-fetch";
+import { describeOperationalError } from "../platform/observability";
+import { getInstallationAccessToken } from "./api";
+import type { GithubAppConfig } from "./config";
+import { githubInstallationHeaders } from "./http";
+import { parseRepositoryFullName } from "./validation";
+
+// One release candidate is a handful of files, each with at most a couple of
+// attestations. These caps bound both the number of requests a gate can make
+// and the bytes any one response can contribute.
+const MAX_DIGEST_LOOKUPS = 8;
+const MAX_RESPONSE_BYTES = 1024 * 1024;
+const MAX_BUNDLES_PER_DIGEST = 8;
+
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+
+export interface AttestationFetchResult {
+  /** Sigstore bundles, untyped — the pure layer parses and bounds them. */
+  bundles: unknown[];
+  /** Set when the lookup could not complete; bundles is then empty. */
+  failureReason: string | null;
+}
+
+/**
+ * Fetch every build attestation covering the given artifact digests.
+ *
+ * A 404 means the repository has no attestation for that digest, which is a
+ * normal, quiet outcome (`bundles: []`, no failure) — most releases publish no
+ * provenance. Only a transport or authorization failure sets `failureReason`,
+ * because "we could not look" and "there is nothing there" must not collapse
+ * into the same verdict.
+ */
+export async function fetchBuildAttestations(
+  config: GithubAppConfig,
+  args: {
+    installationExternalId: string;
+    repositoryFullName: string;
+    artifactDigests: string[];
+  },
+): Promise<AttestationFetchResult> {
+  const digests = [
+    ...new Set(
+      args.artifactDigests
+        .map((digest) => digest.trim().toLowerCase())
+        .filter((digest) => SHA256_HEX.test(digest)),
+    ),
+  ].slice(0, MAX_DIGEST_LOOKUPS);
+  if (!digests.length) return { bundles: [], failureReason: null };
+
+  // Shared validator rather than a local split: it already refuses `.`/`..`
+  // segments, which would otherwise traverse out of the /repos/ path.
+  const repository = parseRepositoryFullName(args.repositoryFullName);
+  if (!repository) return { bundles: [], failureReason: "repository is not in owner/repo form" };
+
+  let token: string;
+  try {
+    token = await getInstallationAccessToken(config, args.installationExternalId);
+  } catch (err) {
+    return { bundles: [], failureReason: describeFailure(err) };
+  }
+
+  const bundles: unknown[] = [];
+  for (const digest of digests) {
+    const outcome = await fetchDigestAttestations(token, repository, digest);
+    if (outcome.failureReason) return { bundles: [], failureReason: outcome.failureReason };
+    bundles.push(...outcome.bundles);
+  }
+  return { bundles, failureReason: null };
+}
+
+async function fetchDigestAttestations(
+  token: string,
+  repository: { owner: string; name: string },
+  digest: string,
+): Promise<AttestationFetchResult> {
+  const url =
+    `https://api.github.com/repos/${encodeURIComponent(repository.owner)}/` +
+    `${encodeURIComponent(repository.name)}/attestations/sha256:${digest}`;
+
+  let response: Response;
+  try {
+    response = await reliableFetch(url, {
+      headers: githubInstallationHeaders(token),
+      // A credentialed request must not chase a redirect off api.github.com.
+      redirect: "manual",
+    });
+  } catch (err) {
+    return { bundles: [], failureReason: describeFailure(err) };
+  }
+
+  // No attestation for these bytes. Not a failure — the common case.
+  if (response.status === 404) return { bundles: [], failureReason: null };
+  if (response.status >= 300 && response.status < 400) {
+    return { bundles: [], failureReason: `attestation lookup redirected (${response.status})` };
+  }
+  if (!response.ok) {
+    return { bundles: [], failureReason: `attestation lookup failed (${response.status})` };
+  }
+
+  const text = await response.text().catch(() => null);
+  if (text === null) return { bundles: [], failureReason: "attestation response unreadable" };
+  if (text.length > MAX_RESPONSE_BYTES) {
+    return { bundles: [], failureReason: "attestation response exceeded the size cap" };
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    return { bundles: [], failureReason: "attestation response was not JSON" };
+  }
+  if (!isRecord(body) || !Array.isArray(body.attestations)) {
+    return { bundles: [], failureReason: null };
+  }
+
+  const bundles: unknown[] = [];
+  for (const entry of body.attestations.slice(0, MAX_BUNDLES_PER_DIGEST)) {
+    if (isRecord(entry) && entry.bundle !== undefined) bundles.push(entry.bundle);
+  }
+  return { bundles, failureReason: null };
+}
+
+/**
+ * Collapse an error into a single short, redacted string. The reason is
+ * persisted with the verdict and rendered to maintainers, so it goes through
+ * the shared redaction path rather than stringifying the error directly.
+ */
+function describeFailure(err: unknown): string {
+  const summary = describeOperationalError(err);
+  const message = summary.message ? `: ${summary.message}` : "";
+  return `${summary.name}${message}`.slice(0, 200);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/server/lib/github-app/attestations.ts
+++ b/server/lib/github-app/attestations.ts
@@ -18,6 +18,7 @@
 
 import { reliableFetch } from "../platform/reliable-fetch";
 import { describeOperationalError } from "../platform/observability";
+import { uncompress } from "snappyjs";
 import { getInstallationAccessToken } from "./api";
 import type { GithubAppConfig } from "./config";
 import { githubInstallationHeaders } from "./http";
@@ -29,6 +30,8 @@ import { parseRepositoryFullName } from "./validation";
 const MAX_DIGEST_LOOKUPS = 8;
 const MAX_RESPONSE_BYTES = 1024 * 1024;
 const MAX_BUNDLES_PER_DIGEST = 8;
+const DIGEST_LOOKUP_CONCURRENCY = 2;
+const ADVISORY_TIMEOUT_MS = 5_000;
 
 const SHA256_HEX = /^[0-9a-f]{64}$/;
 
@@ -40,7 +43,7 @@ export interface AttestationFetchResult {
 }
 
 /**
- * Fetch every build attestation covering the given artifact digests.
+ * Fetch a bounded set of build attestations covering the given artifact digests.
  *
  * A 404 means the repository has no attestation for that digest, which is a
  * normal, quiet outcome (`bundles: []`, no failure) — most releases publish no
@@ -72,18 +75,23 @@ export async function fetchBuildAttestations(
 
   let token: string;
   try {
-    token = await getInstallationAccessToken(config, args.installationExternalId);
+    token = await getInstallationAccessToken(config, args.installationExternalId, {
+      attempts: 1,
+      timeoutMs: ADVISORY_TIMEOUT_MS,
+    });
   } catch (err) {
     return { bundles: [], failureReason: describeFailure(err) };
   }
 
-  const bundles: unknown[] = [];
-  for (const digest of digests) {
-    const outcome = await fetchDigestAttestations(token, repository, digest);
-    if (outcome.failureReason) return { bundles: [], failureReason: outcome.failureReason };
-    bundles.push(...outcome.bundles);
-  }
-  return { bundles, failureReason: null };
+  // At most two requests per candidate. Gate packages are already reviewed
+  // with concurrency three, so this keeps the whole job within six simultaneous
+  // GitHub connections while avoiding one timeout per digest in series.
+  const outcomes = await mapWithConcurrency(digests, DIGEST_LOOKUP_CONCURRENCY, (digest) =>
+    fetchDigestAttestations(token, repository, digest),
+  );
+  const failed = outcomes.find((outcome) => outcome.failureReason);
+  if (failed?.failureReason) return { bundles: [], failureReason: failed.failureReason };
+  return { bundles: outcomes.flatMap((outcome) => outcome.bundles), failureReason: null };
 }
 
 async function fetchDigestAttestations(
@@ -91,9 +99,15 @@ async function fetchDigestAttestations(
   repository: { owner: string; name: string },
   digest: string,
 ): Promise<AttestationFetchResult> {
-  const url =
+  const url = new URL(
     `https://api.github.com/repos/${encodeURIComponent(repository.owner)}/` +
-    `${encodeURIComponent(repository.name)}/attestations/sha256:${digest}`;
+      `${encodeURIComponent(repository.name)}/attestations/sha256:${digest}`,
+  );
+  // This endpoint also returns SBOM, release and custom predicates. Filter at
+  // the source so those records cannot consume the bounded result allowance
+  // before the build-provenance statement we are looking for.
+  url.searchParams.set("predicate_type", "provenance");
+  url.searchParams.set("per_page", String(MAX_BUNDLES_PER_DIGEST));
 
   let response: Response;
   try {
@@ -101,6 +115,8 @@ async function fetchDigestAttestations(
       headers: githubInstallationHeaders(token),
       // A credentialed request must not chase a redirect off api.github.com.
       redirect: "manual",
+      attempts: 1,
+      timeoutMs: ADVISORY_TIMEOUT_MS,
     });
   } catch (err) {
     return { bundles: [], failureReason: describeFailure(err) };
@@ -115,27 +131,167 @@ async function fetchDigestAttestations(
     return { bundles: [], failureReason: `attestation lookup failed (${response.status})` };
   }
 
-  const text = await response.text().catch(() => null);
-  if (text === null) return { bundles: [], failureReason: "attestation response unreadable" };
-  if (text.length > MAX_RESPONSE_BYTES) {
-    return { bundles: [], failureReason: "attestation response exceeded the size cap" };
-  }
-
-  let body: unknown;
-  try {
-    body = JSON.parse(text);
-  } catch {
-    return { bundles: [], failureReason: "attestation response was not JSON" };
-  }
+  const decoded = await readJsonResponse(response, MAX_RESPONSE_BYTES, "attestation response");
+  if (!decoded.ok) return { bundles: [], failureReason: decoded.reason };
+  const body = decoded.value;
   if (!isRecord(body) || !Array.isArray(body.attestations)) {
-    return { bundles: [], failureReason: null };
+    return { bundles: [], failureReason: "attestation response had an unexpected shape" };
   }
 
   const bundles: unknown[] = [];
   for (const entry of body.attestations.slice(0, MAX_BUNDLES_PER_DIGEST)) {
-    if (isRecord(entry) && entry.bundle !== undefined) bundles.push(entry.bundle);
+    if (!isRecord(entry)) continue;
+    if (isRecord(entry.bundle)) {
+      bundles.push(entry.bundle);
+      continue;
+    }
+    // GitHub may return historical/migrated records with a null embedded bundle
+    // and a short-lived URL to a Snappy-compressed bundle. The URL is fetched
+    // without the installation token and under the same advisory deadline.
+    if (typeof entry.bundle_url === "string") {
+      const fetched = await fetchUrlBackedBundle(entry.bundle_url);
+      if (!fetched.ok) return { bundles: [], failureReason: fetched.reason };
+      bundles.push(fetched.bundle);
+      continue;
+    }
+    return { bundles: [], failureReason: "attestation record contained no readable bundle" };
   }
   return { bundles, failureReason: null };
+}
+
+async function fetchUrlBackedBundle(
+  rawUrl: string,
+): Promise<{ ok: true; bundle: unknown } | { ok: false; reason: string }> {
+  let url: URL;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return { ok: false, reason: "attestation bundle URL was invalid" };
+  }
+  if (url.protocol !== "https:" || url.username || url.password) {
+    return { ok: false, reason: "attestation bundle URL was not safe" };
+  }
+
+  let response: Response;
+  try {
+    response = await reliableFetch(url, {
+      redirect: "manual",
+      attempts: 1,
+      timeoutMs: ADVISORY_TIMEOUT_MS,
+      headers: { Accept: "application/json, application/x-snappy", "User-Agent": "drydock-app" },
+    });
+  } catch (err) {
+    return { ok: false, reason: describeFailure(err) };
+  }
+  if (response.status >= 300 && response.status < 400) {
+    return { ok: false, reason: `attestation bundle redirected (${response.status})` };
+  }
+  if (!response.ok) {
+    return { ok: false, reason: `attestation bundle lookup failed (${response.status})` };
+  }
+
+  const read = await readResponseBytes(response, MAX_RESPONSE_BYTES, "attestation bundle");
+  if (!read.ok) return read;
+
+  let bytes = read.bytes;
+  const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase();
+  if (contentType === "application/x-snappy" || url.pathname.endsWith(".sn")) {
+    try {
+      bytes = uncompress(bytes, MAX_RESPONSE_BYTES);
+    } catch {
+      return { ok: false, reason: "attestation bundle was not valid bounded Snappy data" };
+    }
+  }
+
+  const parsed = parseJsonBytes(bytes);
+  return parsed.ok
+    ? { ok: true, bundle: parsed.value }
+    : { ok: false, reason: "attestation bundle was not JSON" };
+}
+
+async function readJsonResponse(
+  response: Response,
+  maxBytes: number,
+  label: string,
+): Promise<{ ok: true; value: unknown } | { ok: false; reason: string }> {
+  const read = await readResponseBytes(response, maxBytes, label);
+  if (!read.ok) return read;
+  const parsed = parseJsonBytes(read.bytes);
+  return parsed.ok ? parsed : { ok: false, reason: `${label} was not JSON` };
+}
+
+async function readResponseBytes(
+  response: Response,
+  maxBytes: number,
+  label: string,
+): Promise<{ ok: true; bytes: Uint8Array } | { ok: false; reason: string }> {
+  const declared = parseContentLength(response.headers.get("content-length"));
+  if (declared !== null && declared > maxBytes) {
+    await response.body?.cancel().catch(() => undefined);
+    return { ok: false, reason: `${label} exceeded the size cap` };
+  }
+  if (!response.body) return { ok: false, reason: `${label} was unreadable` };
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        return { ok: false, reason: `${label} exceeded the size cap` };
+      }
+      chunks.push(value);
+    }
+  } catch {
+    return { ok: false, reason: `${label} was unreadable` };
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return { ok: true, bytes };
+}
+
+function parseJsonBytes(
+  bytes: Uint8Array,
+): { ok: true; value: unknown } | { ok: false; reason: string } {
+  try {
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+    return { ok: true, value: JSON.parse(text) as unknown };
+  } catch {
+    return { ok: false, reason: "invalid JSON" };
+  }
+}
+
+function parseContentLength(value: string | null): number | null {
+  if (!value || !/^\d+$/.test(value.trim())) return null;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isSafeInteger(parsed) ? parsed : null;
+}
+
+async function mapWithConcurrency<T, U>(
+  values: readonly T[],
+  concurrency: number,
+  fn: (value: T) => Promise<U>,
+): Promise<U[]> {
+  const results: U[] = [];
+  let cursor = 0;
+  const workers = Array.from({ length: Math.min(concurrency, values.length) }, async () => {
+    while (cursor < values.length) {
+      const index = cursor;
+      cursor += 1;
+      results[index] = await fn(values[index]);
+    }
+  });
+  await Promise.all(workers);
+  return results;
 }
 
 /**

--- a/server/lib/scan/pipeline-phases.ts
+++ b/server/lib/scan/pipeline-phases.ts
@@ -10,6 +10,7 @@ import type {
   PackageAdapter,
   StagedDetails,
 } from "../ecosystems/package-adapter";
+import type { BuildAttestation } from "../build-attestation";
 import type { IntentEnvelope } from "../intent-envelope";
 import {
   describeOperationalError,
@@ -266,6 +267,10 @@ export interface PersistResultsArgs<TInput, TBroker extends AdapterBroker> {
   // Advisory source-binding classification computed by the pipeline; persisted
   // with the scan but never allowed to influence risk or findings.
   intentEnvelope: IntentEnvelope;
+  // Advisory build-attestation verdict, graded in the control plane by the
+  // workflow-gate job. Null for staged publishes and for gates whose ecosystem
+  // has no attestation source. Like the envelope, never feeds risk or findings.
+  buildAttestation?: BuildAttestation | null;
 }
 
 export interface PersistedScanOutcome {
@@ -308,6 +313,7 @@ export async function persistResults<TInput, TBroker extends AdapterBroker>(
     riskSummary: args.riskSummary,
     releaseConsistency: args.releaseConsistency,
     intentEnvelope: args.intentEnvelope,
+    buildAttestation: args.buildAttestation ?? null,
     safety,
   };
 
@@ -342,6 +348,7 @@ export async function persistResults<TInput, TBroker extends AdapterBroker>(
     risk: args.riskSummary,
     releaseConsistency: args.releaseConsistency,
     intentEnvelope: args.intentEnvelope,
+    buildAttestation: args.buildAttestation ?? null,
     safety,
   };
   const reportJson = stableJson(reportPayload);
@@ -381,6 +388,7 @@ export async function persistResults<TInput, TBroker extends AdapterBroker>(
       baseline: baseline.baseline,
       releaseConsistency: args.releaseConsistency,
       intentEnvelope: args.intentEnvelope,
+      buildAttestation: args.buildAttestation ?? null,
       safety: result.safety,
     },
     ai: args.aiFindings,

--- a/server/lib/scan/pipeline.ts
+++ b/server/lib/scan/pipeline.ts
@@ -1,5 +1,6 @@
 import { type AppDb, type WorkspaceSession } from "../../db/client";
 import type { AiReview } from "../ai-review/types";
+import type { BuildAttestation } from "../build-attestation";
 import type {
   AdapterBroker,
   AdapterConnectionRef,
@@ -48,6 +49,14 @@ export interface ScanPipelineOptions extends ScanInput {
    * and the reviewed artifact bytes were downloaded from that run.
    */
   gateContext?: WorkflowGateIntent;
+  /**
+   * Build-attestation verdict, graded by the workflow-gate job before the scan
+   * starts. Computed in the control plane rather than here because the lookup
+   * needs the installation token; the pipeline only carries the finished,
+   * credential-free verdict into the persisted summary. Absent for staged
+   * publishes, which have no attestation source today.
+   */
+  buildAttestation?: BuildAttestation | null;
   // Adapters parse their own input shape off this object (e.g. the PyPI adapter
   // reads `manifest`/`artifacts`), so allow extra keys to flow through untyped.
   [key: string]: unknown;
@@ -153,6 +162,7 @@ export async function runScanPipeline<TInput, TBroker extends AdapterBroker>(
       riskSummary,
       releaseConsistency,
       intentEnvelope,
+      buildAttestation: input.buildAttestation ?? null,
     });
 
     await recordCompletion({

--- a/server/lib/scan/report-export.ts
+++ b/server/lib/scan/report-export.ts
@@ -1,6 +1,7 @@
 import type { getScan } from "../../db/scans";
 import { parsePersistedAiReview } from "../ai-review/contract";
 import { displayedAiResult } from "../ai-review/types";
+import { normalizeBuildAttestation } from "../build-attestation";
 import { normalizeIntentEnvelope } from "../intent-envelope";
 import { normalizeReleaseConsistency } from "./release-memory";
 import type { ReleaseProvenance, ReleaseProvenanceArtifact } from "../ecosystems/package-adapter";
@@ -64,6 +65,11 @@ export function buildReportExport(detail: ScanDetail) {
     // Advisory source-binding tier (attested / declared / absent). Additive and
     // optional: scans persisted before the envelope existed export `null`.
     intentEnvelope: normalizeIntentEnvelope(summary.intentEnvelope),
+    // Advisory build-attestation verdict — "where did these bytes come from?",
+    // as distinct from the byte-continuity record in `provenance` above.
+    // Workflow-gate reviews only; re-validated so a persisted status cannot
+    // outlive the checks that produced it.
+    buildAttestation: normalizeBuildAttestation(summary.buildAttestation),
     // Staged-artifact byte-verification verdict. Null for workflow gates,
     // legacy scans, and malformed persisted data.
     artifactIntegrity: extractArtifactIntegrity(summary.stagedPublish),

--- a/server/lib/workflow-gate-job.ts
+++ b/server/lib/workflow-gate-job.ts
@@ -4,7 +4,10 @@ import { recordScanEvent } from "../db/events";
 import { getOrganizationOwnerUserId } from "../db/organizations";
 import { createScanJob, discardGateScans, markScanFailed } from "../db/scans";
 import { githubAppInstallations } from "../db/schema";
+import { type BuildAttestation, evaluateBuildAttestation } from "./build-attestation";
+import { fetchWorkflowRunHeadSha } from "./github-app/api";
 import { WorkflowArtifactError } from "./github-app/artifacts";
+import { fetchBuildAttestations } from "./github-app/attestations";
 import {
   type GithubAppConfig,
   GithubAppConfigError,
@@ -258,7 +261,13 @@ export async function executeWorkflowGateJob(
     await discardGateScans(db, gate.id, organizationId, env.ARTIFACTS);
     reviewed = await reviewGatePackages(
       { env, executionCtx, db },
-      { gate, ownerUserId, packages: prepared.packages },
+      {
+        gate,
+        ownerUserId,
+        packages: prepared.packages,
+        config,
+        installationExternalId: prepared.installationExternalId,
+      },
     );
   } catch (err) {
     // A per-package scan failed. Release the claim so a retry re-runs the whole
@@ -436,6 +445,88 @@ interface ReviewedPackage {
 const GATE_PACKAGE_SCAN_CONCURRENCY = 3;
 
 /**
+ * Look up and grade the build attestation covering one candidate's artifacts.
+ *
+ * Advisory and strictly non-blocking: every failure path returns a verdict
+ * (`unavailable`) rather than throwing. Provenance evidence is a bonus signal —
+ * a repository that publishes none is the common case, and a GitHub outage in
+ * the attestation store must not be able to stall a release.
+ *
+ * The lookup asks the repository's attestation store about digests Drydock
+ * recomputed itself, and the verdict compares the answer against the repository
+ * and run the *signed webhook* bound. Both sides of that comparison are
+ * independent of the package, which is what makes a `mismatch` meaningful.
+ */
+async function gradeCandidateAttestation(args: {
+  config: GithubAppConfig;
+  installationExternalId: string;
+  gate: WorkflowGateRecord;
+  headSha: string | null;
+  artifactDigests: string[];
+}): Promise<BuildAttestation> {
+  const { config, installationExternalId, gate, headSha, artifactDigests } = args;
+  try {
+    const fetched = await fetchBuildAttestations(config, {
+      installationExternalId,
+      repositoryFullName: gate.repositoryFullName,
+      artifactDigests,
+    });
+    const verdict = await evaluateBuildAttestation(
+      fetched.failureReason
+        ? { status: "failed", reason: fetched.failureReason }
+        : { status: "ok", bundles: fetched.bundles },
+      {
+        repositoryFullName: gate.repositoryFullName,
+        runId: gate.runId,
+        headSha,
+        artifactDigests,
+      },
+    );
+    // A `mismatch` is the one verdict that asserts something is wrong, so it is
+    // logged at warn where gate operators already watch. Everything else is
+    // routine and stays at info.
+    emitOperationalEvent(
+      verdict.status === "mismatch" ? "warn" : "info",
+      {
+        verified: "github_workflow_gate.build_attestation_verified",
+        partial: "github_workflow_gate.build_attestation_partial",
+        mismatch: "github_workflow_gate.build_attestation_mismatch",
+        absent: "github_workflow_gate.build_attestation_absent",
+        unavailable: "github_workflow_gate.build_attestation_unavailable",
+      }[verdict.status],
+      {
+        organizationId: gate.organizationId,
+        gateId: gate.id,
+        repositoryFullName: gate.repositoryFullName,
+        runId: gate.runId,
+        status: verdict.status,
+        predicateType: verdict.claim?.predicateType ?? null,
+        checks: verdict.checks.map((check) => `${check.kind}:${check.result}`),
+      },
+    );
+    return verdict;
+  } catch (err) {
+    emitOperationalEvent("error", "github_workflow_gate.build_attestation_failed", {
+      organizationId: gate.organizationId,
+      gateId: gate.id,
+      error: describeOperationalError(err),
+    });
+    return {
+      status: "unavailable",
+      claim: null,
+      checks: [
+        {
+          kind: "subject-digest",
+          result: "skipped",
+          detail: "build-attestation lookup raised an error",
+        },
+      ],
+      trustCeiling: "none",
+    };
+  }
+}
+
+/**
  * Run one scan per discovered package, each against its own baseline, and link
  * every scan back to the gate via `scans.gate_id`. A monorepo release bundle
  * fans out into several packages here; the gate decision later aggregates them
@@ -445,11 +536,27 @@ const GATE_PACKAGE_SCAN_CONCURRENCY = 3;
  */
 async function reviewGatePackages(
   ctx: { env: Cloudflare.Env; executionCtx: ExecutionContext; db: AppDb },
-  args: { gate: WorkflowGateRecord; ownerUserId: string; packages: PreparedGatePackage[] },
+  args: {
+    gate: WorkflowGateRecord;
+    ownerUserId: string;
+    packages: PreparedGatePackage[];
+    config: GithubAppConfig;
+    installationExternalId: string;
+  },
 ): Promise<ReviewedPackage[]> {
   const { env, executionCtx, db } = ctx;
-  const { gate, ownerUserId, packages } = args;
+  const { gate, ownerUserId, packages, config, installationExternalId } = args;
   const organizationId = gate.organizationId;
+
+  // Resolved once for the whole gate: every package in a monorepo bundle was
+  // built by the same run, so they share a head commit. Null when the lookup
+  // fails, which degrades the `source-commit` cross-check to skipped.
+  const headSha = await fetchWorkflowRunHeadSha(
+    config,
+    installationExternalId,
+    gate.repositoryFullName,
+    gate.runId,
+  );
 
   return mapWithConcurrency(packages, GATE_PACKAGE_SCAN_CONCURRENCY, async (pkg) => {
     const { candidate, packageAdapter } = pkg;
@@ -475,6 +582,18 @@ async function reviewGatePackages(
       source: "workflow_gate",
     });
 
+    // Advisory build-attestation verdict, graded before the scan runs so the
+    // pipeline only ever handles the credential-free result. A lookup failure
+    // grades `unavailable` rather than throwing: missing provenance evidence
+    // must never block or fail a gate review.
+    const buildAttestation = await gradeCandidateAttestation({
+      config,
+      installationExternalId,
+      gate,
+      headSha,
+      artifactDigests: candidate.artifactDigests,
+    });
+
     try {
       const result = await runScanPipeline(
         { env, executionCtx, db, session: { userId: ownerUserId } },
@@ -483,6 +602,7 @@ async function reviewGatePackages(
           scanId,
           stageId,
           organizationId,
+          buildAttestation,
           // `source` matches the `workflow_gate` value the D1 row already
           // carries; without it the product counter files every gated scan as
           // "unknown" and the npm/gate split is unreadable.

--- a/server/lib/workflow-gates/prepare.ts
+++ b/server/lib/workflow-gates/prepare.ts
@@ -41,6 +41,12 @@ export interface PreparedGateRelease {
   gate: WorkflowGateRecord;
   /** One entry per distinct package the bundle publishes (≥ 1). */
   packages: PreparedGatePackage[];
+  /**
+   * GitHub's own installation id, resolved here so callers that need a second
+   * authenticated lookup (the build-attestation store) do not have to re-read
+   * the installation row.
+   */
+  installationExternalId: string;
 }
 
 /**
@@ -152,7 +158,7 @@ export async function prepareReleaseCandidatesForGate(
       },
     );
     const packages = prepareBundlePackages(bundle.artifacts);
-    return { gate, packages };
+    return { gate, packages, installationExternalId: installation.installationId };
   } catch (err) {
     const reason =
       err instanceof WorkflowArtifactError

--- a/server/lib/workflow-gates/types.ts
+++ b/server/lib/workflow-gates/types.ts
@@ -54,6 +54,16 @@ export interface PreparedReleaseCandidate {
   ecosystem: string;
   pipelineInput: Record<string, unknown>;
   package: { name: string; version: string };
+  /**
+   * SHA-256 of every artifact in *this* candidate, as the control plane
+   * recomputed it from the downloaded bytes.
+   *
+   * Per candidate, not per bundle: a monorepo release fans out into one scan
+   * per package, and each scan's build-attestation lookup must ask about its
+   * own artifacts only. Attributing a sibling package's attestation to this
+   * scan would be exactly the false corroboration the verdict exists to avoid.
+   */
+  artifactDigests: string[];
 }
 
 /**

--- a/server/types.ts
+++ b/server/types.ts
@@ -5,6 +5,7 @@ export type { ReleaseProvenance } from "./lib/ecosystems/package-adapter";
 export type { StagedArtifactIntegrity } from "./lib/ecosystems/artifact-integrity";
 import type { AiReview } from "./lib/ai-review";
 import type { ReleaseConsistency } from "./lib/scan/release-memory";
+import type { BuildAttestation } from "./lib/build-attestation";
 import type { IntentEnvelope } from "./lib/intent-envelope";
 import type { ScanRiskBreakdown } from "./lib/review/risk";
 import type {
@@ -17,6 +18,7 @@ import type {
 
 export type { PackageJsonDiff, PackageJsonDiffEntry } from "./lib/review";
 export type { IntentEnvelope, IntentEnvelopeTier } from "./lib/intent-envelope";
+export type { BuildAttestation, BuildAttestationStatus } from "./lib/build-attestation";
 
 export type Bindings = Cloudflare.Env;
 
@@ -54,6 +56,9 @@ export interface ScanResult {
   releaseConsistency: ReleaseConsistency;
   // Advisory source-binding classification; never feeds risk or findings.
   intentEnvelope: IntentEnvelope;
+  // Advisory build-attestation verdict graded at the workflow gate; null for
+  // staged publishes. Never feeds risk or findings.
+  buildAttestation: BuildAttestation | null;
   safety: {
     tokenExposedToSandbox: boolean;
     directSandboxNetwork: boolean;

--- a/src/pages/Dashboard/ScanDetail/BuildAttestationSection.tsx
+++ b/src/pages/Dashboard/ScanDetail/BuildAttestationSection.tsx
@@ -1,0 +1,118 @@
+import type { BuildAttestation, BuildAttestationStatus } from "../../../../server/types";
+import { Badge, type BadgeTone } from "../../../components/Badge";
+import { SectionLabel } from "../../../components/Typography";
+
+// Advisory build-provenance row, rendered under the source-binding row it
+// complements: the envelope says *what the release is bound to*, this says
+// *what the build claims, and whether that claim survives comparison*.
+//
+// The verdict never changes risk, so tones stay informational — with one
+// exception. `mismatch` is the only state that asserts a contradiction between
+// an attestation and a binding Drydock authenticated itself, and it earns a
+// severity tone because a maintainer who scrolls past it has missed the point
+// of the section. Scans with no verdict (staged publishes, pre-feature scans)
+// render nothing; the parent passes null.
+export function BuildAttestationSection({ attestation }: { attestation: BuildAttestation }) {
+  const claim = attestation.claim;
+  return (
+    <section class="flex flex-col gap-3 min-w-0">
+      <SectionLabel as="h2">Build provenance</SectionLabel>
+      <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
+        <Badge tone={statusTone(attestation.status)}>{attestation.status}</Badge>
+        <span class="text-[13px] leading-[1.55] text-ink-muted min-w-0">
+          {statusDescription(attestation)}
+        </span>
+      </div>
+
+      {claim ? (
+        <ul class="list-none p-0 m-0 flex flex-col gap-2">
+          {claimRows(claim).map((row) => (
+            <li key={row.label} class="grid grid-cols-[132px_minmax(0,1fr)] gap-3 text-[13px]">
+              <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
+                {row.label}
+              </span>
+              <span class="min-w-0 text-ink-muted break-words">{row.value}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {attestation.checks.length ? (
+        <ul class="list-none p-0 m-0 flex flex-col gap-2">
+          {attestation.checks.map((check, index) => (
+            <li
+              key={`${check.kind}-${index}`}
+              class="grid grid-cols-[132px_minmax(0,1fr)] gap-3 text-[13px]"
+            >
+              <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
+                {check.kind}
+              </span>
+              <span class="min-w-0 break-words">
+                <Badge tone={checkTone(check.result)}>{check.result}</Badge>{" "}
+                <span class="text-ink-muted">{check.detail}</span>
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {attestation.status === "verified" ? (
+        <p class="text-[12px] leading-[1.55] text-ink-subtle m-0">
+          Drydock checks the attestation against bindings it holds independently of the package. It
+          does not validate the Sigstore certificate chain or transparency-log inclusion, so this
+          confirms the build claim agrees with the gate — not that a public trust root vouches for
+          the signer.
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+function statusTone(status: BuildAttestationStatus): BadgeTone {
+  if (status === "verified") return "ok";
+  if (status === "mismatch") return "high";
+  if (status === "partial") return "info";
+  return "neutral";
+}
+
+function checkTone(result: "pass" | "fail" | "skipped"): BadgeTone {
+  if (result === "pass") return "ok";
+  if (result === "fail") return "high";
+  return "neutral";
+}
+
+function statusDescription(attestation: BuildAttestation): string {
+  switch (attestation.status) {
+    case "verified":
+      return "A signed build attestation covers these bytes and agrees with the repository and run the gate bound.";
+    case "partial":
+      return "A build attestation covers these bytes and contradicts nothing, but it could not be fully corroborated.";
+    case "mismatch":
+      return "A build attestation for this release disagrees with what the signed webhook bound. Review before releasing.";
+    case "absent":
+      return "This release publishes no build attestation. Byte continuity from CI is still recorded under Provenance.";
+    case "unavailable":
+      return "The build attestation could not be looked up. Absence of evidence, not evidence of a problem.";
+  }
+}
+
+interface ClaimRow {
+  label: string;
+  value: string;
+}
+
+function claimRows(claim: NonNullable<BuildAttestation["claim"]>): ClaimRow[] {
+  const rows: ClaimRow[] = [{ label: "predicate", value: claim.predicateType }];
+  if (claim.repository) rows.push({ label: "repository", value: claim.repository });
+  if (claim.workflowPath) rows.push({ label: "workflow", value: claim.workflowPath });
+  if (claim.ref) rows.push({ label: "ref", value: claim.ref });
+  if (claim.commit) rows.push({ label: "commit", value: claim.commit });
+  if (claim.runId) {
+    rows.push({
+      label: "run",
+      value: claim.runAttempt ? `${claim.runId} (attempt ${claim.runAttempt})` : claim.runId,
+    });
+  }
+  if (claim.builderId) rows.push({ label: "builder", value: claim.builderId });
+  return rows;
+}

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -21,6 +21,7 @@ import {
 } from "../../../models/scan";
 import type { WorkflowGateDecision } from "../../../models/github-app";
 import { displayedAiResult, type AiReview } from "../../../../server/lib/ai-review/types";
+import { normalizeBuildAttestation } from "../../../../server/lib/build-attestation";
 import { normalizeIntentEnvelope } from "../../../../server/lib/intent-envelope";
 import { createPackageDiff, type DiffEntry } from "../../../../server/lib/review";
 import { Alert } from "../../../components/Alert";
@@ -38,6 +39,7 @@ import { GateContextPanel, GateDecisionDialog, GatePackagesPanel } from "./GateD
 import { StageCommandDialogHost } from "./StageCommandDialog";
 import { DiffWorkbench } from "./DiffWorkbench";
 import { RiskSignalsSection } from "../../../features/review/RiskSignalsSection";
+import { BuildAttestationSection } from "./BuildAttestationSection";
 import { IntentEnvelopeSection } from "./IntentEnvelopeSection";
 import { ReleaseConsistencyNotice } from "./ReleaseConsistencyNotice";
 import { ReleaseRecommendation } from "./ReleaseRecommendation";
@@ -131,6 +133,11 @@ export default function ScanDetailPage() {
   // Older scans have no envelope; the normalizer returns null and the section
   // is simply not rendered.
   const intentEnvelope = useComputed(() => normalizeIntentEnvelope(summary.value.intentEnvelope));
+  // Workflow-gate scans only; staged publishes have no attestation source, so
+  // the normalizer returns null and the section is not rendered.
+  const buildAttestation = useComputed(() =>
+    normalizeBuildAttestation(summary.value.buildAttestation),
+  );
 
   const diffEntries = useComputed<DiffEntry[]>(() => {
     const detail = model.detail.value;
@@ -216,6 +223,7 @@ export default function ScanDetailPage() {
   const isWorkflowGate = model.isWorkflowGate.value;
   const gate = model.gate.value;
   const envelope = intentEnvelope.value;
+  const attestation = buildAttestation.value;
 
   const handleDecisionSubmit = async (decision: ScanDecision, reason: string | null) => {
     await model.setDecision(decision, reason);
@@ -338,6 +346,8 @@ export default function ScanDetailPage() {
             />
 
             {envelope ? <IntentEnvelopeSection envelope={envelope} /> : null}
+
+            {attestation ? <BuildAttestationSection attestation={attestation} /> : null}
 
             {detail.scan.packageName ? (
               <div class="flex flex-col gap-2 border-t border-border pt-3">

--- a/src/pages/Dashboard/ScanDetail/types.ts
+++ b/src/pages/Dashboard/ScanDetail/types.ts
@@ -29,6 +29,9 @@ export interface PersistedSummary {
   // predate the feature or may be malformed; readers re-validate through
   // `normalizeIntentEnvelope`.
   intentEnvelope?: unknown;
+  // Advisory build-attestation verdict. Untyped for the same reason as the
+  // envelope; readers re-validate through `normalizeBuildAttestation`.
+  buildAttestation?: unknown;
 }
 
 export type PersistedFinding = PersistedScanDetail["findings"][number];

--- a/test/build-attestation.test.ts
+++ b/test/build-attestation.test.ts
@@ -1,0 +1,421 @@
+import { describe, expect, it } from "vitest";
+import {
+  derEcdsaSignatureToRaw,
+  dssePae,
+  evaluateBuildAttestation,
+  normalizeBuildAttestation,
+  parseInTotoStatement,
+  parseSigstoreBundle,
+  verifyDsseSignature,
+} from "../server/lib/build-attestation";
+
+import {
+  FIXTURE_COMMIT as COMMIT,
+  FIXTURE_REPOSITORY as REPO,
+  FIXTURE_RUN_ID as RUN_ID,
+  signedBundle as buildSignedBundle,
+  slsaV1Statement as buildSlsaV1Statement,
+  type StatementOverrides,
+} from "./helpers/sigstore-bundle";
+
+// The shared fixtures default to no subjects so each caller states the digests
+// it means; every case here is about one reviewed artifact.
+const ARTIFACT_DIGEST = "b".repeat(64);
+
+function slsaV1Statement(overrides: StatementOverrides = {}) {
+  return buildSlsaV1Statement({ digests: [ARTIFACT_DIGEST], ...overrides });
+}
+
+const signedBundle = buildSignedBundle;
+
+const BINDING = {
+  repositoryFullName: REPO,
+  runId: RUN_ID,
+  headSha: COMMIT,
+  artifactDigests: [ARTIFACT_DIGEST],
+};
+
+// ── DSSE / signature layer ───────────────────────────────────────────────────
+
+describe("DSSE encoding and signature verification", () => {
+  it("encodes PAE with byte lengths, not character lengths", () => {
+    // "é" is two UTF-8 bytes; a character-length implementation writes 1 here
+    // and every real signature stops verifying.
+    const payload = new TextEncoder().encode("é");
+    const pae = new TextDecoder().decode(dssePae("t", payload));
+    expect(pae).toBe("DSSEv1 1 t 2 é");
+  });
+
+  it("verifies a genuinely signed bundle through the certificate's key", async () => {
+    const bundle = await signedBundle(slsaV1Statement());
+    const envelope = parseSigstoreBundle(bundle);
+    expect(envelope).not.toBeNull();
+    await expect(verifyDsseSignature(envelope!)).resolves.toMatchObject({
+      verified: true,
+      algorithm: "ecdsa-p256",
+    });
+  });
+
+  it("does not verify a tampered signature", async () => {
+    const bundle = await signedBundle(slsaV1Statement(), { tamperSignature: true });
+    const outcome = await verifyDsseSignature(parseSigstoreBundle(bundle)!);
+    expect(outcome.verified).toBe(false);
+  });
+
+  it("reports missing verification material instead of throwing", async () => {
+    const bundle = await signedBundle(slsaV1Statement(), { omitCertificate: true });
+    await expect(verifyDsseSignature(parseSigstoreBundle(bundle)!)).resolves.toMatchObject({
+      verified: false,
+      reason: expect.stringContaining("certificate"),
+    });
+  });
+
+  it("reads the v0.2 x509CertificateChain bundle layout", async () => {
+    const bundle = (await signedBundle(slsaV1Statement())) as Record<string, unknown>;
+    const leaf = (bundle.verificationMaterial as { certificate: { rawBytes: string } }).certificate;
+    bundle.verificationMaterial = { x509CertificateChain: { certificates: [leaf] } };
+    await expect(verifyDsseSignature(parseSigstoreBundle(bundle)!)).resolves.toMatchObject({
+      verified: true,
+    });
+  });
+
+  it("rejects malformed bundles rather than partially reading them", () => {
+    expect(parseSigstoreBundle(null)).toBeNull();
+    expect(parseSigstoreBundle({})).toBeNull();
+    expect(parseSigstoreBundle({ dsseEnvelope: { payloadType: "t" } })).toBeNull();
+    // Not base64.
+    expect(
+      parseSigstoreBundle({ dsseEnvelope: { payloadType: "t", payload: "not base64!!" } }),
+    ).toBeNull();
+  });
+
+  it("strips DER integer padding when converting an ECDSA signature", () => {
+    // r = 0x00FF… (padded to stay positive), s = 0x01…
+    const signature = Uint8Array.from([0x30, 0x08, 0x02, 0x02, 0x00, 0xff, 0x02, 0x02, 0x01, 0x02]);
+    const raw = derEcdsaSignatureToRaw(signature, 4);
+    expect(raw).not.toBeNull();
+    expect([...raw!]).toEqual([0, 0, 0, 0xff, 0, 0, 0x01, 0x02]);
+  });
+
+  it("refuses an ECDSA signature whose coordinates overflow the curve width", () => {
+    const signature = Uint8Array.from([0x30, 0x08, 0x02, 0x02, 0x01, 0x02, 0x02, 0x02, 0x03, 0x04]);
+    expect(derEcdsaSignatureToRaw(signature, 1)).toBeNull();
+  });
+});
+
+// ── Statement projection ─────────────────────────────────────────────────────
+
+describe("in-toto statement projection", () => {
+  it("projects SLSA v1 build definitions", () => {
+    const payload = new TextEncoder().encode(JSON.stringify(slsaV1Statement()));
+    expect(parseInTotoStatement(payload)).toEqual({
+      predicateType: "https://slsa.dev/provenance/v1",
+      repository: `https://github.com/${REPO}`,
+      workflowPath: ".github/workflows/release.yml",
+      ref: "refs/heads/main",
+      commit: COMMIT,
+      runId: RUN_ID,
+      runAttempt: "1",
+      builderId: "https://github.com/actions/runner/github-hosted",
+      subjectDigests: [ARTIFACT_DIGEST],
+    });
+  });
+
+  it("projects SLSA v0.2 invocations, splitting the ref off the config-source URI", () => {
+    const statement = {
+      _type: "https://in-toto.io/Statement/v1",
+      subject: [{ name: "pkg:npm/widgets", digest: { sha256: ARTIFACT_DIGEST } }],
+      predicateType: "https://slsa.dev/provenance/v0.2",
+      predicate: {
+        builder: { id: "https://github.com/actions/runner" },
+        buildType: "https://github.com/npm/cli/gha/v2",
+        invocation: {
+          configSource: {
+            uri: `git+https://github.com/${REPO}@refs/heads/main`,
+            digest: { sha1: COMMIT },
+            entryPoint: ".github/workflows/publish.yml",
+          },
+        },
+        metadata: {
+          buildInvocationId: `https://github.com/${REPO}/actions/runs/${RUN_ID}/attempts/2`,
+        },
+      },
+    };
+    const claim = parseInTotoStatement(new TextEncoder().encode(JSON.stringify(statement)));
+    expect(claim).toMatchObject({
+      repository: `https://github.com/${REPO}`,
+      ref: "refs/heads/main",
+      commit: COMMIT,
+      runId: RUN_ID,
+      runAttempt: "2",
+      workflowPath: ".github/workflows/publish.yml",
+    });
+  });
+
+  it("keeps only sha256 subject digests", () => {
+    const statement = {
+      _type: "https://in-toto.io/Statement/v1",
+      predicateType: "https://slsa.dev/provenance/v1",
+      subject: [
+        { name: "a", digest: { sha512: "f".repeat(128) } },
+        { name: "b", digest: { sha256: ARTIFACT_DIGEST.toUpperCase() } },
+        { name: "c", digest: { sha256: "not-hex" } },
+      ],
+      predicate: {},
+    };
+    const claim = parseInTotoStatement(new TextEncoder().encode(JSON.stringify(statement)));
+    expect(claim?.subjectDigests).toEqual([ARTIFACT_DIGEST]);
+  });
+
+  it("rejects payloads that are not in-toto statements", () => {
+    const notAStatement = { _type: "https://example.com/other", predicateType: "x" };
+    expect(
+      parseInTotoStatement(new TextEncoder().encode(JSON.stringify(notAStatement))),
+    ).toBeNull();
+    expect(parseInTotoStatement(new TextEncoder().encode("{ not json"))).toBeNull();
+  });
+});
+
+// ── Verdict ──────────────────────────────────────────────────────────────────
+
+describe("build attestation verdict", () => {
+  it("grades a matching signed attestation as verified", async () => {
+    const bundle = await signedBundle(slsaV1Statement());
+    const verdict = await evaluateBuildAttestation({ status: "ok", bundles: [bundle] }, BINDING);
+
+    expect(verdict.status).toBe("verified");
+    expect(verdict.trustCeiling).toBe("self-consistent");
+    expect(checkResults(verdict)).toEqual({
+      "subject-digest": "pass",
+      repository: "pass",
+      "workflow-run": "pass",
+      "source-commit": "pass",
+      signature: "pass",
+    });
+  });
+
+  it("grades a different repository as a mismatch", async () => {
+    const bundle = await signedBundle(
+      slsaV1Statement({ repository: "https://github.com/attacker/widgets" }),
+    );
+    const verdict = await evaluateBuildAttestation({ status: "ok", bundles: [bundle] }, BINDING);
+
+    expect(verdict.status).toBe("mismatch");
+    expect(checkResults(verdict).repository).toBe("fail");
+    expect(verdict.checks.find((check) => check.kind === "repository")?.detail).toContain(
+      "signed webhook bound",
+    );
+  });
+
+  it("grades an attestation for other bytes as a mismatch", async () => {
+    const bundle = await signedBundle(slsaV1Statement({ digests: ["c".repeat(64)] }));
+    const verdict = await evaluateBuildAttestation({ status: "ok", bundles: [bundle] }, BINDING);
+
+    expect(verdict.status).toBe("mismatch");
+    expect(checkResults(verdict)["subject-digest"]).toBe("fail");
+  });
+
+  it("grades a different workflow run as a mismatch", async () => {
+    const bundle = await signedBundle(slsaV1Statement({ runId: "111" }));
+    const verdict = await evaluateBuildAttestation({ status: "ok", bundles: [bundle] }, BINDING);
+    expect(verdict.status).toBe("mismatch");
+    expect(checkResults(verdict)["workflow-run"]).toBe("fail");
+  });
+
+  it("lets a contradiction outrank an agreeable attestation in the same release", async () => {
+    // A release can carry several attestations. Reporting the good one and
+    // dropping the contradiction would hide exactly the signal this exists for.
+    const good = await signedBundle(slsaV1Statement());
+    const bad = await signedBundle(
+      slsaV1Statement({ repository: "https://github.com/attacker/widgets" }),
+    );
+    const verdict = await evaluateBuildAttestation({ status: "ok", bundles: [good, bad] }, BINDING);
+    expect(verdict.status).toBe("mismatch");
+  });
+
+  it("degrades to partial when the signature cannot be verified", async () => {
+    const bundle = await signedBundle(slsaV1Statement(), { tamperSignature: true });
+    const verdict = await evaluateBuildAttestation({ status: "ok", bundles: [bundle] }, BINDING);
+
+    expect(verdict.status).toBe("partial");
+    expect(verdict.trustCeiling).toBe("none");
+    expect(checkResults(verdict).signature).toBe("fail");
+  });
+
+  it("degrades to partial when the predicate corroborates nothing", async () => {
+    // The npm publish attestation covers the bytes but names no build source,
+    // so a signature alone must not read as a verified build claim.
+    const bundle = await signedBundle(
+      slsaV1Statement({
+        predicateType: "https://github.com/npm/attestation/tree/main/specs/publish/v0.1",
+        predicate: { name: "widgets", version: "1.0.0" },
+      }),
+    );
+    const verdict = await evaluateBuildAttestation({ status: "ok", bundles: [bundle] }, BINDING);
+
+    expect(verdict.status).toBe("partial");
+    expect(checkResults(verdict)).toMatchObject({
+      "subject-digest": "pass",
+      repository: "skipped",
+      "workflow-run": "skipped",
+      signature: "pass",
+    });
+  });
+
+  it("skips the commit check when the run head commit is unknown", async () => {
+    const bundle = await signedBundle(slsaV1Statement());
+    const verdict = await evaluateBuildAttestation(
+      { status: "ok", bundles: [bundle] },
+      {
+        ...BINDING,
+        headSha: null,
+      },
+    );
+    expect(verdict.status).toBe("verified");
+    expect(checkResults(verdict)["source-commit"]).toBe("skipped");
+  });
+
+  it("states how many of the reviewed artifacts an attestation actually covers", async () => {
+    // One attested wheel in a three-wheel release is a true `subject-digest`
+    // pass, but reading it as "this release is attested" would be wrong.
+    const bundle = await signedBundle(slsaV1Statement());
+    const verdict = await evaluateBuildAttestation(
+      { status: "ok", bundles: [bundle] },
+      {
+        ...BINDING,
+        artifactDigests: [ARTIFACT_DIGEST, "d".repeat(64), "e".repeat(64)],
+      },
+    );
+    expect(verdict.status).toBe("verified");
+    expect(verdict.checks.find((check) => check.kind === "subject-digest")?.detail).toContain(
+      "1 of 3 reviewed artifacts",
+    );
+
+    const full = await evaluateBuildAttestation({ status: "ok", bundles: [bundle] }, BINDING);
+    expect(full.checks.find((check) => check.kind === "subject-digest")?.detail).toContain(
+      "all 1 reviewed artifact",
+    );
+  });
+
+  it("separates 'nothing published' from 'could not look'", async () => {
+    await expect(
+      evaluateBuildAttestation({ status: "ok", bundles: [] }, BINDING),
+    ).resolves.toMatchObject({ status: "absent", claim: null });
+
+    await expect(
+      evaluateBuildAttestation({ status: "failed", reason: "HTTP 503" }, BINDING),
+    ).resolves.toMatchObject({ status: "unavailable", claim: null });
+  });
+
+  it("reports unavailable when a returned bundle is unreadable", async () => {
+    const verdict = await evaluateBuildAttestation(
+      { status: "ok", bundles: [{ garbage: true }] },
+      BINDING,
+    );
+    expect(verdict.status).toBe("unavailable");
+  });
+});
+
+function checkResults(verdict: { checks: Array<{ kind: string; result: string }> }) {
+  return Object.fromEntries(verdict.checks.map((check) => [check.kind, check.result]));
+}
+
+// ── Persisted-blob normalization ─────────────────────────────────────────────
+
+describe("normalizeBuildAttestation", () => {
+  const verifiedBlob = {
+    status: "verified",
+    trustCeiling: "self-consistent",
+    claim: {
+      predicateType: "https://slsa.dev/provenance/v1",
+      repository: `https://github.com/${REPO}`,
+      workflowPath: ".github/workflows/release.yml",
+      ref: "refs/heads/main",
+      commit: COMMIT,
+      runId: RUN_ID,
+      runAttempt: "1",
+      builderId: "https://github.com/actions/runner/github-hosted",
+      subjectDigests: [ARTIFACT_DIGEST],
+    },
+    checks: [
+      { kind: "subject-digest", result: "pass", detail: "d" },
+      { kind: "repository", result: "pass", detail: "d" },
+      { kind: "signature", result: "pass", detail: "d" },
+    ],
+  };
+
+  it("round-trips a real verdict", async () => {
+    const bundle = await signedBundle(slsaV1Statement());
+    const verdict = await evaluateBuildAttestation({ status: "ok", bundles: [bundle] }, BINDING);
+    expect(normalizeBuildAttestation(JSON.parse(JSON.stringify(verdict)))).toEqual(verdict);
+  });
+
+  it("accepts a well-formed verified blob", () => {
+    expect(normalizeBuildAttestation(verifiedBlob)?.status).toBe("verified");
+  });
+
+  it("refuses a verified status with no supporting checks", () => {
+    // The whole point of the normalizer: a status must not outlive its evidence.
+    expect(normalizeBuildAttestation({ ...verifiedBlob, checks: [] })).toBeNull();
+    expect(normalizeBuildAttestation({ status: "verified" })).toBeNull();
+  });
+
+  it("refuses a verified status whose signature never passed", () => {
+    expect(
+      normalizeBuildAttestation({
+        ...verifiedBlob,
+        checks: verifiedBlob.checks.map((check) =>
+          check.kind === "signature" ? { ...check, result: "fail" } : check,
+        ),
+      }),
+    ).toBeNull();
+  });
+
+  it("refuses a verified status with no independent corroboration", () => {
+    expect(
+      normalizeBuildAttestation({
+        ...verifiedBlob,
+        checks: verifiedBlob.checks.filter((check) => check.kind !== "repository"),
+      }),
+    ).toBeNull();
+  });
+
+  it("refuses a verified status whose trust ceiling was downgraded", () => {
+    expect(normalizeBuildAttestation({ ...verifiedBlob, trustCeiling: "none" })).toBeNull();
+  });
+
+  it("refuses a mismatch that contradicts nothing", () => {
+    expect(normalizeBuildAttestation({ ...verifiedBlob, status: "mismatch" })).toBeNull();
+  });
+
+  it("refuses absent/unavailable blobs that carry a claim", () => {
+    expect(normalizeBuildAttestation({ ...verifiedBlob, status: "absent" })).toBeNull();
+    expect(normalizeBuildAttestation({ ...verifiedBlob, status: "unavailable" })).toBeNull();
+  });
+
+  it("reads pre-feature and malformed values as null", () => {
+    expect(normalizeBuildAttestation(undefined)).toBeNull();
+    expect(normalizeBuildAttestation(null)).toBeNull();
+    expect(normalizeBuildAttestation([])).toBeNull();
+    expect(normalizeBuildAttestation({ status: "nonsense" })).toBeNull();
+  });
+
+  it("drops claim fields that are not well-formed", () => {
+    const normalized = normalizeBuildAttestation({
+      ...verifiedBlob,
+      claim: {
+        ...verifiedBlob.claim,
+        commit: "not-a-commit",
+        runId: "not-a-run",
+        repository: "::::",
+        subjectDigests: [ARTIFACT_DIGEST, "short"],
+      },
+    });
+    expect(normalized?.claim).toMatchObject({
+      commit: null,
+      runId: null,
+      repository: null,
+      subjectDigests: [ARTIFACT_DIGEST],
+    });
+  });
+});

--- a/test/build-attestation.test.ts
+++ b/test/build-attestation.test.ts
@@ -222,15 +222,16 @@ describe("build attestation verdict", () => {
     expect(checkResults(verdict)["workflow-run"]).toBe("fail");
   });
 
-  it("lets a contradiction outrank an agreeable attestation in the same release", async () => {
-    // A release can carry several attestations. Reporting the good one and
-    // dropping the contradiction would hide exactly the signal this exists for.
+  it("keeps verification monotonic when older attestations cover the same bytes", async () => {
+    // Digest lookups span repository history. A retry can produce the same
+    // bytes in a newer run, so an older attestation must not downgrade a
+    // matching current-run attestation.
     const good = await signedBundle(slsaV1Statement());
     const bad = await signedBundle(
       slsaV1Statement({ repository: "https://github.com/attacker/widgets" }),
     );
     const verdict = await evaluateBuildAttestation({ status: "ok", bundles: [good, bad] }, BINDING);
-    expect(verdict.status).toBe("mismatch");
+    expect(verdict.status).toBe("verified");
   });
 
   it("degrades to partial when the signature cannot be verified", async () => {

--- a/test/helpers/sigstore-bundle.ts
+++ b/test/helpers/sigstore-bundle.ts
@@ -1,0 +1,160 @@
+// Signed Sigstore-bundle fixtures, shared by the build-attestation unit specs
+// and the workflow-gate worker specs.
+//
+// The bundles are *really* signed: a fresh P-256 key signs the actual DSSE PAE
+// bytes, and its public key is carried in a DER certificate the parser has to
+// walk exactly as it walks a Fulcio leaf. A fixture with a faked signature
+// would leave the PAE encoding, the certificate walk, and the DER→P1363
+// signature conversion untested — and each of those failing silently degrades
+// every real attestation to `partial` instead of breaking loudly.
+
+import { dssePae } from "../../server/lib/build-attestation";
+
+export const FIXTURE_REPOSITORY = "acme/widgets";
+export const FIXTURE_RUN_ID = "8675309";
+export const FIXTURE_COMMIT = "a".repeat(40);
+
+function der(tag: number, content: Uint8Array): Uint8Array {
+  const length =
+    content.length < 0x80
+      ? Uint8Array.from([content.length])
+      : content.length < 0x100
+        ? Uint8Array.from([0x81, content.length])
+        : Uint8Array.from([0x82, content.length >> 8, content.length & 0xff]);
+  const out = new Uint8Array(1 + length.length + content.length);
+  out[0] = tag;
+  out.set(length, 1);
+  out.set(content, 1 + length.length);
+  return out;
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(parts.reduce((total, part) => total + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+  return out;
+}
+
+/**
+ * Wrap a real SPKI in a certificate shell with the field layout RFC 5280
+ * specifies, so the parser has to count past `[0] version`, serialNumber,
+ * signature, issuer, validity and subject to reach it. The skipped fields are
+ * placeholders — the parser never reads their contents.
+ */
+export function certificateWrapping(spki: Uint8Array): Uint8Array {
+  const placeholder = der(0x30, new Uint8Array(0));
+  const tbs = der(
+    0x30,
+    concat(
+      der(0xa0, der(0x02, Uint8Array.from([2]))), // [0] version v3
+      der(0x02, Uint8Array.from([1])), // serialNumber
+      placeholder, // signature
+      placeholder, // issuer
+      placeholder, // validity
+      placeholder, // subject
+      spki,
+    ),
+  );
+  return der(0x30, concat(tbs, placeholder, der(0x03, Uint8Array.from([0x00]))));
+}
+
+/** WebCrypto emits raw r||s; Sigstore carries DER. Re-encode for the fixture. */
+export function rawEcdsaSignatureToDer(raw: Uint8Array): Uint8Array {
+  const half = raw.length / 2;
+  const encodeInteger = (value: Uint8Array) => {
+    let start = 0;
+    while (start < value.length - 1 && value[start] === 0) start += 1;
+    const magnitude = value.subarray(start);
+    // DER integers are signed: a leading high bit needs a zero pad.
+    const padded = magnitude[0] & 0x80 ? concat(Uint8Array.from([0]), magnitude) : magnitude;
+    return der(0x02, padded);
+  };
+  return der(0x30, concat(encodeInteger(raw.subarray(0, half)), encodeInteger(raw.subarray(half))));
+}
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+export interface StatementOverrides {
+  repository?: string;
+  runId?: string;
+  commit?: string;
+  digests?: string[];
+  predicateType?: string;
+  predicate?: unknown;
+}
+
+export function slsaV1Statement(overrides: StatementOverrides = {}) {
+  const repository = overrides.repository ?? `https://github.com/${FIXTURE_REPOSITORY}`;
+  const runId = overrides.runId ?? FIXTURE_RUN_ID;
+  return {
+    _type: "https://in-toto.io/Statement/v1",
+    subject: (overrides.digests ?? []).map((digest, index) => ({
+      name: `pkg:generic/artifact-${index}`,
+      digest: { sha256: digest },
+    })),
+    predicateType: overrides.predicateType ?? "https://slsa.dev/provenance/v1",
+    predicate: overrides.predicate ?? {
+      buildDefinition: {
+        buildType: "https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1",
+        externalParameters: {
+          workflow: {
+            ref: "refs/heads/main",
+            repository,
+            path: ".github/workflows/release.yml",
+          },
+        },
+        resolvedDependencies: [
+          {
+            uri: `git+${repository}@refs/heads/main`,
+            digest: { gitCommit: overrides.commit ?? FIXTURE_COMMIT },
+          },
+        ],
+      },
+      runDetails: {
+        builder: { id: "https://github.com/actions/runner/github-hosted" },
+        metadata: { invocationId: `${repository}/actions/runs/${runId}/attempts/1` },
+      },
+    },
+  };
+}
+
+export async function signedBundle(
+  statement: unknown,
+  options: { tamperSignature?: boolean; omitCertificate?: boolean } = {},
+): Promise<Record<string, unknown>> {
+  const keyPair = (await crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, [
+    "sign",
+    "verify",
+  ])) as CryptoKeyPair;
+  const spki = new Uint8Array(await crypto.subtle.exportKey("spki", keyPair.publicKey));
+
+  const payload = new TextEncoder().encode(JSON.stringify(statement));
+  const payloadType = "application/vnd.in-toto+json";
+  const rawSignature = new Uint8Array(
+    await crypto.subtle.sign(
+      { name: "ECDSA", hash: "SHA-256" },
+      keyPair.privateKey,
+      dssePae(payloadType, payload),
+    ),
+  );
+  if (options.tamperSignature) rawSignature[0] ^= 0xff;
+
+  return {
+    mediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
+    verificationMaterial: options.omitCertificate
+      ? {}
+      : { certificate: { rawBytes: toBase64(certificateWrapping(spki)) } },
+    dsseEnvelope: {
+      payload: toBase64(payload),
+      payloadType,
+      signatures: [{ sig: toBase64(rawEcdsaSignatureToDer(rawSignature)) }],
+    },
+  };
+}

--- a/test/helpers/sigstore-bundle.ts
+++ b/test/helpers/sigstore-bundle.ts
@@ -44,7 +44,7 @@ function concat(...parts: Uint8Array[]): Uint8Array {
  * signature, issuer, validity and subject to reach it. The skipped fields are
  * placeholders — the parser never reads their contents.
  */
-export function certificateWrapping(spki: Uint8Array): Uint8Array {
+function certificateWrapping(spki: Uint8Array): Uint8Array {
   const placeholder = der(0x30, new Uint8Array(0));
   const tbs = der(
     0x30,
@@ -62,7 +62,7 @@ export function certificateWrapping(spki: Uint8Array): Uint8Array {
 }
 
 /** WebCrypto emits raw r||s; Sigstore carries DER. Re-encode for the fixture. */
-export function rawEcdsaSignatureToDer(raw: Uint8Array): Uint8Array {
+function rawEcdsaSignatureToDer(raw: Uint8Array): Uint8Array {
   const half = raw.length / 2;
   const encodeInteger = (value: Uint8Array) => {
     let start = 0;

--- a/test/workers/workflow-gate-job.test.ts
+++ b/test/workers/workflow-gate-job.test.ts
@@ -20,9 +20,12 @@ import {
   workflowGateCallbackWindowMs,
 } from "../../server/lib/workflow-gate-job";
 import worker from "../../server";
+import { normalizeBuildAttestation } from "../../server/lib/build-attestation";
+import { FIXTURE_COMMIT, signedBundle, slsaV1Statement } from "../helpers/sigstore-bundle";
 
 const WEBHOOK_SECRET = "webhook-secret-value-1234567890";
 const REPORT_BASE_URL = "https://drydock.test";
+const GATE_REPOSITORY = "octo/example";
 
 const originalFetch = globalThis.fetch;
 
@@ -275,6 +278,15 @@ interface ScenarioOpts {
   // HTTP status the mocked GitHub deployment-protection callback returns; a
   // non-2xx makes the decision POST throw so the failure path can be exercised.
   decisionStatus?: number;
+  // Build-attestation evidence the mocked GitHub attestation store serves for
+  // the reviewed wheel. Omitted, the store answers 404 (the common case), which
+  // grades `absent`.
+  attestation?: {
+    /** Repository the attestation claims it built from. */
+    repository?: string;
+    /** Head commit the mocked `/actions/runs/:id` lookup reports. */
+    headSha?: string;
+  };
 }
 
 async function buildScenario(runId: number, opts: ScenarioOpts) {
@@ -308,6 +320,22 @@ async function buildScenario(runId: number, opts: ScenarioOpts) {
     { path: wheelPath, body: wheelBytes },
   ]);
 
+  // Signed with a real key over the real DSSE PAE bytes, and subject-bound to
+  // the digest the gate recomputes from the wheel — so the verdict exercises
+  // the whole chain rather than a stub.
+  const attestationBundle = opts.attestation
+    ? await signedBundle(
+        slsaV1Statement({
+          digests: [declaredSha],
+          runId: String(runId),
+          commit: opts.attestation.headSha ?? FIXTURE_COMMIT,
+          // Defaults to the repository the seeded gate binds, so the happy path
+          // corroborates and only an explicit override contradicts.
+          repository: opts.attestation.repository ?? `https://github.com/${GATE_REPOSITORY}`,
+        }),
+      )
+    : null;
+
   const decisionCalls: DecisionCall[] = [];
   const fetchSpy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = input instanceof Request ? input : new Request(input, init);
@@ -320,6 +348,13 @@ async function buildScenario(runId: number, opts: ScenarioOpts) {
         token: "ghs_install_token",
         expires_at: "2099-01-01T00:00:00Z",
       });
+    }
+    if (request.url.includes(`/attestations/sha256:`)) {
+      if (!attestationBundle) return new Response("{}", { status: 404 });
+      return Response.json({ attestations: [{ bundle: attestationBundle }] });
+    }
+    if (request.url.endsWith(`/actions/runs/${runId}`)) {
+      return Response.json({ head_sha: opts.attestation?.headSha ?? FIXTURE_COMMIT });
     }
     if (request.url.includes(`/actions/runs/${runId}/artifacts`)) {
       return new Response(
@@ -446,7 +481,7 @@ describe("gate callback timeout classification", () => {
 describe("workflow gate scan attachment", () => {
   test("claims a pending gate only when the observed scan link still matches", async () => {
     const seeded = await seedGateForTest({
-      installationExternalId: "9210",
+      installationExternalId: "9230",
       repositoryId: 72011,
       runId: 16161,
     });
@@ -530,6 +565,113 @@ describe("executeWorkflowGateJob", () => {
     expect(types).toContain("github_workflow_gate.reviewed");
     expect(types).not.toContain("github_workflow_gate.approved");
     expect(types).not.toContain("github_workflow_gate.rejected");
+  });
+
+  test("records a verified build attestation on the gate's scan", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9210",
+      repositoryId: 72010,
+      runId: 7801,
+    });
+    await buildScenario(7801, { digestMatches: true, attestation: {} });
+    const ctx = buildCtxWithGateway();
+    const sandboxEnv = buildEnv(buildConfigBindings(), buildLoaderMock().binding);
+    const db = createDb(env.DB);
+
+    await executeWorkflowGateJob(
+      sandboxEnv,
+      ctx,
+      { kind: "workflow_gate", organizationId: seeded.organizationId, gateId: seeded.gateId },
+      db,
+    );
+
+    const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    const persisted = await getScan(db, gate!.scanId!, seeded.organizationId);
+    const summary = persisted?.scan.summaryJson as { buildAttestation?: unknown };
+    const verdict = normalizeBuildAttestation(summary.buildAttestation);
+
+    expect(verdict?.status).toBe("verified");
+    expect(verdict?.trustCeiling).toBe("self-consistent");
+    expect(verdict?.claim?.repository).toBe(`https://github.com/${GATE_REPOSITORY}`);
+    // The attestation covers the digest the control plane recomputed, and the
+    // run + commit it claims are the ones the signed webhook and the run lookup
+    // reported — none of which the package controls.
+    expect(
+      Object.fromEntries(verdict!.checks.map((check) => [check.kind, check.result])),
+    ).toMatchObject({
+      "subject-digest": "pass",
+      repository: "pass",
+      "workflow-run": "pass",
+      "source-commit": "pass",
+      signature: "pass",
+    });
+  });
+
+  test("records a mismatch when the attestation names a different repository", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9231",
+      repositoryId: 72011,
+      runId: 7802,
+    });
+    await buildScenario(7802, {
+      digestMatches: true,
+      attestation: { repository: "https://github.com/attacker/example" },
+    });
+    const ctx = buildCtxWithGateway();
+    const sandboxEnv = buildEnv(buildConfigBindings(), buildLoaderMock().binding);
+    const db = createDb(env.DB);
+
+    await executeWorkflowGateJob(
+      sandboxEnv,
+      ctx,
+      { kind: "workflow_gate", organizationId: seeded.organizationId, gateId: seeded.gateId },
+      db,
+    );
+
+    const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    const persisted = await getScan(db, gate!.scanId!, seeded.organizationId);
+    const summary = persisted?.scan.summaryJson as { buildAttestation?: unknown };
+    const verdict = normalizeBuildAttestation(summary.buildAttestation);
+
+    expect(verdict?.status).toBe("mismatch");
+    // Advisory only: a contradicted attestation is surfaced, never auto-blocked.
+    // The gate still waits on a human, and the risk grade is untouched.
+    expect(gate?.status).toBe("pending");
+    expect(gate?.decision).toBeNull();
+  });
+
+  test("grades the attestation absent when the repository publishes none", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9232",
+      repositoryId: 72012,
+      runId: 7803,
+    });
+    await buildScenario(7803, { digestMatches: true });
+    const ctx = buildCtxWithGateway();
+    const sandboxEnv = buildEnv(buildConfigBindings(), buildLoaderMock().binding);
+    const db = createDb(env.DB);
+
+    await executeWorkflowGateJob(
+      sandboxEnv,
+      ctx,
+      { kind: "workflow_gate", organizationId: seeded.organizationId, gateId: seeded.gateId },
+      db,
+    );
+
+    const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    const persisted = await getScan(db, gate!.scanId!, seeded.organizationId);
+    const summary = persisted?.scan.summaryJson as { buildAttestation?: unknown };
+
+    // No attestation is the common case and must stay quiet: the review
+    // completes normally and the gate is still recommended for approval.
+    expect(normalizeBuildAttestation(summary.buildAttestation)?.status).toBe("absent");
+    expect(persisted?.scan.status).toBe("complete");
+    const reviewed = await gateEventMetadata(
+      seeded.organizationId,
+      seeded.gateId,
+      "github_workflow_gate.reviewed",
+    );
+    expect(reviewed?.recommendation).toBe("approved");
   });
 
   test("rejects the deployment when an artifact path is unsafe", async () => {

--- a/test/workers/workflow-gate-job.test.ts
+++ b/test/workers/workflow-gate-job.test.ts
@@ -1,6 +1,7 @@
 import { createExecutionContext, env } from "cloudflare:test";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { generateKeyPairSync } from "node:crypto";
+import { compress } from "snappyjs";
 import { createDb } from "../../server/db/client";
 import { ensurePersonalOrganization } from "../../server/db/organizations";
 import { createScanJob, getScan } from "../../server/db/scans";
@@ -286,6 +287,10 @@ interface ScenarioOpts {
     repository?: string;
     /** Head commit the mocked `/actions/runs/:id` lookup reports. */
     headSha?: string;
+    /** Serve the bundle through GitHub's null-bundle + Snappy URL shape. */
+    bundleViaUrl?: boolean;
+    /** Return a streamed list response beyond the control-plane byte cap. */
+    oversizedListResponse?: boolean;
   };
 }
 
@@ -337,6 +342,10 @@ async function buildScenario(runId: number, opts: ScenarioOpts) {
     : null;
 
   const decisionCalls: DecisionCall[] = [];
+  const bundleUrl = "https://tmaproduction.blob.core.windows.net/attestations/test/bundle.json.sn";
+  const compressedBundle = attestationBundle
+    ? compress(new TextEncoder().encode(JSON.stringify(attestationBundle)))
+    : null;
   const fetchSpy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const request = input instanceof Request ? input : new Request(input, init);
     if (request.url.endsWith("/deployment_protection_rule")) {
@@ -351,7 +360,31 @@ async function buildScenario(runId: number, opts: ScenarioOpts) {
     }
     if (request.url.includes(`/attestations/sha256:`)) {
       if (!attestationBundle) return new Response("{}", { status: 404 });
-      return Response.json({ attestations: [{ bundle: attestationBundle }] });
+      if (opts.attestation?.oversizedListResponse) {
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new Uint8Array(700 * 1024));
+              controller.enqueue(new Uint8Array(700 * 1024));
+              controller.close();
+            },
+          }),
+          { status: 200 },
+        );
+      }
+      return Response.json({
+        attestations: [
+          opts.attestation?.bundleViaUrl
+            ? { bundle: null, bundle_url: bundleUrl }
+            : { bundle: attestationBundle },
+        ],
+      });
+    }
+    if (request.url === bundleUrl && compressedBundle) {
+      return new Response(compressedBundle, {
+        status: 200,
+        headers: { "content-type": "application/x-snappy" },
+      });
     }
     if (request.url.endsWith(`/actions/runs/${runId}`)) {
       return Response.json({ head_sha: opts.attestation?.headSha ?? FIXTURE_COMMIT });
@@ -573,7 +606,7 @@ describe("executeWorkflowGateJob", () => {
       repositoryId: 72010,
       runId: 7801,
     });
-    await buildScenario(7801, { digestMatches: true, attestation: {} });
+    const scenario = await buildScenario(7801, { digestMatches: true, attestation: {} });
     const ctx = buildCtxWithGateway();
     const sandboxEnv = buildEnv(buildConfigBindings(), buildLoaderMock().binding);
     const db = createDb(env.DB);
@@ -605,6 +638,67 @@ describe("executeWorkflowGateJob", () => {
       "source-commit": "pass",
       signature: "pass",
     });
+    const attestationRequest = scenario.fetchSpy.mock.calls
+      .map(([input, init]) => (input instanceof Request ? input : new Request(input, init)))
+      .find((request) => request.url.includes("/attestations/sha256:"));
+    expect(attestationRequest?.url).toContain("predicate_type=provenance");
+    expect(attestationRequest?.url).toContain("per_page=8");
+  });
+
+  test("records a verified URL-backed Snappy attestation", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9216",
+      repositoryId: 72016,
+      runId: 7804,
+    });
+    await buildScenario(7804, {
+      digestMatches: true,
+      attestation: { bundleViaUrl: true },
+    });
+    const ctx = buildCtxWithGateway();
+    const sandboxEnv = buildEnv(buildConfigBindings(), buildLoaderMock().binding);
+    const db = createDb(env.DB);
+
+    await executeWorkflowGateJob(
+      sandboxEnv,
+      ctx,
+      { kind: "workflow_gate", organizationId: seeded.organizationId, gateId: seeded.gateId },
+      db,
+    );
+
+    const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    const persisted = await getScan(db, gate!.scanId!, seeded.organizationId);
+    const summary = persisted?.scan.summaryJson as { buildAttestation?: unknown };
+    expect(normalizeBuildAttestation(summary.buildAttestation)?.status).toBe("verified");
+  });
+
+  test("bounds the attestation list before materializing it", async () => {
+    const seeded = await seedGateForTest({
+      installationExternalId: "9217",
+      repositoryId: 72017,
+      runId: 7805,
+    });
+    await buildScenario(7805, {
+      digestMatches: true,
+      attestation: { oversizedListResponse: true },
+    });
+    const ctx = buildCtxWithGateway();
+    const sandboxEnv = buildEnv(buildConfigBindings(), buildLoaderMock().binding);
+    const db = createDb(env.DB);
+
+    await executeWorkflowGateJob(
+      sandboxEnv,
+      ctx,
+      { kind: "workflow_gate", organizationId: seeded.organizationId, gateId: seeded.gateId },
+      db,
+    );
+
+    const gate = await getGateForOrganization(db, seeded.organizationId, seeded.gateId);
+    const persisted = await getScan(db, gate!.scanId!, seeded.organizationId);
+    const summary = persisted?.scan.summaryJson as { buildAttestation?: unknown };
+    const verdict = normalizeBuildAttestation(summary.buildAttestation);
+    expect(verdict?.status).toBe("unavailable");
+    expect(verdict?.checks[0]?.detail).toContain("size cap");
   });
 
   test("records a mismatch when the attestation names a different repository", async () => {


### PR DESCRIPTION
## Summary

Add an advisory build-provenance verdict to workflow-gate scans by parsing GitHub Sigstore bundles, grading SLSA claims against independently bound artifact digests, repository, run, and commit, and carrying the result through persistence, reports, and the scan-detail UI. Harden retrieval with bounded streaming, short deadlines, provenance filtering, URL-backed Snappy bundle support, and monotonic selection across historical attestations.

## Trust boundary

GitHub App credentials remain in the control plane; only credential-free parsed bundles reach the verdict layer, package bytes remain unexecuted, and attestation results cannot lower deterministic risk or auto-approve a gate.

## Verification

`pnpm run knip`; `pnpm run verify` (lint, format check, typecheck, and full Vitest suite); focused build-attestation and workflow-gate suites: 59 tests passed.

## Documentation

Updated `docs/build-attestation.md`, `docs/workflow-gates.md`, `docs/self-hosting.md`, and the docs index with permissions, trust ceiling, failure posture, and operator behavior.

## UI evidence

Not captured; the new Build provenance section is data-dependent on a completed workflow-gate scan and is covered by the Worker integration tests.
