### PR TITLE
Stop truncating AI reviewer prose mid-word

### DIFF
--- a/docs/ai-review-eval.md
+++ b/docs/ai-review-eval.md
@@ -14,6 +14,22 @@ it whenever a change can alter reviewer behavior; copy or regenerate the eval
 records for the new version in the same change. Historical rows parse with a
 `null` version and analytics labels them `legacy`.
 
+## Submission bounds
+
+`AI_REVIEW_BOUNDS` in the same file is the single source of the per-field length
+limits, shared by the submission schema, the system prompt's stated budget, and
+`clampAiReviewSubmission`. A submission that overshoots is clamped and
+re-validated rather than discarded, because rejecting the whole call would
+collapse a high-risk review into the low-risk `invalid` fallback.
+
+Clamping prose is maintainer-visible: the summary is rendered verbatim in the
+scan workbench, so a hard mid-word cut reads as the reviewer crashing. Prose
+fields are cut on the last sentence break inside the budget, else the last word
+break, and always end in a ` …` marker; only `file` keeps a plain cut, since a
+trailing ellipsis on a path reads as part of the filename. The prompt states
+the summary budget so the model finishes its verdict inside it instead of
+relying on the clamp.
+
 ## Agent Traces
 
 The AI SDK is wrapped with Cloudflare's Agent Traces integration. Production

--- a/server/lib/ai-review/contract.ts
+++ b/server/lib/ai-review/contract.ts
@@ -6,11 +6,23 @@ export type AiReviewEcosystem = "npm" | "pypi" | "vscode" | "generic";
 // or model-routing policy changes in a way that can alter reviewer behavior.
 // Persisting this with each review keeps analytics and recorded eval cases from
 // silently comparing different reviewer contracts as though they were one.
-export const AI_REVIEWER_VERSION = "1.0.0";
+export const AI_REVIEWER_VERSION = "1.1.0";
 
 // We surface only the highest-signal findings: critical/high, most severe
 // first, capped at this count. Lower-severity context belongs in the summary.
 export const MAX_AI_FINDINGS = 6;
+
+// Shared by the schema, the system prompt, and `clampAiReviewSubmission` so all
+// three enforce the exact same limits. Sized to keep a worst-case submission
+// inside MAX_REVIEW_OUTPUT_TOKENS.
+const AI_REVIEW_BOUNDS = {
+  summary: 1_500,
+  file: 300,
+  evidence: 600,
+  reason: 600,
+  recommendation: 400,
+  findingsCount: 12,
+} as const;
 
 const BASE_REVIEWER_SYSTEM_PROMPT = `Staged package release safety reviewer.
 
@@ -101,8 +113,9 @@ Findings output:
 
 Summary style:
 - Plain prose only — no markdown, bullets, or headings; the UI renders the summary as plain text.
+- Hard budget: ${AI_REVIEW_BOUNDS.summary} characters. The system truncates anything longer, so a summary that runs past it loses its own conclusion. Reach your verdict inside the budget rather than narrating up to it.
 - nothing_unusual: 1-3 sentences naming the kinds of changes and confirming no install-time, entrypoint, dependency, network/process, credential, or obfuscation capability was found. Never inventory routine changes file-by-file.
-- Spend words only on what raises concern, citing concrete paths; stay terse even then.`;
+- Spend words only on what raises concern, citing concrete paths; stay terse even then. A refactor is context, not a finding: describe its shape in a clause, not a file-by-file walkthrough.`;
 
 export function normalizeAiReviewEcosystem(ecosystem: string | undefined): AiReviewEcosystem {
   if (ecosystem === "npm" || ecosystem === "pypi" || ecosystem === "vscode") return ecosystem;
@@ -152,17 +165,6 @@ const releaseAssessmentSchema = z.enum([
   "blocked",
 ]);
 
-// Shared by the schema and `clampAiReviewSubmission` so both enforce the exact
-// same limits. Sized to keep a worst-case submission inside MAX_REVIEW_OUTPUT_TOKENS.
-const AI_REVIEW_BOUNDS = {
-  summary: 1_000,
-  file: 300,
-  evidence: 600,
-  reason: 600,
-  recommendation: 400,
-  findingsCount: 12,
-} as const;
-
 const aiFindingSchema = z
   .object({
     severity: severitySchema,
@@ -185,7 +187,7 @@ export const aiReviewSubmissionSchema = z
       .min(1)
       .max(AI_REVIEW_BOUNDS.summary)
       .describe(
-        "Plain prose, no markdown. 1-3 sentences for an ordinary release; longer only to detail concerns.",
+        `Plain prose, no markdown. 1-3 sentences for an ordinary release; longer only to detail concerns. Hard cap ${AI_REVIEW_BOUNDS.summary} characters — a longer summary is truncated and loses its conclusion.`,
       ),
     // The model may over-report; the system trims to the top MAX_AI_FINDINGS
     // critical/high findings via selectReportedFindings. This cap only keeps a
@@ -206,7 +208,7 @@ export function clampAiReviewSubmission(raw: unknown): unknown {
   return {
     risk: value.risk,
     releaseAssessment: value.releaseAssessment,
-    summary: clampString(value.summary, AI_REVIEW_BOUNDS.summary),
+    summary: clampProse(value.summary, AI_REVIEW_BOUNDS.summary),
     requiresManualReview: value.requiresManualReview,
     findings: Array.isArray(value.findings)
       ? value.findings.slice(0, AI_REVIEW_BOUNDS.findingsCount).map(clampFinding)
@@ -219,11 +221,58 @@ function clampFinding(raw: unknown): unknown {
   const value = raw as Record<string, unknown>;
   return {
     severity: value.severity,
+    // A path is an identifier, not prose: a trailing ellipsis would read as part
+    // of the filename, so an over-long path keeps the plain hard cut.
     file: clampString(value.file, AI_REVIEW_BOUNDS.file),
-    evidence: clampString(value.evidence, AI_REVIEW_BOUNDS.evidence),
-    reason: clampString(value.reason, AI_REVIEW_BOUNDS.reason),
-    recommendation: clampString(value.recommendation, AI_REVIEW_BOUNDS.recommendation),
+    evidence: clampProse(value.evidence, AI_REVIEW_BOUNDS.evidence),
+    reason: clampProse(value.reason, AI_REVIEW_BOUNDS.reason),
+    recommendation: clampProse(value.recommendation, AI_REVIEW_BOUNDS.recommendation),
   };
+}
+
+// Every prose field here is rendered verbatim to a maintainer, so a hard
+// `slice` is not a neutral safety net: it ends the reviewer's sentence
+// mid-word, which reads as the assistant trailing off or crashing rather than
+// as a system-imposed cap. Cut on a boundary instead and mark the cut.
+const TRUNCATION_MARK = " …";
+// Only walk back to a boundary inside the tail of the budget. Without a floor,
+// a field whose last sentence break falls near its start would discard most of
+// the content the model already paid output tokens to produce.
+const MIN_CLAMP_RETENTION = 0.7;
+
+function clampProse(value: unknown, max: number): unknown {
+  if (typeof value !== "string" || value.length <= max) return value;
+  const budget = max - TRUNCATION_MARK.length;
+  const head = withoutDanglingSurrogate(value.slice(0, budget));
+  const floor = Math.floor(budget * MIN_CLAMP_RETENTION);
+  const cut = lastSentenceEnd(head, floor) ?? lastWordEnd(head, floor) ?? head.length;
+  return `${head.slice(0, cut).trimEnd()}${TRUNCATION_MARK}`;
+}
+
+// Sentence-final punctuation only counts when whitespace (or the cut) follows
+// it, so version numbers, relative paths, and abbreviations don't read as
+// sentence ends.
+function lastSentenceEnd(text: string, floor: number): number | null {
+  for (let i = text.length - 1; i >= floor; i -= 1) {
+    if (!".!?".includes(text[i])) continue;
+    const next = text[i + 1];
+    if (next === undefined || /\s/.test(next)) return i + 1;
+  }
+  return null;
+}
+
+function lastWordEnd(text: string, floor: number): number | null {
+  for (let i = text.length - 1; i >= floor; i -= 1) {
+    if (/\s/.test(text[i])) return i;
+  }
+  return null;
+}
+
+// Slicing at a fixed code-unit offset can split a surrogate pair and leave a
+// lone half that serializes as U+FFFD.
+function withoutDanglingSurrogate(text: string): string {
+  const last = text.charCodeAt(text.length - 1);
+  return last >= 0xd800 && last <= 0xdbff ? text.slice(0, -1) : text;
 }
 
 function clampString(value: unknown, max: number): unknown {

--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -611,7 +611,7 @@ describe("ai review orchestration", () => {
   test("a complete submission slightly over the summary bound is clamped, not discarded", async () => {
     // Reproduces the reported failure: validation used to reject the whole call
     // over a few-char overage, dropping a critical finding and collapsing to low.
-    const overLongSummary = "x".repeat(1031);
+    const overLongSummary = `${"word ".repeat(310)}tail.`;
     const { review: ai } = await analyzeWithAi(
       {},
       "mock-reviewer",
@@ -626,10 +626,64 @@ describe("ai review orchestration", () => {
     );
 
     expect(ai.status).toBe("complete");
-    expect(ai.summary.length).toBe(1000);
+    expect(ai.summary.length).toBeLessThanOrEqual(1500);
     expect(ai.findings).toHaveLength(1);
     expect(ai.findings[0].severity).toBe("critical");
     expect(computeScanRisk([], ai)).toBe("high");
+  });
+
+  test("an over-long summary is cut on a boundary and marked, never mid-word", async () => {
+    // The reported UI bug: a 1000-char hard slice ended the rendered summary at
+    // "I searched the availabl", which reads as the reviewer crashing rather
+    // than as a system cap.
+    const sentence = "The prepare script now runs husky and playwright install chromium. ";
+    const { review: ai } = await analyzeWithAi(
+      {},
+      "mock-reviewer",
+      BASE_OPTIONS,
+      submittingModel({
+        risk: "medium",
+        releaseAssessment: "review_recommended",
+        summary: `${sentence.repeat(40)}I searched the available evidence.`,
+        findings: [],
+        requiresManualReview: true,
+      }),
+    );
+
+    expect(ai.status).toBe("complete");
+    expect(ai.summary.length).toBeLessThanOrEqual(1500);
+    expect(ai.summary.endsWith(" …")).toBe(true);
+    // Boundary-aligned: the retained text ends at a whole sentence, and nothing
+    // before the marker is a severed word.
+    expect(ai.summary).toMatch(/chromium\. …$/);
+  });
+
+  test("prose with no whitespace to break on still clamps within bounds", async () => {
+    const { review: ai } = await analyzeWithAi(
+      {},
+      "mock-reviewer",
+      BASE_OPTIONS,
+      submittingModel({
+        risk: "high",
+        releaseAssessment: "suspicious",
+        summary: "A".repeat(4000),
+        findings: [
+          {
+            ...aiFinding("critical", "package.json"),
+            evidence: "B".repeat(2000),
+            reason: "C".repeat(2000),
+            recommendation: "D".repeat(2000),
+          },
+        ],
+        requiresManualReview: true,
+      }),
+    );
+
+    expect(ai.status).toBe("complete");
+    expect(ai.summary.length).toBeLessThanOrEqual(1500);
+    expect(ai.findings[0].evidence.length).toBeLessThanOrEqual(600);
+    expect(ai.findings[0].reason.length).toBeLessThanOrEqual(600);
+    expect(ai.findings[0].recommendation.length).toBeLessThanOrEqual(400);
   });
 
   test("an invalid submit_review does not end the loop; the model retries and completes", async () => {

--- a/test/fixtures/ai-review-eval/cases.json
+++ b/test/fixtures/ai-review-eval/cases.json
@@ -22,7 +22,7 @@
         ],
         "requiresManualReview": true,
         "model": "@cf/moonshotai/kimi-k2.7-code",
-        "reviewerVersion": "1.0.0"
+        "reviewerVersion": "1.1.0"
       }
     },
     {
@@ -38,7 +38,7 @@
         "findings": [],
         "requiresManualReview": false,
         "model": "@cf/moonshotai/kimi-k2.7-code",
-        "reviewerVersion": "1.0.0"
+        "reviewerVersion": "1.1.0"
       }
     },
     {
@@ -62,7 +62,7 @@
         ],
         "requiresManualReview": true,
         "model": "@cf/moonshotai/kimi-k2.7-code",
-        "reviewerVersion": "1.0.0"
+        "reviewerVersion": "1.1.0"
       }
     },
     {
@@ -78,7 +78,7 @@
         "findings": [],
         "requiresManualReview": false,
         "model": "@cf/moonshotai/kimi-k2.7-code",
-        "reviewerVersion": "1.0.0"
+        "reviewerVersion": "1.1.0"
       }
     },
     {
@@ -102,7 +102,7 @@
         ],
         "requiresManualReview": true,
         "model": "@cf/qwen/qwen3-30b-a3b-fp8",
-        "reviewerVersion": "1.0.0"
+        "reviewerVersion": "1.1.0"
       }
     }
   ]


### PR DESCRIPTION
## Summary

A reviewer summary over the schema bound was rescued by `experimental_repairToolCall`, which clamped it with a plain `slice` — the repaired call re-validated and was stored, so the workbench rendered a summary cut mid-word ("I searched the availabl"), reading as a crashed reviewer rather than a system cap. Prose fields now cut on the last sentence break inside the budget, else the last word break, always ending in a ` …` marker, while `file` keeps the plain cut since a trailing ellipsis reads as part of a path. The summary bound goes 1000 → 1500 (the reported review is 1366 chars, so it now renders whole) and the prompt and schema description state the budget so the model finishes its verdict instead of relying on the clamp.

## Trust boundary

None crossed — `clampAiReviewSubmission` still only projects known keys and never invents enums or required fields, so a structurally broken submission fails validation and the model retries; the AI reviewer stays advisory and cannot downgrade deterministic findings.

## Verification

`pnpm run verify`, `pnpm run eval`, and `pnpm run eval:ai` all pass, including three new tests covering the boundary cut (asserting the result is *not* mid-word), the whitespace-free fallback across every prose field, and the rescaled over-bound case. Worth a reviewer's eye: `AI_REVIEWER_VERSION` is bumped to 1.1.0 for the prompt change and the five eval records were rebadged rather than regenerated from live runs, which the promotion checklist permits ("copy or regenerate") but which does not prove 1.1.0 reproduces those outputs. Existing scans keep their already-truncated summaries — only a re-scan regenerates them, so no backfill is included here.

## Documentation

`docs/ai-review-eval.md` gains a "Submission bounds" section describing `AI_REVIEW_BOUNDS` as the shared source for the schema, prompt, and clamp, and the prose-vs-path clamping rule.

## UI evidence

Not applicable — no UI code changed; `ReviewerSummary` already rendered the stored summary verbatim, and the fix is to what gets stored.