### PR TITLE
Shrink the flaky live-replacement starvation test so it cannot time out in CI

### DIFF
--- a/test/workers/registry-version-status.test.ts
+++ b/test/workers/registry-version-status.test.ts
@@ -806,20 +806,21 @@ describe("registry version status resolution", () => {
   });
 
   test("retires live replacements before the lookup limit so they cannot starve the backlog", async () => {
+    // The two oldest reviews are re-staged; the newest one is not. Oldest-first
+    // ordering means the replaced pair would fill a limit of two and starve the
+    // live review unless they are retired before the lookup query runs.
     const org = await seedOrg();
-    const scans = [];
-    for (let index = 0; index < 17; index++) {
-      scans.push(await seedCompletedScan(org, { version: `2.0.${index}` }));
-    }
+    const now = new Date();
+    const minuteAgo = (minutes: number) => new Date(now.getTime() - minutes * 60 * 1000);
+    const replaced = [
+      await seedCompletedScan(org, { version: "2.0.0", createdAt: minuteAgo(3) }),
+      await seedCompletedScan(org, { version: "2.0.1", createdAt: minuteAgo(2) }),
+    ];
+    const live = await seedCompletedScan(org, { version: "2.0.2", createdAt: minuteAgo(1) });
     const fetchMock = stubRegistry((url) => {
       const version = decodeURIComponent(new URL(url).pathname.split("/").at(-2)!);
       return statusResponse("published", PACKAGE, version);
     });
-    const stagedItems = scans.slice(1).map(({ stageId }, index) => ({
-      id: `${stageId}-replacement`,
-      packageName: PACKAGE,
-      version: `2.0.${index + 1}`,
-    }));
 
     const result = await resolveNpmReleaseOutcomes({
       db: createDb(env.DB),
@@ -827,13 +828,20 @@ describe("registry version status resolution", () => {
       organizationId: org.organizationId,
       ownerUserId: org.userId,
       connection: { token: TOKEN, registryUrl: REGISTRY_URL },
-      stagedItems,
+      stagedItems: replaced.map(({ stageId }, index) => ({
+        id: `${stageId}-replacement`,
+        packageName: PACKAGE,
+        version: `2.0.${index}`,
+      })),
+      now,
+      lookupLimit: 2,
     });
 
     expect(result).toMatchObject({ checked: 1, resolved: 1 });
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect((await readScan(scans[0]!.scanId)).registryVersionStatus).toBe("published");
-    for (const scan of scans.slice(1)) {
+    expect(String(fetchMock.mock.calls[0]![0])).toContain("/2.0.2/status");
+    expect((await readScan(live.scanId)).registryVersionStatus).toBe("published");
+    for (const scan of replaced) {
       expect((await readScan(scan.scanId)).registryStatusSupersededAt).toBeTruthy();
     }
   });


### PR DESCRIPTION
## Summary

The "retires live replacements before the lookup limit" test in `test/workers/registry-version-status.test.ts` seeded 17 scans sequentially through D1 and R2 and timed out at 5s on a loaded CI runner (seen on #659, which does not touch this code). It also never proved starvation: the sweep orders candidates oldest-first and the unreplaced scan was the oldest, so it was checked whether or not the supersede ran before the lookup query. The test now seeds three scans with `lookupLimit: 2`, re-stages the two oldest, and leaves the newest live, so it runs in ~100ms and fails with `checked: 0` if the supersede is moved after the query (verified by mutation; the original test passed under that mutation).

## Trust boundary

none

## Verification

- `pnpm run verify` (lint, format, typecheck, knip, node + workers tests) passes.
- Mutation check: moved `supersedeRegistryReleaseIncarnations` after `listScansAwaitingRegistryStatus`; new test fails, original test passed. Source restored.

## Documentation

docs checked, no update needed

## UI evidence

not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)