### PR TITLE
Pin fast-uri to 3.1.6 for the host-confusion and SSRF fixes

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   postcss: ^8.5.23
   nanoid: ^3.3.18
   ws: 8.21.0
+  fast-uri: ^3.1.6
   undici: ^7.29.0
 
 importers:
@@ -2728,8 +2729,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fd-package-json@2.0.0:
     resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
@@ -5341,7 +5342,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -5758,7 +5759,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fd-package-json@2.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,10 @@ overrides:
   # generators from looping indefinitely on a zero-sized alphabet request.
   nanoid: ^3.3.18
   ws: 8.21.0
+  # ajv (via @modelcontextprotocol/sdk) permits fast-uri 3.x releases with the
+  # host-confusion and SSRF advisories fixed in 3.1.6 (GHSA-5jgf-p345-68v8,
+  # GHSA-fph4-wmhf-6fwf, GHSA-f65p-4m7j-42xc, GHSA-jqff-g426-hqxp).
+  fast-uri: ^3.1.6
   # AI SDK 6 permits vulnerable Undici 7 releases; keep the patched cache,
   # retry, cookie, and header handling until its dependency floor catches up.
   undici: ^7.29.0


### PR DESCRIPTION
## Summary

`ajv` (reached via `@modelcontextprotocol/sdk` → `agents`) declares `fast-uri: ^3.0.1`, which still resolved to 3.1.5; the 3.1.6 release patches four high-severity advisories ([GHSA-5jgf-p345-68v8](https://github.com/fastify/fast-uri/security/advisories/GHSA-5jgf-p345-68v8) and [GHSA-jqff-g426-hqxp](https://github.com/fastify/fast-uri/security/advisories/GHSA-jqff-g426-hqxp) host confusion, [GHSA-fph4-wmhf-6fwf](https://github.com/fastify/fast-uri/security/advisories/GHSA-fph4-wmhf-6fwf) and [GHSA-f65p-4m7j-42xc](https://github.com/fastify/fast-uri/security/advisories/GHSA-f65p-4m7j-42xc) SSRF). This raises the floor with a `pnpm-workspace.yaml` override, matching the existing `postcss` / `nanoid` / `undici` security-floor entries. Worth flagging: these are still repository-level advisories on `fastify/fast-uri` and have not propagated to the GitHub global database, so `pnpm audit` reports clean and did not catch this.

## Trust boundary

None directly. `ajv` uses `fast-uri` for JSON Schema `$id`/`$ref` resolution rather than for issuing requests, so the SSRF variants have no obvious reachable path here; the host-confusion variants would only matter if MCP tool schemas ever carried attacker-influenced `$id` values.

## Verification

`pnpm run verify` passes in full (lint, format:check, typecheck, node + Worker suites) on the rebased branch; `pnpm why fast-uri` confirms a single resolved 3.1.6. No new tests — this is a dependency-floor change with no behavior of ours to cover, and the lockfile pin is the assertion.

## Documentation

Docs checked, no update needed — no doc enumerates the override list, and each override's rationale lives inline as a comment in `pnpm-workspace.yaml`.

## UI evidence

Not applicable.