### PR TITLE
Add the dashboard overview strip

### DIFF
--- a/docs/registry-version-status.md
+++ b/docs/registry-version-status.md
@@ -47,6 +47,9 @@ therefore collapses to "we do not know":
   reassurance. `RegistryStatusNotice` and `registryStatusVariant` own that rule.
 - A `staged` status with no decision recorded also renders nothing: that is the
   normal resting state of a release under review.
+- The dashboard overview strip (`server/db/scan-overview.ts`, `docs/ui.md`)
+  counts a null status only as "not settled" alongside `staged` and
+  `validating`; it never becomes a tile of its own.
 
 ## Where it runs
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -70,6 +70,29 @@ Both review pages lead with the diff:
   `DiffView` keeps a `modified` file rendered from one side neutral instead of
   tinting every row as an insertion.
 
+## Dashboard overview strip
+
+`src/features/overview/OverviewStrip.tsx` sits above Recent reviews and answers
+"what is waiting on me, and is it approvable yet" for the active organization.
+npm now stages every trusted-publishing release and holds stage approval until
+its own malware scan settles, so every release sits in a window; the strip is
+that window as four tiles, each a link into the matching `?filter=` on the
+list: **Waiting on you** (completed npm reviews with no decision whose npm
+status is unknown, `staged`, or `validating`, with the age of the oldest),
+**npm still scanning** (`validating`, with how many already have a finished
+Drydock review), **Published, no decision** (the list's
+`published_without_decision` semantics, limited to scans created in the last 30
+days), and **Decided · 30d** (approved vs rejected plus the median
+completion-to-decision time). The first three count only npm staged-publish
+sources (`manual`, `auto_discovery`); workflow-gate and published-pair scans
+carry no npm stage. `ScanOverviewModel` (`src/models/scan-overview.ts`) reads
+`GET /api/v1/scans/overview`, one aggregate D1 statement in
+`server/db/scan-overview.ts`; the dashboard re-reads it whenever the list
+changes and joins an in-flight request rather than repeating it. The strip is
+absent for an organization with no scans, keeps its previous figures while a
+refresh is in flight, and renders a mono loading or error line otherwise. Tiles
+are mono tabular numbers under an 11px mono label, on a 2x2 grid below `lg`.
+
 ## Dashboard onboarding funnel
 
 `src/pages/Dashboard/GettingStarted.tsx` tracks three steps: npm connected, a

--- a/server/db/scan-overview.ts
+++ b/server/db/scan-overview.ts
@@ -1,0 +1,138 @@
+/**
+ * The organization-scoped dashboard overview: what is waiting on a reviewer,
+ * what npm is still validating, what went live without a decision, and how
+ * quickly decisions land. One aggregate statement, one round trip.
+ *
+ * Only npm staged-publish scans feed the npm-status figures. Workflow-gate
+ * scans may describe PyPI or VS Code releases and published-pair reviews have
+ * no stage, so npm's lifecycle status means nothing for either.
+ */
+import { and, eq, inArray, isNull, or, sql, type SQL } from "drizzle-orm";
+import { NPM_RELEASE_OUTCOME_FAILURE_CODES } from "../lib/ecosystems/npm/version-status";
+import type { AppDb } from "./client";
+import { scans } from "./schema";
+
+const SCAN_OVERVIEW_WINDOW_DAYS = 30;
+const WINDOW_MS = SCAN_OVERVIEW_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+
+const NPM_STAGED_SOURCES = ["manual", "auto_discovery"] as const;
+
+export interface ScanOverview {
+  totalScans: number;
+  windowDays: number;
+  /** Completed npm reviews with no decision whose stage npm has not settled. */
+  waiting: { count: number; oldestCompletedAt: string | null };
+  /** npm reviews whose last known status is `validating`; `reviewReady` are those Drydock has finished. */
+  validating: { count: number; reviewReady: number };
+  /** Went live without a decision, created inside the window. Mirrors the list filter of the same name. */
+  publishedWithoutDecision: { count: number };
+  decided: {
+    count: number;
+    approved: number;
+    rejected: number;
+    /** Median completion-to-decision time over decisions inside the window, or null when none carry both timestamps. */
+    medianDecisionMs: number | null;
+  };
+}
+
+function countWhere(condition: SQL): SQL<number> {
+  return sql<number>`coalesce(sum(case when ${condition} then 1 else 0 end), 0)`;
+}
+
+export async function getScanOverview(
+  db: AppDb,
+  organizationId: string,
+  options: { now?: Date } = {},
+): Promise<ScanOverview> {
+  const now = options.now ?? new Date();
+  const windowStart = new Date(now.getTime() - WINDOW_MS);
+  const windowStartMs = windowStart.getTime();
+
+  const npmStaged = inArray(scans.source, [...NPM_STAGED_SOURCES]);
+  const notSuperseded = isNull(scans.registryStatusSupersededAt);
+  const undecided = isNull(scans.decision);
+  const registryFailureCode = sql<string | null>`json_extract(${scans.errorJson}, '$.code')`;
+
+  const waiting = and(
+    npmStaged,
+    notSuperseded,
+    undecided,
+    eq(scans.status, "complete"),
+    or(
+      isNull(scans.registryVersionStatus),
+      inArray(scans.registryVersionStatus, ["staged", "validating"]),
+    ),
+  )!;
+  const validating = and(npmStaged, notSuperseded, eq(scans.registryVersionStatus, "validating"))!;
+  const validatingReviewReady = and(validating, eq(scans.status, "complete"))!;
+  const publishedWithoutDecision = and(
+    npmStaged,
+    notSuperseded,
+    undecided,
+    sql`${scans.createdAt} >= ${windowStartMs}`,
+    or(
+      inArray(scans.registryVersionStatus, ["published", "deleted"]),
+      inArray(registryFailureCode, [
+        NPM_RELEASE_OUTCOME_FAILURE_CODES.published,
+        NPM_RELEASE_OUTCOME_FAILURE_CODES.deleted,
+      ]),
+    ),
+  )!;
+  const decided = sql`${scans.decidedAt} >= ${windowStartMs}`;
+  const decidedApproved = and(decided, eq(scans.decision, "publish"))!;
+  const decidedRejected = and(decided, eq(scans.decision, "no_publish"))!;
+
+  // SQLite has no median aggregate. The ordered scalar subquery below reads the
+  // middle one or two deltas; the outer `avg` collapses both parities.
+  const medianDeltaFilter = sql`${scans.organizationId} = ${organizationId} and ${scans.decidedAt} >= ${windowStartMs} and ${scans.completedAt} is not null`;
+  const medianDecisionMs = sql<number | null>`(
+    select avg(delta) from (
+      select ${scans.decidedAt} - ${scans.completedAt} as delta
+      from ${scans}
+      where ${medianDeltaFilter}
+      order by delta
+      limit 2 - (select count(*) from ${scans} where ${medianDeltaFilter}) % 2
+      offset (select (count(*) - 1) / 2 from ${scans} where ${medianDeltaFilter})
+    )
+  )`;
+
+  const [row] = await db
+    .select({
+      totalScans: sql<number>`count(*)`,
+      waitingCount: countWhere(waiting),
+      waitingOldestCompletedAt: sql<
+        number | null
+      >`min(case when ${waiting} then ${scans.completedAt} end)`,
+      validatingCount: countWhere(validating),
+      validatingReviewReady: countWhere(validatingReviewReady),
+      publishedWithoutDecisionCount: countWhere(publishedWithoutDecision),
+      decidedCount: countWhere(decided),
+      decidedApproved: countWhere(decidedApproved),
+      decidedRejected: countWhere(decidedRejected),
+      medianDecisionMs,
+    })
+    .from(scans)
+    .where(eq(scans.organizationId, organizationId));
+
+  const oldest = row?.waitingOldestCompletedAt;
+  const median = row?.medianDecisionMs;
+  return {
+    totalScans: Number(row?.totalScans ?? 0),
+    windowDays: SCAN_OVERVIEW_WINDOW_DAYS,
+    waiting: {
+      count: Number(row?.waitingCount ?? 0),
+      oldestCompletedAt: typeof oldest === "number" ? new Date(oldest).toISOString() : null,
+    },
+    validating: {
+      count: Number(row?.validatingCount ?? 0),
+      reviewReady: Number(row?.validatingReviewReady ?? 0),
+    },
+    publishedWithoutDecision: { count: Number(row?.publishedWithoutDecisionCount ?? 0) },
+    decided: {
+      count: Number(row?.decidedCount ?? 0),
+      approved: Number(row?.decidedApproved ?? 0),
+      rejected: Number(row?.decidedRejected ?? 0),
+      medianDecisionMs: typeof median === "number" ? Math.round(median) : null,
+    },
+  };
+}

--- a/server/db/scans.ts
+++ b/server/db/scans.ts
@@ -27,6 +27,8 @@ export {
 
 export { LIST_SCANS_DEFAULT_LIMIT, LIST_SCANS_MAX_LIMIT, listScans } from "./scan-list";
 
+export { getScanOverview, type ScanOverview } from "./scan-overview";
+
 export { getScan, getScanCompareData, getScanFile, getScanStatus } from "./scan-detail";
 
 export {

--- a/server/index.ts
+++ b/server/index.ts
@@ -332,6 +332,7 @@ app.get("/api", (c) =>
     endpoints: {
       createScan: "POST /api/v1/scans { stageId }",
       scans: "GET /api/v1/scans",
+      scanOverview: "GET /api/v1/scans/overview",
       scanDetail: "GET /api/v1/scans/:id",
       stagedPublishes: "POST /api/v1/staged-publishes/scan",
       npmConnection: "GET/POST/DELETE /api/v1/npm-connection; POST /api/v1/npm-connection/validate",

--- a/server/routes/scans/index.ts
+++ b/server/routes/scans/index.ts
@@ -5,17 +5,21 @@
  * sharing the result, or diffing versions. No router-level middleware — each
  * handler establishes its own organization context — so the groups compose
  * without ordering constraints. Registration order is preserved anyway so the
- * route table stays byte-identical to the pre-split file.
+ * route table stays byte-identical to the pre-split file, with one exception:
+ * the literal `/overview` path registers before lifecycle's `GET /:id`, which
+ * would otherwise capture it as a scan id.
  */
 import { Hono } from "hono";
 import type { Bindings, Variables } from "../../types";
 import { scanCompareRoutes } from "./compare";
 import { scanDecisionRoutes } from "./decisions";
 import { scanLifecycleRoutes } from "./lifecycle";
+import { scanOverviewRoutes } from "./overview";
 import { scanSharingRoutes } from "./sharing";
 
 export const scansRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
 
+scansRoutes.route("/", scanOverviewRoutes);
 scansRoutes.route("/", scanLifecycleRoutes);
 scansRoutes.route("/", scanDecisionRoutes);
 scansRoutes.route("/", scanSharingRoutes);

--- a/server/routes/scans/overview.ts
+++ b/server/routes/scans/overview.ts
@@ -1,0 +1,18 @@
+/**
+ * The dashboard overview strip: aggregate counts for the active organization.
+ *
+ * Read-only and organization-scoped like the list; nothing here names a scan.
+ */
+import { Hono } from "hono";
+import { createDb } from "../../db/client";
+import { getScanOverview } from "../../db/scans";
+import { requireActiveOrganization } from "../../lib/auth/active-organization";
+import type { Bindings, Variables } from "../../types";
+
+export const scanOverviewRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+
+scanOverviewRoutes.get("/overview", async (c) => {
+  const db = createDb(c.env.DB);
+  const organizationId = await requireActiveOrganization(c, db);
+  return c.json(await getScanOverview(db, organizationId));
+});

--- a/src/features/overview/OverviewStrip.tsx
+++ b/src/features/overview/OverviewStrip.tsx
@@ -1,0 +1,88 @@
+/**
+ * The dashboard overview strip: four call-to-action tiles above Recent reviews.
+ *
+ * Every npm-status figure comes from the persisted registry status, and an
+ * unknown status is counted only as "not settled" — it is never shown as a
+ * verdict. The strip is absent for an organization with no scans, and a
+ * refresh keeps the previous figures on screen so the layout never jumps.
+ *
+ * Each tile is a plain link to the dashboard with the matching `?filter=`;
+ * the list's filter is two-way bound to that query parameter, so following
+ * the link applies the filter without a second code path.
+ */
+import { useComputed, useSignal, type ReadonlySignal } from "@preact/signals";
+import { Show } from "@preact/signals/utils";
+import { useEffect } from "preact/hooks";
+import { LoadingLine, MonoLabel, Muted } from "../../components/Typography";
+import type { ScanOverview } from "../../models/scan-overview";
+import { overviewTileHref, overviewTiles, type OverviewTile } from "./tiles";
+
+export function OverviewStrip({
+  overview,
+  loaded,
+  error,
+}: {
+  overview: ReadonlySignal<ScanOverview | null>;
+  loaded: ReadonlySignal<boolean>;
+  error: ReadonlySignal<string | null>;
+}) {
+  const now = useSignal(Date.now());
+  useEffect(() => {
+    const id = window.setInterval(() => {
+      now.value = Date.now();
+    }, 60_000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  const tiles = useComputed<OverviewTile[] | null>(() => {
+    const data = overview.value;
+    const at = now.value;
+    if (!data || data.totalScans === 0) return null;
+    return overviewTiles(data, at);
+  });
+  const pending = useComputed(() => !loaded.value && overview.value === null);
+  const failed = useComputed(() => (overview.value === null ? error.value : null));
+
+  return (
+    <>
+      <Show when={pending}>{() => <LoadingLine size="inline">Loading overview</LoadingLine>}</Show>
+      <Show when={failed}>
+        {(message) => (
+          <Muted class="text-[12px] font-mono m-0">Overview could not load. {message}</Muted>
+        )}
+      </Show>
+      <Show when={tiles}>
+        {(items) => (
+          <section aria-labelledby="dashboard-overview-heading">
+            <h2 id="dashboard-overview-heading" class="sr-only">
+              Overview
+            </h2>
+            <ul class="grid grid-cols-2 lg:grid-cols-4 gap-3 list-none m-0 p-0">
+              {items.map((tile) => (
+                <li key={tile.id} class="min-w-0">
+                  <OverviewTileLink tile={tile} />
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+      </Show>
+    </>
+  );
+}
+
+function OverviewTileLink({ tile }: { tile: OverviewTile }) {
+  return (
+    <a
+      href={overviewTileHref(tile.filter)}
+      data-overview-tile={tile.id}
+      class="flex flex-col gap-1.5 h-full bg-surface border border-border rounded-lg p-4 no-underline text-ink hover:border-accent focus-visible:border-accent transition-colors duration-150"
+    >
+      <MonoLabel>{tile.label}</MonoLabel>
+      <span class="font-mono text-[18px] font-medium leading-none tracking-[-0.01em] tabular-nums">
+        {tile.value}
+      </span>
+      <span class="font-mono text-[11px] leading-[1.4] text-ink-muted">{tile.detail}</span>
+    </a>
+  );
+}

--- a/src/features/overview/tiles.ts
+++ b/src/features/overview/tiles.ts
@@ -1,0 +1,83 @@
+/**
+ * What each overview tile says, derived from the aggregate. Kept apart from the
+ * component so the copy and the number formatting can be pinned in tests.
+ */
+import { pluralize } from "../../lib/format";
+import type { ScanDecisionFilter } from "../../models/scan";
+import type { ScanOverview } from "../../models/scan-overview";
+
+export interface OverviewTile {
+  id: "waiting" | "validating" | "published" | "decided";
+  label: string;
+  value: string;
+  detail: string;
+  filter: ScanDecisionFilter;
+}
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+/** Compact mono duration: `<1m`, `42m`, `3h`, `5d`. */
+export function formatCompactDuration(ms: number): string {
+  const clamped = Math.max(0, ms);
+  if (clamped < MINUTE_MS) return "<1m";
+  if (clamped < HOUR_MS) return `${Math.floor(clamped / MINUTE_MS)}m`;
+  if (clamped < 2 * DAY_MS) return `${Math.floor(clamped / HOUR_MS)}h`;
+  return `${Math.floor(clamped / DAY_MS)}d`;
+}
+
+export function overviewTiles(overview: ScanOverview, now: number): OverviewTile[] {
+  const { waiting, validating, publishedWithoutDecision, decided, windowDays } = overview;
+  const oldestWaiting = waiting.oldestCompletedAt ? Date.parse(waiting.oldestCompletedAt) : null;
+  return [
+    {
+      id: "waiting",
+      label: "Waiting on you",
+      value: String(waiting.count),
+      detail:
+        waiting.count === 0
+          ? "nothing to decide"
+          : `oldest ${formatCompactDuration(now - (oldestWaiting ?? now))} · decide before approving`,
+      filter: "undecided",
+    },
+    {
+      id: "validating",
+      label: "npm still scanning",
+      value: String(validating.count),
+      detail:
+        validating.count === 0
+          ? "nothing in npm validation"
+          : `${validating.reviewReady} of ${validating.count} Drydock ${pluralize("review", validating.count)} ready first`,
+      filter: "undecided",
+    },
+    {
+      id: "published",
+      label: "Published, no decision",
+      value: String(publishedWithoutDecision.count),
+      detail:
+        publishedWithoutDecision.count === 0
+          ? `none in ${windowDays}d`
+          : `went live unreviewed · ${windowDays}d`,
+      filter: "published_without_decision",
+    },
+    {
+      id: "decided",
+      label: `Decided · ${windowDays}d`,
+      value: String(decided.count),
+      detail:
+        decided.count === 0
+          ? "no decisions yet"
+          : `${decided.approved} approved · ${decided.rejected} rejected${
+              decided.medianDecisionMs === null
+                ? ""
+                : ` · median ${formatCompactDuration(decided.medianDecisionMs)}`
+            }`,
+      filter: "all",
+    },
+  ];
+}
+
+export function overviewTileHref(filter: ScanDecisionFilter): string {
+  return filter === "undecided" ? "/dashboard" : `/dashboard?filter=${filter}`;
+}

--- a/src/models/scan-overview.ts
+++ b/src/models/scan-overview.ts
@@ -1,0 +1,59 @@
+/**
+ * The dashboard overview strip's data: one aggregate read per organization.
+ */
+import { createModel, signal } from "@preact/signals";
+import type { ScanOverview } from "../../server/db/scans";
+import { activeOrganizationId } from "./active-organization";
+import { apiFetch, errorMessage } from "./api";
+
+export type { ScanOverview };
+
+export const ScanOverviewModel = createModel(() => {
+  const overview = signal<ScanOverview | null>(null);
+  const loaded = signal(false);
+  const refreshing = signal(false);
+  const error = signal<string | null>(null);
+  // The list refresh and the dashboard's own load both ask for the overview
+  // at startup and on an organization switch; the second caller joins the
+  // first request instead of paying for it twice.
+  let inflight: { organizationId: string | null; promise: Promise<void> } | null = null;
+
+  async function fetchOverview(organizationId: string | null): Promise<void> {
+    refreshing.value = true;
+    try {
+      const data = await apiFetch<ScanOverview>("/api/v1/scans/overview");
+      if (activeOrganizationId.peek() !== organizationId) return;
+      overview.value = data;
+      error.value = null;
+    } catch (err) {
+      if (activeOrganizationId.peek() !== organizationId) return;
+      error.value = errorMessage(err);
+    } finally {
+      if (inflight?.organizationId === organizationId) inflight = null;
+      if (activeOrganizationId.peek() === organizationId) {
+        loaded.value = true;
+        refreshing.value = false;
+      }
+    }
+  }
+
+  return {
+    overview,
+    loaded,
+    refreshing,
+    error,
+    refresh(): Promise<void> {
+      const organizationId = activeOrganizationId.peek();
+      if (inflight && inflight.organizationId === organizationId) return inflight.promise;
+      if (inflight) {
+        // The organization changed under an in-flight request; its answer is
+        // discarded on arrival, and the strip must not keep the old one.
+        overview.value = null;
+        loaded.value = false;
+      }
+      const promise = fetchOverview(organizationId);
+      inflight = { organizationId, promise };
+      return promise;
+    },
+  };
+});

--- a/src/models/scan-overview.ts
+++ b/src/models/scan-overview.ts
@@ -1,7 +1,7 @@
 /**
  * The dashboard overview strip's data: one aggregate read per organization.
  */
-import { createModel, signal } from "@preact/signals";
+import { createModel, effect, signal } from "@preact/signals";
 import type { ScanOverview } from "../../server/db/scans";
 import { activeOrganizationId } from "./active-organization";
 import { apiFetch, errorMessage } from "./api";
@@ -37,6 +37,19 @@ export const ScanOverviewModel = createModel(() => {
     }
   }
 
+  // Figures belong to one organization. Switching drops them before the new
+  // request answers, so the strip cannot show the previous organization's
+  // queue under the new name; an in-flight answer is discarded on arrival.
+  let organizationId = activeOrganizationId.peek();
+  effect(() => {
+    const next = activeOrganizationId.value;
+    if (next === organizationId) return;
+    organizationId = next;
+    overview.value = null;
+    loaded.value = false;
+    error.value = null;
+  });
+
   return {
     overview,
     loaded,
@@ -45,12 +58,6 @@ export const ScanOverviewModel = createModel(() => {
     refresh(): Promise<void> {
       const organizationId = activeOrganizationId.peek();
       if (inflight && inflight.organizationId === organizationId) return inflight.promise;
-      if (inflight) {
-        // The organization changed under an in-flight request; its answer is
-        // discarded on arrival, and the strip must not keep the old one.
-        overview.value = null;
-        loaded.value = false;
-      }
       const promise = fetchOverview(organizationId);
       inflight = { organizationId, promise };
       return promise;

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -22,10 +22,12 @@ import {
   type ScanDecisionFilter,
   type ScanListItem,
 } from "../../models/scan";
+import { ScanOverviewModel } from "../../models/scan-overview";
 import { StagedPublishesModel } from "../../models/staged-publishes";
 import { Alert } from "../../components/Alert";
 import { Badge, severityTone } from "../../components/Badge";
 import { EmailVerificationBanner } from "../../features/account/EmailVerificationBanner";
+import { OverviewStrip } from "../../features/overview/OverviewStrip";
 import { registryStatusBadge } from "../../features/registry-status";
 import { Button, LinkButton } from "../../components/Button";
 import { Card } from "../../components/Card";
@@ -47,6 +49,7 @@ export default function DashboardPage() {
   const npm = useModel(NpmConnectionModel);
   const organizations = useModel(OrganizationModel);
   const stagedPublishes = useModel(StagedPublishesModel);
+  const overview = useModel(ScanOverviewModel);
   const sessionChecked = useSignal(false);
 
   // Two-way bind the decision filter to ?filter=. The model re-fetches
@@ -77,23 +80,33 @@ export default function DashboardPage() {
       // they are in flight.
       await organizations.load();
       if (cancelled) return;
-      await Promise.all([scans.refresh(), npm.load()]);
+      await Promise.all([scans.refresh(), npm.load(), overview.refresh()]);
     })();
     return () => {
       cancelled = true;
     };
   }, []);
 
+  // Every list mutation (refresh, decision, delete, Check npm) changes what
+  // the overview counts, so the strip follows the list rather than each action
+  // remembering to refresh it. The startup and organization-switch loads above
+  // already hold an in-flight request the model joins instead of repeating.
+  useSignalEffect(() => {
+    void scans.scans.value;
+    if (!overview.loaded.peek()) return;
+    void overview.refresh();
+  });
+
   const onSwitchOrganization = async (organizationId: string) => {
     if (organizations.activate(organizationId)) {
-      await Promise.all([scans.refresh(), npm.load()]);
+      await Promise.all([scans.refresh(), npm.load(), overview.refresh()]);
     }
   };
 
   const onCreateOrganization = async (name: string) => {
     const created = await organizations.create(name);
     if (created) {
-      await Promise.all([scans.refresh(), npm.load()]);
+      await Promise.all([scans.refresh(), npm.load(), overview.refresh()]);
     }
   };
 
@@ -121,7 +134,8 @@ export default function DashboardPage() {
   const user = sessionModel.user.value;
   const scansLoaded = scans.loaded.value;
   const npmLoaded = npm.loaded.value;
-  const workspaceLoaded = scansLoaded && npmLoaded;
+  const overviewLoaded = overview.loaded.value;
+  const workspaceLoaded = scansLoaded && npmLoaded && overviewLoaded;
 
   return (
     <PageShell
@@ -150,18 +164,23 @@ export default function DashboardPage() {
         <>
           <DashboardOnboarding scans={scans} npm={npm} />
           <NpmTokenStaleCallout npm={npm} />
+          <OverviewStrip
+            overview={overview.overview}
+            loaded={overview.loaded}
+            error={overview.error}
+          />
           <RecentReviewsSection scans={scans} stagedPublishes={stagedPublishes} npm={npm} />
         </>
       ) : (
         <LoadingState
           title="Loading workspace"
-          detail={
-            npmLoaded
-              ? "fetching recent reviews"
-              : scansLoaded
-                ? "checking npm connection"
-                : "loading reviews · checking npm connection"
-          }
+          detail={[
+            !scansLoaded && "loading reviews",
+            !npmLoaded && "checking npm connection",
+            !overviewLoaded && "counting the queue",
+          ]
+            .filter(Boolean)
+            .join(" · ")}
         />
       )}
     </PageShell>

--- a/test/dashboard-onboarding-links.test.ts
+++ b/test/dashboard-onboarding-links.test.ts
@@ -15,7 +15,7 @@ describe("dashboard onboarding contracts", () => {
   test("resolves the active organization before organization-scoped startup requests", () => {
     const organizationLoad = dashboardSource.indexOf("await organizations.load();");
     const organizationScopedLoads = dashboardSource.indexOf(
-      "await Promise.all([scans.refresh(), npm.load()]);",
+      "await Promise.all([scans.refresh(), npm.load(), overview.refresh()]);",
     );
 
     expect(organizationLoad).toBeGreaterThan(-1);

--- a/test/e2e/org-switcher.spec.ts
+++ b/test/e2e/org-switcher.spec.ts
@@ -72,6 +72,24 @@ test("OrgSwitcher trigger updates after organizations load", async ({ page }) =>
     });
   });
 
+  // Register the literal route after the broad scan-list matcher so
+  // Playwright gives it precedence. The overview model expects its aggregate
+  // shape; returning the list fixture here would crash the dashboard render.
+  await page.route("**/api/v1/scans/overview", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        totalScans: 1,
+        windowDays: 30,
+        waiting: { count: 0, oldestCompletedAt: null },
+        validating: { count: 0, reviewReady: 0 },
+        publishedWithoutDecision: { count: 0 },
+        decided: { count: 0, approved: 0, rejected: 0, medianDecisionMs: null },
+      }),
+    });
+  });
+
   await page.route("**/api/v1/npm-connection", async (route) => {
     await route.fulfill({
       status: 200,

--- a/test/scan-overview-model.test.ts
+++ b/test/scan-overview-model.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { formatCompactDuration, overviewTiles } from "../src/features/overview/tiles";
+import { setActiveOrganizationId } from "../src/models/active-organization";
+import { ScanOverviewModel, type ScanOverview } from "../src/models/scan-overview";
+
+type ScanOverviewModelInstance = InstanceType<typeof ScanOverviewModel>;
+
+let model: ScanOverviewModelInstance | null = null;
+
+const NOW = Date.parse("2026-09-04T12:00:00.000Z");
+const HOUR_MS = 60 * 60 * 1000;
+
+function overview(partial: Partial<ScanOverview> = {}): ScanOverview {
+  return {
+    totalScans: 12,
+    windowDays: 30,
+    waiting: { count: 3, oldestCompletedAt: new Date(NOW - 5 * HOUR_MS).toISOString() },
+    validating: { count: 2, reviewReady: 1 },
+    publishedWithoutDecision: { count: 1 },
+    decided: { count: 6, approved: 5, rejected: 1, medianDecisionMs: 42 * 60 * 1000 },
+    ...partial,
+  };
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("ScanOverviewModel", () => {
+  afterEach(() => {
+    model?.[Symbol.dispose]();
+    model = null;
+    setActiveOrganizationId(null);
+    vi.unstubAllGlobals();
+  });
+
+  test("loads the overview and clears a previous error", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse(overview())));
+    vi.stubGlobal("fetch", fetchMock);
+    model = new ScanOverviewModel();
+    model.error.value = "stale";
+
+    await model.refresh();
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/v1/scans/overview", expect.anything());
+    expect(model.overview.value?.waiting.count).toBe(3);
+    expect(model.error.value).toBeNull();
+    expect(model.loaded.value).toBe(true);
+    expect(model.refreshing.value).toBe(false);
+  });
+
+  test("records a failed load without dropping the figures already shown", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(jsonResponse(overview()))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ error: "boom" }), { status: 500 })),
+    );
+    model = new ScanOverviewModel();
+
+    await model.refresh();
+    await model.refresh();
+
+    expect(model.error.value).toBe("boom");
+    expect(model.overview.value?.totalScans).toBe(12);
+    expect(model.loaded.value).toBe(true);
+  });
+
+  test("shares one in-flight request between concurrent callers", async () => {
+    const response = deferred<Response>();
+    const fetchMock = vi.fn(() => response.promise);
+    vi.stubGlobal("fetch", fetchMock);
+    model = new ScanOverviewModel();
+
+    const first = model.refresh();
+    const second = model.refresh();
+    expect(second).toBe(first);
+    response.resolve(jsonResponse(overview()));
+    await first;
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("discards an answer that arrives after the organization switched", async () => {
+    const response = deferred<Response>();
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockReturnValueOnce(response.promise)
+        .mockResolvedValue(jsonResponse(overview({ totalScans: 1 }))),
+    );
+    setActiveOrganizationId("org-a");
+    model = new ScanOverviewModel();
+
+    const stale = model.refresh();
+    setActiveOrganizationId("org-b");
+    const fresh = model.refresh();
+    response.resolve(jsonResponse(overview({ totalScans: 99 })));
+    await Promise.all([stale, fresh]);
+
+    expect(model.overview.value?.totalScans).toBe(1);
+    expect(model.loaded.value).toBe(true);
+  });
+});
+
+describe("overviewTiles", () => {
+  test("turns the aggregate into four filter-linked calls to action", () => {
+    const tiles = overviewTiles(overview(), NOW);
+    expect(tiles.map((tile) => [tile.id, tile.value, tile.detail, tile.filter])).toEqual([
+      ["waiting", "3", "oldest 5h · decide before approving", "undecided"],
+      ["validating", "2", "1 of 2 Drydock reviews ready first", "undecided"],
+      ["published", "1", "went live unreviewed · 30d", "published_without_decision"],
+      ["decided", "6", "5 approved · 1 rejected · median 42m", "all"],
+    ]);
+  });
+
+  test("describes empty tiles as states, not promises", () => {
+    const tiles = overviewTiles(
+      overview({
+        waiting: { count: 0, oldestCompletedAt: null },
+        validating: { count: 0, reviewReady: 0 },
+        publishedWithoutDecision: { count: 0 },
+        decided: { count: 0, approved: 0, rejected: 0, medianDecisionMs: null },
+      }),
+      NOW,
+    );
+    expect(tiles.map((tile) => tile.detail)).toEqual([
+      "nothing to decide",
+      "nothing in npm validation",
+      "none in 30d",
+      "no decisions yet",
+    ]);
+  });
+
+  test("omits the median when no decision carried a completion time", () => {
+    const [, , , decided] = overviewTiles(
+      overview({ decided: { count: 2, approved: 2, rejected: 0, medianDecisionMs: null } }),
+      NOW,
+    );
+    expect(decided?.detail).toBe("2 approved · 0 rejected");
+  });
+
+  test("formats durations compactly and never negative", () => {
+    expect(formatCompactDuration(-5)).toBe("<1m");
+    expect(formatCompactDuration(30 * 1000)).toBe("<1m");
+    expect(formatCompactDuration(59 * 60 * 1000)).toBe("59m");
+    expect(formatCompactDuration(47 * HOUR_MS)).toBe("47h");
+    expect(formatCompactDuration(48 * HOUR_MS)).toBe("2d");
+  });
+});

--- a/test/scan-overview-model.test.ts
+++ b/test/scan-overview-model.test.ts
@@ -114,6 +114,22 @@ describe("ScanOverviewModel", () => {
     expect(model.overview.value?.totalScans).toBe(1);
     expect(model.loaded.value).toBe(true);
   });
+
+  test("drops the previous organization's figures the moment the organization switches", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(jsonResponse(overview()))),
+    );
+    setActiveOrganizationId("org-a");
+    model = new ScanOverviewModel();
+    await model.refresh();
+    expect(model.loaded.value).toBe(true);
+
+    setActiveOrganizationId("org-b");
+
+    expect(model.overview.value).toBeNull();
+    expect(model.loaded.value).toBe(false);
+  });
 });
 
 describe("overviewTiles", () => {

--- a/test/workers/api-auth-routes.test.ts
+++ b/test/workers/api-auth-routes.test.ts
@@ -23,6 +23,7 @@ const protectedRoutes: RouteCase[] = [
   { method: "DELETE", path: "/api/v1/npm-connection" },
   { method: "POST", path: "/api/v1/npm-connection/validate", body: {} },
   { method: "GET", path: "/api/v1/scans" },
+  { method: "GET", path: "/api/v1/scans/overview" },
   { method: "POST", path: "/api/v1/scans", body: { stageId: "stage-auth-route-000001" } },
   { method: "GET", path: "/api/v1/scans/scan_auth_route" },
   { method: "DELETE", path: "/api/v1/scans/scan_auth_route" },

--- a/test/workers/scan-overview.test.ts
+++ b/test/workers/scan-overview.test.ts
@@ -1,0 +1,263 @@
+import { env, createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
+import { Hono } from "hono";
+import { describe, expect, test } from "vitest";
+import { createDb } from "../../server/db/client";
+import { ensurePersonalOrganization } from "../../server/db/organizations";
+import { getScanOverview, type ScanSource } from "../../server/db/scans";
+import * as schema from "../../server/db/schema";
+import { scansRoutes } from "../../server/routes/scans";
+import type { Bindings, Variables } from "../../server/types";
+
+const NOW = new Date("2026-09-04T12:00:00.000Z");
+const DAY_MS = 24 * 60 * 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
+
+interface SeededUser {
+  userId: string;
+  organizationId: string;
+}
+
+async function seedUser(): Promise<SeededUser> {
+  const db = createDb(env.DB);
+  const now = new Date();
+  const userId = `user_${crypto.randomUUID()}`;
+  await db.insert(schema.user).values({
+    id: userId,
+    name: "Overview Tester",
+    email: `${userId}@example.com`,
+    emailVerified: true,
+    createdAt: now,
+    updatedAt: now,
+  });
+  const organizationId = await ensurePersonalOrganization(db, { userId });
+  return { userId, organizationId };
+}
+
+interface SeedScan {
+  source?: ScanSource;
+  status?: "pending" | "running" | "complete" | "failed";
+  decision?: "publish" | "no_publish" | null;
+  decidedAt?: Date | null;
+  completedAt?: Date | null;
+  createdAt?: Date;
+  registryVersionStatus?: string | null;
+  registryStatusSupersededAt?: Date | null;
+  errorJson?: unknown;
+}
+
+async function seedScan(owner: SeededUser, input: SeedScan = {}) {
+  const db = createDb(env.DB);
+  const id = `scan_${crypto.randomUUID()}`;
+  const createdAt = input.createdAt ?? new Date(NOW.getTime() - HOUR_MS);
+  const status = input.status ?? "complete";
+  await db.insert(schema.scans).values({
+    id,
+    stageId: `stage-${id.slice(-12)}`,
+    organizationId: owner.organizationId,
+    ownerUserId: owner.userId,
+    packageName: "@drydock/overview",
+    stagedVersion: "1.0.0",
+    risk: "low",
+    status,
+    source: input.source ?? "manual",
+    decision: input.decision ?? null,
+    decidedAt: input.decidedAt ?? null,
+    decidedByUserId: input.decision ? owner.userId : null,
+    errorJson: input.errorJson ?? null,
+    registryVersionStatus: input.registryVersionStatus ?? null,
+    registryVersionStatusAt: input.registryVersionStatus ? createdAt : null,
+    registryStatusSupersededAt: input.registryStatusSupersededAt ?? null,
+    completedAt:
+      input.completedAt === undefined
+        ? status === "complete"
+          ? createdAt
+          : null
+        : input.completedAt,
+    createdAt,
+    updatedAt: createdAt,
+  });
+  return id;
+}
+
+function overview(owner: SeededUser) {
+  return getScanOverview(createDb(env.DB), owner.organizationId, { now: NOW });
+}
+
+describe("getScanOverview", () => {
+  test("reports an empty organization without inventing figures", async () => {
+    const owner = await seedUser();
+    expect(await overview(owner)).toEqual({
+      totalScans: 0,
+      windowDays: 30,
+      waiting: { count: 0, oldestCompletedAt: null },
+      validating: { count: 0, reviewReady: 0 },
+      publishedWithoutDecision: { count: 0 },
+      decided: { count: 0, approved: 0, rejected: 0, medianDecisionMs: null },
+    });
+  });
+
+  test("counts only the organization's own scans", async () => {
+    const owner = await seedUser();
+    const other = await seedUser();
+    await seedScan(owner, { registryVersionStatus: "staged" });
+    await seedScan(other, { registryVersionStatus: "staged" });
+    await seedScan(other, { registryVersionStatus: "validating" });
+    await seedScan(other, { registryVersionStatus: "published" });
+    await seedScan(other, { decision: "publish", decidedAt: NOW });
+
+    const result = await overview(owner);
+    expect(result.totalScans).toBe(1);
+    expect(result.waiting.count).toBe(1);
+    expect(result.validating.count).toBe(0);
+    expect(result.publishedWithoutDecision.count).toBe(0);
+    expect(result.decided.count).toBe(0);
+  });
+
+  test("waiting counts completed undecided npm reviews whose stage has not settled", async () => {
+    const owner = await seedUser();
+    const oldest = new Date(NOW.getTime() - 3 * DAY_MS);
+    await seedScan(owner, { registryVersionStatus: null, completedAt: oldest, createdAt: oldest });
+    await seedScan(owner, { registryVersionStatus: "staged" });
+    await seedScan(owner, { registryVersionStatus: "validating" });
+    // None of these are waiting on a reviewer.
+    await seedScan(owner, { registryVersionStatus: "published" });
+    await seedScan(owner, { registryVersionStatus: "blocked" });
+    await seedScan(owner, { registryVersionStatus: "staged", decision: "publish", decidedAt: NOW });
+    await seedScan(owner, { registryVersionStatus: "staged", status: "running" });
+    await seedScan(owner, { registryVersionStatus: "staged", status: "failed" });
+    await seedScan(owner, { registryVersionStatus: "staged", registryStatusSupersededAt: NOW });
+    await seedScan(owner, { source: "workflow_gate" });
+    await seedScan(owner, { source: "published" });
+
+    const result = await overview(owner);
+    expect(result.totalScans).toBe(11);
+    expect(result.waiting).toEqual({ count: 3, oldestCompletedAt: oldest.toISOString() });
+  });
+
+  test("validating counts npm reviews still under npm's scan and how many Drydock has finished", async () => {
+    const owner = await seedUser();
+    await seedScan(owner, { registryVersionStatus: "validating" });
+    await seedScan(owner, { registryVersionStatus: "validating", status: "running" });
+    await seedScan(owner, {
+      registryVersionStatus: "validating",
+      decision: "publish",
+      decidedAt: NOW,
+    });
+    await seedScan(owner, { registryVersionStatus: "validating", registryStatusSupersededAt: NOW });
+    await seedScan(owner, { registryVersionStatus: "validating", source: "workflow_gate" });
+    await seedScan(owner, { registryVersionStatus: "staged" });
+
+    const result = await overview(owner);
+    expect(result.validating).toEqual({ count: 3, reviewReady: 2 });
+  });
+
+  test("published without decision mirrors the list filter inside the window", async () => {
+    const owner = await seedUser();
+    const insideWindow = new Date(NOW.getTime() - 29 * DAY_MS - 23 * HOUR_MS);
+    const outsideWindow = new Date(NOW.getTime() - 30 * DAY_MS - HOUR_MS);
+    await seedScan(owner, { registryVersionStatus: "published", createdAt: insideWindow });
+    await seedScan(owner, { registryVersionStatus: "deleted" });
+    await seedScan(owner, {
+      status: "failed",
+      errorJson: { code: "staged_release_published" },
+    });
+    // Excluded: decided, blocked, outside the window, superseded, non-npm sources.
+    await seedScan(owner, {
+      registryVersionStatus: "published",
+      decision: "publish",
+      decidedAt: NOW,
+    });
+    await seedScan(owner, { registryVersionStatus: "blocked" });
+    await seedScan(owner, { registryVersionStatus: "published", createdAt: outsideWindow });
+    await seedScan(owner, { registryVersionStatus: "published", registryStatusSupersededAt: NOW });
+    await seedScan(owner, { registryVersionStatus: "published", source: "workflow_gate" });
+    await seedScan(owner, { registryVersionStatus: "published", source: "published" });
+
+    const result = await overview(owner);
+    expect(result.publishedWithoutDecision.count).toBe(3);
+  });
+
+  test("decided splits the window by verdict and reports the median decision time", async () => {
+    const owner = await seedUser();
+    const completed = new Date(NOW.getTime() - 5 * DAY_MS);
+    const decide = (decision: "publish" | "no_publish", afterMs: number) =>
+      seedScan(owner, {
+        decision,
+        completedAt: completed,
+        decidedAt: new Date(completed.getTime() + afterMs),
+      });
+    await decide("publish", 10 * 60 * 1000);
+    await decide("publish", 30 * 60 * 1000);
+    await decide("no_publish", 4 * HOUR_MS);
+    // Just inside the window.
+    await seedScan(owner, {
+      decision: "publish",
+      completedAt: new Date(NOW.getTime() - 31 * DAY_MS),
+      decidedAt: new Date(NOW.getTime() - 30 * DAY_MS + HOUR_MS),
+    });
+    // Just outside the window.
+    await seedScan(owner, {
+      decision: "no_publish",
+      completedAt: new Date(NOW.getTime() - 31 * DAY_MS),
+      decidedAt: new Date(NOW.getTime() - 30 * DAY_MS - HOUR_MS),
+    });
+    await seedScan(owner, { registryVersionStatus: "staged" });
+
+    const result = await overview(owner);
+    expect(result.decided.count).toBe(4);
+    expect(result.decided.approved).toBe(3);
+    expect(result.decided.rejected).toBe(1);
+    // Deltas: 10m, 30m, 4h, 1d1h → median of the middle pair (30m, 4h).
+    expect(result.decided.medianDecisionMs).toBe((30 * 60 * 1000 + 4 * HOUR_MS) / 2);
+  });
+
+  test("median over an odd number of decisions is the middle value", async () => {
+    const owner = await seedUser();
+    const completed = new Date(NOW.getTime() - DAY_MS);
+    for (const afterMs of [HOUR_MS, 3 * HOUR_MS, 9 * HOUR_MS]) {
+      await seedScan(owner, {
+        decision: "publish",
+        completedAt: completed,
+        decidedAt: new Date(completed.getTime() + afterMs),
+      });
+    }
+    // A decision on a row with no completion timestamp counts but cannot time.
+    await seedScan(owner, { decision: "no_publish", decidedAt: NOW, completedAt: null });
+
+    const result = await overview(owner);
+    expect(result.decided.count).toBe(4);
+    expect(result.decided.medianDecisionMs).toBe(3 * HOUR_MS);
+  });
+});
+
+describe("GET /api/v1/scans/overview", () => {
+  function buildTestApp(session: { userId: string }) {
+    const app = new Hono<{ Bindings: Bindings; Variables: Variables }>();
+    app.use("*", async (c, next) => {
+      c.set("authSession", { userId: session.userId });
+      await next();
+    });
+    app.route("/api/v1/scans", scansRoutes);
+    return app;
+  }
+
+  test("returns the active organization's overview", async () => {
+    const owner = await seedUser();
+    const other = await seedUser();
+    await seedScan(owner, { registryVersionStatus: "validating" });
+    await seedScan(other, { registryVersionStatus: "validating" });
+
+    const ctx = createExecutionContext();
+    const res = await buildTestApp(owner).fetch(
+      new Request("http://test.local/api/v1/scans/overview"),
+      env,
+      ctx,
+    );
+    await waitOnExecutionContext(ctx);
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { totalScans: number; validating: { count: number } };
+    expect(body.totalScans).toBe(1);
+    expect(body.validating.count).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

npm's 2026-09-03 change makes every trusted-publishing config stage-only and holds stage approval until npm's own malware scan settles, so every staged release now sits in a window. The dashboard had no overview of that window — just a header and a flat list. This adds an organization-scoped strip above Recent reviews with four call-to-action tiles, each a link into the matching `?filter=` on the list:

- **Waiting on you** — completed npm reviews with no Drydock decision whose npm status is not settled (null, `staged`, or `validating`), with the age of the oldest.
- **npm still scanning** — reviews whose last known npm status is `validating`, with how many already have a finished Drydock review ("1 of 2 Drydock reviews ready first").
- **Published, no decision** — the list's `published_without_decision` semantics (published/deleted, or the published/deleted failure codes), limited to scans created in the last 30 days.
- **Decided · 30d** — count, approved vs rejected, and the median completion-to-decision time.

The first three count only npm staged-publish sources (`manual`, `auto_discovery`); workflow-gate and published-pair scans carry no npm stage. A null npm status is only ever "not settled" and never rendered as a verdict. The strip is absent for an organization with no scans.

**Server:** `GET /api/v1/scans/overview` (Better Auth session + `requireActiveOrganization`, like every other scan route), backed by one aggregate D1 statement in `server/db/scan-overview.ts` (conditional sums plus the classic ordered-scalar-subquery median; no migration, no new index). Registered ahead of lifecycle's `GET /:id` so the literal path is not captured as a scan id.

**UI:** `src/features/overview/OverviewStrip.tsx` + `tiles.ts` (pure tile derivation), `ScanOverviewModel` in `src/models/scan-overview.ts` (signals, no hooks). Mono tabular values under 11px mono labels, 2x2 below `lg`, no icons, no gradients, no SectionLabel boundary. The dashboard re-reads the overview whenever the list changes and joins an in-flight request instead of repeating it; figures stay on screen during a refresh so the layout never jumps; loading and error render as mono lines.

## Testing

- `pnpm run verify` green (lint, format, typecheck, knip, node + workers suites).
- `test/workers/scan-overview.test.ts`: empty org, cross-org isolation, each tile's inclusion/exclusion rules (sources, superseded, running/failed, decided), the 30-day window boundary on both sides for published and decided, even/odd median, and the route through the scans router.
- `test/scan-overview-model.test.ts`: load, error keeps prior figures, in-flight dedupe, stale-organization answer discarded, organization switch clears figures, tile copy and duration formatting.
- `test/workers/api-auth-routes.test.ts`: the new endpoint rejects anonymous requests.
- Verified live against the seeded e2e dev server: tiles render with the seeded undecided review, clicking tiles applies the State select filter (`all`, back to `undecided`), no console/network errors, 2x2 grid at 390px.

## Docs

Updated `docs/ui.md` (new "Dashboard overview strip" section) and `docs/registry-version-status.md` (the strip as a UI consumer of null status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
