### PR TITLE
Hide settled npm releases from the review queue

### DIFF
--- a/docs/registry-version-status.md
+++ b/docs/registry-version-status.md
@@ -100,7 +100,10 @@ default **Undecided** work queue. Likewise, a review with no Drydock decision
 leaves **Undecided** once npm reports `published`, `blocked`, or `deleted`, because
 the stage is no longer actionable. It remains under **All** with its npm status
 badge and, unlike superseded history, can still accept a decision for the audit
-trail. Failure
+trail. **Published without Drydock decision** isolates the `published` rows in
+that history that still have no decision, making releases that bypassed the
+review decision easy to audit; `blocked` and `deleted` rows are excluded because
+they did not go live. Failure
 refinement rechecks ownership after its registry request so a concurrent restage
 cannot attribute the replacement stage's outcome to the older scan. The reminder
 marker remains as send-once history. Deleting a failed newer scan therefore

--- a/docs/registry-version-status.md
+++ b/docs/registry-version-status.md
@@ -63,11 +63,15 @@ five-organization sweep cap bounds status traffic across the invocation. They us
 recheck floors by last known status: 5 minutes for never-asked and `validating`,
 1 hour for `staged`, and 24 hours for `published`, which can later become
 `deleted`. The terminal `blocked` and `deleted` states are never rechecked.
-Reviews older than 30 days stop being asked about at all. Only npm staged-publish scans are eligible;
+Every never-attempted review receives one lookup regardless of age. Once that
+attempt is stamped, reviews older than 30 days stop being asked about. Recent
+work is drained before that legacy first-lookup backlog, so historical reviews
+cannot consume a sweep while a current release waits. Only npm staged-publish scans are eligible;
 workflow-gate scans are excluded because their package coordinates may describe
-PyPI or VS Code releases. Due rows share one oldest-work timeline: creation time
-until the first lookup, then the last-attempt time. This drains new work without
-letting continuous arrivals starve validating, staged, or published rechecks.
+PyPI or VS Code releases. Within each age tier, due rows share one oldest-work
+timeline: creation time until the first lookup, then the last-attempt time. This
+drains new work without letting continuous arrivals starve validating, staged,
+or published rechecks.
 Status writes are fenced by that attempt timestamp, so an older overlapping
 sweep cannot replace a newer answer.
 
@@ -92,7 +96,11 @@ reviews cannot keep presenting a live-looking verdict or command for an obsolete
 stage ID. Any public report capability, badge, or threat-feed listing attached
 to the obsolete stage is retired at the same time. Superseded reviews cannot
 accept or update decisions; they remain under **All** as history but leave the
-default **Undecided** work queue. Failure
+default **Undecided** work queue. Likewise, a review with no Drydock decision
+leaves **Undecided** once npm reports `published`, `blocked`, or `deleted`, because
+the stage is no longer actionable. It remains under **All** with its npm status
+badge and, unlike superseded history, can still accept a decision for the audit
+trail. Failure
 refinement rechecks ownership after its registry request so a concurrent restage
 cannot attribute the replacement stage's outcome to the older scan. The reminder
 marker remains as send-once history. Deleting a failed newer scan therefore

--- a/docs/registry-version-status.md
+++ b/docs/registry-version-status.md
@@ -97,13 +97,15 @@ stage ID. Any public report capability, badge, or threat-feed listing attached
 to the obsolete stage is retired at the same time. Superseded reviews cannot
 accept or update decisions; they remain under **All** as history but leave the
 default **Undecided** work queue. Likewise, a review with no Drydock decision
-leaves **Undecided** once npm reports `published`, `blocked`, or `deleted`, because
-the stage is no longer actionable. It remains under **All** with its npm status
-badge and, unlike superseded history, can still accept a decision for the audit
-trail. **Published without Drydock decision** isolates the `published` rows in
-that history that still have no decision, making releases that bypassed the
-review decision easy to audit; `blocked` and `deleted` rows are excluded because
-they did not go live. Failure
+leaves **Undecided** once npm reports `published`, `blocked`, or `deleted`, or a
+terminal scan failure proves the same outcome, because the stage is no longer
+actionable. It remains under **All** with its npm status badge when one was
+persisted. Completed reviews, unlike superseded history, can still accept a
+decision for the audit trail; failed reviews remain read-only history.
+**Published without Drydock decision** isolates both `published` and
+subsequently `deleted` releases that still have no decision, including a manual
+scan that failed because npm published before the review could read the tarball.
+`blocked` releases are excluded because they did not go live. Failure
 refinement rechecks ownership after its registry request so a concurrent restage
 cannot attribute the replacement stage's outcome to the older scan. The reminder
 marker remains as send-once history. Deleting a failed newer scan therefore
@@ -142,7 +144,9 @@ to review. The recorded `reason` now says which.
 Failed scans are not eligible for the background sweep. They therefore persist
 only terminal `blocked` and `deleted` registry statuses; a `published` lookup is
 kept in the refined failure message instead of storing a snapshot that could
-later become stale.
+later become stale. The dashboard list derives a settled release outcome from
+that safe failure code for queue and audit filtering without presenting it as a
+fresh registry-status badge.
 
 ## Forgotten-approval reminder
 

--- a/server/db/scan-decisions.ts
+++ b/server/db/scan-decisions.ts
@@ -18,7 +18,13 @@ import { githubWorkflowGates, scans } from "./schema";
 export const SCAN_DECISIONS = ["publish", "no_publish"] as const;
 export type ScanDecision = (typeof SCAN_DECISIONS)[number];
 
-export const SCAN_DECISION_FILTERS = ["undecided", "publish", "no_publish", "all"] as const;
+export const SCAN_DECISION_FILTERS = [
+  "undecided",
+  "published_without_decision",
+  "publish",
+  "no_publish",
+  "all",
+] as const;
 export type ScanDecisionFilter = (typeof SCAN_DECISION_FILTERS)[number];
 
 export interface RecordScanDecisionInput {

--- a/server/db/scan-list.ts
+++ b/server/db/scan-list.ts
@@ -5,8 +5,13 @@
  * reading its risk figures off the denormalized summary so a page of rows
  * never has to load findings.
  */
-import { and, desc, eq, isNull, lt, notInArray, or } from "drizzle-orm";
-import { SETTLED_NPM_VERSION_STATUSES } from "../lib/ecosystems/npm/version-status";
+import { and, desc, eq, inArray, isNull, lt, notInArray, or, sql } from "drizzle-orm";
+import {
+  npmReleaseOutcome,
+  NPM_RELEASE_OUTCOME_FAILURE_CODES,
+  SETTLED_NPM_VERSION_STATUSES,
+  type NpmReleaseOutcome,
+} from "../lib/ecosystems/npm/version-status";
 import type { AppDb } from "./client";
 import type { ScanDecisionFilter } from "./scan-decisions";
 import { readScanRiskBreakdown, type ScanRiskSummary } from "./scan-risk";
@@ -42,6 +47,7 @@ export interface ListScansResult {
     reportDigest: string | null;
     registryVersionStatus: string | null;
     registryVersionStatusAt: Date | null;
+    registryReleaseOutcome: NpmReleaseOutcome | null;
     registryStatusSupersededAt: Date | null;
     startedAt: Date | null;
     completedAt: Date | null;
@@ -64,13 +70,21 @@ export async function listScans(
     Math.max(1, Math.floor(options.limit ?? LIST_SCANS_DEFAULT_LIMIT)),
   );
   const decisionFilter = options.decisionFilter ?? "undecided";
+  const registryFailureCode = sql<string | null>`json_extract(${scans.errorJson}, '$.code')`;
+  const settledFailureCodes = Object.values(NPM_RELEASE_OUTCOME_FAILURE_CODES);
+  const publishedStatuses = ["published", "deleted"] as const;
+  const publishedFailureCodes = [
+    NPM_RELEASE_OUTCOME_FAILURE_CODES.published,
+    NPM_RELEASE_OUTCOME_FAILURE_CODES.deleted,
+  ];
 
   const conditions = [eq(scans.organizationId, organizationId)];
   if (decisionFilter === "undecided") {
     // Superseded reviews are immutable history, not pending work: the decision
     // route refuses them, so leaving them in the default queue creates rows the
-    // reviewer can never resolve. Settled npm releases are no longer pending,
-    // but remain decidable history. Both stay visible under the `all` filter.
+    // reviewer can never resolve. Settled npm releases are no longer pending;
+    // completed reviews remain decidable while failed reviews are read-only.
+    // Both stay visible under the `all` filter.
     conditions.push(
       isNull(scans.decision),
       isNull(scans.registryStatusSupersededAt),
@@ -78,12 +92,16 @@ export async function listScans(
         isNull(scans.registryVersionStatus),
         notInArray(scans.registryVersionStatus, [...SETTLED_NPM_VERSION_STATUSES]),
       )!,
+      or(isNull(registryFailureCode), notInArray(registryFailureCode, settledFailureCodes))!,
     );
   } else if (decisionFilter === "published_without_decision") {
     conditions.push(
       isNull(scans.decision),
       isNull(scans.registryStatusSupersededAt),
-      eq(scans.registryVersionStatus, "published"),
+      or(
+        inArray(scans.registryVersionStatus, [...publishedStatuses]),
+        inArray(registryFailureCode, publishedFailureCodes),
+      )!,
     );
   } else if (decisionFilter === "publish") conditions.push(eq(scans.decision, "publish"));
   else if (decisionFilter === "no_publish") conditions.push(eq(scans.decision, "no_publish"));
@@ -122,6 +140,7 @@ export async function listScans(
       reportDigest: scans.reportDigest,
       registryVersionStatus: scans.registryVersionStatus,
       registryVersionStatusAt: scans.registryVersionStatusAt,
+      registryFailureCode,
       registryStatusSupersededAt: scans.registryStatusSupersededAt,
       startedAt: scans.startedAt,
       completedAt: scans.completedAt,
@@ -165,6 +184,7 @@ export async function listScans(
       reportDigest: row.reportDigest,
       registryVersionStatus: row.registryVersionStatus,
       registryVersionStatusAt: row.registryVersionStatusAt,
+      registryReleaseOutcome: npmReleaseOutcome(row.registryVersionStatus, row.registryFailureCode),
       registryStatusSupersededAt: row.registryStatusSupersededAt,
       startedAt: row.startedAt,
       completedAt: row.completedAt,

--- a/server/db/scan-list.ts
+++ b/server/db/scan-list.ts
@@ -79,6 +79,12 @@ export async function listScans(
         notInArray(scans.registryVersionStatus, [...SETTLED_NPM_VERSION_STATUSES]),
       )!,
     );
+  } else if (decisionFilter === "published_without_decision") {
+    conditions.push(
+      isNull(scans.decision),
+      isNull(scans.registryStatusSupersededAt),
+      eq(scans.registryVersionStatus, "published"),
+    );
   } else if (decisionFilter === "publish") conditions.push(eq(scans.decision, "publish"));
   else if (decisionFilter === "no_publish") conditions.push(eq(scans.decision, "no_publish"));
 

--- a/server/db/scan-list.ts
+++ b/server/db/scan-list.ts
@@ -5,7 +5,8 @@
  * reading its risk figures off the denormalized summary so a page of rows
  * never has to load findings.
  */
-import { and, desc, eq, isNull, lt, or } from "drizzle-orm";
+import { and, desc, eq, isNull, lt, notInArray, or } from "drizzle-orm";
+import { SETTLED_NPM_VERSION_STATUSES } from "../lib/ecosystems/npm/version-status";
 import type { AppDb } from "./client";
 import type { ScanDecisionFilter } from "./scan-decisions";
 import { readScanRiskBreakdown, type ScanRiskSummary } from "./scan-risk";
@@ -68,8 +69,16 @@ export async function listScans(
   if (decisionFilter === "undecided") {
     // Superseded reviews are immutable history, not pending work: the decision
     // route refuses them, so leaving them in the default queue creates rows the
-    // reviewer can never resolve. They remain visible under the `all` filter.
-    conditions.push(isNull(scans.decision), isNull(scans.registryStatusSupersededAt));
+    // reviewer can never resolve. Settled npm releases are no longer pending,
+    // but remain decidable history. Both stay visible under the `all` filter.
+    conditions.push(
+      isNull(scans.decision),
+      isNull(scans.registryStatusSupersededAt),
+      or(
+        isNull(scans.registryVersionStatus),
+        notInArray(scans.registryVersionStatus, [...SETTLED_NPM_VERSION_STATUSES]),
+      )!,
+    );
   } else if (decisionFilter === "publish") conditions.push(eq(scans.decision, "publish"));
   else if (decisionFilter === "no_publish") conditions.push(eq(scans.decision, "no_publish"));
 

--- a/server/db/scan-registry-status.ts
+++ b/server/db/scan-registry-status.ts
@@ -300,7 +300,10 @@ export async function listScansAwaitingRegistryStatus(
         isNotNull(scans.registryPackageName),
         isNotNull(scans.registryVersion),
         isNull(scans.registryStatusSupersededAt),
-        gte(scans.createdAt, options.createdAfter),
+        or(
+          gte(scans.createdAt, options.createdAfter),
+          isNull(scans.registryVersionStatusAttemptedAt),
+        )!,
         notExists(
           db
             .select({ id: newerScan.id })
@@ -325,6 +328,9 @@ export async function listScansAwaitingRegistryStatus(
       ),
     )
     .orderBy(
+      asc(
+        sql<number>`case when ${scans.createdAt} >= ${options.createdAfter.getTime()} then 0 else 1 end`,
+      ),
       asc(sql<number>`coalesce(${scans.registryVersionStatusAttemptedAt}, ${scans.createdAt})`),
       asc(scans.createdAt),
       asc(scans.id),

--- a/server/lib/ecosystems/npm/release-outcome.ts
+++ b/server/lib/ecosystems/npm/release-outcome.ts
@@ -21,6 +21,8 @@ const PENDING_RECHECK_MS = 5 * 60 * 1000;
 const STAGED_RECHECK_MS = 60 * 60 * 1000;
 const PUBLISHED_RECHECK_MS = 24 * 60 * 60 * 1000;
 
+// After every review has received its first lookup, stop rechecking releases
+// older than this floor.
 const MAX_RELEASE_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 
 const FORGOTTEN_APPROVAL_DELAY_MS = 6 * 60 * 60 * 1000;

--- a/server/lib/ecosystems/npm/release-outcome.ts
+++ b/server/lib/ecosystems/npm/release-outcome.ts
@@ -12,7 +12,11 @@ import { notifyStagedReleaseAwaitingApproval } from "../../notify";
 import { allowInsecureLocalRegistry, decryptNpmToken } from "./connection";
 import { mapWithConcurrency } from "../../platform/concurrency";
 import { emitOperationalEvent } from "../../platform/observability";
-import { fetchNpmVersionStatus, type NpmVersionStatus } from "./version-status";
+import {
+  fetchNpmVersionStatus,
+  NPM_RELEASE_OUTCOME_FAILURE_CODES,
+  type NpmVersionStatus,
+} from "./version-status";
 
 const LOOKUPS_PER_SWEEP = 16;
 const LOOKUP_CONCURRENCY = 4;
@@ -174,15 +178,15 @@ export async function resolveNpmReleaseOutcomes(
 
 const RELEASE_OUTCOME_FAILURES: Partial<Record<NpmVersionStatus, StagedReleaseFailure>> = {
   published: {
-    code: "staged_release_published",
+    code: NPM_RELEASE_OUTCOME_FAILURE_CODES.published,
     message: "This version was approved and published to npm before the review could read it.",
   },
   deleted: {
-    code: "staged_release_deleted",
+    code: NPM_RELEASE_OUTCOME_FAILURE_CODES.deleted,
     message: "This version was published to npm and then removed before the review could read it.",
   },
   blocked: {
-    code: "staged_release_blocked",
+    code: NPM_RELEASE_OUTCOME_FAILURE_CODES.blocked,
     message: "npm blocked this version during its own validation, so its staged bytes are gone.",
   },
 };

--- a/server/lib/ecosystems/npm/version-status.ts
+++ b/server/lib/ecosystems/npm/version-status.ts
@@ -17,6 +17,14 @@ const NPM_VERSION_STATUSES = ["published", "validating", "staged", "blocked", "d
 // would cross the client/server boundary.
 export const SETTLED_NPM_VERSION_STATUSES = ["published", "blocked", "deleted"] as const;
 
+export type NpmReleaseOutcome = (typeof SETTLED_NPM_VERSION_STATUSES)[number];
+
+export const NPM_RELEASE_OUTCOME_FAILURE_CODES: Record<NpmReleaseOutcome, string> = {
+  published: "staged_release_published",
+  blocked: "staged_release_blocked",
+  deleted: "staged_release_deleted",
+};
+
 export type NpmVersionStatus = (typeof NPM_VERSION_STATUSES)[number];
 
 /**
@@ -32,6 +40,20 @@ function isNpmVersionStatus(value: unknown): value is NpmVersionStatus {
 
 export function isTerminalNpmVersionStatus(value: unknown): boolean {
   return isNpmVersionStatus(value) && !NON_TERMINAL_STATUSES.has(value);
+}
+
+export function npmReleaseOutcome(status: unknown, failureCode: unknown): NpmReleaseOutcome | null {
+  if (
+    typeof status === "string" &&
+    (SETTLED_NPM_VERSION_STATUSES as readonly string[]).includes(status)
+  ) {
+    return status as NpmReleaseOutcome;
+  }
+  if (typeof failureCode !== "string") return null;
+  for (const [outcome, code] of Object.entries(NPM_RELEASE_OUTCOME_FAILURE_CODES)) {
+    if (failureCode === code) return outcome as NpmReleaseOutcome;
+  }
+  return null;
 }
 
 /**

--- a/server/lib/ecosystems/npm/version-status.ts
+++ b/server/lib/ecosystems/npm/version-status.ts
@@ -12,6 +12,11 @@ import { reliableFetch } from "../../platform/reliable-fetch";
  */
 const NPM_VERSION_STATUSES = ["published", "validating", "staged", "blocked", "deleted"] as const;
 
+// Keep this aligned with the client-side stage-action set in
+// `src/lib/npm-stage-follow-up.ts`; importing server runtime code into the UI
+// would cross the client/server boundary.
+export const SETTLED_NPM_VERSION_STATUSES = ["published", "blocked", "deleted"] as const;
+
 export type NpmVersionStatus = (typeof NPM_VERSION_STATUSES)[number];
 
 /**

--- a/src/lib/npm-stage-follow-up.ts
+++ b/src/lib/npm-stage-follow-up.ts
@@ -8,8 +8,18 @@ export interface NpmStageFollowUpScan {
 // adapter without importing server runtime code into the client bundle.
 const STATUSES_WITHOUT_AN_ACTIONABLE_STAGE = new Set(["published", "blocked", "deleted"]);
 
+export type SettledRegistryStatus = "published" | "blocked" | "deleted";
+
+export function settledRegistryStatus(
+  status: string | null | undefined,
+): SettledRegistryStatus | null {
+  return STATUSES_WITHOUT_AN_ACTIONABLE_STAGE.has(status ?? "")
+    ? (status as SettledRegistryStatus)
+    : null;
+}
+
 export function isSettledRegistryStatus(status: string | null | undefined): boolean {
-  return STATUSES_WITHOUT_AN_ACTIONABLE_STAGE.has(status ?? "");
+  return settledRegistryStatus(status) !== null;
 }
 
 /** Whether the UI may offer a web or CLI action against this scan's npm stage. */

--- a/src/lib/npm-stage-follow-up.ts
+++ b/src/lib/npm-stage-follow-up.ts
@@ -18,15 +18,11 @@ export function settledRegistryStatus(
     : null;
 }
 
-export function isSettledRegistryStatus(status: string | null | undefined): boolean {
-  return settledRegistryStatus(status) !== null;
-}
-
 /** Whether the UI may offer a web or CLI action against this scan's npm stage. */
 export function canOfferNpmStageFollowUp(scan: NpmStageFollowUpScan): boolean {
   return (
     scan.source !== "workflow_gate" &&
     scan.registryStatusSupersededAt == null &&
-    !isSettledRegistryStatus(scan.registryVersionStatus)
+    settledRegistryStatus(scan.registryVersionStatus) === null
   );
 }

--- a/src/lib/npm-stage-follow-up.ts
+++ b/src/lib/npm-stage-follow-up.ts
@@ -4,13 +4,19 @@ export interface NpmStageFollowUpScan {
   registryStatusSupersededAt?: string | number | Date | null;
 }
 
+// Keep this aligned with `SETTLED_NPM_VERSION_STATUSES` in the server npm
+// adapter without importing server runtime code into the client bundle.
 const STATUSES_WITHOUT_AN_ACTIONABLE_STAGE = new Set(["published", "blocked", "deleted"]);
+
+export function isSettledRegistryStatus(status: string | null | undefined): boolean {
+  return STATUSES_WITHOUT_AN_ACTIONABLE_STAGE.has(status ?? "");
+}
 
 /** Whether the UI may offer a web or CLI action against this scan's npm stage. */
 export function canOfferNpmStageFollowUp(scan: NpmStageFollowUpScan): boolean {
   return (
     scan.source !== "workflow_gate" &&
     scan.registryStatusSupersededAt == null &&
-    !STATUSES_WITHOUT_AN_ACTIONABLE_STAGE.has(scan.registryVersionStatus ?? "")
+    !isSettledRegistryStatus(scan.registryVersionStatus)
   );
 }

--- a/src/models/scan-api.ts
+++ b/src/models/scan-api.ts
@@ -11,6 +11,7 @@ import type {
   FindingDiffStatus,
   PackageJsonSummary,
 } from "../../server/lib/review";
+import { isSettledRegistryStatus } from "../lib/npm-stage-follow-up";
 import { apiFetch, apiJson } from "./api";
 
 export interface ScanVersionsResponse {
@@ -255,10 +256,16 @@ export type DecisionStatus = "idle" | "saving" | "error";
 export type DeleteStatus = "idle" | "deleting" | "error";
 
 export function scanMatchesDecisionFilter(
-  scan: Pick<ScanListItem, "decision">,
+  scan: Pick<ScanListItem, "decision" | "registryStatusSupersededAt" | "registryVersionStatus">,
   filter: ScanDecisionFilter,
 ): boolean {
   if (filter === "all") return true;
-  if (filter === "undecided") return !scan.decision;
+  if (filter === "undecided") {
+    return (
+      !scan.decision &&
+      scan.registryStatusSupersededAt == null &&
+      !isSettledRegistryStatus(scan.registryVersionStatus)
+    );
+  }
   return scan.decision === filter;
 }

--- a/src/models/scan-api.ts
+++ b/src/models/scan-api.ts
@@ -43,7 +43,12 @@ export interface ScanFileResponse {
 }
 
 export type ScanDecision = "publish" | "no_publish";
-export type ScanDecisionFilter = "undecided" | "publish" | "no_publish" | "all";
+export type ScanDecisionFilter =
+  | "undecided"
+  | "published_without_decision"
+  | "publish"
+  | "no_publish"
+  | "all";
 
 interface ScanRiskSummary {
   artifactRisk: string;
@@ -260,6 +265,13 @@ export function scanMatchesDecisionFilter(
   filter: ScanDecisionFilter,
 ): boolean {
   if (filter === "all") return true;
+  if (filter === "published_without_decision") {
+    return (
+      !scan.decision &&
+      scan.registryStatusSupersededAt == null &&
+      scan.registryVersionStatus === "published"
+    );
+  }
   if (filter === "undecided") {
     return (
       !scan.decision &&

--- a/src/models/scan-api.ts
+++ b/src/models/scan-api.ts
@@ -11,7 +11,7 @@ import type {
   FindingDiffStatus,
   PackageJsonSummary,
 } from "../../server/lib/review";
-import { isSettledRegistryStatus } from "../lib/npm-stage-follow-up";
+import { settledRegistryStatus, type SettledRegistryStatus } from "../lib/npm-stage-follow-up";
 import { apiFetch, apiJson } from "./api";
 
 export interface ScanVersionsResponse {
@@ -86,6 +86,8 @@ export interface ScanListItem {
   /** npm's lifecycle status for this exact staged version, or null if unknown. */
   registryVersionStatus?: string | null;
   registryVersionStatusAt?: string | number | Date | null;
+  /** Settled npm outcome derived from lifecycle status or a terminal scan failure. */
+  registryReleaseOutcome?: SettledRegistryStatus | null;
   /** Set when a newer stage reused this registry package and version. */
   registryStatusSupersededAt?: string | number | Date | null;
   startedAt?: string | number | Date | null;
@@ -261,23 +263,24 @@ export type DecisionStatus = "idle" | "saving" | "error";
 export type DeleteStatus = "idle" | "deleting" | "error";
 
 export function scanMatchesDecisionFilter(
-  scan: Pick<ScanListItem, "decision" | "registryStatusSupersededAt" | "registryVersionStatus">,
+  scan: Pick<
+    ScanListItem,
+    "decision" | "registryReleaseOutcome" | "registryStatusSupersededAt" | "registryVersionStatus"
+  >,
   filter: ScanDecisionFilter,
 ): boolean {
   if (filter === "all") return true;
+  const releaseOutcome =
+    scan.registryReleaseOutcome ?? settledRegistryStatus(scan.registryVersionStatus);
   if (filter === "published_without_decision") {
     return (
       !scan.decision &&
       scan.registryStatusSupersededAt == null &&
-      scan.registryVersionStatus === "published"
+      (releaseOutcome === "published" || releaseOutcome === "deleted")
     );
   }
   if (filter === "undecided") {
-    return (
-      !scan.decision &&
-      scan.registryStatusSupersededAt == null &&
-      !isSettledRegistryStatus(scan.registryVersionStatus)
-    );
+    return !scan.decision && scan.registryStatusSupersededAt == null && releaseOutcome === null;
   }
   return scan.decision === filter;
 }

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -348,6 +348,10 @@ function RecentReviewsSection({
 
 const FILTER_OPTIONS: Array<{ value: ScanDecisionFilter; label: string }> = [
   { value: "undecided", label: "Undecided" },
+  {
+    value: "published_without_decision",
+    label: "Published without Drydock decision",
+  },
   { value: "publish", label: "Approved" },
   { value: "no_publish", label: "Blocked" },
   { value: "all", label: "All" },
@@ -378,7 +382,7 @@ function ScanStateSelect({
       <span aria-hidden class="font-mono text-[11px] uppercase tracking-[0.1em] text-ink-subtle">
         State
       </span>
-      <span class="w-[160px]">
+      <span class="w-[260px]">
         <Select
           id="scan-state-filter"
           size="sm"
@@ -412,6 +416,8 @@ function emptyStateMessage(filter: ScanDecisionFilter, hasAnyScan: boolean | nul
   switch (filter) {
     case "undecided":
       return "Nothing waiting on you. Switch to All to see earlier reviews.";
+    case "published_without_decision":
+      return "No npm releases were published without a Drydock decision.";
     case "publish":
       return "No approved reviews yet.";
     case "no_publish":

--- a/test/scan-list-model.test.ts
+++ b/test/scan-list-model.test.ts
@@ -239,10 +239,16 @@ describe("scanMatchesDecisionFilter", () => {
     },
   );
 
-  test("matches only live published scans without a decision in the bypass filter", () => {
+  test("matches published or subsequently deleted releases without a decision", () => {
     expect(
       scanMatchesDecisionFilter(
         { decision: null, registryVersionStatus: "published" },
+        "published_without_decision",
+      ),
+    ).toBe(true);
+    expect(
+      scanMatchesDecisionFilter(
+        { decision: null, registryVersionStatus: "deleted" },
         "published_without_decision",
       ),
     ).toBe(true);
@@ -268,6 +274,18 @@ describe("scanMatchesDecisionFilter", () => {
         "published_without_decision",
       ),
     ).toBe(false);
+  });
+
+  test.each([
+    ["published", true],
+    ["deleted", true],
+    ["blocked", false],
+  ] as const)("uses a derived %s failure outcome for list filtering", (outcome, wasPublished) => {
+    const scan = { decision: null, registryReleaseOutcome: outcome };
+
+    expect(scanMatchesDecisionFilter(scan, "undecided")).toBe(false);
+    expect(scanMatchesDecisionFilter(scan, "published_without_decision")).toBe(wasPublished);
+    expect(scanMatchesDecisionFilter(scan, "all")).toBe(true);
   });
 
   test("excludes superseded history from undecided", () => {

--- a/test/scan-list-model.test.ts
+++ b/test/scan-list-model.test.ts
@@ -99,6 +99,22 @@ describe("ScanListModel decisions", () => {
     expect(model.scans.value[0]?.riskSummary?.releaseRisk).toBe("none");
   });
 
+  test("removes a decided release from published-without-decision", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(jsonResponse(scanDetail("publish")))),
+    );
+
+    model = new ScanListModel();
+    model.scans.value = [{ ...scanDetail(null).scan, registryVersionStatus: "published" }];
+    model.filter.value = "published_without_decision";
+
+    await model.setDecision("scan-1", "publish", "reviewed after release");
+
+    expect(model.decisionStatus.value).toBe("idle");
+    expect(model.scans.value).toEqual([]);
+  });
+
   test("does not let an older refresh restore a decided scan", async () => {
     const refreshResponse = deferred<Response>();
     const fetchMock = vi
@@ -222,6 +238,37 @@ describe("scanMatchesDecisionFilter", () => {
       ).toBe(true);
     },
   );
+
+  test("matches only live published scans without a decision in the bypass filter", () => {
+    expect(
+      scanMatchesDecisionFilter(
+        { decision: null, registryVersionStatus: "published" },
+        "published_without_decision",
+      ),
+    ).toBe(true);
+    expect(
+      scanMatchesDecisionFilter(
+        { decision: "publish", registryVersionStatus: "published" },
+        "published_without_decision",
+      ),
+    ).toBe(false);
+    expect(
+      scanMatchesDecisionFilter(
+        { decision: null, registryVersionStatus: "blocked" },
+        "published_without_decision",
+      ),
+    ).toBe(false);
+    expect(
+      scanMatchesDecisionFilter(
+        {
+          decision: null,
+          registryVersionStatus: "published",
+          registryStatusSupersededAt: "2026-08-28T00:00:00.000Z",
+        },
+        "published_without_decision",
+      ),
+    ).toBe(false);
+  });
 
   test("excludes superseded history from undecided", () => {
     expect(

--- a/test/scan-list-model.test.ts
+++ b/test/scan-list-model.test.ts
@@ -203,6 +203,34 @@ describe("scanMatchesDecisionFilter", () => {
     expect(scanMatchesDecisionFilter({ decision: "no_publish" }, "publish")).toBe(false);
     expect(scanMatchesDecisionFilter({ decision: "no_publish" }, "all")).toBe(true);
   });
+
+  test.each(["published", "blocked", "deleted"])(
+    "excludes a settled %s release from undecided but not all",
+    (registryVersionStatus) => {
+      const scan = { decision: null, registryVersionStatus };
+
+      expect(scanMatchesDecisionFilter(scan, "undecided")).toBe(false);
+      expect(scanMatchesDecisionFilter(scan, "all")).toBe(true);
+    },
+  );
+
+  test.each([null, "staged", "validating"])(
+    "keeps an unsettled %s release in undecided",
+    (registryVersionStatus) => {
+      expect(
+        scanMatchesDecisionFilter({ decision: null, registryVersionStatus }, "undecided"),
+      ).toBe(true);
+    },
+  );
+
+  test("excludes superseded history from undecided", () => {
+    expect(
+      scanMatchesDecisionFilter(
+        { decision: null, registryStatusSupersededAt: "2026-08-27T00:00:00.000Z" },
+        "undecided",
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("ScanListModel hasAnyScan", () => {

--- a/test/workers/registry-version-status.test.ts
+++ b/test/workers/registry-version-status.test.ts
@@ -73,6 +73,7 @@ async function seedCompletedScan(
     createdAt?: Date;
     source?: ScanSource;
     registryUrl?: string | null;
+    registryVersionStatusAttemptedAt?: Date;
   } = {},
 ) {
   const db = createDb(env.DB);
@@ -102,10 +103,15 @@ async function seedCompletedScan(
     diff: [],
     findings: [],
   });
-  if (overrides.createdAt) {
+  if (overrides.createdAt || overrides.registryVersionStatusAttemptedAt) {
     await db
       .update(schema.scans)
-      .set({ createdAt: overrides.createdAt })
+      .set({
+        ...(overrides.createdAt ? { createdAt: overrides.createdAt } : {}),
+        ...(overrides.registryVersionStatusAttemptedAt
+          ? { registryVersionStatusAttemptedAt: overrides.registryVersionStatusAttemptedAt }
+          : {}),
+      })
       .where(eq(schema.scans.id, scanId));
   }
   return { scanId, stageId };
@@ -410,6 +416,69 @@ describe("registry version status resolution", () => {
     expect(scan.registryVersionStatus).toBe("blocked");
     expect(scan.registryVersionStatusAt).toBeTruthy();
     expect(scan.registryVersionStatusAttemptedAt).toBeTruthy();
+  });
+
+  test.each(["published", "blocked", "deleted"])(
+    "keeps a %s release as decidable history but removes it from the undecided queue",
+    async (status) => {
+      const org = await seedOrg();
+      const { scanId } = await seedCompletedScan(org);
+      const db = createDb(env.DB);
+      stubRegistry(() => statusResponse(status));
+
+      await resolveNpmReleaseOutcomes({
+        db,
+        env,
+        organizationId: org.organizationId,
+        ownerUserId: org.userId,
+        connection: { token: TOKEN, registryUrl: REGISTRY_URL },
+      });
+
+      const undecided = await listScans(db, org.organizationId);
+      expect(undecided.scans.map((scan) => scan.id)).not.toContain(scanId);
+      const history = await listScans(db, org.organizationId, { decisionFilter: "all" });
+      expect(history.scans).toContainEqual(
+        expect.objectContaining({ id: scanId, registryVersionStatus: status }),
+      );
+      await expect(
+        recordScanDecision(db, {
+          scanId,
+          organizationId: org.organizationId,
+          decision: "publish",
+          actorUserId: org.userId,
+        }),
+      ).resolves.toBeTruthy();
+      expect((await readScan(scanId)).decision).toBe("publish");
+    },
+  );
+
+  test("keeps staged, validating, and unresolved releases in the undecided queue", async () => {
+    const org = await seedOrg();
+    const staged = await seedCompletedScan(org, { version: "2.5.0" });
+    const validating = await seedCompletedScan(org, { version: "2.5.1" });
+    const unresolved = await seedCompletedScan(org, { version: "2.5.2" });
+    const db = createDb(env.DB);
+    stubRegistry((url) => {
+      const version = decodeURIComponent(new URL(url).pathname.split("/").at(-2)!);
+      if (version === "2.5.0") return statusResponse("staged", PACKAGE, version);
+      if (version === "2.5.1") return statusResponse("validating", PACKAGE, version);
+      return new Response(null, { status: 404 });
+    });
+
+    await resolveNpmReleaseOutcomes({
+      db,
+      env,
+      organizationId: org.organizationId,
+      ownerUserId: org.userId,
+      connection: { token: TOKEN, registryUrl: REGISTRY_URL },
+    });
+
+    const undecided = await listScans(db, org.organizationId);
+    expect(new Set(undecided.scans.map((scan) => scan.id))).toEqual(
+      new Set([staged.scanId, validating.scanId, unresolved.scanId]),
+    );
+    expect((await readScan(unresolved.scanId)).registryVersionStatus).toBeNull();
+    expect((await readScan(unresolved.scanId)).registryVersionStatusAttemptedAt).toBeTruthy();
   });
 
   test("binds the lookup to registry coordinates when hostile tarball metadata disagrees", async () => {
@@ -910,9 +979,13 @@ describe("registry version status resolution", () => {
     expect(second.checked).toBe(1);
   });
 
-  test("does not chase releases older than the age floor", async () => {
+  test("does not recheck attempted releases older than the age floor", async () => {
     const org = await seedOrg();
-    await seedCompletedScan(org, { createdAt: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000) });
+    const old = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+    await seedCompletedScan(org, {
+      createdAt: old,
+      registryVersionStatusAttemptedAt: old,
+    });
     const fetchMock = stubRegistry(() => statusResponse("published"));
 
     const result = await resolveNpmReleaseOutcomes({
@@ -925,6 +998,66 @@ describe("registry version status resolution", () => {
 
     expect(result.checked).toBe(0);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("gives a never-attempted old review one lookup, then stops", async () => {
+    const org = await seedOrg();
+    const now = new Date();
+    const { scanId } = await seedCompletedScan(org, {
+      createdAt: new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000),
+    });
+    const fetchMock = stubRegistry(() => new Response(null, { status: 404 }));
+    const args = {
+      db: createDb(env.DB),
+      env,
+      organizationId: org.organizationId,
+      ownerUserId: org.userId,
+      connection: { token: TOKEN, registryUrl: REGISTRY_URL },
+    };
+
+    const first = await resolveNpmReleaseOutcomes({ ...args, now });
+    const second = await resolveNpmReleaseOutcomes({
+      ...args,
+      now: new Date(now.getTime() + 10 * 60 * 1000),
+    });
+
+    expect(first.checked).toBe(1);
+    expect(second.checked).toBe(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((await readScan(scanId)).registryVersionStatusAttemptedAt).toBeTruthy();
+  });
+
+  test("checks recent releases before draining the legacy first-lookup backlog", async () => {
+    const org = await seedOrg();
+    const now = new Date();
+    const oldCreatedAt = new Date(now.getTime() - 90 * 24 * 60 * 60 * 1000);
+    const oldOne = await seedCompletedScan(org, { version: "2.9.0", createdAt: oldCreatedAt });
+    const oldTwo = await seedCompletedScan(org, { version: "2.9.1", createdAt: oldCreatedAt });
+    const recent = await seedCompletedScan(org, { version: "3.0.0" });
+    const fetchMock = stubRegistry(() => new Response(null, { status: 404 }));
+
+    const result = await resolveNpmReleaseOutcomes({
+      db: createDb(env.DB),
+      env,
+      organizationId: org.organizationId,
+      ownerUserId: org.userId,
+      connection: { token: TOKEN, registryUrl: REGISTRY_URL },
+      stagedItems: [{ id: recent.stageId, packageName: PACKAGE, version: "3.0.0" }],
+      now,
+      lookupLimit: 2,
+    });
+
+    expect(result.checked).toBe(2);
+    expect(fetchMock.mock.calls.map(([url]) => String(url))).toEqual(
+      expect.arrayContaining([expect.stringContaining("/3.0.0/status")]),
+    );
+    expect((await readScan(recent.scanId)).registryVersionStatusAttemptedAt).toBeTruthy();
+    const attemptedLegacyCount = await Promise.all(
+      [oldOne.scanId, oldTwo.scanId].map(async (scanId) =>
+        Boolean((await readScan(scanId)).registryVersionStatusAttemptedAt),
+      ),
+    );
+    expect(attemptedLegacyCount.filter(Boolean)).toHaveLength(1);
   });
 
   test("does not ask npm about workflow-gate scans from other ecosystems", async () => {
@@ -1347,6 +1480,42 @@ describe("staged failure refinement", () => {
     expect(refined.error.code).toBe(code);
     expect(refined.error.message).not.toContain("token");
     expect(refined.registryStatus).toBe(status);
+  });
+
+  test("keeps a failed blocked scan under all but out of undecided", async () => {
+    const org = await seedOrg();
+    const db = createDb(env.DB);
+    const scanId = crypto.randomUUID();
+    const stageId = `stage-${scanId.slice(0, 8)}`;
+    await createScanJob(db, {
+      id: scanId,
+      stageId,
+      organizationId: org.organizationId,
+      ownerUserId: org.userId,
+      packageName: PACKAGE,
+      stagedVersion: VERSION,
+      registryUrl: REGISTRY_URL,
+    });
+    stubRegistry(() => statusResponse("blocked"));
+
+    const refined = await refine(org, scanId, stageId);
+    await markScanFailed(db, scanId, org.organizationId, refined.error);
+    await recordRegistryVersionStatus(db, {
+      scanId,
+      organizationId: org.organizationId,
+      status: refined.registryStatus,
+    });
+
+    const undecided = await listScans(db, org.organizationId);
+    expect(undecided.scans.map((scan) => scan.id)).not.toContain(scanId);
+    const history = await listScans(db, org.organizationId, { decisionFilter: "all" });
+    expect(history.scans).toContainEqual(
+      expect.objectContaining({
+        id: scanId,
+        status: "failed",
+        registryVersionStatus: "blocked",
+      }),
+    );
   });
 
   test.each(["staged", "validating"])(

--- a/test/workers/registry-version-status.test.ts
+++ b/test/workers/registry-version-status.test.ts
@@ -440,6 +440,12 @@ describe("registry version status resolution", () => {
       expect(history.scans).toContainEqual(
         expect.objectContaining({ id: scanId, registryVersionStatus: status }),
       );
+      const publishedWithoutDecision = await listScans(db, org.organizationId, {
+        decisionFilter: "published_without_decision",
+      });
+      expect(publishedWithoutDecision.scans.map((scan) => scan.id)).toEqual(
+        status === "published" ? [scanId] : [],
+      );
       await expect(
         recordScanDecision(db, {
           scanId,
@@ -449,6 +455,10 @@ describe("registry version status resolution", () => {
         }),
       ).resolves.toBeTruthy();
       expect((await readScan(scanId)).decision).toBe("publish");
+      const afterDecision = await listScans(db, org.organizationId, {
+        decisionFilter: "published_without_decision",
+      });
+      expect(afterDecision.scans.map((scan) => scan.id)).not.toContain(scanId);
     },
   );
 

--- a/test/workers/registry-version-status.test.ts
+++ b/test/workers/registry-version-status.test.ts
@@ -444,7 +444,7 @@ describe("registry version status resolution", () => {
         decisionFilter: "published_without_decision",
       });
       expect(publishedWithoutDecision.scans.map((scan) => scan.id)).toEqual(
-        status === "published" ? [scanId] : [],
+        status === "published" || status === "deleted" ? [scanId] : [],
       );
       await expect(
         recordScanDecision(db, {
@@ -1492,41 +1492,50 @@ describe("staged failure refinement", () => {
     expect(refined.registryStatus).toBe(status);
   });
 
-  test("keeps a failed blocked scan under all but out of undecided", async () => {
-    const org = await seedOrg();
-    const db = createDb(env.DB);
-    const scanId = crypto.randomUUID();
-    const stageId = `stage-${scanId.slice(0, 8)}`;
-    await createScanJob(db, {
-      id: scanId,
-      stageId,
-      organizationId: org.organizationId,
-      ownerUserId: org.userId,
-      packageName: PACKAGE,
-      stagedVersion: VERSION,
-      registryUrl: REGISTRY_URL,
-    });
-    stubRegistry(() => statusResponse("blocked"));
-
-    const refined = await refine(org, scanId, stageId);
-    await markScanFailed(db, scanId, org.organizationId, refined.error);
-    await recordRegistryVersionStatus(db, {
-      scanId,
-      organizationId: org.organizationId,
-      status: refined.registryStatus,
-    });
-
-    const undecided = await listScans(db, org.organizationId);
-    expect(undecided.scans.map((scan) => scan.id)).not.toContain(scanId);
-    const history = await listScans(db, org.organizationId, { decisionFilter: "all" });
-    expect(history.scans).toContainEqual(
-      expect.objectContaining({
+  test.each([
+    ["published", "published", true],
+    ["deleted", "deleted", true],
+    ["blocked", "blocked", false],
+  ])(
+    "uses a failed %s outcome when no registry status was persisted",
+    async (status, expectedOutcome, wasPublished) => {
+      const org = await seedOrg();
+      const db = createDb(env.DB);
+      const scanId = crypto.randomUUID();
+      const stageId = `stage-${scanId.slice(0, 8)}`;
+      await createScanJob(db, {
         id: scanId,
-        status: "failed",
-        registryVersionStatus: "blocked",
-      }),
-    );
-  });
+        stageId,
+        organizationId: org.organizationId,
+        ownerUserId: org.userId,
+        packageName: PACKAGE,
+        stagedVersion: VERSION,
+        registryUrl: REGISTRY_URL,
+      });
+      stubRegistry(() => statusResponse(status));
+
+      const refined = await refine(org, scanId, stageId);
+      await markScanFailed(db, scanId, org.organizationId, refined.error);
+
+      const undecided = await listScans(db, org.organizationId);
+      expect(undecided.scans.map((scan) => scan.id)).not.toContain(scanId);
+      const history = await listScans(db, org.organizationId, { decisionFilter: "all" });
+      expect(history.scans).toContainEqual(
+        expect.objectContaining({
+          id: scanId,
+          status: "failed",
+          registryVersionStatus: null,
+          registryReleaseOutcome: expectedOutcome,
+        }),
+      );
+      const publishedWithoutDecision = await listScans(db, org.organizationId, {
+        decisionFilter: "published_without_decision",
+      });
+      expect(publishedWithoutDecision.scans.map((scan) => scan.id)).toEqual(
+        wasPublished ? [scanId] : [],
+      );
+    },
+  );
 
   test.each(["staged", "validating"])(
     "a release npm still has (%s) really is a token problem",


### PR DESCRIPTION
## Summary

Hide published, blocked, deleted, and superseded npm releases from the default Undecided queue while retaining them as decidable audit history under All. Add a **Published without Drydock decision** filter to surface npm releases that bypassed Drydock. Give legacy reviews one status lookup without allowing the backlog to delay current release checks. Closes #635.

## Trust boundary

Organization-scoped scan listing and credentialed npm lifecycle-status scheduling.

## Verification

- `pnpm run verify`
- `pnpm run test:e2e` (18 passed)

## Documentation

Updated `docs/registry-version-status.md`.

## UI evidence

Live-verified the filter on desktop and mobile.
