### PR TITLE
Restore dependency guide anchor navigation

### DIFF
--- a/src/features/dependency-pr-integrations/DependencyPrIntegrations.tsx
+++ b/src/features/dependency-pr-integrations/DependencyPrIntegrations.tsx
@@ -21,8 +21,8 @@ export function DependencyPrIntegrations() {
         </p>
       </div>
 
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <Card as="article" class="p-5 flex flex-col gap-3">
+      <div class="grid max-w-[920px] grid-cols-1 gap-3 md:grid-cols-2">
+        <Card as="article" class="min-w-0 p-4 flex flex-col gap-3">
           <h3 class="m-0 text-base font-medium">Renovate preset</h3>
           <p class="m-0 text-[13px] leading-[1.55] text-ink-muted">
             Extend one shared preset to add a Drydock column to npm and PyPI update tables.
@@ -30,12 +30,17 @@ export function DependencyPrIntegrations() {
           <code class="block rounded-md bg-surface-raised border border-border px-3 py-2 font-mono text-[11px] leading-[1.55] overflow-x-auto">
             {RENOVATE_PRESET}
           </code>
-          <LinkButton href="/docs#renovate-diff-links" variant="secondary" size="sm">
+          <LinkButton
+            href="/docs#renovate-diff-links"
+            variant="secondary"
+            size="sm"
+            class="mt-auto self-start"
+          >
             Add to Renovate
           </LinkButton>
         </Card>
 
-        <Card as="article" class="p-5 flex flex-col gap-3">
+        <Card as="article" class="min-w-0 p-4 flex flex-col gap-3">
           <h3 class="m-0 text-base font-medium">Dependabot workflow</h3>
           <p class="m-0 text-[13px] leading-[1.55] text-ink-muted">
             Copy a workflow that verifies Dependabot&apos;s signed commit, then upserts one
@@ -44,7 +49,12 @@ export function DependencyPrIntegrations() {
           <div class="font-mono text-[11px] text-ink-subtle">
             npm + PyPI · grouped PRs supported
           </div>
-          <LinkButton href="/docs#dependabot-diff-links" variant="secondary" size="sm">
+          <LinkButton
+            href="/docs#dependabot-diff-links"
+            variant="secondary"
+            size="sm"
+            class="mt-auto self-start"
+          >
             Add to Dependabot
           </LinkButton>
         </Card>

--- a/src/pages/Docs/hash-navigation.ts
+++ b/src/pages/Docs/hash-navigation.ts
@@ -1,0 +1,28 @@
+type ScrollTarget = {
+  scrollIntoView(options?: ScrollIntoViewOptions): void;
+};
+
+type HashTargetRoot = {
+  getElementById(id: string): ScrollTarget | null;
+};
+
+export function docsHashTargetId(hash: string): string | null {
+  if (!hash.startsWith("#") || hash.length === 1) return null;
+
+  try {
+    return decodeURIComponent(hash.slice(1));
+  } catch {
+    return null;
+  }
+}
+
+export function scrollToDocsHash(hash: string, root: HashTargetRoot): boolean {
+  const id = docsHashTargetId(hash);
+  if (!id) return false;
+
+  const target = root.getElementById(id);
+  if (!target) return false;
+
+  target.scrollIntoView({ block: "start" });
+  return true;
+}

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -23,11 +23,33 @@ import {
   TocList,
   WorkflowExample,
 } from "./primitives";
+import { scrollToDocsHash } from "./hash-navigation";
 import { TOC_IDS } from "./toc";
 
 export default function DocsPage() {
   const authed = useAuthedSession();
   const activeId = useSignal(TOC_IDS[0]);
+
+  useEffect(() => {
+    let frame: number | undefined;
+    const scrollToCurrentHash = () => {
+      if (frame !== undefined) window.cancelAnimationFrame(frame);
+      frame = window.requestAnimationFrame(() => {
+        frame = undefined;
+        scrollToDocsHash(window.location.hash, document);
+      });
+    };
+
+    // Cross-page links are intercepted by preact-iso. Once the lazy docs route
+    // mounts, the router scrolls it to the top, so restore the intended anchor
+    // after that route transition has committed.
+    scrollToCurrentHash();
+    window.addEventListener("hashchange", scrollToCurrentHash);
+    return () => {
+      window.removeEventListener("hashchange", scrollToCurrentHash);
+      if (frame !== undefined) window.cancelAnimationFrame(frame);
+    };
+  }, []);
 
   useEffect(() => {
     const visible = new Set<string>();

--- a/test/docs-hash-navigation.test.ts
+++ b/test/docs-hash-navigation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test, vi } from "vitest";
+import { docsHashTargetId, scrollToDocsHash } from "../src/pages/Docs/hash-navigation";
+
+describe("docs hash navigation", () => {
+  test("decodes a valid docs target", () => {
+    expect(docsHashTargetId("#renovate-diff-links")).toBe("renovate-diff-links");
+    expect(docsHashTargetId("#dependency%2Dupdates")).toBe("dependency-updates");
+  });
+
+  test("ignores empty and malformed hashes", () => {
+    expect(docsHashTargetId("")).toBeNull();
+    expect(docsHashTargetId("#")).toBeNull();
+    expect(docsHashTargetId("#%E0%A4%A")).toBeNull();
+  });
+
+  test("scrolls the matching docs title into view", () => {
+    const scrollIntoView = vi.fn();
+    const getElementById = vi.fn((id: string) =>
+      id === "dependabot-diff-links" ? { scrollIntoView } : null,
+    );
+
+    expect(scrollToDocsHash("#dependabot-diff-links", { getElementById })).toBe(true);
+    expect(getElementById).toHaveBeenCalledWith("dependabot-diff-links");
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+  });
+
+  test("does nothing when the target is absent", () => {
+    const getElementById = vi.fn(() => null);
+
+    expect(scrollToDocsHash("#missing", { getElementById })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- restore cross-page docs hash targets after the lazy route commits
- keep dependency integration cards to a readable measure with compact, aligned actions
- cover hash decoding, missing targets, and scroll behavior with focused tests

## Testing
- `pnpm run verify`

Docs checked, no update needed: this fixes navigation to the existing Renovate and Dependabot sections without changing their setup guidance.