### PR TITLE
Query the badge endpoint by dist-tag, defaulting to latest

### DIFF
--- a/docs/public-reports.md
+++ b/docs/public-reports.md
@@ -150,12 +150,17 @@ prerelease row.
 
 **The share dialog hands maintainers the snippet.** Once a share is feed-listed
 (and the scan's ecosystem resolves — see `scanEcosystem`), the dialog shows
-copy-paste README markdown built by `src/lib/badge-markdown.ts`. The badge
-image always reflects the newest listed review, so the click target is chosen
-to not pin what the badge does not: npm links the evergreen package-only
-`/diff/<name>` page (it resolves the latest published pair on load), while
-PyPI and VS Code — which have no package-only diff form — link the share URL
-the maintainer copied, correct at copy time but version-pinned.
+copy-paste README markdown built by `src/lib/badge-markdown.ts`. The snippet is
+for **the release line the copied scan was staged under**: a scan tagged `rc`
+yields `?tag=rc` and alt text `Drydock review (rc)`, while `latest` and untagged
+scans keep the short untagged form (the endpoint already defaults to `latest`).
+Without that, a maintainer who lists a prerelease review would paste a badge
+that never shows it. The badge image always reflects the newest listed review
+_on that line_, so the click target is chosen to not pin what the badge does
+not: npm links the evergreen package-only `/diff/<name>` page (it resolves the
+latest published pair on load), while PyPI and VS Code — which have no
+package-only diff form — link the share URL the maintainer copied, correct at
+copy time but version-pinned.
 
 ## Threat feed
 

--- a/docs/public-reports.md
+++ b/docs/public-reports.md
@@ -121,10 +121,11 @@ review sat just past the limit.
   request would answer a question about the beta line with a review of
   something else, so on PyPI and VS Code every non-default tag is
   `not reviewed`.
-- A malformed tag (anything outside `[A-Za-z0-9][A-Za-z0-9._-]{0,63}`) is a
-  `400`, not a silent fall back to `latest` — the fallback would answer a
-  typo'd parameter with a badge about a different release line and the embedder
-  would never find out.
+- A malformed tag (empty, longer than 64 characters, or containing characters
+  outside npm's URI-safe dist-tag alphabet) is a `400`, not a silent fall back
+  to `latest` — the fallback would answer a typo'd parameter with a badge about
+  a different release line and the embedder would never find out. Valid npm
+  punctuation such as the `~` in `beta~edge` is preserved.
 - Tags are matched exactly, not case-folded, on the same reasoning as npm
   package names.
 

--- a/docs/public-reports.md
+++ b/docs/public-reports.md
@@ -76,10 +76,10 @@ together always verifies, which is what matters for the archival use case.
 
 ## Badge endpoint
 
-`GET /public/badge/:ecosystem/:package` (ecosystems: `npm`, `pypi`, `vscode`;
-npm names may contain `@scope/` slashes) returns a
+`GET /public/badge/:ecosystem/:package[?tag=]` (ecosystems: `npm`, `pypi`,
+`vscode`; npm names may contain `@scope/` slashes) returns a
 [shields.io endpoint-badge](https://shields.io/badges/endpoint-badge) payload
-for the package's most recent **feed-listed** review:
+for the most recent **feed-listed** review of that package's release line:
 
 - Not listed / unknown → `not reviewed` (lightgrey). Always `200` so badge
   proxies never render an error.
@@ -97,6 +97,41 @@ The badge is a name-discoverable index, so it takes the same second opt-in as
 the threat feed — a report shared privately by link never becomes queryable by
 package name.
 
+### Release lines (`?tag=`)
+
+A badge sits next to an install command, so it answers for the release that
+command produces: **`?tag=` defaults to `latest`**. Without that, listing a
+prerelease review silently repoints every embedded badge — including the one
+beside `npm i <pkg>` — at a version nobody installs by default, and a package
+cannot carry a stable badge and a prerelease badge at once.
+
+The tag is the dist-tag the release was staged under
+(`summaryJson.stagedPublish.tag`), filtered in SQL for the same reason the
+ecosystem is: an active prerelease line publishes far more often than the stable
+one, so an unfiltered bounded page would be all `rc` rows while a listed stable
+review sat just past the limit.
+
+- `?tag=beta` → only reviews staged under `beta`. The label becomes
+  `drydock (beta)`, so a README carrying several rows can be read apart;
+  `drydock (rc, unverified)` when the pick is also manifest-claimed.
+- A review with **no** tag answers only the default badge. Two populations are
+  untagged — ecosystems without dist-tags (all PyPI and VS Code reviews, all
+  gate scans) and staged scans predating tag capture — and all of them describe
+  the release a consumer installs by default. Admitting them into a `?tag=beta`
+  request would answer a question about the beta line with a review of
+  something else, so on PyPI and VS Code every non-default tag is
+  `not reviewed`.
+- A malformed tag (anything outside `[A-Za-z0-9][A-Za-z0-9._-]{0,63}`) is a
+  `400`, not a silent fall back to `latest` — the fallback would answer a
+  typo'd parameter with a badge about a different release line and the embedder
+  would never find out.
+- Tags are matched exactly, not case-folded, on the same reasoning as npm
+  package names.
+
+Feed entries carry the same `tag` (null when the release was never staged under
+one — never read null as `latest`), so a partner walking feed → badge filters on
+the value the badge itself uses.
+
 **Verified and unverified badges are visibly different.** Among listed
 candidates the newest **registry-verified** review wins (see package identity
 below), so on npm a workflow-gate scan claiming someone else's name cannot
@@ -110,7 +145,8 @@ name, and a badge is read by people who will not open the report behind it.
 
 Embed via
 `https://img.shields.io/endpoint?url=<origin>/public/badge/npm/<package>`
-(URL-encode the badge URL).
+(URL-encode the badge URL), and add `%3Ftag=beta` to the encoded badge URL for a
+prerelease row.
 
 **The share dialog hands maintainers the snippet.** Once a share is feed-listed
 (and the scan's ecosystem resolves — see `scanEcosystem`), the dialog shows
@@ -126,9 +162,9 @@ the maintainer copied, correct at copy time but version-pinned.
 `GET /public/threat-feed.json` is a discoverable index (schema
 `drydock.threat-feed.v1`, 100 entries per page, newest listings first) meant
 for security partners — Aikido and other ecosystem-intel consumers can poll it.
-Each entry carries package identity, ecosystem, release/artifact risk,
-decision, `totalFindingCount`, timestamps, and a `reportUrl` to the full public
-report.
+Each entry carries package identity, ecosystem, dist-`tag`, release/artifact
+risk, decision, `totalFindingCount`, timestamps, and a `reportUrl` to the full
+public report.
 
 `totalFindingCount` counts deterministic _and_ advisory AI findings. It is
 deliberately not `report.findings.length`: the export routes AI findings
@@ -188,9 +224,13 @@ rather than assuming npm.
 
 Badge and feed responses read through the per-colo Workers cache
 (`caches.default`) and declare `max-age=300`. The cache key is the canonical
-origin plus path, query string ignored, and badge URLs collapse onto their
-package lookup key, so one package has one entry per colo however an embedder
-encoded the name. Case is part of that key for npm — the registry treats
+origin plus path plus — for badges — the resolved `tag`, and badge URLs collapse
+onto their package lookup key, so one package's release line has one entry per
+colo however an embedder encoded the name. Every other query parameter is still
+ignored, so a cache-busting `?_=` cannot force a D1 read-through; the tag
+participates because it is the one parameter that changes the body. A listing
+change purges the entry for the scan's own tag (the default entry when the scan
+has none), not a guessed set of tags. Case is part of that key for npm — the registry treats
 existing names case-sensitively, so `JSONStream` and `jsonstream` are different
 packages and must not share a badge — while PyPI (PEP 503) and VS Code fold, as
 `publicPackageLookupKey` documents. Two consequences: `/badge/npm/React` is its

--- a/server/db/scan-share.ts
+++ b/server/db/scan-share.ts
@@ -1,6 +1,11 @@
 import { and, desc, eq, isNotNull, isNull, or, sql } from "drizzle-orm";
 import { base64UrlEncode } from "../lib/platform/crypto-utils";
-import { publicPackageLookupKey, scanEcosystem } from "../lib/public-feed";
+import {
+  DEFAULT_BADGE_TAG,
+  publicPackageLookupKey,
+  scanDistTag,
+  scanEcosystem,
+} from "../lib/public-feed";
 import type { AppDb } from "./client";
 import { recordScanEvent } from "./events";
 import { scans } from "./schema";
@@ -25,6 +30,13 @@ export interface PublicShareState {
    * stale.
    */
   publicPackageKey?: string | null;
+  /**
+   * The dist-tag this scan's badge lives under, so the purge addresses the
+   * entry the badge write created rather than the default one. Null when the
+   * scan was never staged under a tag — that scan only ever answered the
+   * default badge.
+   */
+  publicBadgeTag?: string | null;
 }
 
 /**
@@ -43,6 +55,7 @@ export async function readPublicShare(
       publicSharedAt: scans.publicSharedAt,
       publicFeedListedAt: scans.publicFeedListedAt,
       publicPackageKey: scans.publicPackageKey,
+      summaryJson: scans.summaryJson,
     })
     .from(scans)
     .where(and(eq(scans.id, input.scanId), eq(scans.organizationId, input.organizationId)))
@@ -53,6 +66,7 @@ export async function readPublicShare(
     publicSharedAt: row.publicSharedAt,
     publicFeedListedAt: row.publicFeedListedAt,
     publicPackageKey: row.publicPackageKey,
+    publicBadgeTag: scanDistTag(row.summaryJson),
   };
 }
 
@@ -142,7 +156,7 @@ export async function enablePublicShare(
 export async function revokePublicShare(
   db: AppDb,
   input: { scanId: string; organizationId: string; actorUserId: string },
-): Promise<{ revoked: boolean; publicPackageKey: string | null }> {
+): Promise<{ revoked: boolean; publicPackageKey: string | null; publicBadgeTag: string | null }> {
   const now = new Date();
   const updated = await db
     .update(scans)
@@ -170,7 +184,7 @@ export async function revokePublicShare(
       source: scans.source,
       summaryJson: scans.summaryJson,
     });
-  if (updated.length === 0) return { revoked: false, publicPackageKey: null };
+  if (updated.length === 0) return { revoked: false, publicPackageKey: null, publicBadgeTag: null };
 
   await recordScanEvent(db, {
     organizationId: input.organizationId,
@@ -182,6 +196,7 @@ export async function revokePublicShare(
   return {
     revoked: true,
     publicPackageKey: badgeLookupKey(updated[0]),
+    publicBadgeTag: scanDistTag(updated[0].summaryJson),
   };
 }
 
@@ -263,6 +278,7 @@ export async function setThreatFeedListing(
     // Always the key, listing or unlisting: an *un*listing is exactly when the
     // cached badge body goes stale, so the caller needs the entry to purge.
     publicPackageKey: badgeKey,
+    publicBadgeTag: scanDistTag(candidate.summaryJson),
     publicShareToken: row.publicShareToken,
     publicSharedAt: row.publicSharedAt,
     publicFeedListedAt: row.publicFeedListedAt,
@@ -382,12 +398,15 @@ export function threatFeedNextCursor(
  * Ecosystem is filtered in SQL over the persisted provenance snapshot
  * (staged-publish scans carry no snapshot and are npm by construction), so a
  * package that is busy in one ecosystem can never crowd another ecosystem's
- * review out of the bounded page.
+ * review out of the bounded page. The dist-tag is filtered the same way and for
+ * the same reason; `badgeTagMatches` documents why an untagged scan answers only
+ * the default (`latest`) badge.
  */
 export async function listBadgeCandidateScans(
   db: AppDb,
   packageName: string,
   ecosystem: "npm" | "pypi" | "vscode",
+  tag: string = DEFAULT_BADGE_TAG,
   limit = 20,
 ): Promise<SharedScanRow[]> {
   const packageKey = publicPackageLookupKey(ecosystem, packageName);
@@ -396,6 +415,15 @@ export async function listBadgeCandidateScans(
     ecosystem === "npm"
       ? or(sql`${provenanceEcosystem} = 'npm'`, sql`${provenanceEcosystem} IS NULL`)
       : sql`${provenanceEcosystem} = ${ecosystem}`;
+  // Filtered in SQL for the same reason as the ecosystem: an active prerelease
+  // line publishes far more often than the stable one, so a bounded page taken
+  // before the tag filter would be all `rc` rows and the `latest` badge would
+  // read "not reviewed" while a listed stable review sat just past the limit.
+  const distTag = sql`json_extract(${scans.summaryJson}, '$.stagedPublish.tag')`;
+  const tagMatches =
+    tag === DEFAULT_BADGE_TAG
+      ? or(sql`${distTag} = ${tag}`, sql`${distTag} IS NULL`)
+      : sql`${distTag} = ${tag}`;
   // Rank registry-backed scans before applying the bounded page. Otherwise a
   // burst of newer manifest-claimed gate scans could crowd the verified review
   // out of the result set before pickBadgeScan gets a chance to prefer it.
@@ -410,6 +438,7 @@ export async function listBadgeCandidateScans(
         isNotNull(scans.publicFeedListedAt),
         eq(scans.status, "complete"),
         ecosystemMatches,
+        tagMatches,
       ),
     )
     .orderBy(packageIdentityPriority, desc(scans.completedAt), desc(scans.id))

--- a/server/index.ts
+++ b/server/index.ts
@@ -298,7 +298,7 @@ app.get("/api", (c) =>
       publicReports:
         "POST/DELETE /api/v1/scans/:id/share; GET /public/reports/:token; GET /public/reports/:token/attestation; GET /public/attestation-key (share token is the capability; no auth)",
       publicFeed:
-        "GET /public/threat-feed.json (feed-listed shared reviews); GET /public/badge/:ecosystem/:package (shields.io endpoint badge)",
+        "GET /public/threat-feed.json (feed-listed shared reviews); GET /public/badge/:ecosystem/:package[?tag=] (shields.io endpoint badge; tag defaults to latest)",
       slack:
         "GET /api/v1/slack; POST /api/v1/slack/connect; GET /api/v1/slack/callback; GET /api/v1/slack/channels; PUT /api/v1/slack/channel; PATCH /api/v1/slack; DELETE /api/v1/slack; POST /api/v1/slack/test",
       health: "GET /api/health",

--- a/server/lib/public-feed.ts
+++ b/server/lib/public-feed.ts
@@ -52,10 +52,10 @@ export function publicPackageLookupKey(ecosystem: PublicEcosystem, packageName: 
  */
 export const DEFAULT_BADGE_TAG = "latest";
 
-// Conservative subset of what npm accepts as a dist-tag. The value is echoed
-// into a shields label and folded into a cache key, so it is validated at the
-// edge rather than sanitized on the way out.
-const BADGE_TAG_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+// npm accepts the URI-safe characters that encodeURIComponent leaves intact.
+// The value is echoed into a shields label and folded into a cache key, so cap
+// its length at the edge while preserving valid tags such as `beta~edge`.
+const BADGE_TAG_RE = /^[A-Za-z0-9!~*'()._-]{1,64}$/;
 
 export function isValidBadgeTag(tag: string): boolean {
   return BADGE_TAG_RE.test(tag);
@@ -140,7 +140,9 @@ export function publicFeedCacheKey(origin: string, routePath: string, search = "
       return badgeCacheKey(
         origin,
         publicPackageLookupKey(ecosystem, name),
-        raw || DEFAULT_BADGE_TAG,
+        // Blank is invalid, not absent. Keep it on its own key so a warmed
+        // default badge cannot bypass the route's validation and answer it.
+        raw ?? DEFAULT_BADGE_TAG,
       );
     }
   }

--- a/server/lib/public-feed.ts
+++ b/server/lib/public-feed.ts
@@ -43,13 +43,68 @@ export function publicPackageLookupKey(ecosystem: PublicEcosystem, packageName: 
   return `${ecosystem}:${normalized}`;
 }
 
+/**
+ * The dist-tag a badge request is about. Absent means `latest`: a badge sits in
+ * a README next to an install command, so the release it describes has to be
+ * the one that command installs — not whichever review happened to be listed
+ * most recently. Without this, listing a prerelease review silently repoints
+ * every embedded badge at the prerelease.
+ */
+export const DEFAULT_BADGE_TAG = "latest";
+
+// Conservative subset of what npm accepts as a dist-tag. The value is echoed
+// into a shields label and folded into a cache key, so it is validated at the
+// edge rather than sanitized on the way out.
+const BADGE_TAG_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+
+export function isValidBadgeTag(tag: string): boolean {
+  return BADGE_TAG_RE.test(tag);
+}
+
+/**
+ * The dist-tag a scan was staged under, or null when there isn't one.
+ *
+ * Only npm staged-publish scans carry it (`summaryJson.stagedPublish.tag`) —
+ * the tag is what the publisher asked the registry for. Workflow-gate scans
+ * review a repo-built artifact that has not been staged under any tag, and
+ * neither PyPI nor the VS Code marketplace has dist-tags at all, so those are
+ * always null. Null is not "latest": see `badgeTagMatches`.
+ */
+export function scanDistTag(summaryJson: unknown): string | null {
+  if (summaryJson && typeof summaryJson === "object" && !Array.isArray(summaryJson)) {
+    const stagedPublish = (summaryJson as { stagedPublish?: unknown }).stagedPublish;
+    if (stagedPublish && typeof stagedPublish === "object" && !Array.isArray(stagedPublish)) {
+      const tag = (stagedPublish as { tag?: unknown }).tag;
+      if (typeof tag === "string" && isValidBadgeTag(tag)) return tag;
+    }
+  }
+  return null;
+}
+
+/**
+ * Whether a scan's persisted tag answers a request for `requestedTag`.
+ *
+ * An untagged scan is only eligible for the `latest` badge. Two populations are
+ * untagged: reviews from ecosystems that have no dist-tags, and staged scans
+ * predating tag capture. Both describe the release a consumer would install by
+ * default, so excluding them would blank working badges — while admitting them
+ * into a `?tag=beta` request would answer a question about the beta line with a
+ * review of something else.
+ */
+export function badgeTagMatches(scanTag: string | null, requestedTag: string): boolean {
+  if (scanTag === null) return requestedTag === DEFAULT_BADGE_TAG;
+  return scanTag === requestedTag;
+}
+
 // Colo-cache keys for the two cacheable public surfaces. These live here, next
 // to `publicPackageLookupKey`, rather than in a route module: the write side
 // (the badge/feed GETs) and the purge side (the dashboard's share and listing
 // mutations) are different routes, and a route importing another route is how
 // the two drifted onto different origins in the first place.
-function badgeCacheKey(origin: string, packageKey: string): Request {
-  return new Request(`${origin}/public/badge-key/${encodeURIComponent(packageKey)}`);
+function badgeCacheKey(origin: string, packageKey: string, tag: string): Request {
+  return new Request(
+    `${origin}/public/badge-key/${encodeURIComponent(packageKey)}/${encodeURIComponent(tag)}`,
+  );
 }
 
 function threatFeedCacheKey(origin: string): Request {
@@ -58,10 +113,16 @@ function threatFeedCacheKey(origin: string): Request {
 
 /**
  * Colo-cache key for a cacheable public path. Badge paths collapse to their
- * canonical package key, so every encoding of one package shares one entry and
- * `purgePublicFeedCache` can delete it by key after a revoke or unlist.
+ * canonical package key plus the requested dist-tag, so every encoding of one
+ * package's tag shares one entry and `purgePublicFeedCache` can delete it by
+ * key after a revoke or unlist.
+ *
+ * The tag is the *only* part of the query string that participates. Two badge
+ * URLs that differ only in a tag describe different releases and must never
+ * share a body, while every other query parameter stays a no-op so a
+ * cache-busting `?_=` cannot force a D1 read-through.
  */
-export function publicFeedCacheKey(origin: string, routePath: string): Request {
+export function publicFeedCacheKey(origin: string, routePath: string, search = ""): Request {
   const badge = /^\/badge\/([^/]+)\/(.+)$/.exec(routePath);
   if (badge) {
     const ecosystem = badge[1] as PublicEcosystem;
@@ -72,10 +133,29 @@ export function publicFeedCacheKey(origin: string, routePath: string): Request {
       } catch {
         // Undecodable name: fall through and key on the raw path.
       }
-      return badgeCacheKey(origin, publicPackageLookupKey(ecosystem, name));
+      // The *raw* tag, not the resolved one: a malformed tag is a 400 from the
+      // route, and folding it onto the default key would let the cache answer
+      // it with a `latest` body that was cached before it ever got there.
+      const raw = new URLSearchParams(search).get("tag")?.trim();
+      return badgeCacheKey(
+        origin,
+        publicPackageLookupKey(ecosystem, name),
+        raw || DEFAULT_BADGE_TAG,
+      );
     }
   }
   return new Request(origin + "/public" + routePath);
+}
+
+/**
+ * The tag a badge request resolves to. An absent, blank, or malformed `tag`
+ * resolves to the default rather than erroring here — the route validates and
+ * rejects malformed tags itself, and this must stay total so a cache key always
+ * exists for whatever the route ends up answering.
+ */
+export function resolveBadgeTag(raw: string | null | undefined): string {
+  const tag = raw?.trim();
+  return tag && isValidBadgeTag(tag) ? tag : DEFAULT_BADGE_TAG;
 }
 
 /**
@@ -94,9 +174,18 @@ export function purgePublicFeedCache(
   executionCtx: ExecutionContext | null,
   origin: string,
   publicPackageKey: string | null,
+  // The scan's own dist-tag. Null (no tag persisted) means the scan could only
+  // ever have answered the default badge, so that is the one entry to drop —
+  // guessing a tag set here would leave the real entry cached.
+  badgeTag: string | null = null,
 ): void {
   coloCacheDelete(executionCtx, threatFeedCacheKey(origin));
-  if (publicPackageKey) coloCacheDelete(executionCtx, badgeCacheKey(origin, publicPackageKey));
+  if (publicPackageKey) {
+    coloCacheDelete(
+      executionCtx,
+      badgeCacheKey(origin, publicPackageKey, badgeTag ?? DEFAULT_BADGE_TAG),
+    );
+  }
 }
 
 function provenanceEcosystem(summaryJson: unknown): PublicEcosystem | null {
@@ -180,6 +269,11 @@ export interface ThreatFeedEntry {
   // Null when a gate scan's provenance snapshot never established one — the
   // feed says "unknown" rather than guessing on a partner's behalf.
   ecosystem: PublicEcosystem | null;
+  // The dist-tag the release was staged under, and the axis the badge endpoint
+  // is queried on. Null for reviews that were never staged under one — every
+  // gate scan, every PyPI and VS Code review, and staged scans predating tag
+  // capture. Consumers must not read null as `latest`.
+  tag: string | null;
   packageIdentity: PackageIdentity;
   releaseRisk: string;
   artifactRisk: string;
@@ -205,6 +299,7 @@ export function buildThreatFeedEntry(row: SharedScanRow, origin: string): Threat
     version: row.stagedVersion,
     previousVersion: row.previousVersion,
     ecosystem: scanEcosystem(row.source, row.summaryJson),
+    tag: scanDistTag(row.summaryJson),
     packageIdentity: scanPackageIdentity(row.source),
     releaseRisk: sharedScanReleaseRisk(row),
     artifactRisk: row.risk,
@@ -270,10 +365,17 @@ const RISK_BADGE_COLOR: Record<string, string> = {
  * that exists — so the distinction has to be visible on the badge, not just in
  * the feed entry that a badge viewer never sees.
  */
-function badgeLabel(row: SharedScanRow): string {
-  return scanPackageIdentity(row.source) === "registry-verified"
-    ? BADGE_LABEL
-    : `${BADGE_LABEL} (unverified)`;
+function badgeLabel(row: SharedScanRow | null, tag: string): string {
+  // A non-default tag is named in the label, not just the message: a README
+  // that carries a stable badge and a prerelease badge shows two rows whose
+  // messages are both "<version> reviewed", and the label is the only part a
+  // reader can use to tell which line each row is about. Both qualifiers are
+  // only ever the validated tag or a literal, so nothing here needs escaping.
+  const qualifiers = [
+    ...(tag === DEFAULT_BADGE_TAG ? [] : [tag]),
+    ...(row && scanPackageIdentity(row.source) === "manifest-claimed" ? ["unverified"] : []),
+  ];
+  return qualifiers.length > 0 ? `${BADGE_LABEL} (${qualifiers.join(", ")})` : BADGE_LABEL;
 }
 
 /**
@@ -288,21 +390,24 @@ function badgeLabel(row: SharedScanRow): string {
  * quietly show neutral grey instead. "We don't know" and "nobody reviewed
  * this" have to be distinguishable.
  */
-export function buildUnavailableBadgePayload(): BadgePayload {
+export function buildUnavailableBadgePayload(tag: string = DEFAULT_BADGE_TAG): BadgePayload {
   return {
     schemaVersion: 1,
-    label: BADGE_LABEL,
+    label: badgeLabel(null, tag),
     message: "unavailable",
     color: "lightgrey",
     cacheSeconds: BADGE_UNAVAILABLE_CACHE_SECONDS,
   };
 }
 
-export function buildBadgePayload(row: SharedScanRow | null): BadgePayload {
+export function buildBadgePayload(
+  row: SharedScanRow | null,
+  tag: string = DEFAULT_BADGE_TAG,
+): BadgePayload {
   if (!row) {
     return {
       schemaVersion: 1,
-      label: BADGE_LABEL,
+      label: badgeLabel(null, tag),
       message: "not reviewed",
       color: "lightgrey",
       cacheSeconds: BADGE_CACHE_SECONDS,
@@ -311,7 +416,7 @@ export function buildBadgePayload(row: SharedScanRow | null): BadgePayload {
   if (row.decision === "no_publish") {
     return {
       schemaVersion: 1,
-      label: badgeLabel(row),
+      label: badgeLabel(row, tag),
       message: `${badgeVersion(row.stagedVersion)} blocked`,
       color: "red",
       cacheSeconds: BADGE_CACHE_SECONDS,
@@ -327,7 +432,7 @@ export function buildBadgePayload(row: SharedScanRow | null): BadgePayload {
     // The grade and its findings stay one click away in the report.
     return {
       schemaVersion: 1,
-      label: badgeLabel(row),
+      label: badgeLabel(row, tag),
       message: `${badgeVersion(row.stagedVersion)} approved`,
       // An unverified name claim still never renders clean green.
       color: scanPackageIdentity(row.source) === "registry-verified" ? "brightgreen" : "lightgrey",
@@ -337,7 +442,7 @@ export function buildBadgePayload(row: SharedScanRow | null): BadgePayload {
   const risk = sharedScanReleaseRisk(row);
   return {
     schemaVersion: 1,
-    label: badgeLabel(row),
+    label: badgeLabel(row, tag),
     message: `${badgeVersion(row.stagedVersion)} reviewed · ${risk} risk`,
     // An unverified claim never renders as a clean green pass: the color is the
     // only thing most readers take from a badge.

--- a/server/routes/github-app.ts
+++ b/server/routes/github-app.ts
@@ -16,7 +16,7 @@ import {
   optionalWorkerExecutionContext,
   workerExecutionContext,
 } from "../lib/platform/execution-context";
-import { purgePublicFeedCache } from "../lib/public-feed";
+import { purgePublicFeedCache, scanDistTag } from "../lib/public-feed";
 import { recordProductEvent } from "../lib/platform/analytics";
 import { describeOperationalError, emitOperationalEvent } from "../lib/platform/observability";
 import { scanArtifactReadBucket } from "../lib/scan/artifacts";
@@ -619,6 +619,9 @@ githubAppRoutes.post("/workflow-gates/:gateId/decision", async (c) => {
         packageName: decidedPackage.scan.packageName,
         summaryJson: decidedPackage.scan.summaryJson,
       }),
+      // Gate scans carry no dist-tag today, so this resolves to the default
+      // entry — passed explicitly so it stays correct if they ever do.
+      scanDistTag(decidedPackage.scan.summaryJson),
     );
   }
 

--- a/server/routes/public-reports.ts
+++ b/server/routes/public-reports.ts
@@ -14,11 +14,15 @@ import { getScan } from "../db/scans";
 import {
   buildBadgePayload,
   buildThreatFeedEntry,
+  badgeTagMatches,
   buildUnavailableBadgePayload,
+  isValidBadgeTag,
   pickBadgeScan,
   PUBLIC_ECOSYSTEMS,
   publicFeedCacheKey,
   publicPackageNameMax,
+  resolveBadgeTag,
+  scanDistTag,
   scanEcosystem,
   THREAT_FEED_SCHEMA,
   type PublicEcosystem,
@@ -90,7 +94,8 @@ const COLO_CACHE_SKIP_HEADER = "x-drydock-colo-cache-skip";
 
 publicReportsRoutes.use("*", async (c, next) => {
   if (c.req.method !== "GET") return next();
-  const routePath = new URL(c.req.url).pathname.replace(/^\/public/, "");
+  const url = new URL(c.req.url);
+  const routePath = url.pathname.replace(/^\/public/, "");
   if (!COLO_CACHED_PATHS.some((re) => re.test(routePath))) return next();
   if (routePath.startsWith("/threat-feed")) {
     // The feed body embeds report URLs built from canonicalOrigin, which falls
@@ -102,16 +107,17 @@ publicReportsRoutes.use("*", async (c, next) => {
     // Only the first page is cacheable; a cursored page must never be served
     // from, or written into, the entry that page one occupies. Backfill pages
     // are rare by nature — a consumer walks them once to catch up.
-    if (new URL(c.req.url).search) return next();
+    if (url.search) return next();
   }
-  // Key on the *canonical* origin and path only. Everything still cacheable at
-  // this point ignores its query string, so a cache-busting query can't force a
+  // Key on the *canonical* origin, the path, and — for badges — the requested
+  // dist-tag, which is the one query parameter that changes the body. Every
+  // other parameter stays ignored, so a cache-busting query still can't force a
   // D1 read-through, and folding badge URLs onto their lookup key means one
-  // package has one entry per colo however the embedder encoded the name. The
-  // origin has to be canonicalOrigin — the same value purgePublicFeedCache uses
-  // from a *dashboard* request — or a deploy bound to a second hostname
+  // package's tag has one entry per colo however the embedder encoded the name.
+  // The origin has to be canonicalOrigin — the same value purgePublicFeedCache
+  // uses from a *dashboard* request — or a deploy bound to a second hostname
   // (workers.dev, a preview alias) writes entries the purge never visits.
-  const cacheKey = publicFeedCacheKey(canonicalOrigin(c), routePath);
+  const cacheKey = publicFeedCacheKey(canonicalOrigin(c), routePath, url.search);
   const cached = await coloCacheMatch(cacheKey);
   if (cached) return cached;
   await next();
@@ -150,7 +156,9 @@ publicReportsRoutes.use("*", async (c, next) => {
       // would cache for minutes over a review that may say "blocked". Kept out
       // of the colo cache for the same reason.
       if (isBadgeRequest) {
-        return c.json(buildUnavailableBadgePayload(), 200, {
+        // Carry the tag through even here, so a throttled prerelease badge
+        // still identifies which README row it belongs to.
+        return c.json(buildUnavailableBadgePayload(resolveBadgeTag(c.req.query("tag"))), 200, {
           "cache-control": "no-store",
           "access-control-allow-origin": "*",
           "retry-after": String(err.retryAfterSeconds),
@@ -210,7 +218,9 @@ publicReportsRoutes.get("/threat-feed.json", async (c) => {
 const BADGE_ERROR_HEADERS = { "access-control-allow-origin": "*" } as const;
 
 // npm names contain slashes (@scope/name), so the route is a wildcard and the
-// name is everything after the ecosystem segment.
+// name is everything after the ecosystem segment. `?tag=` selects the release
+// line; it defaults to `latest`, because a badge describes the release its
+// README's install command produces.
 publicReportsRoutes.get("/badge/:ecosystem/*", async (c) => {
   const ecosystem = c.req.param("ecosystem") as PublicEcosystem;
   if (!PUBLIC_ECOSYSTEMS.includes(ecosystem)) {
@@ -228,18 +238,30 @@ publicReportsRoutes.get("/badge/:ecosystem/*", async (c) => {
   if (!packageName || packageName.length > publicPackageNameMax(ecosystem)) {
     return c.json({ error: "invalid package name" }, 400, BADGE_ERROR_HEADERS);
   }
+  // A malformed tag is rejected rather than quietly resolved to `latest`: the
+  // fallback would answer a question about one release line with a badge about
+  // another, and an embedder who typo'd the parameter would never find out.
+  const rawTag = c.req.query("tag")?.trim();
+  if (rawTag !== undefined && !isValidBadgeTag(rawTag)) {
+    return c.json({ error: "invalid tag" }, 400, BADGE_ERROR_HEADERS);
+  }
+  const tag = resolveBadgeTag(rawTag);
 
   const db = createDb(c.env.DB);
   // Feed-listed scans only (a share link alone never makes a scan
   // name-queryable), the SQL pre-filter re-checked through scanEcosystem, and
   // registry-verified identity preferred over manifest claims.
-  const rows = await listBadgeCandidateScans(db, packageName, ecosystem);
+  const rows = await listBadgeCandidateScans(db, packageName, ecosystem, tag);
   const match = pickBadgeScan(
-    rows.filter((row) => scanEcosystem(row.source, row.summaryJson) === ecosystem),
+    rows.filter(
+      (row) =>
+        scanEcosystem(row.source, row.summaryJson) === ecosystem &&
+        badgeTagMatches(scanDistTag(row.summaryJson), tag),
+    ),
   );
   // Always 200: shields renders the payload either way, and "not reviewed"
   // must not read as an error to badge proxies.
-  return c.json(buildBadgePayload(match), 200, {
+  return c.json(buildBadgePayload(match, tag), 200, {
     "cache-control": "public, max-age=300",
     "access-control-allow-origin": "*",
     // Misses stay out of the colo cache. The "not reviewed" body is identical

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -38,7 +38,7 @@ import {
   optionalWorkerExecutionContext,
   workerExecutionContext,
 } from "../lib/platform/execution-context";
-import { purgePublicFeedCache } from "../lib/public-feed";
+import { purgePublicFeedCache, scanDistTag } from "../lib/public-feed";
 import {
   badgeLookupKey,
   enablePublicShare,
@@ -306,6 +306,9 @@ scansRoutes.post("/:id/decision", async (c) => {
         packageName: updated.scan.packageName,
         summaryJson: updated.scan.summaryJson,
       }),
+      // The scan's own release line: purging the default entry for an `rc`
+      // review would leave the stale rc badge cached and drop an unrelated one.
+      scanDistTag(updated.scan.summaryJson),
     );
   }
 

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -396,6 +396,7 @@ scansRoutes.post("/:id/share", async (c) => {
         optionalWorkerExecutionContext(c),
         canonicalOrigin(c),
         updated.publicPackageKey ?? null,
+        updated.publicBadgeTag ?? null,
       );
       share = updated;
     }
@@ -409,7 +410,7 @@ scansRoutes.delete("/:id/share", async (c) => {
   const { organizationId, role } = await requireActiveOrganizationContext(c, db);
   if (!roleCanManagePublicShares(role)) return c.json({ error: "forbidden" }, 403);
 
-  const { revoked, publicPackageKey } = await revokePublicShare(db, {
+  const { revoked, publicPackageKey, publicBadgeTag } = await revokePublicShare(db, {
     scanId: c.req.param("id"),
     organizationId,
     actorUserId: session.userId,
@@ -418,7 +419,12 @@ scansRoutes.delete("/:id/share", async (c) => {
     const existing = await getScanStatus(db, c.req.param("id"), organizationId);
     if (!existing) return c.json({ error: "not found" }, 404);
   } else {
-    purgePublicFeedCache(optionalWorkerExecutionContext(c), canonicalOrigin(c), publicPackageKey);
+    purgePublicFeedCache(
+      optionalWorkerExecutionContext(c),
+      canonicalOrigin(c),
+      publicPackageKey,
+      publicBadgeTag,
+    );
   }
   return c.json({ revoked });
 });

--- a/src/lib/badge-markdown.ts
+++ b/src/lib/badge-markdown.ts
@@ -1,4 +1,4 @@
-import type { PublicEcosystem } from "../../server/lib/public-feed";
+import { DEFAULT_BADGE_TAG, type PublicEcosystem } from "../../server/lib/public-feed";
 import { packageOnlyDiffPath } from "./package-diff-path";
 
 // README markdown for a package's shields.io status badge. Offered only for
@@ -6,29 +6,43 @@ import { packageOnlyDiffPath } from "./package-diff-path";
 // endpoint serves feed-listed scans exclusively, so handing out the snippet
 // any earlier would mint a permanent "not reviewed" badge.
 //
+// The snippet is for the release line the copied scan was staged under, not for
+// the package as a whole. The endpoint defaults to `latest`, so a maintainer
+// who lists an `rc` review and pastes an untagged snippet would embed a badge
+// that never shows it — the tag has to ride along or the two disagree silently.
+//
 // The click target differs by ecosystem. A README outlives any one release,
-// while the badge always shows the *newest* listed review — so the link must
-// not pin what the badge does not. npm has an evergreen package-only diff form
-// (`/diff/<name>` resolves the latest published pair on load), so the badge
-// links there. PyPI and VS Code have no package-only diff form, so the badge
-// links the share URL of the scan the maintainer copied it from — correct at
-// copy time, and still a live report afterwards, but version-pinned.
+// while the badge always shows the *newest* listed review on its line — so the
+// link must not pin what the badge does not. npm has an evergreen package-only
+// diff form (`/diff/<name>` resolves the latest published pair on load), so the
+// badge links there. PyPI and VS Code have no package-only diff form, so the
+// badge links the share URL of the scan the maintainer copied it from — correct
+// at copy time, and still a live report afterwards, but version-pinned.
 export function badgeMarkdown({
   origin,
   ecosystem,
   packageName,
   reportUrl,
+  tag,
 }: {
   origin: string;
   ecosystem: PublicEcosystem;
   packageName: string;
   reportUrl: string;
+  // The scan's dist-tag. Null (nothing was staged under one) and `latest` both
+  // mean the default badge, which is left untagged so the common snippet stays
+  // the short one.
+  tag?: string | null;
 }): string {
   // The name rides raw inside the endpoint URL (all three ecosystems' name
   // grammars are path-safe, and the badge route decodes the wildcard segment);
   // the endpoint is then encoded as a whole to nest inside shields' `url=`.
-  const endpoint = `${origin}/public/badge/${ecosystem}/${packageName}`;
+  const query = tag && tag !== DEFAULT_BADGE_TAG ? `?tag=${encodeURIComponent(tag)}` : "";
+  const endpoint = `${origin}/public/badge/${ecosystem}/${packageName}${query}`;
   const image = `https://img.shields.io/endpoint?url=${encodeURIComponent(endpoint)}`;
   const target = ecosystem === "npm" ? `${origin}${packageOnlyDiffPath(packageName)}` : reportUrl;
-  return `[![Drydock review](${image})](${target})`;
+  // The alt text names the line too: a README with a stable row and a
+  // prerelease row otherwise has two images called the same thing.
+  const alt = query ? `Drydock review (${tag})` : "Drydock review";
+  return `[![${alt}](${image})](${target})`;
 }

--- a/src/pages/Dashboard/ScanDetail/ShareDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/ShareDialog.tsx
@@ -1,5 +1,5 @@
 import { useComputed, useSignal } from "@preact/signals";
-import type { PublicEcosystem } from "../../../../server/lib/public-feed";
+import { DEFAULT_BADGE_TAG, type PublicEcosystem } from "../../../../server/lib/public-feed";
 import { badgeMarkdown } from "../../../lib/badge-markdown";
 import { formatDateTime } from "../../../lib/format";
 import type { DecisionStatus, PublicShareInfo } from "../../../models/scan";
@@ -19,6 +19,7 @@ export function ShareDialog({
   attestationAvailable,
   badgeEcosystem,
   packageName,
+  badgeTag,
   onEnable,
   onRevoke,
   onSetFeedListing,
@@ -31,6 +32,9 @@ export function ShareDialog({
   attestationAvailable: boolean | null;
   badgeEcosystem: PublicEcosystem | null;
   packageName: string | null;
+  // The dist-tag this release was staged under, so the snippet points at the
+  // line the maintainer just listed rather than at `latest`.
+  badgeTag: string | null;
   onEnable: () => void;
   onRevoke: () => void;
   onSetFeedListing: (listed: boolean) => void;
@@ -64,8 +68,12 @@ export function ShareDialog({
           ecosystem: badgeEcosystem,
           packageName,
           reportUrl: share.url,
+          tag: badgeTag,
         })
       : null;
+  // What the badge answers for. An untagged scan only ever answers the default
+  // badge, so it reads as `latest` rather than as nothing.
+  const badgeLine = badgeTag ?? DEFAULT_BADGE_TAG;
 
   return (
     <Dialog
@@ -143,8 +151,8 @@ export function ShareDialog({
               >
                 threat-feed.json
               </a>{" "}
-              index that security partners consume and powers the status badge for this
-              release&apos;s dist-tag, not just behind this link.
+              index that security partners consume and powers the README badge below, not just
+              behind this link.
             </span>
           </label>
           {badge ? (
@@ -162,7 +170,8 @@ export function ShareDialog({
               </div>
               <EmptyLine>
                 Paste into the package&apos;s README. The badge always shows the newest listed
-                review for this package; unlisting reverts it to &ldquo;not reviewed&rdquo;.
+                review on the <code class="font-mono">{badgeLine}</code> tag — a review of another
+                release line never displaces it; unlisting reverts it to &ldquo;not reviewed&rdquo;.
               </EmptyLine>
             </div>
           ) : null}

--- a/src/pages/Dashboard/ScanDetail/ShareDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/ShareDialog.tsx
@@ -143,8 +143,8 @@ export function ShareDialog({
               >
                 threat-feed.json
               </a>{" "}
-              index that security partners consume and powers the package&apos;s status badge, not
-              just behind this link.
+              index that security partners consume and powers the status badge for this
+              release&apos;s dist-tag, not just behind this link.
             </span>
           </label>
           {badge ? (

--- a/src/pages/Dashboard/ScanDetail/index.tsx
+++ b/src/pages/Dashboard/ScanDetail/index.tsx
@@ -22,7 +22,7 @@ import {
 import type { WorkflowGateDecision } from "../../../models/github-app";
 import { displayedAiResult, type AiReview } from "../../../../server/lib/ai-review/types";
 import { normalizeIntentEnvelope } from "../../../../server/lib/intent-envelope";
-import { scanEcosystem } from "../../../../server/lib/public-feed";
+import { scanDistTag, scanEcosystem } from "../../../../server/lib/public-feed";
 import { createPackageDiff, type DiffEntry } from "../../../../server/lib/review";
 import { Alert } from "../../../components/Alert";
 import { Button } from "../../../components/Button";
@@ -462,6 +462,7 @@ export default function ScanDetailPage() {
           attestationAvailableSignal={model.attestationAvailable}
           badgeEcosystem={scanEcosystem(detail.scan.source ?? "", detail.scan.summaryJson)}
           packageName={detail.scan.packageName}
+          badgeTag={scanDistTag(detail.scan.summaryJson)}
           onEnable={() => void model.enableShare()}
           onRevoke={() => void model.revokeShare()}
           onSetFeedListing={(listed) => void model.setFeedListing(listed)}

--- a/test/badge-markdown.test.ts
+++ b/test/badge-markdown.test.ts
@@ -5,7 +5,7 @@ const ORIGIN = "https://drydock.org";
 const REPORT = "https://drydock.org/reports/tok_abc123";
 
 function imageUrl(markdown: string): string {
-  const match = /!\[Drydock review\]\(([^)]+)\)/.exec(markdown);
+  const match = /!\[Drydock review[^\]]*\]\(([^)]+)\)/.exec(markdown);
   if (!match) throw new Error(`no badge image in ${markdown}`);
   return match[1];
 }
@@ -76,6 +76,50 @@ describe("badgeMarkdown", () => {
       imageUrl(md).slice("https://img.shields.io/endpoint?url=".length),
     );
     expect(nested).toBe("https://drydock.org/public/badge/vscode/publisher.extension");
+  });
+
+  test("a prerelease scan's snippet carries its tag", () => {
+    // The endpoint defaults to `latest`, so an untagged snippet copied from an
+    // rc review would embed a badge that never shows that review.
+    const md = badgeMarkdown({
+      origin: ORIGIN,
+      ecosystem: "npm",
+      packageName: "preact",
+      reportUrl: REPORT,
+      tag: "rc",
+    });
+    const nested = decodeURIComponent(
+      imageUrl(md).slice("https://img.shields.io/endpoint?url=".length),
+    );
+    expect(nested).toBe("https://drydock.org/public/badge/npm/preact?tag=rc");
+    // Still fully encoded from shields' point of view — the `?` and `=` of the
+    // nested query must not terminate shields' own `url=` parameter.
+    const rawNested = imageUrl(md).slice("https://img.shields.io/endpoint?url=".length);
+    expect(rawNested.includes("?")).toBe(false);
+    expect(rawNested.includes("&")).toBe(false);
+    // Two rows in one README need distinguishable alt text.
+    expect(md.startsWith("[![Drydock review (rc)](")).toBe(true);
+    // The link target stays evergreen: a README outlives the release.
+    expect(targetUrl(md)).toBe("https://drydock.org/diff/preact");
+  });
+
+  test("latest and untagged scans keep the short untagged snippet", () => {
+    // `?tag=latest` is the same request as the default, so the common case does
+    // not carry redundant query noise into every README.
+    for (const tag of ["latest", null, undefined]) {
+      const md = badgeMarkdown({
+        origin: ORIGIN,
+        ecosystem: "npm",
+        packageName: "left-pad",
+        reportUrl: REPORT,
+        tag,
+      });
+      const nested = decodeURIComponent(
+        imageUrl(md).slice("https://img.shields.io/endpoint?url=".length),
+      );
+      expect(nested).toBe("https://drydock.org/public/badge/npm/left-pad");
+      expect(md.startsWith("[![Drydock review](")).toBe(true);
+    }
   });
 
   test("markdown shape is a single image link", () => {

--- a/test/workers/threat-feed-badge.test.ts
+++ b/test/workers/threat-feed-badge.test.ts
@@ -72,6 +72,9 @@ async function seedCompletedScan(
     releaseRisk?: string;
     ecosystem?: "npm" | "pypi" | "vscode";
     source?: "manual" | "workflow_gate";
+    // The dist-tag the release was staged under. Only npm staged-publish scans
+    // carry one; omitted means a review that was never staged under a tag.
+    tag?: string;
     // A gate scan with no provenance snapshot at all: a legacy pre-provenance
     // record, or one whose redaction failed. Its ecosystem is unknowable.
     withoutProvenance?: boolean;
@@ -108,9 +111,11 @@ async function seedCompletedScan(
     status: "complete",
     summary: {
       report: { version: 1, digest: "abc123", digestAlgorithm: "sha256" },
+      ...(!gateEcosystem && options.tag ? { stagedPublish: { tag: options.tag } } : {}),
       ...(gateEcosystem
         ? {
             stagedPublish: {
+              ...(options.tag ? { tag: options.tag } : {}),
               provenance: {
                 ecosystem: gateEcosystem,
                 mode: "workflow_gate",
@@ -163,6 +168,7 @@ interface FeedBody {
     package: string | null;
     version: string | null;
     ecosystem: string | null;
+    tag: string | null;
     packageIdentity: string;
     releaseRisk: string;
     decision: string | null;
@@ -181,9 +187,16 @@ interface FeedBody {
 // the same entry even when the two arrive on different hostnames.
 const CANONICAL_TEST_ORIGIN = new URL(env.BETTER_AUTH_URL as string).origin;
 
+// The badge key varies by dist-tag, so the query has to be carried through:
+// purging with the bare path would clear the `latest` entry while the test
+// asserts on a `?tag=beta` one.
 function coloCacheKey(path: string): Request {
-  const bare = path.split("?")[0];
-  return publicFeedCacheKey(CANONICAL_TEST_ORIGIN, bare.replace(/^\/public/, ""));
+  const [bare, search] = path.split("?");
+  return publicFeedCacheKey(
+    CANONICAL_TEST_ORIGIN,
+    bare.replace(/^\/public/, ""),
+    search ? `?${search}` : "",
+  );
 }
 
 async function purgeColoCache(path: string): Promise<void> {
@@ -212,9 +225,11 @@ async function fetchBadge(
   app: ReturnType<typeof buildTestApp>,
   ecosystem: string,
   name: string,
-  options: { cached?: boolean } = {},
+  options: { cached?: boolean; tag?: string } = {},
 ): Promise<{ status: number; body: BadgeBody }> {
-  const path = `/public/badge/${ecosystem}/${name}`;
+  const path =
+    `/public/badge/${ecosystem}/${name}` +
+    (options.tag === undefined ? "" : `?tag=${encodeURIComponent(options.tag)}`);
   if (!options.cached) await purgeColoCache(path);
   const res = await request(app, path);
   return { status: res.status, body: (await res.json()) as BadgeBody };
@@ -638,6 +653,180 @@ describe("shields badge endpoint", () => {
     // rather than a limiter bug. Raise both together or neither.
   }, 30_000);
 
+  test("a listed prerelease review never displaces the default badge", async () => {
+    // The regression this exists for: the badge used to be version-agnostic and
+    // resolved to the newest listed review, so listing an rc repointed every
+    // embedded badge — including the one sitting next to `npm i <pkg>` — at a
+    // release nobody installs by default.
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `pkg-${crypto.randomUUID().slice(0, 8)}`;
+
+    const stable = await seedCompletedScan(owner, {
+      packageName,
+      version: "10.29.8",
+      tag: "latest",
+    });
+    await share(app, stable, { threatFeed: true });
+    await env.DB.prepare("UPDATE scans SET completed_at = 1 WHERE id = ?").bind(stable).run();
+
+    // Newer in every ordering the query applies, and still not the default.
+    const rc = await seedCompletedScan(owner, {
+      packageName,
+      version: "11.0.0-rc.0",
+      risk: "medium",
+      releaseRisk: "medium",
+      tag: "rc",
+    });
+    await share(app, rc, { threatFeed: true });
+
+    expect((await fetchBadge(app, "npm", packageName)).body).toMatchObject({
+      label: "drydock",
+      message: "10.29.8 reviewed · low risk",
+    });
+    // The prerelease line has its own badge, and its label names the tag so a
+    // README carrying both rows can be read apart.
+    expect((await fetchBadge(app, "npm", packageName, { tag: "rc" })).body).toMatchObject({
+      label: "drydock (rc)",
+      message: "11.0.0-rc.0 reviewed · medium risk",
+    });
+    // An explicit `latest` is the same request as the default.
+    expect((await fetchBadge(app, "npm", packageName, { tag: "latest" })).body.message).toBe(
+      "10.29.8 reviewed · low risk",
+    );
+    // A tag nobody listed is "not reviewed", not the stable review under
+    // another name — but still says which line it answered for.
+    expect((await fetchBadge(app, "npm", packageName, { tag: "next" })).body).toMatchObject({
+      label: "drydock (next)",
+      message: "not reviewed",
+    });
+  });
+
+  test("tags do not share a colo cache entry", async () => {
+    // The cache key ignores the query string by design (cache-busting must not
+    // force a D1 read); the tag is the one parameter that changes the body, so
+    // it has to be folded into the key or `?tag=beta` is served the `latest`
+    // body for the rest of the TTL.
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `pkg-${crypto.randomUUID().slice(0, 8)}`;
+
+    const stable = await seedCompletedScan(owner, { packageName, version: "1.0.0", tag: "latest" });
+    await share(app, stable, { threatFeed: true });
+    const beta = await seedCompletedScan(owner, {
+      packageName,
+      version: "2.0.0-beta.1",
+      tag: "beta",
+    });
+    await share(app, beta, { threatFeed: true });
+
+    // Warm the default entry first, then read the beta one through the cache.
+    expect((await fetchBadge(app, "npm", packageName)).body.message).toBe(
+      "1.0.0 reviewed · low risk",
+    );
+    expect(
+      (await fetchBadge(app, "npm", packageName, { tag: "beta", cached: true })).body.message,
+    ).toBe("2.0.0-beta.1 reviewed · low risk");
+    // Still cached per tag, and still ignoring everything else in the query.
+    const busted = await request(app, `/public/badge/npm/${packageName}?tag=beta&bust=1`);
+    expect(((await busted.json()) as BadgeBody).message).toBe("2.0.0-beta.1 reviewed · low risk");
+
+    // Unlisting the beta review purges the entry it actually occupied, and
+    // leaves the default badge alone.
+    await share(app, beta, { threatFeed: false });
+    expect(
+      (await fetchBadge(app, "npm", packageName, { tag: "beta", cached: true })).body.message,
+    ).toBe("not reviewed");
+    expect((await fetchBadge(app, "npm", packageName, { cached: true })).body.message).toBe(
+      "1.0.0 reviewed · low risk",
+    );
+  });
+
+  test("untagged reviews answer only the default badge", async () => {
+    // Two populations have no dist-tag: ecosystems that have none at all, and
+    // staged scans predating tag capture. Both describe the release a consumer
+    // installs by default, so they must keep working — without answering a
+    // question about some other release line.
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `pkg-${crypto.randomUUID().slice(0, 8)}`;
+    const legacy = await seedCompletedScan(owner, { packageName, version: "4.0.0" });
+    await share(app, legacy, { threatFeed: true });
+
+    expect((await fetchBadge(app, "npm", packageName)).body.message).toBe(
+      "4.0.0 reviewed · low risk",
+    );
+    expect((await fetchBadge(app, "npm", packageName, { tag: "beta" })).body.message).toBe(
+      "not reviewed",
+    );
+
+    // Same for an ecosystem with no dist-tag concept at all.
+    const pypiName = `pkg-${crypto.randomUUID().slice(0, 8)}`;
+    const pypi = await seedCompletedScan(owner, {
+      packageName: pypiName,
+      version: "1.2.3",
+      ecosystem: "pypi",
+      source: "workflow_gate",
+    });
+    await share(app, pypi, { threatFeed: true });
+    expect((await fetchBadge(app, "pypi", pypiName)).body.message).toBe(
+      "1.2.3 reviewed · low risk",
+    );
+    expect((await fetchBadge(app, "pypi", pypiName, { tag: "rc" })).body.message).toBe(
+      "not reviewed",
+    );
+  });
+
+  test("a prerelease line cannot crowd the stable review out of the candidate page", async () => {
+    // An active prerelease line publishes far more often than the stable one,
+    // so the tag has to be filtered in SQL: a page taken before the filter
+    // would be all `rc` rows and the default badge would read "not reviewed"
+    // with a listed stable review sitting just past the limit.
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `pkg-${crypto.randomUUID().slice(0, 8)}`;
+    const stable = await seedCompletedScan(owner, { packageName, version: "1.0.0", tag: "latest" });
+    await share(app, stable, { threatFeed: true });
+    await env.DB.prepare("UPDATE scans SET completed_at = 1 WHERE id = ?").bind(stable).run();
+
+    for (let index = 0; index < 21; index += 1) {
+      const rc = await seedCompletedScan(owner, {
+        packageName,
+        version: `2.0.0-rc.${index}`,
+        tag: "rc",
+      });
+      await share(app, rc, { threatFeed: true });
+    }
+
+    expect((await fetchBadge(app, "npm", packageName)).body.message).toBe(
+      "1.0.0 reviewed · low risk",
+    );
+  });
+
+  test("a malformed tag is rejected rather than resolved to latest", async () => {
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `pkg-${crypto.randomUUID().slice(0, 8)}`;
+    const scanId = await seedCompletedScan(owner, { packageName, version: "1.0.0", tag: "latest" });
+    await share(app, scanId, { threatFeed: true });
+    // Warm the default entry: a malformed tag must not be answered out of it.
+    expect((await fetchBadge(app, "npm", packageName)).body.message).toBe(
+      "1.0.0 reviewed · low risk",
+    );
+
+    // Silently falling back would answer a typo'd parameter with a badge about
+    // a different release line, and the embedder would never find out.
+    for (const bad of ["../latest", "beta rc", "a".repeat(65), "‮rtsl"]) {
+      const res = await request(
+        app,
+        `/public/badge/npm/${packageName}?tag=${encodeURIComponent(bad)}`,
+      );
+      expect(res.status).toBe(400);
+      // Badge errors are fetched cross-origin by the same proxies as the 200s.
+      expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    }
+  });
+
   test("badge misses are not written to the colo cache", async () => {
     const app = buildTestApp(null);
     // Every invented name would otherwise add an entry to the same
@@ -774,6 +963,26 @@ describe("public threat feed", () => {
     expect(feed.entries[stagedIndex]?.packageIdentity).toBe("registry-verified");
     // Listed later → appears first.
     expect(stagedIndex).toBeLessThan(gateIndex);
+  });
+
+  test("feed entries carry the dist-tag, null when the release was never staged under one", async () => {
+    // The tag is the axis the badge is queried on, so a partner walking
+    // feed → badge has to see the same value the badge filters by.
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const tagged = `feed-${crypto.randomUUID().slice(0, 8)}`;
+    const untagged = `feed-${crypto.randomUUID().slice(0, 8)}`;
+    await share(app, await seedCompletedScan(owner, { packageName: tagged, tag: "beta" }), {
+      threatFeed: true,
+    });
+    await share(app, await seedCompletedScan(owner, { packageName: untagged }), {
+      threatFeed: true,
+    });
+
+    const feed = await fetchFeed(app);
+    expect(feed.entries.find((entry) => entry.package === tagged)?.tag).toBe("beta");
+    // Null, never "latest": nothing established a tag for this one.
+    expect(feed.entries.find((entry) => entry.package === untagged)?.tag).toBeNull();
   });
 
   test("a null JSON body shares without touching the listing", async () => {

--- a/test/workers/threat-feed-badge.test.ts
+++ b/test/workers/threat-feed-badge.test.ts
@@ -748,6 +748,27 @@ describe("shields badge endpoint", () => {
     });
   });
 
+  test("npm-valid URI-safe punctuation remains addressable as a release line", async () => {
+    // npm accepts dist-tags made from characters encodeURIComponent leaves
+    // intact. Treating `~` as malformed made the persisted non-null tag miss
+    // both the default SQL population and every explicitly queryable line.
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `pkg-${crypto.randomUUID().slice(0, 8)}`;
+    const scanId = await seedCompletedScan(owner, {
+      packageName,
+      version: "2.0.0-beta.1",
+      tag: "beta~edge",
+    });
+    await share(app, scanId, { threatFeed: true });
+
+    expect((await fetchBadge(app, "npm", packageName, { tag: "beta~edge" })).body).toMatchObject({
+      label: "drydock (beta~edge)",
+      message: "2.0.0-beta.1 reviewed · low risk",
+    });
+    expect((await fetchBadge(app, "npm", packageName)).body.message).toBe("not reviewed");
+  });
+
   test("tags do not share a colo cache entry", async () => {
     // The cache key ignores the query string by design (cache-busting must not
     // force a D1 read); the tag is the one parameter that changes the body, so
@@ -862,7 +883,7 @@ describe("shields badge endpoint", () => {
 
     // Silently falling back would answer a typo'd parameter with a badge about
     // a different release line, and the embedder would never find out.
-    for (const bad of ["../latest", "beta rc", "a".repeat(65), "‮rtsl"]) {
+    for (const bad of ["", "   ", "../latest", "beta rc", "a".repeat(65), "‮rtsl"]) {
       const res = await request(
         app,
         `/public/badge/npm/${packageName}?tag=${encodeURIComponent(bad)}`,

--- a/test/workers/threat-feed-badge.test.ts
+++ b/test/workers/threat-feed-badge.test.ts
@@ -495,6 +495,52 @@ describe("shields badge endpoint", () => {
     });
   });
 
+  test("an approved prerelease stays on its own release line", async () => {
+    // Where the approved-badge state and the tag axis meet: the decision must
+    // not launder a prerelease onto the default badge, and the purge the
+    // decision route fires has to address the line the badge actually occupies.
+    const owner = await seedUser();
+    const app = buildTestApp(owner);
+    const packageName = `pkg-${crypto.randomUUID().slice(0, 8)}`;
+    const stable = await seedCompletedScan(owner, { packageName, version: "1.0.0", tag: "latest" });
+    await share(app, stable, { threatFeed: true });
+    const rc = await seedCompletedScan(owner, {
+      packageName,
+      version: "2.0.0-rc.0",
+      risk: "medium",
+      releaseRisk: "medium",
+      tag: "rc",
+    });
+    await share(app, rc, { threatFeed: true });
+    // Warm both entries so the purge below has something to invalidate.
+    expect((await fetchBadge(app, "npm", packageName)).body.message).toBe(
+      "1.0.0 reviewed · low risk",
+    );
+    expect((await fetchBadge(app, "npm", packageName, { tag: "rc" })).body.message).toBe(
+      "2.0.0-rc.0 reviewed · medium risk",
+    );
+
+    const decide = await request(app, `/api/v1/scans/${rc}/decision`, {
+      method: "POST",
+      body: JSON.stringify({ decision: "publish", reason: "intended changes" }),
+    });
+    expect(decide.status).toBe(200);
+
+    // The rc entry was purged, so even a cached read shows the sign-off — and
+    // it is still labelled as the rc line, not as the package's headline.
+    expect(
+      (await fetchBadge(app, "npm", packageName, { tag: "rc", cached: true })).body,
+    ).toMatchObject({
+      label: "drydock (rc)",
+      message: "2.0.0-rc.0 approved",
+      color: "brightgreen",
+    });
+    // The stable badge is untouched by a decision on another line.
+    expect((await fetchBadge(app, "npm", packageName, { cached: true })).body.message).toBe(
+      "1.0.0 reviewed · low risk",
+    );
+  });
+
   test("an approved manifest-claimed release stays visibly unverified", async () => {
     const owner = await seedUser();
     const app = buildTestApp(owner);


### PR DESCRIPTION
## Why

The badge was version-agnostic: it resolved to the newest feed-listed review for a package name, whatever release that review was of. So listing a prerelease review repointed every embedded badge — including the one sitting beside `npm i <pkg>` — at a version nobody installs by default, and a package could not carry a stable badge and a prerelease badge at once. Whichever scan was listed last won.

This surfaced from a real report: `drydock.org/public/badge/npm/preact` reads `11.0.0-beta.2` while npm's `latest` is `10.29.8`.

## What changed

`GET /public/badge/:ecosystem/:package[?tag=]` selects the release line, defaulting to `latest`, because a badge answers for the release its README's install command produces.

- The value is the dist-tag the release was staged under (`summaryJson.stagedPublish.tag`), which staged npm scans have carried all along — nothing new is captured. It is filtered in SQL beside the ecosystem for the same reason: an active prerelease line publishes far more often than the stable one, so an unfiltered bounded page would be all `rc` rows while a listed stable review sat just past the limit.
- Untagged reviews — every gate scan, every PyPI and VS Code review, and staged scans predating tag capture — answer only the default badge. All of them describe the release a consumer installs by default, so excluding them would blank working badges, while admitting them into `?tag=beta` would answer a question about the beta line with a review of something else.
- A non-default tag is named in the label (`drydock (rc)`, composing to `drydock (rc, unverified)`), so a README carrying two rows can be read apart — both messages otherwise read `<version> reviewed`.
- Malformed tags are a `400` rather than a silent fall back to `latest`, which would answer a typo'd parameter with a badge about a different release line.
- The colo cache key includes the tag; without it `?tag=beta` is served the `latest` body for the rest of the TTL. Malformed tags keep their own key so a `400` is never answered out of a warm `latest` entry, and listing/decision changes purge the entry for the scan's own line instead of a guessed set.
- Feed entries carry the same `tag` (null, never `latest`, when nothing established one).
- The share dialog's README snippet (#581) carries the tag, so a maintainer who lists an `rc` review no longer pastes a badge that never shows it.

## Rebase seams worth a reviewer's eye

This landed on top of #581 and #582, which touch the same surface. Three places needed threading and two of them were silent:

- #582's `publish` branch built its label without the tag — an approved `rc` would have rendered as plain `drydock`.
- Both decision routes (`scans.ts`, `github-app.ts`) purged without naming a line, dropping the default entry and leaving a stale `rc` badge cached. No type or test surface caught this until the interaction test was added.

## Known limitation, flagged deliberately

For a package whose maintainer only publishes under a prerelease tag (no `latest` release yet), the default badge now resolves to an untagged manifest-claimed gate scan where previously the registry-verified review won it:

```
default   ->  drydock (unverified)  "9.9.9 reviewed · low risk"
?tag=next ->  drydock (next)        "1.0.0-next.4 reviewed · low risk"
```

The existing mitigations hold — it renders `(unverified)` and never takes the clean green — but it is a real narrowing of that tiebreak's reach. Left as-is pending a call on whether untagged manifest-claimed scans should be ineligible for the npm default badge when any registry-verified listed review exists for the name.

Also unchanged and worth knowing: dist-tags are mutable after publish while the captured tag is not, so promoting an `rc` to `latest` does not move its review onto the latest badge.

## Deploy consequence

`drydock.org/public/badge/npm/preact` will go from `11.0.0-beta.2 reviewed` to `not reviewed`, because the only listed preact scan is tagged `beta` and no `latest` review is listed. That is the honest state. Any badge in the wild whose package's only listed review is a prerelease goes blank until a `latest` review is listed.

## Testing

`pnpm run verify` green. New coverage in `test/workers/threat-feed-badge.test.ts`:

- a listed prerelease never displaces the default badge; `?tag=rc` gets its own
- tags do not share a colo cache entry, and unlisting purges the line it occupied
- untagged reviews answer only the default badge (npm legacy + PyPI)
- a prerelease line cannot crowd the stable review out of the candidate page
- malformed tags 400 with CORS, and are not answered from a warm `latest` entry
- an approved prerelease keeps its line through the decision purge
- feed entries carry `tag`

Plus two in `test/badge-markdown.test.ts` for the tagged and untagged snippet forms.

Docs updated: `docs/public-reports.md` (release lines, caching, feed field, dialog snippet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)