### PR TITLE
Let AI Gateway logs keep the reviewer's request and response bodies

### DIFF
--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -98,6 +98,14 @@ no-package-content rule; a maintainer decision is feedback, never an automatic
 truth label. See
 [`ai-review-eval.md`](./ai-review-eval.md).
 
+AI Gateway logs are the one deliberate exception: request and response bodies
+are retained there, so the changed-file evidence in a prompt and the model's raw
+output are readable to anyone with Cloudflare account access. That is the point
+— the reviewer is only debuggable if its actual inputs and outputs can be
+inspected. It does not widen the prompt itself, which still carries only minimum
+changed-file evidence and never credentials, sessions, or raw headers. Agent
+Traces stay payload-free regardless.
+
 For npm registry tarballs, consumer install lifecycle hooks are `preinstall`, `install`, and `postinstall`. `prepare`, `prepack`, `postpack`, and publish/prepublish hooks are packaging-time hooks and should not be treated as consumer-install evidence unless other evidence shows they changed the shipped artifact.
 
 ## Authorization posture

--- a/server/lib/ai-review/index.ts
+++ b/server/lib/ai-review/index.ts
@@ -439,9 +439,6 @@ export function aiReviewRequestHeaders(
   return {
     "x-session-affinity": scanScopedCacheAffinity(env, options.scanId),
     "cf-aig-metadata": aiGatewayMetadataHeader(options, model, attempt),
-    // Gateway metrics stay available without retaining private package evidence
-    // from the request and response bodies.
-    "cf-aig-collect-log-payload": "false",
     // Account-level Gateway retries would be invisible to per-attempt usage
     // accounting. One Gateway attempt leaves retry/fallback ownership here.
     "cf-aig-max-attempts": "1",

--- a/test/ai-review.test.mjs
+++ b/test/ai-review.test.mjs
@@ -304,11 +304,11 @@ describe("ai review orchestration", () => {
     });
   });
 
-  test("keeps Gateway logs metadata-only and disables hidden retries", () => {
-    expect(aiReviewRequestHeaders({}, BASE_OPTIONS, AI_MODEL, 1)).toMatchObject({
-      "cf-aig-collect-log-payload": "false",
-      "cf-aig-max-attempts": "1",
-    });
+  test("disables hidden Gateway retries and keeps request/response logging on", () => {
+    const headers = aiReviewRequestHeaders({}, BASE_OPTIONS, AI_MODEL, 1);
+
+    expect(headers).toMatchObject({ "cf-aig-max-attempts": "1" });
+    expect(headers).not.toHaveProperty("cf-aig-collect-log-payload");
   });
 
   test("Agent Trace metadata is versioned and excludes review-record identifiers", () => {


### PR DESCRIPTION
## Summary

`aiReviewRequestHeaders` sent `cf-aig-collect-log-payload: false`, which kept Gateway metrics but discarded the prompt and the model's reply — leaving no way to read what the reviewer was actually shown or what it actually answered. This drops that header so AI Gateway retains request and response bodies for review calls; `cf-aig-max-attempts: "1"` and the metadata header are unchanged.

## Trust boundary

AI review data retention. Prompts carry changed-file evidence from scanned packages, including private staged ones, and that evidence is now readable in the Gateway log to anyone with Cloudflare account access. The prompt contents themselves are unchanged (still minimum changed-file evidence, never credentials, sessions, or raw headers), and Agent Traces stay payload-free — `storeMessages`/`storeTools` and `recordInputs`/`recordOutputs` are still disabled.

## Verification

`pnpm run verify` passes (lint, format:check, typecheck, knip, full node + workers suites). The header test was inverted rather than deleted: it now asserts `cf-aig-collect-log-payload` is absent, so a silent re-add fails.

## Documentation

`docs/security-model.md` — the AI review section now records Gateway log payload retention as a deliberate exception and why.

## UI evidence

Not applicable.