### PR TITLE
Trace every invocation so agent turns reach the Agents dashboard

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,7 +127,7 @@ Within a single org sweep, new staged publishes are started through a bounded-co
 - **D1** — Better Auth tables, organizations, npm connections, scans, scan files/findings, workflow gates, release targets, summaries, and audit/event metadata. D1 remains the operational source of truth.
 - **R2** — canonical report JSON and redacted file/diff artifacts. D1 keeps compact metadata and historical fallback samples so list/detail pages remain cheap.
 - **KV** — session-related state where configured.
-- **Workers AI / AI Gateway** — optional advisory review path. The per-organization `ai-review` Flagship flag is a killswitch that is on by default; deterministic findings remain authoritative. Sampled Agent Traces retain no message or tool payloads; Analytics Engine stores only aggregate execution and decision dimensions keyed by reviewer version.
+- **Workers AI / AI Gateway** — optional advisory review path. The per-organization `ai-review` Flagship flag is a killswitch that is on by default; deterministic findings remain authoritative. Agent Traces retain no message or tool payloads; Analytics Engine stores only aggregate execution and decision dimensions keyed by reviewer version.
 
 ## Organization and auth model
 

--- a/docs/examples/wrangler.self-host.jsonc
+++ b/docs/examples/wrangler.self-host.jsonc
@@ -25,12 +25,17 @@
 			"enabled": true,
 			"invocation_logs": true
 		},
-		// Optional sampled Agent Traces. Message and tool payload persistence is
+		// Optional Agent Traces. Message and tool payload persistence is
 		// disabled in code; traces retain operation timing, model/usage metadata,
 		// tool names, and the non-identifying reviewer version only.
+		//
+		// Sampling is per invocation and worker-wide, so a rate low enough to
+		// thin out fetch traffic also thins out the handful of daily agent
+		// turns you actually want to read. Lower `head_sampling_rate` only once
+		// your own traffic makes the span volume matter.
 		"traces": {
 			"enabled": true,
-			"head_sampling_rate": 0.1,
+			"head_sampling_rate": 1,
 			"persist": true
 		}
 	},

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -84,7 +84,7 @@ Workflow gates never publish. GitHub Environment protection holds the publish jo
 
 Package contents are hostile instructions. AI prompts must frame package text as evidence, restrict outputs to schema-validated findings, and keep deterministic findings/risk independent. AI input should include only the minimum changed-file evidence needed for review, never credentials, sessions, raw headers, or operator secrets. Invalid, partial, or unsafe AI output is ignored/unavailable rather than treated as a clean review.
 
-Cloudflare Agent Traces are sampled at 10% for reviewer debugging, with message
+Cloudflare Agent Traces are fully sampled for reviewer debugging, with message
 and tool payload persistence explicitly disabled at both the tracing wrapper
 (`storeMessages`/`storeTools`) and the AI SDK call
 (`recordInputs`/`recordOutputs`). Trace metadata is restricted to an explicit

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -212,10 +212,11 @@ After deploying:
 3. Sign in and create an organization.
 4. Add and validate an npm connection.
 5. Run a test staged-publish review.
-6. Check Worker logs and sampled Agent Traces for structured events without raw
-   package contents or secrets. The template persists 10% of traces while the
-   reviewer wrapper disables message and tool payload storage; remove the
-   `observability.traces` block if you do not want persisted traces at all.
+6. Check Worker logs and Agent Traces for structured events without raw
+   package contents or secrets. The template persists every trace while the
+   reviewer wrapper disables message and tool payload storage; lower
+   `head_sampling_rate` once your traffic makes span volume matter, or remove
+   the `observability.traces` block if you do not want persisted traces at all.
 
 ## GitHub workflow gates
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -13,9 +13,14 @@
 			"enabled": true,
 			"invocation_logs": true
 		},
+		// Head sampling is per invocation and worker-wide, so it cannot be aimed
+		// at the reviewer. Agent turns run a few times a day (one scan per queue
+		// invocation, max_batch_size 1), and at 10% that left the Agents
+		// dashboard empty on most days. Trace everything until the span volume
+		// is worth measuring against the Workers Logs quota.
 		"traces": {
 			"enabled": true,
-			"head_sampling_rate": 0.1,
+			"head_sampling_rate": 1,
 			"persist": true
 		}
 	},


### PR DESCRIPTION
## Summary

The Agents dashboard was always empty, and the cause turned out to be volume, not wiring: agent turns run ~4x/day (43 scans over 10 days, one scan per queue invocation at `max_batch_size: 1`), so a 10% head sampling rate yielded ~0.43 traced turns/day. This raises `head_sampling_rate` to `1` in `wrangler.jsonc` and the self-host template, and updates the four docs that quoted the 10% figure. I verified the instrumentation itself was already correct before changing anything — the built `dist/.../wrangler.json` carries the traces block, `invoke_agent` and the `cloudflare:workers` tracer are in the bundle, `agents@0.20.1` reads the agent name from the `telemetry.functionId` we pass, `cloudflare:workers` exports `tracing` at compat date `2026-05-20`, and the review is `await`ed inside the queue handler. Payload posture is untouched: `storeMessages`/`storeTools`/`recordInputs`/`recordOutputs` all remain false, so only the number of traces changed, not their contents.

## Trust boundary

**Needs an explicit decision before this deploys.** Sampling is worker-wide, so this also covers the fetch handler, and Workers auto-instrumentation records `url.full`/`url.path`/`url.query` on every fetch-handler span. `GET /public/reports/:token` is a capability URL where the 256-bit share token *is* the authorization (`docs/security-model.md:174`), and the app already treats that path as secret-bearing via `redactCapabilityPath()` (`server/index.ts:156`) — so where ~10% of share-link visits previously persisted a live bearer token into a trace, all of them now will. There is no hook to scrub auto-instrumentation attributes and `persist` is worker-wide too, so the options are to accept it (the reader already needs Cloudflare account access, which `docs/security-model.md:96-107` already trusts with AI Gateway prompt bodies), revert to `0.1` and accept a mostly-empty Agents tab, or split the queue consumer into its own Worker so the agent path can be traced at 100% while the fetch path stays low.

## Verification

`pnpm run verify` passed in full (lint, format:check, typecheck, knip, tests). No code paths changed, so no new test surface; e2e was not run for the same reason.

## Documentation

Updated `docs/security-model.md`, `docs/self-hosting.md`, `docs/architecture.md`, and the `docs/examples/wrangler.self-host.jsonc` template so none of them still claim 10% sampling.

## UI evidence

Not applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)