### PR TITLE
Offer the share link only for approved releases

### DIFF
--- a/docs/public-reports.md
+++ b/docs/public-reports.md
@@ -17,6 +17,13 @@ a shields.io badge per package and an opt-in public threat feed.
   `scan.share_revoked`) and surface in the organization audit log.
 - The UI entry point is the **Share** button on the scan detail header; the
   public page renders at `/reports/:token`.
+- That button only appears once the release is decided `publish` — a public
+  report is the organization vouching for a release, and an undecided or blocked
+  one has nothing to vouch for yet. A release that already has a link keeps the
+  button whatever it is decided afterwards, so flipping approved → blocked never
+  strands a live link out of reach of revoke. The API itself is unchanged and
+  still accepts any completed scan; the rule is a product default, not a
+  security boundary.
 
 ## Public endpoints (no auth)
 

--- a/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
+++ b/src/pages/Dashboard/ScanDetail/ScanDetailChrome.tsx
@@ -1,22 +1,41 @@
+import type { ReadonlySignal } from "@preact/signals";
 import { getDashboardReturnUrl } from "../../../lib/query-state";
 import { formatDateTime } from "../../../lib/format";
 import { reportExportFilename } from "../../../../server/lib/scan/report-export";
-import type { PersistedScanDetail } from "../../../models/scan";
+import type { PersistedScanDetail, PublicShareInfo } from "../../../models/scan";
 import { Alert } from "../../../components/Alert";
 import { Badge, severityTone } from "../../../components/Badge";
 import { Button, LinkButton } from "../../../components/Button";
 import { LoadingLine, MonoDetail, MonoLabel } from "../../../components/Typography";
+
+/**
+ * Whether the header offers the Share action.
+ *
+ * A public report is the organization vouching for a release, so the offer only
+ * appears once someone has approved it — an undecided or blocked release has
+ * nothing to vouch for yet. An already-shared release keeps the action whatever
+ * it was decided afterwards: flipping approved → blocked would otherwise strand
+ * a live public link with no way to reach the revoke button.
+ */
+export function shouldOfferShare(
+  decision: string | null | undefined,
+  hasShareLink: boolean,
+): boolean {
+  return decision === "publish" || hasShareLink;
+}
 
 export function ScanDetailHeader({
   detail,
   onDecideClick,
   onDeleteClick,
   onShareClick,
+  shareSignal,
 }: {
   detail?: PersistedScanDetail | null;
   onDecideClick?: () => void;
   onDeleteClick?: () => void;
   onShareClick?: () => void;
+  shareSignal?: ReadonlySignal<PublicShareInfo | null>;
 } = {}) {
   const decision = detail?.scan.decision;
   const decidedAt = detail?.scan.decidedAt;
@@ -64,9 +83,7 @@ export function ScanDetailHeader({
             </div>
           ) : null}
           {detail && isComplete && onShareClick ? (
-            <Button variant="ghost" size="sm" onClick={onShareClick}>
-              Share
-            </Button>
+            <ShareAction decision={decision} shareSignal={shareSignal} onClick={onShareClick} />
           ) : null}
           {detail && isComplete ? (
             <LinkButton
@@ -91,6 +108,28 @@ export function ScanDetailHeader({
         </div>
       ) : null}
     </header>
+  );
+}
+
+/**
+ * Own boundary component so the share signal's subscription stays here: enable
+ * and revoke round-trips re-render this button, not the whole workbench. That
+ * is why `model.share` is deliberately kept out of the scan detail payload.
+ */
+function ShareAction({
+  decision,
+  shareSignal,
+  onClick,
+}: {
+  decision: string | null | undefined;
+  shareSignal?: ReadonlySignal<PublicShareInfo | null>;
+  onClick: () => void;
+}) {
+  if (!shouldOfferShare(decision, shareSignal?.value != null)) return null;
+  return (
+    <Button variant="ghost" size="sm" onClick={onClick}>
+      Share
+    </Button>
   );
 }
 

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -282,6 +282,7 @@ export default function ScanDetailPage() {
           detail?.scan.status === "failed" ? () => (deleteDialogOpen.value = true) : undefined
         }
         onShareClick={onShareClick}
+        shareSignal={model.share}
       />
 
       {error ? <Alert tone="critical">{error}</Alert> : null}

--- a/test/scan-detail-share-action.test.ts
+++ b/test/scan-detail-share-action.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "vitest";
+import { shouldOfferShare } from "../src/pages/Dashboard/ScanDetail/ScanDetailChrome";
+
+describe("shouldOfferShare", () => {
+  test("an approved release offers the link", () => {
+    expect(shouldOfferShare("publish", false)).toBe(true);
+  });
+
+  test("an undecided release does not", () => {
+    expect(shouldOfferShare(null, false)).toBe(false);
+    expect(shouldOfferShare(undefined, false)).toBe(false);
+  });
+
+  test("a blocked release does not", () => {
+    expect(shouldOfferShare("no_publish", false)).toBe(false);
+  });
+
+  test("an existing link keeps the action reachable so it can be revoked", () => {
+    // Approved → shared → decision flipped to blocked. Hiding the action here
+    // would leave a live public report with no way to reach revoke.
+    expect(shouldOfferShare("no_publish", true)).toBe(true);
+    expect(shouldOfferShare(null, true)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

A public report is the organization vouching for a release, so the **Share** button on the scan detail header no longer appears while the release is undecided or blocked. A release that already has a link keeps the button whatever it is decided afterwards — without that carve-out, approving → sharing → flipping to blocked would strand a live public report with no reachable revoke button. The gate lives in an exported `shouldOfferShare` predicate, rendered through a small `ShareAction` boundary component so the share signal's subscription stays off the workbench.

Worth a look before merging: this also removes the only UI path for listing a *blocked* release on the public threat feed, which is arguably the feed's highest-value entry — `buildBadgePayload` renders a red `<version> blocked` badge for exactly that case. Say the word and I'll narrow the rule to undecided-only.

## Trust boundary

None enforced here. The `POST /api/v1/scans/:id/share` endpoint is untouched and still accepts any completed scan; this is a product default, not a security boundary, and the doc note says so.

## Verification

`pnpm run verify` (lint + format + typecheck + tests) passes. New `test/scan-detail-share-action.test.ts` covers approved / undecided / blocked / already-shared.

## Documentation

`docs/public-reports.md` — the new rule is documented under "Share flow".

## UI evidence

No screenshot: the change only removes a button from the header on undecided and blocked releases, and the visibility rule is covered by the unit tests above.