### PR TITLE
Let an approved release's badge say approved

### DIFF
--- a/docs/public-reports.md
+++ b/docs/public-reports.md
@@ -204,7 +204,10 @@ the downstream `max-age` doesn't already absorb, while every invented name would
 add an entry to the namespace that also holds published-tarball bytes. Cursored
 feed pages (`?after=`) are uncached too, since the key ignores the query.
 
-Revoking a share or unlisting a report purges both entries. **That purge is
+Revoking a share, unlisting a report, or recording a release decision on a
+listed scan purges both entries — a publish → no_publish flip must not leave a
+green "approved" badge serving from the deciding admin's own colo for the full
+TTL. **That purge is
 colo-local and best effort**: `caches.default.delete()` clears the entry in the
 colo that handled the revoking request and nowhere else, so other regions keep
 serving the withdrawn badge until `max-age` expires — and shields.io's own cache

--- a/docs/public-reports.md
+++ b/docs/public-reports.md
@@ -83,8 +83,15 @@ for the package's most recent **feed-listed** review:
 
 - Not listed / unknown → `not reviewed` (lightgrey). Always `200` so badge
   proxies never render an error.
-- Listed → `<version> reviewed · <release risk> risk`, colored green / yellow /
-  red by risk; a `no_publish` decision renders `<version> blocked` (red).
+- Listed, undecided → `<version> reviewed · <release risk> risk`, colored
+  green / yellow / red by risk.
+- Listed, approved (`publish`) → `<version> approved` (green when
+  registry-verified). The decision supersedes the pre-decision risk grade in
+  the message: a maintainer read the evidence and signed off, and an approved
+  release wearing "medium risk" would read as a warning about a release the
+  review process cleared. The grade and findings stay in the report behind the
+  badge.
+- Listed, rejected (`no_publish`) → `<version> blocked` (red).
 
 The badge is a name-discoverable index, so it takes the same second opt-in as
 the threat feed — a report shared privately by link never becomes queryable by

--- a/server/db/scan-share.ts
+++ b/server/db/scan-share.ts
@@ -189,9 +189,11 @@ export async function revokePublicShare(
  * The badge cache key a row occupies, or null when it can never occupy one —
  * no package name, or a gate scan whose provenance never established an
  * ecosystem. Same rule as the key written on listing, so a purge always
- * addresses the entry the write created.
+ * addresses the entry the write created. Exported for the decision routes,
+ * which purge a listed scan's badge when the recorded decision changes what
+ * the cached payload asserts.
  */
-function badgeLookupKey(row: {
+export function badgeLookupKey(row: {
   source: string;
   packageName: string | null;
   summaryJson: unknown;

--- a/server/lib/public-feed.ts
+++ b/server/lib/public-feed.ts
@@ -79,8 +79,9 @@ export function publicFeedCacheKey(origin: string, routePath: string): Request {
 }
 
 /**
- * Drop the colo-cached badge and threat feed after a share is revoked or a
- * listing is turned off, so the withdrawal is not delayed by the TTL.
+ * Drop the colo-cached badge and threat feed after a share is revoked, a
+ * listing is turned off, or a release decision is recorded on a listed scan,
+ * so the change is not delayed by the TTL.
  *
  * **This is colo-local.** It clears the entries in the colo that served the
  * revoking admin's request and nowhere else; every other region keeps serving

--- a/server/lib/public-feed.ts
+++ b/server/lib/public-feed.ts
@@ -316,6 +316,23 @@ export function buildBadgePayload(row: SharedScanRow | null): BadgePayload {
       cacheSeconds: BADGE_CACHE_SECONDS,
     };
   }
+  if (row.decision === "publish") {
+    // A recorded publish decision is the product's verdict: a maintainer read
+    // the evidence and signed off. Keeping the pre-decision risk grade in the
+    // message would present the evidence as outranking the decision — an
+    // approved release wearing "medium risk" reads as a warning about a
+    // release the review process explicitly cleared (and a high-risk approval
+    // is, in practice, more often a false positive than a shipped compromise).
+    // The grade and its findings stay one click away in the report.
+    return {
+      schemaVersion: 1,
+      label: badgeLabel(row),
+      message: `${badgeVersion(row.stagedVersion)} approved`,
+      // An unverified name claim still never renders clean green.
+      color: scanPackageIdentity(row.source) === "registry-verified" ? "brightgreen" : "lightgrey",
+      cacheSeconds: BADGE_CACHE_SECONDS,
+    };
+  }
   const risk = sharedScanReleaseRisk(row);
   return {
     schemaVersion: 1,

--- a/server/routes/github-app.ts
+++ b/server/routes/github-app.ts
@@ -4,14 +4,19 @@ import { recordScanEvent } from "../db/events";
 import { organizationRequiresTwoFactorForReleaseDecisions } from "../db/organizations";
 import { RateLimitError, enforceRateLimit } from "../db/rate-limit";
 import { getScan, recordGatePackageDecision } from "../db/scans";
+import { badgeLookupKey } from "../db/scan-share";
 import {
   requireActiveOrganization,
   requireActiveOrganizationContext,
 } from "../lib/auth/active-organization";
 import { userHasTwoFactor, verifyTotpStepUp } from "../lib/auth";
 import { roleCanManageIntegrations } from "../lib/auth/roles";
-import { rateLimitResponse } from "../lib/platform/http";
-import { workerExecutionContext } from "../lib/platform/execution-context";
+import { canonicalOrigin, rateLimitResponse } from "../lib/platform/http";
+import {
+  optionalWorkerExecutionContext,
+  workerExecutionContext,
+} from "../lib/platform/execution-context";
+import { purgePublicFeedCache } from "../lib/public-feed";
 import { recordProductEvent } from "../lib/platform/analytics";
 import { describeOperationalError, emitOperationalEvent } from "../lib/platform/observability";
 import { scanArtifactReadBucket } from "../lib/scan/artifacts";
@@ -598,6 +603,22 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
             : "gate has already been decided",
       },
       409,
+    );
+  }
+
+  // A decision changes what a listed scan's cached badge and feed entry
+  // assert ("reviewed · risk" → "approved"/"blocked"); drop both so the
+  // change is not delayed by the colo TTL in at least this region. Same
+  // canonical-origin purge as the staged decision route and (un)listing.
+  if (decidedPackage.scan.publicFeedListedAt) {
+    purgePublicFeedCache(
+      optionalWorkerExecutionContext(c),
+      canonicalOrigin(c),
+      badgeLookupKey({
+        source: decidedPackage.scan.source,
+        packageName: decidedPackage.scan.packageName,
+        summaryJson: decidedPackage.scan.summaryJson,
+      }),
     );
   }
 

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -40,6 +40,7 @@ import {
 } from "../lib/platform/execution-context";
 import { purgePublicFeedCache } from "../lib/public-feed";
 import {
+  badgeLookupKey,
   enablePublicShare,
   readPublicShare,
   revokePublicShare,
@@ -290,6 +291,22 @@ scansRoutes.post("/:id/decision", async (c) => {
     const existing = await getScan(db, c.req.param("id"), organizationId);
     if (!existing) return c.json({ error: "not found" }, 404);
     return c.json({ error: "decision can only be set on completed scans" }, 409);
+  }
+
+  // A decision changes what a listed scan's cached badge and feed entry
+  // assert ("reviewed · risk" → "approved"/"blocked"), and a publish →
+  // no_publish flip must not leave a brightgreen "approved" badge sitting in
+  // this colo for the full TTL. Same canonical-origin purge as (un)listing.
+  if (updated.scan.publicFeedListedAt) {
+    purgePublicFeedCache(
+      optionalWorkerExecutionContext(c),
+      canonicalOrigin(c),
+      badgeLookupKey({
+        source: updated.scan.source,
+        packageName: updated.scan.packageName,
+        summaryJson: updated.scan.summaryJson,
+      }),
+    );
   }
 
   return c.json(updated);

--- a/test/workers/threat-feed-badge.test.ts
+++ b/test/workers/threat-feed-badge.test.ts
@@ -436,6 +436,57 @@ describe("shields badge endpoint", () => {
     });
   });
 
+  test("an approved release reads approved, not its pre-decision risk grade", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `pkg-${crypto.randomUUID().slice(0, 8)}`;
+    const scanId = await seedCompletedScan(owner, {
+      packageName,
+      version: "4.0.0",
+      risk: "medium",
+      releaseRisk: "medium",
+    });
+    await share(app, scanId, { threatFeed: true });
+    // Before the decision, the badge reports the evidence.
+    expect((await fetchBadge(app, "npm", packageName)).body).toMatchObject({
+      message: "4.0.0 reviewed · medium risk",
+      color: "yellow",
+    });
+
+    const decide = await request(app, `/api/v1/scans/${scanId}/decision`, {
+      method: "POST",
+      body: JSON.stringify({ decision: "publish", reason: "intended changes" }),
+    });
+    expect(decide.status).toBe(200);
+    // After sign-off the decision is the message; the grade stays in the
+    // report behind the badge.
+    expect((await fetchBadge(app, "npm", packageName)).body).toMatchObject({
+      label: "drydock",
+      message: "4.0.0 approved",
+      color: "brightgreen",
+    });
+  });
+
+  test("an approved manifest-claimed release stays visibly unverified", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `pkg-${crypto.randomUUID().slice(0, 8)}`;
+    const scanId = await seedCompletedScan(owner, {
+      packageName,
+      version: "2.0.0",
+      source: "workflow_gate",
+    });
+    await share(app, scanId, { threatFeed: true });
+    // Gate decisions arrive through the gate flow, not /decision; the badge
+    // reads the persisted row either way, so set the decision directly.
+    await env.DB.prepare("UPDATE scans SET decision = 'publish' WHERE id = ?").bind(scanId).run();
+    expect((await fetchBadge(app, "npm", packageName)).body).toMatchObject({
+      label: "drydock (unverified)",
+      message: "2.0.0 approved",
+      color: "lightgrey",
+    });
+  });
+
   test("the badge is ecosystem-scoped", async () => {
     const owner = await seedUser();
     const app = buildTestApp(owner);

--- a/test/workers/threat-feed-badge.test.ts
+++ b/test/workers/threat-feed-badge.test.ts
@@ -465,6 +465,19 @@ describe("shields badge endpoint", () => {
       message: "4.0.0 approved",
       color: "brightgreen",
     });
+
+    // A publish → no_publish flip must not keep serving the cached
+    // "approved" payload: the decision route purges the badge entry, so even
+    // a cached read reflects the reversal immediately in this colo.
+    const reverse = await request(app, `/api/v1/scans/${scanId}/decision`, {
+      method: "POST",
+      body: JSON.stringify({ decision: "no_publish", reason: "compromised" }),
+    });
+    expect(reverse.status).toBe(200);
+    expect((await fetchBadge(app, "npm", packageName, { cached: true })).body).toMatchObject({
+      message: "4.0.0 blocked",
+      color: "red",
+    });
   });
 
   test("an approved manifest-claimed release stays visibly unverified", async () => {
@@ -477,8 +490,9 @@ describe("shields badge endpoint", () => {
       source: "workflow_gate",
     });
     await share(app, scanId, { threatFeed: true });
-    // Gate decisions arrive through the gate flow, not /decision; the badge
-    // reads the persisted row either way, so set the decision directly.
+    // The badge reads the persisted row, not any route: write the decision
+    // directly so the assertion stays independent of which decision flow
+    // (gate or staged) recorded it.
     await env.DB.prepare("UPDATE scans SET decision = 'publish' WHERE id = ?").bind(scanId).run();
     expect((await fetchBadge(app, "npm", packageName)).body).toMatchObject({
       label: "drydock (unverified)",


### PR DESCRIPTION
## What

The shields badge reported pre-decision evidence forever: a release a maintainer reviewed and **approved** kept wearing `reviewed · medium risk`, presenting the evidence as if it outranked the decision. The human sign-off is the product's verdict, so it now headlines:

- Listed, decision `publish` → **`<version> approved`** — brightgreen when registry-verified. The pre-decision grade and its findings stay one click away in the report; keeping "medium risk" in the message read as a warning about a release the review process explicitly cleared (and a high-risk approval is, in practice, more often a false positive than a shipped compromise).
- Listed, undecided → `reviewed · <risk> risk` (unchanged) — evidence only, no sign-off yet.
- `no_publish` → `blocked` red (unchanged).
- The **"unverified never renders clean green" invariant holds**: a manifest-claimed (workflow-gate) approval keeps the `drydock (unverified)` label and lightgrey color.

## Cache-coherence fix that fell out of review

The self-review pass confirmed neither decision route purged the badge colo cache — pre-existing, but this change raised the stakes: a `publish` → `no_publish` flip would have left a brightgreen **approved** badge serving from the deciding admin's own colo for the full TTL. Both decision routes (staged `/decision` and the gate route) now purge the badge + feed entries for feed-listed scans, same canonical-origin pattern as (un)listing. Other colos remain TTL-bounded eventual-consistent, as documented.

## Testing

- `test/workers/threat-feed-badge.test.ts`: approved badge (message/color/label), approved-but-unverified stays lightgrey + labelled, and the reversal is asserted through a **cached** read to prove the new purge. 27/27 pass; `pnpm run verify` green.
- Adversarial self-review pass ran before pushing; the cache-purge gap and one inaccurate test comment were its findings, fixed in the labeled second commit. It also verified the decision value space (only `publish`/`no_publish` reachable), that `pickBadgeScan` can't let a self-approved gate scan borrow a verified row's identity, and that version-string clamping covers the new message.
- docs checked: badge states and purge triggers updated in `docs/public-reports.md`.

Once this deploys, Preact's badge flips from `reviewed · <risk> risk` to `<version> approved` the moment the approved scan's share is feed-listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)