### PR TITLE
Move Agent Trace telemetry to the AI SDK v7 shape

### DIFF
--- a/docs/ai-review-eval.md
+++ b/docs/ai-review-eval.md
@@ -34,9 +34,17 @@ relying on the clamp.
 
 The AI SDK is wrapped with Cloudflare's Agent Traces integration. Production
 and the self-host template enable persisted traces at a 10% head sample. The
-wrapper explicitly sets `storeMessages: false` and `storeTools: false`, because
-prompts and tool results can contain private pre-release source, secrets, or
-hostile instructions.
+wrapper explicitly sets `storeMessages: false` and `storeTools: false`, and the
+call sets `recordInputs: false` and `recordOutputs: false`, because prompts and
+tool results can contain private pre-release source, secrets, or hostile
+instructions.
+
+Trace identity follows the AI SDK v7 shape: `telemetry.functionId` names the
+agent, and `agentId`, `agentVersion`, `conversationId`, and `ecosystem` travel
+in the call's `runtimeContext`, each opted onto the span through
+`telemetry.includeRuntimeContext`. v7 removed `telemetry.metadata`; runtime
+context is an application-data channel, so anything not named there stays off
+the span.
 
 Recorded trace data is limited to operation names and timing, model and token
 usage, tool names, the reviewer version, ecosystem capability label, and a

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -81,14 +81,17 @@ Workflow gates never publish. GitHub Environment protection holds the publish jo
 Package contents are hostile instructions. AI prompts must frame package text as evidence, restrict outputs to schema-validated findings, and keep deterministic findings/risk independent. AI input should include only the minimum changed-file evidence needed for review, never credentials, sessions, raw headers, or operator secrets. Invalid, partial, or unsafe AI output is ignored/unavailable rather than treated as a clean review.
 
 Cloudflare Agent Traces are sampled at 10% for reviewer debugging, with message
-and tool payload persistence explicitly disabled. Trace metadata is restricted
-to operation/timing, model/usage, tool names, reviewer version, ecosystem, and a
-fresh invocation-scoped random id. The reviewer exposes only `run` through a
-narrow Workers AI binding facade so the tracing wrapper cannot copy the AI
-Gateway log id into the trace. It must not include scan, stage,
-organization, package, file, prompt, evidence, or tool-result content. Aggregate
-AI execution and decision events follow the same no-package-content rule; a
-maintainer decision is feedback, never an automatic truth label. See
+and tool payload persistence explicitly disabled at both the tracing wrapper
+(`storeMessages`/`storeTools`) and the AI SDK call
+(`recordInputs`/`recordOutputs`). Trace metadata is restricted to an explicit
+allowlist of runtime-context keys — operation/timing, model/usage, tool names,
+reviewer version, ecosystem, and a fresh invocation-scoped random id. The
+reviewer exposes only `run` through a narrow Workers AI binding facade so the
+tracing wrapper cannot copy the AI Gateway log id into the trace. It must not
+include scan, stage, organization, package, file, prompt, evidence, or
+tool-result content. Aggregate AI execution and decision events follow the same
+no-package-content rule; a maintainer decision is feedback, never an automatic
+truth label. See
 [`ai-review-eval.md`](./ai-review-eval.md).
 
 For npm registry tarballs, consumer install lifecycle hooks are `preinstall`, `install`, and `postinstall`. `prepare`, `prepack`, `postpack`, and publish/prepublish hooks are packaging-time hooks and should not be treated as consumer-install evidence unless other evidence shows they changed the shipped artifact.

--- a/server/lib/ai-review/index.ts
+++ b/server/lib/ai-review/index.ts
@@ -159,7 +159,7 @@ export async function analyzeWithAi(
           // call: an invalid one (rejected by validation, so `execute` never fires)
           // must let the model see the tool error and retry instead of ending the loop.
           stopWhen: [() => submittedReview !== null, ai.stepCountIs(MAX_AGENT_STEPS)],
-          experimental_telemetry: aiReviewTraceTelemetry(options, traceConversationId),
+          ...aiReviewTraceTelemetry(options, traceConversationId),
           // The last step the budget allows offers only submit_review and forces
           // the call: a run that spends every step gathering evidence would
           // otherwise end unrecorded, discarding the whole token spend and
@@ -253,19 +253,37 @@ export async function analyzeWithAi(
   };
 }
 
+// AI SDK v7 dropped `telemetry.metadata`, so trace identity and labels travel in
+// `runtimeContext` and reach the span only via `includeRuntimeContext`. Spread
+// onto the call: `runtimeContext` is a top-level option, not a telemetry field.
 export function aiReviewTraceTelemetry(
   options: Pick<SelectiveAiReviewOptions, "ecosystem">,
   conversationId: string,
 ) {
   return {
-    functionId: AI_REVIEW_AGENT_NAME,
-    metadata: {
+    runtimeContext: {
       agentId: AI_REVIEW_AGENT_NAME,
       agentVersion: AI_REVIEWER_VERSION,
       conversationId,
       // Ecosystem is a closed product capability label, not package or tenant
       // data. Organization, stage, package, file, and evidence fields stay out.
       ecosystem: options.ecosystem,
+    },
+    telemetry: {
+      functionId: AI_REVIEW_AGENT_NAME,
+      // Runtime context is an application-data channel, not a telemetry bag:
+      // nothing reaches a span without being named here.
+      includeRuntimeContext: {
+        agentId: true,
+        agentVersion: true,
+        conversationId: true,
+        ecosystem: true,
+      },
+      // Belt-and-braces against the wrapper's `storeMessages`/`storeTools`:
+      // prompts and tool results carry pre-release source and hostile input, so
+      // no payload recorder may turn them into retained trace evidence.
+      recordInputs: false,
+      recordOutputs: false,
     },
   };
 }

--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -304,12 +304,22 @@ describe("ai review orchestration", () => {
     );
 
     expect(telemetry).toEqual({
-      functionId: "drydock-release-reviewer",
-      metadata: {
+      runtimeContext: {
         agentId: "drydock-release-reviewer",
         agentVersion: AI_REVIEWER_VERSION,
         conversationId: "trace_random",
         ecosystem: "npm",
+      },
+      telemetry: {
+        functionId: "drydock-release-reviewer",
+        includeRuntimeContext: {
+          agentId: true,
+          agentVersion: true,
+          conversationId: true,
+          ecosystem: true,
+        },
+        recordInputs: false,
+        recordOutputs: false,
       },
     });
     expect(JSON.stringify(telemetry)).not.toMatch(/scan_private|stage_private|org_private/);


### PR DESCRIPTION
## Summary

The reviewer runs `ai@7`, but the `generateText` call still passed the v6 `experimental_telemetry: { functionId, metadata }` shape, and v7's `TelemetryOptions` has no `metadata` field — so the SDK's own OpenTelemetry projection dropped `agentId`, `agentVersion`, `conversationId`, and `ecosystem`, and it only kept working because the agents wrapper still reads v6 `metadata` as a back-compat fallback. Identity now travels in the call's top-level `runtimeContext` and is opted onto the span through `telemetry.includeRuntimeContext`, following Cloudflare's agent tracing setup instructions; `ecosystem` moves from `cloudflare.agents.metadata.ecosystem` to `cloudflare.agents.runtime_context.ecosystem`, while the identity keys are consumed into `gen_ai.*` as before so nothing is emitted twice. This also sets `recordInputs: false` / `recordOutputs: false` next to the wrapper's existing `storeMessages` / `storeTools`, so no payload recorder can turn hostile package evidence into retained trace data. Wrangler already enabled traces at a 10% head sample and that is unchanged, as is the `traceIsolatedAiBinding` facade that keeps `aiGatewayLogId` out of the trace.

## Trust boundary

Agent Trace payload persistence — the boundary that keeps pre-release package source, secrets, and prompt-injection text out of retained traces. This change only tightens it: payload recording is now denied at both the wrapper and the AI SDK call, and trace attributes come from an explicit runtime-context allowlist rather than a metadata bag. No scan, stage, organization, package, file, or evidence identifier is added.

## Verification

`pnpm run verify` passes (lint, format check, typecheck, tests), including the updated `test/ai-review.test.mjs` assertion that trace config carries the reviewer version and an invocation-scoped random id but no scan/stage/org identifiers. `pnpm run build` plus `wrangler deploy --dry-run` succeeds with the traces block intact in the generated config. Not deployed, so the attribute rename is verified against the agents wrapper's source rather than against a live sampled trace.

## Documentation

Updated `docs/ai-review-eval.md` (Agent Traces section) and `docs/security-model.md` to describe the v7 runtime-context shape and the two-layer payload denial.

## UI evidence

Not applicable — no UI change.