### PR TITLE
Add a privacy-preserving discoverability scorecard

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,7 @@ The user-facing learning guide is [`../src/pages/Docs/index.tsx`](../src/pages/D
 - [`organization-members.md`](./organization-members.md) — organization invitation/membership behavior.
 - [`audit-log.md`](./audit-log.md) — organization audit log surface, visible-event allowlist, and retention.
 - [`product-analytics.md`](./product-analytics.md) — Analytics Engine counters, privacy posture, and the positional event schema.
+- [`discoverability.md`](./discoverability.md) — Search Console setup, the weekly organic-search scorecard, and the aggregate Analytics Engine outcome snapshot.
 - [`dependency-pr-diff-links.md`](./dependency-pr-diff-links.md) — the `renovate/diff-links.json` shared preset and Dependabot workflow that link dependency-update PRs to public `/diff` pages; the preset path is a public contract.
 - [`two-factor-auth.md`](./two-factor-auth.md) — step-up auth and sensitive actions.
 - [`slack-notifications.md`](./slack-notifications.md) — Slack install and notification flow.

--- a/docs/discoverability.md
+++ b/docs/discoverability.md
@@ -1,0 +1,83 @@
+# Discoverability operations
+
+Drydock keeps search discovery and product outcomes measurable without adding a
+browser tracker. Search impressions, clicks, queries, landing pages, and index
+coverage belong in Google Search Console. Successful anonymous artifact reads,
+signups, integrations, scans, and workflow gates come from the existing
+privacy-preserving Analytics Engine events.
+
+## One-time search setup
+
+1. Add a **Domain property** for `drydock.org` in Google Search Console and
+   complete its DNS ownership verification. A Domain property includes the apex,
+   `www`, and protocol variants while the site redirects visitors to the apex.
+2. Submit `https://drydock.org/sitemap.xml` in the
+   [Sitemaps report](https://support.google.com/webmasters/answer/7451001). The sitemap
+   is already advertised from `public/robots.txt`; explicit submission makes
+   crawl success and errors visible in Search Console.
+3. Use [URL Inspection](https://support.google.com/webmasters/answer/9012289) on
+   the homepage, `/diff`, and every newly published
+   focused guide. Request indexing only after the live test sees a successful,
+   self-canonical 200 response.
+4. Check the [Page indexing report](https://support.google.com/webmasters/answer/7440203)
+   after deployment. A redirect URL should not be
+   indexed; its apex target should be. Treat a sitemap URL that redirects or
+   declares another canonical as a release defect.
+
+Search Console ownership and sitemap submission are external operator actions;
+they cannot be completed by a repository deployment.
+
+## Weekly search scorecard
+
+Use a 28-day window compared with the preceding 28 days, and record:
+
+- total organic clicks and impressions;
+- non-branded clicks and impressions (queries that do not contain `drydock`);
+- clicks, impressions, click-through rate, and average position by landing page;
+- queries earning impressions for the focused npm, PyPI, VS Code, GitHub Actions,
+  package-diff, security-model, and open-source pages;
+- valid indexed sitemap URLs and any canonical, redirect, or crawl exclusions.
+
+Do not optimize a page from a one-week fluctuation. Change a title or page only
+when at least 28 days show a stable mismatch: impressions with weak CTR suggest
+the result copy is wrong; relevant queries with weak position suggest the page
+does not yet answer the intent; no impressions plus an indexing exclusion is a
+technical defect.
+
+## Product-outcome snapshot
+
+Create a Cloudflare API token with `Account Analytics Read`, as described in the
+[Analytics Engine SQL API documentation](https://developers.cloudflare.com/analytics/analytics-engine/sql-api/),
+then run:
+
+```sh
+DRYDOCK_CF_ACCOUNT_ID=<32-character-account-id> \
+DRYDOCK_CF_ANALYTICS_TOKEN=<read-only-token> \
+pnpm run discoverability:snapshot
+```
+
+`-- --days <1-90>` changes the default 28-day window. The command sends four
+fixed aggregate SQL queries to the Analytics Engine SQL API and prints JSON to
+stdout. It measures:
+
+- successful public diff reads, split by ecosystem and cache outcome;
+- signups, explicit organizations, connected integrations, completed scans, and
+  opened workflow gates;
+- connected integrations by kind;
+- completed scans by ecosystem.
+
+Counts use `SUM(_sample_interval)`, so they remain correct when Analytics Engine
+sampling engages. Queries pin analytics schema version `1` and never select the
+organization slot, package name, visitor data, or any identifier.
+
+## Reading the two sources together
+
+Search Console answers whether useful pages are being found. Analytics Engine
+answers whether visitors reach work that Drydock can safely count. The two
+datasets are intentionally not joined: there is no referrer, campaign id,
+cookie, or browser event connecting a search click to a signup or review.
+
+Consequently, `signups / public diff reads` is only a coarse yield, not a user
+conversion rate. Use trends to decide where to investigate, not to claim
+attribution. See [`product-analytics.md`](./product-analytics.md) for the event
+schema and privacy boundary.

--- a/docs/product-analytics.md
+++ b/docs/product-analytics.md
@@ -152,6 +152,11 @@ model, and reviewer version. See
 
 ## Reading the data
 
+For the discoverability scorecard, `pnpm run discoverability:snapshot` runs a
+fixed set of sampled aggregate queries over public diff reads and downstream
+activation outcomes. Search queries and landing-page impressions remain in
+Google Search Console; see [`discoverability.md`](./discoverability.md).
+
 Analytics Engine is queried through the Cloudflare SQL API:
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "e2e:dev:seed": "node test/e2e/dev-server.mjs --seed",
     "e2e:seed": "node scripts/e2e-seed.mjs",
     "ops:snapshot": "node scripts/ops-snapshot.mjs",
+    "discoverability:snapshot": "node scripts/discoverability-snapshot.mjs",
     "agent:tour": "node scripts/agent-tour.mjs",
     "test:e2e": "playwright test",
     "verify": "node scripts/verify.mjs",

--- a/scripts/discoverability-snapshot.mjs
+++ b/scripts/discoverability-snapshot.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// Operator-only, read-only aggregate snapshot for the discoverability funnel.
+// Search impressions and landing-page clicks stay in Google Search Console;
+// this script reads the privacy-preserving product outcomes already recorded in
+// Cloudflare Analytics Engine. It never sends or prints visitor identifiers.
+import { pathToFileURL } from "node:url";
+
+const DEFAULT_DATASET = "drydock_product_events";
+const DEFAULT_DAYS = 28;
+const IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function snapshotQueries(dataset = DEFAULT_DATASET, days = DEFAULT_DAYS) {
+  if (!IDENTIFIER.test(dataset)) throw new Error("dataset must be a SQL identifier");
+  if (!Number.isInteger(days) || days < 1 || days > 90) {
+    throw new Error("days must be an integer from 1 to 90");
+  }
+  const window = `timestamp > NOW() - INTERVAL '${days}' DAY`;
+  const schema = "blob1 = '1'";
+  const weightedCount = "SUM(_sample_interval)";
+
+  return [
+    {
+      name: "discovery_outcomes",
+      sql: `SELECT blob2 AS event, ${weightedCount} AS events FROM ${dataset} WHERE ${schema} AND ${window} AND blob2 IN ('public_diff.viewed', 'user.signed_up', 'organization.created', 'integration.connected', 'scan.completed', 'workflow_gate.opened') GROUP BY event ORDER BY events DESC`,
+    },
+    {
+      name: "public_diff_by_ecosystem_and_cache",
+      sql: `SELECT blob4 AS ecosystem, blob6 AS cache, ${weightedCount} AS views FROM ${dataset} WHERE ${schema} AND ${window} AND blob2 = 'public_diff.viewed' GROUP BY ecosystem, cache ORDER BY views DESC`,
+    },
+    {
+      name: "integrations_by_kind",
+      sql: `SELECT blob4 AS kind, ${weightedCount} AS connections FROM ${dataset} WHERE ${schema} AND ${window} AND blob2 = 'integration.connected' GROUP BY kind ORDER BY connections DESC`,
+    },
+    {
+      name: "completed_scans_by_ecosystem",
+      sql: `SELECT blob4 AS ecosystem, ${weightedCount} AS scans FROM ${dataset} WHERE ${schema} AND ${window} AND blob2 = 'scan.completed' GROUP BY ecosystem ORDER BY scans DESC`,
+    },
+  ];
+}
+
+export function parseSnapshotArgs(argv, env = process.env) {
+  const options = {
+    accountId: env.DRYDOCK_CF_ACCOUNT_ID || "",
+    token: env.DRYDOCK_CF_ANALYTICS_TOKEN || "",
+    dataset: env.DRYDOCK_ANALYTICS_DATASET || DEFAULT_DATASET,
+    days: DEFAULT_DAYS,
+    help: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const readValue = () => {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) throw new Error(`${arg} requires a value`);
+      index += 1;
+      return value;
+    };
+    if (arg === "--") continue;
+    else if (arg === "--help" || arg === "-h") options.help = true;
+    else if (arg === "--days") options.days = Number(readValue());
+    else if (arg === "--dataset") options.dataset = readValue();
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+export async function runDiscoverabilitySnapshot(options, fetchImpl = fetch) {
+  if (!/^[a-f0-9]{32}$/i.test(options.accountId)) {
+    throw new Error("DRYDOCK_CF_ACCOUNT_ID must be a 32-character Cloudflare account id");
+  }
+  if (!options.token) throw new Error("DRYDOCK_CF_ANALYTICS_TOKEN is required");
+
+  const endpoint = `https://api.cloudflare.com/client/v4/accounts/${options.accountId}/analytics_engine/sql`;
+  const queries = snapshotQueries(options.dataset, options.days);
+  const results = await Promise.all(
+    queries.map(async (query) => {
+      const response = await fetchImpl(endpoint, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${options.token}` },
+        body: query.sql,
+      });
+      if (!response.ok) {
+        throw new Error(`Analytics Engine query ${query.name} returned ${response.status}`);
+      }
+      const payload = await response.json();
+      const rows = Array.isArray(payload) ? payload : payload?.data;
+      if (!Array.isArray(rows)) {
+        throw new Error(`Analytics Engine query ${query.name} returned an unexpected shape`);
+      }
+      return [query.name, rows];
+    }),
+  );
+
+  return {
+    generatedAt: new Date().toISOString(),
+    windowDays: options.days,
+    dataset: options.dataset,
+    queries: Object.fromEntries(results),
+  };
+}
+
+function printUsage() {
+  process.stdout.write(
+    `Usage: pnpm run discoverability:snapshot [-- --days <1-90>]\n\nEnvironment:\n  DRYDOCK_CF_ACCOUNT_ID       Cloudflare account id\n  DRYDOCK_CF_ANALYTICS_TOKEN  API token with Account Analytics Read\n  DRYDOCK_ANALYTICS_DATASET   Optional dataset override\n`,
+  );
+}
+
+export async function main(argv = process.argv.slice(2), env = process.env) {
+  const options = parseSnapshotArgs(argv, env);
+  if (options.help) {
+    printUsage();
+    return 0;
+  }
+  const report = await runDiscoverabilitySnapshot(options);
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  return 0;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {
+  main().catch((error) => {
+    process.stderr.write(`discoverability snapshot: ${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/test/discoverability-snapshot.test.mjs
+++ b/test/discoverability-snapshot.test.mjs
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "vitest";
+import {
+  parseSnapshotArgs,
+  runDiscoverabilitySnapshot,
+  snapshotQueries,
+} from "../scripts/discoverability-snapshot.mjs";
+
+describe("discoverability snapshot", () => {
+  test("uses sampled aggregate counts without visitor or customer dimensions", () => {
+    const queries = snapshotQueries("drydock_product_events", 28);
+    expect(queries).toHaveLength(4);
+    for (const query of queries) {
+      expect(query.sql).toContain("SUM(_sample_interval)");
+      expect(query.sql).toContain("INTERVAL '28' DAY");
+      expect(query.sql).not.toMatch(/blob3|organization_id|package_name|user_id|email|ip_address/i);
+    }
+  });
+
+  test("rejects interpolated identifiers and unreasonable windows", () => {
+    expect(() => snapshotQueries("events; DROP TABLE events", 28)).toThrow("SQL identifier");
+    expect(() => snapshotQueries("events", 0)).toThrow("1 to 90");
+    expect(() => snapshotQueries("events", 91)).toThrow("1 to 90");
+  });
+
+  test("parses operator settings from dedicated Drydock variables", () => {
+    expect(
+      parseSnapshotArgs(["--days", "14"], {
+        DRYDOCK_CF_ACCOUNT_ID: "a".repeat(32),
+        DRYDOCK_CF_ANALYTICS_TOKEN: "secret",
+      }),
+    ).toMatchObject({ accountId: "a".repeat(32), token: "secret", days: 14 });
+  });
+
+  test("queries the Cloudflare SQL endpoint and never returns the token", async () => {
+    const calls = [];
+    const fetchImpl = async (url, init) => {
+      calls.push({ url, init });
+      return Response.json([{ event: "public_diff.viewed", events: 12 }]);
+    };
+    const report = await runDiscoverabilitySnapshot(
+      {
+        accountId: "a".repeat(32),
+        token: "top-secret",
+        dataset: "drydock_product_events",
+        days: 28,
+      },
+      fetchImpl,
+    );
+
+    expect(calls).toHaveLength(4);
+    expect(calls[0].url).toBe(
+      `https://api.cloudflare.com/client/v4/accounts/${"a".repeat(32)}/analytics_engine/sql`,
+    );
+    expect(calls.every((call) => call.init.method === "POST")).toBe(true);
+    expect(JSON.stringify(report)).not.toContain("top-secret");
+    expect(report.queries.discovery_outcomes).toEqual([
+      { event: "public_diff.viewed", events: 12 },
+    ]);
+  });
+
+  test("reports status only when a query fails", async () => {
+    await expect(
+      runDiscoverabilitySnapshot(
+        {
+          accountId: "a".repeat(32),
+          token: "must-not-leak",
+          dataset: "drydock_product_events",
+          days: 28,
+        },
+        async () => new Response("denied", { status: 403 }),
+      ),
+    ).rejects.not.toThrow("must-not-leak");
+  });
+});


### PR DESCRIPTION
## Summary
- document the one-time Search Console setup and a 28-day organic-search scorecard
- add a read-only Analytics Engine snapshot for public diff reads and downstream product outcomes
- preserve the existing privacy boundary: no browser tracker, referrer, campaign id, package name, organization slot, or visitor identifier in the queries

## Testing
- `pnpm test -- test/discoverability-snapshot.test.mjs --project node`
- `pnpm run discoverability:snapshot -- --help`
- `pnpm run verify`

Live SQL execution was not run because this workspace has no `DRYDOCK_CF_ACCOUNT_ID` or `DRYDOCK_CF_ANALYTICS_TOKEN`; request construction, response parsing, sampled aggregation, validation, and secret non-disclosure are covered by tests.

## Documentation
- Added `docs/discoverability.md` and linked it from the docs map and product analytics reference.