### PR TITLE
Document stage-only trusted publishing

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ The user-facing learning guide is [`../src/pages/Docs/index.tsx`](../src/pages/D
 
 - [`architecture.md`](./architecture.md) — Worker, sandbox, adapters, storage, org model, and API shape.
 - [`workflow-gates.md`](./workflow-gates.md) — shared GitHub Environment gate flow for PyPI, npm, and VS Code releases.
+- [`npm-staged-publishing.md`](./npm-staged-publishing.md) — restricting an npm trusted publisher to `npm stage publish` so CI can stage a candidate but never make it public, making the staged review unskippable rather than optional; includes how it compares with the workflow gate.
 - [`npm-trusted-publishing.md`](./npm-trusted-publishing.md) — pinning npm trusted publishing (OIDC) to the gate environment so the reviewed workflow is the only credentialed publish path, plus what that does and does not stop.
 - [`diff-baseline.md`](./diff-baseline.md) — default previous-version comparison strategy.
 - [`atpm-public-diff.md`](./atpm-public-diff.md) — the atpm ecosystem on `/diff`: AT Protocol resolution (handle → DID → PDS → record → blob), why it does not go through atpm.dev, the host policy that bounds publisher-named egress, and the record-vs-tarball findings.

--- a/docs/npm-staged-publishing.md
+++ b/docs/npm-staged-publishing.md
@@ -1,0 +1,117 @@
+# npm stage-only trusted publishing: making the review unskippable
+
+[npm staged publishing](https://docs.npmjs.com/staged-publishing/) holds a
+candidate tarball privately so Drydock can review the exact bytes before anyone
+can install them. On its own that is a review a maintainer _chooses_ to run:
+nothing stops the same CI job — or anyone holding a token — from calling
+`npm publish` and skipping the stage entirely.
+
+npm's trusted publishing closes that. A trusted publisher can be configured to
+allow `npm stage publish` and **not** `npm publish`. The CI identity can then
+put a release candidate into npm's staging area but cannot make it public, and
+with tokens disallowed there is no other credential that can. The only route to
+a public version is a human approving a stage with 2FA — after reading the diff.
+
+This page is the recipe, followed by an honest accounting of what it does and
+does not stop. Prerequisite: a working staged-publish review — a Drydock organization with a
+read-scoped npm token connected, so stages are discovered and scanned. The
+in-app guide at `/docs#staged-publishing` covers that setup.
+
+## The recipe
+
+1. **Configure a stage-only trusted publisher.** npm CLI ≥ 11.15.0, 2FA on the
+   account, write access to the package, and the package must already exist on
+   the registry (npm cannot stage a first version).
+
+   ```sh
+   npm trust github <package> \
+     --repo <owner>/<repo> \
+     --file publish.yml \
+     --allow-stage-publish
+   ```
+
+   The load-bearing detail is the omission: `--allow-publish` is **not** passed.
+   At least one of the two flags is required, so passing only
+   `--allow-stage-publish` is what produces a publisher that can stage and
+   nothing else. `npm trust list <package>` shows what the package currently
+   grants.
+
+2. **Set publishing access to "Require two-factor authentication and disallow
+   tokens"** in the package settings on npmjs.com. This removes every token
+   path — legacy, automation, and granular access tokens all stop working for
+   publish — leaving the OIDC exchange as the only credentialed route, and that
+   route is stage-only.
+
+3. **Stage from CI over OIDC, not a token.** The job requests an id-token and
+   runs `npm stage publish`; no `NODE_AUTH_TOKEN` appears anywhere.
+
+   ```yaml
+   jobs:
+     stage:
+       permissions:
+         id-token: write # OIDC; no npm token exists in this workflow
+       steps:
+         - run: npm ci
+         - run: npm stage publish
+   ```
+
+4. **Read the review.** Drydock discovers the stage and scans the private
+   tarball, comparing it with the last published release on the same dist-tag.
+   Record the decision and reason.
+
+5. **Approve on npm with 2FA.** Either `npm stage approve <stage-id>` from the
+   CLI or the Staged Packages tab on npmjs.com. Drydock never holds a credential
+   that can complete this step.
+
+## Why each pin matters
+
+| Publish attempt                                                     | Stopped by                                                                                |
+| ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `npm publish` with any token — laptop, CI secret, stolen token      | Publishing access disallows tokens                                                        |
+| `npm publish` over OIDC from the pinned workflow                    | The trusted publisher grants `stage` only; npm refuses the publish exchange               |
+| `npm stage publish` from another repository, workflow file, or fork | Trusted publisher claim mismatch; npm refuses the exchange                                |
+| Editing the workflow to publish directly instead of staging         | Same claim, same refusal — the grant is on the publisher, not on the command CI runs      |
+| Staging a malicious candidate                                       | Nothing, and deliberately so: a stage is inert until approved, which is where review sits |
+
+One property compounds on top of the table. The artifact npm holds while it is
+staged is the artifact that becomes public on approval — there is no rebuild
+between the review and the publish, so the reviewed bytes and the shipped bytes
+are the same bytes by construction. The workflow gate has to prove that
+separately with a digest re-check.
+
+## Compared with the workflow gate
+
+Both make a review unskippable; they put the hold in different places.
+
+|                       | Stage-only trusted publishing           | [Workflow gate](./npm-trusted-publishing.md)                     |
+| --------------------- | --------------------------------------- | ---------------------------------------------------------------- |
+| Who holds the release | npm, as a private stage                 | GitHub, as a paused deployment                                   |
+| Ecosystems            | npm only                                | npm, PyPI, VS Code                                               |
+| Setup surface         | One `npm trust` call, one token setting | GitHub App, Environment, protection rule, trusted publisher pins |
+| CI credential         | Can stage; can never publish            | Exists only after the review passes                              |
+| Reviewed vs shipped   | Same artifact by construction           | Proven by `sha256sum --check` against the reviewed digests       |
+| Final approval        | A human on npm, with 2FA                | A human in Drydock; the workflow resumes                         |
+
+Stage-only is the shorter setup for a maintainer already running
+`npm stage publish`. The gate is the one that generalizes past npm and past a
+single package.
+
+## What this does not stop
+
+- **An approval nobody read.** Enforcement makes the review unskippable, not
+  thorough. npm will happily take a 2FA approval on a stage the maintainer never
+  opened.
+- **npm account takeover.** Whoever controls the account can re-run `npm trust`
+  with `--allow-publish`, revoke the trust configuration, or re-enable tokens.
+  Every registry-side control roots in account security.
+- **A poisoned source tree.** If the repository's own source is malicious, CI
+  will build it faithfully, npm will attach valid provenance to it, and the
+  stage will contain it. Provenance records where a package was built, not
+  whether its contents are safe. This is the case artifact review exists for:
+  the stage is where a newly added `preinstall` hook or an unexplained new file
+  is visible, and it is visible before anyone can install it.
+- **A package's first version.** npm cannot stage a package that does not exist
+  yet, so the initial publish needs a direct path. Configure the stage-only
+  publisher immediately afterwards.
+- **Drydock unavailability.** The stage simply waits; npm holds it either way.
+  The failure mode is a delayed release, never an unreviewed one.

--- a/docs/npm-trusted-publishing.md
+++ b/docs/npm-trusted-publishing.md
@@ -9,6 +9,12 @@ Environment, make Drydock that environment's deployment-protection rule, and
 disallow tokens. The only way to obtain publish credentials is then to pass the
 review.
 
+For npm specifically there is a second, smaller enforcement shape: pin the
+trusted publisher to `npm stage publish` and let npm hold the candidate instead
+of GitHub holding the job. See
+[`npm-staged-publishing.md`](./npm-staged-publishing.md) for that recipe and a
+comparison of the two.
+
 This page is the recipe, followed by an honest accounting of what it does and
 does not stop. Prerequisite: a working npm workflow gate as described in
 [`workflow-gates.md`](./workflow-gates.md#npm-workflow-gate-notes) — Drydock

--- a/src/pages/Docs/index.tsx
+++ b/src/pages/Docs/index.tsx
@@ -429,6 +429,53 @@ export default function DocsPage() {
                 the credential that completes the publish.
               </Callout>
             </Subsection>
+
+            <Subsection id="staged-enforcement" title="Make staging the only thing CI can do">
+              <Prose>
+                Everything above is a review you choose to run. Nothing yet stops the same workflow
+                &mdash; or anyone holding a token &mdash; from calling{" "}
+                <InlineCode>npm publish</InlineCode> and skipping the stage. npm closes that on the
+                registry side: a trusted publisher can grant{" "}
+                <InlineCode>npm stage publish</InlineCode> without granting{" "}
+                <InlineCode>npm publish</InlineCode>, so CI can prepare a candidate but can never
+                make one public.
+              </Prose>
+              <Steps
+                items={[
+                  <>
+                    Grant the package a stage-only trusted publisher. Omitting{" "}
+                    <InlineCode>--allow-publish</InlineCode> is the entire point: at least one
+                    permission flag is required, so passing only the staging one produces a
+                    publisher that cannot publish. Needs npm CLI 11.15.0 or newer, and the package
+                    must already exist.
+                  </>,
+                  <>
+                    In the package settings on npmjs.com, set publishing access to{" "}
+                    <InlineCode>Require two-factor authentication and disallow tokens</InlineCode>.
+                    That removes every token path, leaving the stage-only exchange as the only
+                    credential the package accepts.
+                  </>,
+                  <>
+                    Give the release job <InlineCode>id-token: write</InlineCode> and have it run{" "}
+                    <InlineCode>npm stage publish</InlineCode>. No npm token belongs anywhere in the
+                    workflow after this.
+                  </>,
+                ]}
+              />
+              <CodeBlock name="stage-only trusted publisher" lang="bash">
+                {`npm trust github <package> \\
+  --repo <owner>/<repo> \\
+  --file publish.yml \\
+  --allow-stage-publish`}
+              </CodeBlock>
+              <Callout label="What this changes">
+                The candidate npm holds is the artifact that goes public on approval, so the bytes
+                you read are the bytes consumers install. It does not make the build trustworthy: a
+                poisoned source tree still produces a valid, provenance-signed candidate. It makes
+                that candidate unable to reach anyone until a human has read it and approved with
+                2FA.
+              </Callout>
+            </Subsection>
           </section>
 
           <section id="workflow-gating" class="flex flex-col gap-8 scroll-mt-6">

--- a/src/pages/Docs/toc.ts
+++ b/src/pages/Docs/toc.ts
@@ -31,6 +31,7 @@ export const TOC: Array<{
     children: [
       { id: "staged-setup", label: "Connect npm" },
       { id: "staged-lifecycle", label: "Run a review" },
+      { id: "staged-enforcement", label: "Make staging mandatory" },
     ],
   },
   {

--- a/src/pages/Guides/index.tsx
+++ b/src/pages/Guides/index.tsx
@@ -55,6 +55,11 @@ const GUIDES: Record<DiscoveryGuidePath, GuideContent> = {
         heading: "Drydock never receives the publish approval.",
         body: "The maintainer records a review decision, then completes or discards the stage through npm with npm's own 2FA step. Drydock needs read-only evidence access, not a token that can publish packages.",
       },
+      {
+        label: "The enforcement",
+        heading: "A trusted publisher can stage without being able to publish.",
+        body: "Staging is a review you choose to run until the registry stops accepting anything else. npm can grant a CI identity permission to stage a release and withhold permission to publish one; with tokens disallowed on the package, no credential exists that can make a version public without a human approving the stage. The candidate npm holds is the artifact that ships, so the reviewed bytes and the installed bytes are the same bytes.",
+      },
     ],
     close: {
       heading: "Stage your next npm publish.",


### PR DESCRIPTION
## Summary

Staged publishing is a review a maintainer *chooses* to run. Nothing in the setup we currently document stops the same CI job — or anyone holding a token — from calling `npm publish` and skipping the stage, which makes the whole path advisory in exactly the situation it exists for. `docs/npm-trusted-publishing.md` solves this for the workflow-gate path and has no counterpart for the staged path.

npm closes it on the registry side: a trusted publisher can be granted `npm stage publish` without `npm publish`. Combined with "disallow tokens" on the package, no credential exists that can make a version public, and the only route to a public release is a human approving a stage with 2FA — after reading the diff.

## What's here

**`docs/npm-staged-publishing.md`** (new) — the enforcement recipe, structured like its workflow-gate counterpart:

- the `npm trust github <package> --repo … --file … --allow-stage-publish` call, with the omission of `--allow-publish` called out as the load-bearing part
- the "Require two-factor authentication and disallow tokens" package setting
- an OIDC staging job with no `NODE_AUTH_TOKEN` anywhere
- a table of what each pin stops, including the row where the answer is "nothing, deliberately" (staging a malicious candidate is *supposed* to succeed; the stage is inert until approved)
- a comparison of the two enforcement shapes — where the release is held, ecosystems covered, setup surface, CI credential, how reviewed-vs-shipped is proven, who approves
- an honest "what this does not stop": an approval nobody read, account takeover, a poisoned source tree, a package's first version, Drydock being down

One asymmetry worth noting in the comparison: on the staged path the artifact npm holds *is* the artifact that goes public, so reviewed bytes and shipped bytes are the same bytes by construction. The gate has to prove that separately with a digest re-check.

**In-app docs** — a `staged-enforcement` subsection ("Make staging the only thing CI can do") at the end of the staged-publishing path, with the three setup steps, the `npm trust` command, and a callout that is explicit about what this does *not* buy: a poisoned source tree still produces a valid, provenance-signed candidate; enforcement only guarantees a human reads it first. Plus the TOC entry.

**Guides** — a fourth section on `/npm-staged-publishing` covering the same idea at marketing altitude.

**Cross-links** — `docs/README.md` index entry, and a pointer from `npm-trusted-publishing.md` so someone landing on the gate recipe finds the smaller npm-only option.

## Testing

- `pnpm run verify` — lint, format, typecheck, logic + Worker suites, all pass
- Rendered `/docs#staged-enforcement` in a headless browser and read back the subsection text: heading, three numbered steps, code block (backslash continuations and `<package>` placeholders intact), and callout all render correctly, and the new TOC entry appears. Note: the dev server's CSP blocks Vite's inline `<style>` injection, so the headless render is unstyled — pre-existing, unrelated to this change; the primitives used are the same ones the neighbouring subsections use.
- npm behavior claims checked against npm's own docs (`npm trust` permission flags, `npm stage publish` / `npm stage approve`, CLI ≥ 11.15.0, and that a package's first version cannot be staged)

Docs are the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)