### PR TITLE
Add the npm trusted-publishing pinned-environment recipe (docs + public guide)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ The user-facing learning guide is [`../src/pages/Docs/index.tsx`](../src/pages/D
 
 - [`architecture.md`](./architecture.md) — Worker, sandbox, adapters, storage, org model, and API shape.
 - [`workflow-gates.md`](./workflow-gates.md) — shared GitHub Environment gate flow for PyPI, npm, and VS Code releases.
+- [`npm-trusted-publishing.md`](./npm-trusted-publishing.md) — pinning npm trusted publishing (OIDC) to the gate environment so the reviewed workflow is the only credentialed publish path, plus what that does and does not stop.
 - [`diff-baseline.md`](./diff-baseline.md) — default previous-version comparison strategy.
 - [`atpm-public-diff.md`](./atpm-public-diff.md) — the atpm ecosystem on `/diff`: AT Protocol resolution (handle → DID → PDS → record → blob), why it does not go through atpm.dev, the host policy that bounds publisher-named egress, and the record-vs-tarball findings.
 - [`atpm-trusted-publishing.md`](./atpm-trusted-publishing.md) — atpm's OIDC trusted publishing, the Sigstore bundles Drydock re-verifies against a pinned root, and the anonymous public-diff link atpm's own dashboard uses to hand a maintainer a pre-publish review with no account. Review only: Drydock does not approve, gate, or watch an atpm release.

--- a/docs/npm-trusted-publishing.md
+++ b/docs/npm-trusted-publishing.md
@@ -1,0 +1,118 @@
+# npm trusted publishing: making the gate the only publish path
+
+The [npm workflow gate](./workflow-gates.md#npm-workflow-gate-notes) pauses a
+publish while Drydock reviews the exact bytes. On its own it is a checkpoint on
+one path: nothing stops a maintainer — or an attacker holding a token — from
+publishing around it. npm's **trusted publishing** (OIDC) closes that. Pin the
+package's publish path to one repository, one workflow file, and one GitHub
+Environment, make Drydock that environment's deployment-protection rule, and
+disallow tokens. The only way to obtain publish credentials is then to pass the
+review.
+
+This page is the recipe, followed by an honest accounting of what it does and
+does not stop. Prerequisite: a working npm workflow gate as described in
+[`workflow-gates.md`](./workflow-gates.md#npm-workflow-gate-notes) — Drydock
+GitHub App installed, release target configured, publish workflow uploading the
+packed tarballs plus `SHA256SUMS`.
+
+## The recipe
+
+On npmjs.com, in the package's settings:
+
+1. **Configure a trusted publisher**: GitHub Actions, with the owning
+   organization/user, the repository, the workflow filename (for example
+   `publish.yml`), and — the load-bearing step — the **environment** set to the
+   gated environment (`production` below). With the environment pinned, npm
+   only exchanges OIDC credentials for a job running inside that environment,
+   which means the job cannot start until the environment's protection rules
+   have passed.
+2. **Set publishing access to "Require two-factor authentication and disallow
+   tokens"**. This removes every token path: legacy tokens, automation tokens,
+   and granular access tokens all stop working for publish.
+
+On GitHub, in the repository:
+
+3. **Harden the `production` environment**: Drydock is its custom
+   deployment-protection rule; **uncheck "Allow administrators to bypass
+   configured protection rules"** (it is on by default); restrict deployment
+   branches/tags to the release branch or tag pattern.
+4. **Protect the workflow file**: a ruleset or branch protection on the branch
+   the workflow publishes from, with `CODEOWNERS` review on
+   `.github/workflows/`. The trusted publisher pins the workflow _path_, not
+   its contents — review on changes to it belongs to the same bar as a release.
+5. **Publish via OIDC, not a token**. The publish job runs in the environment,
+   requests an id-token, verifies the reviewed digests, and publishes with npm
+   CLI ≥ 11.5.1 and no `NODE_AUTH_TOKEN` anywhere in the workflow:
+
+```yaml
+jobs:
+  pack:
+    steps:
+      - run: npm ci
+      - run: npm pack --json > pack.json
+      - run: sha256sum *.tgz > SHA256SUMS
+      - uses: actions/upload-artifact@v4
+        with:
+          name: npm-release-candidates
+          path: |
+            *.tgz
+            SHA256SUMS
+  publish:
+    needs: pack
+    environment: production # must match the trusted publisher's pinned environment
+    permissions:
+      id-token: write # OIDC; no npm token exists in this workflow
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: npm-release-candidates
+      # Fail closed if the downloaded bytes drifted from what was reviewed.
+      - run: sha256sum --check --strict SHA256SUMS
+      - run: npm publish *.tgz
+```
+
+This is the same shape as the recommended gate workflow in
+[`workflow-gates.md`](./workflow-gates.md#npm-workflow-gate-notes); the deltas
+are the `id-token: write` permission and the absence of any token secret.
+
+## Why each pin matters
+
+| Publish attempt                                                | Stopped by                                                                               |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| `npm publish` with any token — laptop, CI secret, stolen token | Publishing access disallows tokens                                                       |
+| OIDC publish from another repository, workflow file, or a fork | Trusted publisher claim mismatch; npm refuses the exchange                               |
+| Editing the workflow to drop `environment: production`         | Environment is pinned in the trusted publisher config; the OIDC exchange fails           |
+| Running the publish job without (or against) a gate decision   | The deployment-protection rule holds the job; a Drydock rejection fails the run closed   |
+| Rebuilding or swapping the tarball after approval              | `sha256sum --check --strict` fails closed; the same digests are in the report Provenance |
+| A repo admin approving the deployment past the rule in the UI  | Admin bypass unchecked on the environment                                                |
+
+Two properties compound on top of the table. Because the publish is OIDC-based,
+npm attaches provenance attestations binding the published version to the
+repository and workflow run — so a version that _did_ ship around this path is
+publicly distinguishable from one that went through it. And the review boundary
+stays intact under workflow tampering: pinning controls _which_ path can
+publish, while Drydock's review of the uploaded bytes judges _what_ that path
+is about to publish — a malicious workflow edit that produces malicious bytes
+still lands in front of the reviewer.
+
+Gate scans arriving through this path carry the `attested` source-binding tier
+(see [`intent-envelope.md`](./intent-envelope.md)): the signed
+`deployment_protection_rule` webhook binds repository, run, and environment,
+and the reviewed bytes were downloaded from that exact run.
+
+## What this does not stop
+
+- **Interactive publish by the npm account itself.** "Disallow tokens" still
+  permits a human with the account password, 2FA, and an OTP to `npm publish`
+  from a laptop. npm has no "trusted publisher only" enforcement today; this is
+  the residual gap only the registry can close. Such a publish is _detectable_
+  — no provenance attestation, no gate review, no report — but not preventable.
+- **npm account takeover, including 2FA.** Whoever controls the account can
+  edit or remove the trusted publisher configuration and re-enable tokens.
+  Every registry-side control roots in account security.
+- **GitHub administrators.** Repo admins can edit the environment's protection
+  rules and org admins can uninstall the App. Keep the admin set small; both
+  actions land in GitHub's audit log.
+- **Drydock unavailability.** The gate stays blocked and GitHub eventually
+  fails the waiting run at its own timeout. The failure mode is a delayed
+  release, never an unreviewed one.

--- a/docs/npm-trusted-publishing.md
+++ b/docs/npm-trusted-publishing.md
@@ -23,9 +23,8 @@ On npmjs.com, in the package's settings:
    organization/user, the repository, the workflow filename (for example
    `publish.yml`), and — the load-bearing step — the **environment** set to the
    gated environment (`production` below). With the environment pinned, npm
-   only exchanges OIDC credentials for a job running inside that environment,
-   which means the job cannot start until the environment's protection rules
-   have passed.
+   refuses the OIDC exchange for any job outside that environment, and a job
+   inside it cannot start until the environment's protection rules have passed.
 2. **Set publishing access to "Require two-factor authentication and disallow
    tokens"**. This removes every token path: legacy tokens, automation tokens,
    and granular access tokens all stop working for publish.
@@ -87,9 +86,10 @@ are the `id-token: write` permission and the absence of any token secret.
 | A repo admin approving the deployment past the rule in the UI  | Admin bypass unchecked on the environment                                                |
 
 Two properties compound on top of the table. Because the publish is OIDC-based,
-npm attaches provenance attestations binding the published version to the
-repository and workflow run — so a version that _did_ ship around this path is
-publicly distinguishable from one that went through it. And the review boundary
+npm attaches provenance attestations (for public repositories) binding the
+published version to the repository and workflow run — so a version that _did_
+ship around this path is publicly distinguishable from one that went through
+it. And the review boundary
 stays intact under workflow tampering: pinning controls _which_ path can
 publish, while Drydock's review of the uploaded bytes judges _what_ that path
 is about to publish — a malicious workflow edit that produces malicious bytes

--- a/docs/workflow-gates.md
+++ b/docs/workflow-gates.md
@@ -115,6 +115,8 @@ jobs:
 
 Drydock should be the deployment-protection rule for the `production` environment. The publish job must consume the exact uploaded artifact reviewed by Drydock; rebuilding after approval breaks the review boundary. The `SHA256SUMS` record/check pair makes that enforceable in CI: the digests match the ones Drydock recomputes and shows in the report Provenance section, and the publish job fails closed on any drift. Drydock ignores `SHA256SUMS` in the bundle (it is not a `.tgz`).
 
+To make this gated workflow the _only_ credentialed publish path — npm trusted publishing pinned to the gate environment, tokens disallowed — see [`npm-trusted-publishing.md`](./npm-trusted-publishing.md).
+
 See [`pypi-workflow-gate.md`](./pypi-workflow-gate.md) for the PyPI-specific
 workflow shape, including build-time `SHA256SUMS` generation and publish-time
 verification.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -31,6 +31,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://drydock.org/npm-trusted-publishing</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://drydock.org/pypi-release-security</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,6 +38,7 @@ export function App() {
           <Route path="/privacy" component={PrivacyPage} />
           <Route path="/npm-staged-publishing" component={DiscoveryGuidePage} />
           <Route path="/github-actions-package-gate" component={DiscoveryGuidePage} />
+          <Route path="/npm-trusted-publishing" component={DiscoveryGuidePage} />
           <Route path="/pypi-release-security" component={DiscoveryGuidePage} />
           <Route path="/vscode-extension-security" component={DiscoveryGuidePage} />
           <Route path="/package-tarball-diff" component={DiscoveryGuidePage} />

--- a/src/lib/public-content-routes.ts
+++ b/src/lib/public-content-routes.ts
@@ -4,6 +4,7 @@
 export const DISCOVERY_GUIDE_PATHS = [
   "/npm-staged-publishing",
   "/github-actions-package-gate",
+  "/npm-trusted-publishing",
   "/pypi-release-security",
   "/vscode-extension-security",
   "/package-tarball-diff",

--- a/src/lib/seo-metadata.ts
+++ b/src/lib/seo-metadata.ts
@@ -36,6 +36,12 @@ export const discoveryGuideSeoByPath = {
       "Hold npm, PyPI, or VS Code publication in a GitHub Environment until the exact built artifacts pass human review.",
     path: "/github-actions-package-gate",
   },
+  "/npm-trusted-publishing": {
+    title: "Lock npm publishing to a reviewed workflow | Drydock",
+    description:
+      "Pin npm trusted publishing to a gated GitHub Environment and disallow tokens, so publish credentials only exist after a human review.",
+    path: "/npm-trusted-publishing",
+  },
   "/pypi-release-security": {
     title: "PyPI release security for wheels and sdists | Drydock",
     description:

--- a/src/pages/Guides/index.tsx
+++ b/src/pages/Guides/index.tsx
@@ -118,7 +118,7 @@ const GUIDES: Record<DiscoveryGuidePath, GuideContent> = {
       },
     ],
     close: {
-      heading: "Pin your publish path this week.",
+      heading: "Pin your publish path.",
       body: "The whole recipe is configuration: one trusted-publisher entry, one environment setting, one token policy. The step-by-step with the workflow YAML and the full bypass table is in the open repository.",
       action: {
         href: "https://github.com/JoviDeCroock/drydock/blob/main/docs/npm-trusted-publishing.md",
@@ -127,10 +127,7 @@ const GUIDES: Record<DiscoveryGuidePath, GuideContent> = {
       detail: ["configuration only", "fails closed"],
     },
     primary: { href: "/docs#workflow-gating", label: "Add a workflow gate" },
-    secondary: {
-      href: "https://github.com/JoviDeCroock/drydock/blob/main/docs/npm-trusted-publishing.md",
-      label: "Read the full recipe",
-    },
+    secondary: { href: "/github-actions-package-gate", label: "How the gate works" },
   },
   "/pypi-release-security": {
     eyebrow: "PyPI release security",

--- a/src/pages/Guides/index.tsx
+++ b/src/pages/Guides/index.tsx
@@ -95,6 +95,43 @@ const GUIDES: Record<DiscoveryGuidePath, GuideContent> = {
     primary: { href: "/docs#workflow-gating", label: "Add a workflow gate" },
     secondary: { href: "/docs#gate-workflow", label: "See workflow examples" },
   },
+  "/npm-trusted-publishing": {
+    eyebrow: "npm trusted publishing",
+    heading: "Make the reviewed workflow the only way to publish.",
+    lead: "A workflow gate is a checkpoint on one path; a stolen token walks around it. Pinning npm trusted publishing to the gated GitHub Environment and disallowing tokens closes that: publish credentials only come into existence after the review passes.",
+    details: ["OIDC, no npm tokens", "environment pinned to the gate", "configuration, not code"],
+    sections: [
+      {
+        label: "Pin the path",
+        heading: "npm issues credentials only inside the gated environment.",
+        body: "A trusted publisher names one repository, one workflow file, and one GitHub Environment. With the environment pinned, the OIDC exchange fails for any other job — including an edited workflow that drops the environment — and the pinned job cannot start until the environment's protection rule, the Drydock review, has passed.",
+      },
+      {
+        label: "Close the side doors",
+        heading: "Every bypass runs into a specific pin.",
+        body: "Package settings disallow tokens, so laptop publishes and CI secrets stop working. Another repository or a fork fails the trusted-publisher claim match. Publishing past a rejection fails closed at the protection rule. Rebuilding after approval fails the digest re-check, and administrator bypass is switched off on the environment itself.",
+      },
+      {
+        label: "The honest residue",
+        heading: "What only the registry can close.",
+        body: "The npm account owner can still publish interactively with 2FA, and whoever controls the account can edit the trusted-publisher configuration. npm has no publisher-only mode today. A release that ships around the pinned path is still visible — it carries no provenance attestation and no review — so bypass becomes detectable even where it is not preventable.",
+      },
+    ],
+    close: {
+      heading: "Pin your publish path this week.",
+      body: "The whole recipe is configuration: one trusted-publisher entry, one environment setting, one token policy. The step-by-step with the workflow YAML and the full bypass table is in the open repository.",
+      action: {
+        href: "https://github.com/JoviDeCroock/drydock/blob/main/docs/npm-trusted-publishing.md",
+        label: "Read the full recipe",
+      },
+      detail: ["configuration only", "fails closed"],
+    },
+    primary: { href: "/docs#workflow-gating", label: "Add a workflow gate" },
+    secondary: {
+      href: "https://github.com/JoviDeCroock/drydock/blob/main/docs/npm-trusted-publishing.md",
+      label: "Read the full recipe",
+    },
+  },
   "/pypi-release-security": {
     eyebrow: "PyPI release security",
     heading: "Review wheels and source distributions before uploading to PyPI.",


### PR DESCRIPTION
## Summary

The npm workflow gate is a checkpoint on one path — a token walks around it. This adds the recipe that makes the gated workflow the **only credentialed publish path**, using capabilities npm and GitHub ship today: trusted publishing pinned to the gate environment, tokens disallowed, admin bypass off, OIDC-only publish job.

Two surfaces, shipped together:

- **`docs/npm-trusted-publishing.md`** — the full engineering recipe: the five pins, the workflow YAML (same shape as the gate workflow, plus `id-token: write` and no token secret), a bypass table mapping each publish attempt to the pin that stops it, and an honest "What this does not stop" section (interactive 2FA publish — the residual gap only the registry can close; account takeover; GitHub admins; outage behavior, which fails closed). Linked from the docs map and the npm workflow-gate notes.
- **`/npm-trusted-publishing`** — a public discovery guide in the existing guides system (path registry, SEO metadata, router, sitemap; prerender/SEO tests pick the path up from `DISCOVERY_GUIDE_PATHS` automatically). The page carries the story in the house three-section format and closes by linking the full recipe in the repo; its GitHub links resolve once this PR merges, which is why both surfaces ship in one PR.

A final `review:` commit from the adversarial pass tightens the OIDC-exchange wording, adds the public-repository qualifier on the provenance claim, and de-duplicates the guide's hero/close CTAs.

## Testing

- `pnpm run verify` (lint, format, typecheck, node + workers suites) — passing on the final commit.
- Guide wiring is covered by the existing registry-driven tests (`test/prerender-routes.test.ts` iterates `DISCOVERY_GUIDE_PATHS` for prerender, SEO, and sitemap well-formedness).
- Docs updated as part of the change (`docs/npm-trusted-publishing.md`, `docs/README.md`, `docs/workflow-gates.md`); no other doc layer affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)