### PR TITLE
Add canonical Release Receipt v1

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ The user-facing learning guide is [`../src/pages/Docs/index.tsx`](../src/pages/D
 - [`intent-envelope.md`](./intent-envelope.md) — advisory source-binding tiers (attested / declared / absent) persisted with every scan.
 - [`artifact-storage.md`](./artifact-storage.md) — D1/R2 report and artifact persistence.
 - [`public-reports.md`](./public-reports.md) — public share links, signed report attestations, badges, and the threat feed.
+- [`release-receipts.md`](./release-receipts.md) — authenticated canonical Release Receipt v1, report digest binding, workflow/staged control evidence, and schema limitations.
 
 ## Operations and setup
 

--- a/docs/release-receipts.md
+++ b/docs/release-receipts.md
@@ -1,0 +1,75 @@
+# Release Receipt v1
+
+A release receipt is a canonical, hash-addressed control record for one completed
+scan. It composes the existing canonical report evidence with release-decision
+and workflow-control evidence; it does not replace, embed, sign, or alter
+`drydock.report.v2` or its public DSSE attestation.
+
+## Endpoint and access
+
+`GET /api/v1/scans/:id/release-receipt.json[?organizationId=...]` is an
+authenticated, organization-scoped download adjacent to `report.json`. It is
+available only for completed scans and returns `private, no-store`.
+
+There is intentionally no public-share receipt route in v1. Public share tokens
+continue to expose only the canonical report export and its existing optional
+attestation. Gate identity and control-plane state therefore do not widen the
+public capability boundary.
+
+## Canonical document
+
+The schema tag is `drydock.release-receipt.v1`. Serialization uses the shared
+stable JSON primitive: object keys are sorted, undefined fields are omitted, and
+no presentation whitespace is added.
+
+- `address` is SHA-256 hex of the exact canonical bytes of `content`. Consumers
+  verify it by stable-serializing `content` and hashing those bytes.
+- `content.report.schema` identifies `drydock.report.v2`.
+- `content.report.digest` is SHA-256 hex of the exact canonical `report.json`
+  bytes returned for the same scan state. This is a reference to the report,
+  not a second report attestation.
+- `x-drydock-receipt-sha256`, the `ETag`, and the download filename carry the
+  SHA-256 of the exact full receipt response bytes. This whole-document digest
+  is deliberately outside the document so the receipt does not make a
+  recursive self-hash claim.
+
+## Evidence semantics
+
+`content.release` records scan id, stage id, package coordinates, source, mode,
+risk, and a structured decision with decision time and the authenticated Drydock reviewer id when one exists. It also states the narrow control classification: a workflow-gate receipt is `workflow_enforced` for the configured publish workflow, while a staged-publish receipt is `advisory` registry-stage observation. Neither classification claims universal registry enforcement. `mode` is `workflow_gate` only for gate scans; manual and auto-discovered registry stages are `staged_publish`.
+
+`content.evidence` separates independent claims:
+
+- `report` says the report reference is present.
+- `reviewedArtifacts` reuses the report's validated workflow provenance
+  (`sha256` per artifact) or staged artifact integrity verdict (registry-declared
+  and computed SHA-1). Missing legacy evidence is `unknown`; an unverified
+  staged digest is `partial`; a validated mismatch is `conflicting`.
+- `intentBinding` reuses the validated intent envelope. Missing or malformed
+  persisted data is `unknown`; an explicit `absent` tier is complete evidence
+  that no source binding was found.
+- `workflowGate` records repository, run, environment, durable gate status,
+  decision, and decision time when the organization-scoped gate row exists.
+  Staged reviews use `not_applicable`. Callback outcome is `unknown` in v1:
+  callback success/failure is not durably persisted, and a stored gate decision
+  is not proof GitHub received it.
+- `registryOutcome` records the registry status and observation time only when a
+  status was observed. It remains `unknown` for workflow gates, unsupported
+  registries, failed lookups, and legacy scans.
+
+The aggregate evidence status covers evidence required by the selected mode.
+Registry outcome is reported independently because an unobserved post-review
+registry state does not make the review evidence incomplete.
+
+## Limitations
+
+- v1 receipts are generated from current persisted state rather than stored as
+  immutable snapshots. Archive the receipt and referenced report together.
+- Receipts are unsigned. Existing signed public-report attestations remain the
+  only signing path and cover only exact report bytes.
+- Callback delivery outcome is unknown until a durable callback-attempt/result
+  record exists.
+- Staged npm integrity currently follows the registry's SHA-1 record; it is byte
+  continuity against that registry record, not a new SHA-256 provenance claim.
+- Registry observation is currently the persisted staged-registry lifecycle
+  status; workflow-gate registries do not yet feed a post-publish observation.

--- a/docs/release-receipts.md
+++ b/docs/release-receipts.md
@@ -18,9 +18,10 @@ public capability boundary.
 
 ## Canonical document
 
-The schema tag is `drydock.release-receipt.v1`. Serialization uses the shared
-stable JSON primitive: object keys are sorted, undefined fields are omitted, and
-no presentation whitespace is added.
+The schema tag is `drydock.release-receipt.v1`. Serialization uses code-point
+key ordering: undefined fields are omitted and no presentation whitespace is
+added. This preserves the existing `drydock.report.v2` byte ordering across
+runtimes rather than depending on host locale.
 
 - `address` is SHA-256 hex of the exact canonical bytes of `content`. Consumers
   verify it by stable-serializing `content` and hashing those bytes.
@@ -48,9 +49,12 @@ risk, and a structured decision with decision time and the authenticated Drydock
 - `intentBinding` reuses the validated intent envelope. Missing or malformed
   persisted data is `unknown`; an explicit `absent` tier is complete evidence
   that no source binding was found.
+- `releaseDecision` is complete only when outcome, decision time, and reviewer
+  are all present. Partial or legacy decisions keep the aggregate status partial.
 - `workflowGate` records repository, run, environment, durable gate status,
   decision, and decision time when the organization-scoped gate row exists.
-  Staged reviews use `not_applicable`. Callback outcome is `unknown` in v1:
+  Pending or errored rows are partial rather than complete. Staged reviews use
+  `not_applicable`. Callback outcome is `unknown` in v1:
   callback success/failure is not durably persisted, and a stored gate decision
   is not proof GitHub received it.
 - `registryOutcome` records the registry status and observation time only when a

--- a/server/lib/platform/canonical-json.ts
+++ b/server/lib/platform/canonical-json.ts
@@ -1,0 +1,8 @@
+export function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, item]) => item !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return `{${entries.map(([key, item]) => `${JSON.stringify(key)}:${canonicalJson(item)}`).join(",")}}`;
+}

--- a/server/lib/scan/release-receipt.ts
+++ b/server/lib/scan/release-receipt.ts
@@ -11,7 +11,7 @@ import {
 type ScanDetail = NonNullable<Awaited<ReturnType<typeof getScan>>>;
 type EvidenceStatus = "complete" | "partial" | "unknown" | "conflicting" | "not_applicable";
 
-export const RELEASE_RECEIPT_SCHEMA = "drydock.release-receipt.v1";
+const RELEASE_RECEIPT_SCHEMA = "drydock.release-receipt.v1";
 
 export async function buildReleaseReceipt(
   detail: ScanDetail,

--- a/server/lib/scan/release-receipt.ts
+++ b/server/lib/scan/release-receipt.ts
@@ -1,7 +1,7 @@
 import type { getScan } from "../../db/scans";
 import type { WorkflowGateRecord } from "../github-app/webhook-gates";
+import { canonicalJson } from "../platform/canonical-json";
 import { sha256Hex } from "../platform/crypto-utils";
-import { stableJson } from "../platform/stable-json";
 import {
   buildReportExport,
   REPORT_EXPORT_SCHEMA,
@@ -26,7 +26,13 @@ export async function buildReleaseReceipt(
     envelope: report.intentEnvelope,
   };
   const gate = buildWorkflowGate(mode, workflowGate);
-  const requiredStatuses = [reviewedArtifacts.status, intentBinding.status, gate.status];
+  const releaseDecision = buildReleaseDecision(detail.scan);
+  const requiredStatuses = [
+    reviewedArtifacts.status,
+    intentBinding.status,
+    releaseDecision.status,
+    gate.status,
+  ];
   const evidenceStatus = aggregateEvidenceStatus(requiredStatuses);
   const content = {
     report: {
@@ -52,19 +58,14 @@ export async function buildReleaseReceipt(
         previousVersion: detail.scan.previousVersion ?? null,
       },
       risk: detail.scan.risk,
-      decision: {
-        outcome: detail.scan.decision ?? null,
-        decidedAt: toIso(detail.scan.decidedAt),
-        reviewer: detail.scan.decidedByUserId
-          ? { kind: "drydock_user" as const, id: detail.scan.decidedByUserId }
-          : null,
-      },
+      decision: releaseDecision.value,
     },
     evidence: {
       status: evidenceStatus,
       report: { status: "complete" as const },
       reviewedArtifacts,
       intentBinding,
+      releaseDecision: { status: releaseDecision.status },
       workflowGate: gate,
       registryOutcome: report.registryStatus
         ? { status: "complete" as const, observation: report.registryStatus }
@@ -73,7 +74,7 @@ export async function buildReleaseReceipt(
   };
   const address = {
     algorithm: "sha256" as const,
-    value: await sha256Hex(stableJson(content)),
+    value: await sha256Hex(canonicalJson(content)),
   };
   return { schema: RELEASE_RECEIPT_SCHEMA, address, content };
 }
@@ -81,7 +82,7 @@ export async function buildReleaseReceipt(
 export type ReleaseReceiptDocument = Awaited<ReturnType<typeof buildReleaseReceipt>>;
 
 export function serializeReleaseReceipt(document: ReleaseReceiptDocument): string {
-  return stableJson(document);
+  return canonicalJson(document);
 }
 
 export function releaseReceiptFilename(scanId: string, documentSha256: string): string {
@@ -94,13 +95,17 @@ function buildReviewedArtifacts(
   report: ReturnType<typeof buildReportExport>,
 ) {
   if (mode === "workflow_gate") {
-    return report.provenance
-      ? {
-          status: "complete" as const,
-          provenance: report.provenance,
-          stagedArtifactIntegrity: null,
-        }
-      : { status: "unknown" as const, provenance: null, stagedArtifactIntegrity: null };
+    if (!report.provenance) {
+      return { status: "unknown" as const, provenance: null, stagedArtifactIntegrity: null };
+    }
+    const digestsValid = report.provenance.artifacts.every((artifact) =>
+      /^[a-f0-9]{64}$/i.test(artifact.sha256),
+    );
+    return {
+      status: digestsValid ? ("complete" as const) : ("conflicting" as const),
+      provenance: report.provenance,
+      stagedArtifactIntegrity: null,
+    };
   }
   const integrity = report.artifactIntegrity;
   const status: EvidenceStatus =
@@ -134,8 +139,12 @@ function buildWorkflowGate(
       callback: { outcome: "unknown" as const, observedAt: null },
     };
   }
+  const complete =
+    (gate.status === "approved" || gate.status === "rejected") &&
+    gate.decision !== null &&
+    gate.decidedAt !== null;
   return {
-    status: "complete" as const,
+    status: complete ? ("complete" as const) : ("partial" as const),
     identity: {
       repository: gate.repositoryFullName,
       runId: gate.runId,
@@ -149,6 +158,27 @@ function buildWorkflowGate(
     // Callback delivery is currently observable only in ephemeral operational
     // logs. A durable gate decision is not proof GitHub received it.
     callback: { outcome: "unknown" as const, observedAt: null },
+  };
+}
+
+function buildReleaseDecision(scan: ScanDetail["scan"]) {
+  const decidedAt = toIso(scan.decidedAt);
+  const reviewer = scan.decidedByUserId
+    ? { kind: "drydock_user" as const, id: scan.decidedByUserId }
+    : null;
+  const value = {
+    outcome: scan.decision ?? null,
+    decidedAt,
+    reviewer,
+  };
+  return {
+    status:
+      value.outcome && value.decidedAt && value.reviewer
+        ? ("complete" as const)
+        : value.outcome || value.decidedAt || value.reviewer
+          ? ("partial" as const)
+          : ("unknown" as const),
+    value,
   };
 }
 

--- a/server/lib/scan/release-receipt.ts
+++ b/server/lib/scan/release-receipt.ts
@@ -1,0 +1,171 @@
+import type { getScan } from "../../db/scans";
+import type { WorkflowGateRecord } from "../github-app/webhook-gates";
+import { sha256Hex } from "../platform/crypto-utils";
+import { stableJson } from "../platform/stable-json";
+import {
+  buildReportExport,
+  REPORT_EXPORT_SCHEMA,
+  serializeReportExportDocument,
+} from "./report-export";
+
+type ScanDetail = NonNullable<Awaited<ReturnType<typeof getScan>>>;
+type EvidenceStatus = "complete" | "partial" | "unknown" | "conflicting" | "not_applicable";
+
+export const RELEASE_RECEIPT_SCHEMA = "drydock.release-receipt.v1";
+
+export async function buildReleaseReceipt(
+  detail: ScanDetail,
+  workflowGate: WorkflowGateRecord | null,
+) {
+  const report = buildReportExport(detail);
+  const reportBytes = serializeReportExportDocument(report);
+  const mode = detail.scan.source === "workflow_gate" ? "workflow_gate" : "staged_publish";
+  const reviewedArtifacts = buildReviewedArtifacts(mode, report);
+  const intentBinding = {
+    status: report.intentEnvelope ? ("complete" as const) : ("unknown" as const),
+    envelope: report.intentEnvelope,
+  };
+  const gate = buildWorkflowGate(mode, workflowGate);
+  const requiredStatuses = [reviewedArtifacts.status, intentBinding.status, gate.status];
+  const evidenceStatus = aggregateEvidenceStatus(requiredStatuses);
+  const content = {
+    report: {
+      schema: REPORT_EXPORT_SCHEMA,
+      digest: { algorithm: "sha256" as const, value: await sha256Hex(reportBytes) },
+    },
+    release: {
+      scanId: detail.scan.id,
+      stageId: detail.scan.stageId,
+      mode,
+      source: detail.scan.source,
+      control: {
+        classification:
+          mode === "workflow_gate" ? ("workflow_enforced" as const) : ("advisory" as const),
+        scope:
+          mode === "workflow_gate"
+            ? ("configured_publish_workflow" as const)
+            : ("registry_stage_observation" as const),
+      },
+      package: {
+        name: detail.scan.packageName ?? null,
+        stagedVersion: detail.scan.stagedVersion ?? null,
+        previousVersion: detail.scan.previousVersion ?? null,
+      },
+      risk: detail.scan.risk,
+      decision: {
+        outcome: detail.scan.decision ?? null,
+        decidedAt: toIso(detail.scan.decidedAt),
+        reviewer: detail.scan.decidedByUserId
+          ? { kind: "drydock_user" as const, id: detail.scan.decidedByUserId }
+          : null,
+      },
+    },
+    evidence: {
+      status: evidenceStatus,
+      report: { status: "complete" as const },
+      reviewedArtifacts,
+      intentBinding,
+      workflowGate: gate,
+      registryOutcome: report.registryStatus
+        ? { status: "complete" as const, observation: report.registryStatus }
+        : { status: "unknown" as const, observation: null },
+    },
+  };
+  const address = {
+    algorithm: "sha256" as const,
+    value: await sha256Hex(stableJson(content)),
+  };
+  return { schema: RELEASE_RECEIPT_SCHEMA, address, content };
+}
+
+export type ReleaseReceiptDocument = Awaited<ReturnType<typeof buildReleaseReceipt>>;
+
+export function serializeReleaseReceipt(document: ReleaseReceiptDocument): string {
+  return stableJson(document);
+}
+
+export function releaseReceiptFilename(scanId: string, documentSha256: string): string {
+  const id = scanId.replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-|-$/g, "") || "scan";
+  return `drydock-release-receipt-${id}-${documentSha256}.json`;
+}
+
+function buildReviewedArtifacts(
+  mode: "workflow_gate" | "staged_publish",
+  report: ReturnType<typeof buildReportExport>,
+) {
+  if (mode === "workflow_gate") {
+    return report.provenance
+      ? {
+          status: "complete" as const,
+          provenance: report.provenance,
+          stagedArtifactIntegrity: null,
+        }
+      : { status: "unknown" as const, provenance: null, stagedArtifactIntegrity: null };
+  }
+  const integrity = report.artifactIntegrity;
+  const status: EvidenceStatus =
+    integrity?.status === "verified"
+      ? "complete"
+      : integrity?.status === "mismatch"
+        ? "conflicting"
+        : integrity
+          ? "partial"
+          : "unknown";
+  return { status, provenance: null, stagedArtifactIntegrity: integrity };
+}
+
+function buildWorkflowGate(
+  mode: "workflow_gate" | "staged_publish",
+  gate: WorkflowGateRecord | null,
+) {
+  if (mode === "staged_publish") {
+    return {
+      status: "not_applicable" as const,
+      identity: null,
+      decision: null,
+      callback: null,
+    };
+  }
+  if (!gate) {
+    return {
+      status: "unknown" as const,
+      identity: { repository: null, runId: null, environment: null },
+      decision: { status: null, outcome: null, decidedAt: null },
+      callback: { outcome: "unknown" as const, observedAt: null },
+    };
+  }
+  return {
+    status: "complete" as const,
+    identity: {
+      repository: gate.repositoryFullName,
+      runId: gate.runId,
+      environment: gate.environment,
+    },
+    decision: {
+      status: gate.status,
+      outcome: gate.decision,
+      decidedAt: toIso(gate.decidedAt),
+    },
+    // Callback delivery is currently observable only in ephemeral operational
+    // logs. A durable gate decision is not proof GitHub received it.
+    callback: { outcome: "unknown" as const, observedAt: null },
+  };
+}
+
+function aggregateEvidenceStatus(
+  statuses: EvidenceStatus[],
+): "complete" | "partial" | "conflicting" {
+  if (statuses.includes("conflicting")) return "conflicting";
+  if (statuses.every((status) => status === "complete" || status === "not_applicable")) {
+    return "complete";
+  }
+  return "partial";
+}
+
+function toIso(value: unknown): string | null {
+  if (value == null) return null;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "number") return new Date(value).toISOString();
+  if (typeof value === "string") return value;
+  return null;
+}

--- a/server/lib/scan/report-export.ts
+++ b/server/lib/scan/report-export.ts
@@ -7,6 +7,7 @@ import { normalizeReleaseConsistency } from "./release-memory";
 import type { ReleaseProvenance, ReleaseProvenanceArtifact } from "../ecosystems/package-adapter";
 import { isEcosystemId } from "../ecosystems/labels";
 import { parseStagedArtifactIntegrity } from "../ecosystems/artifact-integrity";
+import { stableJson } from "../platform/stable-json";
 
 // A persisted scan detail, as returned by getScan (never null at the call site).
 type ScanDetail = NonNullable<Awaited<ReturnType<typeof getScan>>>;
@@ -124,7 +125,7 @@ export function serializeReportExport(detail: ScanDetail): string {
 // a signed envelope (they did — `findingCount` counted AI findings the
 // document's `findings[]` deliberately excludes).
 export function serializeReportExportDocument(document: ReportExportDocument): string {
-  return stableStringify(document);
+  return stableJson(document);
 }
 
 export function reportExportFilename(scan: ReportExportFilenameInput): string {
@@ -144,15 +145,6 @@ function compareFindings(
     (a.line ?? 0) - (b.line ?? 0) ||
     cmp(a.severity, b.severity)
   );
-}
-
-function stableStringify(value: unknown): string {
-  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
-  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
-  const entries = Object.entries(value as Record<string, unknown>)
-    .filter(([, item]) => item !== undefined)
-    .sort(([a], [b]) => cmp(a, b));
-  return `{${entries.map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`).join(",")}}`;
 }
 
 function cmp(a: string, b: string): number {

--- a/server/lib/scan/report-export.ts
+++ b/server/lib/scan/report-export.ts
@@ -7,7 +7,7 @@ import { normalizeReleaseConsistency } from "./release-memory";
 import type { ReleaseProvenance, ReleaseProvenanceArtifact } from "../ecosystems/package-adapter";
 import { isEcosystemId } from "../ecosystems/labels";
 import { parseStagedArtifactIntegrity } from "../ecosystems/artifact-integrity";
-import { stableJson } from "../platform/stable-json";
+import { canonicalJson } from "../platform/canonical-json";
 
 // A persisted scan detail, as returned by getScan (never null at the call site).
 type ScanDetail = NonNullable<Awaited<ReturnType<typeof getScan>>>;
@@ -125,7 +125,7 @@ export function serializeReportExport(detail: ScanDetail): string {
 // a signed envelope (they did — `findingCount` counted AI findings the
 // document's `findings[]` deliberately excludes).
 export function serializeReportExportDocument(document: ReportExportDocument): string {
-  return stableJson(document);
+  return canonicalJson(document);
 }
 
 export function reportExportFilename(scan: ReportExportFilenameInput): string {

--- a/server/routes/scans/sharing.ts
+++ b/server/routes/scans/sharing.ts
@@ -24,6 +24,13 @@ import {
   setThreatFeedListing,
 } from "../../db/scan-share";
 import { reportExportFilename, serializeReportExport } from "../../lib/scan/report-export";
+import {
+  buildReleaseReceipt,
+  releaseReceiptFilename,
+  serializeReleaseReceipt,
+} from "../../lib/scan/release-receipt";
+import { sha256Hex } from "../../lib/platform/crypto-utils";
+import { getGateByScanId } from "../../lib/github-app/webhook-gates";
 import { roleCanManagePublicShares } from "../../lib/auth/roles";
 import type { Bindings, Variables } from "../../types";
 
@@ -166,6 +173,41 @@ scanSharingRoutes.get("/:id/report.json", async (c) => {
     },
   });
 });
+
+scanSharingRoutes.get(
+  "/:id/release-receipt.json",
+  async (c: Context<{ Bindings: Bindings; Variables: Variables }>) => {
+    const db = createDb(c.env.DB);
+    const organizationId = await resolveReportExportOrganization(c, db);
+    if (!organizationId) return c.json({ error: "not found" }, 404);
+    const scanId = c.req.param("id");
+    if (!scanId) return c.json({ error: "not found" }, 404);
+    const detail = await getScan(db, scanId, organizationId, scanArtifactReadBucket(c.env), {
+      files: "omit",
+    });
+    if (!detail) return c.json({ error: "not found" }, 404);
+    if (detail.scan.status !== "complete") {
+      return c.json({ error: "release receipt is only available for completed scans" }, 409);
+    }
+    const gate =
+      detail.scan.source === "workflow_gate"
+        ? await getGateByScanId(db, organizationId, detail.scan.id)
+        : null;
+    const document = await buildReleaseReceipt(detail, gate);
+    const bytes = serializeReleaseReceipt(document);
+    const documentSha256 = await sha256Hex(bytes);
+    return new Response(bytes, {
+      status: 200,
+      headers: {
+        "content-type": "application/json; charset=utf-8",
+        "content-disposition": `attachment; filename="${releaseReceiptFilename(detail.scan.id, documentSha256)}"`,
+        "cache-control": "private, no-store",
+        etag: `"sha256:${documentSha256}"`,
+        "x-drydock-receipt-sha256": documentSha256,
+      },
+    });
+  },
+);
 
 async function resolveReportExportOrganization(
   c: Context<{ Bindings: Bindings; Variables: Variables }>,

--- a/test/canonical-json.test.ts
+++ b/test/canonical-json.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "vitest";
+import { canonicalJson } from "../server/lib/platform/canonical-json";
+
+describe("canonical JSON", () => {
+  test("orders object keys by code point rather than host locale", () => {
+    expect(canonicalJson({ é: 1, a: 2, _: 3, Z: 4 })).toBe('{"Z":4,"_":3,"a":2,"é":1}');
+  });
+
+  test("is stable recursively and omits undefined object properties", () => {
+    expect(canonicalJson({ z: [{ b: 2, a: 1 }], missing: undefined, a: true })).toBe(
+      '{"a":true,"z":[{"a":1,"b":2}]}',
+    );
+  });
+});

--- a/test/workers/release-receipt.test.ts
+++ b/test/workers/release-receipt.test.ts
@@ -6,8 +6,8 @@ import { createDb } from "../../server/db/client";
 import { ensurePersonalOrganization } from "../../server/db/organizations";
 import { createScanJob } from "../../server/db/scans";
 import * as schema from "../../server/db/schema";
+import { canonicalJson } from "../../server/lib/platform/canonical-json";
 import { sha256Hex } from "../../server/lib/platform/crypto-utils";
-import { stableJson } from "../../server/lib/platform/stable-json";
 import { scansRoutes } from "../../server/routes/scans";
 import type { Bindings, Variables } from "../../server/types";
 import { persistScanWithArtifacts } from "./helpers/persist-scan";
@@ -103,12 +103,13 @@ async function seedGate(owner: Owner) {
   const db = createDb(env.DB);
   const now = new Date("2026-08-02T00:00:00.000Z");
   const installationId = crypto.randomUUID();
+  const externalInstallationId = crypto.randomUUID();
   const releaseTargetId = crypto.randomUUID();
   const gateId = crypto.randomUUID();
   await db.insert(schema.githubAppInstallations).values({
     id: installationId,
     organizationId: owner.organizationId,
-    installationId: "12345",
+    installationId: externalInstallationId,
     accountLogin: "octo",
     accountType: "Organization",
     targetType: "Organization",
@@ -180,7 +181,7 @@ describe("canonical release receipt v1", () => {
 
     const document = JSON.parse(bytes) as any;
     expect(document.schema).toBe("drydock.release-receipt.v1");
-    expect(document.address.value).toBe(await sha256Hex(stableJson(document.content)));
+    expect(document.address.value).toBe(await sha256Hex(canonicalJson(document.content)));
     expect(first.headers.get("x-drydock-receipt-sha256")).toBe(await sha256Hex(bytes));
     expect(first.headers.get("etag")).toBe(`"sha256:${await sha256Hex(bytes)}"`);
 
@@ -266,6 +267,14 @@ describe("canonical release receipt v1", () => {
         stagedPublish: { provenance },
       },
     });
+    await createDb(env.DB)
+      .update(schema.scans)
+      .set({
+        decision: "publish",
+        decidedByUserId: owner.userId,
+        decidedAt: new Date("2026-08-02T00:00:00.000Z"),
+      })
+      .where(eq(schema.scans.id, scanId));
     const receipt = (await (
       await request(appFor(owner), scanId, "release-receipt.json")
     ).json()) as any;
@@ -294,6 +303,60 @@ describe("canonical release receipt v1", () => {
       status: "unknown",
       observation: null,
     });
+  });
+
+  test("marks pending gates and malformed artifact digests as incomplete evidence", async () => {
+    const owner = await seedOwner();
+    const gateId = await seedGate(owner);
+    const db = createDb(env.DB);
+    await db
+      .update(schema.githubWorkflowGates)
+      .set({ status: "pending", decision: null, decidedAt: null })
+      .where(eq(schema.githubWorkflowGates.id, gateId));
+    const scanId = await seedCompleted(owner, {
+      source: "workflow_gate",
+      gateId,
+      summary: {
+        intentEnvelope: {
+          tier: "attested",
+          repository: "https://github.com/octo/release",
+          signals: [],
+        },
+        stagedPublish: {
+          provenance: {
+            ecosystem: "pypi",
+            mode: "workflow_gate",
+            artifacts: [{ path: "dist/example.whl", kind: "wheel", sha256: "not-a-digest" }],
+          },
+        },
+      },
+    });
+
+    const receipt = (await (
+      await request(appFor(owner), scanId, "release-receipt.json")
+    ).json()) as any;
+    expect(receipt.content.evidence.status).toBe("conflicting");
+    expect(receipt.content.evidence.reviewedArtifacts.status).toBe("conflicting");
+    expect(receipt.content.evidence.workflowGate.status).toBe("partial");
+    expect(receipt.content.evidence.releaseDecision.status).toBe("unknown");
+  });
+
+  test("keeps incomplete and cross-organization scans outside the receipt boundary", async () => {
+    const owner = await seedOwner();
+    const outsider = await seedOwner();
+    const completeScanId = await seedCompleted(owner);
+    expect((await request(appFor(outsider), completeScanId, "release-receipt.json")).status).toBe(
+      404,
+    );
+
+    const pendingScanId = `scan_${crypto.randomUUID()}`;
+    await createScanJob(createDb(env.DB), {
+      id: pendingScanId,
+      stageId: `stage_${crypto.randomUUID()}`,
+      organizationId: owner.organizationId,
+      ownerUserId: owner.userId,
+    });
+    expect((await request(appFor(owner), pendingScanId, "release-receipt.json")).status).toBe(409);
   });
 
   test("uses explicit unknowns and partial completeness for legacy missing evidence", async () => {

--- a/test/workers/release-receipt.test.ts
+++ b/test/workers/release-receipt.test.ts
@@ -1,0 +1,317 @@
+import { createExecutionContext, env, waitOnExecutionContext } from "cloudflare:test";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { describe, expect, test } from "vitest";
+import { createDb } from "../../server/db/client";
+import { ensurePersonalOrganization } from "../../server/db/organizations";
+import { createScanJob } from "../../server/db/scans";
+import * as schema from "../../server/db/schema";
+import { sha256Hex } from "../../server/lib/platform/crypto-utils";
+import { stableJson } from "../../server/lib/platform/stable-json";
+import { scansRoutes } from "../../server/routes/scans";
+import type { Bindings, Variables } from "../../server/types";
+import { persistScanWithArtifacts } from "./helpers/persist-scan";
+
+interface Owner {
+  userId: string;
+  organizationId: string;
+}
+
+async function seedOwner(): Promise<Owner> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Receipt tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  return { userId, organizationId: (await ensurePersonalOrganization(db, { userId }))! };
+}
+
+function appFor(owner: Owner) {
+  const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+  app.use("*", async (c, next) => {
+    c.set("authSession", { userId: owner.userId });
+    await next();
+  });
+  app.route("/api/v1/scans", scansRoutes);
+  return app;
+}
+
+async function request(app: ReturnType<typeof appFor>, scanId: string, artifact: string) {
+  const ctx = createExecutionContext();
+  const response = await app.fetch(
+    new Request(`http://test.local/api/v1/scans/${scanId}/${artifact}`),
+    env,
+    ctx,
+  );
+  await waitOnExecutionContext(ctx);
+  return response;
+}
+
+async function seedCompleted(
+  owner: Owner,
+  options: {
+    source?: "manual" | "workflow_gate";
+    gateId?: string;
+    summary?: Record<string, unknown>;
+  } = {},
+) {
+  const db = createDb(env.DB);
+  const scanId = `scan_${crypto.randomUUID()}`;
+  const stageId = `stage_${crypto.randomUUID()}`;
+  await createScanJob(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+    source: options.source,
+    gateId: options.gateId,
+  });
+  await persistScanWithArtifacts(db, {
+    id: scanId,
+    stageId,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+    packageJson: { name: "@receipt/example", version: "2.0.0" },
+    previousPackageJson: { name: "@receipt/example", version: "1.0.0" },
+    risk: "medium",
+    status: "complete",
+    summary: {
+      report: {
+        version: 1,
+        digest: "persisted-report-digest",
+        digestAlgorithm: "sha256",
+        generatedAt: "2026-08-01T00:00:00.000Z",
+        rulesVersion: "1.8.0",
+      },
+      ...options.summary,
+    },
+    ai: null,
+    files: [],
+    diff: [],
+    findings: [],
+  });
+  return scanId;
+}
+
+async function seedGate(owner: Owner) {
+  const db = createDb(env.DB);
+  const now = new Date("2026-08-02T00:00:00.000Z");
+  const installationId = crypto.randomUUID();
+  const releaseTargetId = crypto.randomUUID();
+  const gateId = crypto.randomUUID();
+  await db.insert(schema.githubAppInstallations).values({
+    id: installationId,
+    organizationId: owner.organizationId,
+    installationId: "12345",
+    accountLogin: "octo",
+    accountType: "Organization",
+    targetType: "Organization",
+    status: "active",
+    installedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  });
+  await db.insert(schema.githubReleaseTargets).values({
+    id: releaseTargetId,
+    organizationId: owner.organizationId,
+    installationRowId: installationId,
+    ecosystem: "pypi",
+    repositoryId: 42,
+    repositoryFullName: "octo/release",
+    environment: "production",
+    createdAt: now,
+    updatedAt: now,
+  });
+  await db.insert(schema.githubWorkflowGates).values({
+    id: gateId,
+    organizationId: owner.organizationId,
+    installationRowId: installationId,
+    releaseTargetId,
+    deliveryId: crypto.randomUUID(),
+    repositoryId: 42,
+    repositoryFullName: "octo/release",
+    environment: "production",
+    runId: 987654,
+    deploymentId: 123,
+    deploymentCallbackUrl:
+      "https://api.github.com/repos/octo/release/actions/runs/987654/deployment_protection_rule",
+    eventAction: "requested",
+    status: "approved",
+    decision: "approved",
+    decidedAt: now,
+    requestedAt: now,
+    createdAt: now,
+    updatedAt: now,
+  });
+  return gateId;
+}
+
+describe("canonical release receipt v1", () => {
+  test("is deterministic and binds both its content address and exact report bytes", async () => {
+    const owner = await seedOwner();
+    const scanId = await seedCompleted(owner, {
+      summary: {
+        intentEnvelope: {
+          tier: "declared",
+          repository: "https://github.com/octo/release",
+          signals: [{ kind: "manifest-repository", detail: "package manifest repository" }],
+        },
+        stagedPublish: {
+          artifactIntegrity: {
+            algorithm: "sha1",
+            status: "verified",
+            declared: "a".repeat(40),
+            computed: "a".repeat(40),
+          },
+        },
+      },
+    });
+    const app = appFor(owner);
+    const first = await request(app, scanId, "release-receipt.json");
+    const bytes = await first.text();
+    const second = await request(app, scanId, "release-receipt.json");
+    expect(await second.text()).toBe(bytes);
+
+    const document = JSON.parse(bytes) as any;
+    expect(document.schema).toBe("drydock.release-receipt.v1");
+    expect(document.address.value).toBe(await sha256Hex(stableJson(document.content)));
+    expect(first.headers.get("x-drydock-receipt-sha256")).toBe(await sha256Hex(bytes));
+    expect(first.headers.get("etag")).toBe(`"sha256:${await sha256Hex(bytes)}"`);
+
+    const report = await request(app, scanId, "report.json");
+    expect(document.content.report).toEqual({
+      schema: "drydock.report.v2",
+      digest: { algorithm: "sha256", value: await sha256Hex(await report.text()) },
+    });
+  });
+
+  test("keeps staged controls distinct from registry observation", async () => {
+    const owner = await seedOwner();
+    const scanId = await seedCompleted(owner, {
+      summary: {
+        intentEnvelope: { tier: "absent", repository: null, signals: [] },
+        stagedPublish: {
+          artifactIntegrity: {
+            algorithm: "sha1",
+            status: "verified",
+            declared: "b".repeat(40),
+            computed: "b".repeat(40),
+          },
+        },
+      },
+    });
+    const db = createDb(env.DB);
+    await db
+      .update(schema.scans)
+      .set({
+        decision: "publish",
+        decidedByUserId: owner.userId,
+        decidedAt: new Date("2026-08-03T00:00:00.000Z"),
+        registryVersionStatus: "published",
+        registryVersionStatusAt: new Date("2026-08-04T00:00:00.000Z"),
+      })
+      .where(eq(schema.scans.id, scanId));
+
+    const response = await request(appFor(owner), scanId, "release-receipt.json");
+    const receipt = (await response.json()) as any;
+    expect(receipt.content.release).toMatchObject({
+      mode: "staged_publish",
+      source: "manual",
+      control: { classification: "advisory", scope: "registry_stage_observation" },
+      decision: {
+        outcome: "publish",
+        decidedAt: "2026-08-03T00:00:00.000Z",
+        reviewer: { kind: "drydock_user", id: owner.userId },
+      },
+    });
+    expect(receipt.content.evidence.status).toBe("complete");
+    expect(receipt.content.evidence.workflowGate).toEqual({
+      status: "not_applicable",
+      identity: null,
+      decision: null,
+      callback: null,
+    });
+    expect(receipt.content.evidence.registryOutcome).toEqual({
+      status: "complete",
+      observation: { status: "published", observedAt: "2026-08-04T00:00:00.000Z" },
+    });
+  });
+
+  test("binds workflow identity and durable decision without claiming callback delivery", async () => {
+    const owner = await seedOwner();
+    const gateId = await seedGate(owner);
+    const provenance = {
+      ecosystem: "pypi",
+      mode: "workflow_gate",
+      artifacts: [
+        { path: "dist/example-2.0.0.whl", kind: "wheel", sha256: "c".repeat(64) },
+        { path: "dist/example-2.0.0.tar.gz", kind: "sdist", sha256: "d".repeat(64) },
+      ],
+    };
+    const scanId = await seedCompleted(owner, {
+      source: "workflow_gate",
+      gateId,
+      summary: {
+        intentEnvelope: {
+          tier: "attested",
+          repository: "https://github.com/octo/release",
+          signals: [{ kind: "workflow-gate", detail: "octo/release run 987654 production" }],
+        },
+        stagedPublish: { provenance },
+      },
+    });
+    const receipt = (await (
+      await request(appFor(owner), scanId, "release-receipt.json")
+    ).json()) as any;
+
+    expect(receipt.content.release.mode).toBe("workflow_gate");
+    expect(receipt.content.release.control).toEqual({
+      classification: "workflow_enforced",
+      scope: "configured_publish_workflow",
+    });
+    expect(receipt.content.evidence.reviewedArtifacts).toEqual({
+      status: "complete",
+      provenance,
+      stagedArtifactIntegrity: null,
+    });
+    expect(receipt.content.evidence.workflowGate).toEqual({
+      status: "complete",
+      identity: { repository: "octo/release", runId: 987654, environment: "production" },
+      decision: {
+        status: "approved",
+        outcome: "approved",
+        decidedAt: "2026-08-02T00:00:00.000Z",
+      },
+      callback: { outcome: "unknown", observedAt: null },
+    });
+    expect(receipt.content.evidence.registryOutcome).toEqual({
+      status: "unknown",
+      observation: null,
+    });
+  });
+
+  test("uses explicit unknowns and partial completeness for legacy missing evidence", async () => {
+    const owner = await seedOwner();
+    const scanId = await seedCompleted(owner);
+    const receipt = (await (
+      await request(appFor(owner), scanId, "release-receipt.json")
+    ).json()) as any;
+    expect(receipt.content.evidence.status).toBe("partial");
+    expect(receipt.content.evidence.reviewedArtifacts).toEqual({
+      status: "unknown",
+      provenance: null,
+      stagedArtifactIntegrity: null,
+    });
+    expect(receipt.content.evidence.intentBinding).toEqual({ status: "unknown", envelope: null });
+    expect(receipt.content.evidence.registryOutcome).toEqual({
+      status: "unknown",
+      observation: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add an authenticated, organization-scoped `drydock.release-receipt.v1` download for completed scans.
- Bind exact canonical `drydock.report.v2` bytes, reviewed artifact evidence, intent binding, decision/reviewer, workflow identity and gate result, callback uncertainty, and observed registry state.
- Label controls narrowly: workflow enforcement applies only to the configured publish workflow; staged registry review remains advisory.
- Keep the receipt unsigned while the schema stabilizes. Existing public report and DSSE attestation behavior remains separate.

## Canonicalization and evidence semantics

- Canonical JSON uses deterministic code-point ordering rather than locale-sensitive sorting, preserving existing `drydock.report.v2` byte ordering across runtimes.
- The receipt address hashes canonical `content`; the response header/ETag/filename carry the full-document SHA-256 without a recursive self-hash claim.
- Pending or errored workflow gates are partial, not complete.
- Release-decision evidence is complete only when outcome, timestamp, and reviewer are present.
- Malformed workflow provenance SHA-256 values are conflicting evidence, never complete.
- Callback delivery remains explicitly unknown because it is not durably observed.

## Access boundary

- No public receipt route is added.
- Organization resolution reuses the existing scan access boundary.
- Regression coverage includes cross-organization denial and incomplete-scan refusal.

## Verification

- Canonical JSON tests: passed.
- Receipt and report-export Worker tests: passed.
- `pnpm run knip`: passed.
- `pnpm run verify`: passed.
- GitHub CI, e2e, detection evaluation, Aikido, and Workers build: passed on `b592f688`.

No merge performed.