### PR TITLE
Promote rule IDs to a rule manifest and machine-check rule coverage

### DIFF
--- a/.claude/skills/add-detection-rule/SKILL.md
+++ b/.claude/skills/add-detection-rule/SKILL.md
@@ -9,27 +9,27 @@ Deterministic findings are the authoritative review signal; the AI reviewer is a
 
 ## Checklist
 
-1. **Register the rule ID.** Add a key to `DETERMINISTIC_RULE_IDS` in `server/lib/review/rules/rule-ids.ts`. IDs are dot-namespaced by family: `install-script.*`, `code.*`, `file.*`, `diff.*`, `dependency.*`, `package-json.*`, `stage.*`, `tar.*`, `release.*`.
+1. **Register the rule in the manifest.** Add an entry to `DETERMINISTIC_RULES` in `server/lib/review/rules/rule-ids.ts`: `{ id, risk, standingDanger? }` (see `DeterministicRuleSpec`). IDs are dot-namespaced by family: `install-script.*`, `code.*`, `file.*`, `diff.*`, `dependency.*`, `package-json.*`, `stage.*`, `tar.*`, `release.*`. `test/detection-rule-coverage.test.mjs` machine-checks that every registered rule has a corpus fixture (or an explicit exception there) and a docs rule-inventory row, so steps 6 and 8 fail loudly if skipped.
 2. **Implement the rule in its family module** under `server/lib/review/rules/` (`metadata.ts`, `scripts.ts`, `binaries.ts`, `deps.ts`, `entrypoints.ts`; regex sets live in `patterns.ts`). Emit findings with `tag(ruleKey, { severity, file, evidence, reason, line? })` from `server/lib/review/rules/helpers.ts` — `tag` attaches the rule ID; never hand-write `ruleId`. `Finding.severity` is `"info" | "low" | "medium" | "high" | "critical"` (`server/lib/review/index.ts`).
 3. **Wire it into the composer** in `server/lib/review/rules/index.ts`: rules over the staged artifact go through `deterministicFindings` (which calls the family entry functions), rules over the manifest diff go through `packageJsonDiffFindings`. Both stamp `ruleVersion` via `stampVersion`, so family modules never set it.
 4. **Bump `DETERMINISTIC_RULES_VERSION`** in `server/lib/review/rules/index.ts` whenever rule semantics, severities, or coverage change. PyPI-only `pypi.*` rules instead bump `PYPI_RULES_VERSION` in `server/lib/ecosystems/pypi/types.ts`.
-5. **Pick severity with the risk roll-up in mind.** `computeRisk` in `server/lib/review/index.ts` is weighted multi-signal, not max-severity:
-   - `code.*` capability rules (`CODE_CAPABILITY_RULE_IDS`) score by co-occurrence: a lone `code.process-execution` de-escalates to low; two or more distinct capabilities floor at high.
-   - Every other rule is an anchor: its severity maps straight to risk (`severityToRisk`) and sets a floor.
+5. **Pick severity and the manifest `risk` role with the roll-up in mind.** `computeRisk` in `server/lib/review/index.ts` is weighted multi-signal, not max-severity, and derives its rule sets from the manifest:
+   - `risk: "capability"` (the `code.*` signals) scores by co-occurrence: a lone `"weak-lone-capability"` de-escalates to low; two or more distinct capabilities floor at high.
+   - `risk: "anchor"` maps severity straight to risk (`severityToRisk`) and sets a floor.
    - `obfuscated` and `testScoped` finding flags change scoring — read the comments on `computeRisk` before assuming.
-   - If the rule is evidence of active compromise (not a package capability), add it to `STANDING_DANGER_RULE_IDS` in `server/lib/review/risk.ts` so release memory can never discount it as previously-approved context.
+   - If the rule is evidence of active compromise (not a package capability), set `standingDanger: true` on its manifest entry so release memory can never discount it as previously-approved context.
 6. **Add the corpus fixture** at `test/fixtures/security-corpus/cases/<id>.json`. Required fields: `id`, `title`, `category`, `intent`, `stagedFiles` (sandbox-shaped `FileRecord[]`), `expectedRisk` (from `computeRisk()`), and `expectedFindings` as exact `{ ruleId, severity, file }` tuples. Optional: `previousFiles`, `previousPackageJson`/`stagedPackageJson`, `expectedPackageJsonDiff`, `coverageGaps`. Safety policy (see `docs/security-detection-corpus.md`): synthetic `FileRecord` JSON only, `example.invalid` URLs, obviously fake secrets, never runnable malware. PyPI fixtures live in `cases-pypi/` with their own manifest/artifacts schema and two file-namespacing schemes — read the PyPI corpus section of that doc before authoring one.
    - Verify: `pnpm run test:node -- security-corpus.test.mjs` (PyPI: `security-corpus-pypi.test.mjs`).
 7. **Check eval coverage.** The eval harness (`test/eval/detection-eval.test.mjs`, see `docs/detection-eval.md`) reuses the golden cases and adds `test/fixtures/security-corpus/cases-frontier/` (truth-labeled hard cases, reported) and `cases-benign/` (hard-negatives, gated: benign FP rate < 10% at risk >= medium). If the rule could fire on legitimate packages, add a benign hard-negative that proves it stays quiet.
    - Verify: `pnpm run eval` — gates are malicious recall >= 90%, every `expectMinRisk: critical` case caught, zero FPs on benign regression controls, benign hard-negative FP rate < 10%.
-8. **Update docs.** `docs/security-detection-corpus.md` gets a taxonomy entry and a `DETERMINISTIC_RULES_VERSION` changelog note explaining what the version adds and which fixtures pin it; touch `docs/detection-eval.md` only if metrics or gates change.
+8. **Update docs.** `docs/security-detection-corpus.md` gets a rule-inventory table row (machine-checked), a taxonomy entry, and a `DETERMINISTIC_RULES_VERSION` changelog note explaining what the version adds and which fixtures pin it; touch `docs/detection-eval.md` only if metrics or gates change.
 9. **Full gate before commit:** `pnpm run verify`.
 
 ## Worked Example: `diff.bin-added`
 
 A release that adds a `bin` entry puts a new command on the consumer's install path (npm symlinks it into `node_modules/.bin`) even when no script or code pattern fires.
 
-- ID: `diffBinAdded: "diff.bin-added"` in `server/lib/review/rules/rule-ids.ts`.
+- Manifest entry: `diffBinAdded: { id: "diff.bin-added", risk: "anchor" }` in `server/lib/review/rules/rule-ids.ts`.
 - Implementation: `entrypointDiffFindings` in `server/lib/review/rules/entrypoints.ts` walks `packageJsonDiff.bin`, and for each `status === "added"` entry emits `tag("diffBinAdded", { severity: "medium", file: "package.json", line: firstJsonPropertyLine(...), evidence, reason })`. Plain `main`/`exports` retargets are deliberately not flagged — they change on almost every build and would be noise.
 - Wiring: `entrypointDiffFindings` is composed into `packageJsonDiffFindings` in `server/lib/review/rules/index.ts` (it is a manifest-diff rule, so it does not run in `deterministicFindings`).
 - Risk: no `code.*` capability, so the medium severity anchors the roll-up — the fixture's `expectedRisk` is `medium`.

--- a/docs/security-detection-corpus.md
+++ b/docs/security-detection-corpus.md
@@ -73,6 +73,69 @@ The first corpus slice covers:
 - dependency and entrypoint package-json diff changes; unusual non-registry dependency specs raise deterministic findings, a newly added runtime dependency raises `dependency.added` and a spec crossing a major version boundary raises `dependency.major-bump` (the release pulls third-party code the scan never inspects — the node-ipc/peacenotwar and event-stream/flatmap-stream vector), and a newly added `bin` command raises `diff.bin-added` because npm links it onto the consumer's install path;
 - atpm release provenance: unverifiable bundles, subjects copied from another artifact, builds outside the declared trusted publisher, missing attestations, and loss of provenance present on the baseline. A matching verified build is the benign control.
 
+## Rule inventory
+
+The complete deterministic ruleset across all ecosystems. Scoring roles are declared per rule in the
+manifest (`DETERMINISTIC_RULES` in `server/lib/review/rules/rule-ids.ts`): `anchor` severities map
+straight to risk and set a floor, `capability` rules score by co-occurrence, and a
+`weak-lone-capability` de-escalates to low when it fires alone. Standing-danger rules are evidence of
+active compromise, so release memory never discounts them as previously-approved context. `pypi.*`
+and `vscode.*` rules live in their ecosystem registries (`PYPI_RULE_IDS`, `VSCODE_RULE_IDS`) and
+always anchor.
+
+`test/detection-rule-coverage.test.mjs` machine-checks this table against the registries: the rule
+IDs must match exactly, every rule needs a corpus fixture asserting it (or an explicit exception in
+that test naming the unit-test layer that covers it), and fixtures may only assert registered IDs.
+
+| Rule                                      | Registry      | Scored as            | Standing danger |
+| ----------------------------------------- | ------------- | -------------------- | --------------- |
+| `atpm.provenance-invalid`                 | deterministic | anchor               | no              |
+| `atpm.provenance-missing`                 | deterministic | anchor               | no              |
+| `atpm.provenance-publisher-mismatch`      | deterministic | anchor               | no              |
+| `atpm.provenance-subject-mismatch`        | deterministic | anchor               | no              |
+| `atpm.trusted-publishing-lost`            | deterministic | anchor               | no              |
+| `code.credential-access`                  | deterministic | capability           | no              |
+| `code.dynamic-evaluation`                 | deterministic | capability           | no              |
+| `code.network-access`                     | deterministic | capability           | no              |
+| `code.process-execution`                  | deterministic | weak-lone-capability | no              |
+| `code.remote-shell`                       | deterministic | capability           | yes             |
+| `dependency.added`                        | deterministic | anchor               | no              |
+| `dependency.major-bump`                   | deterministic | anchor               | no              |
+| `dependency.optional-added`               | deterministic | anchor               | no              |
+| `dependency.unusual-spec`                 | deterministic | anchor               | no              |
+| `diff.bin-added`                          | deterministic | anchor               | no              |
+| `diff.credential-file-added`              | deterministic | anchor               | no              |
+| `diff.large-new-file`                     | deterministic | anchor               | no              |
+| `file.large-binary`                       | deterministic | anchor               | no              |
+| `file.native-artifact`                    | deterministic | anchor               | no              |
+| `file.outside-files-list`                 | deterministic | anchor               | no              |
+| `file.secret-content`                     | deterministic | anchor               | yes             |
+| `install-script.gyp-command-substitution` | deterministic | anchor               | yes             |
+| `install-script.implicit-node-gyp`        | deterministic | anchor               | yes             |
+| `install-script.lifecycle`                | deterministic | anchor               | yes             |
+| `install-script.preinstall`               | deterministic | anchor               | yes             |
+| `package-json.entrypoint-missing`         | deterministic | anchor               | no              |
+| `package-json.parse-failed`               | deterministic | anchor               | no              |
+| `release.source-drift`                    | deterministic | anchor               | no              |
+| `stage.metadata-mismatch`                 | deterministic | anchor               | no              |
+| `stage.tarball-digest-mismatch`           | deterministic | anchor               | no              |
+| `tar.suspicious-entry`                    | deterministic | anchor               | yes             |
+| `pypi.metadata-missing`                   | pypi          | anchor               | no              |
+| `pypi.metadata-mismatch`                  | pypi          | anchor               | no              |
+| `pypi.native-artifact`                    | pypi          | anchor               | no              |
+| `pypi.pth-execution`                      | pypi          | anchor               | no              |
+| `pypi.record-mismatch`                    | pypi          | anchor               | no              |
+| `pypi.setup-install-command`              | pypi          | anchor               | no              |
+| `pypi.startup-hook`                       | pypi          | anchor               | no              |
+| `pypi.unusual-dependency`                 | pypi          | anchor               | no              |
+| `pypi.wheel-record-missing`               | pypi          | anchor               | no              |
+| `vscode.broad-activation`                 | vscode        | anchor               | no              |
+| `vscode.extension-dependency`             | vscode        | anchor               | no              |
+| `vscode.metadata-mismatch`                | vscode        | anchor               | no              |
+| `vscode.startup-remote-command`           | vscode        | anchor               | no              |
+| `vscode.startup-wasm-loader`              | vscode        | anchor               | no              |
+| `vscode.undeclared-configuration-read`    | vscode        | anchor               | no              |
+
 ## Known coverage gaps
 
 The corpus deliberately records some product gaps instead of hiding them:

--- a/server/lib/review/index.ts
+++ b/server/lib/review/index.ts
@@ -60,7 +60,9 @@ const RISK_RANK: Record<RiskLevel, number> = { low: 0, medium: 1, high: 2, criti
 // Which rules score by capability co-occurrence versus anchoring at their
 // severity is declared per rule in the manifest (`rules/rule-ids.ts`), with
 // the rationale for each classification next to its entry.
-const CODE_CAPABILITY_RULE_IDS = deterministicRuleIds((spec) => spec.risk !== "anchor");
+const CODE_CAPABILITY_RULE_IDS = deterministicRuleIds(
+  (spec) => spec.risk === "capability" || spec.risk === "weak-lone-capability",
+);
 const WEAK_LONE_CAPABILITY_RULE_IDS = deterministicRuleIds(
   (spec) => spec.risk === "weak-lone-capability",
 );

--- a/server/lib/review/index.ts
+++ b/server/lib/review/index.ts
@@ -1,5 +1,5 @@
 import type { TarSuspiciousEntry } from "../tar-parser.js";
-import { DETERMINISTIC_RULE_IDS, DETERMINISTIC_RULES_VERSION } from "./rules";
+import { DETERMINISTIC_RULE_IDS, DETERMINISTIC_RULES_VERSION, deterministicRuleIds } from "./rules";
 import type { DiffEntry } from "./diff";
 
 export type RiskLevel = "low" | "medium" | "high" | "critical";
@@ -57,14 +57,13 @@ export { redactFileRecords, redactFindings, redactJson, redactText } from "./red
 
 const RISK_RANK: Record<RiskLevel, number> = { low: 0, medium: 1, high: 2, critical: 3 };
 
-const CODE_CAPABILITY_RULE_IDS = new Set<string>([
-  DETERMINISTIC_RULE_IDS.codeProcessExecution,
-  DETERMINISTIC_RULE_IDS.codeRemoteShell,
-  DETERMINISTIC_RULE_IDS.codeNetworkAccess,
-  DETERMINISTIC_RULE_IDS.codeDynamicEvaluation,
-  DETERMINISTIC_RULE_IDS.codeCredentialAccess,
-]);
-const WEAK_LONE_CAPABILITY: string = DETERMINISTIC_RULE_IDS.codeProcessExecution;
+// Which rules score by capability co-occurrence versus anchoring at their
+// severity is declared per rule in the manifest (`rules/rule-ids.ts`), with
+// the rationale for each classification next to its entry.
+const CODE_CAPABILITY_RULE_IDS = deterministicRuleIds((spec) => spec.risk !== "anchor");
+const WEAK_LONE_CAPABILITY_RULE_IDS = deterministicRuleIds(
+  (spec) => spec.risk === "weak-lone-capability",
+);
 
 function severityToRisk(severity: string | null | undefined): RiskLevel {
   if (severity === "critical") return "critical";
@@ -167,7 +166,7 @@ export function computeRisk(
 function testCapabilityRisk(capabilities: Map<string, RiskLevel>): RiskLevel {
   let highest: RiskLevel = "low";
   for (const [ruleId, risk] of capabilities) {
-    highest = combineRisk(highest, ruleId === WEAK_LONE_CAPABILITY ? "low" : risk);
+    highest = combineRisk(highest, WEAK_LONE_CAPABILITY_RULE_IDS.has(ruleId) ? "low" : risk);
   }
   return highest;
 }
@@ -183,7 +182,7 @@ function codeCapabilityRisk(
   }
   const [[ruleId, { risk, obfuscated }]] = capabilities;
   if (obfuscated) return risk;
-  return ruleId === WEAK_LONE_CAPABILITY ? "low" : risk;
+  return WEAK_LONE_CAPABILITY_RULE_IDS.has(ruleId) ? "low" : risk;
 }
 
 export function combineRisk(...risks: Array<RiskLevel | null | undefined>): RiskLevel {

--- a/server/lib/review/risk.ts
+++ b/server/lib/review/risk.ts
@@ -2,7 +2,7 @@ import type { AiReview } from "../ai-review/types";
 import { displayedAiResult } from "../ai-review/types";
 import type { FindingProfileEntry, ReleaseConsistency } from "../scan/release-memory";
 import { combineRisk, computeRisk, normalizeRisk, type Finding, type RiskLevel } from "./";
-import { DETERMINISTIC_RULE_IDS } from "./rules/rule-ids";
+import { deterministicRuleIds } from "./rules/rule-ids";
 
 export interface ScanRiskBreakdown {
   artifactRisk: RiskLevel;
@@ -65,15 +65,7 @@ export function computeScanRiskBreakdown(
 }
 
 // Approval never discounts evidence of active compromise.
-const STANDING_DANGER_RULE_IDS = new Set<string>([
-  DETERMINISTIC_RULE_IDS.installScript,
-  DETERMINISTIC_RULE_IDS.installScriptPreinstall,
-  DETERMINISTIC_RULE_IDS.installScriptImplicitNodeGyp,
-  DETERMINISTIC_RULE_IDS.installScriptGypCommandSubstitution,
-  DETERMINISTIC_RULE_IDS.codeRemoteShell,
-  DETERMINISTIC_RULE_IDS.fileSecretContent,
-  DETERMINISTIC_RULE_IDS.tarSuspiciousEntry,
-]);
+const STANDING_DANGER_RULE_IDS = deterministicRuleIds((spec) => spec.standingDanger === true);
 
 function dropPriorApprovedFindings(
   contextFindings: RiskFinding[],

--- a/server/lib/review/rules/index.ts
+++ b/server/lib/review/rules/index.ts
@@ -12,7 +12,8 @@ import { entrypointDiffFindings, entrypointPresenceFindings } from "./entrypoint
 // Lives here (not in a family module) because versioning spans every family.
 export const DETERMINISTIC_RULES_VERSION = "1.28.0";
 
-export { DETERMINISTIC_RULE_IDS } from "./rule-ids";
+export { DETERMINISTIC_RULE_IDS, DETERMINISTIC_RULES, deterministicRuleIds } from "./rule-ids";
+export type { DeterministicRuleSpec } from "./rule-ids";
 export {
   codePatternsFor,
   FINDING_SECRET_PATTERNS,

--- a/server/lib/review/rules/index.ts
+++ b/server/lib/review/rules/index.ts
@@ -12,8 +12,7 @@ import { entrypointDiffFindings, entrypointPresenceFindings } from "./entrypoint
 // Lives here (not in a family module) because versioning spans every family.
 export const DETERMINISTIC_RULES_VERSION = "1.28.0";
 
-export { DETERMINISTIC_RULE_IDS, DETERMINISTIC_RULES, deterministicRuleIds } from "./rule-ids";
-export type { DeterministicRuleSpec } from "./rule-ids";
+export { DETERMINISTIC_RULE_IDS, deterministicRuleIds } from "./rule-ids";
 export {
   codePatternsFor,
   FINDING_SECRET_PATTERNS,

--- a/server/lib/review/rules/rule-ids.ts
+++ b/server/lib/review/rules/rule-ids.ts
@@ -1,35 +1,102 @@
-export const DETERMINISTIC_RULE_IDS = {
-  installScriptPreinstall: "install-script.preinstall",
-  installScript: "install-script.lifecycle",
-  codeProcessExecution: "code.process-execution",
-  codeRemoteShell: "code.remote-shell",
-  codeNetworkAccess: "code.network-access",
-  codeDynamicEvaluation: "code.dynamic-evaluation",
-  codeCredentialAccess: "code.credential-access",
-  fileSecretContent: "file.secret-content",
-  fileLargeBinary: "file.large-binary",
-  fileNativeArtifact: "file.native-artifact",
-  fileOutsideFilesList: "file.outside-files-list",
-  installScriptImplicitNodeGyp: "install-script.implicit-node-gyp",
-  installScriptGypCommandSubstitution: "install-script.gyp-command-substitution",
-  packageJsonParseFailed: "package-json.parse-failed",
-  packageJsonEntrypointMissing: "package-json.entrypoint-missing",
-  diffCredentialFileAdded: "diff.credential-file-added",
-  diffLargeNewFile: "diff.large-new-file",
-  diffBinAdded: "diff.bin-added",
-  dependencyUnusualSpec: "dependency.unusual-spec",
-  dependencyOptionalAdded: "dependency.optional-added",
-  dependencyAdded: "dependency.added",
-  dependencyMajorBump: "dependency.major-bump",
-  stageMetadataMismatch: "stage.metadata-mismatch",
-  stageTarballDigestMismatch: "stage.tarball-digest-mismatch",
-  atpmProvenanceMissing: "atpm.provenance-missing",
-  atpmProvenanceInvalid: "atpm.provenance-invalid",
-  atpmProvenanceSubjectMismatch: "atpm.provenance-subject-mismatch",
-  atpmProvenancePublisherMismatch: "atpm.provenance-publisher-mismatch",
-  atpmTrustedPublishingLost: "atpm.trusted-publishing-lost",
-  tarSuspiciousEntry: "tar.suspicious-entry",
-  releaseSourceDrift: "release.source-drift",
-} as const;
+// The deterministic rule manifest: everything about a rule except its match
+// logic lives on its entry here — the dot-namespaced ID and how the risk
+// roll-up treats it. `computeRisk` (review/index.ts) and release memory
+// (risk.ts) derive their rule sets from this manifest, so reclassifying a rule
+// is a one-line edit. Match logic stays in the family modules under rules/.
+//
+// `test/detection-rule-coverage.test.mjs` machine-checks the manifest: every
+// rule needs a security-corpus fixture asserting its ID (or an explicit
+// exception there) and an entry in the docs/security-detection-corpus.md rule
+// inventory.
+export interface DeterministicRuleSpec {
+  /** Dot-namespaced rule ID; the segment before the first dot is the family. */
+  id: string;
+  /**
+   * How `computeRisk` scores findings from this rule.
+   *
+   * - `anchor`: severity maps straight to risk and sets a floor.
+   * - `capability`: the code.* capability signals (process/network/eval/
+   *   credential). These over- and under-detect under a pure max-severity
+   *   roll-up — a lone capability is weak evidence, but several together are
+   *   the collect-and-exfiltrate shape — so they score by co-occurrence.
+   * - `weak-lone-capability`: a capability that is not evidence of risk on its
+   *   own and de-escalates to low unless it co-occurs with another capability
+   *   or is obfuscated.
+   */
+  risk: "anchor" | "capability" | "weak-lone-capability";
+  /**
+   * Evidence of active compromise rather than a package capability: release
+   * memory never discounts these findings as previously-approved context, even
+   * when a prior approved release carried the same finding.
+   */
+  standingDanger?: true;
+}
 
-export type DeterministicRuleKey = keyof typeof DETERMINISTIC_RULE_IDS;
+export const DETERMINISTIC_RULES = {
+  installScriptPreinstall: {
+    id: "install-script.preinstall",
+    risk: "anchor",
+    standingDanger: true,
+  },
+  installScript: { id: "install-script.lifecycle", risk: "anchor", standingDanger: true },
+  // Process execution is the weak-on-its-own capability: legitimate build and
+  // CLI tooling routinely shells out (the `legit-build-childprocess` benign
+  // hard negative), so alone it is not evidence of risk. It escalates only
+  // when it co-occurs with another capability.
+  codeProcessExecution: { id: "code.process-execution", risk: "weak-lone-capability" },
+  // Deliberately NOT weak, and a standing danger. It used to live inside
+  // process-execution, which meant a release adding
+  // `execSync('curl … | bash')` scored as one weak capability and rolled up to
+  // `low` — the whole shell-mediated dropper class read as benign build
+  // tooling. Spawning `cc` and spawning `curl … | bash` are not the same
+  // evidence.
+  codeRemoteShell: { id: "code.remote-shell", risk: "capability", standingDanger: true },
+  codeNetworkAccess: { id: "code.network-access", risk: "capability" },
+  codeDynamicEvaluation: { id: "code.dynamic-evaluation", risk: "capability" },
+  codeCredentialAccess: { id: "code.credential-access", risk: "capability" },
+  fileSecretContent: { id: "file.secret-content", risk: "anchor", standingDanger: true },
+  fileLargeBinary: { id: "file.large-binary", risk: "anchor" },
+  fileNativeArtifact: { id: "file.native-artifact", risk: "anchor" },
+  fileOutsideFilesList: { id: "file.outside-files-list", risk: "anchor" },
+  installScriptImplicitNodeGyp: {
+    id: "install-script.implicit-node-gyp",
+    risk: "anchor",
+    standingDanger: true,
+  },
+  installScriptGypCommandSubstitution: {
+    id: "install-script.gyp-command-substitution",
+    risk: "anchor",
+    standingDanger: true,
+  },
+  packageJsonParseFailed: { id: "package-json.parse-failed", risk: "anchor" },
+  packageJsonEntrypointMissing: { id: "package-json.entrypoint-missing", risk: "anchor" },
+  diffCredentialFileAdded: { id: "diff.credential-file-added", risk: "anchor" },
+  diffLargeNewFile: { id: "diff.large-new-file", risk: "anchor" },
+  diffBinAdded: { id: "diff.bin-added", risk: "anchor" },
+  dependencyUnusualSpec: { id: "dependency.unusual-spec", risk: "anchor" },
+  dependencyOptionalAdded: { id: "dependency.optional-added", risk: "anchor" },
+  dependencyAdded: { id: "dependency.added", risk: "anchor" },
+  dependencyMajorBump: { id: "dependency.major-bump", risk: "anchor" },
+  stageMetadataMismatch: { id: "stage.metadata-mismatch", risk: "anchor" },
+  stageTarballDigestMismatch: { id: "stage.tarball-digest-mismatch", risk: "anchor" },
+  atpmProvenanceMissing: { id: "atpm.provenance-missing", risk: "anchor" },
+  atpmProvenanceInvalid: { id: "atpm.provenance-invalid", risk: "anchor" },
+  atpmProvenanceSubjectMismatch: { id: "atpm.provenance-subject-mismatch", risk: "anchor" },
+  atpmProvenancePublisherMismatch: { id: "atpm.provenance-publisher-mismatch", risk: "anchor" },
+  atpmTrustedPublishingLost: { id: "atpm.trusted-publishing-lost", risk: "anchor" },
+  tarSuspiciousEntry: { id: "tar.suspicious-entry", risk: "anchor", standingDanger: true },
+  releaseSourceDrift: { id: "release.source-drift", risk: "anchor" },
+} as const satisfies Record<string, DeterministicRuleSpec>;
+
+export type DeterministicRuleKey = keyof typeof DETERMINISTIC_RULES;
+
+export const DETERMINISTIC_RULE_IDS = Object.fromEntries(
+  Object.entries(DETERMINISTIC_RULES).map(([key, spec]) => [key, spec.id]),
+) as { [K in DeterministicRuleKey]: (typeof DETERMINISTIC_RULES)[K]["id"] };
+
+export function deterministicRuleIds(
+  predicate: (spec: DeterministicRuleSpec) => boolean,
+): Set<string> {
+  const specs: DeterministicRuleSpec[] = Object.values(DETERMINISTIC_RULES);
+  return new Set(specs.filter(predicate).map((spec) => spec.id));
+}

--- a/test/detection-rule-coverage.test.mjs
+++ b/test/detection-rule-coverage.test.mjs
@@ -1,0 +1,119 @@
+// Machine checks for the detection rule manifest (the deterministic-guardrail
+// pattern: every recurring add-a-rule mistake becomes a failing test, not a
+// checklist item):
+//
+// 1. Every rule ID a corpus fixture asserts exists in a rule registry, so a
+//    typo'd or stale fixture cannot silently assert nothing.
+// 2. Every registered rule is asserted by at least one corpus fixture, with an
+//    exact exception list for rules whose inputs the corpus harness cannot
+//    represent. The list is a ratchet: adding a rule without a fixture fails
+//    here, and adding a fixture for an excepted rule forces its removal.
+// 3. The rule inventory table in docs/security-detection-corpus.md lists
+//    exactly the registered rule IDs, so the docs cannot drift from the code.
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { describe, expect, test } from "vitest";
+import { DETERMINISTIC_RULES } from "../server/lib/review/rules/rule-ids";
+import { PYPI_RULE_IDS } from "../server/lib/ecosystems/pypi/types";
+import { VSCODE_RULE_IDS } from "../server/lib/ecosystems/vscode/types";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const corpusRoot = join(__dirname, "fixtures/security-corpus");
+const corpusDirs = [
+  "cases",
+  "cases-atpm",
+  "cases-benign",
+  "cases-frontier",
+  "cases-pypi",
+  "cases-vscode",
+];
+
+// Rules the golden corpus cannot exercise because their inputs are not part of
+// the fixture shape (FileRecord[] plus manifest summaries). Each stays covered
+// at the unit layer instead.
+const CORPUS_COVERAGE_EXCEPTIONS = new Map([
+  // Compares staged registry metadata against the packed artifact; covered by
+  // test/staged-artifact-integrity.test.mjs.
+  ["stage.metadata-mismatch", "staged-artifact integrity comparison"],
+  ["stage.tarball-digest-mismatch", "staged-artifact integrity comparison"],
+  // Emitted from tar parser structural metadata (TarSuspiciousEntry), which
+  // FileRecord fixtures cannot carry; covered by test/review.test.mjs.
+  ["tar.suspicious-entry", "tar parser structural metadata"],
+  // Compares the release against the repository fingerprint; covered by
+  // test/release-fingerprint.test.ts.
+  ["release.source-drift", "release fingerprint comparison"],
+  // Compare marketplace metadata and extension manifests outside the vsix
+  // artifact fixtures; covered by test/vscode.test.mjs.
+  ["vscode.metadata-mismatch", "marketplace metadata comparison"],
+  ["vscode.extension-dependency", "extension manifest dependency review"],
+]);
+
+const RULE_ID_PATTERN = /^[a-z][a-z0-9-]*\.[a-z0-9-]+$/;
+
+const registeredIds = new Set([
+  ...Object.values(DETERMINISTIC_RULES).map((spec) => spec.id),
+  ...Object.values(PYPI_RULE_IDS),
+  ...Object.values(VSCODE_RULE_IDS),
+]);
+
+function fixtureAssertedRuleIds() {
+  const asserted = new Map();
+  for (const dir of corpusDirs) {
+    const casesDir = join(corpusRoot, dir);
+    for (const file of readdirSync(casesDir).filter((name) => name.endsWith(".json"))) {
+      const fixture = JSON.parse(readFileSync(join(casesDir, file), "utf8"));
+      for (const finding of fixture.expectedFindings ?? []) {
+        if (!asserted.has(finding.ruleId)) asserted.set(finding.ruleId, []);
+        asserted.get(finding.ruleId).push(`${dir}/${file}`);
+      }
+    }
+  }
+  return asserted;
+}
+
+describe("detection rule coverage", () => {
+  test("rule IDs are well-formed and unique across registries", () => {
+    const all = [
+      ...Object.values(DETERMINISTIC_RULES).map((spec) => spec.id),
+      ...Object.values(PYPI_RULE_IDS),
+      ...Object.values(VSCODE_RULE_IDS),
+    ];
+    for (const id of all) {
+      expect(id, `rule ID ${id} must be dot-namespaced kebab-case`).toMatch(RULE_ID_PATTERN);
+    }
+    expect(new Set(all).size).toBe(all.length);
+  });
+
+  test("every rule ID asserted by a corpus fixture is registered", () => {
+    const unknown = [...fixtureAssertedRuleIds()]
+      .filter(([ruleId]) => !registeredIds.has(ruleId))
+      .map(([ruleId, files]) => `${ruleId} (${files.join(", ")})`);
+    expect(unknown).toEqual([]);
+  });
+
+  test("every registered rule has a corpus fixture or an explicit exception", () => {
+    const asserted = fixtureAssertedRuleIds();
+    const uncovered = [...registeredIds].filter((id) => !asserted.has(id)).sort();
+    expect(uncovered).toEqual([...CORPUS_COVERAGE_EXCEPTIONS.keys()].sort());
+    // The ratchet's other direction: an exception for a rule the corpus now
+    // covers (or that no longer exists) is stale and must be removed.
+    for (const ruleId of CORPUS_COVERAGE_EXCEPTIONS.keys()) {
+      expect(registeredIds.has(ruleId), `exception for unregistered rule ${ruleId}`).toBe(true);
+      expect(asserted.has(ruleId), `stale exception: ${ruleId} now has a fixture`).toBe(false);
+    }
+  });
+
+  test("docs rule inventory matches the registries exactly", () => {
+    const doc = readFileSync(join(__dirname, "../docs/security-detection-corpus.md"), "utf8");
+    const section = doc.split("## Rule inventory")[1]?.split("\n## ")[0];
+    expect(
+      section,
+      "docs/security-detection-corpus.md needs a '## Rule inventory' section",
+    ).toBeTruthy();
+    const documented = new Set(
+      [...section.matchAll(/^\| `([^`]+)`\s+\|/gm)].map((match) => match[1]),
+    );
+    expect([...documented].sort()).toEqual([...registeredIds].sort());
+  });
+});

--- a/test/fixtures/security-corpus/README.md
+++ b/test/fixtures/security-corpus/README.md
@@ -5,6 +5,7 @@ This directory contains Drydock's corpus for deterministic staged-publish review
 - `cases/` holds npm fixtures evaluated by `test/security-corpus.test.mjs`.
 - `cases-pypi/` holds PyPI release-artifact fixtures evaluated by `test/security-corpus-pypi.test.mjs`.
 - `cases-atpm/` holds atpm provenance fixtures evaluated by `test/security-corpus-atpm.test.mjs`.
+- `cases-vscode/` holds VS Code extension fixtures evaluated by `test/security-corpus-vscode.test.mjs`.
 - `cases-frontier/` and `cases-benign/` are eval-only (read by `test/eval/`, not the golden tests). They use the v2 schema and include `real-sanitized` cases distilled from published incidents. See `docs/detection-eval.md` for the schema, the threat-class taxonomy, and the defanging rules (`real-sanitized` cases must carry a `provenance` note).
 - Fixtures are intentionally small JSON documents, not tarballs and not real malware.
 - `stagedFiles`/`previousFiles` (npm) and `artifacts`/`previousArtifacts` (PyPI) use the same `FileRecord` shape returned by the sandbox.

--- a/test/fixtures/security-corpus/cases/gyp-command-substitution.json
+++ b/test/fixtures/security-corpus/cases/gyp-command-substitution.json
@@ -1,0 +1,59 @@
+{
+  "id": "gyp-command-substitution",
+  "title": "Root binding.gyp runs package JavaScript through GYP command substitution",
+  "category": "native-install-surface",
+  "intent": "GYP command substitutions execute shell commands during node-gyp configure, so a root gyp file invoking node on a package script is an install-time execution path that bypasses package.json lifecycle scripts entirely. The substituted script is inert here; the execution channel itself is the critical finding, alongside the implicit node-gyp install hook the root gyp file creates.",
+  "previousPackageJson": {
+    "name": "gyp-command-substitution",
+    "version": "1.0.0"
+  },
+  "stagedPackageJson": {
+    "name": "gyp-command-substitution",
+    "version": "1.0.1"
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 52,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"gyp-command-substitution\",\"version\":\"1.0.0\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 52,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"gyp-command-substitution\",\"version\":\"1.0.1\"}"
+    },
+    {
+      "path": "binding.gyp",
+      "size": 128,
+      "sha256": "binding-gyp",
+      "flags": [],
+      "textSample": "{\"targets\":[{\"target_name\":\"addon\",\"sources\":[\"addon.cc\"],\"defines\":[\"BUILD_CONFIG=<!@(node genconfig.js)\"]}]}"
+    },
+    {
+      "path": "genconfig.js",
+      "size": 34,
+      "sha256": "genconfig-script",
+      "flags": [],
+      "textSample": "console.log(\"-DNDEBUG\");"
+    }
+  ],
+  "expectedRisk": "critical",
+  "expectedFindings": [
+    {
+      "ruleId": "install-script.gyp-command-substitution",
+      "severity": "critical",
+      "file": "binding.gyp"
+    },
+    {
+      "ruleId": "install-script.implicit-node-gyp",
+      "severity": "high",
+      "file": "binding.gyp"
+    }
+  ]
+}

--- a/test/fixtures/security-corpus/cases/postinstall-lifecycle-script.json
+++ b/test/fixtures/security-corpus/cases/postinstall-lifecycle-script.json
@@ -1,0 +1,50 @@
+{
+  "id": "postinstall-lifecycle-script",
+  "title": "Postinstall lifecycle script added to a release",
+  "category": "install-surface",
+  "intent": "Pin the non-preinstall consumer install hook rule (install-script.lifecycle): a postinstall script executes on consumer machines at install time and must anchor the release at high even when the script it runs is inert, so the whole install-hook surface — not just preinstall — is covered by the corpus.",
+  "previousPackageJson": {
+    "name": "postinstall-lifecycle-script",
+    "version": "1.0.0"
+  },
+  "stagedPackageJson": {
+    "name": "postinstall-lifecycle-script",
+    "version": "1.0.1",
+    "scripts": {
+      "postinstall": "node scripts/postinstall.js"
+    }
+  },
+  "previousFiles": [
+    {
+      "path": "package.json",
+      "size": 58,
+      "sha256": "prev-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"postinstall-lifecycle-script\",\"version\":\"1.0.0\"}"
+    }
+  ],
+  "stagedFiles": [
+    {
+      "path": "package.json",
+      "size": 124,
+      "sha256": "staged-package-json",
+      "flags": [],
+      "textSample": "{\"name\":\"postinstall-lifecycle-script\",\"version\":\"1.0.1\",\"scripts\":{\"postinstall\":\"node scripts/postinstall.js\"}}"
+    },
+    {
+      "path": "scripts/postinstall.js",
+      "size": 41,
+      "sha256": "postinstall-script",
+      "flags": [],
+      "textSample": "console.log(\"postinstall placeholder\");"
+    }
+  ],
+  "expectedRisk": "high",
+  "expectedFindings": [
+    {
+      "ruleId": "install-script.lifecycle",
+      "severity": "high",
+      "file": "package.json"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Makes deterministic checks easier to add and tweak by consolidating per-rule bookkeeping into one manifest and machine-checking the pieces that used to be checklist items — without introducing a rule-engine abstraction over the (deliberately imperative, heterogeneous) family modules.

- **Rule manifest.** `DETERMINISTIC_RULE_IDS` becomes `DETERMINISTIC_RULES` in `server/lib/review/rules/rule-ids.ts`: each rule declares its ID, its risk-scoring role (`anchor` / `capability` / `weak-lone-capability`), and the `standingDanger` flag. The classification rationale (why `code.process-execution` is weak alone, why `code.remote-shell` is not) moved next to the entries it describes. `DETERMINISTIC_RULE_IDS` is derived, so `tag()` and every other consumer are unchanged.
- **Derived rule sets.** `CODE_CAPABILITY_RULE_IDS` / the weak-lone-capability check (`computeRisk`, `server/lib/review/index.ts`) and `STANDING_DANGER_RULE_IDS` (release memory, `server/lib/review/risk.ts`) are now derived from the manifest instead of hand-maintained Sets. Reclassifying a rule is a one-line manifest edit.
- **Machine checks** (`test/detection-rule-coverage.test.mjs`): corpus fixtures may only assert registered rule IDs; every registered rule (npm/atpm core + pypi + vscode registries) must have a corpus fixture or an explicit ratcheted exception naming its unit-test layer; and the new rule-inventory table in `docs/security-detection-corpus.md` must match the registries exactly, both directions.
- **Backfilled the two rules the corpus was silently missing:** `install-script.lifecycle` (postinstall fixture) and `install-script.gyp-command-substitution` (root `binding.gyp` running package JS via GYP command substitution). Six rules whose inputs the fixture shape cannot represent (`stage.*`, `tar.suspicious-entry`, `release.source-drift`, `vscode.metadata-mismatch`, `vscode.extension-dependency`) are ratcheted exceptions.

No detection semantics, severities, or risk roll-up behavior change, so `DETERMINISTIC_RULES_VERSION` stays at 1.28.0 — the corpus, risk, and eval suites pin that the derived sets are identical to the old hand-maintained ones.

## Testing

- `pnpm run verify` (lint, format, typecheck, full node + workers suites) — green.
- `pnpm run eval` — malicious recall / benign FP gates green with the two new fixtures.
- New machine-check suite `detection-rule-coverage.test.mjs` (4 tests) green; verified it fails correctly when a rule lacks a fixture or the docs inventory drifts.

Docs updated: rule-inventory section in `docs/security-detection-corpus.md`, corpus fixtures README (`cases-vscode/` was missing), and `.claude/skills/add-detection-rule` steps 1/5/8 now point at the manifest and the machine check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)