### PR TITLE
Deflake the badge throttle test across rate-limit window boundaries

### DIFF
--- a/test/workers/threat-feed-badge.test.ts
+++ b/test/workers/threat-feed-badge.test.ts
@@ -537,8 +537,13 @@ describe("shields badge endpoint", () => {
     const headers = { "cf-connecting-ip": ip };
     let throttled: BadgeBody | null = null;
     // Distinct package names so every request misses the colo cache and pays
-    // the D1 lookup the limiter protects.
-    for (let i = 0; i < 125; i += 1) {
+    // the D1 lookup the limiter protects. The limiter counts inside fixed
+    // wall-clock windows (floor(now / windowMs), see server/db/rate-limit.ts),
+    // so a run that starts near the end of a minute straddles the boundary and
+    // loses its progress — under CI load, 125 consecutive requests are not
+    // guaranteed to land in one window. The cap leaves room to fill a fresh
+    // window (> 2 × the 120 limit) after a straddle wastes the first.
+    for (let i = 0; i < 400; i += 1) {
       const res = await request(app, `/public/badge/npm/miss-${i}`, { headers });
       expect(res.status).toBe(200);
       if (res.headers.has("retry-after")) {


### PR DESCRIPTION
## What

`threat-feed-badge.test.ts > a throttled badge says unavailable, never not-reviewed` failed on PR #575's CI run with `expected null not to be null` — the loop of exactly 125 requests never saw a throttle.

The limiter counts inside **fixed wall-clock windows** (`bucket = floor(now / windowMs)`, `server/db/rate-limit.ts:23`). A run that starts near the end of a minute straddles the window boundary under CI load: the count resets mid-loop and no single window ever exceeds the 120/min limit, so `retry-after` never appears. The 125-request cap assumed all requests land in one window.

Fix: raise the cap to 400 (> 2 × the limit), so a boundary straddle only wastes the first window's requests and the loop still fills a fresh window. The early `break` on throttle keeps the common case exactly as fast as before; the assertions are unchanged.

## Testing

- The full file passes 3/3 consecutive local runs (25 tests each).
- `pnpm run verify` unaffected (test-only change).
- docs checked, no update needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)