### PR TITLE
Add live AI reviewer model comparison

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ New functionality needs tests at the narrowest useful layer; add broader coverag
 - `pnpm run test` — Vitest logic + Worker-runtime suites.
 - `pnpm run test:e2e` — Playwright fake-registry e2e.
 - `pnpm run eval` — detection eval harness.
+- `pnpm run eval:ai:live` — paid live AI-reviewer model comparison; needs Cloudflare credentials and never runs in `verify`. See `docs/ai-review-eval.md`.
 - `pnpm db:generate` — generate Drizzle migrations; never hand-write SQL migrations.
 
 ## Documentation expectations

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ The user-facing learning guide is [`../src/pages/Docs/index.tsx`](../src/pages/D
 
 - [`security-detection-corpus.md`](./security-detection-corpus.md) — rule/eval fixture layout and expected findings.
 - [`detection-eval.md`](./detection-eval.md) — eval harness, metrics, and gates.
-- [`ai-review-eval.md`](./ai-review-eval.md) — versioned AI reviewer contract, recorded-output evals, traces, and feedback loop.
+- [`ai-review-eval.md`](./ai-review-eval.md) — versioned AI reviewer contract, recorded-output evals, live model comparison, traces, and feedback loop.
 - [`release-memory.md`](./release-memory.md) — advisory prior-release finding-profile consistency; discounts already-approved package context from the artifact-risk headline, and never moves release risk or a gate decision.
 - [`release-fingerprint.md`](./release-fingerprint.md) — the history-based `release.source-drift` rule and its FP posture.
 - [`organization-members.md`](./organization-members.md) — organization invitation/membership behavior.

--- a/docs/ai-review-eval.md
+++ b/docs/ai-review-eval.md
@@ -86,13 +86,72 @@ threat class, then compare the new version by category. Keep model failover's
 runtime behavior covered by the mocked orchestration tests in
 `test/ai-review.test.mjs` as well.
 
+## Live model comparison
+
+The offline eval cannot rank hosted models, so model routing has its own
+harness. Run:
+
+```sh
+CLOUDFLARE_ACCOUNT_ID=... CLOUDFLARE_API_TOKEN=... pnpm run eval:ai:live
+```
+
+It drives the real `analyzeWithAi` agent loop against real Workers AI models
+over the npm security corpus, one model at a time (no failover, or the
+comparison would measure the wrong model). It is paid and network-bound, so it
+is gated behind `AI_REVIEW_LIVE_EVAL` and never runs in `pnpm test` or
+`pnpm run verify`. Reports land in `.context/eval/ai-review-model-compare.json`
+and `.context/eval/ai-review-model-compare.md`.
+
+Environment: `AI_REVIEW_LIVE_MODELS` (comma-separated ids, defaults to the two
+routed models), `AI_REVIEW_LIVE_LIMIT` (cap fixtures while iterating; the report
+states how many were dropped), `AI_REVIEW_LIVE_GATEWAY`.
+
+It reports three things, in priority order:
+
+1. **Completion rate.** How often the model lands a valid `submit_review`
+   before the step budget ends. Every candidate on the Workers AI catalog is a
+   reasoning model, and reasoning tokens bill against `MAX_REVIEW_OUTPUT_TOKENS`
+   — a model can spend the whole budget thinking and never submit. That returns
+   `invalid`, which floors the scan at medium and escalates the release to a
+   human. A model that scores well on the cases it finishes but often fails to
+   finish is worse for the product than a duller model that always submits.
+2. **Detection quality.** Catch rate on malicious fixtures and false-positive
+   rate on benign hard-negatives, scored with the same predicates the recorded
+   eval uses so the two reports mean the same thing.
+3. **Cost.** Measured tokens priced per model, with cached input billed
+   separately. The loop re-sends a prefix that grows to the evidence cap, up to
+   `MAX_AGENT_STEPS` times, so cached-input share dominates the bill: a model
+   with no published cache tier re-bills the whole prefix every step and can
+   cost more than one with double its list price. `MODEL_PRICING` in
+   `test/eval/ai-review-live-harness.mjs` carries the list prices and the date
+   they were checked — refresh it with any routing change, because a stale table
+   silently reorders the comparison.
+
+Two things the harness deliberately does not do. It asserts no winner: picking a
+model is a judgement call across all three axes. And it covers npm-shaped
+fixtures only: today that is 46 fixtures (33 malicious, 13 benign). The 14 PyPI
+fixtures carry adapter-shaped inputs and appear in the report's `skipped` list
+rather than being dropped silently; VS Code fixtures are not loaded by the
+detection corpus loader at all, so covering VSIX means extending `loadCorpus`
+first.
+
+Context window is not a selection criterion. Evidence is capped at
+`MAX_TOTAL_TOOL_RESPONSE_CHARS`, so any window past that is spend on capacity
+the reviewer refuses to use; treat it as a floor to clear, not a feature to buy.
+
 ## Promotion checklist
 
-1. Bump `AI_REVIEWER_VERSION` for behavioral changes.
+1. Bump `AI_REVIEWER_VERSION` for behavioral changes. Model routing is part of
+   that contract: changing `AI_MODEL` or `AI_FALLBACK_MODEL` is a version bump,
+   and the recorded eval records must be reissued at the new version in the
+   same change.
 2. Run the normal reviewer tests and `pnpm run eval:ai`.
-3. Compare completion rate, latency, steps, tokens, and decision distribution
+3. For a routing change, run `pnpm run eval:ai:live` over the candidate set and
+   read completion rate before detection quality before cost. Refresh
+   `MODEL_PRICING` first.
+4. Compare completion rate, latency, steps, tokens, and decision distribution
    by reviewer version; do not treat maintainer action as ground truth.
-4. Refresh and adjudicate recorded outputs for risky categories, including
+5. Refresh and adjudicate recorded outputs for risky categories, including
    prompt injection, missing evidence, and model failover.
-5. Preserve deterministic findings as authoritative and keep human release
+6. Preserve deterministic findings as authoritative and keep human release
    approval mandatory.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:workers": "vitest run --project workers",
     "eval": "vitest run --project node test/eval/detection-eval.test.mjs",
     "eval:ai": "vitest run --project node test/eval/ai-review-eval.test.mjs",
+    "eval:ai:live": "AI_REVIEW_LIVE_EVAL=1 vitest run --project node test/eval/ai-review-live.test.mjs",
     "fuzz": "FUZZ_RUNS=20000 vitest run --project node --testTimeout=600000 test/archive-parser.fuzz.test.mjs",
     "e2e:fixtures": "node test/e2e/build-fixtures.mjs",
     "e2e:registry": "node test/e2e/fake-registry.mjs",

--- a/server/lib/ai-review/contract.ts
+++ b/server/lib/ai-review/contract.ts
@@ -6,7 +6,7 @@ export type AiReviewEcosystem = "npm" | "pypi" | "vscode" | "generic";
 // or model-routing policy changes in a way that can alter reviewer behavior.
 // Persisting this with each review keeps analytics and recorded eval cases from
 // silently comparing different reviewer contracts as though they were one.
-export const AI_REVIEWER_VERSION = "1.1.0";
+export const AI_REVIEWER_VERSION = "1.2.0";
 
 // We surface only the highest-signal findings: critical/high, most severe
 // first, capped at this count. Lower-severity context belongs in the summary.

--- a/server/lib/ai-review/index.ts
+++ b/server/lib/ai-review/index.ts
@@ -27,8 +27,21 @@ export { displayedAiResult } from "./types";
 export { AI_REVIEWER_VERSION } from "./contract";
 
 // Reviewer model order: prefer the strongest affordable model, then fail over.
+//
+// Both candidates must survive this loop's shape, not just answer a prompt: up
+// to MAX_AGENT_STEPS re-sends of a prefix that grows to the evidence cap. That
+// makes the cached-input price, not the headline input price, the cost driver,
+// and it makes the context window a floor rather than a feature — evidence is
+// capped at MAX_TOTAL_TOOL_RESPONSE_CHARS, so anything past ~64k is unusable
+// spend. The fallback is deliberately an agentic model with a deep cache
+// discount rather than the cheapest listing: a failover that cannot finish the
+// loop returns `invalid`, which floors the scan at medium and escalates to
+// manual review, so a "cheap" model that misses the submission costs more than
+// it saves. Re-check both against docs/ai-review-eval.md's live comparison
+// before changing either; changing them is a routing change, so bump
+// AI_REVIEWER_VERSION with it.
 export const AI_MODEL = "@cf/moonshotai/kimi-k2.7-code";
-export const AI_FALLBACK_MODEL = "@cf/qwen/qwen3-30b-a3b-fp8";
+export const AI_FALLBACK_MODEL = "@cf/deepseek-ai/deepseek-v4-flash-0731";
 export const AI_MODEL_CANDIDATES = [AI_MODEL, AI_FALLBACK_MODEL] as const;
 const AI_REVIEW_AGENT_NAME = "drydock-release-reviewer";
 
@@ -137,10 +150,7 @@ export async function analyzeWithAi(
             binding: traceIsolatedAiBinding(env.AI),
             gateway: { id: "drydock-gateway" },
           })(candidateModel, {
-            extraHeaders: {
-              "x-session-affinity": scanScopedCacheAffinity(env, options.scanId),
-              "cf-aig-metadata": aiGatewayMetadataHeader(options, candidateModel, attempt),
-            },
+            extraHeaders: aiReviewRequestHeaders(env, options, candidateModel, attempt),
           });
         const tools = createAiReviewTools(
           options,
@@ -284,6 +294,23 @@ function isRetryableAiError(err: unknown): boolean {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// The per-request headers that decide cache affinity and Gateway attribution.
+// Exported because the offline model comparison in
+// `test/eval/ai-review-live-harness.mjs` builds its own Workers AI model over
+// REST credentials: measuring cached-token share against different headers than
+// production sends would compare the wrong thing.
+export function aiReviewRequestHeaders(
+  env: Cloudflare.Env,
+  options: SelectiveAiReviewOptions,
+  model: string,
+  attempt: number,
+): Record<string, string> {
+  return {
+    "x-session-affinity": scanScopedCacheAffinity(env, options.scanId),
+    "cf-aig-metadata": aiGatewayMetadataHeader(options, model, attempt),
+  };
 }
 
 export function aiGatewayMetadataHeader(

--- a/test/ai-review-model-compare.test.mjs
+++ b/test/ai-review-model-compare.test.mjs
@@ -1,0 +1,354 @@
+// Offline coverage for the live comparison harness. The live run itself is
+// paid and network-bound (test/eval/ai-review-live.test.mjs); the pieces that
+// decide what the report *says* — case construction, cost math, scoring, and
+// truncation reporting — are pure and are covered here so a wrong verdict can
+// never be blamed on the harness after the money is spent.
+
+import { describe, expect, test } from "vitest";
+import {
+  buildLiveCases,
+  DEFAULT_COMPARISON_MODELS,
+  estimateCost,
+  MODEL_PRICING,
+  renderMarkdown,
+  runAiReviewModelComparison,
+  scoreRun,
+  summarizeModel,
+} from "./eval/ai-review-live-harness.mjs";
+import { AI_FALLBACK_MODEL, AI_MODEL } from "../server/lib/ai-review/index.ts";
+
+const KIMI = "@cf/moonshotai/kimi-k2.7-code";
+const FLASH = "@cf/deepseek-ai/deepseek-v4-flash-0731";
+const QWEN_NO_CACHE = "@cf/qwen/qwen3.8-27b";
+
+function usage(overrides = {}) {
+  return {
+    inputTokens: 100_000,
+    cachedInputTokens: 80_000,
+    outputTokens: 3_000,
+    totalTokens: 103_000,
+    steps: 6,
+    ...overrides,
+  };
+}
+
+describe("model pricing table", () => {
+  test("prices every model the reviewer can route to", () => {
+    for (const model of DEFAULT_COMPARISON_MODELS) {
+      expect(MODEL_PRICING[model]).toBeDefined();
+    }
+    expect(DEFAULT_COMPARISON_MODELS).toEqual([AI_MODEL, AI_FALLBACK_MODEL]);
+  });
+});
+
+describe("estimateCost", () => {
+  test("bills cached input at the cached rate", () => {
+    // 20k fresh @ $0.95/M + 80k cached @ $0.19/M + 3k out @ $4.00/M
+    expect(estimateCost(KIMI, usage())).toBeCloseTo(0.019 + 0.0152 + 0.012, 6);
+  });
+
+  test("bills the whole prefix at full rate when no cached tier is published", () => {
+    // The trap this harness exists to catch: qwen3.8-27b's $0.45/M input looks
+    // cheaper than kimi's $0.95/M, but with no cache tier the agent loop
+    // re-bills every step at full rate and it ends up more expensive.
+    const qwen = estimateCost(QWEN_NO_CACHE, usage());
+    const kimi = estimateCost(KIMI, usage());
+    expect(qwen).toBeCloseTo(100_000 * (0.45 / 1e6) + 3_000 * (3.2 / 1e6), 6);
+    expect(qwen).toBeGreaterThan(kimi);
+  });
+
+  test("is cheapest on the fallback model for an identical loop", () => {
+    expect(estimateCost(FLASH, usage())).toBeLessThan(estimateCost(KIMI, usage()));
+  });
+
+  test("never counts more cached tokens than billed input", () => {
+    const cost = estimateCost(KIMI, usage({ inputTokens: 1_000, cachedInputTokens: 50_000 }));
+    expect(cost).toBeGreaterThan(0);
+    expect(cost).toBeCloseTo(1_000 * (0.19 / 1e6) + 3_000 * (4.0 / 1e6), 6);
+  });
+
+  test("returns null for an unpriced model or missing usage", () => {
+    expect(estimateCost("@cf/unknown/model", usage())).toBeNull();
+    expect(estimateCost(KIMI, null)).toBeNull();
+  });
+});
+
+describe("buildLiveCases", () => {
+  test("builds npm reviewer options from the security corpus", () => {
+    const { cases } = buildLiveCases();
+    expect(cases.length).toBeGreaterThan(0);
+    for (const testCase of cases) {
+      expect(testCase.options.ecosystem).toBe("npm");
+      expect(testCase.options.files.length).toBeGreaterThan(0);
+      expect(Array.isArray(testCase.options.diff)).toBe(true);
+      expect(Array.isArray(testCase.options.ruleFindings)).toBe(true);
+      expect(testCase.options.packageJsonDiff).toBeDefined();
+      expect(typeof testCase.options.previousVersionAvailable).toBe("boolean");
+    }
+  });
+
+  test("gives each fixture a stable scan id so cache affinity is comparable across models", () => {
+    const first = buildLiveCases().cases.map((testCase) => testCase.options.scanId);
+    const second = buildLiveCases().cases.map((testCase) => testCase.options.scanId);
+    expect(first).toEqual(second);
+    expect(new Set(first).size).toBe(first.length);
+  });
+
+  test("reports non-npm fixtures as skipped instead of dropping them silently", () => {
+    const { cases, skipped } = buildLiveCases();
+    expect(skipped.length).toBeGreaterThan(0);
+    for (const entry of skipped) expect(entry.reason).toBeTruthy();
+    const ids = new Set(cases.map((testCase) => testCase.id));
+    for (const entry of skipped) expect(ids.has(entry.id)).toBe(false);
+  });
+
+  test("carries the deterministic risk alongside each case", () => {
+    const { cases } = buildLiveCases();
+    const malicious = cases.filter((testCase) => testCase.verdict === "malicious");
+    expect(malicious.length).toBeGreaterThan(0);
+    for (const testCase of cases) {
+      expect(["low", "medium", "high", "critical"]).toContain(testCase.deterministicRisk);
+    }
+  });
+});
+
+function review(overrides = {}) {
+  return {
+    status: "complete",
+    risk: "critical",
+    releaseAssessment: "blocked",
+    summary: "s",
+    findings: [],
+    requiresManualReview: true,
+    model: KIMI,
+    reviewerVersion: "1.2.0",
+    ...overrides,
+  };
+}
+
+const maliciousCase = {
+  id: "m",
+  kind: "regression",
+  verdict: "malicious",
+  threatClass: "t",
+  deterministicRisk: "critical",
+};
+const benignCase = {
+  id: "b",
+  kind: "benign",
+  verdict: "benign",
+  threatClass: "t",
+  deterministicRisk: "low",
+};
+
+describe("scoreRun", () => {
+  test("passes a malicious fixture the model escalated", () => {
+    const run = scoreRun(maliciousCase, { review: review(), usage: usage(), durationMs: 1_000 });
+    expect(run.passed).toBe(true);
+    expect(run.completed).toBe(true);
+    expect(run.steps).toBe(6);
+  });
+
+  test("fails a malicious fixture the model cleared", () => {
+    const cleared = review({
+      risk: "low",
+      releaseAssessment: "nothing_unusual",
+      requiresManualReview: false,
+    });
+    expect(scoreRun(maliciousCase, { review: cleared, usage: usage() }).passed).toBe(false);
+  });
+
+  test("fails a benign fixture the model escalated", () => {
+    expect(scoreRun(benignCase, { review: review(), usage: usage() }).passed).toBe(false);
+  });
+
+  test("records an incomplete review as not completed and zero usage", () => {
+    const run = scoreRun(maliciousCase, { review: review({ status: "invalid" }), usage: null });
+    expect(run.completed).toBe(false);
+    expect(run.status).toBe("invalid");
+    expect(run.inputTokens).toBe(0);
+    expect(run.steps).toBe(0);
+  });
+});
+
+describe("summarizeModel", () => {
+  const runs = [
+    scoreRun(maliciousCase, { review: review(), usage: usage(), durationMs: 1_000 }),
+    scoreRun(benignCase, {
+      review: review({
+        risk: "low",
+        releaseAssessment: "nothing_unusual",
+        requiresManualReview: false,
+      }),
+      usage: usage(),
+      durationMs: 3_000,
+    }),
+    scoreRun(
+      { ...maliciousCase, id: "m2" },
+      { review: review({ status: "invalid" }), usage: null },
+    ),
+  ];
+
+  test("reports completion, catch, and false-positive rates separately", () => {
+    const summary = summarizeModel(KIMI, runs);
+    expect(summary.completionRate).toBeCloseTo(2 / 3, 6);
+    expect(summary.invalidRate).toBeCloseTo(1 / 3, 6);
+    expect(summary.catchRate).toBeCloseTo(1 / 2, 6);
+    expect(summary.falsePositiveRate).toBe(0);
+  });
+
+  test("reports cached input share over the whole run, not per case", () => {
+    expect(summarizeModel(KIMI, runs).cachedInputShare).toBeCloseTo(160_000 / 200_000, 6);
+  });
+
+  test("leaves rates null rather than inventing a denominator", () => {
+    const summary = summarizeModel(KIMI, [runs[0]]);
+    expect(summary.falsePositiveRate).toBeNull();
+    expect(summary.catchRate).toBe(1);
+  });
+});
+
+describe("renderMarkdown", () => {
+  const base = {
+    generatedAt: "2026-08-19T00:00:00.000Z",
+    reviewerVersion: "1.2.0",
+    models: [KIMI],
+    caseCount: 2,
+    skipped: [{ id: "pypi-x", ecosystem: "pypi", reason: "non-npm fixture shape" }],
+    truncated: 0,
+    byModel: [
+      summarizeModel(KIMI, [scoreRun(maliciousCase, { review: review(), usage: usage() })]),
+    ],
+  };
+
+  test("renders a comparison row per model", () => {
+    const markdown = renderMarkdown(base);
+    expect(markdown).toContain(KIMI);
+    expect(markdown).toContain("Misses: none.");
+    expect(markdown).toContain("skipped (non-npm fixture shape): 1");
+  });
+
+  test("says so loudly when the run was truncated", () => {
+    expect(renderMarkdown({ ...base, truncated: 30 })).toContain("**truncated**: 30");
+    expect(renderMarkdown(base)).not.toContain("truncated");
+  });
+
+  test("lists misses with their fixture id", () => {
+    const missed = summarizeModel(KIMI, [
+      scoreRun(maliciousCase, {
+        review: review({
+          risk: "low",
+          releaseAssessment: "nothing_unusual",
+          requiresManualReview: false,
+        }),
+        usage: usage(),
+      }),
+    ]);
+    expect(renderMarkdown({ ...base, byModel: [missed] })).toContain("`m` (malicious/t)");
+  });
+});
+
+function npmRecord(id, verdict) {
+  return {
+    id,
+    title: id,
+    ecosystem: "npm",
+    kind: "regression",
+    verdict,
+    threatClass: "test",
+    source: "synthetic",
+    expectMinRisk: verdict === "benign" ? "low" : "high",
+    expectAnyRule: [],
+    fx: {
+      previousPackageJson: { name: id, version: "1.0.0" },
+      stagedPackageJson: { name: id, version: "1.1.0" },
+      previousFiles: [
+        { path: "index.js", size: 10, sha256: `${id}-prev`, flags: [], textSample: "export {};\n" },
+      ],
+      stagedFiles: [
+        {
+          path: "index.js",
+          size: 20,
+          sha256: `${id}-next`,
+          flags: [],
+          textSample: "export const a = 1;\n",
+        },
+      ],
+    },
+  };
+}
+
+const twoCaseCorpus = {
+  regression: [npmRecord("case-a", "malicious"), npmRecord("case-b", "benign")],
+  frontier: [],
+  benign: [],
+};
+
+describe("runAiReviewModelComparison", () => {
+  const stubAnalyze =
+    (byModel) =>
+    async (_env, [model], options) => ({
+      review: review({ ...byModel(model, options) }),
+      usage: usage(),
+    });
+
+  test("runs every fixture against every model without failing over between them", async () => {
+    const seen = [];
+    const result = await runAiReviewModelComparison({
+      accountId: "acct",
+      apiKey: "key",
+      models: [KIMI, FLASH],
+      corpus: twoCaseCorpus,
+      analyze: stubAnalyze((model, options) => {
+        seen.push([model, options.scanId]);
+        return {};
+      }),
+    });
+
+    expect(seen).toEqual([
+      [KIMI, "ai-review-live-case-a"],
+      [KIMI, "ai-review-live-case-b"],
+      [FLASH, "ai-review-live-case-a"],
+      [FLASH, "ai-review-live-case-b"],
+    ]);
+    expect(result.byModel.map((entry) => entry.model)).toEqual([KIMI, FLASH]);
+    expect(result.caseCount).toBe(2);
+    expect(result.truncated).toBe(0);
+  });
+
+  test("scores each model independently and prices its own usage", async () => {
+    const result = await runAiReviewModelComparison({
+      accountId: "acct",
+      apiKey: "key",
+      models: [KIMI, FLASH],
+      corpus: twoCaseCorpus,
+      // Both models escalate everything: right on the malicious case, a false
+      // positive on the benign one.
+      analyze: stubAnalyze(() => ({})),
+    });
+
+    const [kimi, flash] = result.byModel;
+    expect(kimi.catchRate).toBe(1);
+    expect(kimi.falsePositiveRate).toBe(1);
+    expect(flash.catchRate).toBe(1);
+    expect(flash.totalCostUsd).toBeLessThan(kimi.totalCostUsd);
+  });
+
+  test("reports how many fixtures a limit dropped", async () => {
+    const calls = [];
+    const result = await runAiReviewModelComparison({
+      accountId: "acct",
+      apiKey: "key",
+      models: [KIMI],
+      corpus: twoCaseCorpus,
+      limit: 1,
+      analyze: stubAnalyze(() => ({})),
+      onProgress: (entry) => calls.push(entry.run.id),
+    });
+
+    expect(result.caseCount).toBe(1);
+    expect(result.truncated).toBe(1);
+    expect(calls).toEqual(["case-a"]);
+    expect(renderMarkdown(result)).toContain("**truncated**: 1");
+  });
+});

--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -148,7 +148,7 @@ describe("AI review prompt selection", () => {
 describe("ai review orchestration", () => {
   test("pins the reviewer model order", () => {
     expect(AI_MODEL).toBe("@cf/moonshotai/kimi-k2.7-code");
-    expect(AI_FALLBACK_MODEL).toBe("@cf/qwen/qwen3-30b-a3b-fp8");
+    expect(AI_FALLBACK_MODEL).toBe("@cf/deepseek-ai/deepseek-v4-flash-0731");
     expect(AI_MODEL_CANDIDATES).toEqual([AI_MODEL, AI_FALLBACK_MODEL]);
   });
   test("selects the cheaper model first for a clean low-signal release", () => {

--- a/test/eval/ai-review-harness.mjs
+++ b/test/eval/ai-review-harness.mjs
@@ -10,7 +10,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const CORPUS_PATH = join(__dirname, "..", "fixtures", "ai-review-eval", "cases.json");
 const RISK_RANK = { low: 0, medium: 1, high: 2, critical: 3 };
 
-function isMaliciousCaught(review) {
+export function isMaliciousCaught(review) {
   return (
     review.status === "complete" &&
     (RISK_RANK[review.risk] >= RISK_RANK.high ||
@@ -22,7 +22,7 @@ function isMaliciousCaught(review) {
   );
 }
 
-function isBenignClean(review) {
+export function isBenignClean(review) {
   return (
     review.status === "complete" &&
     review.risk === "low" &&
@@ -34,7 +34,7 @@ function isBenignClean(review) {
   );
 }
 
-function isUncertaintyEscalated(review) {
+export function isUncertaintyEscalated(review) {
   return (
     review.status !== "complete" ||
     review.requiresManualReview ||

--- a/test/eval/ai-review-live-harness.mjs
+++ b/test/eval/ai-review-live-harness.mjs
@@ -1,0 +1,353 @@
+// Live AI reviewer model comparison.
+//
+// This is NOT `ai-review-harness.mjs`. That one grades *recorded* reviews and
+// gates the scoring contract offline; a green run there says nothing about
+// which hosted model to route to. This harness calls real Workers AI models
+// through the real `analyzeWithAi` agent loop and reports, per model, the three
+// numbers that actually decide routing:
+//
+//   - detection quality  — catch rate on malicious fixtures, false-positive
+//                          rate on benign hard-negatives
+//   - completion rate    — how often the model lands a valid `submit_review`
+//                          before the step budget ends. A model that returns
+//                          `invalid` looks healthy in logs but floors the scan
+//                          at medium and escalates every release to a human, so
+//                          this is a routing blocker, not a quality nit.
+//   - cost               — measured tokens priced per model, with cached input
+//                          billed separately. The agent loop re-sends a growing
+//                          prefix up to MAX_AGENT_STEPS times, so cached-input
+//                          share dominates the bill and a model with no cache
+//                          tier can cost more than one with a higher list price.
+//
+// It costs real money and needs real credentials, so it never runs as part of
+// `pnpm test` or `pnpm run verify`. See docs/ai-review-eval.md.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createWorkersAI } from "workers-ai-provider";
+import {
+  computeRisk,
+  createPackageDiff,
+  deterministicFindings,
+  packageJsonDiffFindings,
+  summarizePackageJsonDiff,
+} from "../../server/lib/review";
+import { AI_REVIEWER_VERSION } from "../../server/lib/ai-review/contract.ts";
+import {
+  AI_FALLBACK_MODEL,
+  AI_MODEL,
+  aiReviewRequestHeaders,
+  analyzeWithAi,
+} from "../../server/lib/ai-review/index.ts";
+import { isBenignClean, isMaliciousCaught, isUncertaintyEscalated } from "./ai-review-harness.mjs";
+import { loadCorpus } from "./harness.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Workers AI list prices, USD per million tokens, from
+// https://developers.cloudflare.com/workers-ai/platform/pricing/ (checked
+// 2026-08-19). `cachedInput: null` means the model has no cached-input tier
+// published — every step of the agent loop re-bills the whole prefix at the
+// full input rate, which is why a low `input` price is not a low cost.
+// Refresh these alongside any routing change; a stale table silently reorders
+// the comparison.
+export const MODEL_PRICING = {
+  "@cf/moonshotai/kimi-k2.7-code": { input: 0.95, output: 4.0, cachedInput: 0.19 },
+  "@cf/deepseek-ai/deepseek-v4-flash-0731": { input: 0.44, output: 1.32, cachedInput: 0.014 },
+  "@cf/deepseek-ai/deepseek-v4-pro-0813": { input: 1.32, output: 3.96, cachedInput: 0.044 },
+  "@cf/zai-org/glm-5.2": { input: 1.4, output: 4.4, cachedInput: 0.26 },
+  "@cf/qwen/qwen3.8-27b": { input: 0.45, output: 3.2, cachedInput: null },
+  "@cf/qwen/qwen3-30b-a3b-fp8": { input: 0.051, output: 0.335, cachedInput: null },
+};
+
+export const DEFAULT_COMPARISON_MODELS = [AI_MODEL, AI_FALLBACK_MODEL];
+
+const PER_MILLION = 1_000_000;
+
+// `usage.inputTokens` is the full billed input; `cachedInputTokens` is the
+// subset of it that was a cache read. Splitting them is the whole point of the
+// exercise, so an unpriced cache tier bills the entire input at the full rate
+// rather than quietly discounting it.
+export function estimateCost(model, usage) {
+  const pricing = MODEL_PRICING[model];
+  if (!pricing || !usage) return null;
+  const input = usage.inputTokens ?? 0;
+  const output = usage.outputTokens ?? 0;
+  const cached = pricing.cachedInput === null ? 0 : Math.min(usage.cachedInputTokens ?? 0, input);
+  const fresh = input - cached;
+  return (
+    (fresh * pricing.input + cached * (pricing.cachedInput ?? 0) + output * pricing.output) /
+    PER_MILLION
+  );
+}
+
+// The reviewer's npm evidence contract, built from the same detection code the
+// product runs so the comparison can never drift from what ships. PyPI fixtures
+// carry adapter-shaped inputs instead of `stagedFiles` and are reported as
+// skipped rather than silently dropped. VS Code fixtures never reach here at
+// all: `loadCorpus` does not read `cases-vscode`, so extending this to VSIX
+// means extending the detection corpus loader first.
+export function buildLiveCases(corpus = loadCorpus()) {
+  const records = [...corpus.regression, ...corpus.frontier, ...corpus.benign];
+  const cases = [];
+  const skipped = [];
+
+  for (const record of records) {
+    if (record.ecosystem !== "npm" || !record.fx.stagedFiles) {
+      skipped.push({ id: record.id, ecosystem: record.ecosystem, reason: "non-npm fixture shape" });
+      continue;
+    }
+
+    const previousFiles = record.fx.previousFiles ?? [];
+    const stagedFiles = record.fx.stagedFiles;
+    const diff = createPackageDiff(previousFiles, stagedFiles);
+    const packageJsonDiff = summarizePackageJsonDiff(
+      record.fx.previousPackageJson,
+      record.fx.stagedPackageJson,
+    );
+    const ruleFindings = [
+      ...deterministicFindings(stagedFiles, diff, record.fx.stagedPackageJson, {
+        entrypointResolution: "npm",
+      }),
+      ...packageJsonDiffFindings(packageJsonDiff),
+    ];
+
+    cases.push({
+      id: record.id,
+      title: record.title,
+      kind: record.kind,
+      verdict: record.verdict,
+      threatClass: record.threatClass,
+      deterministicRisk: computeRisk(ruleFindings),
+      options: {
+        // A stable per-fixture scan id keeps cache affinity consistent across
+        // models, so the cached-token share reflects the loop's own prefix
+        // reuse rather than which fixture happened to run first.
+        scanId: `ai-review-live-${record.id}`,
+        organizationId: "ai-review-live-eval",
+        ecosystem: "npm",
+        files: stagedFiles,
+        previousFiles,
+        diff,
+        packageJsonDiff,
+        ruleFindings,
+        previousVersionAvailable: previousFiles.length > 0,
+      },
+    });
+  }
+
+  return { cases, skipped };
+}
+
+// A fixture's live outcome, scored on the same predicates the recorded eval
+// uses so the two reports mean the same thing.
+export function scoreRun(testCase, result) {
+  const review = result.review;
+  const completed = review.status === "complete";
+  const passed =
+    testCase.verdict === "malicious"
+      ? isMaliciousCaught(review)
+      : testCase.verdict === "benign"
+        ? isBenignClean(review)
+        : isUncertaintyEscalated(review);
+
+  return {
+    id: testCase.id,
+    kind: testCase.kind,
+    verdict: testCase.verdict,
+    threatClass: testCase.threatClass,
+    deterministicRisk: testCase.deterministicRisk,
+    status: review.status,
+    completed,
+    passed,
+    risk: review.risk,
+    releaseAssessment: review.releaseAssessment,
+    findingCount: review.findings.length,
+    requiresManualReview: review.requiresManualReview,
+    summary: review.summary,
+    steps: result.usage?.steps ?? 0,
+    inputTokens: result.usage?.inputTokens ?? 0,
+    cachedInputTokens: result.usage?.cachedInputTokens ?? 0,
+    outputTokens: result.usage?.outputTokens ?? 0,
+    durationMs: result.durationMs ?? 0,
+  };
+}
+
+function mean(values) {
+  return values.length ? values.reduce((total, value) => total + value, 0) / values.length : 0;
+}
+
+function rate(passed, total) {
+  return total ? passed / total : null;
+}
+
+export function summarizeModel(model, runs) {
+  const malicious = runs.filter((run) => run.verdict === "malicious");
+  const benign = runs.filter((run) => run.verdict === "benign");
+  const completed = runs.filter((run) => run.completed);
+  const costs = runs.map((run) => estimateCost(model, run)).filter((cost) => cost !== null);
+  const totalInput = runs.reduce((total, run) => total + run.inputTokens, 0);
+  const totalCached = runs.reduce((total, run) => total + run.cachedInputTokens, 0);
+
+  return {
+    model,
+    total: runs.length,
+    // Completion rate is listed first deliberately: a model that scores well on
+    // the cases it finishes but rarely finishes is worse for the product than a
+    // duller model that always lands a submission.
+    completionRate: rate(completed.length, runs.length),
+    invalidRate: rate(runs.filter((run) => run.status === "invalid").length, runs.length),
+    unavailableRate: rate(runs.filter((run) => run.status === "unavailable").length, runs.length),
+    catchRate: rate(malicious.filter((run) => run.passed).length, malicious.length),
+    falsePositiveRate: rate(benign.filter((run) => !run.passed).length, benign.length),
+    manualReviewRate: rate(runs.filter((run) => run.requiresManualReview).length, runs.length),
+    avgSteps: mean(runs.map((run) => run.steps)),
+    avgDurationMs: mean(runs.map((run) => run.durationMs)),
+    avgInputTokens: mean(runs.map((run) => run.inputTokens)),
+    avgOutputTokens: mean(runs.map((run) => run.outputTokens)),
+    cachedInputShare: totalInput ? totalCached / totalInput : 0,
+    avgCostUsd: costs.length ? mean(costs) : null,
+    totalCostUsd: costs.length ? costs.reduce((total, cost) => total + cost, 0) : null,
+    runs,
+  };
+}
+
+function liveLanguageModelFactory({ accountId, apiKey, gatewayId }, options) {
+  const provider = createWorkersAI({ accountId, apiKey, gateway: { id: gatewayId } });
+  return (model) =>
+    provider(model, {
+      // Mirror production's headers exactly. Measuring cached-token share under
+      // different affinity headers than the Worker sends would compare a
+      // request shape that never ships. `attempt` is always 1 here: the
+      // harness measures a first attempt, not retry behavior.
+      extraHeaders: aiReviewRequestHeaders({ AI_CACHE_AFFINITY: "" }, options, model, 1),
+    });
+}
+
+export async function runAiReviewModelComparison({
+  accountId,
+  apiKey,
+  gatewayId = "drydock-gateway",
+  models = DEFAULT_COMPARISON_MODELS,
+  corpus,
+  limit,
+  onProgress,
+  // Test seam, mirroring `analyzeWithAi`'s own `languageModelOverride`: lets the
+  // offline suite exercise per-model isolation, progress reporting, and
+  // truncation bookkeeping without spending money on the network.
+  analyze = analyzeWithAi,
+} = {}) {
+  const { cases: allCases, skipped } = buildLiveCases(corpus);
+  const cases = typeof limit === "number" ? allCases.slice(0, limit) : allCases;
+  const models_ = [...models];
+  const byModel = [];
+
+  for (const model of models_) {
+    const runs = [];
+    for (const testCase of cases) {
+      const startedAt = Date.now();
+      // One model at a time: `analyzeWithAi` takes a candidate list and fails
+      // over, which is exactly what a per-model comparison must not do.
+      const result = await analyze(
+        {},
+        [model],
+        testCase.options,
+        liveLanguageModelFactory({ accountId, apiKey, gatewayId }, testCase.options),
+      );
+      const run = scoreRun(testCase, { ...result, durationMs: Date.now() - startedAt });
+      runs.push(run);
+      onProgress?.({ model, run });
+    }
+    byModel.push(summarizeModel(model, runs));
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    reviewerVersion: AI_REVIEWER_VERSION,
+    models: models_,
+    caseCount: cases.length,
+    // Never let a bounded run read as full coverage.
+    skipped,
+    truncated: cases.length < allCases.length ? allCases.length - cases.length : 0,
+    byModel,
+  };
+}
+
+function percent(value) {
+  return value === null ? "n/a" : `${(value * 100).toFixed(0)}%`;
+}
+
+function usd(value) {
+  return value === null ? "n/a" : `$${value.toFixed(4)}`;
+}
+
+export function renderMarkdown(result) {
+  const lines = [
+    "# AI reviewer live model comparison",
+    "",
+    `- generated: ${result.generatedAt}`,
+    `- reviewer version: ${result.reviewerVersion}`,
+    `- fixtures per model: ${result.caseCount}`,
+  ];
+  if (result.truncated) {
+    lines.push(`- **truncated**: ${result.truncated} npm fixtures not run (\`--limit\`)`);
+  }
+  if (result.skipped.length) {
+    lines.push(`- skipped (non-npm fixture shape): ${result.skipped.length}`);
+  }
+  lines.push(
+    "",
+    "| model | completion | catch | false pos | cached in | avg steps | avg cost | total cost |",
+    "| --- | --- | --- | --- | --- | --- | --- | --- |",
+    ...result.byModel.map((entry) =>
+      [
+        entry.model,
+        percent(entry.completionRate),
+        percent(entry.catchRate),
+        percent(entry.falsePositiveRate),
+        percent(entry.cachedInputShare),
+        entry.avgSteps.toFixed(1),
+        usd(entry.avgCostUsd),
+        usd(entry.totalCostUsd),
+      ].join(" | "),
+    ),
+    "",
+    "Completion rate is the routing blocker: an incomplete review floors the scan",
+    "at medium risk and escalates the release to a human, whatever the model scored",
+    "on the cases it did finish.",
+    "",
+  );
+
+  for (const entry of result.byModel) {
+    const misses = entry.runs.filter((run) => !run.passed);
+    lines.push(`## ${entry.model}`, "");
+    lines.push(
+      `- invalid: ${percent(entry.invalidRate)} · unavailable: ${percent(entry.unavailableRate)}`,
+      `- avg latency: ${(entry.avgDurationMs / 1000).toFixed(1)}s · avg tokens in/out: ${entry.avgInputTokens.toFixed(0)}/${entry.avgOutputTokens.toFixed(0)}`,
+      "",
+      misses.length ? "Misses:" : "Misses: none.",
+      "",
+    );
+    for (const miss of misses) {
+      lines.push(
+        `- \`${miss.id}\` (${miss.verdict}/${miss.threatClass}) → ${miss.status}/${miss.risk}`,
+      );
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+export function writeAiReviewModelComparisonReport(result) {
+  try {
+    const outDir = join(__dirname, "..", "..", ".context", "eval");
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(join(outDir, "ai-review-model-compare.json"), JSON.stringify(result, null, 2));
+    writeFileSync(join(outDir, "ai-review-model-compare.md"), renderMarkdown(result));
+  } catch {
+    // Report writing is best-effort; never fail a paid live run over a
+    // filesystem issue.
+  }
+}

--- a/test/eval/ai-review-live.test.mjs
+++ b/test/eval/ai-review-live.test.mjs
@@ -1,0 +1,80 @@
+// Paid, network-bound entry point for the live model comparison.
+//
+// Gated off by default so `pnpm test` and `pnpm run verify` stay offline and
+// free. Enable with `pnpm run eval:ai:live`, which sets AI_REVIEW_LIVE_EVAL and
+// requires Cloudflare credentials:
+//
+//   CLOUDFLARE_ACCOUNT_ID=... CLOUDFLARE_API_TOKEN=... pnpm run eval:ai:live
+//
+// Optional: AI_REVIEW_LIVE_MODELS (comma-separated model ids to compare),
+// AI_REVIEW_LIVE_LIMIT (cap fixtures per model while iterating),
+// AI_REVIEW_LIVE_GATEWAY (AI Gateway id).
+//
+// This asserts nothing about which model wins — picking a model is a judgement
+// call over detection quality, completion rate, and cost together. It fails
+// only on the one condition that makes the whole report meaningless: no model
+// produced a single completed review, which means the run was misconfigured
+// rather than informative.
+
+import { describe, expect, test } from "vitest";
+import {
+  DEFAULT_COMPARISON_MODELS,
+  renderMarkdown,
+  runAiReviewModelComparison,
+  writeAiReviewModelComparisonReport,
+} from "./ai-review-live-harness.mjs";
+
+const enabled = process.env.AI_REVIEW_LIVE_EVAL === "1";
+const accountId = process.env.CLOUDFLARE_ACCOUNT_ID;
+const apiKey = process.env.CLOUDFLARE_API_TOKEN;
+
+const models = process.env.AI_REVIEW_LIVE_MODELS
+  ? process.env.AI_REVIEW_LIVE_MODELS.split(",")
+      .map((model) => model.trim())
+      .filter(Boolean)
+  : DEFAULT_COMPARISON_MODELS;
+// An unparseable limit would slice the corpus to nothing and bill a run that
+// compares zero fixtures, so reject it up front rather than reporting an empty
+// comparison as a result.
+function parseLimit(raw) {
+  if (!raw) return undefined;
+  const limit = Number(raw);
+  if (!Number.isInteger(limit) || limit < 1) {
+    throw new Error(`AI_REVIEW_LIVE_LIMIT must be a positive integer, got ${JSON.stringify(raw)}.`);
+  }
+  return limit;
+}
+
+const limit = parseLimit(process.env.AI_REVIEW_LIVE_LIMIT);
+
+describe.skipIf(!enabled)("AI reviewer live model comparison", () => {
+  test(
+    "compares candidate models over the npm security corpus",
+    { timeout: 3_600_000 },
+    async () => {
+      if (!accountId || !apiKey) {
+        throw new Error(
+          "Live model comparison needs CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN.",
+        );
+      }
+
+      const result = await runAiReviewModelComparison({
+        accountId,
+        apiKey,
+        gatewayId: process.env.AI_REVIEW_LIVE_GATEWAY || undefined,
+        models,
+        limit,
+        onProgress: ({ model, run }) => {
+          process.stdout.write(
+            `  ${model} ${run.id}: ${run.status} risk=${run.risk} steps=${run.steps} ${run.passed ? "pass" : "MISS"}\n`,
+          );
+        },
+      });
+
+      writeAiReviewModelComparisonReport(result);
+      process.stdout.write(`\n${renderMarkdown(result)}\n`);
+
+      expect(result.byModel.some((entry) => entry.completionRate > 0)).toBe(true);
+    },
+  );
+});

--- a/test/eval/harness.mjs
+++ b/test/eval/harness.mjs
@@ -81,7 +81,7 @@ function normalize(fx, kind, ecosystem) {
   };
 }
 
-function loadCorpus() {
+export function loadCorpus() {
   const regression = [
     ...readCases(join(CORPUS_DIR, "cases")).map((fx) => normalize(fx, "regression", "npm")),
     ...readCases(join(CORPUS_DIR, "cases-pypi")).map((fx) => normalize(fx, "regression", "pypi")),

--- a/test/fixtures/ai-review-eval/cases.json
+++ b/test/fixtures/ai-review-eval/cases.json
@@ -22,7 +22,7 @@
         ],
         "requiresManualReview": true,
         "model": "@cf/moonshotai/kimi-k2.7-code",
-        "reviewerVersion": "1.1.0"
+        "reviewerVersion": "1.2.0"
       }
     },
     {
@@ -38,7 +38,7 @@
         "findings": [],
         "requiresManualReview": false,
         "model": "@cf/moonshotai/kimi-k2.7-code",
-        "reviewerVersion": "1.1.0"
+        "reviewerVersion": "1.2.0"
       }
     },
     {
@@ -62,7 +62,7 @@
         ],
         "requiresManualReview": true,
         "model": "@cf/moonshotai/kimi-k2.7-code",
-        "reviewerVersion": "1.1.0"
+        "reviewerVersion": "1.2.0"
       }
     },
     {
@@ -78,7 +78,7 @@
         "findings": [],
         "requiresManualReview": false,
         "model": "@cf/moonshotai/kimi-k2.7-code",
-        "reviewerVersion": "1.1.0"
+        "reviewerVersion": "1.2.0"
       }
     },
     {
@@ -101,8 +101,8 @@
           }
         ],
         "requiresManualReview": true,
-        "model": "@cf/qwen/qwen3-30b-a3b-fp8",
-        "reviewerVersion": "1.1.0"
+        "model": "@cf/deepseek-ai/deepseek-v4-flash-0731",
+        "reviewerVersion": "1.2.0"
       }
     }
   ]


### PR DESCRIPTION
## Summary

Adds an opt-in paid Workers AI comparison harness that measures reviewer completion, detection quality, and cached-token-aware cost, switches the fallback to DeepSeek V4 Flash, bumps the reviewer contract, and updates tests and documentation.

## Trust boundary

The opt-in harness sends synthetic npm security-corpus evidence through AI Gateway using caller-supplied Cloudflare credentials; production artifact execution and npm-token egress boundaries are unchanged.

## Verification

`pnpm run verify` passed; `pnpm run eval:ai:live` was not rerun during publication because it is paid and requires working Cloudflare credentials.

## Documentation

Updated [docs/ai-review-eval.md](docs/ai-review-eval.md), [docs/README.md](docs/README.md), and [AGENTS.md](AGENTS.md).

## UI evidence

Not applicable.