### PR TITLE
Add agent-harness edit hooks for Claude Code and Codex CLI

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/scripts/hooks/guard-protected-paths.mjs\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PROJECT_DIR/scripts/hooks/post-edit-check.mjs\"",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,30 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/scripts/hooks/guard-protected-paths.mjs\"",
+            "statusMessage": "Guarding generated migration paths",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/scripts/hooks/post-edit-check.mjs\"",
+            "statusMessage": "Checking edited file with oxfmt/oxlint",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -73,6 +73,15 @@ them out of the worker boot graph.
 
 Run `pnpm run verify` before every commit, so each commit passes lint + format + typecheck + tests. There is no git hook enforcing this — it is run explicitly. CI (`.github/workflows/ci.yml`) runs the same core checks and then installs Chromium and runs `pnpm run test:e2e`.
 
+## Agent hooks
+
+`scripts/hooks/` holds harness-agnostic hook scripts that give coding agents edit-time feedback. Each accepts the target file as `argv[2]` or as hook JSON on stdin (Claude Code's `tool_input.file_path` shape; Codex CLI's `apply_patch` patch envelope is also parsed):
+
+- `post-edit-check.mjs` — after an Edit/Write, runs `oxfmt --check` + `oxlint` scoped to the edited file and exits 2 with a concise message on violations. Report-only by design: rewriting the file in place would invalidate the harness's file-state tracking and cause "file modified since read" friction on the next edit. It fails open (exit 0) on unparseable input, missing files, or missing binaries — `pnpm run verify` stays authoritative. The target file is never executed.
+- `guard-protected-paths.mjs` — before an Edit/Write, blocks (exit 2) writes to `drizzle/**/*.sql` and `drizzle/meta/**`; migrations are generated via `pnpm db:generate` (Bash, unaffected). It only blocks clearly matched paths and fails open otherwise.
+
+Wired for Claude Code in `.claude/settings.json` (PreToolUse/PostToolUse on `Edit|Write`) and for Codex CLI in `.codex/hooks.json` (same schema; Codex maps `Edit`/`Write` matchers onto `apply_patch` and requires trusting project hooks via `/hooks` once). Tests: `test/agent-hooks.test.mjs`.
+
 ## Banned hooks
 
 `useState` and `useReducer` are forbidden via oxlint's `no-restricted-imports` from `preact/hooks` (and `react`, defensively). The codebase is migrating component-local state to:

--- a/scripts/hooks/guard-protected-paths.mjs
+++ b/scripts/hooks/guard-protected-paths.mjs
@@ -1,0 +1,40 @@
+// PreToolUse guard: blocks agent Edit/Write tools from touching hand-forbidden
+// paths. D1 migrations under drizzle/ are generated artifacts — AGENTS.md says
+// to never hand-write SQL migrations: change server/db/schema.ts and run
+// `pnpm db:generate` instead (that runs via Bash, which this guard does not
+// intercept, so the legitimate workflow is unaffected).
+//
+// Exit contract (Claude Code hooks, mirrored by Codex CLI's hooks engine):
+// exit 2 blocks the tool call and feeds stderr back to the model; exit 0
+// allows it. On unparseable or empty input this guard fails OPEN (exit 0):
+// blocking every edit because one payload failed to parse would be worse than
+// missing a guarded path, and `pnpm run verify` plus review still catch drift.
+// It only blocks when a resolved path clearly matches a protected pattern.
+//
+// Usage: guard-protected-paths.mjs [file] (or hook JSON on stdin).
+import path from "node:path";
+import { repoRelative, repoRoot, resolveTargetFiles } from "./hook-input.mjs";
+
+// Protected patterns: drizzle/**/*.sql and drizzle/meta/**. Compared
+// case-insensitively so a differently-cased spelling cannot slip through on
+// case-insensitive filesystems (macOS); the repo has no legitimately
+// different-cased sibling paths.
+function isProtected(absolute) {
+  const relative = repoRelative(absolute);
+  if (relative === null) return false; // outside the repo — not ours to guard
+  const lower = relative.toLowerCase();
+  if (lower === "drizzle/meta" || lower.startsWith("drizzle/meta/")) return true;
+  return lower.startsWith("drizzle/") && lower.endsWith(".sql");
+}
+
+const { files } = await resolveTargetFiles();
+const blocked = files.filter(isProtected);
+if (blocked.length === 0) process.exit(0);
+
+const listed = blocked.map((file) => path.relative(repoRoot, file)).join(", ");
+process.stderr.write(
+  `Blocked write to generated D1 migration path: ${listed}. ` +
+    "Never hand-edit drizzle/**/*.sql or drizzle/meta/** (AGENTS.md). " +
+    "Edit server/db/schema.ts and run `pnpm db:generate` to produce the migration.\n",
+);
+process.exit(2);

--- a/scripts/hooks/hook-input.mjs
+++ b/scripts/hooks/hook-input.mjs
@@ -1,0 +1,87 @@
+// Shared input parsing for the agent-harness hook scripts in this directory.
+//
+// The scripts are tool-agnostic: they accept the edited/target file either as
+// argv[2] (so any harness or a human can invoke them directly) or as a JSON
+// payload on stdin. The stdin shape follows Claude Code's hook contract
+// (PreToolUse/PostToolUse: `tool_input.file_path` for Edit/Write), which
+// OpenAI Codex CLI's Claude-compatible hooks engine also speaks — except that
+// Codex serializes file edits as the `apply_patch` tool whose `tool_input` is
+// `{ command: "*** Begin Patch ..." }`, so we also extract file paths from
+// that patch envelope.
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// scripts/hooks/hook-input.mjs -> repo root, independent of the process cwd.
+export const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+// Hook harnesses write the payload and close stdin immediately; the timeout
+// only guards against being spawned with an open, silent stdin.
+const STDIN_TIMEOUT_MS = 3000;
+
+function readStdin() {
+  if (process.stdin.isTTY) return Promise.resolve("");
+  return new Promise((resolve) => {
+    let data = "";
+    const finish = () => {
+      clearTimeout(timer);
+      resolve(data);
+    };
+    const timer = setTimeout(finish, STDIN_TIMEOUT_MS);
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on("end", finish);
+    process.stdin.on("error", finish);
+  });
+}
+
+const PATCH_FILE_LINE = /^\*{3} (?:Add|Update|Delete) File: (.+)$/;
+const PATCH_MOVE_LINE = /^\*{3} Move to: (.+)$/;
+
+/**
+ * Resolves the file paths a tool call is about to touch (or just touched).
+ *
+ * Returns `{ files, parsed }` with absolute paths. `parsed: false` means the
+ * input could not be understood at all (no argv path and empty or malformed
+ * stdin); callers decide whether that fails open or closed.
+ */
+export async function resolveTargetFiles(argv = process.argv) {
+  if (typeof argv[2] === "string" && argv[2].length > 0) {
+    return { files: [path.resolve(argv[2])], parsed: true };
+  }
+  const raw = await readStdin();
+  if (raw.trim() === "") return { files: [], parsed: false };
+  let payload;
+  try {
+    payload = JSON.parse(raw);
+  } catch {
+    return { files: [], parsed: false };
+  }
+  if (payload === null || typeof payload !== "object") return { files: [], parsed: false };
+  const cwd =
+    typeof payload.cwd === "string" && payload.cwd.length > 0 ? payload.cwd : process.cwd();
+  const toolInput = payload.tool_input;
+  if (toolInput === null || typeof toolInput !== "object") return { files: [], parsed: true };
+  // Claude Code Edit/Write (and anything speaking the same contract).
+  if (typeof toolInput.file_path === "string" && toolInput.file_path.length > 0) {
+    return { files: [path.resolve(cwd, toolInput.file_path)], parsed: true };
+  }
+  // Codex CLI apply_patch: raw patch text listing the files it touches.
+  if (typeof toolInput.command === "string" && toolInput.command.includes("*** Begin Patch")) {
+    const files = [];
+    for (const line of toolInput.command.split("\n")) {
+      const match = PATCH_FILE_LINE.exec(line) ?? PATCH_MOVE_LINE.exec(line);
+      if (match !== null) files.push(path.resolve(cwd, match[1].trim()));
+    }
+    return { files, parsed: true };
+  }
+  return { files: [], parsed: true };
+}
+
+/** Repo-relative posix-style path, or null when the file is outside the repo. */
+export function repoRelative(absolute) {
+  const relative = path.relative(repoRoot, absolute);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) return null;
+  return relative.split(path.sep).join("/");
+}

--- a/scripts/hooks/post-edit-check.mjs
+++ b/scripts/hooks/post-edit-check.mjs
@@ -62,7 +62,7 @@ function runTool(binary, args) {
   return result;
 }
 
-const NOISE_LINE = /^(Checking formatting|Finished in |Found \d+ warning|.*npm advisory)/;
+const NOISE_LINE = /^(Checking formatting|Finished in |Found \d+ warning)/;
 
 function trimmedOutput(result) {
   const lines = `${result.stdout}${result.stderr}`
@@ -85,7 +85,7 @@ for (const file of files) {
   if (format !== null && format.status !== 0) {
     problems.push(
       `${label}: oxfmt --check failed — not formatted (or unparseable). ` +
-        "Fix the formatting in your next edit, or run `pnpm exec oxfmt <file>` and re-read the file.",
+        `Fix the formatting in your next edit, or run \`pnpm exec oxfmt "${label}"\` and re-read the file.`,
     );
   }
 

--- a/scripts/hooks/post-edit-check.mjs
+++ b/scripts/hooks/post-edit-check.mjs
@@ -1,0 +1,102 @@
+// PostToolUse check: after an agent edits a file, run the repo's formatter and
+// linter (`oxfmt --check`, `oxlint`) scoped to that file and feed violations
+// back to the model via exit 2 + a concise stderr message.
+//
+// Deliberately report-only: a hook that rewrites the file in place right after
+// an Edit invalidates the harness's file-state tracking and causes "file
+// modified since read" friction on the model's next edit. So this reports and
+// lets the model apply the fix itself.
+//
+// The target file is never executed: it is only passed as an argument to
+// oxfmt/oxlint, which parse it as text. No infinite-loop risk either — the
+// hook mutates nothing, so it cannot re-trigger itself.
+//
+// Fails OPEN (exit 0) on anything that is not a real violation: unparseable
+// payload, missing/deleted file, unsupported extension, ignored path, missing
+// tool binaries, tool crash or timeout. `pnpm run verify` stays authoritative.
+//
+// Usage: post-edit-check.mjs [file] (or hook JSON on stdin).
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { repoRelative, repoRoot, resolveTargetFiles } from "./hook-input.mjs";
+
+const LINT_EXTENSIONS = new Set([".js", ".jsx", ".cjs", ".mjs", ".ts", ".tsx"]);
+const FORMAT_EXTENSIONS = new Set([...LINT_EXTENSIONS, ".css"]);
+// Mirrors the ignorePatterns of .oxlintrc.json / .oxfmtrc.json that name repo
+// paths; explicitly-passed files bypass the tools' own ignore handling.
+const SKIPPED_REPO_PREFIXES = [
+  "dist/",
+  ".wrangler/",
+  "drizzle/",
+  "node_modules/",
+  ".claude/",
+  ".agents/",
+  "test/fixtures/oxlint-signals/",
+];
+const TOOL_TIMEOUT_MS = 30_000;
+const MAX_STDERR_CHARS = 4000;
+
+function shouldSkip(absolute) {
+  if (absolute.endsWith(".d.ts")) return true;
+  const relative = repoRelative(absolute);
+  // Outside the repo (e.g. scratch files): still checkable, nothing to skip.
+  if (relative === null) return absolute.includes(`${path.sep}node_modules${path.sep}`);
+  return (
+    SKIPPED_REPO_PREFIXES.some((prefix) => relative.startsWith(prefix)) ||
+    relative.includes("/node_modules/")
+  );
+}
+
+/** Runs a repo-local binary; returns null (fail open) when it cannot run. */
+function runTool(binary, args) {
+  const bin = path.join(repoRoot, "node_modules", ".bin", binary);
+  if (!fs.existsSync(bin)) return null;
+  const result = spawnSync(bin, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    timeout: TOOL_TIMEOUT_MS,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error !== undefined || result.signal !== null) return null;
+  return result;
+}
+
+const NOISE_LINE = /^(Checking formatting|Finished in |Found \d+ warning|.*npm advisory)/;
+
+function trimmedOutput(result) {
+  const lines = `${result.stdout}${result.stderr}`
+    .split("\n")
+    .filter((line) => line.trim() !== "" && !NOISE_LINE.test(line));
+  return lines.join("\n").slice(0, MAX_STDERR_CHARS);
+}
+
+const { files } = await resolveTargetFiles();
+const problems = [];
+
+for (const file of files) {
+  const extension = path.extname(file);
+  if (!FORMAT_EXTENSIONS.has(extension)) continue;
+  if (!fs.existsSync(file) || !fs.statSync(file).isFile()) continue;
+  if (shouldSkip(file)) continue;
+  const label = repoRelative(file) ?? file;
+
+  const format = runTool("oxfmt", ["--check", "--", file]);
+  if (format !== null && format.status !== 0) {
+    problems.push(
+      `${label}: oxfmt --check failed — not formatted (or unparseable). ` +
+        "Fix the formatting in your next edit, or run `pnpm exec oxfmt <file>` and re-read the file.",
+    );
+  }
+
+  if (LINT_EXTENSIONS.has(extension)) {
+    const lint = runTool("oxlint", ["--", file]);
+    if (lint !== null && lint.status !== 0) {
+      problems.push(`${label}: oxlint reported errors:\n${trimmedOutput(lint)}`);
+    }
+  }
+}
+
+if (problems.length === 0) process.exit(0);
+process.stderr.write(`${problems.join("\n").slice(0, MAX_STDERR_CHARS)}\n`);
+process.exit(2);

--- a/test/agent-hooks.test.mjs
+++ b/test/agent-hooks.test.mjs
@@ -1,0 +1,189 @@
+// Tests for the agent-harness hook scripts in scripts/hooks/. Each script is
+// invoked as a child process, exactly as Claude Code / Codex CLI would run it:
+// hook JSON on stdin or a file path as argv[2]. The scripts must give accurate
+// exit codes (2 = violation/block, 0 = allow), fail open on malformed input,
+// and never execute the target file's code.
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, test } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const guardScript = path.join(repoRoot, "scripts", "hooks", "guard-protected-paths.mjs");
+const checkScript = path.join(repoRoot, "scripts", "hooks", "post-edit-check.mjs");
+
+const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "drydock-agent-hooks-"));
+afterAll(() => {
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+function runHook(script, { stdin, args = [] } = {}) {
+  const result = spawnSync(process.execPath, [script, ...args], {
+    input: stdin ?? "",
+    encoding: "utf8",
+    timeout: 60_000,
+  });
+  return { status: result.status, stderr: result.stderr, stdout: result.stdout };
+}
+
+function editPayload(filePath) {
+  return JSON.stringify({
+    hook_event_name: "PreToolUse",
+    tool_name: "Edit",
+    cwd: repoRoot,
+    tool_input: { file_path: filePath, old_string: "a", new_string: "b" },
+  });
+}
+
+describe("guard-protected-paths", () => {
+  test("blocks Edit payloads targeting drizzle SQL migrations", () => {
+    const target = path.join(repoRoot, "drizzle", "0000_initial.sql");
+    const result = runHook(guardScript, { stdin: editPayload(target) });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("drizzle/0000_initial.sql");
+    expect(result.stderr).toContain("pnpm db:generate");
+  });
+
+  test("blocks relative drizzle/meta paths resolved against the payload cwd", () => {
+    const result = runHook(guardScript, {
+      stdin: editPayload("drizzle/meta/0000_snapshot.json"),
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("drizzle/meta/0000_snapshot.json");
+  });
+
+  test("blocks protected paths passed as argv for non-JSON harnesses", () => {
+    const result = runHook(guardScript, {
+      args: [path.join(repoRoot, "drizzle", "9999_new_migration.sql")],
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("pnpm db:generate");
+  });
+
+  test("blocks Codex apply_patch payloads touching migrations", () => {
+    const patch = [
+      "*** Begin Patch",
+      "*** Update File: drizzle/0001_org-ownership.sql",
+      "@@",
+      "-a",
+      "+b",
+      "*** End Patch",
+    ].join("\n");
+    const result = runHook(guardScript, {
+      stdin: JSON.stringify({
+        hook_event_name: "PreToolUse",
+        tool_name: "apply_patch",
+        cwd: repoRoot,
+        tool_input: { command: patch },
+      }),
+    });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("drizzle/0001_org-ownership.sql");
+  });
+
+  test("allows edits to regular repo files", () => {
+    const result = runHook(guardScript, {
+      stdin: editPayload(path.join(repoRoot, "server", "index.ts")),
+    });
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+
+  test("allows .sql files outside the repo", () => {
+    const result = runHook(guardScript, {
+      stdin: editPayload(path.join(tempDir, "scratch.sql")),
+    });
+    expect(result.status).toBe(0);
+  });
+
+  test("fails open (does not block) on malformed stdin", () => {
+    const result = runHook(guardScript, { stdin: "definitely not json" });
+    expect(result.status).toBe(0);
+  });
+
+  test("fails open on empty stdin", () => {
+    const result = runHook(guardScript, { stdin: "" });
+    expect(result.status).toBe(0);
+  });
+});
+
+describe("post-edit-check", () => {
+  test("passes a clean, formatted file", () => {
+    const file = path.join(tempDir, "clean.ts");
+    fs.writeFileSync(file, "export const answer = 42;\n");
+    const result = runHook(checkScript, { args: [file] });
+    expect(result.status).toBe(0);
+    expect(result.stderr).toBe("");
+  });
+
+  test("reports formatting violations with exit 2", () => {
+    const file = path.join(tempDir, "unformatted.ts");
+    fs.writeFileSync(file, "const   x=1;\nexport { x };\n");
+    const result = runHook(checkScript, { stdin: editPayload(file) });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("oxfmt --check failed");
+  });
+
+  test("reports lint violations with exit 2", () => {
+    const file = path.join(tempDir, "lint-violation.ts");
+    fs.writeFileSync(file, "export const a = 1;\ndebugger;\n");
+    const result = runHook(checkScript, { stdin: editPayload(file) });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("no-debugger");
+  });
+
+  test("handles paths containing spaces", () => {
+    const file = path.join(tempDir, "has space.ts");
+    fs.writeFileSync(file, "export const a = 1;\ndebugger;\n");
+    const result = runHook(checkScript, { stdin: editPayload(file) });
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain("no-debugger");
+  });
+
+  test("never executes the target file", () => {
+    const marker = path.join(tempDir, "executed.marker");
+    const file = path.join(tempDir, "side-effect.mjs");
+    fs.writeFileSync(
+      file,
+      `import fs from "node:fs";\n\nfs.writeFileSync(${JSON.stringify(marker)}, "executed");\n`,
+    );
+    runHook(checkScript, { stdin: editPayload(file) });
+    expect(fs.existsSync(marker)).toBe(false);
+  });
+
+  test("skips files the repo lint/format configs ignore", () => {
+    // In-repo fixture with intentional lint violations; explicitly ignored by
+    // .oxlintrc.json, so the hook must not report it.
+    const file = path.join(repoRoot, "test", "fixtures", "oxlint-signals", "conditional-jsx.tsx");
+    const result = runHook(checkScript, { stdin: editPayload(file) });
+    expect(result.status).toBe(0);
+  });
+
+  test("ignores non-lintable extensions", () => {
+    const file = path.join(tempDir, "notes.md");
+    fs.writeFileSync(file, "# notes\n");
+    const result = runHook(checkScript, { stdin: editPayload(file) });
+    expect(result.status).toBe(0);
+  });
+
+  test("fails open when the file no longer exists", () => {
+    const result = runHook(checkScript, {
+      stdin: editPayload(path.join(tempDir, "deleted-since-edit.ts")),
+    });
+    expect(result.status).toBe(0);
+  });
+
+  test("fails open on malformed stdin", () => {
+    const result = runHook(checkScript, { stdin: "{ truncated" });
+    expect(result.status).toBe(0);
+  });
+
+  test("fails open on payloads without a file path", () => {
+    const result = runHook(checkScript, {
+      stdin: JSON.stringify({ hook_event_name: "PostToolUse", tool_name: "Bash", tool_input: {} }),
+    });
+    expect(result.status).toBe(0);
+  });
+});

--- a/tooling/knip.jsonc
+++ b/tooling/knip.jsonc
@@ -1,5 +1,11 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
+  // Agent-harness hooks: the entry points are invoked by Claude Code and Codex
+  // CLI from .claude/settings.json / .codex/hooks.json, which knip can't read.
+  "entry": [
+    "scripts/hooks/guard-protected-paths.mjs",
+    "scripts/hooks/post-edit-check.mjs"
+  ],
   "ignore": [
     // Package fixtures are hostile-evidence samples the fixture builder reads as
     // bytes at runtime; they are never part of the module graph.


### PR DESCRIPTION
Checked-in, harness-agnostic hook scripts that give coding agents edit-time feedback and enforce the "never hand-write SQL migrations" guardrail.

## What's wired

**Scripts (`scripts/hooks/`, Node-only, no new dependencies).** Each accepts the target file as `argv[2]` or as hook JSON on stdin (`tool_input.file_path`, plus Codex's `apply_patch` patch envelope), so any harness can reuse them:

- `post-edit-check.mjs` (PostToolUse) — runs `oxfmt --check` + `oxlint` scoped to the just-edited file; exits 2 with a concise stderr message on violations so the harness feeds them back to the model. Skips paths the repo's lint/format configs ignore. The target file is never executed — it is only passed as an argument to the tools.
- `guard-protected-paths.mjs` (PreToolUse) — blocks Edit/Write to `drizzle/**/*.sql` and `drizzle/meta/**` with a message pointing at `server/db/schema.ts` + `pnpm db:generate` (which runs via Bash and is unaffected).

**Claude Code** — `.claude/settings.json` (new; project settings): `PreToolUse` and `PostToolUse` on matcher `Edit|Write`, commands referenced via `$CLAUDE_PROJECT_DIR` so they work from any cwd.

**Codex CLI** — supported, and wired. Current Codex CLI (verified against codex 0.144.1 and the openai/codex source) ships a Claude-compatible hooks engine: project-level hooks load from `<repo>/.codex/hooks.json` with the same PreToolUse/PostToolUse + exit-2 contract, and `Edit`/`Write` are accepted as matcher aliases for `apply_patch`. Differences handled: the `apply_patch` payload carries the raw patch text in `tool_input.command` (the shared parser extracts `*** Add/Update/Delete File:` / `*** Move to:` paths), and Codex sets no `$CLAUDE_PROJECT_DIR`, so the commands locate the repo via `git rev-parse --show-toplevel`. Note: Codex requires a one-time trust review of project hooks via `/hooks`.

## Why report-only (no auto-format)

The post-edit hook deliberately runs `oxfmt --check` instead of rewriting the file: a hook that mutates the file right after an Edit invalidates the harness's file-state tracking and causes "file modified since read" friction on the model's next edit. Violations are reported; the model applies the fix itself.

## Failure semantics

- `post-edit-check` fails **open** (exit 0) on unparseable payloads, deleted files, unsupported extensions, ignored paths, and missing/crashed tool binaries — `pnpm run verify` stays authoritative.
- The guard fails **closed only for clearly matched protected paths**; on parse failure it does not block everything.

## Testing

- `test/agent-hooks.test.mjs` (node Vitest project) invokes each script as a child process with sample stdin payloads and argv: clean file, format violation, lint violation, path with spaces, blocked drizzle/meta/apply_patch paths, malformed/empty stdin, deleted file, ignored fixture — plus an invariant test that the hook never executes the target file's code.
- `pnpm run verify` passes.
- Docs: added an "Agent hooks" section to `docs/tooling.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)