### PR TITLE
Onboarding dead-end fixes: copyable code blocks, tokenless /reports

### DIFF
--- a/docs/public-reports.md
+++ b/docs/public-reports.md
@@ -17,6 +17,12 @@ a shields.io badge per package and an opt-in public threat feed.
   `scan.share_revoked`) and surface in the organization audit log.
 - The UI entry point is the **Share** button on the scan detail header; the
   public page renders at `/reports/:token`.
+- `/reports` with no token is not an error state: there is no public index to
+  land on, so the page skips the lookup entirely and explains what a public
+  report is, why reports are unlisted, and points at `/diff` and the docs. Only
+  a token that is present and rejected gets the "invalid or revoked" message.
+  The explainer renders after mount, because the prerendered `/reports`
+  document is also the shell served for every `/reports/:token` request.
 - Restaging the same registry package/version retires the older stage identity
   and its public share capability. The obsolete review also leaves the badge
   and threat feed; already-cached derived responses may remain visible for the

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -1,0 +1,46 @@
+import { useSignal } from "@preact/signals";
+import { Show } from "@preact/signals/utils";
+import { Button } from "./Button";
+
+/**
+ * Copy-to-clipboard affordance: a button plus an aria-live confirmation so the
+ * result reaches screen readers without shifting the button's accessible name.
+ * Clipboard access is denied outside secure contexts and in some permission
+ * setups, so the failure message points at manual selection — callers must keep
+ * the copied text selectable next to this button.
+ */
+export function CopyButton({
+  text,
+  label = "Copy",
+  size = "sm",
+  variant = "secondary",
+}: {
+  text: string;
+  label?: string;
+  size?: "sm" | "md";
+  variant?: "secondary" | "ghost";
+}) {
+  const copyState = useSignal<"copied" | "failed" | null>(null);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      copyState.value = "copied";
+    } catch {
+      copyState.value = "failed";
+    }
+  };
+
+  return (
+    <span class="inline-flex flex-wrap items-center gap-2">
+      <Button variant={variant} size={size} onClick={() => void copy()}>
+        {label}
+      </Button>
+      <span class="text-[12px] text-ink-subtle" aria-live="polite">
+        <Show<"copied" | "failed" | null> when={copyState}>
+          {(state) => (state === "copied" ? "Copied." : "Copy failed — select it manually.")}
+        </Show>
+      </span>
+    </span>
+  );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -56,8 +56,9 @@ export function App() {
             cannot match the prerender URL `/reports` — without the bare route
             the shell falls through to `default` and every share link serves a
             200 whose body says "Page not found" until the bundle hydrates.
-            PublicReportPage renders its loading skeleton for an empty token,
-            which is the correct shell.
+            PublicReportPage server-renders its loading skeleton for an empty
+            token — the correct shell for a real share link — and swaps in the
+            "no public index" explainer once mounted on the client.
           */}
           <Route path="/reports" component={PublicReportPage} />
           <Route path="/reports/:token" component={PublicReportPage} />

--- a/src/lib/query-state.ts
+++ b/src/lib/query-state.ts
@@ -16,7 +16,9 @@ export function buildQueryUrl(updates: QueryUpdates): string {
     }
   }
   const search = params.toString();
-  return window.location.pathname + (search ? `?${search}` : "");
+  // Preserve the hash: query writes go through history.replaceState, and
+  // rebuilding the URL without it silently drops #anchor deep links.
+  return window.location.pathname + (search ? `?${search}` : "") + window.location.hash;
 }
 
 function currentLocationKey(): string {
@@ -90,7 +92,9 @@ export function useQuerySignal<T>(signal: Signal<T>, options: QuerySignalOptions
     }
     const write = () => {
       const next = buildQueryUrl({ [name]: serialized });
-      if (next !== currentLocationKey()) location.route(next, true);
+      // Compare including the hash — buildQueryUrl carries it, so a
+      // hash-free key would make every write with an anchor look dirty.
+      if (next !== currentLocationKey() + window.location.hash) location.route(next, true);
     };
     if (!debounceMs) {
       write();

--- a/src/pages/Dashboard/ScanDetail/StageCommandDialog.tsx
+++ b/src/pages/Dashboard/ScanDetail/StageCommandDialog.tsx
@@ -1,5 +1,4 @@
 import { useEffect } from "preact/hooks";
-import { useSignal } from "@preact/signals";
 import { Show } from "@preact/signals/utils";
 import {
   dismissStageCommandPrompt,
@@ -7,6 +6,7 @@ import {
   type StageCommandPrompt,
 } from "../../../models/stage-command-prompt";
 import { Button, LinkButton } from "../../../components/Button";
+import { CopyButton } from "../../../components/CopyButton";
 import { Dialog } from "../../../components/Dialog";
 
 /**
@@ -30,22 +30,8 @@ export function StageCommandDialogHost() {
 }
 
 function StageCommandDialog({ prompt }: { prompt: StageCommandPrompt }) {
-  // null while untouched so the <Show> boundary renders nothing until a copy is
-  // actually attempted.
-  const copyState = useSignal<"copied" | "failed" | null>(null);
   const approving = prompt.decision === "publish";
   const target = [prompt.packageName, prompt.stagedVersion].filter(Boolean).join("@");
-
-  const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(prompt.command);
-      copyState.value = "copied";
-    } catch {
-      // Clipboard access is denied outside secure contexts and in some
-      // permission setups; the command stays selectable either way.
-      copyState.value = "failed";
-    }
-  };
 
   return (
     <Dialog
@@ -77,18 +63,9 @@ function StageCommandDialog({ prompt }: { prompt: StageCommandPrompt }) {
         <code class="font-mono text-[12px] leading-[1.6] text-ink bg-surface-2 border border-border rounded px-2.5 py-2 whitespace-pre-wrap break-words">
           {prompt.command}
         </code>
-        <div class="flex flex-wrap items-center gap-2">
-          <Button variant="secondary" size="sm" onClick={() => void copy()}>
-            Copy command
-          </Button>
-          {/* aria-live so the confirmation reaches screen readers; the button
-              label stays stable so its accessible name does not shift. */}
-          <span class="text-[12px] text-ink-subtle" aria-live="polite">
-            <Show<"copied" | "failed" | null> when={copyState}>
-              {(state) => (state === "copied" ? "Copied." : "Copy failed — select it manually.")}
-            </Show>
-          </span>
-        </div>
+        {/* The command above stays selectable, which is what CopyButton's
+            failure message points at when the clipboard is unavailable. */}
+        <CopyButton text={prompt.command} label="Copy command" />
       </div>
 
       <p class="m-0 text-[12px] leading-[1.6] text-ink-subtle">

--- a/src/pages/Docs/primitives.tsx
+++ b/src/pages/Docs/primitives.tsx
@@ -10,6 +10,7 @@ import { useEffect, useMemo } from "preact/hooks";
 import { type Signal, useComputed } from "@preact/signals";
 import { Badge, type BadgeTone } from "../../components/Badge";
 import { Card } from "../../components/Card";
+import { CopyButton } from "../../components/CopyButton";
 import { cn } from "../../components/cn";
 import { MonoLabel } from "../../components/Typography";
 import { ensureHighlighter, highlighterReady, tokenizeLines } from "../../components/highlight";
@@ -342,11 +343,16 @@ export function CodeBlock({
         embedded ? "border-0 rounded-none" : "rounded-md border border-border",
       )}
     >
-      {name ? (
-        <div class="px-4 py-2 border-b border-border font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
+      {/* One toolbar for both shapes: the optional file name on the left, the
+          copy affordance on the right. The block's own text stays selectable —
+          copying a workflow file by hand means dragging across a scrolling
+          <pre>, which is where docs readers give up. */}
+      <div class="px-4 py-2 border-b border-border flex items-center justify-between gap-3">
+        <span class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle min-w-0 truncate">
           {name}
-        </div>
-      ) : null}
+        </span>
+        <CopyButton text={children} />
+      </div>
       <pre class="m-0 p-4 overflow-x-auto font-mono text-[12px] leading-[1.55] text-ink">
         <code>
           {tokens ? (

--- a/src/pages/PublicReport/index.tsx
+++ b/src/pages/PublicReport/index.tsx
@@ -61,17 +61,39 @@ interface LoadedPublicReport {
 const CHANGED_STATUSES = new Set(["added", "removed", "modified"]);
 const MAX_LISTED_CHANGES = 200;
 
+/**
+ * The share token *is* the capability, so `/reports` with no token is not a
+ * revoked link — it is someone who trimmed the URL, or a chat client that cut
+ * the token off the end. That state gets an explainer, and never a lookup: an
+ * empty token would only 404 and render "invalid or revoked" at a visitor who
+ * was never given a link in the first place.
+ */
+export function hasShareToken(token: string | null | undefined): boolean {
+  return typeof token === "string" && token.trim() !== "";
+}
+
 export default function PublicReportPage() {
   const route = useRoute();
   const token = route.params.token ?? "";
+  const tokenPresent = hasShareToken(token);
   const authed = useAuthedSession();
   const report = useSignal<LoadedPublicReport | null>(null);
   const errorState = useSignal<"none" | "not_found" | "failed">("none");
+  // The prerendered `/reports` document is also the shell served for every
+  // `/reports/:token` request (see `assetFallbackRequest`), so the explainer
+  // must not be in the server-rendered output — a share link would flash "there
+  // is no public index" before the bundle takes over. Deferring it to the
+  // client keeps the loading skeleton as the shell for both.
+  const mounted = useSignal(false);
+  useEffect(() => {
+    mounted.value = true;
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
     report.value = null;
     errorState.value = "none";
+    if (!hasShareToken(token)) return;
     void (async () => {
       const keyRequest = fetch("/public/attestation-key", {
         headers: { accept: "application/json" },
@@ -118,6 +140,56 @@ export default function PublicReportPage() {
   const changedFiles = useComputed(
     () => report.value?.data.diff?.filter((entry) => CHANGED_STATUSES.has(entry.status)) ?? [],
   );
+
+  if (!tokenPresent) {
+    if (!mounted.value) {
+      return (
+        <PageShell width="doc" headerActions={<MarketingHeaderActions authed={authed} />}>
+          <LoadingState title="Loading public review" detail="fetching report" />
+        </PageShell>
+      );
+    }
+    return (
+      <PageShell width="doc" headerActions={<MarketingHeaderActions authed={authed} />}>
+        <header class="flex flex-col gap-2">
+          <p class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle m-0">
+            Public release review
+          </p>
+          <h1 class="text-2xl font-semibold tracking-[-0.015em] m-0">This page needs a link</h1>
+          <Muted class="m-0 text-[14px] leading-[1.65] max-w-[680px]">
+            A Drydock public report is a single release review that the package's owner chose to
+            share: the same canonical report export Drydock produced for them — risk, findings, and
+            the files the release changed — served read-only at its own link.
+          </Muted>
+        </header>
+
+        <Card class="flex flex-col gap-3">
+          <SectionLabel as="h2">Why there is no index</SectionLabel>
+          <EmptyLine>
+            The link is the permission. Each report has its own unguessable address, reports are
+            never listed or searchable, and the owner can revoke a link at any time — so{" "}
+            <code class="font-mono text-[12px] text-ink">/reports</code> on its own has nothing to
+            show. If someone sent you a report, open their full link: chat clients and mail readers
+            sometimes cut the token off the end.
+          </EmptyLine>
+        </Card>
+
+        <section class="flex flex-col gap-3">
+          <SectionLabel as="h2">Where to go next</SectionLabel>
+          <EmptyLine>
+            You can diff any published npm, PyPI, or atpm package against its previous version
+            without an account, or read how staged reviews, sharing, and signed attestations work.
+          </EmptyLine>
+          <div class="flex flex-wrap gap-2">
+            <LinkButton href="/diff">Diff a package</LinkButton>
+            <LinkButton href="/docs" variant="secondary">
+              Read the docs
+            </LinkButton>
+          </div>
+        </section>
+      </PageShell>
+    );
+  }
 
   if (errorState.value === "not_found") {
     return (

--- a/test/public-report-token.test.ts
+++ b/test/public-report-token.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import { hasShareToken } from "../src/pages/PublicReport/index";
+
+// `hasShareToken` gates both halves of the tokenless `/reports` state: the page
+// skips the `/public/reports/<token>` lookup entirely when it is false, and
+// renders the "no public index" explainer instead of the revoked/invalid error.
+// There is no DOM test environment in this repo, so the render itself is not
+// asserted here — the branch is a single call to this predicate.
+describe("hasShareToken", () => {
+  test("a share token routes to the report lookup", () => {
+    expect(hasShareToken("k4YQ2s1a")).toBe(true);
+  });
+
+  test("a bare /reports visit has no token to look up", () => {
+    // `route.params.token` is undefined on the tokenless route; the page
+    // coalesces it to "" before this call, so both spellings must be false.
+    expect(hasShareToken(undefined)).toBe(false);
+    expect(hasShareToken(null)).toBe(false);
+    expect(hasShareToken("")).toBe(false);
+  });
+
+  test("a whitespace-only token is not a link either", () => {
+    // A pasted link that wrapped can leave "%20" behind, which decodes to a
+    // space. Firing the lookup for it would answer with the revoked message.
+    expect(hasShareToken(" ")).toBe(false);
+    expect(hasShareToken("\n\t")).toBe(false);
+  });
+});


### PR DESCRIPTION
Part 1 of 4 of the maintainer-onboarding stack (replaces #625). Independent of the rest — mergeable on its own.

- New shared `CopyButton` primitive (`src/components/CopyButton.tsx`); Docs `CodeBlock`s gain a copy affordance with zero call-site changes, and `StageCommandDialog` dedupes its inline copy logic onto it.
- Bare `/reports` explains what public reports are (owner-shared, unguessable link) instead of claiming the link was revoked; no fetch fires without a token, and the explainer is mount-gated so prerendered share links never flash it. Present-but-invalid tokens keep the current message.
- `buildQueryUrl` preserves the URL hash through query writes so `#anchor` deep links survive `replaceState` (needed by part 3's `#gate-setup` link, but correct on its own).

Testing: `pnpm run verify` + `knip` green on this branch in isolation; new `test/public-report-token.test.ts` covers the tokenless predicate. Docs: `docs/public-reports.md` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)