### PR TITLE
Show newly discovered reviews immediately

### DIFF
--- a/src/models/scan-list-model.ts
+++ b/src/models/scan-list-model.ts
@@ -20,6 +20,8 @@ import { errorMessage } from "./api";
 interface ScanListRefreshOptions {
   /** Keep every page the user has already loaded instead of returning to page one. */
   preserveLoaded?: boolean;
+  /** Also reveal this many newly created rows without making the user paginate. */
+  includeNewItems?: number;
 }
 
 const LIST_SCANS_REFRESH_LIMIT = 100;
@@ -68,19 +70,20 @@ export const ScanListModel = createModel(() => {
     const organizationId = activeOrganizationId.peek();
     const currentFilter = filter.peek();
     const loadedCount = options.preserveLoaded ? scans.peek().length : 0;
+    const requestedCount = loadedCount + Math.max(0, options.includeNewItems ?? 0);
     refreshing.value = true;
     try {
       const firstLimit =
-        loadedCount > 0 ? Math.min(LIST_SCANS_REFRESH_LIMIT, loadedCount) : undefined;
+        loadedCount > 0 ? Math.min(LIST_SCANS_REFRESH_LIMIT, requestedCount) : undefined;
       const firstPage = await listScans({ filter: currentFilter, limit: firstLimit });
       if (!isCurrentRefresh(requestId, mutationId, organizationId)) return;
       const refreshed = [...firstPage.scans];
       let cursor = firstPage.nextCursor;
-      while (options.preserveLoaded && refreshed.length < loadedCount && cursor) {
+      while (options.preserveLoaded && refreshed.length < requestedCount && cursor) {
         const page = await listScans({
           cursor,
           filter: currentFilter,
-          limit: Math.min(LIST_SCANS_REFRESH_LIMIT, loadedCount - refreshed.length),
+          limit: Math.min(LIST_SCANS_REFRESH_LIMIT, requestedCount - refreshed.length),
         });
         if (!isCurrentRefresh(requestId, mutationId, organizationId)) return;
         refreshed.push(...page.scans);
@@ -269,6 +272,13 @@ export const ScanListModel = createModel(() => {
     hasAnyScan,
     hasAnyDecision,
     refresh,
+
+    async refreshAfterDiscovery(createdScanCount: number): Promise<void> {
+      const activeFilter = filter.peek();
+      const newlyMatchingItems =
+        activeFilter === "undecided" || activeFilter === "all" ? createdScanCount : 0;
+      await refresh({ preserveLoaded: true, includeNewItems: newlyMatchingItems });
+    },
 
     /**
      * Settle the funnel's last step. Called by the getting-started panel only,

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -250,7 +250,7 @@ async function discoverStagedPublishes(
   scans: ReturnType<typeof useModel<typeof ScanListModel.prototype>>,
 ) {
   const result = await stagedPublishes.discover();
-  await scans.refresh({ preserveLoaded: true });
+  await scans.refreshAfterDiscovery(result?.created ?? 0);
   if (result) scans.scheduleRegistryStatusRefreshes();
 }
 

--- a/test/scan-list-model.test.ts
+++ b/test/scan-list-model.test.ts
@@ -537,6 +537,59 @@ describe("ScanListModel registry status refreshes", () => {
     expect(model.nextCursor.value).toBe("cursor-after-refresh");
   });
 
+  test.each(["undecided", "all"] as const)(
+    "reveals newly discovered reviews in the %s list without another pagination step",
+    async (filter) => {
+      const existingScans = [
+        { ...scanDetail(null).scan, id: "scan-a" },
+        { ...scanDetail(null).scan, id: "scan-b" },
+      ];
+      const refreshedScans = [{ ...scanDetail(null).scan, id: "scan-new" }, ...existingScans];
+      const fetchMock = vi.fn(() =>
+        Promise.resolve(jsonResponse({ scans: refreshedScans, nextCursor: null })),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      model = new ScanListModel();
+      model.filter.value = filter;
+      model.scans.value = existingScans;
+      model.nextCursor.value = "cursor-b";
+
+      await model.refreshAfterDiscovery(1);
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/api/v1/scans?filter=${filter}&limit=3`,
+        expect.any(Object),
+      );
+      expect(model.scans.value.map((scan) => scan.id)).toEqual(["scan-new", "scan-a", "scan-b"]);
+      expect(model.nextCursor.value).toBeNull();
+    },
+  );
+
+  test.each(["published_without_decision", "publish", "no_publish"] as const)(
+    "does not expand the %s list for newly discovered undecided reviews",
+    async (filter) => {
+      const existingScans = [
+        { ...scanDetail(null).scan, id: "scan-a" },
+        { ...scanDetail(null).scan, id: "scan-b" },
+      ];
+      const fetchMock = vi.fn(() =>
+        Promise.resolve(jsonResponse({ scans: existingScans, nextCursor: "cursor-b" })),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+      model = new ScanListModel();
+      model.filter.value = filter;
+      model.scans.value = existingScans;
+
+      await model.refreshAfterDiscovery(1);
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/api/v1/scans?filter=${filter}&limit=2`,
+        expect.any(Object),
+      );
+      expect(model.scans.value).toHaveLength(2);
+    },
+  );
+
   test("ignores pagination that an overlapping refresh superseded", async () => {
     const loadMoreResponse = deferred<Response>();
     const refreshResponse = deferred<Response>();


### PR DESCRIPTION
## Summary

Expand the post-discovery refresh so newly created npm reviews appear immediately instead of remaining behind pagination.

## Trust boundary

None.

## Verification

`pnpm run verify` passed, including lint, formatting, typecheck, knip, and Node/Worker tests; adversarial diff review also passed.

## Documentation

Docs checked, no update needed.

## UI evidence

Not captured; the behavior is covered by scan-list model regression tests.