### PR TITLE
Fix canonical public discovery routes

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -11,6 +11,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://drydock.org/diff</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://drydock.org/privacy</loc>
     <changefreq>monthly</changefreq>
     <priority>0.3</priority>

--- a/server/index.ts
+++ b/server/index.ts
@@ -63,6 +63,8 @@ export { NpmAdapterBroker } from "./lib/ecosystems/npm";
 const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 const CANONICAL_HOSTNAME = "drydock.org";
 const LEGACY_HOSTNAME = "drydock.resynapse.dev";
+const WWW_HOSTNAME = "www.drydock.org";
+const CANONICAL_STATIC_PATHS = new Set(["/diff", "/docs", "/privacy"]);
 const SERVER_OWNED_PATH_PREFIXES = ["/api", "/webhooks", "/og", "/public"];
 const DASHBOARD_STATIC_ASSET_PATHS = new Set([
   "/dashboard",
@@ -77,10 +79,20 @@ const DASHBOARD_STATIC_ASSET_PATHS = new Set([
   "/dashboard/settings/github-app/callback/",
 ]);
 
-function canonicalDomainRedirect(request: Request): Response | null {
+function canonicalRequestRedirect(request: Request): Response | null {
   const url = new URL(request.url);
-  if (url.hostname !== LEGACY_HOSTNAME) return null;
-  url.hostname = CANONICAL_HOSTNAME;
+  let redirect = false;
+
+  if (url.hostname === LEGACY_HOSTNAME || url.hostname === WWW_HOSTNAME) {
+    url.hostname = CANONICAL_HOSTNAME;
+    redirect = true;
+  }
+  if (url.pathname.endsWith("/") && CANONICAL_STATIC_PATHS.has(url.pathname.slice(0, -1))) {
+    url.pathname = url.pathname.slice(0, -1);
+    redirect = true;
+  }
+
+  if (!redirect) return null;
   return Response.redirect(url.toString(), 308);
 }
 
@@ -92,6 +104,13 @@ function isServerOwnedPath(path: string): boolean {
 
 function assetFallbackRequest(request: Request): Request {
   const url = new URL(request.url);
+  // The static asset binding stores prerendered routes as /route/index.html and
+  // redirects a bare /route request to /route/. Fetch that generated document
+  // internally so the public URL can stay on the self-canonical, no-slash form.
+  if (CANONICAL_STATIC_PATHS.has(url.pathname)) {
+    url.pathname = `${url.pathname}/`;
+    return new Request(url, request);
+  }
   if (isPackageDiffDetailPath(url.pathname)) {
     url.pathname = "/diff/";
     url.search = "";
@@ -152,7 +171,7 @@ app.use("*", async (c, next) => {
   applySecurityHeaders(c);
 });
 
-app.use("*", async (c, next) => canonicalDomainRedirect(c.req.raw) ?? next());
+app.use("*", async (c, next) => canonicalRequestRedirect(c.req.raw) ?? next());
 
 // GitHub App webhooks are signed by GitHub itself, not Better Auth, and arrive
 // without an Origin/Referer header. They must be mounted before the auth and

--- a/test/workers/canonical-domain.test.ts
+++ b/test/workers/canonical-domain.test.ts
@@ -62,6 +62,27 @@ describe("canonical domain routing", () => {
     );
   });
 
+  test("redirects the www host and canonicalizes static paths in one hop", async () => {
+    const res = await fetchWorker("https://www.drydock.org/docs/?from=bookmark");
+
+    expect(res.status).toBe(308);
+    expect(res.headers.get("Location")).toBe("https://drydock.org/docs?from=bookmark");
+  });
+
+  test("serves canonical public routes without the asset binding's slash redirect", async () => {
+    const res = await fetchWorker("https://drydock.org/docs?from=search", assetEnv);
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("asset:/docs/?from=search");
+  });
+
+  test("permanently redirects non-canonical trailing-slash public routes", async () => {
+    const res = await fetchWorker("https://drydock.org/diff/?package=preact");
+
+    expect(res.status).toBe(308);
+    expect(res.headers.get("Location")).toBe("https://drydock.org/diff?package=preact");
+  });
+
   test("serves generated app assets through the Worker-first fallback", async () => {
     const res = await fetchWorker("https://drydock.org/dashboard/settings?tab=general", assetEnv);
 

--- a/test/wrangler-config.test.mjs
+++ b/test/wrangler-config.test.mjs
@@ -10,6 +10,13 @@ describe("Wrangler static asset routing", () => {
     expect(assetsBlock).toContain('"binding": "ASSETS"');
     expect(assetsBlock).toContain('"run_worker_first": true');
   });
+
+  test("routes both canonical host spellings to the Worker", () => {
+    const config = readFileSync(new URL("../wrangler.jsonc", import.meta.url), "utf8");
+
+    expect(config).toContain('"pattern": "drydock.org"');
+    expect(config).toContain('"pattern": "www.drydock.org"');
+  });
 });
 
 describe("Wrangler public egress routing", () => {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -160,6 +160,10 @@
 			"custom_domain": true
 		},
 		{
+			"pattern": "www.drydock.org",
+			"custom_domain": true
+		},
+		{
 			"pattern": "drydock.resynapse.dev",
 			"custom_domain": true
 		},


### PR DESCRIPTION
## Summary
- route `www.drydock.org` through the Worker and permanently redirect it to the apex domain
- serve prerendered public pages at their self-canonical no-slash URLs without an intermediate asset redirect
- include the anonymous package diff tool in the sitemap

## Testing
- `pnpm run verify`

## Documentation
- Docs checked; no update needed. The externally visible routing contract is covered by Worker and Wrangler configuration tests.

## Deployment note
Delete the two existing `www` A records before deploying this Wrangler configuration. Cloudflare Workers Custom Domains will create and manage the proxied DNS record and certificate for `www.drydock.org`.