### PR TITLE
Open Worker-route links outside the SPA router

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -11,6 +11,11 @@ This file is only a compact implementation map.
 - Tailwind CSS v4 via `@tailwindcss/vite`.
 - Tokens live in `src/style.css` under `@theme`; dark mode follows `prefers-color-scheme`.
 - State uses `@preact/signals`; `useState`/`useReducer` are banned by oxlint.
+- Links to Worker routes (`/public/*`, `/api/*`) need `target="_blank"` (plus
+  `rel="noreferrer"`) or `download`. `preact-iso` intercepts same-origin anchor
+  clicks, and those paths have no `<Route>`, so a plain anchor renders the SPA
+  404 instead of reaching the server. `test/server-route-links.test.ts` guards
+  the literal-href case.
 
 ## Primitives
 

--- a/src/pages/Dashboard/ScanDetail/ShareDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/ShareDialog.tsx
@@ -114,7 +114,12 @@ export function ShareDialog({
             />
             <span>
               List publicly — the report appears in the discoverable{" "}
-              <a href="/public/threat-feed.json" class="text-ink-muted underline hover:text-ink">
+              <a
+                href="/public/threat-feed.json"
+                target="_blank"
+                rel="noreferrer"
+                class="text-ink-muted underline hover:text-ink"
+              >
                 threat-feed.json
               </a>{" "}
               index that security partners consume and powers the package&apos;s status badge, not

--- a/src/pages/PublicReport/index.tsx
+++ b/src/pages/PublicReport/index.tsx
@@ -263,7 +263,12 @@ export default function PublicReportPage() {
             The signed attestation covers the exact JSON served for this link: its subject digest is
             the SHA-256 of the report bytes, signed with Drydock's Ed25519 key (DSSE envelope, key
             published at{" "}
-            <a href="/public/attestation-key" class="text-ink-muted underline hover:text-ink">
+            <a
+              href="/public/attestation-key"
+              target="_blank"
+              rel="noreferrer"
+              class="text-ink-muted underline hover:text-ink"
+            >
               /public/attestation-key
             </a>
             ).

--- a/test/server-route-links.test.ts
+++ b/test/server-route-links.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+
+// `/public/*` and `/api/*` are Worker routes, not `preact-iso` routes. A plain
+// same-origin anchor to one of them is intercepted by the router's click
+// handler, which finds no matching `<Route>` and renders the SPA 404 instead of
+// hitting the server — the link only works on a hard load or paste. The router
+// skips links that carry a `target` or `download` attribute, so one of those is
+// required. Reported from production: the attestation-key link on
+// `/reports/:token` 404'd when clicked.
+const srcDir = fileURLToPath(new URL("../src", import.meta.url));
+
+function tsxFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return tsxFiles(full);
+    return entry.isFile() && entry.name.endsWith(".tsx") ? [full] : [];
+  });
+}
+
+/** The JSX opening tag containing `index`, e.g. `<a href="/public/x" class="y">`. */
+function enclosingTag(source: string, index: number): string {
+  const start = source.lastIndexOf("<", index);
+  const end = source.indexOf(">", index);
+  return start === -1 || end === -1 ? "" : source.slice(start, end + 1);
+}
+
+describe("links to Worker routes", () => {
+  // Only literal hrefs are checked; an href built from a variable is invisible
+  // here, so this is a guard against the common shape, not a proof.
+  const serverHref = /href=\{?[`"]\/(public|api)\//g;
+
+  test("do not client-route into the SPA 404", () => {
+    const offenders: string[] = [];
+    for (const file of tsxFiles(srcDir)) {
+      const source = readFileSync(file, "utf8");
+      for (const match of source.matchAll(serverHref)) {
+        const tag = enclosingTag(source, match.index);
+        if (!/\btarget=/.test(tag) && !/\bdownload\b/.test(tag)) {
+          offenders.push(`${file.slice(srcDir.length + 1)}: ${tag.replace(/\s+/g, " ")}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  test("the guard recognises an unguarded link", () => {
+    const sample = '<a href="/public/attestation-key" class="underline">key</a>';
+    const tag = enclosingTag(sample, sample.search(serverHref));
+    expect(tag).toBe('<a href="/public/attestation-key" class="underline">');
+    expect(/\btarget=/.test(tag)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Clicking the `/public/attestation-key` link on a public report (`/reports/:token`) rendered the SPA 404: `preact-iso` intercepts same-origin anchor clicks and `/public/*` is a Worker route with no `<Route>`, so the navigation never reached the server. That link and the `/public/threat-feed.json` link in the share dialog now carry `target="_blank" rel="noreferrer"`, which the router skips, and a source-level test guards the literal-href case for `/public/*` and `/api/*`. The existing download buttons were already safe — the router also skips links with a `download` attribute.

## Trust boundary

None. Both links point at public, credential-free endpoints and no request handling changed.

## Verification

`pnpm run verify` (lint, format, typecheck, tests) passes. The new `test/server-route-links.test.ts` was confirmed to fail against the pre-fix sources, listing exactly the two offending anchors.

## Documentation

`docs/ui.md` — added the Worker-route link convention to the stack notes.

## UI evidence

Not applicable; the only visual change is that these two links now open in a new tab.