### PR TITLE
Offer GitHub sign-in when the operator configures it

### DIFF
--- a/docs/product-analytics.md
+++ b/docs/product-analytics.md
@@ -103,23 +103,23 @@ low-volume one out of the dataset.
 
 ## Events
 
-| event                      | emitted from                  | answers                                     |
-| -------------------------- | ----------------------------- | ------------------------------------------- |
-| `scan.queued`              | `POST /api/v1/scans`          | queued → completed drop-off                 |
-| `scan.completed`           | `recordCompletion`            | volume, latency, risk mix, finding counts   |
-| `scan.failed`              | `executeScanJob`, gate runner | failure rate by error code                  |
-| `scan.discarded`           | `executeScanJob`              | queued scans retired before they ever ran   |
-| `scan.decided`             | both decision paths           | time-to-decision; agreement with the grade  |
-| `ai_review.finished`       | `maybeRunAiReview`            | reviewer health — the silent-failure rate   |
-| `ai_review.decided`        | both decision paths           | feedback by assessment and reviewer version |
-| `npm_connection.validated` | npm connection validation     | onboarding funnel                           |
-| `public_diff.viewed`       | `loadRequestedDiff`           | growth-loop traffic, cache hit rate         |
+| event                      | emitted from                  | answers                                              |
+| -------------------------- | ----------------------------- | ---------------------------------------------------- |
+| `scan.queued`              | `POST /api/v1/scans`          | queued → completed drop-off                          |
+| `scan.completed`           | `recordCompletion`            | volume, latency, risk mix, finding counts            |
+| `scan.failed`              | `executeScanJob`, gate runner | failure rate by error code                           |
+| `scan.discarded`           | `executeScanJob`              | queued scans retired before they ever ran            |
+| `scan.decided`             | both decision paths           | time-to-decision; agreement with the grade           |
+| `ai_review.finished`       | `maybeRunAiReview`            | reviewer health — the silent-failure rate            |
+| `ai_review.decided`        | both decision paths           | feedback by assessment and reviewer version          |
+| `npm_connection.validated` | npm connection validation     | onboarding funnel                                    |
+| `public_diff.viewed`       | `loadRequestedDiff`           | growth-loop traffic, cache hit rate                  |
 | `user.signed_up`           | Better Auth user-create hook  | acquisition, by method (`email_password` / `github`) |
-| `organization.created`     | `POST /api/v1/organizations`  | teams, excluding lazy personal workspaces   |
-| `integration.connected`    | npm / GitHub / Slack connect  | activation, by integration kind             |
-| `workflow_gate.opened`     | `deployment_protection_rule`  | gate volume                                 |
-| `workflow_gate.reviewed`   | gate runner                   | recommendation mix; review latency          |
-| `workflow_gate.decided`    | human route + auto-block path | approval rate, human vs automatic           |
+| `organization.created`     | `POST /api/v1/organizations`  | teams, excluding lazy personal workspaces            |
+| `integration.connected`    | npm / GitHub / Slack connect  | activation, by integration kind                      |
+| `workflow_gate.opened`     | `deployment_protection_rule`  | gate volume                                          |
+| `workflow_gate.reviewed`   | gate runner                   | recommendation mix; review latency                   |
+| `workflow_gate.decided`    | human route + auto-block path | approval rate, human vs automatic                    |
 
 `scan.failed` fires only on a terminal failure, so a scan that succeeds on retry
 is not filed as a failure. Both the npm queue path and the workflow-gate runner

--- a/docs/product-analytics.md
+++ b/docs/product-analytics.md
@@ -114,7 +114,7 @@ low-volume one out of the dataset.
 | `ai_review.decided`        | both decision paths           | feedback by assessment and reviewer version |
 | `npm_connection.validated` | npm connection validation     | onboarding funnel                           |
 | `public_diff.viewed`       | `loadRequestedDiff`           | growth-loop traffic, cache hit rate         |
-| `user.signed_up`           | Better Auth user-create hook  | acquisition — the funnel's numerator        |
+| `user.signed_up`           | Better Auth user-create hook  | acquisition, by method (`email_password` / `github`) |
 | `organization.created`     | `POST /api/v1/organizations`  | teams, excluding lazy personal workspaces   |
 | `integration.connected`    | npm / GitHub / Slack connect  | activation, by integration kind             |
 | `workflow_gate.opened`     | `deployment_protection_rule`  | gate volume                                 |

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -134,14 +134,21 @@ Optional integrations:
   (`GET /api/auth-config` reports availability). This is identity-only OAuth —
   the grant shares the user's profile and verified email, requests no repo
   scopes, and never installs the GitHub App; workflow-gate installation stays a
-  separate step. Any GitHub OAuth app works; the workflow-gate GitHub App's own
-  client id/secret can be reused if the app enables "Request user
+  separate step. Any GitHub OAuth app works. The workflow-gate GitHub App's own
+  client id/secret can be reused only if the app both enables "Request user
   authorization" with `<BETTER_AUTH_URL>/api/auth/callback/github` as a
-  callback URL. Accounts created this way arrive with a provider-verified
-  email, so they skip the email-verification wall. Note that GitHub sign-in is
-  authenticated by GitHub (including any 2FA on the GitHub account); Drydock's
-  own TOTP challenge applies to password sign-ins, and the TOTP step-up on
-  release decisions is unaffected by sign-in method.
+  callback URL **and** grants the "Email addresses" (read-only) account
+  permission — GitHub Apps ignore OAuth scope parameters, and without that
+  permission the email lookup fails, so sign-ins with a private email are
+  rejected and the rest arrive unverified. Social sign-ins are never asked for
+  email verification (the wall applies to the email sign-in route only), and a
+  provider-verified email also satisfies the verified-email checks elsewhere
+  (e.g. accepting an invitation). Implicit account linking is disabled: a
+  GitHub sign-in whose email already belongs to a password account fails back
+  to the login page instead of attaching to that account, because the Drydock
+  TOTP challenge guards only password sign-ins and linking by email match
+  would let an inbox takeover skip it. The TOTP step-up on release decisions
+  is unaffected by sign-in method.
 - Slack: `SLACK_CLIENT_ID` and `SLACK_CLIENT_SECRET`
 
 Do not commit `.dev.vars`, private keys, tokens, or generated credential

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -129,6 +129,19 @@ Optional integrations:
 - GitHub App: `GITHUB_APP_ID`, `GITHUB_APP_SLUG`, `GITHUB_APP_CLIENT_ID`,
   `GITHUB_APP_CLIENT_SECRET`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_APP_WEBHOOK_SECRET`,
   and optional `GITHUB_APP_STATE_SECRET` (otherwise `BETTER_AUTH_SECRET` is used)
+- GitHub sign-in: `GITHUB_OAUTH_CLIENT_ID` and `GITHUB_OAUTH_CLIENT_SECRET`.
+  When both are set, the login and register pages offer "Continue with GitHub"
+  (`GET /api/auth-config` reports availability). This is identity-only OAuth —
+  the grant shares the user's profile and verified email, requests no repo
+  scopes, and never installs the GitHub App; workflow-gate installation stays a
+  separate step. Any GitHub OAuth app works; the workflow-gate GitHub App's own
+  client id/secret can be reused if the app enables "Request user
+  authorization" with `<BETTER_AUTH_URL>/api/auth/callback/github` as a
+  callback URL. Accounts created this way arrive with a provider-verified
+  email, so they skip the email-verification wall. Note that GitHub sign-in is
+  authenticated by GitHub (including any 2FA on the GitHub account); Drydock's
+  own TOTP challenge applies to password sign-ins, and the TOTP step-up on
+  release decisions is unaffected by sign-in method.
 - Slack: `SLACK_CLIENT_ID` and `SLACK_CLIENT_SECRET`
 
 Do not commit `.dev.vars`, private keys, tokens, or generated credential

--- a/docs/two-factor-auth.md
+++ b/docs/two-factor-auth.md
@@ -38,6 +38,11 @@ swaps to a "Verify it's you" step that accepts either:
 - a TOTP code → `POST /api/auth/two-factor/verify-totp`, or
 - a backup recovery code → `POST /api/auth/two-factor/verify-backup-code`.
 
+The challenge guards password sign-ins. GitHub sign-in (when the operator
+configures it, see [`self-hosting.md`](./self-hosting.md)) is authenticated by
+GitHub itself, including any 2FA on the GitHub account; the release-decision
+TOTP step-up below applies regardless of how the session was created.
+
 Only after the second factor succeeds is a full session cookie set. The client model logic lives
 in `src/models/auth.ts` (`signIn` returns `{ twoFactorRequired }`; `completeTwoFactorSignIn`)
 and `src/models/two-factor.ts`.

--- a/docs/two-factor-auth.md
+++ b/docs/two-factor-auth.md
@@ -41,7 +41,10 @@ swaps to a "Verify it's you" step that accepts either:
 The challenge guards password sign-ins. GitHub sign-in (when the operator
 configures it, see [`self-hosting.md`](./self-hosting.md)) is authenticated by
 GitHub itself, including any 2FA on the GitHub account; the release-decision
-TOTP step-up below applies regardless of how the session was created.
+TOTP step-up below applies regardless of how the session was created. To keep
+this split safe, implicit account linking is disabled: a social sign-in can
+never attach to an existing password account by email match, so it cannot be
+used to skip an enrolled TOTP challenge.
 
 Only after the second factor succeeds is a full session cookie set. The client model logic lives
 in `src/models/auth.ts` (`signIn` returns `{ twoFactorRequired }`; `completeTwoFactorSignIn`)

--- a/server/env.d.ts
+++ b/server/env.d.ts
@@ -31,6 +31,12 @@ declare global {
       SEND_EMAIL?: SendEmailBinding;
       EMAIL_FROM_ADDRESS?: string;
       EMAIL_FROM_NAME?: string;
+      // GitHub sign-in (Better Auth social provider). Identity-only OAuth —
+      // authorizing never installs anything on a repo or org. The GitHub App's
+      // own client id/secret may be reused here once the app's "Request user
+      // authorization" callback includes /api/auth/callback/github.
+      GITHUB_OAUTH_CLIENT_ID?: string;
+      GITHUB_OAUTH_CLIENT_SECRET?: string;
       GITHUB_APP_ID?: string;
       GITHUB_APP_SLUG?: string;
       GITHUB_APP_CLIENT_ID?: string;

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,7 +5,7 @@ import { pruneExpiredAuthRows } from "./db/auth-retention";
 import { listAutoDiscoveryNpmConnections } from "./db/npm-connections";
 import { getOrganizationOwnerUserId } from "./db/organizations";
 import { RateLimitError, enforceRateLimit } from "./db/rate-limit";
-import { createAuth, getAuthSession } from "./lib/auth";
+import { createAuth, getAuthSession, isGithubSignInEnabled } from "./lib/auth";
 import { rateLimitResponse } from "./lib/platform/http";
 import { allowInsecureLocalRegistry } from "./lib/ecosystems/npm/connection";
 import { isPackageDiffDetailPath, rewritePackageDiffMetadata } from "./lib/public-diff/page";
@@ -262,6 +262,12 @@ function authIpLimit(path: string): { bucket: string; max: number; windowMs: num
   return null;
 }
 
+// Which optional sign-in methods this deployment offers. Anonymous on purpose
+// (registered ahead of the session gate below): the login and register pages
+// need it before any session exists. Deployment configuration only — no user
+// data, no secrets.
+app.get("/api/auth-config", (c) => c.json({ githubSignIn: isGithubSignInEnabled(c.env) }));
+
 app.use("/api/*", async (c, next) => {
   const session = await getAuthSession(c.get("auth"), c.req.raw);
   if (!session) return c.json({ error: "unauthorized" }, 401);
@@ -301,6 +307,7 @@ app.get("/api", (c) =>
         "GET /public/threat-feed.json (feed-listed shared reviews); GET /public/badge/:ecosystem/:package (shields.io endpoint badge)",
       slack:
         "GET /api/v1/slack; POST /api/v1/slack/connect; GET /api/v1/slack/callback; GET /api/v1/slack/channels; PUT /api/v1/slack/channel; PATCH /api/v1/slack; DELETE /api/v1/slack; POST /api/v1/slack/test",
+      authConfig: "GET /api/auth-config (anonymous; which optional sign-in methods are offered)",
       health: "GET /api/health",
     },
     auth: "Better Auth is required for every non-auth API endpoint except the anonymous /api/public/* package-diff endpoints (public registry data only) and /public/reports/* (a share token is the capability; the owning organization opted in per scan).",

--- a/server/lib/auth/index.ts
+++ b/server/lib/auth/index.ts
@@ -88,6 +88,16 @@ function isLocalAuthUrl(url: string | undefined): boolean {
   }
 }
 
+/**
+ * GitHub sign-in is identity-only OAuth (profile + verified email) — it never
+ * installs the GitHub App and grants no repo access. Enabled by the operator
+ * via a dedicated credential pair so a deployment can run the workflow-gate
+ * App without offering social sign-in, or vice versa.
+ */
+export function isGithubSignInEnabled(env: Cloudflare.Env): boolean {
+  return Boolean(env.GITHUB_OAUTH_CLIENT_ID && env.GITHUB_OAUTH_CLIENT_SECRET);
+}
+
 export function createAuth(env: Cloudflare.Env) {
   if (!env.DB) throw new Error("DB binding is required for Better Auth");
   if (!env.BETTER_AUTH_SECRET) throw new Error("BETTER_AUTH_SECRET is required");
@@ -95,6 +105,7 @@ export function createAuth(env: Cloudflare.Env) {
   const db = createDb(env.DB);
   const trustedOrigins = env.BETTER_AUTH_URL ? [env.BETTER_AUTH_URL] : [];
   const emailVerificationEnabled = Boolean(env.SEND_EMAIL) && !isLocalAuthUrl(env.BETTER_AUTH_URL);
+  const githubSignIn = isGithubSignInEnabled(env);
   return betterAuth({
     appName: "Drydock",
     secret: env.BETTER_AUTH_SECRET,
@@ -124,20 +135,35 @@ export function createAuth(env: Cloudflare.Env) {
       maxPasswordLength: 256,
       ...(nativeScryptAvailable ? { password: nativeScryptPassword } : {}),
     },
+    ...(githubSignIn
+      ? {
+          socialProviders: {
+            github: {
+              clientId: env.GITHUB_OAUTH_CLIENT_ID as string,
+              clientSecret: env.GITHUB_OAUTH_CLIENT_SECRET as string,
+            },
+          },
+        }
+      : {}),
     databaseHooks: {
       user: {
         create: {
           // Top of the funnel. Fires once per account row, so it counts real
           // signups rather than sign-in attempts. Nothing identifying is
           // recorded — not the email, not the user id (see the privacy posture
-          // in lib/platform/analytics.ts). `emailVerificationEnabled` rides
-          // along as the outcome because an unverified account cannot reach a
-          // scan, and that is the first place the funnel leaks.
-          after: async () => {
+          // in lib/platform/analytics.ts). The outcome tracks whether the
+          // account can reach a scan immediately: an unverified password
+          // account cannot, and that is the first place the funnel leaks.
+          // Method is inferred rather than read from context: GitHub supplies
+          // a provider-verified email, so social accounts are the only ones
+          // created with emailVerified already true; password sign-ups always
+          // start unverified regardless of whether verification is enforced.
+          after: async (createdUser) => {
+            const social = Boolean((createdUser as { emailVerified?: boolean }).emailVerified);
             recordProductEvent(env, {
               name: "user.signed_up",
-              method: "email_password",
-              outcome: emailVerificationEnabled ? "verification_pending" : "active",
+              method: social ? "github" : "email_password",
+              outcome: social || !emailVerificationEnabled ? "active" : "verification_pending",
             });
           },
         },

--- a/server/lib/auth/index.ts
+++ b/server/lib/auth/index.ts
@@ -145,6 +145,18 @@ export function createAuth(env: Cloudflare.Env) {
           },
         }
       : {}),
+    account: {
+      accountLinking: {
+        // Never link a social sign-in to an existing password account by email
+        // match. Better Auth's implicit linking would sign the caller straight
+        // in on the OAuth callback — and the twoFactor plugin only challenges
+        // /sign-in/email, so implicit linking would let anyone who controls
+        // the account's email address bypass an enrolled TOTP challenge.
+        // Disabled, a GitHub sign-in against an already-registered email fails
+        // closed to the login page; the owner signs in with their password.
+        disableImplicitLinking: true,
+      },
+    },
     databaseHooks: {
       user: {
         create: {
@@ -158,6 +170,9 @@ export function createAuth(env: Cloudflare.Env) {
           // a provider-verified email, so social accounts are the only ones
           // created with emailVerified already true; password sign-ups always
           // start unverified regardless of whether verification is enforced.
+          // Known skew: a GitHub account whose email arrives unverified (e.g.
+          // the provider app lacks the Email addresses read permission, see
+          // docs/self-hosting.md) is counted as email_password.
           after: async (createdUser) => {
             const social = Boolean((createdUser as { emailVerified?: boolean }).emailVerified);
             recordProductEvent(env, {

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -95,12 +95,22 @@ const SessionModel = createModel(() => {
 
     // Starts the GitHub OAuth redirect. Better Auth returns the provider's
     // authorize URL; the browser navigates there and comes back through
-    // /api/auth/callback/github, which redirects to callbackURL signed in.
-    async signInWithGitHub(returnTo?: string): Promise<void> {
+    // /api/auth/callback/github, which redirects to callbackURL signed in. On
+    // failure it lands on errorPath (the page that started the flow) with
+    // ?error=…, keeping returnTo so a retry still ends up in the right place.
+    async signInWithGitHub(
+      returnTo?: string,
+      errorPath: "/login" | "/register" = "/login",
+    ): Promise<void> {
+      const destination = returnTo ?? "/dashboard";
+      const errorCallbackURL =
+        destination === "/dashboard"
+          ? `${errorPath}?error=github`
+          : `${errorPath}?error=github&returnTo=${encodeURIComponent(destination)}`;
       const data = await authPost("/api/auth/sign-in/social", {
         provider: "github",
-        callbackURL: returnTo ?? "/dashboard",
-        errorCallbackURL: "/login?error=github",
+        callbackURL: destination,
+        errorCallbackURL,
       });
       const url = data && typeof data === "object" ? (data as { url?: unknown }).url : null;
       if (typeof url !== "string" || !url) {

--- a/src/models/auth.ts
+++ b/src/models/auth.ts
@@ -93,6 +93,22 @@ const SessionModel = createModel(() => {
       await this.load();
     },
 
+    // Starts the GitHub OAuth redirect. Better Auth returns the provider's
+    // authorize URL; the browser navigates there and comes back through
+    // /api/auth/callback/github, which redirects to callbackURL signed in.
+    async signInWithGitHub(returnTo?: string): Promise<void> {
+      const data = await authPost("/api/auth/sign-in/social", {
+        provider: "github",
+        callbackURL: returnTo ?? "/dashboard",
+        errorCallbackURL: "/login?error=github",
+      });
+      const url = data && typeof data === "object" ? (data as { url?: unknown }).url : null;
+      if (typeof url !== "string" || !url) {
+        throw new AuthError("GitHub sign-in could not start");
+      }
+      window.location.assign(url);
+    },
+
     async signUp(name: string, email: string, password: string, returnTo?: string): Promise<void> {
       await authPost("/api/auth/sign-up/email", {
         name,
@@ -126,6 +142,38 @@ const SessionModel = createModel(() => {
 });
 
 export const sessionModel = new SessionModel();
+
+// Which optional sign-in methods the deployment offers (GET /api/auth-config,
+// anonymous). Defaults stay false on any failure so the password form — which
+// needs no configuration — is never blocked on this lookup.
+const AuthConfigModel = createModel(() => {
+  const githubSignIn = signal(false);
+  const loaded = signal(false);
+
+  return {
+    githubSignIn,
+    loaded,
+
+    async load(): Promise<void> {
+      if (this.loaded.peek()) return;
+      try {
+        const res = await fetch("/api/auth-config", {
+          credentials: "same-origin",
+          headers: { accept: "application/json" },
+        });
+        if (res.ok) {
+          const data = (await res.json()) as { githubSignIn?: boolean } | null;
+          this.githubSignIn.value = Boolean(data?.githubSignIn);
+        }
+      } catch {
+        // Offline or misconfigured — leave every optional method hidden.
+      }
+      this.loaded.value = true;
+    },
+  };
+});
+
+export const authConfigModel = new AuthConfigModel();
 
 async function fetchSession(): Promise<AuthSession | null> {
   const res = await fetch("/api/auth/get-session", {

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -211,7 +211,11 @@ export default function LoginPage() {
           Sign in to review held releases and revisit saved reports.
         </Muted>
 
-        <SocialSignIn returnTo={returnTo} onError={(message) => (error.value = message)} />
+        <SocialSignIn
+          returnTo={returnTo}
+          errorPath="/login"
+          onError={(message) => (error.value = message)}
+        />
 
         <form class="flex flex-col gap-4 mt-2" onSubmit={onSubmit}>
           <Field label="Email" for="login-email">

--- a/src/pages/Auth/Login.tsx
+++ b/src/pages/Auth/Login.tsx
@@ -12,6 +12,7 @@ import { Field } from "../../components/Field";
 import { Input } from "../../components/Input";
 import { PageShell } from "../../components/PageShell";
 import { Eyebrow, Muted } from "../../components/Typography";
+import { SocialSignIn } from "./SocialSignIn";
 
 export default function LoginPage() {
   const location = useLocation();
@@ -20,7 +21,13 @@ export default function LoginPage() {
   const code = useSignal("");
   const useBackup = useSignal(false);
   const step = useSignal<"credentials" | "twoFactor">("credentials");
-  const error = useSignal<string | null>(null);
+  // A failed or cancelled OAuth redirect lands back here with ?error=…
+  // (the errorCallbackURL passed when the redirect started).
+  const error = useSignal<string | null>(
+    location.query.error
+      ? "GitHub sign-in didn't complete. Try again, or use your email and password."
+      : null,
+  );
   const loading = useSignal(false);
   const needsVerificationFor = useSignal<string | null>(null);
   const resending = useSignal(false);
@@ -203,6 +210,8 @@ export default function LoginPage() {
         <Muted class="text-[13px] m-0">
           Sign in to review held releases and revisit saved reports.
         </Muted>
+
+        <SocialSignIn returnTo={returnTo} onError={(message) => (error.value = message)} />
 
         <form class="flex flex-col gap-4 mt-2" onSubmit={onSubmit}>
           <Field label="Email" for="login-email">

--- a/src/pages/Auth/Register.tsx
+++ b/src/pages/Auth/Register.tsx
@@ -19,7 +19,13 @@ export default function RegisterPage() {
   const name = useSignal("");
   const email = useSignal("");
   const password = useSignal("");
-  const error = useSignal<string | null>(null);
+  // A failed or cancelled OAuth redirect lands back here with ?error=…
+  // (the errorCallbackURL passed when the redirect started).
+  const error = useSignal<string | null>(
+    location.query.error
+      ? "GitHub sign-in didn't complete. Try again, or create an account with email."
+      : null,
+  );
   const loading = useSignal(false);
   const verificationSentTo = useSignal<string | null>(null);
   const resending = useSignal(false);
@@ -122,7 +128,11 @@ export default function RegisterPage() {
           live.
         </Muted>
 
-        <SocialSignIn returnTo={returnTo} onError={(message) => (error.value = message)} />
+        <SocialSignIn
+          returnTo={returnTo}
+          errorPath="/register"
+          onError={(message) => (error.value = message)}
+        />
 
         <form class="flex flex-col gap-4 mt-2" onSubmit={onSubmit}>
           <Field label="Name" for="register-name">

--- a/src/pages/Auth/Register.tsx
+++ b/src/pages/Auth/Register.tsx
@@ -12,6 +12,7 @@ import { Field } from "../../components/Field";
 import { Input } from "../../components/Input";
 import { PageShell } from "../../components/PageShell";
 import { Eyebrow, Muted } from "../../components/Typography";
+import { SocialSignIn } from "./SocialSignIn";
 
 export default function RegisterPage() {
   const location = useLocation();
@@ -120,6 +121,8 @@ export default function RegisterPage() {
           Create a workspace, connect npm or a GitHub gate, and review held releases before they go
           live.
         </Muted>
+
+        <SocialSignIn returnTo={returnTo} onError={(message) => (error.value = message)} />
 
         <form class="flex flex-col gap-4 mt-2" onSubmit={onSubmit}>
           <Field label="Name" for="register-name">

--- a/src/pages/Auth/SocialSignIn.tsx
+++ b/src/pages/Auth/SocialSignIn.tsx
@@ -15,9 +15,12 @@ import { Muted } from "../../components/Typography";
  */
 export function SocialSignIn({
   returnTo,
+  errorPath,
   onError,
 }: {
   returnTo: string;
+  /** The page that starts the flow, so a failed redirect lands back on it. */
+  errorPath: "/login" | "/register";
   onError: (message: string) => void;
 }) {
   const starting = useSignal(false);
@@ -29,7 +32,7 @@ export function SocialSignIn({
   const onGitHub = async () => {
     starting.value = true;
     try {
-      await sessionModel.signInWithGitHub(returnTo);
+      await sessionModel.signInWithGitHub(returnTo, errorPath);
       // The browser is navigating to GitHub; leave the button disabled.
     } catch (err) {
       starting.value = false;

--- a/src/pages/Auth/SocialSignIn.tsx
+++ b/src/pages/Auth/SocialSignIn.tsx
@@ -1,0 +1,60 @@
+import { useEffect } from "preact/hooks";
+import { useSignal } from "@preact/signals";
+import { Show } from "@preact/signals/utils";
+import { authConfigModel, sessionModel } from "../../models/auth";
+import { errorMessage } from "../../models/api";
+import { Button } from "../../components/Button";
+import { Muted } from "../../components/Typography";
+
+/**
+ * "Continue with GitHub" plus the `or` divider, rendered only when the
+ * deployment has the OAuth credential pair configured. Identity-only: the
+ * authorize grant shares the user's profile and verified email, never repo
+ * access — installing the GitHub App for workflow gates stays a separate,
+ * optional step.
+ */
+export function SocialSignIn({
+  returnTo,
+  onError,
+}: {
+  returnTo: string;
+  onError: (message: string) => void;
+}) {
+  const starting = useSignal(false);
+
+  useEffect(() => {
+    void authConfigModel.load();
+  }, []);
+
+  const onGitHub = async () => {
+    starting.value = true;
+    try {
+      await sessionModel.signInWithGitHub(returnTo);
+      // The browser is navigating to GitHub; leave the button disabled.
+    } catch (err) {
+      starting.value = false;
+      onError(errorMessage(err));
+    }
+  };
+
+  return (
+    <Show when={authConfigModel.githubSignIn}>
+      <div class="flex flex-col gap-3 mt-2">
+        <Button variant="secondary" disabled={starting} onClick={onGitHub}>
+          <Show when={starting} fallback="Continue with GitHub">
+            Redirecting to GitHub…
+          </Show>
+        </Button>
+        <Muted class="text-[12px] m-0">
+          GitHub shares your name and verified email. Nothing is installed and no repository access
+          is granted.
+        </Muted>
+        <div class="flex items-center gap-3" aria-hidden>
+          <span class="h-px flex-1 bg-border" />
+          <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-ink-subtle">or</span>
+          <span class="h-px flex-1 bg-border" />
+        </div>
+      </div>
+    </Show>
+  );
+}

--- a/test/workers/auth-config.test.ts
+++ b/test/workers/auth-config.test.ts
@@ -53,8 +53,11 @@ describe("auth config", () => {
     expect(url.hostname).toBe("github.com");
     expect(url.pathname).toBe("/login/oauth/authorize");
     expect(url.searchParams.get("client_id")).toBe("Iv1.test-client-id");
-    // Identity-only authorization: no repo or org scopes ever.
-    expect(url.searchParams.get("scope") ?? "").not.toContain("repo");
+    // Identity-only authorization: profile + verified email, no repo or org
+    // scopes ever. Asserted exactly so a scope widening cannot slip through.
+    expect(url.searchParams.get("scope")).toBe("read:user user:email");
+    // The callback operators must whitelist on the OAuth app.
+    expect(url.searchParams.get("redirect_uri")).toBe(`${ORIGIN}/api/auth/callback/github`);
   });
 
   test("POST /api/auth/sign-in/social is rejected when no provider is configured", async () => {

--- a/test/workers/auth-config.test.ts
+++ b/test/workers/auth-config.test.ts
@@ -1,0 +1,80 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { describe, expect, test } from "vitest";
+import worker from "../../server";
+
+const ORIGIN = "http://example.com";
+
+const githubEnv = {
+  ...env,
+  GITHUB_OAUTH_CLIENT_ID: "Iv1.test-client-id",
+  GITHUB_OAUTH_CLIENT_SECRET: "test-client-secret",
+};
+
+describe("auth config", () => {
+  test("GET /api/auth-config is anonymous and reports github sign-in off by default", async () => {
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request(`${ORIGIN}/api/auth-config`), env, ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ githubSignIn: false });
+  });
+
+  test("GET /api/auth-config reports github sign-in when the credential pair is set", async () => {
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(new Request(`${ORIGIN}/api/auth-config`), githubEnv, ctx);
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ githubSignIn: true });
+  });
+
+  test("POST /api/auth/sign-in/social starts the GitHub authorize redirect when enabled", async () => {
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request(`${ORIGIN}/api/auth/sign-in/social`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json",
+          origin: ORIGIN,
+        },
+        body: JSON.stringify({ provider: "github", callbackURL: "/dashboard" }),
+      }),
+      githubEnv,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { url?: string; redirect?: boolean };
+    expect(data.redirect).toBe(true);
+    const url = new URL(data.url ?? "");
+    expect(url.hostname).toBe("github.com");
+    expect(url.pathname).toBe("/login/oauth/authorize");
+    expect(url.searchParams.get("client_id")).toBe("Iv1.test-client-id");
+    // Identity-only authorization: no repo or org scopes ever.
+    expect(url.searchParams.get("scope") ?? "").not.toContain("repo");
+  });
+
+  test("POST /api/auth/sign-in/social is rejected when no provider is configured", async () => {
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(
+      new Request(`${ORIGIN}/api/auth/sign-in/social`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          accept: "application/json",
+          origin: ORIGIN,
+        },
+        body: JSON.stringify({ provider: "github", callbackURL: "/dashboard" }),
+      }),
+      env,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(res.status).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
## What

Second slice of the onboarding-funnel work: remove the signup walls for the audience that already lives on GitHub.

- **GitHub social sign-in** via Better Auth, enabled by a dedicated `GITHUB_OAUTH_CLIENT_ID` / `GITHUB_OAUTH_CLIENT_SECRET` pair (`server/lib/auth/index.ts`). Identity-only OAuth (`read:user user:email`, asserted exactly in tests) — **authorizing never installs the GitHub App and grants no repo access**; workflow-gate installation stays a separate, optional step. The workflow-gate App's own client credentials can be reused if it enables user authorization with the `/api/auth/callback/github` callback and the "Email addresses" read permission (documented).
- **Anonymous `GET /api/auth-config`** reports which optional sign-in methods the deployment offers; it's registered ahead of the session gate and returns deployment configuration only. The login/register pages use it to conditionally render **Continue with GitHub** (shared `SocialSignIn` block with an explicit "nothing is installed, no repository access" line).
- **GitHub accounts skip the email-verification wall**: they arrive with a provider-verified email, so the funnel's first measured leak (`verification_pending`) doesn't apply to them. `user.signed_up` now records the method (`github` / `email_password`).
- OAuth failures land back on the page that started the flow with `returnTo` preserved and a readable message.

## Security posture

- **Implicit account linking is disabled** (`account.accountLinking.disableImplicitLinking: true`). better-auth 1.6.25 would otherwise link a GitHub sign-in to an existing verified password account by email match and issue a session on the callback — and its twoFactor plugin only challenges `/sign-in/email`, so an inbox/GitHub takeover could bypass an enrolled Drydock TOTP challenge. With linking disabled, a GitHub sign-in against an already-registered email fails closed to the login page. Found by the adversarial self-review pass (verified against the installed dist, not guessed); fixed in the second commit.
- Drydock's TOTP challenge continues to guard password sign-ins; GitHub sign-ins are authenticated by GitHub (including its 2FA). The release-decision TOTP **step-up is unaffected by sign-in method**.
- `/api/auth/sign-in/social` is covered by the existing sign-in IP rate-limit bucket, the origin check, and Better Auth's state parameter. `normalizeAuthReturnTo` already rejects absolute/protocol-relative redirect targets.

## Not in this PR (deliberate)

Session-on-signup for password users (dropping `requireEmailVerification` and gating only sensitive actions on verification) is a broader security-posture change across routes — deferred so it can be designed with per-route verification checks rather than bolted on here.

## Testing

- `pnpm run verify` passes. New `test/workers/auth-config.test.ts`: anonymous config route (off by default / on with the pair), the authorize redirect (exact scope + redirect_uri), and rejection when no provider is configured.
- Not exercised end-to-end: the live GitHub callback (needs real OAuth credentials); the dev/e2e environments don't set the pair, so their flows are unchanged.
- docs checked: `docs/self-hosting.md`, `docs/two-factor-auth.md`, `docs/product-analytics.md` updated; `/api` index lists the new route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)