### PR TITLE
Complete the Renovate preset's column superset and cover it with a test

### DIFF
--- a/docs/dependency-pr-diff-links.md
+++ b/docs/dependency-pr-diff-links.md
@@ -27,21 +27,43 @@ A failed preset resolution is not a soft miss: Renovate raises a
 `CONFIG_VALIDATION` error and stops processing the downstream repository
 entirely — adopters lose all updates, not just the column — so treat the path
 like a published API: additive changes only, never rename or move the file.
+`test/renovate-diff-links.test.mjs` pins the path, because this repository uses
+Dependabot and so never renders the preset itself.
 
 Shape notes, so edits keep the links correct:
 
 - The column is added via `packageRules` scoped with `matchDatasources`, the
   same mechanism as Renovate's built-in `security:openssf-scorecard` preset.
   Only `npm` and `pypi` get a column — those are the ecosystems `/diff` serves.
-- `prBodyColumns` is a non-mergeable array where the last matching packageRule
-  wins, so the preset lists a superset: Renovate's defaults plus the
-  `mergeConfidence:*` (`Age`, `Confidence`) and `security:openssf-scorecard`
-  (`OpenSSF`) columns plus `Drydock`. Renovate drops columns that end up empty,
-  so each repo renders only the columns its other presets actually populate.
-  Without the superset, this preset would silently erase the merge-confidence
-  badges for every `config:recommended` adopter. The extends order in the
-  snippet matters for the same reason: listed first, a base preset's own
-  `prBodyColumns` rule would win and drop the `Drydock` column instead.
+- `prBodyColumns` is not a mergeable option. Within one upgrade the last
+  matching packageRule replaces the list outright; across a branch Renovate then
+  unions the lists of every upgrade in it, which is why a mixed-ecosystem group
+  still shows the column. The replacement is the part that bites: listed last,
+  this preset's list becomes the whole list for every npm and PyPI upgrade, so
+  it repeats every column an upstream preset could have asked for — Renovate's
+  defaults (`Package`, `Type`, `Update`, `Change`, `Pending`), all four
+  `mergeConfidence:*` badges (`Age`, `Adoption`, `Passing`, `Confidence`), and
+  `security:openssf-scorecard`'s `OpenSSF` — plus `Drydock`. Without the
+  superset this preset would silently erase badges the adopter opted into. The
+  extends order in the snippet matters for the same reason: listed first, a base
+  preset's own `prBodyColumns` rule would win and drop the `Drydock` column
+  instead. `test/renovate-diff-links.test.mjs` holds copies of the upstream
+  lists, so a column added upstream fails there rather than in an adopter's PR.
+- The superset makes the table wider than one added column, and that is the
+  accepted cost of the point above. `config:recommended` extends
+  `mergeConfidence:age-confidence-badges`, whose list is only `Package`,
+  `Change`, `Age`, `Confidence`, so adopting this preset also brings `Type` and
+  `Update` back — their definitions are Renovate defaults and populated for
+  ordinary dependency updates. For the same reason all four merge-confidence
+  cells render Mend badge images for an adopter whose base config never enabled
+  merge confidence: the `mergeConfidence:*` presets add only the columns, never
+  the definitions. Renovate drops columns that end up empty, so nothing renders
+  a blank column, but nothing renders a narrower table than this list either.
+  That is the deliberate trade: a table wider than an adopter asked for is
+  recoverable — they append their own `packageRules` entry with `prBodyColumns`,
+  and repo-level rules are evaluated after preset ones, so theirs wins — while a
+  badge this preset deleted is a feature they opted into disappearing with no
+  signal.
 - `packageName`, not `depName`: for npm alias specs (`npm:real-pkg@1.2.3`) and
   normalized PyPI names, `packageName` is the package actually being installed;
   `depName` is what the manifest calls it. Linking `depName` could present a
@@ -55,6 +77,13 @@ Shape notes, so edits keep the links correct:
   confidently wrong one, matching `dependencyDiffHref` in the app.
 - Triple-stash (`{{{…}}}`) follows upstream preset convention for URLs; Renovate
   compiles templates with `noEscape`, so it is stylistic, not load-bearing.
+- Nothing scopes the link to the public registry, and nothing can.
+  `matchDatasources: ["npm"]` also matches a package resolved from a private or
+  self-hosted registry, which `/diff` cannot look up, so those rows link a page
+  that will not find the package. Renovate's template field allowlist does not
+  expose `registryUrl`, so the definition cannot see which registry an upgrade
+  came from; a dead link on internal packages is the residual cost of the
+  column.
 
 ## Dependabot
 

--- a/renovate/diff-links.json
+++ b/renovate/diff-links.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "description": [
     "Adds a Drydock column to Renovate PR tables: every npm and PyPI update links to a line-level diff of the published packages at drydock.org/diff.",
-    "Usage: \"extends\": [\"config:recommended\", \"github>JoviDeCroock/drydock//renovate/diff-links\"] — list this preset after base presets so its columns win."
+    "Usage: \"extends\": [\"config:recommended\", \"github>JoviDeCroock/drydock//renovate/diff-links\"] — list this preset after base presets so its columns win.",
+    "prBodyColumns replaces rather than merges, so the column list restates Renovate's default, merge-confidence, and OpenSSF columns; columns that end up empty are dropped."
   ],
   "packageRules": [
     {
@@ -14,6 +15,8 @@
         "Change",
         "Pending",
         "Age",
+        "Adoption",
+        "Passing",
         "Confidence",
         "OpenSSF",
         "Drydock"
@@ -31,6 +34,8 @@
         "Change",
         "Pending",
         "Age",
+        "Adoption",
+        "Passing",
         "Confidence",
         "OpenSSF",
         "Drydock"

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -738,10 +738,13 @@ export default function DocsPage() {
 }`}
               </CodeBlock>
               <Prose>
-                List the preset after your base presets so its column layout wins. Updates without
-                two distinct published versions of one package — pins, digests, replacements, and
-                some lockfile-only changes — omit the link, and columns that end up empty are
-                dropped from the table.
+                List the preset after your base presets so its column layout wins. Renovate has no
+                way to append a single column, so the preset restates the whole layout — the
+                standard columns, the merge-confidence badges, and OpenSSF — and your table can come
+                out wider than your base preset alone renders it. Updates without two distinct
+                published versions of one package — pins, digests, replacements, and some
+                lockfile-only changes — omit the link, and columns that end up empty are dropped
+                from the table.
               </Prose>
             </Subsection>
 

--- a/test/renovate-diff-links.test.mjs
+++ b/test/renovate-diff-links.test.mjs
@@ -1,0 +1,170 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+import { parseDiffSpec } from "../src/lib/package-diff-path";
+
+// The Renovate preset is the one Drydock artifact no test in this repository
+// exercises by running it: this repository uses Dependabot, so nothing here ever
+// renders the preset. These assertions stand in for that, and they guard three
+// things that break adopters silently.
+//
+// The values copied from Renovate below were read from renovatebot/renovate at
+// lib/config/options/index.ts (prBodyColumns default) and
+// lib/config/presets/internal/{merge-confidence,security}.preset.ts. The
+// template semantics they encode were verified by rendering both definitions
+// through Renovate's own compiled `util/template` module.
+const PRESET_PATH = "renovate/diff-links.json";
+
+const preset = JSON.parse(
+  readFileSync(fileURLToPath(new URL(`../${PRESET_PATH}`, import.meta.url)), "utf8"),
+);
+
+const rulesByDatasource = new Map(
+  preset.packageRules.map((rule) => [rule.matchDatasources.join(","), rule]),
+);
+
+// prBodyColumns is not a mergeable option, so within one upgrade the last
+// matching packageRule replaces the list outright. Listing this preset after a
+// base preset therefore erases whatever columns that base preset asked for
+// unless they are repeated here. Every upstream list that can precede us:
+const UPSTREAM_COLUMNS = {
+  "renovate defaults": ["Package", "Type", "Update", "Change", "Pending"],
+  "mergeConfidence:age-confidence-badges": ["Package", "Change", "Age", "Confidence"],
+  "mergeConfidence:all-badges": ["Package", "Change", "Age", "Adoption", "Passing", "Confidence"],
+  "security:openssf-scorecard": ["Package", "Type", "Update", "Change", "Pending", "OpenSSF"],
+};
+
+// Sample upgrades, one per URL shape the preset has to produce. Field names are
+// Renovate template fields; a template that interpolates anything else fails the
+// substitution below rather than silently rendering an empty path segment.
+const SAMPLES = [
+  {
+    label: "unscoped npm",
+    datasource: "npm",
+    fields: { packageName: "lodash", currentVersion: "4.17.20", newVersion: "4.17.21" },
+    expected: {
+      ecosystem: "npm",
+      packageName: "lodash",
+      fromVersion: "4.17.20",
+      toVersion: "4.17.21",
+    },
+  },
+  {
+    label: "scoped npm",
+    datasource: "npm",
+    fields: { packageName: "@babel/core", currentVersion: "7.24.0", newVersion: "7.25.1" },
+    expected: {
+      ecosystem: "npm",
+      packageName: "@babel/core",
+      fromVersion: "7.24.0",
+      toVersion: "7.25.1",
+    },
+  },
+  {
+    label: "npm build metadata",
+    datasource: "npm",
+    fields: { packageName: "pkg", currentVersion: "1.0.0+build.1", newVersion: "1.0.1+build.2" },
+    expected: {
+      ecosystem: "npm",
+      packageName: "pkg",
+      fromVersion: "1.0.0+build.1",
+      toVersion: "1.0.1+build.2",
+    },
+  },
+  {
+    label: "pypi project",
+    datasource: "pypi",
+    fields: { packageName: "requests", currentVersion: "2.31.0", newVersion: "2.32.0" },
+    expected: {
+      ecosystem: "pypi",
+      packageName: "requests",
+      fromVersion: "2.31.0",
+      toVersion: "2.32.0",
+    },
+  },
+  {
+    label: "pypi PEP 440 epoch",
+    datasource: "pypi",
+    fields: { packageName: "pkg", currentVersion: "1!1.0", newVersion: "1!1.1" },
+    expected: {
+      ecosystem: "pypi",
+      packageName: "pkg",
+      fromVersion: "1!1.0",
+      toVersion: "1!1.1",
+    },
+  },
+];
+
+function drydockDefinition(datasource) {
+  const rule = rulesByDatasource.get(datasource);
+  if (!rule) throw new Error(`no packageRule for datasource ${datasource}`);
+  return rule.prBodyDefinitions.Drydock;
+}
+
+// Renovate compiles the definition with Handlebars; this pulls out just the link
+// target and substitutes the triple-stashed fields, which is all the URL shape
+// depends on. An unknown field throws rather than substituting empty.
+function diffUrl(datasource, fields) {
+  const definition = drydockDefinition(datasource);
+  const match = /\]\((https:\/\/drydock\.org[^)]*)\)/.exec(definition);
+  if (!match) throw new Error(`no drydock.org link in ${definition}`);
+  return match[1].replace(/\{\{\{(\w+)\}\}\}/g, (_, field) => {
+    if (!(field in fields)) throw new Error(`template interpolates unknown field ${field}`);
+    return fields[field];
+  });
+}
+
+describe("renovate diff-links preset", () => {
+  // Renovate resolves `github>JoviDeCroock/drydock//renovate/diff-links` to this
+  // path on the default branch. A failed preset resolution is not a soft miss:
+  // it raises CONFIG_VALIDATION and stops Renovate processing the adopting
+  // repository entirely, so every adopter loses all updates, not just a column.
+  // Moving the file already fails this suite at import; the literal below exists
+  // so that updating PRESET_PATH to match a move fails too.
+  test("stays at the path adopters reference", () => {
+    expect(PRESET_PATH).toBe("renovate/diff-links.json");
+  });
+
+  // Only the ecosystems /diff serves get a column. Adding one here means adding
+  // a URL shape, so the sample list below has to grow with it.
+  test("covers exactly the datasources with a diff URL shape", () => {
+    expect(preset.packageRules.map((rule) => rule.matchDatasources)).toEqual([["npm"], ["pypi"]]);
+    expect(new Set(SAMPLES.map((sample) => sample.datasource))).toEqual(new Set(["npm", "pypi"]));
+  });
+
+  test.each(Object.entries(UPSTREAM_COLUMNS))(
+    "keeps every column %s asks for",
+    (_name, columns) => {
+      for (const rule of preset.packageRules) {
+        expect(rule.prBodyColumns).toEqual(expect.arrayContaining(columns));
+        expect(rule.prBodyColumns).toContain("Drydock");
+      }
+    },
+  );
+
+  test.each(SAMPLES)(
+    "$label links a URL the diff router parses",
+    ({ datasource, fields, expected }) => {
+      const url = new URL(diffUrl(datasource, fields));
+      expect(parseDiffSpec(url.pathname)).toEqual(expected);
+    },
+  );
+
+  // Guards, verified against Renovate's template engine: no link unless the pair
+  // is two distinct published versions of one package. `equals` is a Renovate
+  // helper, and all four fields are in Renovate's template allowlist.
+  test.each(["npm", "pypi"])(
+    "%s definition drops the link for non-diffable updates",
+    (datasource) => {
+      const definition = drydockDefinition(datasource);
+      expect(definition).toContain("{{#if currentVersion}}");
+      expect(definition).toContain("{{#if newVersion}}");
+      expect(definition).toContain("{{#unless newName}}");
+      expect(definition).toContain("{{#unless (equals currentVersion newVersion)}}");
+      // packageName, not depName: for npm alias specs and normalized PyPI names,
+      // depName is what the manifest calls the dependency, which can be a
+      // different package than the one actually installed.
+      expect(definition).not.toContain("depName");
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Review of the `renovate/diff-links.json` preset against Renovate's own source and template engine. The link templates themselves are correct — the column list was not.

`prBodyColumns` is not a mergeable option, so within an upgrade the last matching packageRule replaces the list outright. Listed after a base preset (as documented), this preset's list becomes the whole list for every npm and PyPI upgrade, which is why it restates every column an upstream preset could have asked for. It was missing `Adoption` and `Passing`, so adopting it silently deleted two badges from any repository extending `mergeConfidence:all-badges` — precisely the failure the superset exists to prevent.

- **Preset:** add `Adoption` and `Passing` to both rules, in upstream order.
- **Test:** `test/renovate-diff-links.test.mjs`. Nothing here rendered the preset before — this repository uses Dependabot — so the file had no coverage at all despite `docs/dependency-pr-diff-links.md` calling its path a public contract whose breakage raises `CONFIG_VALIDATION` and halts every adopting repository. The test pins the contracted path, holds copies of each upstream column list (Renovate defaults, both `mergeConfidence:*` presets, `security:openssf-scorecard`), and round-trips each link template through `parseDiffSpec`, so a URL shape cannot drift from the router that parses it.
- **Docs:** the superset widens the table rather than adding one column (`config:recommended` extends `mergeConfidence:age-confidence-badges`, whose list omits `Type`/`Update`/`Pending`, and the merge-confidence badge *definitions* are Renovate defaults that render whether or not the adopter enabled them); branch-level `prBodyColumns` is unioned across upgrades, not simply last-wins; and a private-registry package gets a dead link that the preset cannot avoid, because `registryUrl` is not in Renovate's template field allowlist.

## Verification

Beyond the repo gate, the preset was checked against Renovate itself:

- `renovate-config-validator --no-global` passes on the preset and on a consumer config extending it.
- Both `Drydock` definitions rendered through Renovate's compiled `util/template` module over 14 upgrade shapes: correct URLs for unscoped/scoped/aliased/prerelease/`+build` npm and plain/mixed-case/underscore/PEP-440-epoch/extras PyPI; no link for pin, digest, replacement, and missing `currentVersion`. `equals` is a registered helper and all four guarded fields are in Renovate's template allowlist.
- Every rendered URL shape returns 200 on drydock.org, including the scoped-npm and PyPI forms.

## Testing

- `oxlint`, `oxfmt --check`, `tsc --noEmit`, `knip` — clean
- `vitest run --project node` — 1675 passed, 1 skipped
- `vitest run --project workers` — 601 passed

(Run as the individual gate steps rather than `pnpm run verify`: this branch was built in a scratch worktree sharing the primary workspace's `node_modules`, which `pnpm` wants to purge.)

## Docs

`docs/dependency-pr-diff-links.md` and the Docs page "Diffs in dependency PRs" section updated; `docs/README.md` index entry still accurate, no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)