### PR TITLE
Lint the design token system: no off-system colors, no sub-floor text

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -60,6 +60,16 @@
   },
   "overrides": [
     {
+      // The design token system is a UI contract. Server-rendered images
+      // (the OG card SVG) legitimately carry literal colors: no dark mode, no
+      // Tailwind.
+      "files": ["src/**"],
+      "rules": {
+        "design-local/no-off-system-color": "error",
+        "design-local/no-sub-floor-text": "error"
+      }
+    },
+    {
       "files": ["server/**"],
       "excludeFiles": ["server/lib/platform/observability.ts"],
       "rules": {

--- a/docs/design.md
+++ b/docs/design.md
@@ -54,6 +54,7 @@ The system has three small-text sizes (10/11/12px). They are not interchangeable
 - `--fg-subtle` is now AA-passing at all sizes (6.2:1 on `--bg`). Don't pair sub-11px text with anything lower contrast.
 - White text on `--accent` (Button primary) requires 13px / 500 minimum — `--accent` is 4.97:1, so 13px/500 clears AA. Smaller white-on-accent controls (the view-switcher pills) use the soft-accent active treatment instead — `bg-accent-soft` + `text-accent` + accent border — never white-on-accent below 13px.
 - Severity-as-text uses the `-text` variants (`text-warn-text`, `text-ok-text`). The saturated tokens (`text-warn`, `text-ok`) are reserved for shapes — chart segments, borders, alert discs.
+- Machine-checked in `src/`: `design-local/no-off-system-color` rejects Tailwind palette colors, raw hex/rgb values in classes or `style` props, and saturated severity tokens as text; `design-local/no-sub-floor-text` rejects arbitrary text sizes below 10px. Colors come from the `src/style.css` tokens only.
 
 ## Color
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -199,15 +199,18 @@ hand and hardest to see in review. Both are scoped to `src/**` (server-rendered 
 such as the OG card legitimately carry literal colors) and scan every static string
 literal and template quasi token by token, so class maps in plain objects are covered,
 not just `class=`. `no-off-system-color` reports a Tailwind default-palette utility
-(`text-red-600`, `hover:bg-zinc-100`), a raw color inside an arbitrary value or a
-`style` prop (`bg-[#fafafa]`, `shadow-[…rgba(…)]`, `style={{ color: "#c2410c" }}`), and a
+(`text-red-600`, `hover:bg-zinc-100`), a raw color inside an arbitrary value or
+anywhere in the value of a color-carrying style property (`bg-[#fafafa]`, `shadow-[…rgba(…)]`,
+`style={{ boxShadow: "0 0 0 1px #e4e4e7" }}`), and a
 saturated severity token used as a text color (`text-warn`, `text-ok/80`), pointing at the
 `-text` variant. `var(--color-…)` inside an arbitrary value, `white`/`black`, and prose
-containing `#123` are not reported. `no-sub-floor-text` reports an arbitrary `text-[…]`
-size below 10px in `px`, `rem`, or `em`; whether a 10px string is a glyph or a label stays a
+containing `#123` are not reported. `no-sub-floor-text` reports an arbitrary `text-[…]`,
+`text-[length:…]`, or `[font-size:…]` size below 10px in `px`, `rem`, or `em`, with or without a
+`/leading` modifier; whether a 10px string is a glyph or a label stays a
 review judgement. Fixtures and test: `test/fixtures/oxlint-design/src/off-system-color.tsx`,
 `test/fixtures/oxlint-design/src/sub-floor-text.tsx`, `test/fixtures/oxlint-design/src/tokens-clean.tsx`,
-and `test/oxlint-design-tokens.test.mjs`. Both ship as `error` with no existing violations.
+`test/fixtures/oxlint-design/server/card.ts` (must stay unreported: the fixture config uses the
+same `src/**` override as the repo config), and `test/oxlint-design-tokens.test.mjs`. Both ship as `error` with no existing violations.
 
 ### What belongs in an agent file
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -192,6 +192,23 @@ elements away is a spacing question and is not reported. Fixture and test:
 
 The rule ships as `error` with no existing violations, so every infraction fails lint.
 
+### Local rules: `design-local/no-off-system-color` and `design-local/no-sub-floor-text`
+
+The same plugin pins the two `docs/design.md` rules that are cheapest to break by
+hand and hardest to see in review. Both are scoped to `src/**` (server-rendered images
+such as the OG card legitimately carry literal colors) and scan every static string
+literal and template quasi token by token, so class maps in plain objects are covered,
+not just `class=`. `no-off-system-color` reports a Tailwind default-palette utility
+(`text-red-600`, `hover:bg-zinc-100`), a raw color inside an arbitrary value or a
+`style` prop (`bg-[#fafafa]`, `shadow-[…rgba(…)]`, `style={{ color: "#c2410c" }}`), and a
+saturated severity token used as a text color (`text-warn`, `text-ok/80`), pointing at the
+`-text` variant. `var(--color-…)` inside an arbitrary value, `white`/`black`, and prose
+containing `#123` are not reported. `no-sub-floor-text` reports an arbitrary `text-[…]`
+size below 10px in `px`, `rem`, or `em`; whether a 10px string is a glyph or a label stays a
+review judgement. Fixtures and test: `test/fixtures/oxlint-design/src/off-system-color.tsx`,
+`test/fixtures/oxlint-design/src/sub-floor-text.tsx`, `test/fixtures/oxlint-design/src/tokens-clean.tsx`,
+and `test/oxlint-design-tokens.test.mjs`. Both ship as `error` with no existing violations.
+
 ### What belongs in an agent file
 
 `AGENTS.md` is the shared repository contract; `CLAUDE.md` imports it. Keep durable

--- a/test/fixtures/oxlint-design/oxlintrc.json
+++ b/test/fixtures/oxlint-design/oxlintrc.json
@@ -8,8 +8,17 @@
     }
   ],
   "rules": {
-    "design-local/no-stacked-section-rule": "error",
-    "design-local/no-off-system-color": "error",
-    "design-local/no-sub-floor-text": "error"
-  }
+    "design-local/no-stacked-section-rule": "error"
+  },
+  // Same shape as the repo config: the token rules apply to src/** only, so
+  // server/ here must stay unreported.
+  "overrides": [
+    {
+      "files": ["src/**"],
+      "rules": {
+        "design-local/no-off-system-color": "error",
+        "design-local/no-sub-floor-text": "error"
+      }
+    }
+  ]
 }

--- a/test/fixtures/oxlint-design/oxlintrc.json
+++ b/test/fixtures/oxlint-design/oxlintrc.json
@@ -8,6 +8,8 @@
     }
   ],
   "rules": {
-    "design-local/no-stacked-section-rule": "error"
+    "design-local/no-stacked-section-rule": "error",
+    "design-local/no-off-system-color": "error",
+    "design-local/no-sub-floor-text": "error"
   }
 }

--- a/test/fixtures/oxlint-design/server/card.ts
+++ b/test/fixtures/oxlint-design/server/card.ts
@@ -1,0 +1,4 @@
+// Server-rendered image: literal colors are legitimate here and the token
+// rules are scoped to src/**, so nothing in this file may be reported.
+export const okGreen = "#15803d";
+export const card = { fill: "rgb(220, 38, 38)", label: "text-red-600 text-[8px]" };

--- a/test/fixtures/oxlint-design/src/clean.tsx
+++ b/test/fixtures/oxlint-design/src/clean.tsx
@@ -66,7 +66,7 @@ export function DirectionalColorsOnly() {
   return (
     <SectionLabel
       as="h2"
-      class="border-t-border border-b-accent border-t-[#fff] border-b-[color:var(--border)] border-t-[var(--border)]"
+      class="border-t-border border-b-accent border-t-[var(--color-border)] border-b-[color:var(--border)] border-t-[var(--border)]"
     >
       Findings
     </SectionLabel>

--- a/test/fixtures/oxlint-design/src/off-system-color.tsx
+++ b/test/fixtures/oxlint-design/src/off-system-color.tsx
@@ -1,0 +1,44 @@
+// Every color here leaves the docs/design.md token system.
+// Line numbers are asserted in test/oxlint-design-tokens.test.mjs.
+import { cn } from "./cn";
+
+export function PaletteText() {
+  return <span class="text-red-600">danger</span>;
+}
+
+export function PaletteWithVariant() {
+  return <div class="hover:bg-zinc-100 dark:border-slate-700">hover</div>;
+}
+
+export function ArbitraryHex() {
+  return <div class="bg-[#fafafa]">surface</div>;
+}
+
+export function ArbitraryFunction() {
+  return <div class="shadow-[0_0_0_1px_rgba(0,0,0,0.2)]">ring</div>;
+}
+
+export function InlineStyle() {
+  return <div style={{ borderColor: "#e4e4e7" }}>rule</div>;
+}
+
+export function InlineStyleFunction() {
+  return <div style={{ color: "rgb(24, 24, 27)" }}>ink</div>;
+}
+
+export function SaturatedText() {
+  return <span class="text-warn">amber label</span>;
+}
+
+export function SaturatedTextInMap() {
+  const tones = { ok: "bg-ok-soft text-ok", danger: "text-danger-text" };
+  return <span class={tones.ok}>ok</span>;
+}
+
+export function SaturatedTextInCn({ active }: { active: boolean }) {
+  return <span class={cn("font-mono", active && "text-info/80")}>info</span>;
+}
+
+export function TemplateClass({ size }: { size: string }) {
+  return <span class={`text-emerald-500 ${size}`}>template</span>;
+}

--- a/test/fixtures/oxlint-design/src/off-system-color.tsx
+++ b/test/fixtures/oxlint-design/src/off-system-color.tsx
@@ -26,6 +26,15 @@ export function InlineStyleFunction() {
   return <div style={{ color: "rgb(24, 24, 27)" }}>ink</div>;
 }
 
+export function InlineStyleEmbedded() {
+  return <div style={{ boxShadow: "0 0 0 1px #e4e4e7", border: "1px solid rgb(0,0,0)" }}>x</div>;
+}
+
+export function StyleMap() {
+  const styles = { background: "linear-gradient(#fff, #000)" };
+  return <div style={styles}>gradient</div>;
+}
+
 export function SaturatedText() {
   return <span class="text-warn">amber label</span>;
 }

--- a/test/fixtures/oxlint-design/src/sub-floor-text.tsx
+++ b/test/fixtures/oxlint-design/src/sub-floor-text.tsx
@@ -1,0 +1,19 @@
+// Every size here is below the docs/design.md 10px floor.
+// Line numbers are asserted in test/oxlint-design-tokens.test.mjs.
+
+export function NinePx() {
+  return <span class="text-[9px]">tiny</span>;
+}
+
+export function HalfRem() {
+  return <span class="font-mono text-[0.5rem]">tiny</span>;
+}
+
+export function WithVariant() {
+  return <span class="lg:text-[8px]">tiny</span>;
+}
+
+export function InMap() {
+  const sizes = { micro: "text-[6px] uppercase" };
+  return <span class={sizes.micro}>tiny</span>;
+}

--- a/test/fixtures/oxlint-design/src/sub-floor-text.tsx
+++ b/test/fixtures/oxlint-design/src/sub-floor-text.tsx
@@ -17,3 +17,15 @@ export function InMap() {
   const sizes = { micro: "text-[6px] uppercase" };
   return <span class={sizes.micro}>tiny</span>;
 }
+
+export function LeadingShorthand() {
+  return <span class="text-[9px]/3">tiny</span>;
+}
+
+export function LengthHint() {
+  return <span class="text-[length:9px]/[12px]">tiny</span>;
+}
+
+export function ArbitraryProperty() {
+  return <span class="[font-size:9px]">tiny</span>;
+}

--- a/test/fixtures/oxlint-design/src/tokens-clean.tsx
+++ b/test/fixtures/oxlint-design/src/tokens-clean.tsx
@@ -43,3 +43,12 @@ export function SmallButAllowed({ active }: { active: boolean }) {
     </span>
   );
 }
+
+export function ShorthandAboveFloor() {
+  return <span class="text-[13px]/5 text-[length:11px] [font-size:12px]">fine</span>;
+}
+
+export function PropertyValueWithoutColor() {
+  const meta = { href: "#section-1", label: "Issue #1234" };
+  return <a href={meta.href}>{meta.label}</a>;
+}

--- a/test/fixtures/oxlint-design/src/tokens-clean.tsx
+++ b/test/fixtures/oxlint-design/src/tokens-clean.tsx
@@ -1,0 +1,45 @@
+// Everything here stays on the token system and above the size floor.
+import { cn } from "./cn";
+
+export function TokenColors() {
+  return (
+    <div class="bg-surface text-ink border border-border">
+      <span class="text-warn-text bg-warn-soft">amber label</span>
+      <span class="text-ok-text">ok</span>
+      <span class="text-accent hover:text-accent-hover">link</span>
+    </div>
+  );
+}
+
+export function SaturatedShapes() {
+  return (
+    <div class="border-l-2 border-warn">
+      <span class="w-4 h-4 rounded-full bg-danger" aria-hidden />
+      <span class="bg-current" />
+    </div>
+  );
+}
+
+export function TokenInArbitraryValue() {
+  return <div class="shadow-[0_0_0_3px_var(--color-accent-soft)] bg-ink/15">focus</div>;
+}
+
+export function StructuralWhiteAndBlack() {
+  return <div class="backdrop:bg-black/40 text-white">overlay</div>;
+}
+
+export function InlineStyleWithoutColor({ width }: { width: number }) {
+  return <div style={{ width: `${width}%`, height: "6px" }} />;
+}
+
+export function ProseWithHash() {
+  return <p>See issue #123 and commit #abc — neither is a color.</p>;
+}
+
+export function SmallButAllowed({ active }: { active: boolean }) {
+  return (
+    <span class={cn("text-[10px] text-ink-subtle", active && "text-[11px]")}>
+      ▸ <span class="text-[12px]">helper</span> <span class="text-xs">also 12px</span>
+    </span>
+  );
+}

--- a/test/oxlint-design-tokens.test.mjs
+++ b/test/oxlint-design-tokens.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "vitest";
+
+// Drive the design-local plugin through the real oxlint runtime against the
+// fixture tree, as test/oxlint-stacked-section-rule.test.mjs does. JS plugins
+// are alpha, so an end-to-end check is more trustworthy than a mocked context.
+
+const fixtureDir = fileURLToPath(new URL("./fixtures/oxlint-design/", import.meta.url));
+const oxlintBin = fileURLToPath(new URL("../node_modules/.bin/oxlint", import.meta.url));
+
+function runRule(ruleCode) {
+  let stdout;
+  try {
+    stdout = execFileSync(oxlintBin, ["-c", "oxlintrc.json", "--format=json", "src"], {
+      cwd: fixtureDir,
+      encoding: "utf8",
+    });
+  } catch (err) {
+    // oxlint exits non-zero when it reports errors; the JSON is on stdout.
+    stdout = err.stdout?.toString() ?? "";
+  }
+  const report = JSON.parse(stdout);
+  return (report.diagnostics ?? [])
+    .filter((d) => d.code === ruleCode)
+    .map((d) => ({
+      filename: d.filename?.replaceAll("\\", "/"),
+      line: d.labels?.[0]?.span?.line,
+      message: d.help ?? d.message ?? "",
+    }));
+}
+
+describe("design-local/no-off-system-color", () => {
+  const flagged = runRule("design-local(no-off-system-color)");
+  const inFixture = flagged.filter((d) => d.filename === "src/off-system-color.tsx");
+
+  it("flags palette colors, raw colors, and saturated severity text", () => {
+    const lines = inFixture.map((d) => d.line).sort((a, b) => a - b);
+    // Palette text (6), two palette utilities behind variants (10, 10), an
+    // arbitrary hex (14), an arbitrary rgba (18), a hex in a style prop (22),
+    // an rgb() in a style prop (26), text-warn (30), text-ok inside a class
+    // map (34), text-info/80 inside cn() (39), and a palette color in a
+    // template literal (43).
+    assert.deepEqual(
+      lines,
+      [6, 10, 10, 14, 18, 22, 26, 30, 34, 39, 43],
+      `expected eleven off-system colors, got:\n${JSON.stringify(flagged, null, 2)}`,
+    );
+  });
+
+  it("names the token and points at the -text variant for saturated severity text", () => {
+    const messageAt = (line) => inFixture.find((d) => d.line === line)?.message ?? "";
+    assert.match(messageAt(6), /`text-red-600` is a Tailwind default-palette color/);
+    assert.match(messageAt(14), /`bg-\[#fafafa\]` carries a raw color/);
+    assert.match(messageAt(22), /Raw CSS color `#e4e4e7`/);
+    assert.match(messageAt(30), /Use `text-warn-text` for text/);
+    assert.match(messageAt(39), /Use `text-info-text` for text/);
+  });
+
+  it("leaves tokens, shapes, var() values, white/black, and prose alone", () => {
+    const other = flagged.filter((d) => d.filename !== "src/off-system-color.tsx");
+    assert.deepEqual(other, [], `unexpected violations:\n${JSON.stringify(other, null, 2)}`);
+  });
+});
+
+describe("design-local/no-sub-floor-text", () => {
+  const flagged = runRule("design-local(no-sub-floor-text)");
+
+  it("flags arbitrary text sizes below 10px in px and rem, behind variants, and in maps", () => {
+    const lines = flagged
+      .filter((d) => d.filename === "src/sub-floor-text.tsx")
+      .map((d) => d.line)
+      .sort((a, b) => a - b);
+    assert.deepEqual(lines, [5, 9, 13, 17], `got:\n${JSON.stringify(flagged, null, 2)}`);
+    assert.match(flagged.find((d) => d.line === 9)?.message ?? "", /`text-\[0\.5rem\]`/);
+  });
+
+  it("allows 10px and up, including the named sizes", () => {
+    const other = flagged.filter((d) => d.filename !== "src/sub-floor-text.tsx");
+    assert.deepEqual(other, [], `unexpected violations:\n${JSON.stringify(other, null, 2)}`);
+  });
+});

--- a/test/oxlint-design-tokens.test.mjs
+++ b/test/oxlint-design-tokens.test.mjs
@@ -13,7 +13,7 @@ const oxlintBin = fileURLToPath(new URL("../node_modules/.bin/oxlint", import.me
 function runRule(ruleCode) {
   let stdout;
   try {
-    stdout = execFileSync(oxlintBin, ["-c", "oxlintrc.json", "--format=json", "src"], {
+    stdout = execFileSync(oxlintBin, ["-c", "oxlintrc.json", "--format=json", "src", "server"], {
       cwd: fixtureDir,
       encoding: "utf8",
     });
@@ -39,13 +39,14 @@ describe("design-local/no-off-system-color", () => {
     const lines = inFixture.map((d) => d.line).sort((a, b) => a - b);
     // Palette text (6), two palette utilities behind variants (10, 10), an
     // arbitrary hex (14), an arbitrary rgba (18), a hex in a style prop (22),
-    // an rgb() in a style prop (26), text-warn (30), text-ok inside a class
-    // map (34), text-info/80 inside cn() (39), and a palette color in a
-    // template literal (43).
+    // an rgb() in a style prop (26), two colors embedded in longer style values
+    // (30, 30), a gradient in a style map (34), text-warn (39), text-ok inside
+    // a class map (43), text-info/80 inside cn() (48), and a palette color in a
+    // template literal (52).
     assert.deepEqual(
       lines,
-      [6, 10, 10, 14, 18, 22, 26, 30, 34, 39, 43],
-      `expected eleven off-system colors, got:\n${JSON.stringify(flagged, null, 2)}`,
+      [6, 10, 10, 14, 18, 22, 26, 30, 30, 34, 39, 43, 48, 52],
+      `expected fourteen off-system colors, got:\n${JSON.stringify(flagged, null, 2)}`,
     );
   });
 
@@ -54,11 +55,12 @@ describe("design-local/no-off-system-color", () => {
     assert.match(messageAt(6), /`text-red-600` is a Tailwind default-palette color/);
     assert.match(messageAt(14), /`bg-\[#fafafa\]` carries a raw color/);
     assert.match(messageAt(22), /Raw CSS color `#e4e4e7`/);
-    assert.match(messageAt(30), /Use `text-warn-text` for text/);
-    assert.match(messageAt(39), /Use `text-info-text` for text/);
+    assert.match(messageAt(30), /Raw CSS color `0 0 0 1px #e4e4e7`/);
+    assert.match(messageAt(39), /Use `text-warn-text` for text/);
+    assert.match(messageAt(48), /Use `text-info-text` for text/);
   });
 
-  it("leaves tokens, shapes, var() values, white/black, and prose alone", () => {
+  it("leaves tokens, shapes, var() values, white/black, prose, and non-src files alone", () => {
     const other = flagged.filter((d) => d.filename !== "src/off-system-color.tsx");
     assert.deepEqual(other, [], `unexpected violations:\n${JSON.stringify(other, null, 2)}`);
   });
@@ -72,11 +74,18 @@ describe("design-local/no-sub-floor-text", () => {
       .filter((d) => d.filename === "src/sub-floor-text.tsx")
       .map((d) => d.line)
       .sort((a, b) => a - b);
-    assert.deepEqual(lines, [5, 9, 13, 17], `got:\n${JSON.stringify(flagged, null, 2)}`);
+    // px (5), rem (9), behind a variant (13), in a class map (17), with a
+    // line-height shorthand (22), a length hint (26), and as an arbitrary
+    // property (30).
+    assert.deepEqual(
+      lines,
+      [5, 9, 13, 17, 22, 26, 30],
+      `got:\n${JSON.stringify(flagged, null, 2)}`,
+    );
     assert.match(flagged.find((d) => d.line === 9)?.message ?? "", /`text-\[0\.5rem\]`/);
   });
 
-  it("allows 10px and up, including the named sizes", () => {
+  it("allows 10px and up, including the named sizes, and ignores non-src files", () => {
     const other = flagged.filter((d) => d.filename !== "src/sub-floor-text.tsx");
     assert.deepEqual(other, [], `unexpected violations:\n${JSON.stringify(other, null, 2)}`);
   });

--- a/tooling/oxlint/design-local/class-tokens.mjs
+++ b/tooling/oxlint/design-local/class-tokens.mjs
@@ -1,0 +1,42 @@
+/**
+ * Shared helpers for reading Tailwind utility tokens out of static strings.
+ * The design rules only reason about static class strings: a class assembled
+ * at runtime is not resolved.
+ */
+
+/**
+ * Strip responsive/state variants (`lg:`, `hover:`, `dark:`) and the important
+ * marker from a utility token. Colons inside arbitrary variants/values are not
+ * variant separators.
+ */
+export function utilityWithoutVariants(token) {
+  let bracketDepth = 0;
+  let parenDepth = 0;
+  let lastVariantSeparator = -1;
+  for (let index = 0; index < token.length; index++) {
+    const char = token[index];
+    if (char === "[") bracketDepth++;
+    else if (char === "]") bracketDepth--;
+    else if (char === "(") parenDepth++;
+    else if (char === ")") parenDepth--;
+    else if (char === ":" && bracketDepth === 0 && parenDepth === 0) {
+      lastVariantSeparator = index;
+    }
+  }
+  return token
+    .slice(lastVariantSeparator + 1)
+    .replace(/^!/, "")
+    .replace(/!$/, "");
+}
+
+/** Every static string a node contributes: literals and template quasis. */
+export function staticStrings(node) {
+  if (node.type === "Literal" && typeof node.value === "string") return [node.value];
+  if (node.type === "TemplateLiteral") return node.quasis.map((quasi) => quasi.value.cooked ?? "");
+  return [];
+}
+
+/** Whitespace-separated tokens of a class-like string. */
+export function classTokens(text) {
+  return text.split(/\s+/).filter(Boolean);
+}

--- a/tooling/oxlint/design-local/index.mjs
+++ b/tooling/oxlint/design-local/index.mjs
@@ -5,9 +5,13 @@
  * Loaded via `jsPlugins` in `.oxlintrc.json` under the `design-local` alias.
  * Rules:
  *   - design-local/no-stacked-section-rule
+ *   - design-local/no-off-system-color
+ *   - design-local/no-sub-floor-text
  */
 
+import noOffSystemColor from "./no-off-system-color.mjs";
 import noStackedSectionRule from "./no-stacked-section-rule.mjs";
+import noSubFloorText from "./no-sub-floor-text.mjs";
 
 const plugin = {
   meta: {
@@ -16,6 +20,8 @@ const plugin = {
   },
   rules: {
     "no-stacked-section-rule": noStackedSectionRule,
+    "no-off-system-color": noOffSystemColor,
+    "no-sub-floor-text": noSubFloorText,
   },
 };
 

--- a/tooling/oxlint/design-local/no-off-system-color.mjs
+++ b/tooling/oxlint/design-local/no-off-system-color.mjs
@@ -1,0 +1,109 @@
+/**
+ * Keep every color on the `docs/design.md` token system.
+ *
+ * The palette in `src/style.css` is the whole color vocabulary: `--color-ink`,
+ * `--color-accent`, the severity pairs, and their `-soft`/`-text` variants, each
+ * with a light and a dark value. Three things bypass it and each has shipped or
+ * nearly shipped by eye:
+ *
+ *   - A Tailwind default-palette utility (`text-red-500`, `bg-zinc-100`). It has
+ *     no dark-mode value, and severity hues outside the token pairs break the
+ *     "color = signal" rule.
+ *   - A raw color in an arbitrary value or a `style` prop (`bg-[#fff]`,
+ *     `shadow-[0_0_0_1px_rgba(0,0,0,.2)]`, `style={{ color: "#c2410c" }}`).
+ *     Same dark-mode problem, and the contrast work in design.md never sees it.
+ *   - A saturated severity token as a text color (`text-warn`, `text-ok`). Those
+ *     fail WCAG AA on white (3.8:1 and 3.0:1); design.md reserves them for shapes
+ *     and provides `text-warn-text` / `text-ok-text` for text.
+ *
+ *   <span class="text-red-600">…</span>                    // flagged (palette)
+ *   <div class="bg-[#fafafa]">…</div>                      // flagged (raw color)
+ *   <div style={{ borderColor: "#e4e4e7" }}>…</div>        // flagged (raw color)
+ *   <span class="text-warn">…</span>                       // flagged (use text-warn-text)
+ *   <span class="text-warn-text bg-warn-soft">…</span>     // ok
+ *   <div class="border-warn">…</div>                       // ok (shape)
+ *   <div class="shadow-[0_0_0_3px_var(--color-accent-soft)]">…</div> // ok (token via var)
+ *   <div class="bg-black/40 text-white">…</div>            // ok (structural, not palette)
+ *
+ * Scope and limitations: every static string literal and template quasi in
+ * `src/` is scanned token by token, so class maps in plain objects
+ * (`const tones = { warn: "text-warn-text" }`) are covered, not just `class=`.
+ * Tokens assembled at runtime are not resolved. `white`/`black` are allowed:
+ * the design uses them for overlays and white-on-accent, which design.md sizes
+ * explicitly.
+ */
+
+import { classTokens, staticStrings, utilityWithoutVariants } from "./class-tokens.mjs";
+
+const COLOR_UTILITY =
+  "(?:text|bg|border(?:-[trblxyse])?|ring|ring-offset|inset-ring|outline|decoration|fill|stroke|from|via|to|accent|caret|divide|placeholder|shadow|inset-shadow)";
+const PALETTE_HUE =
+  "(?:red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose|slate|gray|zinc|neutral|stone)";
+
+const PALETTE_UTILITY = new RegExp(`^${COLOR_UTILITY}-${PALETTE_HUE}-\\d{2,3}$`);
+// Arbitrary values join parts with `_`, which is a word character, so a plain
+// `\b` would miss `shadow-[0_0_0_1px_rgba(…)]`.
+const RAW_COLOR_INSIDE =
+  /#[0-9a-f]{3,8}(?![0-9a-f])|(?<![A-Za-z0-9-])(?:rgba?|hsla?|oklch|oklab|color)\(/i;
+const RAW_COLOR_LITERAL = /^\s*(?:#[0-9a-f]{3,8}|(?:rgba?|hsla?|oklch|oklab|color)\([^)]*\))\s*$/i;
+const SATURATED_SEVERITY_TEXT = /^text-(danger|warn|info|ok)$/;
+
+/** `bg-[#fff]`, `shadow-[0_0_0_1px_rgba(0,0,0,.2)]`: an arbitrary value carrying a raw color. */
+function arbitraryRawColor(utility) {
+  const open = utility.indexOf("[");
+  if (open === -1 || !utility.endsWith("]")) return false;
+  return RAW_COLOR_INSIDE.test(utility.slice(open + 1, -1));
+}
+
+/** Drop a trailing opacity modifier (`text-warn/50`). */
+function withoutOpacity(utility) {
+  return utility.replace(/\/\d{1,3}$/, "").replace(/\/\[[^\]]*\]$/, "");
+}
+
+/** @type {import("eslint").Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Use docs/design.md color tokens: no Tailwind palette colors, raw color values, or saturated severity tokens as text",
+      recommended: true,
+    },
+    messages: {
+      palette:
+        "`{{token}}` is a Tailwind default-palette color. It has no dark-mode value and sits outside the docs/design.md token system; use an ink, accent, or severity token from src/style.css.",
+      rawColor:
+        "`{{token}}` carries a raw color value. Colors come from the src/style.css tokens (a `bg-…`/`text-…` utility, or `var(--color-…)` inside an arbitrary value) so light and dark mode both resolve — see docs/design.md, “Color”.",
+      rawLiteral:
+        "Raw CSS color `{{token}}`. Use a token class or `var(--color-…)` so light and dark mode both resolve — see docs/design.md, “Color”.",
+      saturatedText:
+        "`{{token}}` is the saturated severity token, which fails WCAG AA as text on white. Use `{{token}}-text` for text; the saturated token is for shapes (borders, discs, chart segments) — see docs/design.md, “Severity”.",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    function check(node) {
+      for (const text of staticStrings(node)) {
+        if (RAW_COLOR_LITERAL.test(text)) {
+          context.report({ node, messageId: "rawLiteral", data: { token: text.trim() } });
+          continue;
+        }
+        for (const token of classTokens(text)) {
+          const utility = withoutOpacity(utilityWithoutVariants(token));
+          if (PALETTE_UTILITY.test(utility)) {
+            context.report({ node, messageId: "palette", data: { token } });
+          } else if (arbitraryRawColor(utility)) {
+            context.report({ node, messageId: "rawColor", data: { token } });
+          } else if (SATURATED_SEVERITY_TEXT.test(utility)) {
+            context.report({ node, messageId: "saturatedText", data: { token: utility } });
+          }
+        }
+      }
+    }
+
+    return { Literal: check, TemplateLiteral: check };
+  },
+};
+
+export default rule;

--- a/tooling/oxlint/design-local/no-off-system-color.mjs
+++ b/tooling/oxlint/design-local/no-off-system-color.mjs
@@ -10,8 +10,10 @@
  *     no dark-mode value, and severity hues outside the token pairs break the
  *     "color = signal" rule.
  *   - A raw color in an arbitrary value or a `style` prop (`bg-[#fff]`,
- *     `shadow-[0_0_0_1px_rgba(0,0,0,.2)]`, `style={{ color: "#c2410c" }}`).
- *     Same dark-mode problem, and the contrast work in design.md never sees it.
+ *     `shadow-[0_0_0_1px_rgba(0,0,0,.2)]`, `style={{ color: "#c2410c" }}`,
+ *     `style={{ border: "1px solid #ccc" }}`). Same dark-mode problem, and the
+ *     contrast work in design.md never sees it. Named CSS colors (`"red"`) are
+ *     not recognized; nothing in the design uses them.
  *   - A saturated severity token as a text color (`text-warn`, `text-ok`). Those
  *     fail WCAG AA on white (3.8:1 and 3.0:1); design.md reserves them for shapes
  *     and provides `text-warn-text` / `text-ok-text` for text.
@@ -47,6 +49,10 @@ const RAW_COLOR_INSIDE =
   /#[0-9a-f]{3,8}(?![0-9a-f])|(?<![A-Za-z0-9-])(?:rgba?|hsla?|oklch|oklab|color)\(/i;
 const RAW_COLOR_LITERAL = /^\s*(?:#[0-9a-f]{3,8}|(?:rgba?|hsla?|oklch|oklab|color)\([^)]*\))\s*$/i;
 const SATURATED_SEVERITY_TEXT = /^text-(danger|warn|info|ok)$/;
+// Object keys whose string value is CSS that can carry a color (camelCase or
+// kebab-case): color, background, borderColor, boxShadow, fill, outline, …
+const CSS_COLOR_PROPERTY =
+  /color|background|border|shadow|fill|stroke|outline|caret|accent|decoration/i;
 
 /** `bg-[#fff]`, `shadow-[0_0_0_1px_rgba(0,0,0,.2)]`: an arbitrary value carrying a raw color. */
 function arbitraryRawColor(utility) {
@@ -83,9 +89,23 @@ const rule = {
   },
 
   create(context) {
+    // A string that is the value of a color-carrying CSS property
+    // (`style={{ color: … }}`, `const styles = { boxShadow: "0 0 0 1px #e4e4e7" }`)
+    // is CSS, not a class list, so a color anywhere inside it is raw. Elsewhere
+    // only a string that *is* a color counts: prose and hrefs legitimately
+    // contain `#1234`.
+    function isStyleValue(node) {
+      const parent = node.parent;
+      if (parent?.type !== "Property" || parent.value !== node) return false;
+      const key = parent.key?.name ?? parent.key?.value;
+      return typeof key === "string" && CSS_COLOR_PROPERTY.test(key);
+    }
+
     function check(node) {
       for (const text of staticStrings(node)) {
-        if (RAW_COLOR_LITERAL.test(text)) {
+        const raw =
+          RAW_COLOR_LITERAL.test(text) || (isStyleValue(node) && RAW_COLOR_INSIDE.test(text));
+        if (raw) {
           context.report({ node, messageId: "rawLiteral", data: { token: text.trim() } });
           continue;
         }

--- a/tooling/oxlint/design-local/no-stacked-section-rule.mjs
+++ b/tooling/oxlint/design-local/no-stacked-section-rule.mjs
@@ -37,31 +37,13 @@
 
 const SECTION_LABEL = "SectionLabel";
 
+import { utilityWithoutVariants } from "./class-tokens.mjs";
+
 // Tailwind's directional border namespace contains both widths and colors:
 // `border-t-2` sets a width, while `border-t-border` only sets a color and does
 // not draw anything by itself. Recognize the built-in numeric/px widths and
 // arbitrary length values, plus `border-y` because it draws both horizontal
-// edges. Colons inside arbitrary variants/values are not variant separators.
-function utilityWithoutVariants(token) {
-  let bracketDepth = 0;
-  let parenDepth = 0;
-  let lastVariantSeparator = -1;
-  for (let index = 0; index < token.length; index++) {
-    const char = token[index];
-    if (char === "[") bracketDepth++;
-    else if (char === "]") bracketDepth--;
-    else if (char === "(") parenDepth++;
-    else if (char === ")") parenDepth--;
-    else if (char === ":" && bracketDepth === 0 && parenDepth === 0) {
-      lastVariantSeparator = index;
-    }
-  }
-  return token
-    .slice(lastVariantSeparator + 1)
-    .replace(/^!/, "")
-    .replace(/!$/, "");
-}
-
+// edges.
 function isZeroCssLength(value) {
   return /^[-+]?(?:0+(?:\.0*)?|\.0+)(?:[A-Za-z%]+)?$/.test(value.trim());
 }

--- a/tooling/oxlint/design-local/no-sub-floor-text.mjs
+++ b/tooling/oxlint/design-local/no-sub-floor-text.mjs
@@ -1,0 +1,60 @@
+/**
+ * Keep text at or above the 10px floor from `docs/design.md`.
+ *
+ * The system has three small sizes with fixed roles: 10px is scanning-only
+ * glyphs and structural metadata, 11px is the floor for anything the user reads
+ * as a label, 12px is compact helper copy. Nothing below 10px has a role, and
+ * an arbitrary `text-[9px]` is how one appears — it looks fine in a dense row on
+ * a retina display and fails the reader on everything else.
+ *
+ *   <span class="text-[9px]">…</span>      // flagged
+ *   <span class="text-[0.5rem]">…</span>   // flagged (8px)
+ *   <span class="text-[10px]">▸</span>     // ok (scanning glyph; the role is reviewed, not linted)
+ *   <span class="text-[11px]">Label</span> // ok
+ *
+ * Whether a 10px string is a glyph or a label is a judgement design.md leaves to
+ * review; this rule only closes the floor.
+ */
+
+import { classTokens, staticStrings, utilityWithoutVariants } from "./class-tokens.mjs";
+
+const FLOOR_PX = 10;
+const ARBITRARY_TEXT_SIZE = /^text-\[(\d*\.?\d+)(px|rem|em)\]$/;
+
+function pixels(value, unit) {
+  const number = Number(value);
+  return unit === "px" ? number : number * 16;
+}
+
+/** @type {import("eslint").Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "No text size below the docs/design.md 10px floor",
+      recommended: true,
+    },
+    messages: {
+      belowFloor:
+        "`{{token}}` sets text below the 10px floor. docs/design.md has no role for it: 10px is scanning-only glyphs, 11px is the floor for anything read as a label — see “Minimum size + contrast rules”.",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    function check(node) {
+      for (const text of staticStrings(node)) {
+        for (const token of classTokens(text)) {
+          const match = utilityWithoutVariants(token).match(ARBITRARY_TEXT_SIZE);
+          if (match && pixels(match[1], match[2]) < FLOOR_PX) {
+            context.report({ node, messageId: "belowFloor", data: { token } });
+          }
+        }
+      }
+    }
+
+    return { Literal: check, TemplateLiteral: check };
+  },
+};
+
+export default rule;

--- a/tooling/oxlint/design-local/no-sub-floor-text.mjs
+++ b/tooling/oxlint/design-local/no-sub-floor-text.mjs
@@ -9,17 +9,23 @@
  *
  *   <span class="text-[9px]">…</span>      // flagged
  *   <span class="text-[0.5rem]">…</span>   // flagged (8px)
+ *   <span class="text-[9px]/3">…</span>    // flagged (line-height shorthand)
+ *   <span class="[font-size:9px]">…</span> // flagged (arbitrary property)
  *   <span class="text-[10px]">▸</span>     // ok (scanning glyph; the role is reviewed, not linted)
  *   <span class="text-[11px]">Label</span> // ok
  *
  * Whether a 10px string is a glyph or a label is a judgement design.md leaves to
- * review; this rule only closes the floor.
+ * review; this rule only closes the floor. `em` is converted at 16px, the root
+ * size; the design never sets a smaller parent size.
  */
 
 import { classTokens, staticStrings, utilityWithoutVariants } from "./class-tokens.mjs";
 
 const FLOOR_PX = 10;
-const ARBITRARY_TEXT_SIZE = /^text-\[(\d*\.?\d+)(px|rem|em)\]$/;
+// `text-[9px]`, `text-[length:9px]`, and the arbitrary property `[font-size:9px]`,
+// each with an optional `/leading` modifier after the bracket.
+const ARBITRARY_TEXT_SIZE =
+  /^(?:text-\[(?:length:)?|\[font-size:)(\d*\.?\d+)(px|rem|em)\](?:\/.*)?$/;
 
 function pixels(value, unit) {
   const number = Number(value);


### PR DESCRIPTION
## Summary

`docs/design.md` says colors come from the `src/style.css` tokens, that saturated severity tokens are for shapes only (they fail WCAG AA as text on white), and that no text sits below the 10px floor. All three were prose to read and remember. `src/` currently obeys them: zero raw hex, zero Tailwind palette utilities, zero bare `text-warn`/`text-ok`.

Two new `design-local` oxlint rules, scoped to `src/**`, keep it that way:

- `no-off-system-color` flags a Tailwind default-palette utility (`text-red-600`, `hover:bg-zinc-100`), a raw color in an arbitrary value or a `style` prop (`bg-[#fafafa]`, `shadow-[…rgba(…)]`, `style={{ color: "#c2410c" }}`), and a saturated severity token used as text (`text-warn`, `text-info/80`), pointing at the `-text` variant. `var(--color-…)` in arbitrary values, `white`/`black`, and prose containing `#123` are not reported.
- `no-sub-floor-text` flags an arbitrary `text-[…]` size below 10px in px, rem, or em. Whether a 10px string is a glyph or a label stays a review judgement.

Both scan every static string literal and template quasi, so class maps in plain objects (`const tones = { warn: "…" }`) are covered, not just `class=`. The variant-stripping helper moves to `tooling/oxlint/design-local/class-tokens.mjs` and is shared with `no-stacked-section-rule`.

Scoping to `src/**` is deliberate: the server-rendered OG card SVG carries literal colors legitimately (a rendered image, no dark mode). Those were the only hits outside `src/`.

One fixture line in the existing stacked-rule fixture used `border-t-[#fff]` to demonstrate a color-only border utility; it now uses `border-t-[var(--color-border)]`, which exercises the same branch.

Part of the agent-legibility pass; the other three PRs are independent.

## Testing

- `test/oxlint-design-tokens.test.mjs` drives both rules through the real oxlint runtime against fixtures: 11 flagged colors across palette/arbitrary/style/severity/cn()/template cases, 4 flagged sizes, and a clean fixture covering tokens, shapes, `var()` values, white/black, prose hashes, and 10/11/12px.
- The existing stacked-rule test still passes against the adjusted fixture.
- `pnpm run lint` is clean on the whole repo; `pnpm run verify:quick` passes.
- docs updated: `docs/tooling.md` local-rules section, one line in `docs/design.md` hard rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)